### PR TITLE
[FLINK-14093][Table]compatible java8 lambdas and exceptions compile error

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/OperationTreeBuilder.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/OperationTreeBuilder.java
@@ -557,7 +557,7 @@ public final class OperationTreeBuilder {
 								.subList(1, unresolvedCall.getChildren().size())
 								.stream()
 								.map(ex -> ExpressionUtils.extractValue(ex, String.class)
-									.orElseThrow(() -> new TableException("Expected string literal as alias.")))
+									.<TableException>orElseThrow(() -> new TableException("Expected string literal as alias.")))
 								.collect(Collectors.toList());
 		}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/factories/AggregateOperationFactory.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/factories/AggregateOperationFactory.java
@@ -547,7 +547,7 @@ public final class AggregateOperationFactory {
 			List<String> aliases = children.subList(1, children.size())
 				.stream()
 				.map(alias -> ExpressionUtils.extractValue(alias, String.class)
-					.orElseThrow(() -> new ValidationException("Unexpected alias: " + alias)))
+					.<ValidationException>orElseThrow(() -> new ValidationException("Unexpected alias: " + alias)))
 				.collect(toList());
 
 			if (!isFunctionOfKind(children.get(0), TABLE_AGGREGATE)) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/factories/CalculatedTableFactory.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/factories/CalculatedTableFactory.java
@@ -87,7 +87,7 @@ public class CalculatedTableFactory {
 			List<String> aliases = children.subList(1, children.size())
 				.stream()
 				.map(alias -> ExpressionUtils.extractValue(alias, String.class)
-					.orElseThrow(() -> new ValidationException("Unexpected alias: " + alias)))
+					.<ValidationException>orElseThrow(() -> new ValidationException("Unexpected alias: " + alias)))
 				.collect(toList());
 
 			if (!isFunctionOfKind(children.get(0), TABLE)) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/factories/ProjectionOperationFactory.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/factories/ProjectionOperationFactory.java
@@ -97,7 +97,7 @@ public final class ProjectionOperationFactory {
 		final Set<String> names = new LinkedHashSet<>();
 
 		extractNames(namedExpressions).stream()
-			.map(name -> name.orElseThrow(() -> new TableException("Could not name a field in a projection.")))
+			.map(name -> name.<TableException>orElseThrow(() -> new TableException("Could not name a field in a projection.")))
 			.forEach(name -> {
 				if (!names.add(name)) {
 					throw new ValidationException("Ambiguous column name: " + name);


### PR DESCRIPTION
## What is the purpose of the change

compatible java8 lambdas and exceptions compile error

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)