### PR TITLE
[FLINK-14038]Add default GC options for flink on yarn to facilitate debugging

### DIFF
--- a/docs/_includes/generated/core_configuration.html
+++ b/docs/_includes/generated/core_configuration.html
@@ -64,7 +64,7 @@
         </tr>
         <tr>
             <td><h5>jvm.heapdump.directory</h5></td>
-            <td style="word-wrap: break-word;">"/var/folders/ck/2gym0wnn4cg48v53_t2slm4r0000gn/T/"</td>
+            <td style="word-wrap: break-word;">System.getProperty("java.io.tmpdir")</td>
             <td>String</td>
             <td>The directory to save heap dump file when OOMs happen.</td>
         </tr>

--- a/docs/_includes/generated/core_configuration.html
+++ b/docs/_includes/generated/core_configuration.html
@@ -51,22 +51,28 @@
             <td>Directories for temporary files, separated by",", "|", or the system's java.io.File.pathSeparator.</td>
         </tr>
         <tr>
+            <td><h5>jvm.crash-on-oom</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Flag to activate crashing the JVM on OOMs.</td>
+        </tr>
+        <tr>
             <td><h5>jvm.gc-logging</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>When enabled, jvm will be launched with default gc options which will log gc infos under log directory</td>
+            <td>Flag to activate the JVM's GC logging. The GC log file will be created in the log directory.</td>
+        </tr>
+        <tr>
+            <td><h5>jvm.heap-dump-directory</h5></td>
+            <td style="word-wrap: break-word;">"."</td>
+            <td>String</td>
+            <td>The directory to save the heap dump file when OOMs happen. This option is only relevant if <span markdown="span">`jvm.heapdump-on-oom`</span> has been activated.</td>
         </tr>
         <tr>
             <td><h5>jvm.heapdump-on-oom</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
-            <td>When enabled, jvm will save heapdump files when OOMs happen.</td>
-        </tr>
-        <tr>
-            <td><h5>jvm.heapdump.directory</h5></td>
-            <td style="word-wrap: break-word;">System.getProperty("java.io.tmpdir")</td>
-            <td>String</td>
-            <td>The directory to save heap dump file when OOMs happen.</td>
+            <td>Flag to activate creating a heap dump in case of OOMs. The directory for the heap dump can be configured via <span markdown="span">`jvm.heap-dump-directory`</span>.</td>
         </tr>
         <tr>
             <td><h5>parallelism.default</h5></td>

--- a/docs/_includes/generated/core_configuration.html
+++ b/docs/_includes/generated/core_configuration.html
@@ -51,6 +51,24 @@
             <td>Directories for temporary files, separated by",", "|", or the system's java.io.File.pathSeparator.</td>
         </tr>
         <tr>
+            <td><h5>jvm.gc-logging</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>When enabled, jvm will be launched with default gc options which will log gc infos under log directory</td>
+        </tr>
+        <tr>
+            <td><h5>jvm.heapdump-on-oom</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>When enabled, jvm will save heapdump files when OOMs happen.</td>
+        </tr>
+        <tr>
+            <td><h5>jvm.heapdump.directory</h5></td>
+            <td style="word-wrap: break-word;">"/var/folders/ck/2gym0wnn4cg48v53_t2slm4r0000gn/T/"</td>
+            <td>String</td>
+            <td>The directory to save heap dump file when OOMs happen.</td>
+        </tr>
+        <tr>
             <td><h5>parallelism.default</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -309,18 +309,27 @@ public class CoreOptions {
 			.defaultValue(true)
 			.withDescription(
 				Description.builder()
-					.text("Flag to activate crashing the JVM on OOMs. If enabled, a heap dump will be created as well. The directory for the heap dump can be configured via %s.",
-						TextElement.code("jvm.heapdump-directory"))
+					.text("Flag to activate crashing the JVM on OOMs.")
 					.build());
 
-	public static final ConfigOption<String> JVM_HEAPDUMP_DIRECTORY =
-		key("jvm.heapdump-directory")
+	public static final ConfigOption<Boolean> JVM_HEAP_DUMP_ON_OOM =
+		key("jvm.heapdump-on-oom")
+			.booleanType()
+			.defaultValue(true)
+			.withDescription(
+				Description.builder()
+					.text("Flag to activate creating a heap dump in case of OOMs. The directory for the heap dump can be configured via %s.",
+						TextElement.code("jvm.heap-dump-directory"))
+					.build());
+
+	public static final ConfigOption<String> JVM_HEAP_DUMP_DIRECTORY =
+		key("jvm.heap-dump-directory")
 			.stringType()
 			.defaultValue(".")
 			.withDescription(
 				Description.builder()
 					.text("The directory to save the heap dump file when OOMs happen. This option is only relevant if %s has been activated.",
-						TextElement.code(JVM_CRASH_ON_OOM.key()))
+						TextElement.code(JVM_HEAP_DUMP_ON_OOM.key()))
 					.build());
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -23,6 +23,7 @@ import org.apache.flink.annotation.docs.ConfigGroup;
 import org.apache.flink.annotation.docs.ConfigGroups;
 import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.description.Description;
+import org.apache.flink.configuration.description.TextElement;
 
 import org.apache.flink.shaded.guava18.com.google.common.base.Splitter;
 import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
@@ -296,25 +297,31 @@ public class CoreOptions {
 				" the writer will directly create the file directly at the output path, without creating a containing" +
 				" directory.");
 
-	public static final ConfigOption<Boolean> FLINK_JVM_DEFAULT_GC_LOGGING =
+	public static final ConfigOption<Boolean> JVM_GC_LOGGING =
 		key("jvm.gc-logging")
 			.booleanType()
 			.defaultValue(false)
-			.withDescription("When enabled, jvm will be launched with default gc options which will log gc infos" +
-				" under log directory");
+			.withDescription("Flag to activate the JVM's GC logging. The GC log file will be created in the log directory.");
 
-	public static final ConfigOption<Boolean> FLINK_JVM_HEAPDUMP_ON_OOM =
-		key("jvm.heapdump-on-oom")
+	public static final ConfigOption<Boolean> JVM_CRASH_ON_OOM =
+		key("jvm.crash-on-oom")
 			.booleanType()
 			.defaultValue(true)
-			.withDescription("When enabled, jvm will save heapdump files when OOMs happen.");
+			.withDescription(
+				Description.builder()
+					.text("Flag to activate crashing the JVM on OOMs. If enabled, a heap dump will be created as well. The directory for the heap dump can be configured via %s.",
+						TextElement.code("jvm.heapdump-directory"))
+					.build());
 
-	@Documentation.OverrideDefault("System.getProperty(\"java.io.tmpdir\")")
-	public static final ConfigOption<String> FLINK_JVM_HEAPDUMP_DIRECTORY =
-		key("jvm.heapdump.directory")
+	public static final ConfigOption<String> JVM_HEAPDUMP_DIRECTORY =
+		key("jvm.heapdump-directory")
 			.stringType()
-			.defaultValue(System.getProperty("java.io.tmpdir"))
-			.withDescription("The directory to save heap dump file when OOMs happen.");
+			.defaultValue(".")
+			.withDescription(
+				Description.builder()
+					.text("The directory to save the heap dump file when OOMs happen. This option is only relevant if %s has been activated.",
+						TextElement.code(JVM_CRASH_ON_OOM.key()))
+					.build());
 
 	/**
 	 * The total number of input plus output connections that a file system for the given scheme may open.

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -296,6 +296,22 @@ public class CoreOptions {
 				" the writer will directly create the file directly at the output path, without creating a containing" +
 				" directory.");
 
+	public static final ConfigOption<Boolean> FLINK_JVM_DEFAULT_GC_LOGGING =
+		key("jvm.gc-logging")
+			.defaultValue(false)
+			.withDescription("When enabled, jvm will be launched with default gc options which will log gc infos" +
+				" under log directory");
+
+	public static final ConfigOption<Boolean> FLINK_JVM_HEAPDUMP_ON_OOM =
+		key("jvm.heapdump-on-oom")
+			.defaultValue(true)
+			.withDescription("When enabled, jvm will save heapdump files when OOMs happen.");
+
+	public static final ConfigOption<String> FLINK_JVM_HEAPDUMP_DIRECTORY =
+		key("jvm.heapdump.directory")
+			.defaultValue(System.getProperty("java.io.tmpdir"))
+			.withDescription("The directory to save heap dump file when OOMs happen.");
+
 	/**
 	 * The total number of input plus output connections that a file system for the given scheme may open.
 	 * Unlimited be default.

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -298,17 +298,21 @@ public class CoreOptions {
 
 	public static final ConfigOption<Boolean> FLINK_JVM_DEFAULT_GC_LOGGING =
 		key("jvm.gc-logging")
+			.booleanType()
 			.defaultValue(false)
 			.withDescription("When enabled, jvm will be launched with default gc options which will log gc infos" +
 				" under log directory");
 
 	public static final ConfigOption<Boolean> FLINK_JVM_HEAPDUMP_ON_OOM =
 		key("jvm.heapdump-on-oom")
+			.booleanType()
 			.defaultValue(true)
 			.withDescription("When enabled, jvm will save heapdump files when OOMs happen.");
 
+	@Documentation.OverrideDefault("System.getProperty(\"java.io.tmpdir\")")
 	public static final ConfigOption<String> FLINK_JVM_HEAPDUMP_DIRECTORY =
 		key("jvm.heapdump.directory")
+			.stringType()
 			.defaultValue(System.getProperty("java.io.tmpdir"))
 			.withDescription("The directory to save heap dump file when OOMs happen.");
 

--- a/flink-dist/src/main/flink-bin/bin/flink-console.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-console.sh
@@ -56,7 +56,20 @@ case $SERVICE in
     ;;
 esac
 
+if [ "$FLINK_IDENT_STRING" = "" ]; then
+    FLINK_IDENT_STRING="$USER"
+fi
+
 FLINK_TM_CLASSPATH=`constructFlinkClassPath`
+
+FLINK_LOG_PREFIX="${FLINK_LOG_DIR}/flink-${FLINK_IDENT_STRING}-${SERVICE}"
+gclog="${FLINK_LOG_PREFIX}.gc_log"
+
+FLINK_HEAPDUMP_NAME="flink-${FLINK_IDENT_STRING}-${SERVICE}.hprof"
+rm -rf ${FLINK_JVM_HEAPDUMP_DIRECTORY}/${FLINK_HEAPDUMP_NAME}
+setGCLoggingOpts $gclog
+setHeapdumpOpts $FLINK_HEAPDUMP_NAME $log
+JVM_ARGS=("${FLINK_JVM_GC_LOGGING_OPTS[@]}" "${FLINK_JVM_HEAPDUMP_OPTS[@]}" "${JVM_ARGS[@]}")
 
 log_setting=("-Dlog4j.configuration=file:${FLINK_CONF_DIR}/log4j-console.properties" "-Dlogback.configurationFile=file:${FLINK_CONF_DIR}/logback-console.xml")
 
@@ -65,7 +78,7 @@ JAVA_VERSION=$(${JAVA_RUN} -version 2>&1 | sed 's/.*version "\(.*\)\.\(.*\)\..*"
 # Only set JVM 8 arguments if we have correctly extracted the version
 if [[ ${JAVA_VERSION} =~ ${IS_NUMBER} ]]; then
     if [ "$JAVA_VERSION" -lt 18 ]; then
-        JVM_ARGS="$JVM_ARGS -XX:MaxPermSize=256m"
+        JVM_ARGS=("${JVM_ARGS[@]}" "-XX:MaxPermSize=256m")
     fi
 fi
 

--- a/flink-dist/src/main/flink-bin/bin/flink-console.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-console.sh
@@ -62,14 +62,14 @@ fi
 
 FLINK_TM_CLASSPATH=`constructFlinkClassPath`
 
-FLINK_LOG_PREFIX="${FLINK_LOG_DIR}/flink-${FLINK_IDENT_STRING}-${SERVICE}"
-gclog="${FLINK_LOG_PREFIX}.gc_log"
+local filename="flink-${FLINK_IDENT_STRING}-${SERVICE}"
+FLINK_LOG_PREFIX="${FLINK_LOG_DIR}/${filename}"
+gclog="${FLINK_LOG_PREFIX}-gc.log"
 
-FLINK_HEAPDUMP_NAME="flink-${FLINK_IDENT_STRING}-${SERVICE}.hprof"
-rm -rf ${FLINK_JVM_HEAPDUMP_DIRECTORY}/${FLINK_HEAPDUMP_NAME}
-setGCLoggingOpts $gclog
-setHeapdumpOpts $FLINK_HEAPDUMP_NAME $log
-JVM_ARGS=("${FLINK_JVM_GC_LOGGING_OPTS[@]}" "${FLINK_JVM_HEAPDUMP_OPTS[@]}" "${JVM_ARGS[@]}")
+local heap_dump_file_path="${FLINK_JVM_HEAPDUMP_DIRECTORY}/${filename}.hprof"
+local gc_logging_opts=$(getGCLoggingOpts $gclog)
+local crash_on_oom_opts=$(getCrashOnOOMOpts $heap_dump_file_path)
+JVM_ARGS=("${gc_logging_opts[@]}" "${crash_on_oom_opts[@]}" "${JVM_ARGS[@]}")
 
 log_setting=("-Dlog4j.configuration=file:${FLINK_CONF_DIR}/log4j-console.properties" "-Dlogback.configurationFile=file:${FLINK_CONF_DIR}/logback-console.xml")
 

--- a/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
@@ -82,16 +82,12 @@ fi
 # This allows us to start multiple daemon of each type.
 id=$([ -f "$pid" ] && echo $(wc -l < "$pid") || echo "0")
 
-local filename="flink-${FLINK_IDENT_STRING}-${DAEMON}-${id}-${HOSTNAME}"
+filename="flink-${FLINK_IDENT_STRING}-${DAEMON}-${id}-${HOSTNAME}"
 FLINK_LOG_PREFIX="${FLINK_LOG_DIR}/${filename}"
 log="${FLINK_LOG_PREFIX}.log"
 out="${FLINK_LOG_PREFIX}.out"
-gclog="${FLINK_LOG_PREFIX}-gc.log"
 
-local heap_dump_file_path="${FLINK_JVM_HEAPDUMP_DIRECTORY}/${filename}.hprof"
-local gc_logging_opts=$(getGCLoggingOpts ${gclog})
-local crash_on_oom_opts=$(getCrashOnOOMOpts ${heap_dump_file_path})
-JVM_ARGS=("${gc_logging_opts[@]}" "${crash_on_oom_opts[@]}" "${JVM_ARGS[@]}")
+JVM_ARGS=$(getJvmArgs "${filename}")
 
 log_setting=("-Dlog.file=${log}" "-Dlog4j.configuration=file:${FLINK_CONF_DIR}/log4j.properties" "-Dlogback.configurationFile=file:${FLINK_CONF_DIR}/logback.xml")
 
@@ -100,7 +96,7 @@ JAVA_VERSION=$(${JAVA_RUN} -version 2>&1 | sed 's/.*version "\(.*\)\.\(.*\)\..*"
 # Only set JVM 8 arguments if we have correctly extracted the version
 if [[ ${JAVA_VERSION} =~ ${IS_NUMBER} ]]; then
     if [ "$JAVA_VERSION" -lt 18 ]; then
-        JVM_ARGS=("${JVM_ARGS[@]}" "-XX:MaxPermSize=256m")
+        JVM_ARGS="$JVM_ARGS -XX:MaxPermSize=256m"
     fi
 fi
 
@@ -131,7 +127,7 @@ case $STARTSTOP in
         FLINK_ENV_JAVA_OPTS=$(eval echo ${FLINK_ENV_JAVA_OPTS})
 
         echo "Starting $DAEMON daemon on host $HOSTNAME."
-        $JAVA_RUN "${JVM_ARGS[@]}" ${FLINK_ENV_JAVA_OPTS} "${log_setting[@]}" -classpath "`manglePathList "$FLINK_TM_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" ${CLASS_TO_RUN} "${ARGS[@]}" > "$out" 200<&- 2>&1 < /dev/null &
+        $JAVA_RUN ${JVM_ARGS} ${FLINK_ENV_JAVA_OPTS} "${log_setting[@]}" -classpath "`manglePathList "$FLINK_TM_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" ${CLASS_TO_RUN} "${ARGS[@]}" > "$out" 200<&- 2>&1 < /dev/null &
 
         mypid=$!
 

--- a/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
@@ -82,16 +82,16 @@ fi
 # This allows us to start multiple daemon of each type.
 id=$([ -f "$pid" ] && echo $(wc -l < "$pid") || echo "0")
 
-FLINK_LOG_PREFIX="${FLINK_LOG_DIR}/flink-${FLINK_IDENT_STRING}-${DAEMON}-${id}-${HOSTNAME}"
+local filename="flink-${FLINK_IDENT_STRING}-${DAEMON}-${id}-${HOSTNAME}"
+FLINK_LOG_PREFIX="${FLINK_LOG_DIR}/${filename}"
 log="${FLINK_LOG_PREFIX}.log"
 out="${FLINK_LOG_PREFIX}.out"
-gclog="${FLINK_LOG_PREFIX}.gc_log"
+gclog="${FLINK_LOG_PREFIX}-gc.log"
 
-FLINK_HEAPDUMP_NAME="flink-${FLINK_IDENT_STRING}-${DAEMON}-${id}-${HOSTNAME}.hprof"
-rm -rf ${FLINK_JVM_HEAPDUMP_DIRECTORY}/${FLINK_HEAPDUMP_NAME}
-setGCLoggingOpts $gclog
-setHeapdumpOpts $FLINK_HEAPDUMP_NAME $log
-JVM_ARGS=("${FLINK_JVM_GC_LOGGING_OPTS[@]}" "${FLINK_JVM_HEAPDUMP_OPTS[@]}" "${JVM_ARGS[@]}")
+local heap_dump_file_path="${FLINK_JVM_HEAPDUMP_DIRECTORY}/${filename}.hprof"
+local gc_logging_opts=$(getGCLoggingOpts ${gclog})
+local crash_on_oom_opts=$(getCrashOnOOMOpts ${heap_dump_file_path})
+JVM_ARGS=("${gc_logging_opts[@]}" "${crash_on_oom_opts[@]}" "${JVM_ARGS[@]}")
 
 log_setting=("-Dlog.file=${log}" "-Dlog4j.configuration=file:${FLINK_CONF_DIR}/log4j.properties" "-Dlogback.configurationFile=file:${FLINK_CONF_DIR}/logback.xml")
 

--- a/flink-dist/src/main/flink-bin/mesos-bin/mesos-appmaster-job.sh
+++ b/flink-dist/src/main/flink-bin/mesos-bin/mesos-appmaster-job.sh
@@ -31,6 +31,13 @@ CC_CLASSPATH=`manglePathList $(constructFlinkClassPath):$INTERNAL_HADOOP_CLASSPA
 
 log="${FLINK_LOG_DIR}/flink-${FLINK_IDENT_STRING}-mesos-appmaster-${HOSTNAME}.log"
 log_setting="-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback.xml"
+gclog="${FLINK_LOG_DIR}/flink-${FLINK_IDENT_STRING}-mesos-appmaster-${HOSTNAME}.gc_log"
+
+FLINK_HEAPDUMP_NAME="flink-${FLINK_IDENT_STRING}-mesos-appmaster-${HOSTNAME}.hprof"
+rm -rf ${FLINK_JVM_HEAPDUMP_DIRECTORY}/${FLINK_HEAPDUMP_NAME}
+setGCLoggingOpts $gclog
+setHeapdumpOpts $FLINK_HEAPDUMP_NAME $log
+JVM_ARGS=("${FLINK_JVM_GC_LOGGING_OPTS[@]}" "${FLINK_JVM_HEAPDUMP_OPTS[@]}" "${JVM_ARGS[@]}")
 
 exec $JAVA_RUN $JVM_ARGS -classpath "$CC_CLASSPATH" $log_setting org.apache.flink.mesos.entrypoint.MesosJobClusterEntrypoint "$@"
 

--- a/flink-dist/src/main/flink-bin/mesos-bin/mesos-appmaster-job.sh
+++ b/flink-dist/src/main/flink-bin/mesos-bin/mesos-appmaster-job.sh
@@ -29,15 +29,15 @@ fi
 
 CC_CLASSPATH=`manglePathList $(constructFlinkClassPath):$INTERNAL_HADOOP_CLASSPATHS`
 
-log="${FLINK_LOG_DIR}/flink-${FLINK_IDENT_STRING}-mesos-appmaster-${HOSTNAME}.log"
+local filename="flink-${FLINK_IDENT_STRING}-mesos-appmaster-${HOSTNAME}"
+log="${FLINK_LOG_DIR}/${filename}.log"
 log_setting="-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback.xml"
-gclog="${FLINK_LOG_DIR}/flink-${FLINK_IDENT_STRING}-mesos-appmaster-${HOSTNAME}.gc_log"
+gclog="${FLINK_LOG_DIR}/${filename}-gc.log"
 
-FLINK_HEAPDUMP_NAME="flink-${FLINK_IDENT_STRING}-mesos-appmaster-${HOSTNAME}.hprof"
-rm -rf ${FLINK_JVM_HEAPDUMP_DIRECTORY}/${FLINK_HEAPDUMP_NAME}
-setGCLoggingOpts $gclog
-setHeapdumpOpts $FLINK_HEAPDUMP_NAME $log
-JVM_ARGS=("${FLINK_JVM_GC_LOGGING_OPTS[@]}" "${FLINK_JVM_HEAPDUMP_OPTS[@]}" "${JVM_ARGS[@]}")
+local heapdump_file_path="${FLINK_JVM_HEAPDUMP_DIRECTORY}/${filename}.hprof"
+local gc_logging_opts=$(getGCLoggingOpts ${gclog})
+local crash_on_oom_opts=$(getCrashOnOOMOpts ${heapdump_file_path})
+JVM_ARGS=("${gc_logging_opts[@]}" "${crash_on_oom_opts[@]}" "${JVM_ARGS[@]}")
 
 exec $JAVA_RUN $JVM_ARGS -classpath "$CC_CLASSPATH" $log_setting org.apache.flink.mesos.entrypoint.MesosJobClusterEntrypoint "$@"
 

--- a/flink-dist/src/main/flink-bin/mesos-bin/mesos-appmaster-job.sh
+++ b/flink-dist/src/main/flink-bin/mesos-bin/mesos-appmaster-job.sh
@@ -29,15 +29,11 @@ fi
 
 CC_CLASSPATH=`manglePathList $(constructFlinkClassPath):$INTERNAL_HADOOP_CLASSPATHS`
 
-local filename="flink-${FLINK_IDENT_STRING}-mesos-appmaster-${HOSTNAME}"
+filename="flink-${FLINK_IDENT_STRING}-mesos-appmaster-${HOSTNAME}"
 log="${FLINK_LOG_DIR}/${filename}.log"
 log_setting="-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback.xml"
-gclog="${FLINK_LOG_DIR}/${filename}-gc.log"
 
-local heapdump_file_path="${FLINK_JVM_HEAPDUMP_DIRECTORY}/${filename}.hprof"
-local gc_logging_opts=$(getGCLoggingOpts ${gclog})
-local crash_on_oom_opts=$(getCrashOnOOMOpts ${heapdump_file_path})
-JVM_ARGS=("${gc_logging_opts[@]}" "${crash_on_oom_opts[@]}" "${JVM_ARGS[@]}")
+JVM_ARGS=$(getJvmArgs "${filename}")
 
 exec $JAVA_RUN $JVM_ARGS -classpath "$CC_CLASSPATH" $log_setting org.apache.flink.mesos.entrypoint.MesosJobClusterEntrypoint "$@"
 

--- a/flink-dist/src/main/flink-bin/mesos-bin/mesos-appmaster.sh
+++ b/flink-dist/src/main/flink-bin/mesos-bin/mesos-appmaster.sh
@@ -31,6 +31,13 @@ CC_CLASSPATH=`manglePathList $(constructFlinkClassPath):$INTERNAL_HADOOP_CLASSPA
 
 log="${FLINK_LOG_DIR}/flink-${FLINK_IDENT_STRING}-mesos-appmaster-${HOSTNAME}.log"
 log_setting="-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback.xml"
+gclog="${FLINK_LOG_DIR}/flink-${FLINK_IDENT_STRING}-mesos-appmaster-${HOSTNAME}.gc_log"
+
+FLINK_HEAPDUMP_NAME="flink-${FLINK_IDENT_STRING}-mesos-appmaster-${HOSTNAME}.hprof"
+rm -rf ${FLINK_JVM_HEAPDUMP_DIRECTORY}/${FLINK_HEAPDUMP_NAME}
+setGCLoggingOpts $gclog
+setHeapdumpOpts $FLINK_HEAPDUMP_NAME $log
+JVM_ARGS=("${FLINK_JVM_GC_LOGGING_OPTS[@]}" "${FLINK_JVM_HEAPDUMP_OPTS[@]}" "${JVM_ARGS[@]}")
 
 ENTRY_POINT=org.apache.flink.mesos.entrypoint.MesosSessionClusterEntrypoint
 

--- a/flink-dist/src/main/flink-bin/mesos-bin/mesos-appmaster.sh
+++ b/flink-dist/src/main/flink-bin/mesos-bin/mesos-appmaster.sh
@@ -29,15 +29,11 @@ fi
 
 CC_CLASSPATH=`manglePathList $(constructFlinkClassPath):$INTERNAL_HADOOP_CLASSPATHS`
 
-local filename=flink-"${FLINK_IDENT_STRING}-mesos-appmaster-${HOSTNAME}"
+filename=flink-"${FLINK_IDENT_STRING}-mesos-appmaster-${HOSTNAME}"
 log="${FLINK_LOG_DIR}/${filename}.log"
 log_setting="-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback.xml"
-gclog="${FLINK_LOG_DIR}/${filename}-gc.log"
 
-local heap_dump_file_path="${FLINK_JVM_HEAPDUMP_DIRECTORY}/${filename}.hprof"
-local gc_logging_opts=$(getGCLoggingOpts ${gclog})
-local crash_on_oom_opts=$(getCrashOnOOMOpts ${heap_dump_file_path})
-JVM_ARGS=("${gc_logging_opts[@]}" "${crash_on_oom_opts[@]}" "${JVM_ARGS[@]}")
+JVM_ARGS=$(getJvmArgs "${filename}")
 
 ENTRY_POINT=org.apache.flink.mesos.entrypoint.MesosSessionClusterEntrypoint
 

--- a/flink-dist/src/main/flink-bin/mesos-bin/mesos-appmaster.sh
+++ b/flink-dist/src/main/flink-bin/mesos-bin/mesos-appmaster.sh
@@ -29,15 +29,15 @@ fi
 
 CC_CLASSPATH=`manglePathList $(constructFlinkClassPath):$INTERNAL_HADOOP_CLASSPATHS`
 
-log="${FLINK_LOG_DIR}/flink-${FLINK_IDENT_STRING}-mesos-appmaster-${HOSTNAME}.log"
+local filename=flink-"${FLINK_IDENT_STRING}-mesos-appmaster-${HOSTNAME}"
+log="${FLINK_LOG_DIR}/${filename}.log"
 log_setting="-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback.xml"
-gclog="${FLINK_LOG_DIR}/flink-${FLINK_IDENT_STRING}-mesos-appmaster-${HOSTNAME}.gc_log"
+gclog="${FLINK_LOG_DIR}/${filename}-gc.log"
 
-FLINK_HEAPDUMP_NAME="flink-${FLINK_IDENT_STRING}-mesos-appmaster-${HOSTNAME}.hprof"
-rm -rf ${FLINK_JVM_HEAPDUMP_DIRECTORY}/${FLINK_HEAPDUMP_NAME}
-setGCLoggingOpts $gclog
-setHeapdumpOpts $FLINK_HEAPDUMP_NAME $log
-JVM_ARGS=("${FLINK_JVM_GC_LOGGING_OPTS[@]}" "${FLINK_JVM_HEAPDUMP_OPTS[@]}" "${JVM_ARGS[@]}")
+local heap_dump_file_path="${FLINK_JVM_HEAPDUMP_DIRECTORY}/${filename}.hprof"
+local gc_logging_opts=$(getGCLoggingOpts ${gclog})
+local crash_on_oom_opts=$(getCrashOnOOMOpts ${heap_dump_file_path})
+JVM_ARGS=("${gc_logging_opts[@]}" "${crash_on_oom_opts[@]}" "${JVM_ARGS[@]}")
 
 ENTRY_POINT=org.apache.flink.mesos.entrypoint.MesosSessionClusterEntrypoint
 

--- a/flink-dist/src/main/flink-bin/mesos-bin/mesos-taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/mesos-bin/mesos-taskmanager.sh
@@ -27,6 +27,13 @@ CC_CLASSPATH=`manglePathList $(constructFlinkClassPath):$INTERNAL_HADOOP_CLASSPA
 
 log=flink-taskmanager.log
 log_setting="-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback.xml"
+gclog="flink-taskmanager.gc_log"
+
+FLINK_HEAPDUMP_NAME="flink-taskmanager.hprof"
+rm -rf ${FLINK_JVM_HEAPDUMP_DIRECTORY}/${FLINK_HEAPDUMP_NAME}
+setGCLoggingOpts $gclog
+setHeapdumpOpts $FLINK_HEAPDUMP_NAME $log
+JVM_ARGS=("${FLINK_JVM_GC_LOGGING_OPTS[@]}" "${FLINK_JVM_HEAPDUMP_OPTS[@]}" "${JVM_ARGS[@]}")
 
 # Add precomputed memory JVM options
 if [ -z "${FLINK_ENV_JAVA_OPTS_MEM}" ]; then

--- a/flink-dist/src/main/flink-bin/mesos-bin/mesos-taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/mesos-bin/mesos-taskmanager.sh
@@ -25,15 +25,11 @@ bin=`cd "$bin"; pwd`
 
 CC_CLASSPATH=`manglePathList $(constructFlinkClassPath):$INTERNAL_HADOOP_CLASSPATHS`
 
-local filename="flink-taskmanager"
+filename="flink-taskmanager"
 log="${filename}.log"
 log_setting="-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback.xml"
-gclog="${filename}-gc.log"
 
-local heap_dump_file_path="${FLINK_JVM_HEAPDUMP_DIRECTORY}/${filename}.hprof"
-local gc_logging_opts=$(getGCLoggingOpts ${gclog})
-local crash_on_oom_opts=$(getCrashOnOOMOpts ${heap_dump_file_path})
-JVM_ARGS=("${gc_logging_opts[@]}" "${crash_on_oom_opts[@]}" "${JVM_ARGS[@]}")s
+JVM_ARGS=$(getJvmArgs "${filename}")
 
 # Add precomputed memory JVM options
 if [ -z "${FLINK_ENV_JAVA_OPTS_MEM}" ]; then

--- a/flink-dist/src/main/flink-bin/mesos-bin/mesos-taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/mesos-bin/mesos-taskmanager.sh
@@ -25,15 +25,15 @@ bin=`cd "$bin"; pwd`
 
 CC_CLASSPATH=`manglePathList $(constructFlinkClassPath):$INTERNAL_HADOOP_CLASSPATHS`
 
-log=flink-taskmanager.log
+local filename="flink-taskmanager"
+log="${filename}.log"
 log_setting="-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback.xml"
-gclog="flink-taskmanager.gc_log"
+gclog="${filename}-gc.log"
 
-FLINK_HEAPDUMP_NAME="flink-taskmanager.hprof"
-rm -rf ${FLINK_JVM_HEAPDUMP_DIRECTORY}/${FLINK_HEAPDUMP_NAME}
-setGCLoggingOpts $gclog
-setHeapdumpOpts $FLINK_HEAPDUMP_NAME $log
-JVM_ARGS=("${FLINK_JVM_GC_LOGGING_OPTS[@]}" "${FLINK_JVM_HEAPDUMP_OPTS[@]}" "${JVM_ARGS[@]}")
+local heap_dump_file_path="${FLINK_JVM_HEAPDUMP_DIRECTORY}/${filename}.hprof"
+local gc_logging_opts=$(getGCLoggingOpts ${gclog})
+local crash_on_oom_opts=$(getCrashOnOOMOpts ${heap_dump_file_path})
+JVM_ARGS=("${gc_logging_opts[@]}" "${crash_on_oom_opts[@]}" "${JVM_ARGS[@]}")s
 
 # Add precomputed memory JVM options
 if [ -z "${FLINK_ENV_JAVA_OPTS_MEM}" ]; then

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -390,6 +390,7 @@ public class BootstrapTools {
 	public static String getTaskManagerShellCommand(
 			Configuration flinkConfig,
 			ContaineredTaskManagerParameters tmParams,
+			String appId,
 			String configDirectory,
 			String logDirectory,
 			boolean hasLogback,
@@ -404,7 +405,7 @@ public class BootstrapTools {
 		final TaskExecutorProcessSpec taskExecutorProcessSpec = tmParams.getTaskExecutorProcessSpec();
 		startCommandValues.put("jvmmem", TaskExecutorProcessUtils.generateJvmParametersStr(taskExecutorProcessSpec));
 
-		String javaOpts = flinkConfig.getString(CoreOptions.FLINK_JVM_OPTIONS);
+		String javaOpts = getJvmOpts(appId, "taskmanager", logDirectory, flinkConfig);
 		if (flinkConfig.getString(CoreOptions.FLINK_TM_JVM_OPTIONS).length() > 0) {
 			javaOpts += " " + flinkConfig.getString(CoreOptions.FLINK_TM_JVM_OPTIONS);
 		}
@@ -525,6 +526,73 @@ public class BootstrapTools {
 		}
 
 		return clonedConfiguration;
+	}
+
+	/**
+	 * Format the default gc logging options.
+	 * @param logDirectory to save the gc log
+	 * @return the formatted gc logging options string
+	 */
+	public static String getGCLoggingOpts(String logDirectory) {
+		return "-Xloggc:" + logDirectory + "/gc.log " +
+			"-XX:+PrintGCApplicationStoppedTime " +
+			"-XX:+PrintGCDetails " +
+			"-XX:+PrintGCDateStamps " +
+			"-XX:+UseGCLogFileRotation " +
+			"-XX:NumberOfGCLogFiles=10 " +
+			"-XX:GCLogFileSize=10M " +
+			"-XX:+PrintPromotionFailure " +
+			"-XX:+PrintGCCause";
+	}
+
+	/**
+	 * Format the default heapdump options.
+	 * @param appId application id
+	 * @param ident the ident of the process, taskmanager/jobmanager
+	 * @param logDirectory to print some logs
+	 * @param heapdumpDir to save heap dump file
+	 * @return the formatted heapdump options string
+	 */
+	public static String getHeapdumpOpts(String appId, String ident, String logDirectory, String heapdumpDir) {
+		String dumpDestName = String.format("flink-%s-heapdump.hprof", ident);
+		String dumpFileDestPath = new File(heapdumpDir, appId + "-" + dumpDestName).getAbsolutePath();
+
+		String oomScript = String.format("printf '%%s\\n' 'OutOfMemoryError! Killing current process %%p...'" +
+				" 'Check gc logs and heapdump file(%s) for details.' > " + logDirectory + "/%s.err; kill -9 %%p",
+			dumpFileDestPath, ident);
+		return String.format("-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=%s -XX:OnOutOfMemoryError=\\\"%s\\\"",
+			dumpFileDestPath,
+			oomScript);
+	}
+
+	/**
+	 * Get the jvm options.
+	 * @param appId application id
+	 * @param ident the ident of the process, taskmanager/jobmanager
+	 * @param logDirectory to print some logs
+	 * @param conf flink configuration
+	 */
+	public static String getJvmOpts(
+		String appId,
+		String ident,
+		String logDirectory,
+		Configuration conf) {
+		String commonOpts = "";
+		boolean enableGCLogging = conf.getBoolean(CoreOptions.FLINK_JVM_DEFAULT_GC_LOGGING);
+		if (enableGCLogging) {
+			// Add default gc logging options if enabled
+			commonOpts += getGCLoggingOpts(logDirectory);
+		}
+		boolean enableHeapDump = conf.getBoolean(CoreOptions.FLINK_JVM_HEAPDUMP_ON_OOM);
+		if (enableHeapDump) {
+			// Add default heap dump options if enabled
+			String heapdumpDir = conf.getString(CoreOptions.FLINK_JVM_HEAPDUMP_DIRECTORY);
+			commonOpts += " " + getHeapdumpOpts(appId, ident, logDirectory, heapdumpDir);
+		}
+		if (!conf.getString(CoreOptions.FLINK_JVM_OPTIONS).isEmpty()) {
+			commonOpts += " " + conf.getString(CoreOptions.FLINK_JVM_OPTIONS);
+		}
+		return commonOpts;
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
@@ -149,8 +149,7 @@ public class BootstrapToolsTest extends TestLogger {
 	@Test
 	public void testGetTaskManagerShellCommand() {
 		final Configuration cfg = new Configuration();
-		cfg.setBoolean(CoreOptions.FLINK_JVM_DEFAULT_GC_LOGGING, true);
-		cfg.setString(CoreOptions.FLINK_JVM_HEAPDUMP_DIRECTORY, "/tmp");
+		cfg.setBoolean(CoreOptions.JVM_GC_LOGGING, true);
 		final TaskExecutorProcessSpec taskExecutorProcessSpec = new TaskExecutorProcessSpec(
 			new CPUResource(1.0),
 			new MemorySize(0), // frameworkHeapSize
@@ -167,8 +166,9 @@ public class BootstrapToolsTest extends TestLogger {
 		// no logging, with/out krb5
 		final String java = "$JAVA_HOME/bin/java";
 		final String jvmmem = "-Xmx111 -Xms111 -XX:MaxDirectMemorySize=222 -XX:MaxMetaspaceSize=333";
-		final String defaultGCLoggingOpts = BootstrapTools.getGCLoggingOpts("./logs");
-		final String heapdumpOpts = BootstrapTools.getHeapdumpOpts("test", "taskmanager", "./logs", "/tmp");
+		final String identifier = "taskmanager";
+		final String defaultGCLoggingOpts = BootstrapTools.getGCLoggingOpts("./logs", identifier);
+		final String heapdumpOpts = BootstrapTools.getCrashOnOOMOpts("test", identifier, cfg.getString(CoreOptions.JVM_HEAPDUMP_DIRECTORY));
 		final String jvmOpts = "-Djvm"; // if set
 		final String tmJvmOpts = "-DtmJvm"; // if set
 		final String logfile = "-Dlog.file=./logs/taskmanager.log"; // if set

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
@@ -149,6 +149,8 @@ public class BootstrapToolsTest extends TestLogger {
 	@Test
 	public void testGetTaskManagerShellCommand() {
 		final Configuration cfg = new Configuration();
+		cfg.setBoolean(CoreOptions.FLINK_JVM_DEFAULT_GC_LOGGING, true);
+		cfg.setString(CoreOptions.FLINK_JVM_HEAPDUMP_DIRECTORY, "/tmp");
 		final TaskExecutorProcessSpec taskExecutorProcessSpec = new TaskExecutorProcessSpec(
 			new CPUResource(1.0),
 			new MemorySize(0), // frameworkHeapSize
@@ -165,6 +167,8 @@ public class BootstrapToolsTest extends TestLogger {
 		// no logging, with/out krb5
 		final String java = "$JAVA_HOME/bin/java";
 		final String jvmmem = "-Xmx111 -Xms111 -XX:MaxDirectMemorySize=222 -XX:MaxMetaspaceSize=333";
+		final String defaultGCLoggingOpts = BootstrapTools.getGCLoggingOpts("./logs");
+		final String heapdumpOpts = BootstrapTools.getHeapdumpOpts("test", "taskmanager", "./logs", "/tmp");
 		final String jvmOpts = "-Djvm"; // if set
 		final String tmJvmOpts = "-DtmJvm"; // if set
 		final String logfile = "-Dlog.file=./logs/taskmanager.log"; // if set
@@ -183,127 +187,137 @@ public class BootstrapToolsTest extends TestLogger {
 
 		assertEquals(
 			java + " " + jvmmem +
-				"" + // jvmOpts
-				"" + // logging
+				" " + defaultGCLoggingOpts +
+				" " + heapdumpOpts +
 				" " + mainClass + " " + dynamicConfigs + " " + basicArgs + " " + redirects,
 			BootstrapTools
-				.getTaskManagerShellCommand(cfg, containeredParams, "./conf", "./logs",
-					false, false, false, this.getClass(), ""));
+				.getTaskManagerShellCommand(cfg, containeredParams, "test", "./conf", "./logs",
+					false, false, false, this.getClass(), "").trim());
 
 		assertEquals(
 			java + " " + jvmmem +
-				"" + // jvmOpts
-				"" + // logging
+				" " + defaultGCLoggingOpts +
+				" " + heapdumpOpts +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
-				.getTaskManagerShellCommand(cfg, containeredParams, "./conf", "./logs",
+				.getTaskManagerShellCommand(cfg, containeredParams, "test", "./conf", "./logs",
 					false, false, false, this.getClass(), mainArgs));
 
 		final String krb5 = "-Djava.security.krb5.conf=krb5.conf";
 		assertEquals(
 			java + " " + jvmmem +
-				" " + krb5 + // jvmOpts
-				"" + // logging
+				" " + defaultGCLoggingOpts +
+				" " + heapdumpOpts +
+				" " + krb5 +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
-				.getTaskManagerShellCommand(cfg, containeredParams, "./conf", "./logs",
+				.getTaskManagerShellCommand(cfg, containeredParams, "test", "./conf", "./logs",
 					false, false, true, this.getClass(), mainArgs));
 
 		// logback only, with/out krb5
 		assertEquals(
 			java + " " + jvmmem +
-				"" + // jvmOpts
+				" " + defaultGCLoggingOpts +
+				" " + heapdumpOpts +
 				" " + logfile + " " + logback +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
-				.getTaskManagerShellCommand(cfg, containeredParams, "./conf", "./logs",
+				.getTaskManagerShellCommand(cfg, containeredParams, "test", "./conf", "./logs",
 					true, false, false, this.getClass(), mainArgs));
 
 		assertEquals(
 			java + " " + jvmmem +
-				" " + krb5 + // jvmOpts
+				" " + defaultGCLoggingOpts +
+				" " + heapdumpOpts +
+				" " + krb5 +
 				" " + logfile + " " + logback +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
-				.getTaskManagerShellCommand(cfg, containeredParams, "./conf", "./logs",
+				.getTaskManagerShellCommand(cfg, containeredParams, "test", "./conf", "./logs",
 					true, false, true, this.getClass(), mainArgs));
 
 		// log4j, with/out krb5
 		assertEquals(
 			java + " " + jvmmem +
-				"" + // jvmOpts
+				" " + defaultGCLoggingOpts +
+				" " + heapdumpOpts +
 				" " + logfile + " " + log4j +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
-				.getTaskManagerShellCommand(cfg, containeredParams, "./conf", "./logs",
+				.getTaskManagerShellCommand(cfg, containeredParams, "test", "./conf", "./logs",
 					false, true, false, this.getClass(), mainArgs));
 
 		assertEquals(
 			java + " " + jvmmem +
-				" " + krb5 + // jvmOpts
+				" " + defaultGCLoggingOpts +
+				" " + heapdumpOpts +
+				" " + krb5 +
 				" " + logfile + " " + log4j +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
-				.getTaskManagerShellCommand(cfg, containeredParams, "./conf", "./logs",
+				.getTaskManagerShellCommand(cfg, containeredParams, "test", "./conf", "./logs",
 					false, true, true, this.getClass(), mainArgs));
 
 		// logback + log4j, with/out krb5
 		assertEquals(
 			java + " " + jvmmem +
-				"" + // jvmOpts
+				" " + defaultGCLoggingOpts +
+				" " + heapdumpOpts +
 				" " + logfile + " " + logback + " " + log4j +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
-				.getTaskManagerShellCommand(cfg, containeredParams, "./conf", "./logs",
+				.getTaskManagerShellCommand(cfg, containeredParams, "test", "./conf", "./logs",
 					true, true, false, this.getClass(), mainArgs));
 
 		assertEquals(
 			java + " " + jvmmem +
-				" " + krb5 + // jvmOpts
+				" " + defaultGCLoggingOpts +
+				" " + heapdumpOpts +
+				" " + krb5 +
 				" " + logfile + " " + logback + " " + log4j +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
-				.getTaskManagerShellCommand(cfg, containeredParams, "./conf", "./logs",
+				.getTaskManagerShellCommand(cfg, containeredParams, "test", "./conf", "./logs",
 					true, true, true, this.getClass(), mainArgs));
 
 		// logback + log4j, with/out krb5, different JVM opts
 		cfg.setString(CoreOptions.FLINK_JVM_OPTIONS, jvmOpts);
 		assertEquals(
 			java + " " + jvmmem +
-				" " + jvmOpts +
+				" " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts +
 				" " + logfile + " " + logback + " " + log4j +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
-				.getTaskManagerShellCommand(cfg, containeredParams, "./conf", "./logs",
+				.getTaskManagerShellCommand(cfg, containeredParams, "test", "./conf", "./logs",
 					true, true, false, this.getClass(), mainArgs));
 
 		assertEquals(
 			java + " " + jvmmem +
-				" " + jvmOpts + " " + krb5 + // jvmOpts
+				" " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts + " " + krb5 + // jvmOpts
 				" " + logfile + " " + logback + " " + log4j +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
-				.getTaskManagerShellCommand(cfg, containeredParams, "./conf", "./logs",
+				.getTaskManagerShellCommand(cfg, containeredParams, "test", "./conf", "./logs",
 					true, true, true, this.getClass(), mainArgs));
 
 		// logback + log4j, with/out krb5, different JVM opts
 		cfg.setString(CoreOptions.FLINK_TM_JVM_OPTIONS, tmJvmOpts);
 		assertEquals(
 			java + " " + jvmmem +
-				" " + jvmOpts + " " + tmJvmOpts +
+				" " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts + " " + tmJvmOpts +
 				" " + logfile + " " + logback + " " + log4j +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
-				.getTaskManagerShellCommand(cfg, containeredParams, "./conf", "./logs",
+				.getTaskManagerShellCommand(cfg, containeredParams, "test", "./conf", "./logs",
 					true, true, false, this.getClass(), mainArgs));
 
 		assertEquals(
 			java + " " + jvmmem +
-				" " + jvmOpts + " " + tmJvmOpts + " " + krb5 + // jvmOpts
+				" " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts + " " + tmJvmOpts + " " + krb5 + // jvmOpts
 				" " + logfile + " " + logback + " " + log4j +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
-				.getTaskManagerShellCommand(cfg, containeredParams, "./conf", "./logs",
+				.getTaskManagerShellCommand(cfg, containeredParams, "test", "./conf", "./logs",
 					true, true, true, this.getClass(), mainArgs));
 
 		// now try some configurations with different yarn.container-start-command-template
@@ -312,11 +326,11 @@ public class BootstrapToolsTest extends TestLogger {
 			"%java% 1 %jvmmem% 2 %jvmopts% 3 %logging% 4 %class% 5 %args% 6 %redirects%");
 		assertEquals(
 			java + " 1 " + jvmmem +
-				" 2 " + jvmOpts + " " + tmJvmOpts + " " + krb5 + // jvmOpts
+				" 2 " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts + " " + tmJvmOpts + " " + krb5 + // jvmOpts
 				" 3 " + logfile + " " + logback + " " + log4j +
 				" 4 " + mainClass + " 5 " + args + " 6 " + redirects,
 			BootstrapTools
-				.getTaskManagerShellCommand(cfg, containeredParams, "./conf", "./logs",
+				.getTaskManagerShellCommand(cfg, containeredParams, "test", "./conf", "./logs",
 					true, true, true, this.getClass(), mainArgs));
 
 		cfg.setString(ConfigConstants.YARN_CONTAINER_START_COMMAND_TEMPLATE,
@@ -324,13 +338,12 @@ public class BootstrapToolsTest extends TestLogger {
 		assertEquals(
 			java +
 				" " + logfile + " " + logback + " " + log4j +
-				" " + jvmOpts + " " + tmJvmOpts + " " + krb5 + // jvmOpts
+				" " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts + " " + tmJvmOpts + " " + krb5 + // jvmOpts
 				" " + jvmmem +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
-				.getTaskManagerShellCommand(cfg, containeredParams, "./conf", "./logs",
+				.getTaskManagerShellCommand(cfg, containeredParams, "test", "./conf", "./logs",
 					true, true, true, this.getClass(), mainArgs));
-
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
@@ -168,7 +168,7 @@ public class BootstrapToolsTest extends TestLogger {
 		final String jvmmem = "-Xmx111 -Xms111 -XX:MaxDirectMemorySize=222 -XX:MaxMetaspaceSize=333";
 		final String identifier = "taskmanager";
 		final String defaultGCLoggingOpts = BootstrapTools.getGCLoggingOpts("./logs", identifier);
-		final String heapdumpOpts = BootstrapTools.getCrashOnOOMOpts("test", identifier, cfg.getString(CoreOptions.JVM_HEAPDUMP_DIRECTORY));
+		final String crashHeapDumpOnOOMOpts = BootstrapTools.getCrashOnOOMOpts() + " " + BootstrapTools.getHeapDumpOnOOMOpts("test", identifier, cfg.getString(CoreOptions.JVM_HEAP_DUMP_DIRECTORY));
 		final String jvmOpts = "-Djvm"; // if set
 		final String tmJvmOpts = "-DtmJvm"; // if set
 		final String logfile = "-Dlog.file=./logs/taskmanager.log"; // if set
@@ -188,7 +188,7 @@ public class BootstrapToolsTest extends TestLogger {
 		assertEquals(
 			java + " " + jvmmem +
 				" " + defaultGCLoggingOpts +
-				" " + heapdumpOpts +
+				" " + crashHeapDumpOnOOMOpts +
 				" " + mainClass + " " + dynamicConfigs + " " + basicArgs + " " + redirects,
 			BootstrapTools
 				.getTaskManagerShellCommand(cfg, containeredParams, "test", "./conf", "./logs",
@@ -197,7 +197,7 @@ public class BootstrapToolsTest extends TestLogger {
 		assertEquals(
 			java + " " + jvmmem +
 				" " + defaultGCLoggingOpts +
-				" " + heapdumpOpts +
+				" " + crashHeapDumpOnOOMOpts +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
 				.getTaskManagerShellCommand(cfg, containeredParams, "test", "./conf", "./logs",
@@ -207,7 +207,7 @@ public class BootstrapToolsTest extends TestLogger {
 		assertEquals(
 			java + " " + jvmmem +
 				" " + defaultGCLoggingOpts +
-				" " + heapdumpOpts +
+				" " + crashHeapDumpOnOOMOpts +
 				" " + krb5 +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
@@ -218,7 +218,7 @@ public class BootstrapToolsTest extends TestLogger {
 		assertEquals(
 			java + " " + jvmmem +
 				" " + defaultGCLoggingOpts +
-				" " + heapdumpOpts +
+				" " + crashHeapDumpOnOOMOpts +
 				" " + logfile + " " + logback +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
@@ -228,7 +228,7 @@ public class BootstrapToolsTest extends TestLogger {
 		assertEquals(
 			java + " " + jvmmem +
 				" " + defaultGCLoggingOpts +
-				" " + heapdumpOpts +
+				" " + crashHeapDumpOnOOMOpts +
 				" " + krb5 +
 				" " + logfile + " " + logback +
 				" " + mainClass + " " + args + " " + redirects,
@@ -240,7 +240,7 @@ public class BootstrapToolsTest extends TestLogger {
 		assertEquals(
 			java + " " + jvmmem +
 				" " + defaultGCLoggingOpts +
-				" " + heapdumpOpts +
+				" " + crashHeapDumpOnOOMOpts +
 				" " + logfile + " " + log4j +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
@@ -250,7 +250,7 @@ public class BootstrapToolsTest extends TestLogger {
 		assertEquals(
 			java + " " + jvmmem +
 				" " + defaultGCLoggingOpts +
-				" " + heapdumpOpts +
+				" " + crashHeapDumpOnOOMOpts +
 				" " + krb5 +
 				" " + logfile + " " + log4j +
 				" " + mainClass + " " + args + " " + redirects,
@@ -262,7 +262,7 @@ public class BootstrapToolsTest extends TestLogger {
 		assertEquals(
 			java + " " + jvmmem +
 				" " + defaultGCLoggingOpts +
-				" " + heapdumpOpts +
+				" " + crashHeapDumpOnOOMOpts +
 				" " + logfile + " " + logback + " " + log4j +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
@@ -272,7 +272,7 @@ public class BootstrapToolsTest extends TestLogger {
 		assertEquals(
 			java + " " + jvmmem +
 				" " + defaultGCLoggingOpts +
-				" " + heapdumpOpts +
+				" " + crashHeapDumpOnOOMOpts +
 				" " + krb5 +
 				" " + logfile + " " + logback + " " + log4j +
 				" " + mainClass + " " + args + " " + redirects,
@@ -284,7 +284,7 @@ public class BootstrapToolsTest extends TestLogger {
 		cfg.setString(CoreOptions.FLINK_JVM_OPTIONS, jvmOpts);
 		assertEquals(
 			java + " " + jvmmem +
-				" " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts +
+				" " + defaultGCLoggingOpts + " " + crashHeapDumpOnOOMOpts + " " + jvmOpts +
 				" " + logfile + " " + logback + " " + log4j +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
@@ -293,7 +293,7 @@ public class BootstrapToolsTest extends TestLogger {
 
 		assertEquals(
 			java + " " + jvmmem +
-				" " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts + " " + krb5 + // jvmOpts
+				" " + defaultGCLoggingOpts + " " + crashHeapDumpOnOOMOpts + " " + jvmOpts + " " + krb5 + // jvmOpts
 				" " + logfile + " " + logback + " " + log4j +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
@@ -304,7 +304,7 @@ public class BootstrapToolsTest extends TestLogger {
 		cfg.setString(CoreOptions.FLINK_TM_JVM_OPTIONS, tmJvmOpts);
 		assertEquals(
 			java + " " + jvmmem +
-				" " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts + " " + tmJvmOpts +
+				" " + defaultGCLoggingOpts + " " + crashHeapDumpOnOOMOpts + " " + jvmOpts + " " + tmJvmOpts +
 				" " + logfile + " " + logback + " " + log4j +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
@@ -313,7 +313,7 @@ public class BootstrapToolsTest extends TestLogger {
 
 		assertEquals(
 			java + " " + jvmmem +
-				" " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts + " " + tmJvmOpts + " " + krb5 + // jvmOpts
+				" " + defaultGCLoggingOpts + " " + crashHeapDumpOnOOMOpts + " " + jvmOpts + " " + tmJvmOpts + " " + krb5 + // jvmOpts
 				" " + logfile + " " + logback + " " + log4j +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
@@ -326,7 +326,7 @@ public class BootstrapToolsTest extends TestLogger {
 			"%java% 1 %jvmmem% 2 %jvmopts% 3 %logging% 4 %class% 5 %args% 6 %redirects%");
 		assertEquals(
 			java + " 1 " + jvmmem +
-				" 2 " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts + " " + tmJvmOpts + " " + krb5 + // jvmOpts
+				" 2 " + defaultGCLoggingOpts + " " + crashHeapDumpOnOOMOpts + " " + jvmOpts + " " + tmJvmOpts + " " + krb5 + // jvmOpts
 				" 3 " + logfile + " " + logback + " " + log4j +
 				" 4 " + mainClass + " 5 " + args + " 6 " + redirects,
 			BootstrapTools
@@ -338,7 +338,7 @@ public class BootstrapToolsTest extends TestLogger {
 		assertEquals(
 			java +
 				" " + logfile + " " + logback + " " + log4j +
-				" " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts + " " + tmJvmOpts + " " + krb5 + // jvmOpts
+				" " + defaultGCLoggingOpts + " " + crashHeapDumpOnOOMOpts + " " + jvmOpts + " " + tmJvmOpts + " " + krb5 + // jvmOpts
 				" " + jvmmem +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -505,7 +505,7 @@ public final class Utils {
 		boolean hasLog4j = new File(workingDirectory, "log4j.properties").exists();
 
 		String launchCommand = BootstrapTools.getTaskManagerShellCommand(
-				flinkConfig, tmParams, ".", ApplicationConstants.LOG_DIR_EXPANSION_VAR,
+				flinkConfig, tmParams, appId, ".", ApplicationConstants.LOG_DIR_EXPANSION_VAR,
 				hasLogback, hasLog4j, hasKrb5, taskManagerMainClass, taskManagerDynamicProperties);
 
 		if (log.isDebugEnabled()) {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -893,6 +893,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		final boolean hasLog4j = logConfigFilePath != null && logConfigFilePath.endsWith(CONFIG_FILE_LOG4J_NAME);
 
 		final ContainerLaunchContext amContainer = setupApplicationMasterContainer(
+				appId.toString(),
 				yarnClusterEntrypoint,
 				hasLogback,
 				hasLog4j,
@@ -1516,7 +1517,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		pluginsDir.ifPresent(effectiveShipFiles::add);
 	}
 
-	ContainerLaunchContext setupApplicationMasterContainer(
+	protected ContainerLaunchContext setupApplicationMasterContainer(
+			String appId,
 			String yarnClusterEntrypoint,
 			boolean hasLogback,
 			boolean hasLog4j,
@@ -1524,8 +1526,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			int jobManagerMemoryMb) {
 		// ------------------ Prepare Application Master Container  ------------------------------
 
-		// respect custom JVM options in the YAML file
-		String javaOpts = flinkConfiguration.getString(CoreOptions.FLINK_JVM_OPTIONS);
+		String javaOpts = BootstrapTools.getJvmOpts(
+			appId, "jobmanager", ApplicationConstants.LOG_DIR_EXPANSION_VAR, flinkConfiguration);
 		if (flinkConfiguration.getString(CoreOptions.FLINK_JM_JVM_OPTIONS).length() > 0) {
 			javaOpts += " " + flinkConfiguration.getString(CoreOptions.FLINK_JM_JVM_OPTIONS);
 		}

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
@@ -154,10 +155,16 @@ public class YarnClusterDescriptorTest extends TestLogger {
 	@Test
 	public void testSetupApplicationMasterContainer() {
 		Configuration cfg = new Configuration();
+		cfg.setBoolean(CoreOptions.FLINK_JVM_DEFAULT_GC_LOGGING, true);
+		cfg.setString(CoreOptions.FLINK_JVM_HEAPDUMP_DIRECTORY, "/tmp");
 		YarnClusterDescriptor clusterDescriptor = createYarnClusterDescriptor(cfg);
 
 		final String java = "$JAVA_HOME/bin/java";
 		final String jvmmem = "-Xms424m -Xmx424m";
+		final String defaultGCLoggingOpts =
+			BootstrapTools.getGCLoggingOpts(ApplicationConstants.LOG_DIR_EXPANSION_VAR);
+		final String heapdumpOpts =
+			BootstrapTools.getHeapdumpOpts("test", "jobmanager", ApplicationConstants.LOG_DIR_EXPANSION_VAR, "/tmp");
 		final String jvmOpts = "-Djvm"; // if set
 		final String jmJvmOpts = "-DjmJvm"; // if set
 		final String krb5 = "-Djava.security.krb5.conf=krb5.conf";
@@ -178,11 +185,12 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			// no logging, with/out krb5
 			assertEquals(
 				java + " " + jvmmem +
-					"" + // jvmOpts
-					"" + // logging
+					" " + defaultGCLoggingOpts +
+					" " + heapdumpOpts +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
+						"test",
 						mainClass,
 						false,
 						false,
@@ -192,11 +200,13 @@ public class YarnClusterDescriptorTest extends TestLogger {
 
 			assertEquals(
 				java + " " + jvmmem +
-					" " + krb5 + // jvmOpts
-					"" + // logging
+					" " + defaultGCLoggingOpts +
+					" " + heapdumpOpts +
+					" " + krb5 +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
+						"test",
 						mainClass,
 						false,
 						false,
@@ -207,11 +217,13 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			// logback only, with/out krb5
 			assertEquals(
 				java + " " + jvmmem +
-					"" + // jvmOpts
+					" " + defaultGCLoggingOpts +
+					" " + heapdumpOpts +
 					" " + logfile + " " + logback +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
+						"test",
 						mainClass,
 						true,
 						false,
@@ -221,11 +233,14 @@ public class YarnClusterDescriptorTest extends TestLogger {
 
 			assertEquals(
 				java + " " + jvmmem +
-					" " + krb5 + // jvmOpts
+					" " + defaultGCLoggingOpts +
+					" " + heapdumpOpts +
+					" " + krb5 +
 					" " + logfile + " " + logback +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
+						"test",
 						mainClass,
 						true,
 						false,
@@ -236,11 +251,13 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			// log4j, with/out krb5
 			assertEquals(
 				java + " " + jvmmem +
-					"" + // jvmOpts
+					" " + defaultGCLoggingOpts +
+					" " + heapdumpOpts +
 					" " + logfile + " " + log4j +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
+						"test",
 						mainClass,
 						false,
 						true,
@@ -250,11 +267,14 @@ public class YarnClusterDescriptorTest extends TestLogger {
 
 			assertEquals(
 				java + " " + jvmmem +
-					" " + krb5 + // jvmOpts
+					" " + defaultGCLoggingOpts +
+					" " + heapdumpOpts +
+					" " + krb5 +
 					" " + logfile + " " + log4j +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
+						"test",
 						mainClass,
 						false,
 						true,
@@ -265,11 +285,13 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			// logback + log4j, with/out krb5
 			assertEquals(
 				java + " " + jvmmem +
-					"" + // jvmOpts
+					" " + defaultGCLoggingOpts +
+					" " + heapdumpOpts +
 					" " + logfile + " " + logback + " " + log4j +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
+						"test",
 						mainClass,
 						true,
 						true,
@@ -279,11 +301,14 @@ public class YarnClusterDescriptorTest extends TestLogger {
 
 			assertEquals(
 				java + " " + jvmmem +
-					" " + krb5 + // jvmOpts
+					" " + defaultGCLoggingOpts +
+					" " + heapdumpOpts +
+					" " + krb5 +
 					" " + logfile + " " + logback + " " + log4j +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
+						"test",
 						mainClass,
 						true,
 						true,
@@ -297,11 +322,12 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			cfg.setString(CoreOptions.FLINK_JVM_OPTIONS, jvmOpts);
 			assertEquals(
 				java + " " + jvmmem +
-					" " + jvmOpts +
+					" " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts +
 					" " + logfile + " " + logback + " " + log4j +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
+						"test",
 						mainClass,
 						true,
 						true,
@@ -311,11 +337,12 @@ public class YarnClusterDescriptorTest extends TestLogger {
 
 			assertEquals(
 				java + " " + jvmmem +
-					" " + jvmOpts + " " + krb5 + // jvmOpts
+					" " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts + " " + krb5 + // jvmOpts
 					" " + logfile + " " + logback + " " + log4j +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
+						"test",
 						mainClass,
 						true,
 						true,
@@ -328,11 +355,12 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			cfg.setString(CoreOptions.FLINK_JM_JVM_OPTIONS, jmJvmOpts);
 			assertEquals(
 				java + " " + jvmmem +
-					" " + jvmOpts + " " + jmJvmOpts +
+					" " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts + " " + jmJvmOpts +
 					" " + logfile + " " + logback + " " + log4j +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
+						"test",
 						mainClass,
 						true,
 						true,
@@ -342,11 +370,12 @@ public class YarnClusterDescriptorTest extends TestLogger {
 
 			assertEquals(
 				java + " " + jvmmem +
-					" " + jvmOpts + " " + jmJvmOpts + " " + krb5 + // jvmOpts
+					" " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts + " " + jmJvmOpts + " " + krb5 + // jvmOpts
 					" " + logfile + " " + logback + " " + log4j +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
+						"test",
 						mainClass,
 						true,
 						true,
@@ -360,11 +389,12 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				"%java% 1 %jvmmem% 2 %jvmopts% 3 %logging% 4 %class% 5 %args% 6 %redirects%");
 			assertEquals(
 				java + " 1 " + jvmmem +
-					" 2 " + jvmOpts + " " + jmJvmOpts + " " + krb5 + // jvmOpts
+					" 2 " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts + " " + jmJvmOpts + " " + krb5 + // jvmOpts
 					" 3 " + logfile + " " + logback + " " + log4j +
 					" 4 " + mainClass + " 5 6 " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
+						"test",
 						mainClass,
 						true,
 						true,
@@ -378,11 +408,12 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			assertEquals(
 				java +
 					" " + logfile + " " + logback + " " + log4j +
-					" " + jvmOpts + " " + jmJvmOpts + " " + krb5 + // jvmOpts
+					" " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts + " " + jmJvmOpts + " " + krb5 + // jvmOpts
 					" " + jvmmem +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
+						"test",
 						mainClass,
 						true,
 						true,

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -163,8 +163,8 @@ public class YarnClusterDescriptorTest extends TestLogger {
 		final String identifier = "jobmanager";
 		final String defaultGCLoggingOpts =
 			BootstrapTools.getGCLoggingOpts(ApplicationConstants.LOG_DIR_EXPANSION_VAR, identifier);
-		final String heapdumpOpts =
-			BootstrapTools.getCrashOnOOMOpts("test", identifier, cfg.getString(CoreOptions.JVM_HEAPDUMP_DIRECTORY));
+		final String crashHeapDumpOnOOMsOpts =
+			BootstrapTools.getCrashOnOOMOpts() + " " + BootstrapTools.getHeapDumpOnOOMOpts("test", identifier, cfg.getString(CoreOptions.JVM_HEAP_DUMP_DIRECTORY));
 		final String jvmOpts = "-Djvm"; // if set
 		final String jmJvmOpts = "-DjmJvm"; // if set
 		final String krb5 = "-Djava.security.krb5.conf=krb5.conf";
@@ -186,7 +186,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			assertEquals(
 				java + " " + jvmmem +
 					" " + defaultGCLoggingOpts +
-					" " + heapdumpOpts +
+					" " + crashHeapDumpOnOOMsOpts +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
@@ -201,7 +201,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			assertEquals(
 				java + " " + jvmmem +
 					" " + defaultGCLoggingOpts +
-					" " + heapdumpOpts +
+					" " + crashHeapDumpOnOOMsOpts +
 					" " + krb5 +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
@@ -218,7 +218,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			assertEquals(
 				java + " " + jvmmem +
 					" " + defaultGCLoggingOpts +
-					" " + heapdumpOpts +
+					" " + crashHeapDumpOnOOMsOpts +
 					" " + logfile + " " + logback +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
@@ -234,7 +234,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			assertEquals(
 				java + " " + jvmmem +
 					" " + defaultGCLoggingOpts +
-					" " + heapdumpOpts +
+					" " + crashHeapDumpOnOOMsOpts +
 					" " + krb5 +
 					" " + logfile + " " + logback +
 					" " + mainClass + " " + redirects,
@@ -252,7 +252,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			assertEquals(
 				java + " " + jvmmem +
 					" " + defaultGCLoggingOpts +
-					" " + heapdumpOpts +
+					" " + crashHeapDumpOnOOMsOpts +
 					" " + logfile + " " + log4j +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
@@ -268,7 +268,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			assertEquals(
 				java + " " + jvmmem +
 					" " + defaultGCLoggingOpts +
-					" " + heapdumpOpts +
+					" " + crashHeapDumpOnOOMsOpts +
 					" " + krb5 +
 					" " + logfile + " " + log4j +
 					" " + mainClass + " " + redirects,
@@ -286,7 +286,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			assertEquals(
 				java + " " + jvmmem +
 					" " + defaultGCLoggingOpts +
-					" " + heapdumpOpts +
+					" " + crashHeapDumpOnOOMsOpts +
 					" " + logfile + " " + logback + " " + log4j +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
@@ -302,7 +302,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			assertEquals(
 				java + " " + jvmmem +
 					" " + defaultGCLoggingOpts +
-					" " + heapdumpOpts +
+					" " + crashHeapDumpOnOOMsOpts +
 					" " + krb5 +
 					" " + logfile + " " + logback + " " + log4j +
 					" " + mainClass + " " + redirects,
@@ -322,7 +322,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			cfg.setString(CoreOptions.FLINK_JVM_OPTIONS, jvmOpts);
 			assertEquals(
 				java + " " + jvmmem +
-					" " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts +
+					" " + defaultGCLoggingOpts + " " + crashHeapDumpOnOOMsOpts + " " + jvmOpts +
 					" " + logfile + " " + logback + " " + log4j +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
@@ -337,7 +337,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 
 			assertEquals(
 				java + " " + jvmmem +
-					" " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts + " " + krb5 + // jvmOpts
+					" " + defaultGCLoggingOpts + " " + crashHeapDumpOnOOMsOpts + " " + jvmOpts + " " + krb5 + // jvmOpts
 					" " + logfile + " " + logback + " " + log4j +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
@@ -355,7 +355,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			cfg.setString(CoreOptions.FLINK_JM_JVM_OPTIONS, jmJvmOpts);
 			assertEquals(
 				java + " " + jvmmem +
-					" " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts + " " + jmJvmOpts +
+					" " + defaultGCLoggingOpts + " " + crashHeapDumpOnOOMsOpts + " " + jvmOpts + " " + jmJvmOpts +
 					" " + logfile + " " + logback + " " + log4j +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
@@ -370,7 +370,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 
 			assertEquals(
 				java + " " + jvmmem +
-					" " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts + " " + jmJvmOpts + " " + krb5 + // jvmOpts
+					" " + defaultGCLoggingOpts + " " + crashHeapDumpOnOOMsOpts + " " + jvmOpts + " " + jmJvmOpts + " " + krb5 + // jvmOpts
 					" " + logfile + " " + logback + " " + log4j +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
@@ -389,7 +389,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				"%java% 1 %jvmmem% 2 %jvmopts% 3 %logging% 4 %class% 5 %args% 6 %redirects%");
 			assertEquals(
 				java + " 1 " + jvmmem +
-					" 2 " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts + " " + jmJvmOpts + " " + krb5 + // jvmOpts
+					" 2 " + defaultGCLoggingOpts + " " + crashHeapDumpOnOOMsOpts + " " + jvmOpts + " " + jmJvmOpts + " " + krb5 + // jvmOpts
 					" 3 " + logfile + " " + logback + " " + log4j +
 					" 4 " + mainClass + " 5 6 " + redirects,
 				clusterDescriptor
@@ -408,7 +408,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			assertEquals(
 				java +
 					" " + logfile + " " + logback + " " + log4j +
-					" " + defaultGCLoggingOpts + " " + heapdumpOpts + " " + jvmOpts + " " + jmJvmOpts + " " + krb5 + // jvmOpts
+					" " + defaultGCLoggingOpts + " " + crashHeapDumpOnOOMsOpts + " " + jvmOpts + " " + jmJvmOpts + " " + krb5 + // jvmOpts
 					" " + jvmmem +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -155,16 +155,16 @@ public class YarnClusterDescriptorTest extends TestLogger {
 	@Test
 	public void testSetupApplicationMasterContainer() {
 		Configuration cfg = new Configuration();
-		cfg.setBoolean(CoreOptions.FLINK_JVM_DEFAULT_GC_LOGGING, true);
-		cfg.setString(CoreOptions.FLINK_JVM_HEAPDUMP_DIRECTORY, "/tmp");
+		cfg.setBoolean(CoreOptions.JVM_GC_LOGGING, true);
 		YarnClusterDescriptor clusterDescriptor = createYarnClusterDescriptor(cfg);
 
 		final String java = "$JAVA_HOME/bin/java";
 		final String jvmmem = "-Xms424m -Xmx424m";
+		final String identifier = "jobmanager";
 		final String defaultGCLoggingOpts =
-			BootstrapTools.getGCLoggingOpts(ApplicationConstants.LOG_DIR_EXPANSION_VAR);
+			BootstrapTools.getGCLoggingOpts(ApplicationConstants.LOG_DIR_EXPANSION_VAR, identifier);
 		final String heapdumpOpts =
-			BootstrapTools.getHeapdumpOpts("test", "jobmanager", ApplicationConstants.LOG_DIR_EXPANSION_VAR, "/tmp");
+			BootstrapTools.getCrashOnOOMOpts("test", identifier, cfg.getString(CoreOptions.JVM_HEAPDUMP_DIRECTORY));
 		final String jvmOpts = "-Djvm"; // if set
 		final String jmJvmOpts = "-DjmJvm"; // if set
 		final String krb5 = "-Djava.security.krb5.conf=krb5.conf";


### PR DESCRIPTION

## What is the purpose of the change

When long full gc or oom happen in flink applications running on yarn, there are no good ways to debugging or check the reason. mostly we just got an timeout exceptions like:
```
java.lang.IllegalStateException: Update task on TaskManager container_e860_1567429198842_571077_01_000006 @ zjy-hadoop-prc-st320.bj (dataPort=50990) failed due to:
	at org.apache.flink.runtime.executiongraph.Execution.lambda$sendUpdatePartitionInfoRpcCall$14(Execution.java:1395)
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:760)
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:736)
	at java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:442)
	at org.apache.flink.runtime.rpc.akka.AkkaRpcActor.handleRunAsync(AkkaRpcActor.java:397)
	at org.apache.flink.runtime.rpc.akka.AkkaRpcActor.handleRpcMessage(AkkaRpcActor.java:190)
	at org.apache.flink.runtime.rpc.akka.FencedAkkaRpcActor.handleRpcMessage(FencedAkkaRpcActor.java:74)
	at org.apache.flink.runtime.rpc.akka.AkkaRpcActor.handleMessage(AkkaRpcActor.java:152)
	at akka.japi.pf.UnitCaseStatement.apply(CaseStatements.scala:26)
	at akka.japi.pf.UnitCaseStatement.apply(CaseStatements.scala:21)
	at scala.PartialFunction$class.applyOrElse(PartialFunction.scala:123)
	at akka.japi.pf.UnitCaseStatement.applyOrElse(CaseStatements.scala:21)
	at scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:170)
	at scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:171)
	at scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:171)
	at akka.actor.Actor$class.aroundReceive(Actor.scala:517)
	at akka.actor.AbstractActor.aroundReceive(AbstractActor.scala:225)
	at akka.actor.ActorCell.receiveMessage(ActorCell.scala:592)
	at akka.actor.ActorCell.invoke(ActorCell.scala:561)
	at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:258)
	at akka.dispatch.Mailbox.run(Mailbox.scala:225)
	at akka.dispatch.Mailbox.exec(Mailbox.scala:235)
	at akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
Caused by: java.util.concurrent.CompletionException: akka.pattern.AskTimeoutException: Ask timed out on [Actor[akka.tcp://flink@zjy-hadoop-prc-st320.bj:62051/user/taskmanager_0#-171547157]] after [10000 ms]. Message of type [org.apache.flink.runtime.rpc.messages.RemoteRpcInvocation]. A typical reason for `AskTimeoutException` is that the recipient actor didn't send a reply.
	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:292)
	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:308)
	at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:593)
	at java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:577)
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474)
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1977)
	at org.apache.flink.runtime.concurrent.FutureUtils$1.onComplete(FutureUtils.java:871)
	at akka.dispatch.OnComplete.internal(Future.scala:263)
	at akka.dispatch.OnComplete.internal(Future.scala:261)
	at akka.dispatch.japi$CallbackBridge.apply(Future.scala:191)
	at akka.dispatch.japi$CallbackBridge.apply(Future.scala:188)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:36)
	at org.apache.flink.runtime.concurrent.Executors$DirectExecutionContext.execute(Executors.java:74)
	at scala.concurrent.impl.CallbackRunnable.executeWithValue(Promise.scala:44)
	at scala.concurrent.impl.Promise$DefaultPromise.tryComplete(Promise.scala:252)
	at akka.pattern.PromiseActorRef$$anonfun$1.apply$mcV$sp(AskSupport.scala:644)
	at akka.actor.Scheduler$$anon$4.run(Scheduler.scala:205)
	at scala.concurrent.Future$InternalCallbackExecutor$.unbatchedExecute(Future.scala:601)
	at scala.concurrent.BatchingExecutor$class.execute(BatchingExecutor.scala:109)
	at scala.concurrent.Future$InternalCallbackExecutor$.execute(Future.scala:599)
	at akka.actor.LightArrayRevolverScheduler$TaskHolder.executeTask(LightArrayRevolverScheduler.scala:328)
	at akka.actor.LightArrayRevolverScheduler$$anon$4.executeBucket$1(LightArrayRevolverScheduler.scala:279)
	at akka.actor.LightArrayRevolverScheduler$$anon$4.nextTick(LightArrayRevolverScheduler.scala:283)
	at akka.actor.LightArrayRevolverScheduler$$anon$4.run(LightArrayRevolverScheduler.scala:235)
	at java.lang.Thread.run(Thread.java:748)
Caused by: akka.pattern.AskTimeoutException: Ask timed out on [Actor[akka.tcp://flink@zjy-hadoop-prc-st320.bj:62051/user/taskmanager_0#-171547157]] after [10000 ms]. Message of type [org.apache.flink.runtime.rpc.messages.RemoteRpcInvocation]. A typical reason for `AskTimeoutException` is that the recipient actor didn't send a reply.
	at akka.pattern.PromiseActorRef$$anonfun$2.apply(AskSupport.scala:635)
	at akka.pattern.PromiseActorRef$$anonfun$2.apply(AskSupport.scala:635)
	at akka.pattern.PromiseActorRef$$anonfun$1.apply$mcV$sp(AskSupport.scala:648)
	... 9 more
```
This PR is trying to add default GC options, and thus to facillitate debugging such issues.

## Brief change log

  - Add default GC options when depolying application on yarn.

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.


This change added tests and can be verified as follows:

  - slightly modified the YarnClusterDescriptorTest and BootstrapToolsTest, and passed
  - Manually tested on real yarn cluster

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
