### PR TITLE
[FLINK-11859][runtime]Improve SpanningRecordSerializer performance by serializing record length to data buffer directly.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializer.java
@@ -24,7 +24,6 @@ import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 
 /**
  * Record serializer which serializes the complete record to an intermediate
@@ -44,18 +43,11 @@ public class SpanningRecordSerializer<T extends IOReadableWritable> implements R
 	/** Intermediate buffer for data serialization (wrapped from {@link #serializationBuffer}). */
 	private ByteBuffer dataBuffer;
 
-	/** Intermediate buffer for length serialization. */
-	private final ByteBuffer lengthBuffer;
-
 	public SpanningRecordSerializer() {
 		serializationBuffer = new DataOutputSerializer(128);
 
-		lengthBuffer = ByteBuffer.allocate(4);
-		lengthBuffer.order(ByteOrder.BIG_ENDIAN);
-
 		// ensure initial state with hasRemaining false (for correct continueWritingWithNextBufferBuilder logic)
 		dataBuffer = serializationBuffer.wrapAsByteBuffer();
-		lengthBuffer.position(4);
 	}
 
 	/**
@@ -72,13 +64,16 @@ public class SpanningRecordSerializer<T extends IOReadableWritable> implements R
 		}
 
 		serializationBuffer.clear();
-		lengthBuffer.clear();
+		// the initial capacity of the serialization buffer should be no less than 4
+		serializationBuffer.skipBytesToWrite(4);
 
 		// write data and length
 		record.write(serializationBuffer);
 
-		int len = serializationBuffer.length();
-		lengthBuffer.putInt(0, len);
+		int len = serializationBuffer.length() - 4;
+		serializationBuffer.setPosition(0);
+		serializationBuffer.writeInt(len);
+		serializationBuffer.skipBytesToWrite(len);
 
 		dataBuffer = serializationBuffer.wrapAsByteBuffer();
 	}
@@ -92,7 +87,6 @@ public class SpanningRecordSerializer<T extends IOReadableWritable> implements R
 	 */
 	@Override
 	public SerializationResult copyToBufferBuilder(BufferBuilder targetBuffer) {
-		targetBuffer.append(lengthBuffer);
 		targetBuffer.append(dataBuffer);
 		targetBuffer.commit();
 
@@ -100,7 +94,7 @@ public class SpanningRecordSerializer<T extends IOReadableWritable> implements R
 	}
 
 	private SerializationResult getSerializationResult(BufferBuilder targetBuffer) {
-		if (dataBuffer.hasRemaining() || lengthBuffer.hasRemaining()) {
+		if (dataBuffer.hasRemaining()) {
 			return SerializationResult.PARTIAL_RECORD_MEMORY_SEGMENT_FULL;
 		}
 		return !targetBuffer.isFull()
@@ -111,7 +105,6 @@ public class SpanningRecordSerializer<T extends IOReadableWritable> implements R
 	@Override
 	public void reset() {
 		dataBuffer.position(0);
-		lengthBuffer.position(0);
 	}
 
 	@Override
@@ -122,6 +115,6 @@ public class SpanningRecordSerializer<T extends IOReadableWritable> implements R
 
 	@Override
 	public boolean hasSerializedData() {
-		return lengthBuffer.hasRemaining() || dataBuffer.hasRemaining();
+		return dataBuffer.hasRemaining();
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

The purpose of this pr is to improve the performance of SpanningRecordSerializer. Currently, the data and length filed of a serialized record are stored separately in two buffer (the lengthBuffer and the serializationBuffer), thus need two times of copy when transferring the intermediate data to BufferBuilder. This pr tries to optimize the serialization process by removing the lengthBuffer and write the length field to serializationBuffer directly, which can avoid the copy of length buffer.

## Brief change log

  - *Remove the length buffer of SpanningRecordSerializer and serialize the record length to data buffer directly. More specifically, the initial 4 bytes of the data buffer is reserved for length field and after the the serialization of record, the reserved space will be filled with record length.*


## Verifying this change

 - This change is already covered by existing tests, such as *SpanningRecordSerializerTest* and *SpanningRecordSerializationTest*.
 - The performance gain is proved by the micro-benchmark and the whole results can be found in this jira [FLINK-11859](https://issues.apache.org/jira/browse/FLINK-11859). 


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
