### PR TITLE
[FLINK-13949][rest]Delete deduplicating JobVertexDetailsInfo.VertexTa…

### DIFF
--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -2516,7 +2516,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
       "type" : "array",
       "items" : {
         "type" : "object",
-        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobVertexDetailsInfo:VertexTaskDetail",
+        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:SubtaskExecutionAttemptDetailsInfo",
         "properties" : {
           "subtask" : {
             "type" : "integer"

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -1637,7 +1637,7 @@
           "type" : "array",
           "items" : {
             "type" : "object",
-            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobVertexDetailsInfo:VertexTaskDetail",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobVertexDetailsInfo:SubtaskExecutionAttemptDetailsInfo",
             "properties" : {
               "subtask" : {
                 "type" : "integer"
@@ -1691,11 +1691,11 @@
                   }
                 }
               },
-              "start_time" : {
-                "type" : "integer"
-              },
               "taskmanager-id" : {
                 "type" : "string"
+              },
+              "start_time" : {
+                "type" : "integer"
               }
             }
           }
@@ -1967,9 +1967,6 @@
         "duration" : {
           "type" : "integer"
         },
-        "taskmanager-id" : {
-          "type" : "string"
-        },
         "metrics" : {
           "type" : "object",
           "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:IOMetricsInfo",
@@ -1999,6 +1996,12 @@
               "type" : "boolean"
             }
           }
+        },
+        "taskmanager-id" : {
+          "type" : "string"
+        },
+        "start_time" : {
+          "type" : "integer"
         }
       }
     }
@@ -2050,9 +2053,6 @@
         "duration" : {
           "type" : "integer"
         },
-        "taskmanager-id" : {
-          "type" : "string"
-        },
         "metrics" : {
           "type" : "object",
           "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:IOMetricsInfo",
@@ -2082,6 +2082,12 @@
               "type" : "boolean"
             }
           }
+        },
+        "taskmanager-id" : {
+          "type" : "string"
+        },
+        "start_time" : {
+          "type" : "integer"
         }
       }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexDetailsHandler.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.rest.handler.job;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.AccessExecution;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.rest.NotFoundException;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.legacy.ExecutionGraphCache;
 import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
-import org.apache.flink.runtime.rest.handler.util.MutableIOMetrics;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
 import org.apache.flink.runtime.rest.messages.JobVertexDetailsInfo;
@@ -37,8 +36,7 @@ import org.apache.flink.runtime.rest.messages.JobVertexIdPathParameter;
 import org.apache.flink.runtime.rest.messages.JobVertexMessageParameters;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
-import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
-import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptDetailsInfo;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
 import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
@@ -107,49 +105,12 @@ public class JobVertexDetailsHandler extends AbstractExecutionGraphHandler<JobVe
 	}
 
 	private static JobVertexDetailsInfo createJobVertexDetailsInfo(AccessExecutionJobVertex jobVertex, JobID jobID, @Nullable MetricFetcher metricFetcher) {
-		List<JobVertexDetailsInfo.VertexTaskDetail> subtasks = new ArrayList<>();
+		List<SubtaskExecutionAttemptDetailsInfo> subtasks = new ArrayList<>();
 		final long now = System.currentTimeMillis();
-		int num = 0;
 		for (AccessExecutionVertex vertex : jobVertex.getTaskVertices()) {
-			final ExecutionState status = vertex.getExecutionState();
-
-			TaskManagerLocation location = vertex.getCurrentAssignedResourceLocation();
-			String locationString = location == null ? "(unassigned)" : location.getHostname() + ":" + location.dataPort();
-			String resourceId = location == null ? "(unassigned)" : location.getResourceID().getResourceIdString();
-
-			long startTime = vertex.getStateTimestamp(ExecutionState.DEPLOYING);
-			if (startTime == 0) {
-				startTime = -1;
-			}
-			long endTime = status.isTerminal() ? vertex.getStateTimestamp(status) : -1;
-			long duration = startTime > 0 ? ((endTime > 0 ? endTime : now) - startTime) : -1;
-
-			MutableIOMetrics counts = new MutableIOMetrics();
-			counts.addIOMetrics(
-				vertex.getCurrentExecutionAttempt(),
-				metricFetcher,
-				jobID.toString(),
-				jobVertex.getJobVertexId().toString());
-			subtasks.add(new JobVertexDetailsInfo.VertexTaskDetail(
-				num,
-				status,
-				vertex.getCurrentExecutionAttempt().getAttemptNumber(),
-				locationString,
-				startTime,
-				endTime,
-				duration,
-				new IOMetricsInfo(
-					counts.getNumBytesIn(),
-					counts.isNumBytesInComplete(),
-					counts.getNumBytesOut(),
-					counts.isNumBytesOutComplete(),
-					counts.getNumRecordsIn(),
-					counts.isNumRecordsInComplete(),
-					counts.getNumRecordsOut(),
-					counts.isNumRecordsOutComplete()),
-				resourceId));
-
-			num++;
+			final AccessExecution execution = vertex.getCurrentExecutionAttempt();
+			final JobVertexID jobVertexID = jobVertex.getJobVertexId();
+			subtasks.add(SubtaskExecutionAttemptDetailsInfo.create(execution, metricFetcher, jobID, jobVertexID));
 		}
 
 		return new JobVertexDetailsInfo(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandler.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.RestHandlerException;
 import org.apache.flink.runtime.rest.handler.legacy.ExecutionGraphCache;
 import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
-import org.apache.flink.runtime.rest.handler.util.MutableIOMetrics;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
 import org.apache.flink.runtime.rest.messages.JobVertexIdPathParameter;
@@ -69,18 +68,9 @@ public class SubtaskCurrentAttemptDetailsHandler extends AbstractSubtaskHandler<
 
 		final AccessExecution execution = executionVertex.getCurrentExecutionAttempt();
 
-		final MutableIOMetrics ioMetrics = new MutableIOMetrics();
-
 		final JobID jobID = request.getPathParameter(JobIDPathParameter.class);
 		final JobVertexID jobVertexID = request.getPathParameter(JobVertexIdPathParameter.class);
 
-		ioMetrics.addIOMetrics(
-			execution,
-			metricFetcher,
-			jobID.toString(),
-			jobVertexID.toString()
-		);
-
-		return SubtaskExecutionAttemptDetailsInfo.create(execution, ioMetrics);
+		return SubtaskExecutionAttemptDetailsInfo.create(execution, metricFetcher, jobID, jobVertexID);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfo.java
@@ -18,10 +18,9 @@
 
 package org.apache.flink.runtime.rest.messages;
 
-import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.rest.handler.job.JobVertexDetailsHandler;
-import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
+import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptDetailsInfo;
 import org.apache.flink.runtime.rest.messages.json.JobVertexIDDeserializer;
 import org.apache.flink.runtime.rest.messages.json.JobVertexIDSerializer;
 
@@ -61,7 +60,7 @@ public class JobVertexDetailsInfo implements ResponseBody {
 	private final long now;
 
 	@JsonProperty(FIELD_NAME_SUBTASKS)
-	private final List<VertexTaskDetail> subtasks;
+	private final List<SubtaskExecutionAttemptDetailsInfo> subtasks;
 
 	@JsonCreator
 	public JobVertexDetailsInfo(
@@ -69,7 +68,7 @@ public class JobVertexDetailsInfo implements ResponseBody {
 			@JsonProperty(FIELD_NAME_VERTEX_NAME) String name,
 			@JsonProperty(FIELD_NAME_PARALLELISM) int parallelism,
 			@JsonProperty(FIELD_NAME_NOW) long now,
-			@JsonProperty(FIELD_NAME_SUBTASKS) List<VertexTaskDetail> subtasks) {
+			@JsonProperty(FIELD_NAME_SUBTASKS) List<SubtaskExecutionAttemptDetailsInfo> subtasks) {
 		this.id = checkNotNull(id);
 		this.name = checkNotNull(name);
 		this.parallelism = parallelism;
@@ -78,7 +77,7 @@ public class JobVertexDetailsInfo implements ResponseBody {
 	}
 
 	@JsonIgnore
-	public List<VertexTaskDetail> getSubtasks() {
+	public List<SubtaskExecutionAttemptDetailsInfo> getSubtasks() {
 		return Collections.unmodifiableList(subtasks);
 	}
 
@@ -103,111 +102,5 @@ public class JobVertexDetailsInfo implements ResponseBody {
 	@Override
 	public int hashCode() {
 		return Objects.hash(id, name, parallelism, now, subtasks);
-	}
-
-	//---------------------------------------------------------------------------------
-	// Static helper classes
-	//---------------------------------------------------------------------------------
-
-	/**
-	 * Vertex task detail class.
-	 */
-	public static final class VertexTaskDetail {
-		public static final String FIELD_NAME_SUBTASK = "subtask";
-		public static final String FIELD_NAME_STATUS = "status";
-		public static final String FIELD_NAME_ATTEMPT = "attempt";
-		public static final String FIELD_NAME_HOST = "host";
-		public static final String FIELD_NAME_START_TIME = "start-time";
-		public static final String FIELD_NAME_COMPATIBLE_START_TIME = "start_time";
-		public static final String FIELD_NAME_END_TIME = "end-time";
-		public static final String FIELD_NAME_DURATION = "duration";
-		public static final String FIELD_NAME_METRICS = "metrics";
-		public static final String FIELD_NAME_TASKMANAGER_ID = "taskmanager-id";
-
-		@JsonProperty(FIELD_NAME_SUBTASK)
-		private final int subtask;
-
-		@JsonProperty(FIELD_NAME_STATUS)
-		private final ExecutionState status;
-
-		@JsonProperty(FIELD_NAME_ATTEMPT)
-		private final int attempt;
-
-		@JsonProperty(FIELD_NAME_HOST)
-		private final String host;
-
-		@JsonProperty(FIELD_NAME_START_TIME)
-		private final long startTime;
-
-		@JsonProperty(FIELD_NAME_COMPATIBLE_START_TIME)
-		private final long startTimeCompatible;
-
-		@JsonProperty(FIELD_NAME_END_TIME)
-		private final long endTime;
-
-		@JsonProperty(FIELD_NAME_DURATION)
-		private final long duration;
-
-		@JsonProperty(FIELD_NAME_METRICS)
-		private final IOMetricsInfo metrics;
-
-		@JsonProperty(FIELD_NAME_TASKMANAGER_ID)
-		private final String taskmanagerId;
-
-		@JsonCreator
-		public VertexTaskDetail(
-				@JsonProperty(FIELD_NAME_SUBTASK) int subtask,
-				@JsonProperty(FIELD_NAME_STATUS) ExecutionState status,
-				@JsonProperty(FIELD_NAME_ATTEMPT) int attempt,
-				@JsonProperty(FIELD_NAME_HOST) String host,
-				@JsonProperty(FIELD_NAME_START_TIME) long startTime,
-				@JsonProperty(FIELD_NAME_END_TIME) long endTime,
-				@JsonProperty(FIELD_NAME_DURATION) long duration,
-				@JsonProperty(FIELD_NAME_METRICS) IOMetricsInfo metrics,
-				@JsonProperty(FIELD_NAME_TASKMANAGER_ID) String taskmanagerId) {
-			this.subtask = subtask;
-			this.status = checkNotNull(status);
-			this.attempt = attempt;
-			this.host = checkNotNull(host);
-			this.startTime = startTime;
-			this.startTimeCompatible = startTime;
-			this.endTime = endTime;
-			this.duration = duration;
-			this.metrics = checkNotNull(metrics);
-			this.taskmanagerId = checkNotNull(taskmanagerId);
-		}
-
-		@JsonIgnore
-		public int getAttempt() {
-			return attempt;
-		}
-
-		@Override
-		public boolean equals(Object o) {
-			if (this == o) {
-				return true;
-			}
-
-			if (null == o || this.getClass() != o.getClass()) {
-				return false;
-			}
-
-			VertexTaskDetail that = (VertexTaskDetail) o;
-			return subtask == that.subtask &&
-				Objects.equals(status, that.status) &&
-				attempt == that.attempt &&
-				Objects.equals(host, that.host) &&
-				startTime == that.startTime &&
-				startTimeCompatible == that.startTimeCompatible &&
-				endTime == that.endTime &&
-				duration == that.duration &&
-				Objects.equals(metrics, that.metrics) &&
-				Objects.equals(taskmanagerId, that.taskmanagerId);
-		}
-
-		@Override
-		public int hashCode() {
-			return Objects.hash(subtask, status, attempt, host, startTime, startTimeCompatible, endTime, duration, metrics, taskmanagerId);
-		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfoTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.rest.messages;
 
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptDetailsInfo;
 import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
 
 import java.util.ArrayList;
@@ -47,8 +48,8 @@ public class JobVertexDetailsInfoTest extends RestResponseMarshallingTestBase<Jo
 			random.nextBoolean(),
 			random.nextLong(),
 			random.nextBoolean());
-		List<JobVertexDetailsInfo.VertexTaskDetail> vertexTaskDetailList = new ArrayList<>();
-		vertexTaskDetailList.add(new JobVertexDetailsInfo.VertexTaskDetail(
+		List<SubtaskExecutionAttemptDetailsInfo> vertexTaskDetailList = new ArrayList<>();
+		vertexTaskDetailList.add(new SubtaskExecutionAttemptDetailsInfo(
 			0,
 			ExecutionState.CREATED,
 			random.nextInt(),
@@ -58,7 +59,7 @@ public class JobVertexDetailsInfoTest extends RestResponseMarshallingTestBase<Jo
 			1L,
 			jobVertexMetrics,
 			"taskmanagerId1"));
-		vertexTaskDetailList.add(new JobVertexDetailsInfo.VertexTaskDetail(
+		vertexTaskDetailList.add(new SubtaskExecutionAttemptDetailsInfo(
 			1,
 			ExecutionState.FAILED,
 			random.nextInt(),
@@ -68,7 +69,7 @@ public class JobVertexDetailsInfoTest extends RestResponseMarshallingTestBase<Jo
 			1L,
 			jobVertexMetrics,
 			"taskmanagerId2"));
-		vertexTaskDetailList.add(new JobVertexDetailsInfo.VertexTaskDetail(
+		vertexTaskDetailList.add(new SubtaskExecutionAttemptDetailsInfo(
 			2,
 			ExecutionState.FINISHED,
 			random.nextInt(),

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/BatchFineGrainedRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/BatchFineGrainedRecoveryITCase.java
@@ -45,13 +45,13 @@ import org.apache.flink.runtime.rest.messages.JobIdsWithStatusesOverviewHeaders;
 import org.apache.flink.runtime.rest.messages.JobMessageParameters;
 import org.apache.flink.runtime.rest.messages.JobVertexDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.JobVertexDetailsInfo;
-import org.apache.flink.runtime.rest.messages.JobVertexDetailsInfo.VertexTaskDetail;
 import org.apache.flink.runtime.rest.messages.JobVertexMessageParameters;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.rest.messages.MessageParameters;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
 import org.apache.flink.runtime.rest.messages.job.JobDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
+import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptDetailsInfo;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
 import org.apache.flink.test.util.TestEnvironment;
 import org.apache.flink.util.Collector;
@@ -604,7 +604,7 @@ public class BatchFineGrainedRecoveryITCase extends TestLogger {
 		private final String name;
 		private final int attempt;
 
-		private InternalTaskInfo(String name, VertexTaskDetail vertexTaskDetail) {
+		private InternalTaskInfo(String name, SubtaskExecutionAttemptDetailsInfo vertexTaskDetail) {
 			this.name = name;
 			this.attempt = vertexTaskDetail.getAttempt();
 		}


### PR DESCRIPTION


## What is the purpose of the change
This pull request use SubtaskExecutionAttemptDetailsInfo instead of JobVertexDetailsInfo.VertexTaskDetail, delete deduplicated subtask object.


## Brief change log
- delete JobVertexDetailsInfo.VertexTaskDetail
- SubtaskExecutionAttemptDetailsInfo add field start_time for adapting JobVertexDetailsInfo.VertexTaskDetail.


## Verifying this change

This change is already covered by existing tests, such as JobVertexDetailsInfoTest.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

