### PR TITLE
[FLINK-13748][S3][build] Fix jaxb relocation for S3.

### DIFF
--- a/flink-filesystems/flink-s3-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-s3-fs-hadoop/pom.xml
@@ -106,11 +106,6 @@ under the License.
 									<pattern>com.amazon</pattern>
 									<shadedPattern>org.apache.flink.fs.s3base.shaded.com.amazon</shadedPattern>
 								</relocation>
-								<!-- relocated S3 hadoop dependencies -->
-								<relocation>
-									<pattern>javax.xml.bind</pattern>
-									<shadedPattern>org.apache.flink.fs.s3hadoop.shaded.javax.xml.bind</shadedPattern>
-								</relocation>
 								<!-- shade Flink's Hadoop FS utility classes -->
 								<relocation>
 									<pattern>org.apache.flink.runtime.util</pattern>
@@ -146,6 +141,63 @@ under the License.
 					<version>2.3.0</version>
 				</dependency>
 			</dependencies>
+
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-shade-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>shade-flink</id>
+								<phase>package</phase>
+								<goals>
+									<goal>shade</goal>
+								</goals>
+								<configuration>
+									<shadeTestJar>false</shadeTestJar>
+									<artifactSet>
+										<includes>
+											<include>*:*</include>
+										</includes>
+									</artifactSet>
+									<relocations>
+										<!-- relocate the references to Hadoop to match the shaded Hadoop config -->
+										<relocation>
+											<pattern>org.apache.hadoop</pattern>
+											<shadedPattern>org.apache.flink.fs.shaded.hadoop3.org.apache.hadoop</shadedPattern>
+										</relocation>
+										<!-- relocate the AWS dependencies -->
+										<relocation>
+											<pattern>com.amazon</pattern>
+											<shadedPattern>org.apache.flink.fs.s3base.shaded.com.amazon</shadedPattern>
+										</relocation>
+
+										<!-- relocated S3 hadoop dependencies -->
+										<relocation>
+											<pattern>javax.xml.bind</pattern>
+											<shadedPattern>org.apache.flink.fs.s3hadoop.shaded.javax.xml.bind</shadedPattern>
+										</relocation>
+										<!-- shade Flink's Hadoop FS utility classes -->
+										<relocation>
+											<pattern>org.apache.flink.runtime.util</pattern>
+											<shadedPattern>org.apache.flink.fs.s3hadoop.common</shadedPattern>
+										</relocation>
+									</relocations>
+									<filters>
+										<filter>
+											<artifact>*</artifact>
+											<excludes>
+												<exclude>META-INF/maven/org.apache.flink/force-shading/**</exclude>
+											</excludes>
+										</filter>
+									</filters>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
 		</profile>
 	</profiles>
 

--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -271,10 +271,6 @@ under the License.
 									<shadedPattern>org.apache.flink.fs.s3presto.shaded.io.airlift</shadedPattern>
 								</relocation>
 								<relocation>
-									<pattern>javax.xml.bind</pattern>
-									<shadedPattern>org.apache.flink.fs.s3presto.shaded.javax.xml.bind</shadedPattern>
-								</relocation>
-								<relocation>
 									<pattern>org.HdrHistogram</pattern>
 									<shadedPattern>org.apache.flink.fs.s3presto.shaded.org.HdrHistogram</shadedPattern>
 								</relocation>
@@ -342,6 +338,130 @@ under the License.
 					<version>2.3.0</version>
 				</dependency>
 			</dependencies>
+
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-enforcer-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>ban-openjdk.jol</id>
+								<goals>
+									<goal>enforce</goal>
+								</goals>
+								<configuration>
+									<rules>
+										<bannedDependencies>
+											<excludes>
+												<!-- Incompatible license -->
+												<exclude>org.openjdk.jol:*</exclude>
+											</excludes>
+										</bannedDependencies>
+									</rules>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-shade-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>shade-flink</id>
+								<phase>package</phase>
+								<goals>
+									<goal>shade</goal>
+								</goals>
+								<configuration>
+									<shadeTestJar>false</shadeTestJar>
+									<artifactSet>
+										<includes>
+											<include>*:*</include>
+										</includes>
+									</artifactSet>
+									<relocations>
+										<!-- relocate the references to Hadoop to match the pre-shaded hadoop artifact -->
+										<relocation>
+											<pattern>org.apache.hadoop</pattern>
+											<shadedPattern>org.apache.flink.fs.shaded.hadoop3.org.apache.hadoop</shadedPattern>
+										</relocation>
+										<!-- relocate the AWS dependencies -->
+										<relocation>
+											<pattern>com.amazon</pattern>
+											<shadedPattern>org.apache.flink.fs.s3base.shaded.com.amazon</shadedPattern>
+										</relocation>
+										<!-- relocate S3 presto and dependencies -->
+										<relocation>
+											<pattern>com.facebook</pattern>
+											<shadedPattern>org.apache.flink.fs.s3presto.shaded.com.facebook</shadedPattern>
+										</relocation>
+										<relocation>
+											<pattern>com.fasterxml</pattern>
+											<shadedPattern>org.apache.flink.fs.s3presto.shaded.com.fasterxml</shadedPattern>
+										</relocation>
+										<relocation>
+											<pattern>io.airlift</pattern>
+											<shadedPattern>org.apache.flink.fs.s3presto.shaded.io.airlift</shadedPattern>
+										</relocation>
+										<relocation>
+											<pattern>javax.xml.bind</pattern>
+											<shadedPattern>org.apache.flink.fs.s3presto.shaded.javax.xml.bind</shadedPattern>
+										</relocation>
+										<relocation>
+											<pattern>org.HdrHistogram</pattern>
+											<shadedPattern>org.apache.flink.fs.s3presto.shaded.org.HdrHistogram</shadedPattern>
+										</relocation>
+										<relocation>
+											<pattern>org.joda</pattern>
+											<shadedPattern>org.apache.flink.fs.s3presto.shaded.org.joda</shadedPattern>
+										</relocation>
+										<relocation>
+											<pattern>org.weakref</pattern>
+											<shadedPattern>org.apache.flink.fs.s3presto.shaded.org.weakref</shadedPattern>
+										</relocation>
+										<relocation>
+											<pattern>org.openjdk</pattern>
+											<shadedPattern>org.apache.flink.fs.s3presto.shaded.org.openjdk</shadedPattern>
+										</relocation>
+										<relocation>
+											<pattern>com.google</pattern>
+											<shadedPattern>org.apache.flink.fs.s3presto.shaded.com.google</shadedPattern>
+										</relocation>
+
+										<!-- shade Flink's Hadoop FS utility classes -->
+										<relocation>
+											<pattern>org.apache.flink.runtime.util</pattern>
+											<shadedPattern>org.apache.flink.fs.s3presto.common</shadedPattern>
+										</relocation>
+									</relocations>
+									<filters>
+										<filter>
+											<artifact>*</artifact>
+											<excludes>
+												<exclude>META-INF/maven/org.weakref/**</exclude>
+												<exclude>META-INF/maven/org.hdrhistogram/**</exclude>
+												<exclude>META-INF/maven/joda-time/**</exclude>
+												<exclude>META-INF/maven/io.airlift/**</exclude>
+												<exclude>META-INF/maven/com*/**</exclude>
+												<exclude>META-INF/maven/org.apache.flink/force-shading/**</exclude>
+												<exclude>META-INF/LICENSE.txt</exclude>
+											</excludes>
+										</filter>
+										<filter>
+											<artifact>com.facebook.presto.hadoop:hadoop-apache2</artifact>
+											<includes>
+												<include>com/facebook/presto/hadoop/**</include>
+											</includes>
+										</filter>
+									</filters>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
 		</profile>
 	</profiles>
 


### PR DESCRIPTION
## What is the purpose of the change

Fixes shading on Presto and Hadoop S3 FileSystems.

## Brief change log

Changes the `pom.xml` in the `flink-s3-fs-hadoop` and `flink-s3-fs-presto`.

## Verifying this change

This change is already covered by existing tests, such as the s3 e2e tests and can be verified by running the cron jobs on Travis.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (**yes** although its build process, not the logic / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
