### PR TITLE
[FLINK-14033][yarn] upload user artifacts for yarn job cluster

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -573,6 +573,15 @@ public class JobGraph implements Serializable {
 		));
 	}
 
+	public void setUserArtifactRemotePath(String entryName, String remotePath) {
+		userArtifacts.computeIfPresent(entryName, (key, originalEntry) -> new DistributedCache.DistributedCacheEntry(
+			remotePath,
+			originalEntry.isExecutable,
+			null,
+			originalEntry.isZipped
+		));
+	}
+
 	public void writeUserArtifactEntriesToConfiguration() {
 		for (Map.Entry<String, DistributedCache.DistributedCacheEntry> userArtifact : userArtifacts.entrySet()) {
 			DistributedCache.writeFileInfoToConfig(

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.yarn;
 
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.AkkaOptions;
@@ -32,7 +31,6 @@ import org.apache.flink.yarn.util.YarnTestUtils;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
-import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -48,7 +46,6 @@ import static org.apache.flink.yarn.configuration.YarnConfigOptions.CLASSPATH_IN
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 /**
  * Test cases for the deployment of Yarn Flink clusters.
@@ -129,31 +126,9 @@ public class YARNITCase extends YarnTestBase {
 				assertThat(jobResult, is(notNullValue()));
 				assertThat(jobResult.getSerializedThrowable().isPresent(), is(false));
 
-				waitApplicationFinishedElseKillIt(applicationId, yarnAppTerminateTimeout, yarnClusterDescriptor);
+				waitApplicationFinishedElseKillIt(
+					applicationId, yarnAppTerminateTimeout, yarnClusterDescriptor, sleepIntervalInMS);
 			}
 		}
 	}
-
-	private void waitApplicationFinishedElseKillIt(
-			ApplicationId applicationId,
-			Duration timeout,
-			YarnClusterDescriptor yarnClusterDescriptor) throws Exception {
-		Deadline deadline = Deadline.now().plus(timeout);
-		YarnApplicationState state = getYarnClient().getApplicationReport(applicationId).getYarnApplicationState();
-
-		while (state != YarnApplicationState.FINISHED) {
-			if (state == YarnApplicationState.FAILED || state == YarnApplicationState.KILLED) {
-				fail("Application became FAILED or KILLED while expecting FINISHED");
-			}
-
-			if (deadline.isOverdue()) {
-				yarnClusterDescriptor.killCluster(applicationId);
-				fail("Application didn't finish before timeout");
-			}
-
-			sleep(sleepIntervalInMS);
-			state = getYarnClient().getApplicationReport(applicationId).getYarnApplicationState();
-		}
-	}
-
 }

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnDistributedCacheITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnDistributedCacheITCase.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.flink.client.deployment.ClusterSpecification;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.AkkaOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.yarn.testjob.YarnTestCacheJob;
+import org.apache.flink.yarn.util.YarnTestUtils;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.client.api.YarnClient;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test cases for the deployment of Yarn Flink with Distributed Cache.
+ */
+public class YarnDistributedCacheITCase extends YarnTestBase {
+
+	private final Duration yarnAppTerminateTimeout = Duration.ofSeconds(10);
+
+	private final int sleepIntervalInMS = 100;
+
+	@BeforeClass
+	public static void setup() {
+		YARN_CONFIGURATION.set(YarnTestBase.TEST_CLUSTER_NAME_KEY, "flink-yarn-tests-with-distributed-cache");
+		startYARNWithConfig(YARN_CONFIGURATION);
+	}
+
+	@Test
+	public void testPerJobModeWithDistributedCache() throws Exception {
+		runTest(() -> {
+			Configuration configuration = new Configuration();
+			configuration.setString(AkkaOptions.ASK_TIMEOUT, "30 s");
+			final YarnClient yarnClient = getYarnClient();
+
+			try (final YarnClusterDescriptor yarnClusterDescriptor = new YarnClusterDescriptor(
+				configuration,
+				getYarnConfiguration(),
+				yarnClient,
+				true)) {
+
+				yarnClusterDescriptor.setLocalJarPath(new Path(flinkUberjar.getAbsolutePath()));
+				yarnClusterDescriptor.addShipFiles(Arrays.asList(flinkLibFolder.listFiles()));
+				yarnClusterDescriptor.addShipFiles(Arrays.asList(flinkShadedHadoopDir.listFiles()));
+
+				final ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
+					.setMasterMemoryMB(768)
+					.setTaskManagerMemoryMB(1024)
+					.setSlotsPerTaskManager(1)
+					.setNumberTaskManagers(1)
+					.createClusterSpecification();
+
+				final JobGraph jobGraph = YarnTestCacheJob.getDistributedCacheJobGraph();
+
+				File testingJar = YarnTestBase.findFile("..", new YarnTestUtils.TestJarFinder("flink-yarn-tests"));
+
+				jobGraph.addJar(new org.apache.flink.core.fs.Path(testingJar.toURI()));
+
+				try (ClusterClient<ApplicationId> clusterClient = yarnClusterDescriptor.deployJobCluster(
+					clusterSpecification,
+					jobGraph,
+					false)) {
+
+					ApplicationId applicationId = clusterClient.getClusterId();
+
+					final CompletableFuture<JobResult> jobResultCompletableFuture = clusterClient.requestJobResult(jobGraph.getJobID());
+
+					final JobResult jobResult = jobResultCompletableFuture.get();
+
+					assertThat(jobResult, is(notNullValue()));
+					assertThat(jobResult.getSerializedThrowable().isPresent(), is(false));
+
+					waitApplicationFinishedElseKillIt(applicationId, yarnAppTerminateTimeout, yarnClusterDescriptor, sleepIntervalInMS);
+				}
+			}
+		});
+	}
+}

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/testjob/YarnTestCacheJob.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/testjob/YarnTestCacheJob.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn.testjob;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableList;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Properties;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * Testing job for distributed cache in per job cluster mode.
+ */
+public class YarnTestCacheJob {
+	private static final List<String> LIST = ImmutableList.of("test1", "test2");
+
+	public static JobGraph getDistributedCacheJobGraph() {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		String cacheFilePath = Thread.currentThread().getContextClassLoader().getResource("cache.properties").getFile();
+
+		env.registerCachedFile(cacheFilePath, "cacheFile", false);
+
+		env.addSource(new GenericSourceFunction(LIST, TypeInformation.of(String.class)))
+			.setParallelism(1)
+			.map(new MapperFunction(), TypeInformation.of(String.class))
+			.setParallelism(1)
+			.addSink(new DiscardingSink<String>())
+			.setParallelism(1);
+
+		return env.getStreamGraph().getJobGraph();
+	}
+
+	private static class MapperFunction extends RichMapFunction<String, String> {
+		private Properties properties;
+		private static final long serialVersionUID = -1238033916372648233L;
+
+		@Override
+		public void open(Configuration config) throws IOException {
+			// access cached file via RuntimeContext and DistributedCache
+			File cacheFile = getRuntimeContext().getDistributedCache().getFile("cacheFile");
+			FileInputStream inputStream = new FileInputStream(cacheFile);
+			properties = new Properties();
+			properties.load(inputStream);
+			checkArgument(properties.size() == 2, "The property file should contains 2 pair of key values");
+		}
+
+		@Override
+		public String map(String value) {
+			return (String) properties.getOrDefault(value, "null");
+		}
+	}
+
+	private static class GenericSourceFunction<T> implements SourceFunction<T>, ResultTypeQueryable<T> {
+		private List<T> inputDataset;
+		private TypeInformation returnType;
+
+		GenericSourceFunction(List<T> inputDataset, TypeInformation returnType) {
+			this.inputDataset = inputDataset;
+			this.returnType = returnType;
+		}
+
+		@Override
+		public void run(SourceContext<T> ctx) throws Exception {
+
+			for (T t : inputDataset) {
+				ctx.collect(t);
+			}
+		}
+
+		@Override
+		public void cancel() {}
+
+		@Override
+		public TypeInformation getProducedType() {
+			return this.returnType;
+		}
+	}
+}

--- a/flink-yarn-tests/src/test/resources/cache.properties
+++ b/flink-yarn-tests/src/test/resources/cache.properties
@@ -1,0 +1,20 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+test1=hello
+test2=world


### PR DESCRIPTION
## What is the purpose of the change

Upload user artifacts that registered in distributed caches for yarn job clusters. Currently, distributed caches are not handled correctly. The solution proposed is to upload local files onto the remote file system and update the registered file in cache entry. 

## Brief change-log
  - Modified the AbstractClusterDescriptor to handle with artifacts for per job mode before starting 
     application master.

## Verifying this change

The change is end to end testing in YarnDistributedCacheITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
