### PR TITLE
[FLINK-13896]make scala-maven-plugin compile target jvm version consistent with java version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1782,6 +1782,7 @@ under the License.
 					<configuration>
 						<args>
 							<arg>-nobootcp</arg>
+							<arg>-target:jvm-${java.version}</arg>
 						</args>
 						<jvmArgs>
 							<arg>-Xss2m</arg>


### PR DESCRIPTION
## What is the purpose of the change

*Make scala-maven-plugin compile target jvm version consistent with java version*


## Brief change log
  - *specify target JVM language*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
