### PR TITLE
[FLINK-13965] Keep hasDeprecatedKeys and deprecatedKeys methods in ConfigOption and mark it with @Deprecated annotation

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigOption.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigOption.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.description.Description;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -193,6 +194,31 @@ public class ConfigOption<T> {
 	 */
 	public T defaultValue() {
 		return defaultValue;
+	}
+
+	/**
+	 * Checks whether this option has deprecated keys.
+	 * @return True if the option has deprecated keys, false if not.
+	 * @deprecated Replaced by {@link #hasFallbackKeys()}
+	 */
+	@Deprecated
+	public boolean hasDeprecatedKeys() {
+		return fallbackKeys == EMPTY ? false :
+			Arrays.stream(fallbackKeys).anyMatch(FallbackKey::isDeprecated);
+	}
+
+	/**
+	 * Gets the deprecated keys, in the order to be checked.
+	 * @return The option's deprecated keys.
+	 * @deprecated Replaced by {@link #fallbackKeys()}
+	 */
+	@Deprecated
+	public Iterable<String> deprecatedKeys() {
+		return fallbackKeys == EMPTY ? Collections.<String>emptyList() :
+			Arrays.stream(fallbackKeys)
+				.filter(FallbackKey::isDeprecated)
+				.map(FallbackKey::getKey)
+				.collect(Collectors.toList());
 	}
 
 	/**

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigOptionTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigOptionTest.java
@@ -20,10 +20,15 @@ package org.apache.flink.configuration;
 
 import org.apache.flink.util.TestLogger;
 
+import org.apache.flink.shaded.guava18.com.google.common.collect.Sets;
+
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
@@ -86,4 +91,30 @@ public class ConfigOptionTest extends TestLogger {
 		assertThat(fallbackKeys, containsInAnyOrder("fallback1", "fallback2"));
 		assertThat(deprecatedKeys, containsInAnyOrder("deprecated1", "deprecated2"));
 	}
+
+	@Test
+	public void testDeprecationForDeprecatedKeys() {
+		String[] deprecatedKeys = new String[] { "deprecated1", "deprecated2" };
+		final Set<String> expectedDeprecatedKeys = new HashSet<>(Arrays.asList(deprecatedKeys));
+
+		final ConfigOption<Integer> optionWithDeprecatedKeys = ConfigOptions
+			.key("key")
+			.defaultValue(0)
+			.withDeprecatedKeys(deprecatedKeys)
+			.withFallbackKeys("fallback1");
+
+		assertTrue(optionWithDeprecatedKeys.hasDeprecatedKeys());
+		assertEquals(expectedDeprecatedKeys, Sets.newHashSet(optionWithDeprecatedKeys.deprecatedKeys()));
+	}
+
+	@Test
+	public void testNoDeprecationForFallbackKeysWithoutDeprecated() {
+		final ConfigOption<Integer> optionWithFallbackKeys = ConfigOptions
+			.key("key")
+			.defaultValue(0)
+			.withFallbackKeys("fallback1");
+
+		assertFalse(optionWithFallbackKeys.hasDeprecatedKeys());
+	}
+
 }


### PR DESCRIPTION


## What is the purpose of the change

*This pull request reversed two deleted method `hasDeprecatedKeys` and `deprecatedKeys`, then marked them with `@Deprecated`*


## Brief change log

  - *Reversed two deleted methods*
  - *Added test case for the two methods*


## Verifying this change


This change is already covered by existing tests, such as *testDeprecationForDeprecatedKeys*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
