### PR TITLE
[FLINK-14067] Decouple PlanExecutor from JSON plan generation

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.client;
 
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.PlanExecutor;
@@ -29,7 +28,6 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.optimizer.DataStatistics;
 import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.plan.OptimizedPlan;
-import org.apache.flink.optimizer.plandump.PlanJSONDumpGenerator;
 import org.apache.flink.optimizer.plantranslate.JobGraphGenerator;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.minicluster.JobExecutorService;
@@ -138,22 +136,5 @@ public class LocalExecutor extends PlanExecutor {
 				ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1);
 
 		plan.setDefaultParallelism(slotsPerTaskManager * numTaskManagers);
-	}
-
-	/**
-	 * Creates a JSON representation of the given dataflow's execution plan.
-	 *
-	 * @param plan The dataflow plan.
-	 * @return The dataflow's execution plan, as a JSON string.
-	 */
-	@Override
-	public String getOptimizerPlanAsJSON(Plan plan) {
-		final int parallelism = plan.getDefaultParallelism() == ExecutionConfig.PARALLELISM_DEFAULT ? 1 : plan.getDefaultParallelism();
-
-		Optimizer pc = new Optimizer(new DataStatistics(), this.baseConfiguration);
-		pc.setDefaultParallelism(parallelism);
-		OptimizedPlan op = pc.compile(plan);
-
-		return new PlanJSONDumpGenerator().getOptimizerPlanAsJSON(op);
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
@@ -28,7 +28,6 @@ import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.optimizer.DataStatistics;
 import org.apache.flink.optimizer.Optimizer;
-import org.apache.flink.optimizer.dag.DataSinkNode;
 import org.apache.flink.optimizer.plan.OptimizedPlan;
 import org.apache.flink.optimizer.plandump.PlanJSONDumpGenerator;
 import org.apache.flink.optimizer.plantranslate.JobGraphGenerator;
@@ -37,8 +36,6 @@ import org.apache.flink.runtime.minicluster.JobExecutorService;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
 import org.apache.flink.runtime.minicluster.RpcServiceSharing;
-
-import java.util.List;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -158,50 +155,5 @@ public class LocalExecutor extends PlanExecutor {
 		OptimizedPlan op = pc.compile(plan);
 
 		return new PlanJSONDumpGenerator().getOptimizerPlanAsJSON(op);
-	}
-
-	// --------------------------------------------------------------------------------------------
-	//  Static variants that internally bring up an instance and shut it down after the execution
-	// --------------------------------------------------------------------------------------------
-
-	/**
-	 * Executes the given dataflow plan.
-	 *
-	 * @param plan The dataflow plan.
-	 * @return The execution result.
-	 *
-	 * @throws Exception Thrown, if either the startup of the local execution context, or the execution
-	 *                   caused an exception.
-	 */
-	public static JobExecutionResult execute(Plan plan) throws Exception {
-		return new LocalExecutor().executePlan(plan);
-	}
-
-	/**
-	 * Creates a JSON representation of the given dataflow's execution plan.
-	 *
-	 * @param plan The dataflow plan.
-	 * @return The dataflow's execution plan, as a JSON string.
-	 * @throws Exception Thrown, if the optimization process that creates the execution plan failed.
-	 */
-	public static String optimizerPlanAsJSON(Plan plan) throws Exception {
-		final int parallelism = plan.getDefaultParallelism() == ExecutionConfig.PARALLELISM_DEFAULT ? 1 : plan.getDefaultParallelism();
-
-		Optimizer pc = new Optimizer(new DataStatistics(), new Configuration());
-		pc.setDefaultParallelism(parallelism);
-		OptimizedPlan op = pc.compile(plan);
-
-		return new PlanJSONDumpGenerator().getOptimizerPlanAsJSON(op);
-	}
-
-	/**
-	 * Creates a JSON representation of the given dataflow plan.
-	 *
-	 * @param plan The dataflow plan.
-	 * @return The dataflow plan (prior to optimization) as a JSON string.
-	 */
-	public static String getPlanAsJSON(Plan plan) {
-		List<DataSinkNode> sinks = Optimizer.createPreOptimizedPlan(plan);
-		return new PlanJSONDumpGenerator().getPactPlanAsJSON(sinks);
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
@@ -27,11 +27,6 @@ import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
-import org.apache.flink.optimizer.DataStatistics;
-import org.apache.flink.optimizer.Optimizer;
-import org.apache.flink.optimizer.costs.DefaultCostEstimator;
-import org.apache.flink.optimizer.plan.OptimizedPlan;
-import org.apache.flink.optimizer.plandump.PlanJSONDumpGenerator;
 
 import java.net.InetSocketAddress;
 import java.net.URL;
@@ -126,12 +121,5 @@ public class RemoteExecutor extends PlanExecutor {
 		try (ClusterClient<?>  client = new RestClusterClient<>(clientConfiguration, "RemoteExecutor")) {
 			return client.run(program, defaultParallelism).getJobExecutionResult();
 		}
-	}
-
-	@Override
-	public String getOptimizerPlanAsJSON(Plan plan) {
-		Optimizer opt = new Optimizer(new DataStatistics(), new DefaultCostEstimator(), new Configuration());
-		OptimizedPlan optPlan = opt.compile(plan);
-		return new PlanJSONDumpGenerator().getOptimizerPlanAsJSON(optPlan);
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -24,8 +24,6 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.ExecutionEnvironment;
-import org.apache.flink.optimizer.plan.OptimizedPlan;
-import org.apache.flink.optimizer.plandump.PlanJSONDumpGenerator;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 
 import java.net.URL;
@@ -72,15 +70,6 @@ public class ContextEnvironment extends ExecutionEnvironment {
 
 		lastJobExecutionResult = jobSubmissionResult.getJobExecutionResult();
 		return lastJobExecutionResult;
-	}
-
-	@Override
-	public String getExecutionPlan() throws Exception {
-		Plan plan = createProgramPlan("unnamed job");
-
-		OptimizedPlan op = ClusterClient.getOptimizedPlan(client.compiler, plan, getParallelism());
-		PlanJSONDumpGenerator gen = new PlanJSONDumpGenerator();
-		return gen.getOptimizerPlanAsJSON(op);
 	}
 
 	private void verifyExecuteIsCalledOnceWhenInDetachedMode() {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/OptimizerPlanEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/OptimizerPlanEnvironment.java
@@ -54,15 +54,6 @@ public class OptimizerPlanEnvironment extends ExecutionEnvironment {
 		throw new ProgramAbortException();
 	}
 
-	@Override
-	public String getExecutionPlan() throws Exception {
-		Plan plan = createProgramPlan(null, false);
-		this.optimizerPlan = compiler.compile(plan);
-
-		// do not go on with anything now!
-		throw new ProgramAbortException();
-	}
-
 	public FlinkPlan getOptimizedPlan(PackagedProgram prog) throws ProgramInvocationException {
 
 		// temporarily write syserr and sysout to a byte array.

--- a/flink-core/src/main/java/org/apache/flink/api/common/Plan.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/Plan.java
@@ -18,6 +18,14 @@
 
 package org.apache.flink.api.common;
 
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.cache.DistributedCache.DistributedCacheEntry;
+import org.apache.flink.api.common.operators.GenericDataSinkBase;
+import org.apache.flink.api.common.operators.Operator;
+import org.apache.flink.util.Visitable;
+import org.apache.flink.util.Visitor;
+
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
@@ -27,17 +35,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.io.IOException;
 
-import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.cache.DistributedCache.DistributedCacheEntry;
-import org.apache.flink.api.common.operators.GenericDataSinkBase;
-import org.apache.flink.api.common.operators.Operator;
-import org.apache.flink.util.Visitable;
-import org.apache.flink.util.Visitor;
-
-import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * This class represents Flink programs, in the form of dataflow plans.
  *
@@ -48,8 +49,8 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 public class Plan implements Visitable<Operator<?>> {
 
 	/**
-	 * A collection of all sinks in the plan. Since the plan is traversed from the sinks to the sources, this
-	 * collection must contain all the sinks.
+	 * A collection of all sinks in the plan. Since the plan is traversed from the sinks to the
+	 * sources, this collection must contain all the sinks.
 	 */
 	protected final List<GenericDataSinkBase<?>> sinks = new ArrayList<>(4);
 
@@ -58,16 +59,16 @@ public class Plan implements Visitable<Operator<?>> {
 
 	/** The default parallelism to use for nodes that have no explicitly specified parallelism. */
 	protected int defaultParallelism = ExecutionConfig.PARALLELISM_DEFAULT;
-	
+
 	/** Hash map for files in the distributed cache: registered name to cache entry. */
 	protected HashMap<String, DistributedCacheEntry> cacheFile = new HashMap<>();
-	
+
 	/** Config object for runtime execution parameters. */
 	protected ExecutionConfig executionConfig;
 
-	/** The ID of the Job that this dataflow plan belongs to */
+	/** The ID of the Job that this dataflow plan belongs to. */
 	private JobID jobId;
-	
+
 	private long sessionTimeout;
 
 	// ------------------------------------------------------------------------
@@ -75,10 +76,10 @@ public class Plan implements Visitable<Operator<?>> {
 	/**
 	 * Creates a new dataflow plan with the given name, describing the data flow that ends at the
 	 * given data sinks.
-	 * 
+	 *
 	 * <p>If not all of the sinks of a data flow are given to the plan, the flow might
 	 * not be translated entirely.</p>
-	 *  
+	 *
 	 * @param sinks The collection will the sinks of the job's data flow.
 	 * @param jobName The name to display for the job.
 	 */
@@ -87,17 +88,20 @@ public class Plan implements Visitable<Operator<?>> {
 	}
 
 	/**
-	 * Creates a new program plan with the given name and default parallelism, describing the data flow that ends
-	 * at the given data sinks.
-	 * <p>
-	 * If not all of the sinks of a data flow are given to the plan, the flow might
-	 * not be translated entirely.
+	 * Creates a new program plan with the given name and default parallelism, describing the data
+	 * flow that ends at the given data sinks.
+	 *
+	 * <p>If not all of the sinks of a data flow are given to the plan, the flow might not be
+	 * translated entirely.
 	 *
 	 * @param sinks The collection will the sinks of the job's data flow.
 	 * @param jobName The name to display for the job.
 	 * @param defaultParallelism The default parallelism for the job.
 	 */
-	public Plan(Collection<? extends GenericDataSinkBase<?>> sinks, String jobName, int defaultParallelism) {
+	public Plan(
+			Collection<? extends GenericDataSinkBase<?>> sinks,
+			String jobName,
+			int defaultParallelism) {
 		this.sinks.addAll(sinks);
 		this.jobName = jobName;
 		this.defaultParallelism = defaultParallelism;
@@ -105,11 +109,11 @@ public class Plan implements Visitable<Operator<?>> {
 
 	/**
 	 * Creates a new program plan with the given name, containing initially a single data sink.
-	 * <p>
-	 * If not all of the sinks of a data flow are given, the flow might
-	 * not be translated entirely, but only the parts of the flow reachable by traversing backwards
-	 * from the given data sinks.
-	 * 
+	 *
+	 * <p>If not all of the sinks of a data flow are given, the flow might not be translated
+	 * entirely, but only the parts of the flow reachable by traversing backwards from the given
+	 * data sinks.
+	 *
 	 * @param sink The data sink of the data flow.
 	 * @param jobName The name to display for the job.
 	 */
@@ -118,12 +122,12 @@ public class Plan implements Visitable<Operator<?>> {
 	}
 
 	/**
-	 * Creates a new program plan with the given name and default parallelism, containing initially a single data
-	 * sink.
-	 * <p>
-	 * If not all of the sinks of a data flow are given, the flow might
-	 * not be translated entirely, but only the parts of the flow reachable by traversing backwards
-	 * from the given data sinks.
+	 * Creates a new program plan with the given name and default parallelism, containing initially
+	 * a single data sink.
+	 *
+	 * <p>If not all of the sinks of a data flow are given, the flow might not be translated
+	 * entirely, but only the parts of the flow reachable by traversing backwards from the given
+	 * data sinks.
 	 *
 	 * @param sink The data sink of the data flow.
 	 * @param jobName The name to display for the job.
@@ -134,13 +138,13 @@ public class Plan implements Visitable<Operator<?>> {
 	}
 
 	/**
-	 * Creates a new program plan, describing the data flow that ends at the
-	 * given data sinks. The display name for the job is generated using a timestamp.
-	 * <p>
-	 * If not all of the sinks of a data flow are given, the flow might
-	 * not be translated entirely, but only the parts of the flow reachable by traversing backwards
-	 * from the given data sinks. 
-	 *  
+	 * Creates a new program plan, describing the data flow that ends at the given data sinks. The
+	 * display name for the job is generated using a timestamp.
+	 *
+	 * <p>If not all of the sinks of a data flow are given, the flow might not be translated
+	 * entirely,
+	 * but only the parts of the flow reachable by traversing backwards from the given data sinks.
+	 *
 	 * @param sinks The collection will the sinks of the data flow.
 	 */
 	public Plan(Collection<? extends GenericDataSinkBase<?>> sinks) {
@@ -148,12 +152,12 @@ public class Plan implements Visitable<Operator<?>> {
 	}
 
 	/**
-	 * Creates a new program plan with the given default parallelism, describing the data flow that ends at the
-	 * given data sinks. The display name for the job is generated using a timestamp.
-	 * <p>
-	 * If not all of the sinks of a data flow are given, the flow might
-	 * not be translated entirely, but only the parts of the flow reachable by traversing backwards
-	 * from the given data sinks.
+	 * Creates a new program plan with the given default parallelism, describing the data flow that
+	 * ends at the given data sinks. The display name for the job is generated using a timestamp.
+	 *
+	 * <p>If not all of the sinks of a data flow are given, the flow might not be translated
+	 * entirely,
+	 * but only the parts of the flow reachable by traversing backwards from the given data sinks.
 	 *
 	 * @param sinks The collection will the sinks of the data flow.
 	 * @param defaultParallelism The default parallelism for the job.
@@ -163,12 +167,12 @@ public class Plan implements Visitable<Operator<?>> {
 	}
 
 	/**
-	 * Creates a new program plan with single data sink.
-	 * The display name for the job is generated using a timestamp.
-	 * <p>
-	 * If not all of the sinks of a data flow are given to the plan, the flow might
-	 * not be translated entirely. 
-	 * 
+	 * Creates a new program plan with single data sink. The display name for the job is generated
+	 * using a timestamp.
+	 *
+	 * <p>If not all of the sinks of a data flow are given to the plan, the flow might not be
+	 * translated entirely.
+	 *
 	 * @param sink The data sink of the data flow.
 	 */
 	public Plan(GenericDataSinkBase<?> sink) {
@@ -176,11 +180,11 @@ public class Plan implements Visitable<Operator<?>> {
 	}
 
 	/**
-	 * Creates a new program plan with single data sink and the given default parallelism.
-	 * The display name for the job is generated using a timestamp.
-	 * <p>
-	 * If not all of the sinks of a data flow are given to the plan, the flow might
-	 * not be translated entirely.
+	 * Creates a new program plan with single data sink and the given default parallelism. The
+	 * display name for the job is generated using a timestamp.
+	 *
+	 * <p>If not all of the sinks of a data flow are given to the plan, the flow might not be
+	 * translated entirely.
 	 *
 	 * @param sink The data sink of the data flow.
 	 * @param defaultParallelism The default parallelism for the job.
@@ -193,12 +197,12 @@ public class Plan implements Visitable<Operator<?>> {
 
 	/**
 	 * Adds a data sink to the set of sinks in this program.
-	 * 
+	 *
 	 * @param sink The data sink to add.
 	 */
 	public void addDataSink(GenericDataSinkBase<?> sink) {
 		checkNotNull(sink, "The data sink must not be null.");
-		
+
 		if (!this.sinks.contains(sink)) {
 			this.sinks.add(sink);
 		}
@@ -206,7 +210,7 @@ public class Plan implements Visitable<Operator<?>> {
 
 	/**
 	 * Gets all the data sinks of this job.
-	 * 
+	 *
 	 * @return All sinks of the program.
 	 */
 	public Collection<? extends GenericDataSinkBase<?>> getDataSinks() {
@@ -215,13 +219,13 @@ public class Plan implements Visitable<Operator<?>> {
 
 	/**
 	 * Gets the name of this job.
-	 * 
+	 *
 	 * @return The name of the job.
 	 */
 	public String getJobName() {
 		return this.jobName;
 	}
-	
+
 	/**
 	 * Sets the jobName for this Plan.
 	 *
@@ -233,10 +237,9 @@ public class Plan implements Visitable<Operator<?>> {
 	}
 
 	/**
-	 * Gets the ID of the job that the dataflow plan belongs to.
-	 * If this ID is not set, then the dataflow represents its own
-	 * independent job.
-	 * 
+	 * Gets the ID of the job that the dataflow plan belongs to. If this ID is not set, then the
+	 * dataflow represents its own independent job.
+	 *
 	 * @return The ID of the job that the dataflow plan belongs to.
 	 */
 	public JobID getJobId() {
@@ -244,10 +247,9 @@ public class Plan implements Visitable<Operator<?>> {
 	}
 
 	/**
-	 * Sets the ID of the job that the dataflow plan belongs to.
-	 * If this ID is set to {@code null}, then the dataflow represents its own
-	 * independent job.
-	 * 
+	 * Sets the ID of the job that the dataflow plan belongs to. If this ID is set to {@code null},
+	 * then the dataflow represents its own independent job.
+	 *
 	 * @param jobId The ID of the job that the dataflow plan belongs to.
 	 */
 	public void setJobId(JobID jobId) {
@@ -263,31 +265,33 @@ public class Plan implements Visitable<Operator<?>> {
 	}
 
 	/**
-	 * Gets the default parallelism for this job. That degree is always used when an operator
-	 * is not explicitly given a parallelism.
+	 * Gets the default parallelism for this job. That degree is always used when an operator is not
+	 * explicitly given a parallelism.
 	 *
 	 * @return The default parallelism for the plan.
 	 */
 	public int getDefaultParallelism() {
 		return this.defaultParallelism;
 	}
-	
+
 	/**
-	 * Sets the default parallelism for this plan. That degree is always used when an operator
-	 * is not explicitly given a parallelism.
+	 * Sets the default parallelism for this plan. That degree is always used when an operator is
+	 * not explicitly given a parallelism.
 	 *
 	 * @param defaultParallelism The default parallelism for the plan.
 	 */
 	public void setDefaultParallelism(int defaultParallelism) {
-		checkArgument(defaultParallelism >= 1 || defaultParallelism == ExecutionConfig.PARALLELISM_DEFAULT,
-			"The default parallelism must be positive, or ExecutionConfig.PARALLELISM_DEFAULT if the system should use the globally configured default.");
-		
+		checkArgument(
+				defaultParallelism >= 1 || defaultParallelism == ExecutionConfig.PARALLELISM_DEFAULT,
+				"The default parallelism must be positive, or ExecutionConfig.PARALLELISM_DEFAULT if the system should use the globally configured default.");
+
 		this.defaultParallelism = defaultParallelism;
 	}
 
 	/**
-	 * Gets the optimizer post-pass class for this job. The post-pass typically creates utility classes
-	 * for data types and is specific to a particular data model (record, tuple, Scala, ...)
+	 * Gets the optimizer post-pass class for this job. The post-pass typically creates utility
+	 * classes for data types and is specific to a particular data model (record, tuple, Scala,
+	 * ...)
 	 *
 	 * @return The name of the class implementing the optimizer post-pass.
 	 */
@@ -297,11 +301,11 @@ public class Plan implements Visitable<Operator<?>> {
 
 	/**
 	 * Gets the execution config object.
-	 * 
+	 *
 	 * @return The execution config object.
 	 */
 	public ExecutionConfig getExecutionConfig() {
-		if(executionConfig == null) {
+		if (executionConfig == null) {
 			throw new RuntimeException("Execution config has not been set properly for this plan");
 		}
 		return executionConfig;
@@ -309,7 +313,7 @@ public class Plan implements Visitable<Operator<?>> {
 
 	/**
 	 * Sets the runtime config object defining execution parameters.
-	 * 
+	 *
 	 * @param executionConfig The execution config to use.
 	 */
 	public void setExecutionConfig(ExecutionConfig executionConfig) {
@@ -320,7 +324,7 @@ public class Plan implements Visitable<Operator<?>> {
 
 	/**
 	 * Traverses the job depth first from all data sinks on towards the sources.
-	 * 
+	 *
 	 * @see Visitable#accept(Visitor)
 	 */
 	@Override
@@ -329,9 +333,10 @@ public class Plan implements Visitable<Operator<?>> {
 			sink.accept(visitor);
 		}
 	}
-	
+
 	/**
-	 *  register cache files in program level
+	 * Register cache files at program level.
+	 *
 	 * @param entry contains all relevant information
 	 * @param name user defined name of that file
 	 * @throws java.io.IOException
@@ -345,21 +350,22 @@ public class Plan implements Visitable<Operator<?>> {
 	}
 
 	/**
-	 * return the registered caches files
+	 * Return the registered cached files.
+	 *
 	 * @return Set of (name, filePath) pairs
 	 */
-	public Set<Entry<String,DistributedCacheEntry>> getCachedFiles() {
+	public Set<Entry<String, DistributedCacheEntry>> getCachedFiles() {
 		return this.cacheFile.entrySet();
 	}
-	
+
 	public int getMaximumParallelism() {
 		MaxDopVisitor visitor = new MaxDopVisitor();
 		accept(visitor);
 		return Math.max(visitor.maxDop, this.defaultParallelism);
 	}
-	
+
 	// --------------------------------------------------------------------------------------------
-	
+
 	private static final class MaxDopVisitor implements Visitor<Operator<?>> {
 
 		private final Set<Operator> visitedOperators = new HashSet<>();
@@ -375,6 +381,7 @@ public class Plan implements Visitable<Operator<?>> {
 		}
 
 		@Override
-		public void postVisit(Operator<?> visitable) {}
+		public void postVisit(Operator<?> visitable) {
+		}
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/PlanExecutor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/PlanExecutor.java
@@ -69,10 +69,8 @@ public abstract class PlanExecutor {
 	 * 
 	 * @param plan The program to get the execution plan for.
 	 * @return The execution plan, as a JSON string.
-	 * 
-	 * @throws Exception Thrown, if the executor could not connect to the compiler.
 	 */
-	public abstract String getOptimizerPlanAsJSON(Plan plan) throws Exception;
+	public abstract String getOptimizerPlanAsJSON(Plan plan);
 
 	// ------------------------------------------------------------------------
 	//  Executor Factories

--- a/flink-core/src/main/java/org/apache/flink/api/common/PlanExecutor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/PlanExecutor.java
@@ -63,14 +63,6 @@ public abstract class PlanExecutor {
 	 * @throws Exception Thrown, if job submission caused an exception.
 	 */
 	public abstract JobExecutionResult executePlan(Plan plan) throws Exception;
-	
-	/**
-	 * Gets the programs execution plan in a JSON format.
-	 * 
-	 * @param plan The program to get the execution plan for.
-	 * @return The execution plan, as a JSON string.
-	 */
-	public abstract String getOptimizerPlanAsJSON(Plan plan);
 
 	// ------------------------------------------------------------------------
 	//  Executor Factories

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -837,7 +837,7 @@ public abstract class ExecutionEnvironment {
 	 */
 	@Internal
 	public Plan createProgramPlan() {
-		return createProgramPlan(null);
+		return createProgramPlan(getDefaultName());
 	}
 
 	/**

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -771,7 +771,7 @@ public abstract class ExecutionEnvironment {
 	 * @throws Exception Thrown, if the compiler could not be instantiated.
 	 */
 	public String getExecutionPlan() throws Exception {
-		Plan p = createProgramPlan(null, false);
+		Plan p = createProgramPlan(getDefaultName(), false);
 		return ExecutionPlanUtil.getExecutionPlanAsJSON(p);
 	}
 
@@ -869,6 +869,8 @@ public abstract class ExecutionEnvironment {
 	 */
 	@Internal
 	public Plan createProgramPlan(String jobName, boolean clearSinks) {
+		checkNotNull(jobName);
+
 		if (this.sinks.isEmpty()) {
 			if (wasExecuted) {
 				throw new RuntimeException("No new data sinks have been defined since the " +
@@ -879,10 +881,6 @@ public abstract class ExecutionEnvironment {
 						"A program needs at least one sink that consumes data. " +
 						"Examples are writing the data set or printing it.");
 			}
-		}
-
-		if (jobName == null) {
-			jobName = getDefaultName();
 		}
 
 		OperatorTranslation translator = new OperatorTranslation();

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -766,13 +766,14 @@ public abstract class ExecutionEnvironment {
 	/**
 	 * Creates the plan with which the system will execute the program, and returns it as
 	 * a String using a JSON representation of the execution data flow graph.
-	 * Note that this needs to be called, before the plan is executed.
 	 *
 	 * @return The execution plan of the program, as a JSON String.
-	 * @throws Exception Thrown, if the compiler could not be instantiated, or the master could not
-	 *                   be contacted to retrieve information relevant to the execution planning.
+	 * @throws Exception Thrown, if the compiler could not be instantiated.
 	 */
-	public abstract String getExecutionPlan() throws Exception;
+	public String getExecutionPlan() throws Exception {
+		Plan p = createProgramPlan(null, false);
+		return ExecutionPlanUtil.getExecutionPlanAsJSON(p);
+	}
 
 	/**
 	 * Registers a file at the distributed cache under the given name. The file will be accessible

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionPlanUtil.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionPlanUtil.java
@@ -22,6 +22,8 @@ package org.apache.flink.api.java;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.Plan;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * A utility for extracting an execution plan (as JSON) from a {@link Plan}.
  */
@@ -34,6 +36,7 @@ public class ExecutionPlanUtil {
 	 * Extracts the execution plan (as JSON) from the given {@link Plan}.
 	 */
 	public static String getExecutionPlanAsJSON(Plan plan) {
+		checkNotNull(plan);
 		ExecutionPlanJSONGenerator jsonGenerator = getJSONGenerator();
 		return jsonGenerator.getExecutionPlan(plan);
 	}
@@ -52,8 +55,7 @@ public class ExecutionPlanUtil {
 
 	private static Class<? extends ExecutionPlanJSONGenerator> loadJSONGeneratorClass(String className) {
 		try {
-			Class<?> generatorClass = Class.forName(
-					"org.apache.flink.optimizer.plandump.ExecutionPlanJSONGenerator");
+			Class<?> generatorClass = Class.forName(className);
 			return generatorClass.asSubclass(ExecutionPlanJSONGenerator.class);
 		} catch (ClassNotFoundException cnfe) {
 			throw new RuntimeException("Could not load the plan generator class (" + className
@@ -71,6 +73,10 @@ public class ExecutionPlanUtil {
 	 */
 	@Internal
 	public interface ExecutionPlanJSONGenerator {
+
+		/**
+		 * Returns the execution plan as a JSON string.
+		 */
 		String getExecutionPlan(Plan plan);
 	}
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionPlanUtil.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionPlanUtil.java
@@ -14,33 +14,27 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.flink.api.java;
 
-import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.Plan;
-import org.apache.flink.api.common.operators.CollectionExecutor;
+import org.apache.flink.api.common.PlanExecutor;
+import org.apache.flink.configuration.Configuration;
 
 /**
- * Version of {@link ExecutionEnvironment} that allows serial, local, collection-based executions of Flink programs.
+ * A utility for extracting an execution plan (as JSON) from a {@link Plan}.
  */
-@PublicEvolving
-public class CollectionEnvironment extends ExecutionEnvironment {
+class ExecutionPlanUtil {
 
-	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
-		Plan p = createProgramPlan(jobName);
-
-		// We need to reverse here. Object-Reuse enabled, means safe mode is disabled.
-		CollectionExecutor exec = new CollectionExecutor(getConfig());
-		this.lastJobExecutionResult = exec.execute(p);
-		return this.lastJobExecutionResult;
-	}
-
-	@Override
-	public int getParallelism() {
-		return 1; // always serial
+	/**
+	 * Extracts the execution plan (as JSON) from the given {@link Plan}.
+	 */
+	static String getExecutionPlanAsJSON(Plan plan) {
+		// make sure that we do not start an executor in any case here.
+		// if one runs, fine, of not, we only create the class but disregard immediately afterwards
+		PlanExecutor tempExecutor = PlanExecutor.createLocalExecutor(new Configuration());
+		return tempExecutor.getOptimizerPlanAsJSON(plan);
 	}
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
@@ -78,13 +78,6 @@ public class LocalEnvironment extends ExecutionEnvironment {
 	}
 
 	@Override
-	public String getExecutionPlan() throws Exception {
-		final Plan p = createProgramPlan("plan", false);
-		final PlanExecutor tempExecutor = PlanExecutor.createLocalExecutor(configuration);
-		return tempExecutor.getOptimizerPlanAsJSON(p);
-	}
-
-	@Override
 	public String toString() {
 		return "Local Environment (parallelism = " + (getParallelism() == ExecutionConfig.PARALLELISM_DEFAULT ? "default" : getParallelism()) + ").";
 	}

--- a/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
@@ -161,13 +161,6 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 	}
 
 	@Override
-	public String getExecutionPlan() throws Exception {
-		final Plan p = createProgramPlan("plan", false);
-		final PlanExecutor tempExecutor = PlanExecutor.createLocalExecutor(new Configuration());
-		return tempExecutor.getOptimizerPlanAsJSON(p);
-	}
-
-	@Override
 	public String toString() {
 		return "Remote Environment (" + this.host + ":" + this.port + " - parallelism = " +
 				(getParallelism() == -1 ? "default" : getParallelism()) + ").";

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plan/StreamingPlan.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plan/StreamingPlan.java
@@ -23,9 +23,6 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 
 import javax.annotation.Nullable;
 
-import java.io.File;
-import java.io.IOException;
-
 /**
  * Abstract class representing Flink Streaming plans.
  */
@@ -45,7 +42,4 @@ public abstract class StreamingPlan implements FlinkPlan {
 	public abstract JobGraph getJobGraph(@Nullable JobID jobID);
 
 	public abstract String getStreamingPlanAsJSON();
-
-	public abstract void dumpStreamingPlanAsJSON(File file) throws IOException;
-
 }

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plan/StreamingPlan.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plan/StreamingPlan.java
@@ -18,17 +18,16 @@
 
 package org.apache.flink.optimizer.plan;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 
 import javax.annotation.Nullable;
 
+import java.io.File;
+import java.io.IOException;
+
 /**
- * Abstract class representing Flink Streaming plans
- * 
+ * Abstract class representing Flink Streaming plans.
  */
 public abstract class StreamingPlan implements FlinkPlan {
 

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plandump/ExecutionPlanJSONGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plandump/ExecutionPlanJSONGenerator.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.flink.optimizer.plandump;
+
+import org.apache.flink.api.common.Plan;
+import org.apache.flink.api.java.ExecutionPlanUtil;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.optimizer.DataStatistics;
+import org.apache.flink.optimizer.Optimizer;
+import org.apache.flink.optimizer.costs.DefaultCostEstimator;
+import org.apache.flink.optimizer.plan.OptimizedPlan;
+
+/**
+ * Utility for extracting an execution plan (as JSON) from a given {@link Plan}.
+ *
+ * <p>We need this util here in the optimizer because it is the only module that has {@link
+ * Optimizer}, {@link OptimizedPlan}, and {@link PlanJSONDumpGenerator} available. We use this
+ * reflectively from the batch execution environments to generate the plan, which we cannot do
+ * there. It is used from {@link ExecutionPlanUtil}.
+ */
+@SuppressWarnings("unused")
+public class ExecutionPlanJSONGenerator implements ExecutionPlanUtil.ExecutionPlanJSONGenerator {
+
+	@Override
+	public String getExecutionPlan(Plan plan) {
+		Optimizer opt = new Optimizer(
+				new DataStatistics(),
+				new DefaultCostEstimator(),
+				new Configuration());
+		OptimizedPlan optPlan = opt.compile(plan);
+		return new PlanJSONDumpGenerator().getOptimizerPlanAsJSON(optPlan);
+	}
+}

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/plandump/ExecutionPlanUtilTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/plandump/ExecutionPlanUtilTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.flink.optimizer.plandump;
+
+import org.apache.flink.api.common.Plan;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.ExecutionPlanUtil;
+import org.apache.flink.api.java.tuple.Tuple2;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.StringContains.containsString;
+
+/**
+ * Tests for {@link ExecutionPlanUtil}. We have to test this here in flink-optimizer because the
+ * util only works when {@link ExecutionPlanJSONGenerator} is available, which is in
+ * flink-optimizer.
+ */
+public class ExecutionPlanUtilTest {
+
+	@Test
+	public void executionPlanCanBeRetrieved() {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(8);
+
+		env
+				.readCsvFile("file:///will/never/be/executed")
+				.types(String.class, Double.class)
+				.name("sourceThatWillNotRun")
+				.map((in) -> in)
+				.returns(new TypeHint<Tuple2<String, Double>>() {})
+				.name("theMap")
+				.writeAsText("file:///will/not/be/executed")
+				.name("sinkThatWillNotRun");
+
+		Plan plan = env.createProgramPlan();
+		String executionPlanAsJSON = ExecutionPlanUtil.getExecutionPlanAsJSON(plan);
+
+		assertThat(executionPlanAsJSON, containsString("sourceThatWillNotRun"));
+		assertThat(executionPlanAsJSON, containsString("sinkThatWillNotRun"));
+		assertThat(executionPlanAsJSON, containsString("theMap"));
+	}
+}

--- a/flink-scala-shell/src/test/java/org/apache/flink/api/java/FlinkILoopTest.java
+++ b/flink-scala-shell/src/test/java/org/apache/flink/api/java/FlinkILoopTest.java
@@ -133,7 +133,7 @@ public class FlinkILoopTest extends TestLogger {
 		}
 
 		@Override
-		public String getOptimizerPlanAsJSON(Plan plan) throws Exception {
+		public String getOptimizerPlanAsJSON(Plan plan) {
 			return null;
 		}
 

--- a/flink-scala-shell/src/test/java/org/apache/flink/api/java/FlinkILoopTest.java
+++ b/flink-scala-shell/src/test/java/org/apache/flink/api/java/FlinkILoopTest.java
@@ -132,11 +132,6 @@ public class FlinkILoopTest extends TestLogger {
 			return null;
 		}
 
-		@Override
-		public String getOptimizerPlanAsJSON(Plan plan) {
-			return null;
-		}
-
 		public String getHost() {
 			return host;
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -55,10 +55,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -733,21 +729,6 @@ public class StreamGraph extends StreamingPlan {
 		}
 		catch (Exception e) {
 			throw new RuntimeException("JSON plan creation failed", e);
-		}
-	}
-
-	@Override
-	public void dumpStreamingPlanAsJSON(File file) throws IOException {
-		PrintWriter pw = null;
-		try {
-			pw = new PrintWriter(new FileOutputStream(file), false);
-			pw.write(getStreamingPlanAsJSON());
-			pw.flush();
-
-		} finally {
-			if (pw != null) {
-				pw.close();
-			}
 		}
 	}
 }

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestEnvironment.java
@@ -27,7 +27,6 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.optimizer.DataStatistics;
 import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.plan.OptimizedPlan;
-import org.apache.flink.optimizer.plandump.PlanJSONDumpGenerator;
 import org.apache.flink.optimizer.plantranslate.JobGraphGenerator;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.minicluster.JobExecutor;
@@ -111,14 +110,6 @@ public class TestEnvironment extends ExecutionEnvironment {
 
 		this.lastJobExecutionResult = jobExecutor.executeJobBlocking(jobGraph);
 		return this.lastJobExecutionResult;
-	}
-
-	@Override
-	public String getExecutionPlan() throws Exception {
-		OptimizedPlan op = compileProgram("unused");
-
-		PlanJSONDumpGenerator jsonGen = new PlanJSONDumpGenerator();
-		return jsonGen.getOptimizerPlanAsJSON(op);
 	}
 
 	private OptimizedPlan compileProgram(String jobName) {

--- a/flink-tests/src/test/java/org/apache/flink/test/optimizer/jsonplan/JsonJobGraphGenerationTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/optimizer/jsonplan/JsonJobGraphGenerationTest.java
@@ -354,11 +354,6 @@ public class JsonJobGraphGenerationTest {
 			throw new AbortError();
 		}
 
-		@Override
-		public String getExecutionPlan() throws Exception {
-			throw new UnsupportedOperationException();
-		}
-
 		public static void setAsNext(final JsonValidator validator, final int defaultParallelism) {
 			initializeContextEnvironment(new ExecutionEnvironmentFactory() {
 				@Override

--- a/flink-tests/src/test/java/org/apache/flink/test/util/PlanExposingEnvironment.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/util/PlanExposingEnvironment.java
@@ -39,11 +39,6 @@ public final class PlanExposingEnvironment extends ExecutionEnvironment {
 		throw new OptimizerPlanEnvironment.ProgramAbortException();
 	}
 
-	@Override
-	public String getExecutionPlan() throws Exception {
-		throw new OptimizerPlanEnvironment.ProgramAbortException();
-	}
-
 	public void setAsContext() {
 		ExecutionEnvironmentFactory factory = new ExecutionEnvironmentFactory() {
 			@Override


### PR DESCRIPTION
## What is the purpose of the change

{{PlanExecutor}} has a method {{getOptimizerPlanAsJSON()}} that is used by DataSet environments to get a JSON version of the execution plan. To ease future work and to make it more maintainable we should get rid of that method and instead have a dedicated utility for generating JSON plans that the environments can use.

(The only reason this method is on the executor is because only {{flink-clients}} via {{flink-optimizer}} has the required components to derive a JSON plan.)


## Brief change log
Please look at the list of commits for a changelog, each commit is an isolated refactoring on the path to the final result.

## Verifying this change

* Added a test for the new `ExecutionPlanUtil`

## Documentation

  - Does this pull request introduce a new feature? no
