### PR TITLE
[FLINK-7151] add a basic function ddl

### DIFF
--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -757,6 +757,22 @@ class CatalogFunction(object):
         """
         return self._j_catalog_function.getClassName()
 
+    def get_language(self):
+        """
+        Get the language of the function definition.
+
+        :return: The Language enum of the functin class.
+        """
+        return self._j_catalog_function.getLanguage()
+
+    def is_system_function(self):
+        """
+        Whether the function is a system function.
+
+        :return: Whether the function is a system function.
+        """
+        return self._j_catalog_function.isSystemFunction()
+
     def get_properties(self):
         """
         Get the properties of the function.

--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -29,6 +29,8 @@
     "org.apache.flink.sql.parser.ddl.SqlCreateTable.TableCreationContext",
     "org.apache.flink.sql.parser.ddl.SqlCreateView",
     "org.apache.flink.sql.parser.ddl.SqlDropView",
+    "org.apache.flink.sql.parser.ddl.SqlCreateFunction",
+    "org.apache.flink.sql.parser.ddl.SqlDropFunction",
     "org.apache.flink.sql.parser.ddl.SqlTableColumn",
     "org.apache.flink.sql.parser.ddl.SqlTableOption",
     "org.apache.flink.sql.parser.ddl.SqlWatermark",
@@ -342,7 +344,6 @@
     "SUBCLASS_ORIGIN"
     "SUBSTITUTE"
     "TABLE_NAME"
-    "TEMPORARY"
     "TIES"
     "TIMESTAMPADD"
     "TIMESTAMPDIFF"
@@ -431,6 +432,7 @@
   # List of methods for parsing extensions to "CREATE [OR REPLACE]" calls.
   # Each must accept arguments "(SqlParserPos pos, boolean replace)".
   createStatementParserMethods: [
+    "SqlCreateFunction",
     "SqlCreateTable",
     "SqlCreateView",
     "SqlCreateDatabase"
@@ -439,6 +441,7 @@
   # List of methods for parsing extensions to "DROP" calls.
   # Each must accept arguments "(Span s)".
   dropStatementParserMethods: [
+    "SqlDropFunction",
     "SqlDropTable",
     "SqlDropView",
     "SqlDropDatabase"

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -352,6 +352,42 @@ SqlNodeList TableProperties():
     {  return new SqlNodeList(proList, span.end(this)); }
 }
 
+SqlCreate SqlCreateFunction(Span s, boolean replace) :
+{
+    SqlIdentifier functionName = null;
+    SqlCharStringLiteral functionClassName = null;
+    SqlCharStringLiteral functionLanguage = null;
+    boolean ifNotExists = false;
+    boolean isSystemFunction = false;
+
+}
+{
+    <TEMPORARY>
+    (
+        <SYSTEM>   { isSystemFunction = true; }
+    |
+        {isSystemFunction = false; }
+    )
+    <FUNCTION>
+    (
+        <IF> <NOT> <EXISTS> { ifNotExists = true; }
+    |
+        { ifNotExists = false; }
+    )
+    functionName = CompoundIdentifier()
+    [ <AS> <QUOTED_STRING> {
+        String p = SqlParserUtil.parseString(token.image);
+        functionClassName = SqlLiteral.createCharString(p, getPos());
+    }]
+    [ <LANGUAGE> <QUOTED_STRING> {
+        String lang = SqlParserUtil.parseString(token.image);
+        functionLanguage = SqlLiteral.createCharString(lang, getPos());
+    }]
+    {
+        return new SqlCreateFunction(s.pos(), functionName, functionClassName, functionLanguage, ifNotExists, isSystemFunction);
+    }
+}
+
 SqlCreate SqlCreateTable(Span s, boolean replace) :
 {
     final SqlParserPos startPos = s.pos();
@@ -428,6 +464,40 @@ SqlDrop SqlDropTable(Span s, boolean replace) :
 
     {
          return new SqlDropTable(s.pos(), tableName, ifExists);
+    }
+}
+
+SqlDrop SqlDropFunction(Span s, boolean replace) :
+{
+    SqlIdentifier functionName = null;
+    SqlCharStringLiteral functionLanguage = null;
+    boolean ifExists = false;
+    boolean isSystemFunction = false;
+
+}
+{
+    <TEMPORARY>
+    (
+        <SYSTEM>  { isSystemFunction = true; }
+    |
+        {isSystemFunction = false; }
+    )
+    <FUNCTION>
+
+    (
+        <IF> <EXISTS> { ifExists = true; }
+    |
+        { ifExists = false; }
+    )
+
+    functionName = CompoundIdentifier()
+
+    [ <LANGUAGE> <QUOTED_STRING> {
+        String lang = SqlParserUtil.parseString(token.image);
+        functionLanguage = SqlLiteral.createCharString(lang, getPos());
+    }]
+    {
+        return new SqlDropFunction(s.pos(), functionName, functionLanguage, ifExists, isSystemFunction);
     }
 }
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateFunction.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateFunction.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl;
+
+import org.apache.flink.sql.parser.ExtendedSqlNode;
+import org.apache.flink.sql.parser.error.SqlValidateException;
+
+import org.apache.calcite.sql.SqlCharStringLiteral;
+import org.apache.calcite.sql.SqlCreate;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import javax.annotation.Nonnull;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * CREATE FUNCTION DDL sql call.
+ */
+public class SqlCreateFunction extends SqlCreate implements ExtendedSqlNode {
+	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("CREATE FUNCTION", SqlKind.CREATE_FUNCTION);
+
+	private SqlIdentifier functionName;
+	private SqlCharStringLiteral functionClassName;
+	private SqlCharStringLiteral functionLanguage;
+	private boolean isSystemFunction;
+
+	public SqlCreateFunction(
+		SqlParserPos pos,
+		SqlIdentifier functionName,
+		SqlCharStringLiteral functionClassName,
+		SqlCharStringLiteral functionLanguage,
+		boolean ifNotExists,
+		boolean isSystemFunction) {
+		super(OPERATOR, pos, false, ifNotExists);
+		this.functionName = requireNonNull(functionName);
+		this.functionClassName = requireNonNull(functionClassName);
+		this.isSystemFunction = requireNonNull(isSystemFunction);
+		this.functionLanguage = functionLanguage;
+	}
+
+	@Override
+	public SqlOperator getOperator() {
+		return OPERATOR;
+	}
+
+	@Nonnull
+	@Override
+	public List<SqlNode> getOperandList() {
+		return ImmutableNullableList.of(functionName, functionClassName, functionLanguage);
+	}
+
+	@Override
+	public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+		writer.keyword("CREATE");
+		if (isSystemFunction) {
+			writer.keyword("TEMPORARY SYSTEM");
+		} else {
+			writer.keyword("TEMPORARY");
+		}
+		writer.keyword("FUNCTION");
+		if (ifNotExists) {
+			writer.keyword("IF NOT EXISTS");
+		}
+		functionName.unparse(writer, leftPrec, rightPrec);
+		writer.keyword("AS");
+		functionClassName.unparse(writer, leftPrec, rightPrec);
+		if (functionLanguage != null) {
+			writer.keyword("LANGUAGE");
+			functionLanguage.unparse(writer, leftPrec, rightPrec);
+		}
+	}
+
+	@Override
+	public void validate() throws SqlValidateException {
+		// no-op
+	}
+
+	public boolean isIfNotExists() {
+		return ifNotExists;
+	}
+
+	public boolean isSystemFunction() {
+		return isSystemFunction;
+	}
+
+	public SqlIdentifier getFunctionName() {
+		return this.functionName;
+	}
+
+	public SqlCharStringLiteral getFunctionClassName() {
+		return this.functionClassName;
+	}
+
+	public SqlCharStringLiteral getFunctionLanguage() {
+		return this.functionLanguage;
+	}
+
+	public String[] fullFunctionName() {
+		return functionName.names.toArray(new String[0]);
+	}
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropFunction.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropFunction.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl;
+
+import org.apache.flink.sql.parser.ExtendedSqlNode;
+import org.apache.flink.sql.parser.error.SqlValidateException;
+
+import org.apache.calcite.sql.SqlCharStringLiteral;
+import org.apache.calcite.sql.SqlDrop;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import javax.annotation.Nonnull;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * DROP FUNCTION DDL sql call.
+ */
+public class SqlDropFunction extends SqlDrop implements ExtendedSqlNode {
+	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("DROP FUNCTION", SqlKind.DROP_FUNCTION);
+
+	private SqlIdentifier functionName;
+	private SqlCharStringLiteral functionLanguage;
+	private boolean isSystemFunction;
+
+	public SqlDropFunction(
+		SqlParserPos pos,
+		SqlIdentifier functionName,
+		SqlCharStringLiteral functionLanguage,
+		boolean ifExists,
+		boolean isSystemFunction) {
+		super(OPERATOR, pos, ifExists);
+		this.functionName = requireNonNull(functionName);
+		this.isSystemFunction = requireNonNull(isSystemFunction);
+		this.functionLanguage = functionLanguage;
+	}
+
+	@Nonnull
+	@Override
+	public List<SqlNode> getOperandList() {
+		return ImmutableNullableList.of(functionName, functionLanguage);
+	}
+
+	@Override
+	public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+		writer.keyword("DROP");
+		if (isSystemFunction) {
+			writer.keyword("TEMPORARY SYSTEM");
+		} else {
+			writer.keyword("TEMPORARY");
+		}
+		writer.keyword("FUNCTION");
+		if (ifExists) {
+			writer.keyword("IF EXISTS");
+		}
+		functionName.unparse(writer, leftPrec, rightPrec);
+		if (functionLanguage != null) {
+			writer.keyword("LANGUAGE");
+			functionLanguage.unparse(writer, leftPrec, rightPrec);
+		}
+	}
+
+	@Override
+	public void validate() throws SqlValidateException {
+		// no-op
+	}
+
+	public SqlCharStringLiteral getFunctionLanguage() {
+		return this.functionLanguage;
+	}
+
+	public String[] fullFunctionName() {
+		return functionName.names.toArray(new String[0]);
+	}
+
+	public boolean getIfExists() {
+		return this.ifExists;
+	}
+}

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -543,6 +543,43 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	}
 
 	@Test
+	public void testCreateFunction() {
+		check("CREATE TEMPORARY FUNCTION catalog1.db1.function1 AS 'org.apache.fink.function.function1'",
+			"CREATE TEMPORARY FUNCTION `CATALOG1`.`DB1`.`FUNCTION1` AS 'org.apache.fink.function.function1'");
+
+		check("CREATE TEMPORARY SYSTEM FUNCTION catalog1.db1.function1 AS 'org.apache.fink.function.function1'",
+			"CREATE TEMPORARY SYSTEM FUNCTION `CATALOG1`.`DB1`.`FUNCTION1` AS 'org.apache.fink.function.function1'");
+
+		check("CREATE TEMPORARY FUNCTION db1.function1 AS 'org.apache.fink.function.function1'",
+			"CREATE TEMPORARY FUNCTION `DB1`.`FUNCTION1` AS 'org.apache.fink.function.function1'");
+
+		check("CREATE TEMPORARY FUNCTION function1 AS 'org.apache.fink.function.function1'",
+			"CREATE TEMPORARY FUNCTION `FUNCTION1` AS 'org.apache.fink.function.function1'");
+
+		check("CREATE TEMPORARY FUNCTION IF NOT EXISTS catalog1.db1.function1 AS 'org.apache.fink.function.function1'",
+			"CREATE TEMPORARY FUNCTION IF NOT EXISTS `CATALOG1`.`DB1`.`FUNCTION1` AS 'org.apache.fink.function.function1'");
+
+		check("CREATE TEMPORARY FUNCTION function1 AS 'org.apache.fink.function.function1' LANGUAGE 'JAVA'",
+			"CREATE TEMPORARY FUNCTION `FUNCTION1` AS 'org.apache.fink.function.function1' LANGUAGE 'JAVA'");
+
+	}
+
+	@Test
+	public void testDropTemporaryFunction() {
+		check("DROP TEMPORARY FUNCTION catalog1.db1.function1",
+			"DROP TEMPORARY FUNCTION `CATALOG1`.`DB1`.`FUNCTION1`");
+
+		check("DROP TEMPORARY SYSTEM FUNCTION catalog1.db1.function1",
+			"DROP TEMPORARY SYSTEM FUNCTION `CATALOG1`.`DB1`.`FUNCTION1`");
+
+		check("DROP TEMPORARY FUNCTION IF EXISTS catalog1.db1.function1",
+			"DROP TEMPORARY FUNCTION IF EXISTS `CATALOG1`.`DB1`.`FUNCTION1`");
+
+		check("DROP TEMPORARY FUNCTION IF EXISTS catalog1.db1.function1 LANGUAGE 'JAVA'",
+			"DROP TEMPORARY FUNCTION IF EXISTS `CATALOG1`.`DB1`.`FUNCTION1` LANGUAGE 'JAVA'");
+	}
+
+	@Test
 	public void testInsertPartitionSpecs() {
 		conformance0 = FlinkSqlConformance.HIVE;
 		final String sql1 = "insert into emps(x,y) partition (x='ab', y='bc') select * from emps";

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -58,7 +58,9 @@ import org.apache.flink.table.operations.ModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;
 import org.apache.flink.table.operations.TableSourceQueryOperation;
+import org.apache.flink.table.operations.ddl.CreateFunctionOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
+import org.apache.flink.table.operations.ddl.DropFunctionOperation;
 import org.apache.flink.table.operations.ddl.DropTableOperation;
 import org.apache.flink.table.operations.utils.OperationTreeBuilder;
 import org.apache.flink.table.sinks.TableSink;
@@ -473,10 +475,21 @@ public class TableEnvironmentImpl implements TableEnvironment {
 			catalogManager.dropTable(
 				dropTableOperation.getTableIdentifier(),
 				dropTableOperation.isIfExists());
+		} else if (operation instanceof CreateFunctionOperation) {
+			CreateFunctionOperation createFunctionOperation = (CreateFunctionOperation) operation;
+			catalogManager.createFunction(
+				createFunctionOperation.getCatalogFunction(),
+				createFunctionOperation.getFunctionIdentifier(),
+				createFunctionOperation.isIgnoreIfExists());
+		} else if (operation instanceof DropFunctionOperation) {
+			DropFunctionOperation dropFunctionOperation = (DropFunctionOperation) operation;
+			catalogManager.dropFunction(
+				dropFunctionOperation.getFunctionIdentifier(),
+				dropFunctionOperation.isIfExists());
 		} else {
 			throw new TableException(
 				"Unsupported SQL query! sqlUpdate() only accepts a single SQL statements of " +
-					"type INSERT, CREATE TABLE, DROP TABLE");
+					"type INSERT, CREATE TABLE, DROP TABLE, CREATE FUNCTION, DROP FUNCTION");
 		}
 	}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogFunctionImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogFunctionImpl.java
@@ -32,18 +32,31 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class CatalogFunctionImpl implements CatalogFunction {
 	private final String className; // Fully qualified class name of the function
+	private final Language language;
 	private final Map<String, String> properties;
+	private final boolean isSystem;
 
 	public CatalogFunctionImpl(String className, Map<String, String> properties) {
-		checkArgument(!StringUtils.isNullOrWhitespaceOnly(className), "className cannot be null or empty");
+		this(className, Language.JAVA, properties, false);
+	}
 
+	public CatalogFunctionImpl(String className, Language language, Map<String, String> properties, boolean isSystem) {
+		checkArgument(!StringUtils.isNullOrWhitespaceOnly(className), "className cannot be null or empty");
+		checkArgument(language != null, "language cannot be null");
 		this.className = className;
+		this.language = language;
 		this.properties = checkNotNull(properties, "properties cannot be null");
+		this.isSystem = isSystem;
 	}
 
 	@Override
 	public String getClassName() {
 		return this.className;
+	}
+
+	@Override
+	public Language getLanguage() {
+		return this.language;
 	}
 
 	@Override
@@ -53,7 +66,12 @@ public class CatalogFunctionImpl implements CatalogFunction {
 
 	@Override
 	public CatalogFunction copy() {
-		return new CatalogFunctionImpl(getClassName(), new HashMap<>(getProperties()));
+		return new CatalogFunctionImpl(getClassName(), getLanguage(), new HashMap<>(getProperties()), isSystem);
+	}
+
+	@Override
+	public Boolean isSystemFunction() {
+		return isSystem;
 	}
 
 	@Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -24,6 +24,8 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.catalog.exceptions.FunctionAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.FunctionNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.util.StringUtils;
@@ -548,6 +550,35 @@ public class CatalogManager {
 	}
 
 	/**
+	 * Create a function in a given fully qualified path.
+	 *
+	 * @param catalogFunction  The function to put in the given path
+	 * @param objectIdentifier  The fully qualified path of the function to create.
+	 * @param ignoreIfExists If false exception will be thrown if the function already exist
+	 */
+	public void createFunction(CatalogFunction catalogFunction, ObjectIdentifier objectIdentifier, boolean ignoreIfExists) {
+		execute(
+			(catalog, path) -> catalog.createFunction(path, catalogFunction, ignoreIfExists),
+			objectIdentifier,
+			ignoreIfExists,
+			"CreateFunction");
+	}
+
+	/**
+	 * Drops a function in a given fully qualified path.
+	 *
+	 * @param objectIdentifier The fully qualified path of the function to create.
+	 * @param ignoreIfNotExists  If false exception will be thrown if the function to be dropped doesn't exist
+	 */
+	public void dropFunction(ObjectIdentifier objectIdentifier, boolean ignoreIfNotExists) {
+		execute(
+			(catalog, path) -> catalog.dropFunction(path, ignoreIfNotExists),
+			objectIdentifier,
+			ignoreIfNotExists,
+			"DropFunction");
+	}
+
+	/**
 	 * A command that modifies given {@link Catalog} in an {@link ObjectPath}. This unifies error handling
 	 * across different commands.
 	 */
@@ -564,7 +595,8 @@ public class CatalogManager {
 		if (catalog.isPresent()) {
 			try {
 				command.execute(catalog.get(), objectIdentifier.toObjectPath());
-			} catch (TableAlreadyExistException | TableNotExistException | DatabaseNotExistException e) {
+			} catch (TableAlreadyExistException | TableNotExistException | DatabaseNotExistException |
+				FunctionAlreadyExistException | FunctionNotExistException e) {
 				throw new ValidationException(getErrorMessage(objectIdentifier, commandName), e);
 			} catch (Exception e) {
 				throw new TableException(getErrorMessage(objectIdentifier, commandName), e);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateFunctionOperation.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.ddl;
+
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.OperationUtils;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Operation to describe a CREATE FUNCTION statement.
+ */
+public class CreateFunctionOperation implements CreateOperation {
+	private final ObjectIdentifier functionIdentifier;
+	private CatalogFunction catalogFunction;
+	private boolean ignoreIfExists;
+
+	public CreateFunctionOperation(
+		ObjectIdentifier functionIdentifier,
+		CatalogFunction catalogFunction,
+		boolean ignoreIfExists) {
+		this.functionIdentifier = functionIdentifier;
+		this.catalogFunction = catalogFunction;
+		this.ignoreIfExists = ignoreIfExists;
+	}
+
+	public ObjectIdentifier getFunctionIdentifier() {
+		return functionIdentifier;
+	}
+
+	public boolean isIgnoreIfExists() {
+		return ignoreIfExists;
+	}
+
+	public CatalogFunction getCatalogFunction() {
+		return catalogFunction;
+	}
+
+	@Override
+	public String asSummaryString() {
+		Map<String, Object> params = new LinkedHashMap<>();
+		params.put("catalogFunction", catalogFunction.getProperties());
+		params.put("functionIdentifier", functionIdentifier);
+		params.put("ignoreIfExists", ignoreIfExists);
+
+		return OperationUtils.formatWithChildren(
+			"CREATE FUNCTION",
+			params,
+			Collections.emptyList(),
+			Operation::asSummaryString);
+	}
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropFunctionOperation.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.ddl;
+
+import org.apache.flink.table.catalog.Language;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.OperationUtils;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * Operation to describe a DROP FUNCTION statement.
+ */
+public class DropFunctionOperation implements DropOperation {
+	private final ObjectIdentifier functionIdentifier;
+	private final Language language;
+	private final boolean ifExists;
+
+	public DropFunctionOperation(ObjectIdentifier functionIdentifier, Language language, boolean ifExists) {
+		checkArgument(language != null, "language cannot be null");
+		this.functionIdentifier = functionIdentifier;
+		this.language = language;
+		this.ifExists = ifExists;
+	}
+
+	public ObjectIdentifier getFunctionIdentifier() {
+		return this.functionIdentifier;
+	}
+
+	public boolean isIfExists() {
+		return this.ifExists;
+	}
+
+	@Override
+	public String asSummaryString() {
+		Map<String, Object> params = new LinkedHashMap<>();
+		params.put("functionIdentifier", functionIdentifier);
+		params.put("IfExists", ifExists);
+
+		return OperationUtils.formatWithChildren(
+			"DROP FUNCTION",
+			params,
+			Collections.emptyList(),
+			Operation::asSummaryString);
+	}
+
+	public Language getLanguage() {
+		return language;
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogFunction.java
@@ -34,6 +34,20 @@ public interface CatalogFunction {
 	String getClassName();
 
 	/**
+	 * Get the function language.
+	 *
+	 * @return the language of the class
+	 */
+	Language getLanguage();
+
+	/**
+	 * Get Whether it is system function.
+	 *
+	 * @return Whether it is system function
+	 */
+	Boolean isSystemFunction();
+
+	/**
 	 * Get the properties of the function.
 	 *
 	 * @return the properties of the function

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Language.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Language.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+/**
+ * Supported languages for UDF definition in function DDL.
+ */
+public enum Language {
+	JAVA("java"),
+	SCALA("scala"),
+	PYTHON("python");
+
+	private String name;
+
+	Language(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/LanguageNotSupportException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/LanguageNotSupportException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.exceptions;
+
+/**
+ * Exception for trying to define function with a not supported language string.
+ */
+public class LanguageNotSupportException extends Exception {
+
+	private static final String MSG = "Language %s is not supported in flink runtime.";
+
+	public LanguageNotSupportException(String language) {
+		this(language, null);
+	}
+
+	public LanguageNotSupportException(String language, Throwable cause) {
+		super(String.format(MSG, language), cause);
+	}
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/LanguageTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/LanguageTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test Language enum.
+ */
+public class LanguageTest {
+
+	@Test
+	public void testConversion() {
+		Assert.assertEquals(Language.valueOf("JAVA"), Language.JAVA);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -1,0 +1,1472 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.Locale;
+import java.util.Set;
+
+/*
+ * THIS FILE HAS BEEN COPIED FROM THE APACHE CALCITE PROJECT UNTIL CALCITE-3349 IS FIXED AND RELEASED.
+ * (Added lines: 1175)
+ */
+
+/**
+ * Enumerates the possible types of {@link SqlNode}.
+ *
+ * <p>The values are immutable, canonical constants, so you can use Kinds to
+ * find particular types of expressions quickly. To identity a call to a common
+ * operator such as '=', use {@link SqlNode#isA}:</p>
+ *
+ * <blockquote>
+ * exp.{@link SqlNode#isA isA}({@link #EQUALS})
+ * </blockquote>
+ *
+ * <p>Only commonly-used nodes have their own type; other nodes are of type
+ * {@link #OTHER}. Some of the values, such as {@link #SET_QUERY}, represent
+ * aggregates.</p>
+ *
+ * <p>To quickly choose between a number of options, use a switch statement:</p>
+ *
+ * <blockquote>
+ * <pre>switch (exp.getKind()) {
+ * case {@link #EQUALS}:
+ *     ...;
+ * case {@link #NOT_EQUALS}:
+ *     ...;
+ * default:
+ *     throw new AssertionError("unexpected");
+ * }</pre>
+ * </blockquote>
+ *
+ * <p>Note that we do not even have to check that a {@code SqlNode} is a
+ * {@link SqlCall}.</p>
+ *
+ * <p>To identify a category of expressions, use {@code SqlNode.isA} with
+ * an aggregate SqlKind. The following expression will return <code>true</code>
+ * for calls to '=' and '&gt;=', but <code>false</code> for the constant '5', or
+ * a call to '+':</p>
+ *
+ * <blockquote>
+ * <pre>exp.isA({@link #COMPARISON SqlKind.COMPARISON})</pre>
+ * </blockquote>
+ *
+ * <p>RexNode also has a {@code getKind} method; {@code SqlKind} values are
+ * preserved during translation from {@code SqlNode} to {@code RexNode}, where
+ * applicable.</p>
+ *
+ * <p>There is no water-tight definition of "common", but that's OK. There will
+ * always be operators that don't have their own kind, and for these we use the
+ * {@code SqlOperator}. But for really the common ones, e.g. the many places
+ * where we are looking for {@code AND}, {@code OR} and {@code EQUALS}, the enum
+ * helps.</p>
+ *
+ * <p>(If we were using Scala, {@link SqlOperator} would be a case
+ * class, and we wouldn't need {@code SqlKind}. But we're not.)</p>
+ */
+public enum SqlKind {
+	//~ Static fields/initializers ---------------------------------------------
+
+	// the basics
+
+	/**
+	 * Expression not covered by any other {@link SqlKind} value.
+	 *
+	 * @see #OTHER_FUNCTION
+	 */
+	OTHER,
+
+	/**
+	 * SELECT statement or sub-query.
+	 */
+	SELECT,
+
+	/**
+	 * JOIN operator or compound FROM clause.
+	 *
+	 * <p>A FROM clause with more than one table is represented as if it were a
+	 * join. For example, "FROM x, y, z" is represented as
+	 * "JOIN(x, JOIN(x, y))".</p>
+	 */
+	JOIN,
+
+	/**
+	 * Identifier
+	 */
+	IDENTIFIER,
+
+	/**
+	 * A literal.
+	 */
+	LITERAL,
+
+	/**
+	 * Function that is not a special function.
+	 *
+	 * @see #FUNCTION
+	 */
+	OTHER_FUNCTION,
+
+	/**
+	 * POSITION Function
+	 */
+	POSITION,
+
+	/**
+	 * EXPLAIN statement
+	 */
+	EXPLAIN,
+
+	/**
+	 * DESCRIBE SCHEMA statement
+	 */
+	DESCRIBE_SCHEMA,
+
+	/**
+	 * DESCRIBE TABLE statement
+	 */
+	DESCRIBE_TABLE,
+
+	/**
+	 * INSERT statement
+	 */
+	INSERT,
+
+	/**
+	 * DELETE statement
+	 */
+	DELETE,
+
+	/**
+	 * UPDATE statement
+	 */
+	UPDATE,
+
+	/**
+	 * "ALTER scope SET option = value" statement.
+	 */
+	SET_OPTION,
+
+	/**
+	 * A dynamic parameter.
+	 */
+	DYNAMIC_PARAM,
+
+	/**
+	 * ORDER BY clause.
+	 *
+	 * @see #DESCENDING
+	 * @see #NULLS_FIRST
+	 * @see #NULLS_LAST
+	 */
+	ORDER_BY,
+
+	/** WITH clause. */
+	WITH,
+
+	/** Item in WITH clause. */
+	WITH_ITEM,
+
+	/**
+	 * Union
+	 */
+	UNION,
+
+	/**
+	 * Except
+	 */
+	EXCEPT,
+
+	/**
+	 * Intersect
+	 */
+	INTERSECT,
+
+	/**
+	 * AS operator
+	 */
+	AS,
+
+	/**
+	 * ARGUMENT_ASSIGNMENT operator, {@code =>}
+	 */
+	ARGUMENT_ASSIGNMENT,
+
+	/**
+	 * DEFAULT operator
+	 */
+	DEFAULT,
+
+	/**
+	 * OVER operator
+	 */
+	OVER,
+
+	/**
+	 * RESPECT NULLS operator
+	 */
+	RESPECT_NULLS("RESPECT NULLS"),
+
+	/**
+	 * IGNORE NULLS operator
+	 */
+	IGNORE_NULLS("IGNORE NULLS"),
+
+	/**
+	 * FILTER operator
+	 */
+	FILTER,
+
+	/**
+	 * WITHIN_GROUP operator
+	 */
+	WITHIN_GROUP,
+
+	/**
+	 * Window specification
+	 */
+	WINDOW,
+
+	/**
+	 * MERGE statement
+	 */
+	MERGE,
+
+	/**
+	 * TABLESAMPLE operator
+	 */
+	TABLESAMPLE,
+
+	/**
+	 * MATCH_RECOGNIZE clause
+	 */
+	MATCH_RECOGNIZE,
+
+	/**
+	 * SNAPSHOT operator
+	 */
+	SNAPSHOT,
+
+	// binary operators
+
+	/**
+	 * The arithmetic multiplication operator, "*".
+	 */
+	TIMES,
+
+	/**
+	 * The arithmetic division operator, "/".
+	 */
+	DIVIDE,
+
+	/**
+	 * The arithmetic remainder operator, "MOD" (and "%" in some dialects).
+	 */
+	MOD,
+
+	/**
+	 * The arithmetic plus operator, "+".
+	 *
+	 * @see #PLUS_PREFIX
+	 */
+	PLUS,
+
+	/**
+	 * The arithmetic minus operator, "-".
+	 *
+	 * @see #MINUS_PREFIX
+	 */
+	MINUS,
+
+	/**
+	 * the alternation operator in a pattern expression within a match_recognize clause
+	 */
+	PATTERN_ALTER,
+
+	/**
+	 * the concatenation operator in a pattern expression within a match_recognize clause
+	 */
+	PATTERN_CONCAT,
+
+	// comparison operators
+
+	/**
+	 * The "IN" operator.
+	 */
+	IN,
+
+	/**
+	 * The "NOT IN" operator.
+	 *
+	 * <p>Only occurs in SqlNode trees. Is expanded to NOT(IN ...) before
+	 * entering RelNode land.
+	 */
+	NOT_IN("NOT IN"),
+
+	/**
+	 * The less-than operator, "&lt;".
+	 */
+	LESS_THAN("<"),
+
+	/**
+	 * The greater-than operator, "&gt;".
+	 */
+	GREATER_THAN(">"),
+
+	/**
+	 * The less-than-or-equal operator, "&lt;=".
+	 */
+	LESS_THAN_OR_EQUAL("<="),
+
+	/**
+	 * The greater-than-or-equal operator, "&gt;=".
+	 */
+	GREATER_THAN_OR_EQUAL(">="),
+
+	/**
+	 * The equals operator, "=".
+	 */
+	EQUALS("="),
+
+	/**
+	 * The not-equals operator, "&#33;=" or "&lt;&gt;".
+	 * The latter is standard, and preferred.
+	 */
+	NOT_EQUALS("<>"),
+
+	/**
+	 * The is-distinct-from operator.
+	 */
+	IS_DISTINCT_FROM,
+
+	/**
+	 * The is-not-distinct-from operator.
+	 */
+	IS_NOT_DISTINCT_FROM,
+
+	/**
+	 * The logical "OR" operator.
+	 */
+	OR,
+
+	/**
+	 * The logical "AND" operator.
+	 */
+	AND,
+
+	// other infix
+
+	/**
+	 * Dot
+	 */
+	DOT,
+
+	/**
+	 * The "OVERLAPS" operator for periods.
+	 */
+	OVERLAPS,
+
+	/**
+	 * The "CONTAINS" operator for periods.
+	 */
+	CONTAINS,
+
+	/**
+	 * The "PRECEDES" operator for periods.
+	 */
+	PRECEDES,
+
+	/**
+	 * The "IMMEDIATELY PRECEDES" operator for periods.
+	 */
+	IMMEDIATELY_PRECEDES("IMMEDIATELY PRECEDES"),
+
+	/**
+	 * The "SUCCEEDS" operator for periods.
+	 */
+	SUCCEEDS,
+
+	/**
+	 * The "IMMEDIATELY SUCCEEDS" operator for periods.
+	 */
+	IMMEDIATELY_SUCCEEDS("IMMEDIATELY SUCCEEDS"),
+
+	/**
+	 * The "EQUALS" operator for periods.
+	 */
+	PERIOD_EQUALS("EQUALS"),
+
+	/**
+	 * The "LIKE" operator.
+	 */
+	LIKE,
+
+	/**
+	 * The "SIMILAR" operator.
+	 */
+	SIMILAR,
+
+	/**
+	 * The "~" operator.
+	 */
+	POSIX_REGEX_CASE_SENSITIVE,
+
+	/**
+	 * The "~*" operator.
+	 */
+	POSIX_REGEX_CASE_INSENSITIVE,
+
+	/**
+	 * The "BETWEEN" operator.
+	 */
+	BETWEEN,
+
+	/**
+	 * A "CASE" expression.
+	 */
+	CASE,
+
+	/**
+	 * The "NULLIF" operator.
+	 */
+	NULLIF,
+
+	/**
+	 * The "COALESCE" operator.
+	 */
+	COALESCE,
+
+	/**
+	 * The "DECODE" function (Oracle).
+	 */
+	DECODE,
+
+	/**
+	 * The "NVL" function (Oracle).
+	 */
+	NVL,
+
+	/**
+	 * The "GREATEST" function (Oracle).
+	 */
+	GREATEST,
+
+	/**
+	 * The "LEAST" function (Oracle).
+	 */
+	LEAST,
+
+	/**
+	 * The "TIMESTAMP_ADD" function (ODBC, SQL Server, MySQL).
+	 */
+	TIMESTAMP_ADD,
+
+	/**
+	 * The "TIMESTAMP_DIFF" function (ODBC, SQL Server, MySQL).
+	 */
+	TIMESTAMP_DIFF,
+
+	// prefix operators
+
+	/**
+	 * The logical "NOT" operator.
+	 */
+	NOT,
+
+	/**
+	 * The unary plus operator, as in "+1".
+	 *
+	 * @see #PLUS
+	 */
+	PLUS_PREFIX,
+
+	/**
+	 * The unary minus operator, as in "-1".
+	 *
+	 * @see #MINUS
+	 */
+	MINUS_PREFIX,
+
+	/**
+	 * The "EXISTS" operator.
+	 */
+	EXISTS,
+
+	/**
+	 * The "SOME" quantification operator (also called "ANY").
+	 */
+	SOME,
+
+	/**
+	 * The "ALL" quantification operator.
+	 */
+	ALL,
+
+	/**
+	 * The "VALUES" operator.
+	 */
+	VALUES,
+
+	/**
+	 * Explicit table, e.g. <code>select * from (TABLE t)</code> or <code>TABLE
+	 * t</code>. See also {@link #COLLECTION_TABLE}.
+	 */
+	EXPLICIT_TABLE,
+
+	/**
+	 * Scalar query; that is, a sub-query used in an expression context, and
+	 * returning one row and one column.
+	 */
+	SCALAR_QUERY,
+
+	/**
+	 * ProcedureCall
+	 */
+	PROCEDURE_CALL,
+
+	/**
+	 * NewSpecification
+	 */
+	NEW_SPECIFICATION,
+
+
+	/**
+	 * Special functions in MATCH_RECOGNIZE.
+	 */
+	FINAL,
+
+	RUNNING,
+
+	PREV,
+
+	NEXT,
+
+	FIRST,
+
+	LAST,
+
+	CLASSIFIER,
+
+	MATCH_NUMBER,
+
+	/**
+	 * The "SKIP TO FIRST" qualifier of restarting point in a MATCH_RECOGNIZE
+	 * clause.
+	 */
+	SKIP_TO_FIRST,
+
+	/**
+	 * The "SKIP TO LAST" qualifier of restarting point in a MATCH_RECOGNIZE
+	 * clause.
+	 */
+	SKIP_TO_LAST,
+
+	// postfix operators
+
+	/**
+	 * DESC in ORDER BY. A parse tree, not a true expression.
+	 */
+	DESCENDING,
+
+	/**
+	 * NULLS FIRST clause in ORDER BY. A parse tree, not a true expression.
+	 */
+	NULLS_FIRST,
+
+	/**
+	 * NULLS LAST clause in ORDER BY. A parse tree, not a true expression.
+	 */
+	NULLS_LAST,
+
+	/**
+	 * The "IS TRUE" operator.
+	 */
+	IS_TRUE,
+
+	/**
+	 * The "IS FALSE" operator.
+	 */
+	IS_FALSE,
+
+	/**
+	 * The "IS NOT TRUE" operator.
+	 */
+	IS_NOT_TRUE,
+
+	/**
+	 * The "IS NOT FALSE" operator.
+	 */
+	IS_NOT_FALSE,
+
+	/**
+	 * The "IS UNKNOWN" operator.
+	 */
+	IS_UNKNOWN,
+
+	/**
+	 * The "IS NULL" operator.
+	 */
+	IS_NULL,
+
+	/**
+	 * The "IS NOT NULL" operator.
+	 */
+	IS_NOT_NULL,
+
+	/**
+	 * The "PRECEDING" qualifier of an interval end-point in a window
+	 * specification.
+	 */
+	PRECEDING,
+
+	/**
+	 * The "FOLLOWING" qualifier of an interval end-point in a window
+	 * specification.
+	 */
+	FOLLOWING,
+
+	/**
+	 * The field access operator, ".".
+	 *
+	 * <p>(Only used at the RexNode level; at
+	 * SqlNode level, a field-access is part of an identifier.)</p>
+	 */
+	FIELD_ACCESS,
+
+	/**
+	 * Reference to an input field.
+	 *
+	 * <p>(Only used at the RexNode level.)</p>
+	 */
+	INPUT_REF,
+
+	/**
+	 * Reference to an input field, with a qualified name and an identifier
+	 *
+	 * <p>(Only used at the RexNode level.)</p>
+	 */
+	TABLE_INPUT_REF,
+
+	/**
+	 * Reference to an input field, with pattern var as modifier
+	 *
+	 * <p>(Only used at the RexNode level.)</p>
+	 */
+	PATTERN_INPUT_REF,
+	/**
+	 * Reference to a sub-expression computed within the current relational
+	 * operator.
+	 *
+	 * <p>(Only used at the RexNode level.)</p>
+	 */
+	LOCAL_REF,
+
+	/**
+	 * Reference to correlation variable.
+	 *
+	 * <p>(Only used at the RexNode level.)</p>
+	 */
+	CORREL_VARIABLE,
+
+	/**
+	 * the repetition quantifier of a pattern factor in a match_recognize clause.
+	 */
+	PATTERN_QUANTIFIER,
+
+	// functions
+
+	/**
+	 * The row-constructor function. May be explicit or implicit:
+	 * {@code VALUES 1, ROW (2)}.
+	 */
+	ROW,
+
+	/**
+	 * The non-standard constructor used to pass a
+	 * COLUMN_LIST parameter to a user-defined transform.
+	 */
+	COLUMN_LIST,
+
+	/**
+	 * The "CAST" operator, and also the PostgreSQL-style infix cast operator
+	 * "::".
+	 */
+	CAST,
+
+	/**
+	 * The "NEXT VALUE OF sequence" operator.
+	 */
+	NEXT_VALUE,
+
+	/**
+	 * The "CURRENT VALUE OF sequence" operator.
+	 */
+	CURRENT_VALUE,
+
+	/**
+	 * The "FLOOR" function
+	 */
+	FLOOR,
+
+	/**
+	 * The "CEIL" function
+	 */
+	CEIL,
+
+	/**
+	 * The "TRIM" function.
+	 */
+	TRIM,
+
+	/**
+	 * The "LTRIM" function (Oracle).
+	 */
+	LTRIM,
+
+	/**
+	 * The "RTRIM" function (Oracle).
+	 */
+	RTRIM,
+
+	/**
+	 * The "EXTRACT" function.
+	 */
+	EXTRACT,
+
+	/**
+	 * The "REVERSE" function (SQL Server, MySQL).
+	 */
+	REVERSE,
+
+	/**
+	 * Call to a function using JDBC function syntax.
+	 */
+	JDBC_FN,
+
+	/**
+	 * The MULTISET value constructor.
+	 */
+	MULTISET_VALUE_CONSTRUCTOR,
+
+	/**
+	 * The MULTISET query constructor.
+	 */
+	MULTISET_QUERY_CONSTRUCTOR,
+
+	/**
+	 * The JSON value expression.
+	 */
+	JSON_VALUE_EXPRESSION,
+
+	/**
+	 * The {@code JSON_ARRAYAGG} aggregate function.
+	 */
+	JSON_ARRAYAGG,
+
+	/**
+	 * The {@code JSON_OBJECTAGG} aggregate function.
+	 */
+	JSON_OBJECTAGG,
+
+	/**
+	 * The "UNNEST" operator.
+	 */
+	UNNEST,
+
+	/**
+	 * The "LATERAL" qualifier to relations in the FROM clause.
+	 */
+	LATERAL,
+
+	/**
+	 * Table operator which converts user-defined transform into a relation, for
+	 * example, <code>select * from TABLE(udx(x, y, z))</code>. See also the
+	 * {@link #EXPLICIT_TABLE} prefix operator.
+	 */
+	COLLECTION_TABLE,
+
+	/**
+	 * Array Value Constructor, e.g. {@code Array[1, 2, 3]}.
+	 */
+	ARRAY_VALUE_CONSTRUCTOR,
+
+	/**
+	 * Array Query Constructor, e.g. {@code Array(select deptno from dept)}.
+	 */
+	ARRAY_QUERY_CONSTRUCTOR,
+
+	/**
+	 * Map Value Constructor, e.g. {@code Map['washington', 1, 'obama', 44]}.
+	 */
+	MAP_VALUE_CONSTRUCTOR,
+
+	/**
+	 * Map Query Constructor, e.g. {@code MAP (SELECT empno, deptno FROM emp)}.
+	 */
+	MAP_QUERY_CONSTRUCTOR,
+
+	/**
+	 * CURSOR constructor, for example, <code>select * from
+	 * TABLE(udx(CURSOR(select ...), x, y, z))</code>
+	 */
+	CURSOR,
+
+	// internal operators (evaluated in validator) 200-299
+
+	/**
+	 * Literal chain operator (for composite string literals).
+	 * An internal operator that does not appear in SQL syntax.
+	 */
+	LITERAL_CHAIN,
+
+	/**
+	 * Escape operator (always part of LIKE or SIMILAR TO expression).
+	 * An internal operator that does not appear in SQL syntax.
+	 */
+	ESCAPE,
+
+	/**
+	 * The internal REINTERPRET operator (meaning a reinterpret cast).
+	 * An internal operator that does not appear in SQL syntax.
+	 */
+	REINTERPRET,
+
+	/** The internal {@code EXTEND} operator that qualifies a table name in the
+	 * {@code FROM} clause. */
+	EXTEND,
+
+	/** The internal {@code CUBE} operator that occurs within a {@code GROUP BY}
+	 * clause. */
+	CUBE,
+
+	/** The internal {@code ROLLUP} operator that occurs within a {@code GROUP BY}
+	 * clause. */
+	ROLLUP,
+
+	/** The internal {@code GROUPING SETS} operator that occurs within a
+	 * {@code GROUP BY} clause. */
+	GROUPING_SETS,
+
+	/** The {@code GROUPING(e, ...)} function. */
+	GROUPING,
+
+	/** @deprecated Use {@link #GROUPING}. */
+	@Deprecated // to be removed before 2.0
+		GROUPING_ID,
+
+	/** The {@code GROUP_ID()} function. */
+	GROUP_ID,
+
+	/** The internal "permute" function in a MATCH_RECOGNIZE clause. */
+	PATTERN_PERMUTE,
+
+	/** The special patterns to exclude enclosing pattern from output in a
+	 * MATCH_RECOGNIZE clause. */
+	PATTERN_EXCLUDED,
+
+	// Aggregate functions
+
+	/** The {@code COUNT} aggregate function. */
+	COUNT,
+
+	/** The {@code SUM} aggregate function. */
+	SUM,
+
+	/** The {@code SUM0} aggregate function. */
+	SUM0,
+
+	/** The {@code MIN} aggregate function. */
+	MIN,
+
+	/** The {@code MAX} aggregate function. */
+	MAX,
+
+	/** The {@code LEAD} aggregate function. */
+	LEAD,
+
+	/** The {@code LAG} aggregate function. */
+	LAG,
+
+	/** The {@code FIRST_VALUE} aggregate function. */
+	FIRST_VALUE,
+
+	/** The {@code LAST_VALUE} aggregate function. */
+	LAST_VALUE,
+
+	/** The {@code ANY_VALUE} aggregate function. */
+	ANY_VALUE,
+
+	/** The {@code COVAR_POP} aggregate function. */
+	COVAR_POP,
+
+	/** The {@code COVAR_SAMP} aggregate function. */
+	COVAR_SAMP,
+
+	/** The {@code REGR_COUNT} aggregate function. */
+	REGR_COUNT,
+
+	/** The {@code REGR_SXX} aggregate function. */
+	REGR_SXX,
+
+	/** The {@code REGR_SYY} aggregate function. */
+	REGR_SYY,
+
+	/** The {@code AVG} aggregate function. */
+	AVG,
+
+	/** The {@code STDDEV_POP} aggregate function. */
+	STDDEV_POP,
+
+	/** The {@code STDDEV_SAMP} aggregate function. */
+	STDDEV_SAMP,
+
+	/** The {@code VAR_POP} aggregate function. */
+	VAR_POP,
+
+	/** The {@code VAR_SAMP} aggregate function. */
+	VAR_SAMP,
+
+	/** The {@code NTILE} aggregate function. */
+	NTILE,
+
+	/** The {@code NTH_VALUE} aggregate function. */
+	NTH_VALUE,
+
+	/** The {@code LISTAGG} aggregate function. */
+	LISTAGG,
+
+	/** The {@code COLLECT} aggregate function. */
+	COLLECT,
+
+	/** The {@code FUSION} aggregate function. */
+	FUSION,
+
+	/** The {@code SINGLE_VALUE} aggregate function. */
+	SINGLE_VALUE,
+
+	/** The {@code BIT_AND} aggregate function. */
+	BIT_AND,
+
+	/** The {@code BIT_OR} aggregate function. */
+	BIT_OR,
+
+	/** The {@code ROW_NUMBER} window function. */
+	ROW_NUMBER,
+
+	/** The {@code RANK} window function. */
+	RANK,
+
+	/** The {@code PERCENT_RANK} window function. */
+	PERCENT_RANK,
+
+	/** The {@code DENSE_RANK} window function. */
+	DENSE_RANK,
+
+	/** The {@code ROW_NUMBER} window function. */
+	CUME_DIST,
+
+	// Group functions
+
+	/** The {@code TUMBLE} group function. */
+	TUMBLE,
+
+	/** The {@code TUMBLE_START} auxiliary function of
+	 * the {@link #TUMBLE} group function. */
+	TUMBLE_START,
+
+	/** The {@code TUMBLE_END} auxiliary function of
+	 * the {@link #TUMBLE} group function. */
+	TUMBLE_END,
+
+	/** The {@code HOP} group function. */
+	HOP,
+
+	/** The {@code HOP_START} auxiliary function of
+	 * the {@link #HOP} group function. */
+	HOP_START,
+
+	/** The {@code HOP_END} auxiliary function of
+	 * the {@link #HOP} group function. */
+	HOP_END,
+
+	/** The {@code SESSION} group function. */
+	SESSION,
+
+	/** The {@code SESSION_START} auxiliary function of
+	 * the {@link #SESSION} group function. */
+	SESSION_START,
+
+	/** The {@code SESSION_END} auxiliary function of
+	 * the {@link #SESSION} group function. */
+	SESSION_END,
+
+	/** Column declaration. */
+	COLUMN_DECL,
+
+	/** Attribute definition. */
+	ATTRIBUTE_DEF,
+
+	/** {@code CHECK} constraint. */
+	CHECK,
+
+	/** {@code UNIQUE} constraint. */
+	UNIQUE,
+
+	/** {@code PRIMARY KEY} constraint. */
+	PRIMARY_KEY,
+
+	/** {@code FOREIGN KEY} constraint. */
+	FOREIGN_KEY,
+
+	// DDL and session control statements follow. The list is not exhaustive: feel
+	// free to add more.
+
+	/** {@code COMMIT} session control statement. */
+	COMMIT,
+
+	/** {@code ROLLBACK} session control statement. */
+	ROLLBACK,
+
+	/** {@code ALTER SESSION} DDL statement. */
+	ALTER_SESSION,
+
+	/** {@code CREATE SCHEMA} DDL statement. */
+	CREATE_SCHEMA,
+
+	/** {@code CREATE FOREIGN SCHEMA} DDL statement. */
+	CREATE_FOREIGN_SCHEMA,
+
+	/** {@code DROP SCHEMA} DDL statement. */
+	DROP_SCHEMA,
+
+	/** {@code CREATE TABLE} DDL statement. */
+	CREATE_TABLE,
+
+	/** {@code ALTER TABLE} DDL statement. */
+	ALTER_TABLE,
+
+	/** {@code DROP TABLE} DDL statement. */
+	DROP_TABLE,
+
+	/** {@code CREATE VIEW} DDL statement. */
+	CREATE_VIEW,
+
+	/** {@code ALTER VIEW} DDL statement. */
+	ALTER_VIEW,
+
+	/** {@code DROP VIEW} DDL statement. */
+	DROP_VIEW,
+
+	/** {@code CREATE MATERIALIZED VIEW} DDL statement. */
+	CREATE_MATERIALIZED_VIEW,
+
+	/** {@code ALTER MATERIALIZED VIEW} DDL statement. */
+	ALTER_MATERIALIZED_VIEW,
+
+	/** {@code DROP MATERIALIZED VIEW} DDL statement. */
+	DROP_MATERIALIZED_VIEW,
+
+	/** {@code CREATE SEQUENCE} DDL statement. */
+	CREATE_SEQUENCE,
+
+	/** {@code ALTER SEQUENCE} DDL statement. */
+	ALTER_SEQUENCE,
+
+	/** {@code DROP SEQUENCE} DDL statement. */
+	DROP_SEQUENCE,
+
+	/** {@code CREATE INDEX} DDL statement. */
+	CREATE_INDEX,
+
+	/** {@code ALTER INDEX} DDL statement. */
+	ALTER_INDEX,
+
+	/** {@code DROP INDEX} DDL statement. */
+	DROP_INDEX,
+
+	/** {@code CREATE TYPE} DDL statement. */
+	CREATE_TYPE,
+
+	/** {@code DROP TYPE} DDL statement. */
+	DROP_TYPE,
+
+	/** {@code CREATE FUNCTION} DDL statement. */
+	CREATE_FUNCTION,
+
+	/** {@code DROP FUNCTION} DDL statement. */
+	DROP_FUNCTION,
+
+	/** DDL statement not handled above.
+	 *
+	 * <p><b>Note to other projects</b>: If you are extending Calcite's SQL parser
+	 * and have your own object types you no doubt want to define CREATE and DROP
+	 * commands for them. Use OTHER_DDL in the short term, but we are happy to add
+	 * new enum values for your object types. Just ask!
+	 */
+	OTHER_DDL;
+
+	//~ Static fields/initializers ---------------------------------------------
+
+	// Most of the static fields are categories, aggregating several kinds into
+	// a set.
+
+	/**
+	 * Category consisting of set-query node types.
+	 *
+	 * <p>Consists of:
+	 * {@link #EXCEPT},
+	 * {@link #INTERSECT},
+	 * {@link #UNION}.
+	 */
+	public static final EnumSet<SqlKind> SET_QUERY =
+		EnumSet.of(UNION, INTERSECT, EXCEPT);
+
+	/**
+	 * Category consisting of all built-in aggregate functions.
+	 */
+	public static final EnumSet<SqlKind> AGGREGATE =
+		EnumSet.of(COUNT, SUM, SUM0, MIN, MAX, LEAD, LAG, FIRST_VALUE,
+			LAST_VALUE, COVAR_POP, COVAR_SAMP, REGR_COUNT, REGR_SXX, REGR_SYY,
+			AVG, STDDEV_POP, STDDEV_SAMP, VAR_POP, VAR_SAMP, NTILE, COLLECT,
+			FUSION, SINGLE_VALUE, ROW_NUMBER, RANK, PERCENT_RANK, DENSE_RANK,
+			CUME_DIST, JSON_ARRAYAGG, JSON_OBJECTAGG, BIT_AND, BIT_OR, LISTAGG);
+
+	/**
+	 * Category consisting of all DML operators.
+	 *
+	 * <p>Consists of:
+	 * {@link #INSERT},
+	 * {@link #UPDATE},
+	 * {@link #DELETE},
+	 * {@link #MERGE},
+	 * {@link #PROCEDURE_CALL}.
+	 *
+	 * <p>NOTE jvs 1-June-2006: For now we treat procedure calls as DML;
+	 * this makes it easy for JDBC clients to call execute or
+	 * executeUpdate and not have to process dummy cursor results.  If
+	 * in the future we support procedures which return results sets,
+	 * we'll need to refine this.
+	 */
+	public static final EnumSet<SqlKind> DML =
+		EnumSet.of(INSERT, DELETE, UPDATE, MERGE, PROCEDURE_CALL);
+
+	/**
+	 * Category consisting of all DDL operators.
+	 */
+	public static final EnumSet<SqlKind> DDL =
+		EnumSet.of(COMMIT, ROLLBACK, ALTER_SESSION,
+			CREATE_SCHEMA, CREATE_FOREIGN_SCHEMA, DROP_SCHEMA,
+			CREATE_TABLE, ALTER_TABLE, DROP_TABLE,
+			CREATE_FUNCTION, DROP_FUNCTION,
+			CREATE_VIEW, ALTER_VIEW, DROP_VIEW,
+			CREATE_MATERIALIZED_VIEW, ALTER_MATERIALIZED_VIEW,
+			DROP_MATERIALIZED_VIEW,
+			CREATE_SEQUENCE, ALTER_SEQUENCE, DROP_SEQUENCE,
+			CREATE_INDEX, ALTER_INDEX, DROP_INDEX,
+			CREATE_TYPE, DROP_TYPE,
+			SET_OPTION, OTHER_DDL);
+
+	/**
+	 * Category consisting of query node types.
+	 *
+	 * <p>Consists of:
+	 * {@link #SELECT},
+	 * {@link #EXCEPT},
+	 * {@link #INTERSECT},
+	 * {@link #UNION},
+	 * {@link #VALUES},
+	 * {@link #ORDER_BY},
+	 * {@link #EXPLICIT_TABLE}.
+	 */
+	public static final EnumSet<SqlKind> QUERY =
+		EnumSet.of(SELECT, UNION, INTERSECT, EXCEPT, VALUES, WITH, ORDER_BY,
+			EXPLICIT_TABLE);
+
+	/**
+	 * Category consisting of all expression operators.
+	 *
+	 * <p>A node is an expression if it is NOT one of the following:
+	 * {@link #AS},
+	 * {@link #ARGUMENT_ASSIGNMENT},
+	 * {@link #DEFAULT},
+	 * {@link #DESCENDING},
+	 * {@link #SELECT},
+	 * {@link #JOIN},
+	 * {@link #OTHER_FUNCTION},
+	 * {@link #CAST},
+	 * {@link #TRIM},
+	 * {@link #LITERAL_CHAIN},
+	 * {@link #JDBC_FN},
+	 * {@link #PRECEDING},
+	 * {@link #FOLLOWING},
+	 * {@link #ORDER_BY},
+	 * {@link #COLLECTION_TABLE},
+	 * {@link #TABLESAMPLE},
+	 * or an aggregate function, DML or DDL.
+	 */
+	public static final Set<SqlKind> EXPRESSION =
+		EnumSet.complementOf(
+			concat(
+				EnumSet.of(AS, ARGUMENT_ASSIGNMENT, DEFAULT,
+					RUNNING, FINAL, LAST, FIRST, PREV, NEXT,
+					FILTER, WITHIN_GROUP, IGNORE_NULLS, RESPECT_NULLS,
+					DESCENDING, CUBE, ROLLUP, GROUPING_SETS, EXTEND, LATERAL,
+					SELECT, JOIN, OTHER_FUNCTION, POSITION, CAST, TRIM, FLOOR, CEIL,
+					TIMESTAMP_ADD, TIMESTAMP_DIFF, EXTRACT,
+					LITERAL_CHAIN, JDBC_FN, PRECEDING, FOLLOWING, ORDER_BY,
+					NULLS_FIRST, NULLS_LAST, COLLECTION_TABLE, TABLESAMPLE,
+					VALUES, WITH, WITH_ITEM, SKIP_TO_FIRST, SKIP_TO_LAST,
+					JSON_VALUE_EXPRESSION),
+				AGGREGATE, DML, DDL));
+
+	/**
+	 * Category of all SQL statement types.
+	 *
+	 * <p>Consists of all types in {@link #QUERY}, {@link #DML} and {@link #DDL}.
+	 */
+	public static final EnumSet<SqlKind> TOP_LEVEL = concat(QUERY, DML, DDL);
+
+	/**
+	 * Category consisting of regular and special functions.
+	 *
+	 * <p>Consists of regular functions {@link #OTHER_FUNCTION} and special
+	 * functions {@link #ROW}, {@link #TRIM}, {@link #CAST}, {@link #REVERSE}, {@link #JDBC_FN}.
+	 */
+	public static final Set<SqlKind> FUNCTION =
+		EnumSet.of(OTHER_FUNCTION, ROW, TRIM, LTRIM, RTRIM, CAST, REVERSE, JDBC_FN, POSITION);
+
+	/**
+	 * Category of SqlAvgAggFunction.
+	 *
+	 * <p>Consists of {@link #AVG}, {@link #STDDEV_POP}, {@link #STDDEV_SAMP},
+	 * {@link #VAR_POP}, {@link #VAR_SAMP}.
+	 */
+	public static final Set<SqlKind> AVG_AGG_FUNCTIONS =
+		EnumSet.of(AVG, STDDEV_POP, STDDEV_SAMP, VAR_POP, VAR_SAMP);
+
+	/**
+	 * Category of SqlCovarAggFunction.
+	 *
+	 * <p>Consists of {@link #COVAR_POP}, {@link #COVAR_SAMP}, {@link #REGR_SXX},
+	 * {@link #REGR_SYY}.
+	 */
+	public static final Set<SqlKind> COVAR_AVG_AGG_FUNCTIONS =
+		EnumSet.of(COVAR_POP, COVAR_SAMP, REGR_COUNT, REGR_SXX, REGR_SYY);
+
+	/**
+	 * Category of comparison operators.
+	 *
+	 * <p>Consists of:
+	 * {@link #IN},
+	 * {@link #EQUALS},
+	 * {@link #NOT_EQUALS},
+	 * {@link #LESS_THAN},
+	 * {@link #GREATER_THAN},
+	 * {@link #LESS_THAN_OR_EQUAL},
+	 * {@link #GREATER_THAN_OR_EQUAL}.
+	 */
+	public static final Set<SqlKind> COMPARISON =
+		EnumSet.of(
+			IN, EQUALS, NOT_EQUALS,
+			LESS_THAN, GREATER_THAN,
+			GREATER_THAN_OR_EQUAL, LESS_THAN_OR_EQUAL);
+
+	/**
+	 * Category of binary arithmetic.
+	 *
+	 * <p>Consists of:
+	 * {@link #PLUS}
+	 * {@link #MINUS}
+	 * {@link #TIMES}
+	 * {@link #DIVIDE}
+	 * {@link #MOD}.
+	 */
+	public static final Set<SqlKind> BINARY_ARITHMETIC =
+		EnumSet.of(PLUS, MINUS, TIMES, DIVIDE, MOD);
+
+	/**
+	 * Category of binary equality.
+	 *
+	 * <p>Consists of:
+	 * {@link #EQUALS}
+	 * {@link #NOT_EQUALS}
+	 */
+	public static final Set<SqlKind> BINARY_EQUALITY =
+		EnumSet.of(EQUALS, NOT_EQUALS);
+
+	/**
+	 * Category of binary comparison.
+	 *
+	 * <p>Consists of:
+	 * {@link #EQUALS}
+	 * {@link #NOT_EQUALS}
+	 * {@link #GREATER_THAN}
+	 * {@link #GREATER_THAN_OR_EQUAL}
+	 * {@link #LESS_THAN}
+	 * {@link #LESS_THAN_OR_EQUAL}
+	 * {@link #IS_DISTINCT_FROM}
+	 * {@link #IS_NOT_DISTINCT_FROM}
+	 */
+	public static final Set<SqlKind> BINARY_COMPARISON =
+		EnumSet.of(
+			EQUALS, NOT_EQUALS,
+			GREATER_THAN, GREATER_THAN_OR_EQUAL,
+			LESS_THAN, LESS_THAN_OR_EQUAL,
+			IS_DISTINCT_FROM, IS_NOT_DISTINCT_FROM);
+
+	/** Lower-case name. */
+	public final String lowerName = name().toLowerCase(Locale.ROOT);
+	public final String sql;
+
+	SqlKind() {
+		sql = name();
+	}
+
+	SqlKind(String sql) {
+		this.sql = sql;
+	}
+
+	/** Returns the kind that corresponds to this operator but in the opposite
+	 * direction. Or returns this, if this kind is not reversible.
+	 *
+	 * <p>For example, {@code GREATER_THAN.reverse()} returns {@link #LESS_THAN}.
+	 */
+	public SqlKind reverse() {
+		switch (this) {
+			case GREATER_THAN:
+				return LESS_THAN;
+			case GREATER_THAN_OR_EQUAL:
+				return LESS_THAN_OR_EQUAL;
+			case LESS_THAN:
+				return GREATER_THAN;
+			case LESS_THAN_OR_EQUAL:
+				return GREATER_THAN_OR_EQUAL;
+			default:
+				return this;
+		}
+	}
+
+	/** Returns the kind that you get if you apply NOT to this kind.
+	 *
+	 * <p>For example, {@code IS_NOT_NULL.negate()} returns {@link #IS_NULL}.
+	 *
+	 * <p>For {@link #IS_TRUE}, {@link #IS_FALSE}, {@link #IS_NOT_TRUE},
+	 * {@link #IS_NOT_FALSE}, nullable inputs need to be treated carefully.
+	 *
+	 * <p>{@code NOT(IS_TRUE(null))} = {@code NOT(false)} = {@code true},
+	 * while {@code IS_FALSE(null)} = {@code false},
+	 * so {@code NOT(IS_TRUE(X))} should be {@code IS_NOT_TRUE(X)}.
+	 * On the other hand,
+	 * {@code IS_TRUE(NOT(null))} = {@code IS_TRUE(null)} = {@code false}.
+	 *
+	 * <p>This is why negate() != negateNullSafe() for these operators.
+	 */
+	public SqlKind negate() {
+		switch (this) {
+			case IS_TRUE:
+				return IS_NOT_TRUE;
+			case IS_FALSE:
+				return IS_NOT_FALSE;
+			case IS_NULL:
+				return IS_NOT_NULL;
+			case IS_NOT_TRUE:
+				return IS_TRUE;
+			case IS_NOT_FALSE:
+				return IS_FALSE;
+			case IS_NOT_NULL:
+				return IS_NULL;
+			case IS_DISTINCT_FROM:
+				return IS_NOT_DISTINCT_FROM;
+			case IS_NOT_DISTINCT_FROM:
+				return IS_DISTINCT_FROM;
+			default:
+				return this;
+		}
+	}
+
+	/** Returns the kind that you get if you negate this kind.
+	 * To conform to null semantics, null value should not be compared.
+	 *
+	 * <p>For {@link #IS_TRUE}, {@link #IS_FALSE}, {@link #IS_NOT_TRUE} and
+	 * {@link #IS_NOT_FALSE}, nullable inputs need to be treated carefully:
+	 *
+	 * <ul>
+	 * <li>NOT(IS_TRUE(null)) = NOT(false) = true
+	 * <li>IS_TRUE(NOT(null)) = IS_TRUE(null) = false
+	 * <li>IS_FALSE(null) = false
+	 * <li>IS_NOT_TRUE(null) = true
+	 * </ul>
+	 */
+	public SqlKind negateNullSafe() {
+		switch (this) {
+			case EQUALS:
+				return NOT_EQUALS;
+			case NOT_EQUALS:
+				return EQUALS;
+			case LESS_THAN:
+				return GREATER_THAN_OR_EQUAL;
+			case GREATER_THAN:
+				return LESS_THAN_OR_EQUAL;
+			case LESS_THAN_OR_EQUAL:
+				return GREATER_THAN;
+			case GREATER_THAN_OR_EQUAL:
+				return LESS_THAN;
+			case IS_TRUE:
+				return IS_FALSE;
+			case IS_FALSE:
+				return IS_TRUE;
+			case IS_NOT_TRUE:
+				return IS_NOT_FALSE;
+			case IS_NOT_FALSE:
+				return IS_NOT_TRUE;
+			// (NOT x) IS NULL => x IS NULL
+			// Similarly (NOT x) IS NOT NULL => x IS NOT NULL
+			case IS_NOT_NULL:
+			case IS_NULL:
+				return this;
+			default:
+				return this.negate();
+		}
+	}
+
+	/**
+	 * Returns whether this {@code SqlKind} belongs to a given category.
+	 *
+	 * <p>A category is a collection of kinds, not necessarily disjoint. For
+	 * example, QUERY is { SELECT, UNION, INTERSECT, EXCEPT, VALUES, ORDER_BY,
+	 * EXPLICIT_TABLE }.
+	 *
+	 * @param category Category
+	 * @return Whether this kind belongs to the given category
+	 */
+	public final boolean belongsTo(Collection<SqlKind> category) {
+		return category.contains(this);
+	}
+
+	@SafeVarargs
+	private static <E extends Enum<E>> EnumSet<E> concat(EnumSet<E> set0,
+														 EnumSet<E>... sets) {
+		EnumSet<E> set = set0.clone();
+		for (EnumSet<E> s : sets) {
+			set.addAll(s);
+		}
+		return set;
+	}
+}
+
+// End SqlKind.java

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.table.planner.operations;
 
+import org.apache.flink.sql.parser.ddl.SqlCreateFunction;
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
+import org.apache.flink.sql.parser.ddl.SqlDropFunction;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.TableColumn;
@@ -32,6 +34,7 @@ import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.FunctionCatalog;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
+import org.apache.flink.table.catalog.Language;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
@@ -41,7 +44,9 @@ import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.operations.CatalogSinkModifyOperation;
 import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.ddl.CreateFunctionOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
+import org.apache.flink.table.operations.ddl.DropFunctionOperation;
 import org.apache.flink.table.planner.calcite.CalciteParser;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.planner.catalog.CatalogManagerCalciteSchema;
@@ -442,6 +447,60 @@ public class SqlToOperationConverterTest {
 		assertArrayEquals(
 			expected,
 			columnExpressions);
+	}
+
+	@Test
+	public void testCreateFunction() {
+		final String sql = "CREATE TEMPORARY FUNCTION func1 AS 'org.apache.flink.function.function1'";
+		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
+		SqlNode node = getParserBySqlDialect(SqlDialect.DEFAULT).parse(sql);
+		assert node instanceof SqlCreateFunction;
+		Operation operation = SqlToOperationConverter.convert(planner, catalogManager, node).get();
+		assert operation instanceof CreateFunctionOperation;
+		CreateFunctionOperation op = (CreateFunctionOperation) operation;
+		CatalogFunction catalogFunction = op.getCatalogFunction();
+		assertEquals("org.apache.flink.function.function1", catalogFunction.getClassName());
+		assertEquals(Boolean.FALSE, catalogFunction.isSystemFunction());
+		assertEquals(Language.JAVA, catalogFunction.getLanguage());
+	}
+
+	@Test
+	public void testCreateSystemFunctionWithLanguage() {
+		final String sql = "CREATE TEMPORARY SYSTEM FUNCTION func1 AS 'org.apache.flink.function.function1' LANGUAGE 'SCALA'";
+		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
+		SqlNode node = getParserBySqlDialect(SqlDialect.DEFAULT).parse(sql);
+		assert node instanceof SqlCreateFunction;
+		Operation operation = SqlToOperationConverter.convert(planner, catalogManager, node).get();
+		assert operation instanceof CreateFunctionOperation;
+		CreateFunctionOperation op = (CreateFunctionOperation) operation;
+		CatalogFunction catalogFunction = op.getCatalogFunction();
+		assertEquals("org.apache.flink.function.function1", catalogFunction.getClassName());
+		assertEquals(Boolean.TRUE, catalogFunction.isSystemFunction());
+		assertEquals(Language.SCALA, catalogFunction.getLanguage());
+	}
+
+	@Test
+	public void testDropFunction() {
+		final String sql = "DROP TEMPORARY FUNCTION func1";
+		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
+		SqlNode node = getParserBySqlDialect(SqlDialect.DEFAULT).parse(sql);
+		assert node instanceof SqlDropFunction;
+		Operation operation = SqlToOperationConverter.convert(planner, catalogManager, node).get();
+		assert operation instanceof DropFunctionOperation;
+		DropFunctionOperation op = (DropFunctionOperation) operation;
+		assertEquals(Language.JAVA, op.getLanguage());
+	}
+
+	@Test
+	public void testDropSystemFunctionWithLanguage() {
+		final String sql = "DROP TEMPORARY SYSTEM FUNCTION func1 LANGUAGE 'SCALA'";
+		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
+		SqlNode node = getParserBySqlDialect(SqlDialect.DEFAULT).parse(sql);
+		assert node instanceof SqlDropFunction;
+		Operation operation = SqlToOperationConverter.convert(planner, catalogManager, node).get();
+		assert operation instanceof DropFunctionOperation;
+		DropFunctionOperation op = (DropFunctionOperation) operation;
+		assertEquals(Language.SCALA, op.getLanguage());
 	}
 
 	//~ Tool Methods ----------------------------------------------------------

--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -1,0 +1,1472 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.Locale;
+import java.util.Set;
+
+/*
+ * THIS FILE HAS BEEN COPIED FROM THE APACHE CALCITE PROJECT UNTIL CALCITE-3349 IS FIXED AND RELEASED.
+ * (Added lines: 1175)
+ */
+
+/**
+ * Enumerates the possible types of {@link SqlNode}.
+ *
+ * <p>The values are immutable, canonical constants, so you can use Kinds to
+ * find particular types of expressions quickly. To identity a call to a common
+ * operator such as '=', use {@link org.apache.calcite.sql.SqlNode#isA}:</p>
+ *
+ * <blockquote>
+ * exp.{@link org.apache.calcite.sql.SqlNode#isA isA}({@link #EQUALS})
+ * </blockquote>
+ *
+ * <p>Only commonly-used nodes have their own type; other nodes are of type
+ * {@link #OTHER}. Some of the values, such as {@link #SET_QUERY}, represent
+ * aggregates.</p>
+ *
+ * <p>To quickly choose between a number of options, use a switch statement:</p>
+ *
+ * <blockquote>
+ * <pre>switch (exp.getKind()) {
+ * case {@link #EQUALS}:
+ *     ...;
+ * case {@link #NOT_EQUALS}:
+ *     ...;
+ * default:
+ *     throw new AssertionError("unexpected");
+ * }</pre>
+ * </blockquote>
+ *
+ * <p>Note that we do not even have to check that a {@code SqlNode} is a
+ * {@link SqlCall}.</p>
+ *
+ * <p>To identify a category of expressions, use {@code SqlNode.isA} with
+ * an aggregate SqlKind. The following expression will return <code>true</code>
+ * for calls to '=' and '&gt;=', but <code>false</code> for the constant '5', or
+ * a call to '+':</p>
+ *
+ * <blockquote>
+ * <pre>exp.isA({@link #COMPARISON SqlKind.COMPARISON})</pre>
+ * </blockquote>
+ *
+ * <p>RexNode also has a {@code getKind} method; {@code SqlKind} values are
+ * preserved during translation from {@code SqlNode} to {@code RexNode}, where
+ * applicable.</p>
+ *
+ * <p>There is no water-tight definition of "common", but that's OK. There will
+ * always be operators that don't have their own kind, and for these we use the
+ * {@code SqlOperator}. But for really the common ones, e.g. the many places
+ * where we are looking for {@code AND}, {@code OR} and {@code EQUALS}, the enum
+ * helps.</p>
+ *
+ * <p>(If we were using Scala, {@link SqlOperator} would be a case
+ * class, and we wouldn't need {@code SqlKind}. But we're not.)</p>
+ */
+public enum SqlKind {
+	//~ Static fields/initializers ---------------------------------------------
+
+	// the basics
+
+	/**
+	 * Expression not covered by any other {@link SqlKind} value.
+	 *
+	 * @see #OTHER_FUNCTION
+	 */
+	OTHER,
+
+	/**
+	 * SELECT statement or sub-query.
+	 */
+	SELECT,
+
+	/**
+	 * JOIN operator or compound FROM clause.
+	 *
+	 * <p>A FROM clause with more than one table is represented as if it were a
+	 * join. For example, "FROM x, y, z" is represented as
+	 * "JOIN(x, JOIN(x, y))".</p>
+	 */
+	JOIN,
+
+	/**
+	 * Identifier
+	 */
+	IDENTIFIER,
+
+	/**
+	 * A literal.
+	 */
+	LITERAL,
+
+	/**
+	 * Function that is not a special function.
+	 *
+	 * @see #FUNCTION
+	 */
+	OTHER_FUNCTION,
+
+	/**
+	 * POSITION Function
+	 */
+	POSITION,
+
+	/**
+	 * EXPLAIN statement
+	 */
+	EXPLAIN,
+
+	/**
+	 * DESCRIBE SCHEMA statement
+	 */
+	DESCRIBE_SCHEMA,
+
+	/**
+	 * DESCRIBE TABLE statement
+	 */
+	DESCRIBE_TABLE,
+
+	/**
+	 * INSERT statement
+	 */
+	INSERT,
+
+	/**
+	 * DELETE statement
+	 */
+	DELETE,
+
+	/**
+	 * UPDATE statement
+	 */
+	UPDATE,
+
+	/**
+	 * "ALTER scope SET option = value" statement.
+	 */
+	SET_OPTION,
+
+	/**
+	 * A dynamic parameter.
+	 */
+	DYNAMIC_PARAM,
+
+	/**
+	 * ORDER BY clause.
+	 *
+	 * @see #DESCENDING
+	 * @see #NULLS_FIRST
+	 * @see #NULLS_LAST
+	 */
+	ORDER_BY,
+
+	/** WITH clause. */
+	WITH,
+
+	/** Item in WITH clause. */
+	WITH_ITEM,
+
+	/**
+	 * Union
+	 */
+	UNION,
+
+	/**
+	 * Except
+	 */
+	EXCEPT,
+
+	/**
+	 * Intersect
+	 */
+	INTERSECT,
+
+	/**
+	 * AS operator
+	 */
+	AS,
+
+	/**
+	 * ARGUMENT_ASSIGNMENT operator, {@code =>}
+	 */
+	ARGUMENT_ASSIGNMENT,
+
+	/**
+	 * DEFAULT operator
+	 */
+	DEFAULT,
+
+	/**
+	 * OVER operator
+	 */
+	OVER,
+
+	/**
+	 * RESPECT NULLS operator
+	 */
+	RESPECT_NULLS("RESPECT NULLS"),
+
+	/**
+	 * IGNORE NULLS operator
+	 */
+	IGNORE_NULLS("IGNORE NULLS"),
+
+	/**
+	 * FILTER operator
+	 */
+	FILTER,
+
+	/**
+	 * WITHIN_GROUP operator
+	 */
+	WITHIN_GROUP,
+
+	/**
+	 * Window specification
+	 */
+	WINDOW,
+
+	/**
+	 * MERGE statement
+	 */
+	MERGE,
+
+	/**
+	 * TABLESAMPLE operator
+	 */
+	TABLESAMPLE,
+
+	/**
+	 * MATCH_RECOGNIZE clause
+	 */
+	MATCH_RECOGNIZE,
+
+	/**
+	 * SNAPSHOT operator
+	 */
+	SNAPSHOT,
+
+	// binary operators
+
+	/**
+	 * The arithmetic multiplication operator, "*".
+	 */
+	TIMES,
+
+	/**
+	 * The arithmetic division operator, "/".
+	 */
+	DIVIDE,
+
+	/**
+	 * The arithmetic remainder operator, "MOD" (and "%" in some dialects).
+	 */
+	MOD,
+
+	/**
+	 * The arithmetic plus operator, "+".
+	 *
+	 * @see #PLUS_PREFIX
+	 */
+	PLUS,
+
+	/**
+	 * The arithmetic minus operator, "-".
+	 *
+	 * @see #MINUS_PREFIX
+	 */
+	MINUS,
+
+	/**
+	 * the alternation operator in a pattern expression within a match_recognize clause
+	 */
+	PATTERN_ALTER,
+
+	/**
+	 * the concatenation operator in a pattern expression within a match_recognize clause
+	 */
+	PATTERN_CONCAT,
+
+	// comparison operators
+
+	/**
+	 * The "IN" operator.
+	 */
+	IN,
+
+	/**
+	 * The "NOT IN" operator.
+	 *
+	 * <p>Only occurs in SqlNode trees. Is expanded to NOT(IN ...) before
+	 * entering RelNode land.
+	 */
+	NOT_IN("NOT IN"),
+
+	/**
+	 * The less-than operator, "&lt;".
+	 */
+	LESS_THAN("<"),
+
+	/**
+	 * The greater-than operator, "&gt;".
+	 */
+	GREATER_THAN(">"),
+
+	/**
+	 * The less-than-or-equal operator, "&lt;=".
+	 */
+	LESS_THAN_OR_EQUAL("<="),
+
+	/**
+	 * The greater-than-or-equal operator, "&gt;=".
+	 */
+	GREATER_THAN_OR_EQUAL(">="),
+
+	/**
+	 * The equals operator, "=".
+	 */
+	EQUALS("="),
+
+	/**
+	 * The not-equals operator, "&#33;=" or "&lt;&gt;".
+	 * The latter is standard, and preferred.
+	 */
+	NOT_EQUALS("<>"),
+
+	/**
+	 * The is-distinct-from operator.
+	 */
+	IS_DISTINCT_FROM,
+
+	/**
+	 * The is-not-distinct-from operator.
+	 */
+	IS_NOT_DISTINCT_FROM,
+
+	/**
+	 * The logical "OR" operator.
+	 */
+	OR,
+
+	/**
+	 * The logical "AND" operator.
+	 */
+	AND,
+
+	// other infix
+
+	/**
+	 * Dot
+	 */
+	DOT,
+
+	/**
+	 * The "OVERLAPS" operator for periods.
+	 */
+	OVERLAPS,
+
+	/**
+	 * The "CONTAINS" operator for periods.
+	 */
+	CONTAINS,
+
+	/**
+	 * The "PRECEDES" operator for periods.
+	 */
+	PRECEDES,
+
+	/**
+	 * The "IMMEDIATELY PRECEDES" operator for periods.
+	 */
+	IMMEDIATELY_PRECEDES("IMMEDIATELY PRECEDES"),
+
+	/**
+	 * The "SUCCEEDS" operator for periods.
+	 */
+	SUCCEEDS,
+
+	/**
+	 * The "IMMEDIATELY SUCCEEDS" operator for periods.
+	 */
+	IMMEDIATELY_SUCCEEDS("IMMEDIATELY SUCCEEDS"),
+
+	/**
+	 * The "EQUALS" operator for periods.
+	 */
+	PERIOD_EQUALS("EQUALS"),
+
+	/**
+	 * The "LIKE" operator.
+	 */
+	LIKE,
+
+	/**
+	 * The "SIMILAR" operator.
+	 */
+	SIMILAR,
+
+	/**
+	 * The "~" operator.
+	 */
+	POSIX_REGEX_CASE_SENSITIVE,
+
+	/**
+	 * The "~*" operator.
+	 */
+	POSIX_REGEX_CASE_INSENSITIVE,
+
+	/**
+	 * The "BETWEEN" operator.
+	 */
+	BETWEEN,
+
+	/**
+	 * A "CASE" expression.
+	 */
+	CASE,
+
+	/**
+	 * The "NULLIF" operator.
+	 */
+	NULLIF,
+
+	/**
+	 * The "COALESCE" operator.
+	 */
+	COALESCE,
+
+	/**
+	 * The "DECODE" function (Oracle).
+	 */
+	DECODE,
+
+	/**
+	 * The "NVL" function (Oracle).
+	 */
+	NVL,
+
+	/**
+	 * The "GREATEST" function (Oracle).
+	 */
+	GREATEST,
+
+	/**
+	 * The "LEAST" function (Oracle).
+	 */
+	LEAST,
+
+	/**
+	 * The "TIMESTAMP_ADD" function (ODBC, SQL Server, MySQL).
+	 */
+	TIMESTAMP_ADD,
+
+	/**
+	 * The "TIMESTAMP_DIFF" function (ODBC, SQL Server, MySQL).
+	 */
+	TIMESTAMP_DIFF,
+
+	// prefix operators
+
+	/**
+	 * The logical "NOT" operator.
+	 */
+	NOT,
+
+	/**
+	 * The unary plus operator, as in "+1".
+	 *
+	 * @see #PLUS
+	 */
+	PLUS_PREFIX,
+
+	/**
+	 * The unary minus operator, as in "-1".
+	 *
+	 * @see #MINUS
+	 */
+	MINUS_PREFIX,
+
+	/**
+	 * The "EXISTS" operator.
+	 */
+	EXISTS,
+
+	/**
+	 * The "SOME" quantification operator (also called "ANY").
+	 */
+	SOME,
+
+	/**
+	 * The "ALL" quantification operator.
+	 */
+	ALL,
+
+	/**
+	 * The "VALUES" operator.
+	 */
+	VALUES,
+
+	/**
+	 * Explicit table, e.g. <code>select * from (TABLE t)</code> or <code>TABLE
+	 * t</code>. See also {@link #COLLECTION_TABLE}.
+	 */
+	EXPLICIT_TABLE,
+
+	/**
+	 * Scalar query; that is, a sub-query used in an expression context, and
+	 * returning one row and one column.
+	 */
+	SCALAR_QUERY,
+
+	/**
+	 * ProcedureCall
+	 */
+	PROCEDURE_CALL,
+
+	/**
+	 * NewSpecification
+	 */
+	NEW_SPECIFICATION,
+
+
+	/**
+	 * Special functions in MATCH_RECOGNIZE.
+	 */
+	FINAL,
+
+	RUNNING,
+
+	PREV,
+
+	NEXT,
+
+	FIRST,
+
+	LAST,
+
+	CLASSIFIER,
+
+	MATCH_NUMBER,
+
+	/**
+	 * The "SKIP TO FIRST" qualifier of restarting point in a MATCH_RECOGNIZE
+	 * clause.
+	 */
+	SKIP_TO_FIRST,
+
+	/**
+	 * The "SKIP TO LAST" qualifier of restarting point in a MATCH_RECOGNIZE
+	 * clause.
+	 */
+	SKIP_TO_LAST,
+
+	// postfix operators
+
+	/**
+	 * DESC in ORDER BY. A parse tree, not a true expression.
+	 */
+	DESCENDING,
+
+	/**
+	 * NULLS FIRST clause in ORDER BY. A parse tree, not a true expression.
+	 */
+	NULLS_FIRST,
+
+	/**
+	 * NULLS LAST clause in ORDER BY. A parse tree, not a true expression.
+	 */
+	NULLS_LAST,
+
+	/**
+	 * The "IS TRUE" operator.
+	 */
+	IS_TRUE,
+
+	/**
+	 * The "IS FALSE" operator.
+	 */
+	IS_FALSE,
+
+	/**
+	 * The "IS NOT TRUE" operator.
+	 */
+	IS_NOT_TRUE,
+
+	/**
+	 * The "IS NOT FALSE" operator.
+	 */
+	IS_NOT_FALSE,
+
+	/**
+	 * The "IS UNKNOWN" operator.
+	 */
+	IS_UNKNOWN,
+
+	/**
+	 * The "IS NULL" operator.
+	 */
+	IS_NULL,
+
+	/**
+	 * The "IS NOT NULL" operator.
+	 */
+	IS_NOT_NULL,
+
+	/**
+	 * The "PRECEDING" qualifier of an interval end-point in a window
+	 * specification.
+	 */
+	PRECEDING,
+
+	/**
+	 * The "FOLLOWING" qualifier of an interval end-point in a window
+	 * specification.
+	 */
+	FOLLOWING,
+
+	/**
+	 * The field access operator, ".".
+	 *
+	 * <p>(Only used at the RexNode level; at
+	 * SqlNode level, a field-access is part of an identifier.)</p>
+	 */
+	FIELD_ACCESS,
+
+	/**
+	 * Reference to an input field.
+	 *
+	 * <p>(Only used at the RexNode level.)</p>
+	 */
+	INPUT_REF,
+
+	/**
+	 * Reference to an input field, with a qualified name and an identifier
+	 *
+	 * <p>(Only used at the RexNode level.)</p>
+	 */
+	TABLE_INPUT_REF,
+
+	/**
+	 * Reference to an input field, with pattern var as modifier
+	 *
+	 * <p>(Only used at the RexNode level.)</p>
+	 */
+	PATTERN_INPUT_REF,
+	/**
+	 * Reference to a sub-expression computed within the current relational
+	 * operator.
+	 *
+	 * <p>(Only used at the RexNode level.)</p>
+	 */
+	LOCAL_REF,
+
+	/**
+	 * Reference to correlation variable.
+	 *
+	 * <p>(Only used at the RexNode level.)</p>
+	 */
+	CORREL_VARIABLE,
+
+	/**
+	 * the repetition quantifier of a pattern factor in a match_recognize clause.
+	 */
+	PATTERN_QUANTIFIER,
+
+	// functions
+
+	/**
+	 * The row-constructor function. May be explicit or implicit:
+	 * {@code VALUES 1, ROW (2)}.
+	 */
+	ROW,
+
+	/**
+	 * The non-standard constructor used to pass a
+	 * COLUMN_LIST parameter to a user-defined transform.
+	 */
+	COLUMN_LIST,
+
+	/**
+	 * The "CAST" operator, and also the PostgreSQL-style infix cast operator
+	 * "::".
+	 */
+	CAST,
+
+	/**
+	 * The "NEXT VALUE OF sequence" operator.
+	 */
+	NEXT_VALUE,
+
+	/**
+	 * The "CURRENT VALUE OF sequence" operator.
+	 */
+	CURRENT_VALUE,
+
+	/**
+	 * The "FLOOR" function
+	 */
+	FLOOR,
+
+	/**
+	 * The "CEIL" function
+	 */
+	CEIL,
+
+	/**
+	 * The "TRIM" function.
+	 */
+	TRIM,
+
+	/**
+	 * The "LTRIM" function (Oracle).
+	 */
+	LTRIM,
+
+	/**
+	 * The "RTRIM" function (Oracle).
+	 */
+	RTRIM,
+
+	/**
+	 * The "EXTRACT" function.
+	 */
+	EXTRACT,
+
+	/**
+	 * The "REVERSE" function (SQL Server, MySQL).
+	 */
+	REVERSE,
+
+	/**
+	 * Call to a function using JDBC function syntax.
+	 */
+	JDBC_FN,
+
+	/**
+	 * The MULTISET value constructor.
+	 */
+	MULTISET_VALUE_CONSTRUCTOR,
+
+	/**
+	 * The MULTISET query constructor.
+	 */
+	MULTISET_QUERY_CONSTRUCTOR,
+
+	/**
+	 * The JSON value expression.
+	 */
+	JSON_VALUE_EXPRESSION,
+
+	/**
+	 * The {@code JSON_ARRAYAGG} aggregate function.
+	 */
+	JSON_ARRAYAGG,
+
+	/**
+	 * The {@code JSON_OBJECTAGG} aggregate function.
+	 */
+	JSON_OBJECTAGG,
+
+	/**
+	 * The "UNNEST" operator.
+	 */
+	UNNEST,
+
+	/**
+	 * The "LATERAL" qualifier to relations in the FROM clause.
+	 */
+	LATERAL,
+
+	/**
+	 * Table operator which converts user-defined transform into a relation, for
+	 * example, <code>select * from TABLE(udx(x, y, z))</code>. See also the
+	 * {@link #EXPLICIT_TABLE} prefix operator.
+	 */
+	COLLECTION_TABLE,
+
+	/**
+	 * Array Value Constructor, e.g. {@code Array[1, 2, 3]}.
+	 */
+	ARRAY_VALUE_CONSTRUCTOR,
+
+	/**
+	 * Array Query Constructor, e.g. {@code Array(select deptno from dept)}.
+	 */
+	ARRAY_QUERY_CONSTRUCTOR,
+
+	/**
+	 * Map Value Constructor, e.g. {@code Map['washington', 1, 'obama', 44]}.
+	 */
+	MAP_VALUE_CONSTRUCTOR,
+
+	/**
+	 * Map Query Constructor, e.g. {@code MAP (SELECT empno, deptno FROM emp)}.
+	 */
+	MAP_QUERY_CONSTRUCTOR,
+
+	/**
+	 * CURSOR constructor, for example, <code>select * from
+	 * TABLE(udx(CURSOR(select ...), x, y, z))</code>
+	 */
+	CURSOR,
+
+	// internal operators (evaluated in validator) 200-299
+
+	/**
+	 * Literal chain operator (for composite string literals).
+	 * An internal operator that does not appear in SQL syntax.
+	 */
+	LITERAL_CHAIN,
+
+	/**
+	 * Escape operator (always part of LIKE or SIMILAR TO expression).
+	 * An internal operator that does not appear in SQL syntax.
+	 */
+	ESCAPE,
+
+	/**
+	 * The internal REINTERPRET operator (meaning a reinterpret cast).
+	 * An internal operator that does not appear in SQL syntax.
+	 */
+	REINTERPRET,
+
+	/** The internal {@code EXTEND} operator that qualifies a table name in the
+	 * {@code FROM} clause. */
+	EXTEND,
+
+	/** The internal {@code CUBE} operator that occurs within a {@code GROUP BY}
+	 * clause. */
+	CUBE,
+
+	/** The internal {@code ROLLUP} operator that occurs within a {@code GROUP BY}
+	 * clause. */
+	ROLLUP,
+
+	/** The internal {@code GROUPING SETS} operator that occurs within a
+	 * {@code GROUP BY} clause. */
+	GROUPING_SETS,
+
+	/** The {@code GROUPING(e, ...)} function. */
+	GROUPING,
+
+	/** @deprecated Use {@link #GROUPING}. */
+	@Deprecated // to be removed before 2.0
+		GROUPING_ID,
+
+	/** The {@code GROUP_ID()} function. */
+	GROUP_ID,
+
+	/** The internal "permute" function in a MATCH_RECOGNIZE clause. */
+	PATTERN_PERMUTE,
+
+	/** The special patterns to exclude enclosing pattern from output in a
+	 * MATCH_RECOGNIZE clause. */
+	PATTERN_EXCLUDED,
+
+	// Aggregate functions
+
+	/** The {@code COUNT} aggregate function. */
+	COUNT,
+
+	/** The {@code SUM} aggregate function. */
+	SUM,
+
+	/** The {@code SUM0} aggregate function. */
+	SUM0,
+
+	/** The {@code MIN} aggregate function. */
+	MIN,
+
+	/** The {@code MAX} aggregate function. */
+	MAX,
+
+	/** The {@code LEAD} aggregate function. */
+	LEAD,
+
+	/** The {@code LAG} aggregate function. */
+	LAG,
+
+	/** The {@code FIRST_VALUE} aggregate function. */
+	FIRST_VALUE,
+
+	/** The {@code LAST_VALUE} aggregate function. */
+	LAST_VALUE,
+
+	/** The {@code ANY_VALUE} aggregate function. */
+	ANY_VALUE,
+
+	/** The {@code COVAR_POP} aggregate function. */
+	COVAR_POP,
+
+	/** The {@code COVAR_SAMP} aggregate function. */
+	COVAR_SAMP,
+
+	/** The {@code REGR_COUNT} aggregate function. */
+	REGR_COUNT,
+
+	/** The {@code REGR_SXX} aggregate function. */
+	REGR_SXX,
+
+	/** The {@code REGR_SYY} aggregate function. */
+	REGR_SYY,
+
+	/** The {@code AVG} aggregate function. */
+	AVG,
+
+	/** The {@code STDDEV_POP} aggregate function. */
+	STDDEV_POP,
+
+	/** The {@code STDDEV_SAMP} aggregate function. */
+	STDDEV_SAMP,
+
+	/** The {@code VAR_POP} aggregate function. */
+	VAR_POP,
+
+	/** The {@code VAR_SAMP} aggregate function. */
+	VAR_SAMP,
+
+	/** The {@code NTILE} aggregate function. */
+	NTILE,
+
+	/** The {@code NTH_VALUE} aggregate function. */
+	NTH_VALUE,
+
+	/** The {@code LISTAGG} aggregate function. */
+	LISTAGG,
+
+	/** The {@code COLLECT} aggregate function. */
+	COLLECT,
+
+	/** The {@code FUSION} aggregate function. */
+	FUSION,
+
+	/** The {@code SINGLE_VALUE} aggregate function. */
+	SINGLE_VALUE,
+
+	/** The {@code BIT_AND} aggregate function. */
+	BIT_AND,
+
+	/** The {@code BIT_OR} aggregate function. */
+	BIT_OR,
+
+	/** The {@code ROW_NUMBER} window function. */
+	ROW_NUMBER,
+
+	/** The {@code RANK} window function. */
+	RANK,
+
+	/** The {@code PERCENT_RANK} window function. */
+	PERCENT_RANK,
+
+	/** The {@code DENSE_RANK} window function. */
+	DENSE_RANK,
+
+	/** The {@code ROW_NUMBER} window function. */
+	CUME_DIST,
+
+	// Group functions
+
+	/** The {@code TUMBLE} group function. */
+	TUMBLE,
+
+	/** The {@code TUMBLE_START} auxiliary function of
+	 * the {@link #TUMBLE} group function. */
+	TUMBLE_START,
+
+	/** The {@code TUMBLE_END} auxiliary function of
+	 * the {@link #TUMBLE} group function. */
+	TUMBLE_END,
+
+	/** The {@code HOP} group function. */
+	HOP,
+
+	/** The {@code HOP_START} auxiliary function of
+	 * the {@link #HOP} group function. */
+	HOP_START,
+
+	/** The {@code HOP_END} auxiliary function of
+	 * the {@link #HOP} group function. */
+	HOP_END,
+
+	/** The {@code SESSION} group function. */
+	SESSION,
+
+	/** The {@code SESSION_START} auxiliary function of
+	 * the {@link #SESSION} group function. */
+	SESSION_START,
+
+	/** The {@code SESSION_END} auxiliary function of
+	 * the {@link #SESSION} group function. */
+	SESSION_END,
+
+	/** Column declaration. */
+	COLUMN_DECL,
+
+	/** Attribute definition. */
+	ATTRIBUTE_DEF,
+
+	/** {@code CHECK} constraint. */
+	CHECK,
+
+	/** {@code UNIQUE} constraint. */
+	UNIQUE,
+
+	/** {@code PRIMARY KEY} constraint. */
+	PRIMARY_KEY,
+
+	/** {@code FOREIGN KEY} constraint. */
+	FOREIGN_KEY,
+
+	// DDL and session control statements follow. The list is not exhaustive: feel
+	// free to add more.
+
+	/** {@code COMMIT} session control statement. */
+	COMMIT,
+
+	/** {@code ROLLBACK} session control statement. */
+	ROLLBACK,
+
+	/** {@code ALTER SESSION} DDL statement. */
+	ALTER_SESSION,
+
+	/** {@code CREATE SCHEMA} DDL statement. */
+	CREATE_SCHEMA,
+
+	/** {@code CREATE FOREIGN SCHEMA} DDL statement. */
+	CREATE_FOREIGN_SCHEMA,
+
+	/** {@code DROP SCHEMA} DDL statement. */
+	DROP_SCHEMA,
+
+	/** {@code CREATE TABLE} DDL statement. */
+	CREATE_TABLE,
+
+	/** {@code ALTER TABLE} DDL statement. */
+	ALTER_TABLE,
+
+	/** {@code DROP TABLE} DDL statement. */
+	DROP_TABLE,
+
+	/** {@code CREATE VIEW} DDL statement. */
+	CREATE_VIEW,
+
+	/** {@code ALTER VIEW} DDL statement. */
+	ALTER_VIEW,
+
+	/** {@code DROP VIEW} DDL statement. */
+	DROP_VIEW,
+
+	/** {@code CREATE MATERIALIZED VIEW} DDL statement. */
+	CREATE_MATERIALIZED_VIEW,
+
+	/** {@code ALTER MATERIALIZED VIEW} DDL statement. */
+	ALTER_MATERIALIZED_VIEW,
+
+	/** {@code DROP MATERIALIZED VIEW} DDL statement. */
+	DROP_MATERIALIZED_VIEW,
+
+	/** {@code CREATE SEQUENCE} DDL statement. */
+	CREATE_SEQUENCE,
+
+	/** {@code ALTER SEQUENCE} DDL statement. */
+	ALTER_SEQUENCE,
+
+	/** {@code DROP SEQUENCE} DDL statement. */
+	DROP_SEQUENCE,
+
+	/** {@code CREATE INDEX} DDL statement. */
+	CREATE_INDEX,
+
+	/** {@code ALTER INDEX} DDL statement. */
+	ALTER_INDEX,
+
+	/** {@code DROP INDEX} DDL statement. */
+	DROP_INDEX,
+
+	/** {@code CREATE TYPE} DDL statement. */
+	CREATE_TYPE,
+
+	/** {@code DROP TYPE} DDL statement. */
+	DROP_TYPE,
+
+	/** {@code CREATE FUNCTION} DDL statement. */
+	CREATE_FUNCTION,
+
+	/** {@code DROP FUNCTION} DDL statement. */
+	DROP_FUNCTION,
+
+	/** DDL statement not handled above.
+	 *
+	 * <p><b>Note to other projects</b>: If you are extending Calcite's SQL parser
+	 * and have your own object types you no doubt want to define CREATE and DROP
+	 * commands for them. Use OTHER_DDL in the short term, but we are happy to add
+	 * new enum values for your object types. Just ask!
+	 */
+	OTHER_DDL;
+
+	//~ Static fields/initializers ---------------------------------------------
+
+	// Most of the static fields are categories, aggregating several kinds into
+	// a set.
+
+	/**
+	 * Category consisting of set-query node types.
+	 *
+	 * <p>Consists of:
+	 * {@link #EXCEPT},
+	 * {@link #INTERSECT},
+	 * {@link #UNION}.
+	 */
+	public static final EnumSet<SqlKind> SET_QUERY =
+		EnumSet.of(UNION, INTERSECT, EXCEPT);
+
+	/**
+	 * Category consisting of all built-in aggregate functions.
+	 */
+	public static final EnumSet<SqlKind> AGGREGATE =
+		EnumSet.of(COUNT, SUM, SUM0, MIN, MAX, LEAD, LAG, FIRST_VALUE,
+			LAST_VALUE, COVAR_POP, COVAR_SAMP, REGR_COUNT, REGR_SXX, REGR_SYY,
+			AVG, STDDEV_POP, STDDEV_SAMP, VAR_POP, VAR_SAMP, NTILE, COLLECT,
+			FUSION, SINGLE_VALUE, ROW_NUMBER, RANK, PERCENT_RANK, DENSE_RANK,
+			CUME_DIST, JSON_ARRAYAGG, JSON_OBJECTAGG, BIT_AND, BIT_OR, LISTAGG);
+
+	/**
+	 * Category consisting of all DML operators.
+	 *
+	 * <p>Consists of:
+	 * {@link #INSERT},
+	 * {@link #UPDATE},
+	 * {@link #DELETE},
+	 * {@link #MERGE},
+	 * {@link #PROCEDURE_CALL}.
+	 *
+	 * <p>NOTE jvs 1-June-2006: For now we treat procedure calls as DML;
+	 * this makes it easy for JDBC clients to call execute or
+	 * executeUpdate and not have to process dummy cursor results.  If
+	 * in the future we support procedures which return results sets,
+	 * we'll need to refine this.
+	 */
+	public static final EnumSet<SqlKind> DML =
+		EnumSet.of(INSERT, DELETE, UPDATE, MERGE, PROCEDURE_CALL);
+
+	/**
+	 * Category consisting of all DDL operators.
+	 */
+	public static final EnumSet<SqlKind> DDL =
+		EnumSet.of(COMMIT, ROLLBACK, ALTER_SESSION,
+			CREATE_SCHEMA, CREATE_FOREIGN_SCHEMA, DROP_SCHEMA,
+			CREATE_TABLE, ALTER_TABLE, DROP_TABLE,
+			CREATE_FUNCTION, DROP_FUNCTION,
+			CREATE_VIEW, ALTER_VIEW, DROP_VIEW,
+			CREATE_MATERIALIZED_VIEW, ALTER_MATERIALIZED_VIEW,
+			DROP_MATERIALIZED_VIEW,
+			CREATE_SEQUENCE, ALTER_SEQUENCE, DROP_SEQUENCE,
+			CREATE_INDEX, ALTER_INDEX, DROP_INDEX,
+			CREATE_TYPE, DROP_TYPE,
+			SET_OPTION, OTHER_DDL);
+
+	/**
+	 * Category consisting of query node types.
+	 *
+	 * <p>Consists of:
+	 * {@link #SELECT},
+	 * {@link #EXCEPT},
+	 * {@link #INTERSECT},
+	 * {@link #UNION},
+	 * {@link #VALUES},
+	 * {@link #ORDER_BY},
+	 * {@link #EXPLICIT_TABLE}.
+	 */
+	public static final EnumSet<SqlKind> QUERY =
+		EnumSet.of(SELECT, UNION, INTERSECT, EXCEPT, VALUES, WITH, ORDER_BY,
+			EXPLICIT_TABLE);
+
+	/**
+	 * Category consisting of all expression operators.
+	 *
+	 * <p>A node is an expression if it is NOT one of the following:
+	 * {@link #AS},
+	 * {@link #ARGUMENT_ASSIGNMENT},
+	 * {@link #DEFAULT},
+	 * {@link #DESCENDING},
+	 * {@link #SELECT},
+	 * {@link #JOIN},
+	 * {@link #OTHER_FUNCTION},
+	 * {@link #CAST},
+	 * {@link #TRIM},
+	 * {@link #LITERAL_CHAIN},
+	 * {@link #JDBC_FN},
+	 * {@link #PRECEDING},
+	 * {@link #FOLLOWING},
+	 * {@link #ORDER_BY},
+	 * {@link #COLLECTION_TABLE},
+	 * {@link #TABLESAMPLE},
+	 * or an aggregate function, DML or DDL.
+	 */
+	public static final Set<SqlKind> EXPRESSION =
+		EnumSet.complementOf(
+			concat(
+				EnumSet.of(AS, ARGUMENT_ASSIGNMENT, DEFAULT,
+					RUNNING, FINAL, LAST, FIRST, PREV, NEXT,
+					FILTER, WITHIN_GROUP, IGNORE_NULLS, RESPECT_NULLS,
+					DESCENDING, CUBE, ROLLUP, GROUPING_SETS, EXTEND, LATERAL,
+					SELECT, JOIN, OTHER_FUNCTION, POSITION, CAST, TRIM, FLOOR, CEIL,
+					TIMESTAMP_ADD, TIMESTAMP_DIFF, EXTRACT,
+					LITERAL_CHAIN, JDBC_FN, PRECEDING, FOLLOWING, ORDER_BY,
+					NULLS_FIRST, NULLS_LAST, COLLECTION_TABLE, TABLESAMPLE,
+					VALUES, WITH, WITH_ITEM, SKIP_TO_FIRST, SKIP_TO_LAST,
+					JSON_VALUE_EXPRESSION),
+				AGGREGATE, DML, DDL));
+
+	/**
+	 * Category of all SQL statement types.
+	 *
+	 * <p>Consists of all types in {@link #QUERY}, {@link #DML} and {@link #DDL}.
+	 */
+	public static final EnumSet<SqlKind> TOP_LEVEL = concat(QUERY, DML, DDL);
+
+	/**
+	 * Category consisting of regular and special functions.
+	 *
+	 * <p>Consists of regular functions {@link #OTHER_FUNCTION} and special
+	 * functions {@link #ROW}, {@link #TRIM}, {@link #CAST}, {@link #REVERSE}, {@link #JDBC_FN}.
+	 */
+	public static final Set<SqlKind> FUNCTION =
+		EnumSet.of(OTHER_FUNCTION, ROW, TRIM, LTRIM, RTRIM, CAST, REVERSE, JDBC_FN, POSITION);
+
+	/**
+	 * Category of SqlAvgAggFunction.
+	 *
+	 * <p>Consists of {@link #AVG}, {@link #STDDEV_POP}, {@link #STDDEV_SAMP},
+	 * {@link #VAR_POP}, {@link #VAR_SAMP}.
+	 */
+	public static final Set<SqlKind> AVG_AGG_FUNCTIONS =
+		EnumSet.of(AVG, STDDEV_POP, STDDEV_SAMP, VAR_POP, VAR_SAMP);
+
+	/**
+	 * Category of SqlCovarAggFunction.
+	 *
+	 * <p>Consists of {@link #COVAR_POP}, {@link #COVAR_SAMP}, {@link #REGR_SXX},
+	 * {@link #REGR_SYY}.
+	 */
+	public static final Set<SqlKind> COVAR_AVG_AGG_FUNCTIONS =
+		EnumSet.of(COVAR_POP, COVAR_SAMP, REGR_COUNT, REGR_SXX, REGR_SYY);
+
+	/**
+	 * Category of comparison operators.
+	 *
+	 * <p>Consists of:
+	 * {@link #IN},
+	 * {@link #EQUALS},
+	 * {@link #NOT_EQUALS},
+	 * {@link #LESS_THAN},
+	 * {@link #GREATER_THAN},
+	 * {@link #LESS_THAN_OR_EQUAL},
+	 * {@link #GREATER_THAN_OR_EQUAL}.
+	 */
+	public static final Set<SqlKind> COMPARISON =
+		EnumSet.of(
+			IN, EQUALS, NOT_EQUALS,
+			LESS_THAN, GREATER_THAN,
+			GREATER_THAN_OR_EQUAL, LESS_THAN_OR_EQUAL);
+
+	/**
+	 * Category of binary arithmetic.
+	 *
+	 * <p>Consists of:
+	 * {@link #PLUS}
+	 * {@link #MINUS}
+	 * {@link #TIMES}
+	 * {@link #DIVIDE}
+	 * {@link #MOD}.
+	 */
+	public static final Set<SqlKind> BINARY_ARITHMETIC =
+		EnumSet.of(PLUS, MINUS, TIMES, DIVIDE, MOD);
+
+	/**
+	 * Category of binary equality.
+	 *
+	 * <p>Consists of:
+	 * {@link #EQUALS}
+	 * {@link #NOT_EQUALS}
+	 */
+	public static final Set<SqlKind> BINARY_EQUALITY =
+		EnumSet.of(EQUALS, NOT_EQUALS);
+
+	/**
+	 * Category of binary comparison.
+	 *
+	 * <p>Consists of:
+	 * {@link #EQUALS}
+	 * {@link #NOT_EQUALS}
+	 * {@link #GREATER_THAN}
+	 * {@link #GREATER_THAN_OR_EQUAL}
+	 * {@link #LESS_THAN}
+	 * {@link #LESS_THAN_OR_EQUAL}
+	 * {@link #IS_DISTINCT_FROM}
+	 * {@link #IS_NOT_DISTINCT_FROM}
+	 */
+	public static final Set<SqlKind> BINARY_COMPARISON =
+		EnumSet.of(
+			EQUALS, NOT_EQUALS,
+			GREATER_THAN, GREATER_THAN_OR_EQUAL,
+			LESS_THAN, LESS_THAN_OR_EQUAL,
+			IS_DISTINCT_FROM, IS_NOT_DISTINCT_FROM);
+
+	/** Lower-case name. */
+	public final String lowerName = name().toLowerCase(Locale.ROOT);
+	public final String sql;
+
+	SqlKind() {
+		sql = name();
+	}
+
+	SqlKind(String sql) {
+		this.sql = sql;
+	}
+
+	/** Returns the kind that corresponds to this operator but in the opposite
+	 * direction. Or returns this, if this kind is not reversible.
+	 *
+	 * <p>For example, {@code GREATER_THAN.reverse()} returns {@link #LESS_THAN}.
+	 */
+	public SqlKind reverse() {
+		switch (this) {
+			case GREATER_THAN:
+				return LESS_THAN;
+			case GREATER_THAN_OR_EQUAL:
+				return LESS_THAN_OR_EQUAL;
+			case LESS_THAN:
+				return GREATER_THAN;
+			case LESS_THAN_OR_EQUAL:
+				return GREATER_THAN_OR_EQUAL;
+			default:
+				return this;
+		}
+	}
+
+	/** Returns the kind that you get if you apply NOT to this kind.
+	 *
+	 * <p>For example, {@code IS_NOT_NULL.negate()} returns {@link #IS_NULL}.
+	 *
+	 * <p>For {@link #IS_TRUE}, {@link #IS_FALSE}, {@link #IS_NOT_TRUE},
+	 * {@link #IS_NOT_FALSE}, nullable inputs need to be treated carefully.
+	 *
+	 * <p>{@code NOT(IS_TRUE(null))} = {@code NOT(false)} = {@code true},
+	 * while {@code IS_FALSE(null)} = {@code false},
+	 * so {@code NOT(IS_TRUE(X))} should be {@code IS_NOT_TRUE(X)}.
+	 * On the other hand,
+	 * {@code IS_TRUE(NOT(null))} = {@code IS_TRUE(null)} = {@code false}.
+	 *
+	 * <p>This is why negate() != negateNullSafe() for these operators.
+	 */
+	public SqlKind negate() {
+		switch (this) {
+			case IS_TRUE:
+				return IS_NOT_TRUE;
+			case IS_FALSE:
+				return IS_NOT_FALSE;
+			case IS_NULL:
+				return IS_NOT_NULL;
+			case IS_NOT_TRUE:
+				return IS_TRUE;
+			case IS_NOT_FALSE:
+				return IS_FALSE;
+			case IS_NOT_NULL:
+				return IS_NULL;
+			case IS_DISTINCT_FROM:
+				return IS_NOT_DISTINCT_FROM;
+			case IS_NOT_DISTINCT_FROM:
+				return IS_DISTINCT_FROM;
+			default:
+				return this;
+		}
+	}
+
+	/** Returns the kind that you get if you negate this kind.
+	 * To conform to null semantics, null value should not be compared.
+	 *
+	 * <p>For {@link #IS_TRUE}, {@link #IS_FALSE}, {@link #IS_NOT_TRUE} and
+	 * {@link #IS_NOT_FALSE}, nullable inputs need to be treated carefully:
+	 *
+	 * <ul>
+	 * <li>NOT(IS_TRUE(null)) = NOT(false) = true
+	 * <li>IS_TRUE(NOT(null)) = IS_TRUE(null) = false
+	 * <li>IS_FALSE(null) = false
+	 * <li>IS_NOT_TRUE(null) = true
+	 * </ul>
+	 */
+	public SqlKind negateNullSafe() {
+		switch (this) {
+			case EQUALS:
+				return NOT_EQUALS;
+			case NOT_EQUALS:
+				return EQUALS;
+			case LESS_THAN:
+				return GREATER_THAN_OR_EQUAL;
+			case GREATER_THAN:
+				return LESS_THAN_OR_EQUAL;
+			case LESS_THAN_OR_EQUAL:
+				return GREATER_THAN;
+			case GREATER_THAN_OR_EQUAL:
+				return LESS_THAN;
+			case IS_TRUE:
+				return IS_FALSE;
+			case IS_FALSE:
+				return IS_TRUE;
+			case IS_NOT_TRUE:
+				return IS_NOT_FALSE;
+			case IS_NOT_FALSE:
+				return IS_NOT_TRUE;
+			// (NOT x) IS NULL => x IS NULL
+			// Similarly (NOT x) IS NOT NULL => x IS NOT NULL
+			case IS_NOT_NULL:
+			case IS_NULL:
+				return this;
+			default:
+				return this.negate();
+		}
+	}
+
+	/**
+	 * Returns whether this {@code SqlKind} belongs to a given category.
+	 *
+	 * <p>A category is a collection of kinds, not necessarily disjoint. For
+	 * example, QUERY is { SELECT, UNION, INTERSECT, EXCEPT, VALUES, ORDER_BY,
+	 * EXPLICIT_TABLE }.
+	 *
+	 * @param category Category
+	 * @return Whether this kind belongs to the given category
+	 */
+	public final boolean belongsTo(Collection<SqlKind> category) {
+		return category.contains(this);
+	}
+
+	@SafeVarargs
+	private static <E extends Enum<E>> EnumSet<E> concat(EnumSet<E> set0,
+														 EnumSet<E>... sets) {
+		EnumSet<E> set = set0.clone();
+		for (EnumSet<E> s : sets) {
+			set.addAll(s);
+		}
+		return set;
+	}
+}
+
+// End SqlKind.java

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.table.sqlexec;
 
+import org.apache.flink.sql.parser.ddl.SqlCreateFunction;
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
+import org.apache.flink.sql.parser.ddl.SqlDropFunction;
 import org.apache.flink.sql.parser.ddl.SqlDropTable;
 import org.apache.flink.sql.parser.ddl.SqlTableColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableOption;
@@ -28,15 +30,20 @@ import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.calcite.FlinkTypeFactory;
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.CatalogFunctionImpl;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.catalog.Language;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.operations.CatalogSinkModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.PlannerQueryOperation;
+import org.apache.flink.table.operations.ddl.CreateFunctionOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
+import org.apache.flink.table.operations.ddl.DropFunctionOperation;
 import org.apache.flink.table.operations.ddl.DropTableOperation;
 import org.apache.flink.table.types.utils.TypeConversions;
 
@@ -96,6 +103,10 @@ public class SqlToOperationConverter {
 			return Optional.of(converter.convertCreateTable((SqlCreateTable) validated));
 		} if (validated instanceof SqlDropTable) {
 			return Optional.of(converter.convertDropTable((SqlDropTable) validated));
+		} else if (validated instanceof SqlCreateFunction) {
+			return Optional.of(converter.convertCreateFunction((SqlCreateFunction) validated));
+		} else if (validated instanceof SqlDropFunction) {
+			return Optional.of(converter.convertDropFunction((SqlDropFunction) validated));
 		} else if (validated instanceof RichSqlInsert) {
 			SqlNodeList targetColumnList = ((RichSqlInsert) validated).getTargetColumnList();
 			if (targetColumnList != null && targetColumnList.size() != 0) {
@@ -160,6 +171,36 @@ public class SqlToOperationConverter {
 		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
 		return new DropTableOperation(identifier, sqlDropTable.getIfExists());
+	}
+
+	/** Convert CREATE FUNCTION statement. */
+	private Operation convertCreateFunction(SqlCreateFunction sqlCreateFunction) {
+		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlCreateFunction.fullFunctionName());
+		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
+		Language language = sqlCreateFunction.getFunctionLanguage() == null
+			? Language.JAVA : Language.valueOf(sqlCreateFunction.getFunctionLanguage().toValue());
+		CatalogFunction catalogFunction =
+			new CatalogFunctionImpl(
+				sqlCreateFunction.getFunctionClassName().toValue(),
+				language,
+				new HashMap<String, String>(),
+				sqlCreateFunction.isSystemFunction());
+		return new CreateFunctionOperation(
+			identifier,
+			catalogFunction,
+			sqlCreateFunction.isIfNotExists());
+	}
+
+	/** Convert DROP FUNCTION statement. */
+	private Operation convertDropFunction(SqlDropFunction sqlDropFunction) {
+		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlDropFunction.fullFunctionName());
+		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
+		Language language = sqlDropFunction.getFunctionLanguage() == null
+			? Language.JAVA : Language.valueOf(sqlDropFunction.getFunctionLanguage().toValue());
+		return  new DropFunctionOperation(
+			identifier,
+			language,
+			sqlDropFunction.getIfExists());
 	}
 
 	/** Fallback method for sql query. */

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.expressions.resolver.lookups.TableReferenceLookup
 import org.apache.flink.table.factories.{TableFactoryService, TableFactoryUtil, TableSinkFactory}
 import org.apache.flink.table.functions.{AggregateFunction, ScalarFunction, TableFunction, UserDefinedAggregateFunction, _}
 import org.apache.flink.table.module.{Module, ModuleManager}
-import org.apache.flink.table.operations.ddl.{CreateTableOperation, DropTableOperation}
+import org.apache.flink.table.operations.ddl.{CreateFunctionOperation, CreateTableOperation, DropTableOperation, DropFunctionOperation}
 import org.apache.flink.table.operations.utils.OperationTreeBuilder
 import org.apache.flink.table.operations.{CatalogQueryOperation, TableSourceQueryOperation, _}
 import org.apache.flink.table.planner.{ParserImpl, PlanningConfigurationBuilder}
@@ -485,9 +485,19 @@ abstract class TableEnvImpl(
         catalogManager.dropTable(
           dropTableOperation.getTableIdentifier,
           dropTableOperation.isIfExists)
-      case _ => throw new TableException(
-        "Unsupported SQL query! sqlUpdate() only accepts a single SQL statements of " +
-          "type INSERT, CREATE TABLE, DROP TABLE")
+      case createFunctionOperation: CreateFunctionOperation =>
+        catalogManager.createFunction(
+          createFunctionOperation.getCatalogFunction,
+          createFunctionOperation.getFunctionIdentifier,
+          createFunctionOperation.isIgnoreIfExists)
+      case dropFunctionOperation: DropFunctionOperation =>
+        catalogManager.dropFunction(
+          dropFunctionOperation.getFunctionIdentifier,
+          dropFunctionOperation.isIfExists)
+      case _ =>
+        throw new TableException(
+          "Unsupported SQL query! sqlUpdate() only accepts SQL statements of " +
+            "type INSERT, CREATE TABLE, DROP TABLE, CREATE FUNCTION, DROP FUNCTION.")
     }
   }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.table.sqlexec;
 
+import org.apache.flink.sql.parser.ddl.SqlCreateFunction;
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
+import org.apache.flink.sql.parser.ddl.SqlDropFunction;
 import org.apache.flink.sql.parser.dml.RichSqlInsert;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.SqlDialect;
@@ -29,12 +31,14 @@ import org.apache.flink.table.api.Types;
 import org.apache.flink.table.calcite.CalciteParser;
 import org.apache.flink.table.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CatalogFunction;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.CatalogManagerCalciteSchema;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.FunctionCatalog;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
+import org.apache.flink.table.catalog.Language;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
@@ -44,7 +48,9 @@ import org.apache.flink.table.expressions.PlannerExpressionConverter;
 import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.operations.CatalogSinkModifyOperation;
 import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.ddl.CreateFunctionOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
+import org.apache.flink.table.operations.ddl.DropFunctionOperation;
 import org.apache.flink.table.planner.PlanningConfigurationBuilder;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.utils.TypeConversions;
@@ -404,6 +410,60 @@ public class SqlToOperationConverterTest {
 			expectedEx.expectMessage(item.expectedError);
 			SqlToOperationConverter.convert(planner, catalogManager, node);
 		}
+	}
+
+	@Test
+	public void testCreateFunction() {
+		final String sql = "CREATE TEMPORARY FUNCTION func1 AS 'org.apache.flink.function.function1'";
+		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
+		SqlNode node = getParserBySqlDialect(SqlDialect.DEFAULT).parse(sql);
+		assert node instanceof SqlCreateFunction;
+		Operation operation = SqlToOperationConverter.convert(planner, catalogManager, node).get();
+		assert operation instanceof CreateFunctionOperation;
+		CreateFunctionOperation op = (CreateFunctionOperation) operation;
+		CatalogFunction catalogFunction = op.getCatalogFunction();
+		assertEquals("org.apache.flink.function.function1", catalogFunction.getClassName());
+		assertEquals(Boolean.FALSE, catalogFunction.isSystemFunction());
+		assertEquals(Language.JAVA, catalogFunction.getLanguage());
+	}
+
+	@Test
+	public void testCreateSystemFunctionWithLanguage() {
+		final String sql = "CREATE TEMPORARY SYSTEM FUNCTION func1 AS 'org.apache.flink.function.function1' LANGUAGE 'SCALA'";
+		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
+		SqlNode node = getParserBySqlDialect(SqlDialect.DEFAULT).parse(sql);
+		assert node instanceof SqlCreateFunction;
+		Operation operation = SqlToOperationConverter.convert(planner, catalogManager, node).get();
+		assert operation instanceof CreateFunctionOperation;
+		CreateFunctionOperation op = (CreateFunctionOperation) operation;
+		CatalogFunction catalogFunction = op.getCatalogFunction();
+		assertEquals("org.apache.flink.function.function1", catalogFunction.getClassName());
+		assertEquals(Boolean.TRUE, catalogFunction.isSystemFunction());
+		assertEquals(Language.SCALA, catalogFunction.getLanguage());
+	}
+
+	@Test
+	public void testDropFunction() {
+		final String sql = "DROP TEMPORARY FUNCTION func1";
+		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
+		SqlNode node = getParserBySqlDialect(SqlDialect.DEFAULT).parse(sql);
+		assert node instanceof SqlDropFunction;
+		Operation operation = SqlToOperationConverter.convert(planner, catalogManager, node).get();
+		assert operation instanceof DropFunctionOperation;
+		DropFunctionOperation op = (DropFunctionOperation) operation;
+		assertEquals(Language.JAVA, op.getLanguage());
+	}
+
+	@Test
+	public void testDropSystemFunctionWithLanguage() {
+		final String sql = "DROP TEMPORARY SYSTEM FUNCTION func1 LANGUAGE 'SCALA'";
+		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
+		SqlNode node = getParserBySqlDialect(SqlDialect.DEFAULT).parse(sql);
+		assert node instanceof SqlDropFunction;
+		Operation operation = SqlToOperationConverter.convert(planner, catalogManager, node).get();
+		assert operation instanceof DropFunctionOperation;
+		DropFunctionOperation op = (DropFunctionOperation) operation;
+		assertEquals(Language.SCALA, op.getLanguage());
 	}
 
 	//~ Tool Methods ----------------------------------------------------------

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/catalog/CatalogFunctionITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/catalog/CatalogFunctionITCase.scala
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog
+
+import java.util
+
+import org.apache.flink.api.scala.ExecutionEnvironment
+import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.table.api.scala.{BatchTableEnvironment, StreamTableEnvironment}
+import org.junit.{Before, Test}
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.MatcherAssert.assertThat
+
+
+/** Test cases for catalog function. */
+@RunWith(classOf[Parameterized])
+class CatalogFunctionITCase(isStreaming: Boolean) {
+
+  private val batchExec: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+  private var batchEnv: BatchTableEnvironment = _
+  private val streamExec: StreamExecutionEnvironment = StreamExecutionEnvironment
+    .getExecutionEnvironment
+  private var streamEnv: StreamTableEnvironment = _
+
+  @Before
+  def before(): Unit = {
+    batchExec.setParallelism(4)
+    streamExec.setParallelism(4)
+    batchEnv = BatchTableEnvironment.create(batchExec)
+    streamEnv = StreamTableEnvironment.create(streamExec)
+  }
+
+  def tableEnv: TableEnvironment = {
+    if (isStreaming) {
+      streamEnv
+    } else {
+      batchEnv
+    }
+  }
+
+  @Test
+  def testCreateFunction(): Unit = {
+    val ddl1 =
+      """
+        |create temporary function f1
+        |  as 'org.apache.flink.function.TestFunction'
+      """.stripMargin
+    tableEnv.sqlUpdate(ddl1)
+    assert(tableEnv.listFunctions().contains("f1"))
+
+    tableEnv.sqlUpdate("DROP TEMPORARY FUNCTION IF EXISTS catalog1.database1.f1")
+    assert(tableEnv.listFunctions().contains("f1"))
+  }
+
+  @Test
+  def testCreateSystemFunction(): Unit = {
+    val ddl1 =
+      """
+        |create temporary system function f2
+        |  as 'org.apache.flink.function.TestFunction'
+      """.stripMargin
+    tableEnv.sqlUpdate(ddl1)
+    assert(tableEnv.listFunctions().contains("f2"))
+
+    tableEnv.sqlUpdate("DROP TEMPORARY SYSTEM FUNCTION IF EXISTS catalog1.database1.f2")
+    assert(tableEnv.listFunctions().contains("f2"))
+  }
+
+  @Test
+  def testCreateFunctionWithFullPath(): Unit = {
+    val ddl1 =
+      """
+        |create temporary function default_catalog.default_database.f2
+        |  as 'org.apache.flink.function.TestFunction'
+      """.stripMargin
+    tableEnv.sqlUpdate(ddl1)
+    assert(tableEnv.listFunctions().contains("f2"))
+
+    tableEnv.sqlUpdate("DROP TEMPORARY FUNCTION IF EXISTS default_catalog.default_database.f2")
+    assert(!tableEnv.listFunctions().contains("f2"))
+  }
+
+  @Test
+  def testCreateFunctionWithLanguage(): Unit = {
+    val ddl1 =
+      """
+        |create temporary function default_catalog.default_database.f2
+        |  as 'org.apache.flink.function.TestFunction' language 'SCALA'
+      """.stripMargin
+    tableEnv.sqlUpdate(ddl1)
+    assert(tableEnv.listFunctions().contains("f2"))
+
+    tableEnv.sqlUpdate("DROP TEMPORARY FUNCTION IF EXISTS default_catalog.default_database.f2")
+    assert(!tableEnv.listFunctions().contains("f2"))
+  }
+
+  @Test
+  def testCreateFunctionNotExists(): Unit = {
+    val ddl3 =
+    """
+      |create temporary function if not exists catalog1.database1.f3
+      |  as 'org.apache.flink.function.TestFunction'
+    """.stripMargin
+    tableEnv.sqlUpdate(ddl3)
+
+    val ddl4 =
+      """
+        |create temporary function catalog1.database1.f3
+        |  as 'org.apache.flink.function.TestFunction'
+    """.stripMargin
+
+    try {
+      tableEnv.sqlUpdate(ddl4)
+    } catch {
+      case e: Exception => {
+        assertThat(e.getMessage(), containsString("Catalog catalog1 does not exist."));
+      }
+    }
+  }
+
+  @Test
+  def testDropFunctionNonExists(): Unit = {
+    tableEnv.sqlUpdate("DROP TEMPORARY FUNCTION IF EXISTS catalog1.database1.f4")
+
+    try {
+      tableEnv.sqlUpdate("DROP TEMPORARY FUNCTION catalog1.database1.f4")
+    } catch {
+      case e: Exception => {
+        assertThat(e.getMessage(), containsString("Catalog catalog1 does not exist."));
+      }
+    }
+  }
+}
+
+object CatalogFunctionITCase {
+  @Parameterized.Parameters(name = "{0}")
+  def parameters(): java.util.Collection[Boolean] = {
+    util.Arrays.asList(true, false)
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add basic function DDL in Parser and register function to the table environments

## Brief change log

1) Add SqlCreateFunction and SqlDropFunction DDL sql Call
2) Add CreatFunction and DropFunction operations

## Verifying this change
1) Add test cases in FlinkSqlParserImplTest for parser verify on function DDL.
2) Add test cases in SqlToOperationConverterTest for planner verification.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
