### PR TITLE
[hotfix][API/DataStream] Add missing assert for checkpoint lock checks

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
@@ -209,7 +209,7 @@ public class ContinuousFileReaderOperator<OUT> extends AbstractStreamOperator<OU
 
 	private void waitSplitReaderFinished() throws InterruptedException {
 		// make sure that we hold the checkpointing lock
-		Thread.holdsLock(checkpointLock);
+		assert Thread.holdsLock(checkpointLock);
 
 		// close the reader to signal that no more splits will come. By doing this,
 		// the reader will exit as soon as it finishes processing the already pending splits.


### PR DESCRIPTION
## What is the purpose of the change

The return value of `Thread.holdsLock(checkpointLock)` is unused, which are supposed to be validated by an assertion instead.

## Brief change log

- Add assert clause to validate the return value of `Thread.holdsLock(checkpointLock)`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
