### PR TITLE
[FLINK-13993][runtime] Using FlinkUserCodeClassLoaders to load the user class in the perjob mode

### DIFF
--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -65,7 +65,7 @@
         <tr>
             <td><h5>yarn.per-job-cluster.include-user-jar</h5></td>
             <td style="word-wrap: break-word;">"ORDER"</td>
-            <td>Defines whether user-jars are included in the system class path for per-job-clusters as well as their positioning in the path. They can be positioned at the beginning ("FIRST"), at the end ("LAST"), or be positioned based on their name ("ORDER").</td>
+            <td>Defines whether user-jars are included in the system class path for per-job-clusters as well as their positioning in the path. They can be positioned at the beginning ("FIRST"), at the end ("LAST"), or be positioned based on their name ("ORDER"). "DISABLED" means the user-jars are excluded from the system class path.</td>
         </tr>
         <tr>
             <td><h5>yarn.properties-file.location</h5></td>

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -183,8 +183,6 @@ public class PackagedProgram {
 			}
 
 			checkJarFile(jarFileUrl);
-		} else if (!isPython) {
-			throw new IllegalArgumentException("The jar file must not be null.");
 		}
 
 		this.jarFile = jarFileUrl;

--- a/flink-clients/src/test/java/org/apache/flink/client/program/PackagedProgramTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/PackagedProgramTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.client.program;
 
+import org.apache.flink.client.cli.CliFrontendTestUtils;
 import org.apache.flink.configuration.ConfigConstants;
 
 import org.junit.Assert;
@@ -28,9 +29,12 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.nio.file.Files;
+import java.util.Collections;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+
+import static org.junit.Assert.fail;
 
 /**
  * Tests for the {@link PackagedProgram}.
@@ -55,6 +59,18 @@ public class PackagedProgramTest {
 		final List<File> files = PackagedProgram.extractContainedLibraries(fakeJar.toURI().toURL());
 		Assert.assertEquals(1, files.size());
 		Assert.assertArrayEquals(nestedJarContent, Files.readAllBytes(files.iterator().next().toPath()));
+	}
+
+	@Test
+	public void testNotThrowExceptionWhenJarFileIsNull() {
+		try {
+			new PackagedProgram(null,
+				Collections.singletonList(new File(CliFrontendTestUtils.getTestJarPath()).toURI().toURL()),
+				"org.apache.flink.client.testjar.WordCount", new String[0]);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail("can not throw exception");
+		}
 	}
 
 	private static final class NullOutputStream extends java.io.OutputStream {

--- a/flink-container/docker/Dockerfile
+++ b/flink-container/docker/Dockerfile
@@ -28,6 +28,7 @@ ENV FLINK_LIB_DIR $FLINK_HOME/lib
 ENV FLINK_PLUGINS_DIR $FLINK_HOME/plugins
 ENV FLINK_OPT_DIR $FLINK_HOME/opt
 ENV FLINK_JOB_ARTIFACTS_DIR $FLINK_INSTALL_PATH/artifacts
+ENV FLINK_JOB_DIR $FLINK_HOME/job
 ENV PATH $PATH:$FLINK_HOME/bin
 
 # flink-dist can point to a directory or a tarball on the local system
@@ -51,7 +52,7 @@ ADD $job_artifacts/* $FLINK_JOB_ARTIFACTS_DIR/
 
 RUN set -x && \
   ln -s $FLINK_INSTALL_PATH/flink-[0-9]* $FLINK_HOME && \
-  for jar in $FLINK_JOB_ARTIFACTS_DIR/*.jar; do [ -f "$jar" ] || continue; ln -s $jar $FLINK_LIB_DIR; done && \
+  ln -s $FLINK_JOB_ARTIFACTS_DIR $FLINK_JOB_DIR && \
   if [ -n "$python_version" ]; then ln -s $FLINK_OPT_DIR/flink-python*.jar $FLINK_LIB_DIR; fi && \
   if [ -f ${FLINK_INSTALL_PATH}/flink-shaded-hadoop* ]; then ln -s ${FLINK_INSTALL_PATH}/flink-shaded-hadoop* $FLINK_LIB_DIR; fi && \
   addgroup -S flink && adduser -D -S -H -G flink -h $FLINK_HOME flink && \

--- a/flink-container/pom.xml
+++ b/flink-container/pom.xml
@@ -95,6 +95,66 @@ under the License.
 							</descriptors>
 						</configuration>
 					</execution>
+					<execution>
+						<id>create-test-dependency-user-jar</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<archive>
+								<manifest>
+									<mainClass>org.apache.flink.container.entrypoint.testjar.UserJar</mainClass>
+								</manifest>
+							</archive>
+							<finalName>maven</finalName>
+							<attach>false</attach>
+							<descriptors>
+								<descriptor>src/test/assembly/test-assembly-user-jar.xml</descriptor>
+							</descriptors>
+						</configuration>
+					</execution>
+					<execution>
+						<id>create-test-dependency-user-jar-depend</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<finalName>maven</finalName>
+							<attach>false</attach>
+							<descriptors>
+								<descriptor>src/test/assembly/test-assembly-user-jar-depend-jar.xml</descriptor>
+							</descriptors>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<!--Remove the external jar test code from the test-classes directory since it mustn't be in the
+			classpath when running the tests to actually test whether the user code class loader
+			is properly used.-->
+			<plugin>
+				<artifactId>maven-clean-plugin</artifactId>
+				<version>2.5</version><!--$NO-MVN-MAN-VER$-->
+				<executions>
+					<execution>
+						<id>remove-externaltestclasses</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>clean</goal>
+						</goals>
+						<configuration>
+							<excludeDefaultDirectories>true</excludeDefaultDirectories>
+							<filesets>
+								<fileset>
+									<directory>${project.build.testOutputDirectory}</directory>
+									<includes>
+										<include>**/testjar/*.class</include>
+									</includes>
+								</fileset>
+							</filesets>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 		</plugins>

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPoint.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPoint.java
@@ -77,7 +77,7 @@ public final class StandaloneJobClusterEntryPoint extends JobClusterEntrypoint {
 	protected DispatcherResourceManagerComponentFactory<?> createDispatcherResourceManagerComponentFactory(Configuration configuration) {
 		return new JobDispatcherResourceManagerComponentFactory(
 			StandaloneResourceManagerFactory.INSTANCE,
-			new ClassPathJobGraphRetriever(jobId, savepointRestoreSettings, programArguments, jobClassName));
+			new ClassPathJobGraphRetriever(jobId, savepointRestoreSettings, programArguments, jobClassName, null));
 	}
 
 	public static void main(String[] args) {

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPoint.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPoint.java
@@ -36,9 +36,11 @@ import org.apache.flink.runtime.util.SignalHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.nio.file.Paths;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_HOME_DIR;
 
 /**
  * {@link JobClusterEntrypoint} which is started with a job in a predefined
@@ -60,6 +62,8 @@ public final class StandaloneJobClusterEntryPoint extends JobClusterEntrypoint {
 	@Nullable
 	private final String jobClassName;
 
+	private static final String DEFAULT_FLINK_HOME = "/opt/flink";
+
 	private StandaloneJobClusterEntryPoint(
 			Configuration configuration,
 			@Nonnull JobID jobId,
@@ -77,7 +81,9 @@ public final class StandaloneJobClusterEntryPoint extends JobClusterEntrypoint {
 	protected DispatcherResourceManagerComponentFactory<?> createDispatcherResourceManagerComponentFactory(Configuration configuration) {
 		return new JobDispatcherResourceManagerComponentFactory(
 			StandaloneResourceManagerFactory.INSTANCE,
-			new ClassPathJobGraphRetriever(jobId, savepointRestoreSettings, programArguments, jobClassName, null));
+			new ClassPathJobGraphRetriever(jobId, savepointRestoreSettings, programArguments, jobClassName,
+				Paths.get(System.getenv(ENV_FLINK_HOME_DIR) == null ? DEFAULT_FLINK_HOME : System.getenv(ENV_FLINK_HOME_DIR),
+					ClassPathJobGraphRetriever.DEFAULT_JOB_DIR).toString()));
 	}
 
 	public static void main(String[] args) {

--- a/flink-container/src/test/assembly/test-assembly-user-jar-depend-jar.xml
+++ b/flink-container/src/test/assembly/test-assembly-user-jar-depend-jar.xml
@@ -1,0 +1,35 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<assembly>
+	<id>test-user-jar-depend</id>
+	<formats>
+		<format>jar</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.testOutputDirectory}</directory>
+			<outputDirectory>/</outputDirectory>
+			<includes>
+				<include>org/apache/flink/container/entrypoint/testjar/UserJarDepend.class</include>
+			</includes>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/flink-container/src/test/assembly/test-assembly-user-jar.xml
+++ b/flink-container/src/test/assembly/test-assembly-user-jar.xml
@@ -1,0 +1,35 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<assembly>
+	<id>test-user-jar</id>
+	<formats>
+		<format>jar</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.testOutputDirectory}</directory>
+			<outputDirectory>/</outputDirectory>
+			<includes>
+				<include>org/apache/flink/container/entrypoint/testjar/UserJar.class</include>
+			</includes>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/testjar/UserJar.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/testjar/UserJar.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.container.entrypoint.testjar;
+
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+
+/**
+ * This class can used to test situation that the jar is not in the system classpath.
+ */
+public class UserJar {
+	public static void main(String[] args) throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		final DataStreamSource<Integer> source = env.fromElements(new UserJarDepend().getValue(), 1, 2, 3, 4);
+		final SingleOutputStreamOperator<Integer> mapper = source.map(element -> 2 * element);
+		mapper.addSink(new DiscardingSink<>());
+
+		ParameterTool parameterTool = ParameterTool.fromArgs(args);
+		env.execute(UserJar.class.getCanonicalName() + "-" + parameterTool.getRequired("arg"));
+	}
+}

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/testjar/UserJarDepend.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/testjar/UserJarDepend.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.container.entrypoint.testjar;
+
+/**
+ * This class is depended by {@link UserJar}.
+ */
+class UserJarDepend {
+
+	private int value = 0;
+
+	int getValue() {
+		return value;
+	}
+}

--- a/flink-mesos/pom.xml
+++ b/flink-mesos/pom.xml
@@ -146,6 +146,13 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-shaded-hadoop-2</artifactId>
+			<version>${hadoop.version}-${flink.shaded.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>
@@ -288,6 +295,22 @@ under the License.
 									<shadedPattern>org.apache.flink.mesos.shaded.com.fasterxml.jackson</shadedPattern>
 								</relocation>
 							</relocations>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>dependency-convergence</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<skip>true</skip>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
@@ -92,7 +92,7 @@ public class MesosJobClusterEntrypoint extends JobClusterEntrypoint {
 
 		// TM configuration
 		taskManagerParameters = MesosEntrypointUtils.createTmParameters(config, LOG);
-		taskManagerContainerSpec = MesosEntrypointUtils.createContainerSpec(config, dynamicProperties);
+		taskManagerContainerSpec = MesosEntrypointUtils.createJobClusterContainerSpec(config, dynamicProperties);
 	}
 
 	@Override

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosSessionClusterEntrypoint.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosSessionClusterEntrypoint.java
@@ -91,7 +91,7 @@ public class MesosSessionClusterEntrypoint extends SessionClusterEntrypoint {
 
 		// TM configuration
 		taskManagerParameters = MesosEntrypointUtils.createTmParameters(config, LOG);
-		taskManagerContainerSpec = MesosEntrypointUtils.createContainerSpec(config, dynamicProperties);
+		taskManagerContainerSpec = MesosEntrypointUtils.createSessionClusterContainerSpec(config, dynamicProperties);
 	}
 
 	@Override

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/entrypoint/MesosEntrypointUtilsTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/entrypoint/MesosEntrypointUtilsTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.mesos.entrypoint;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.runtime.clusterframework.overlays.ContainerOverlay;
+import org.apache.flink.runtime.clusterframework.overlays.FlinkDistributionOverlay;
+import org.apache.flink.runtime.clusterframework.overlays.FlinkJobOverlay;
+import org.apache.flink.runtime.clusterframework.overlays.HadoopConfOverlay;
+import org.apache.flink.runtime.clusterframework.overlays.HadoopUserOverlay;
+import org.apache.flink.runtime.clusterframework.overlays.KeytabOverlay;
+import org.apache.flink.runtime.clusterframework.overlays.Krb5ConfOverlay;
+import org.apache.flink.runtime.clusterframework.overlays.SSLStoreOverlay;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_BIN_DIR;
+import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_CONF_DIR;
+import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_LIB_DIR;
+import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_PLUGINS_DIR;
+
+
+/**
+ * Test for {@link MesosEntrypointUtils}.
+ */
+public class MesosEntrypointUtilsTest {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+
+	File binFolder;
+	File libFolder;
+	File pluginsFolder;
+	File confFolder;
+
+	@Before
+	public void init() throws IOException {
+		binFolder = temporaryFolder.newFolder("bin");
+		libFolder = temporaryFolder.newFolder("lib");
+		pluginsFolder = temporaryFolder.newFolder("plugins");
+		confFolder = temporaryFolder.newFolder("conf");
+
+		// adjust the test environment for the purposes of this test
+		Map<String, String> map = new HashMap<>(System.getenv());
+		map.put(ENV_FLINK_BIN_DIR, binFolder.getAbsolutePath());
+		map.put(ENV_FLINK_LIB_DIR, libFolder.getAbsolutePath());
+		map.put(ENV_FLINK_PLUGINS_DIR, pluginsFolder.getAbsolutePath());
+		map.put(ENV_FLINK_CONF_DIR, confFolder.getAbsolutePath());
+		CommonTestUtils.setEnv(map);
+	}
+
+	@Test
+	public void testBuildSessionOverlays() throws IOException {
+
+		Configuration configuration = new Configuration();
+		List<ContainerOverlay> containerOverlays =
+			MesosEntrypointUtils.buildOverlays(new Configuration(), false);
+		List<Class> expectedClass =
+			Arrays.asList(HadoopConfOverlay.newBuilder().fromEnvironment(configuration).build().getClass(),
+				HadoopUserOverlay.newBuilder().fromEnvironment(configuration).build().getClass(),
+				KeytabOverlay.newBuilder().fromEnvironment(configuration).build().getClass(),
+				Krb5ConfOverlay.newBuilder().fromEnvironment(configuration).build().getClass(),
+				SSLStoreOverlay.newBuilder().fromEnvironment(configuration).build().getClass(),
+				FlinkDistributionOverlay.newBuilder().fromEnvironment(configuration).build().getClass()
+			);
+
+		List<Class> results = containerOverlays.stream().map(ContainerOverlay::getClass).collect(Collectors.toList());
+
+		assert(CollectionUtils.isEqualCollection(expectedClass, results));
+	}
+
+	@Test
+	public void testBuildJobOverlays() throws IOException {
+
+		Configuration configuration = new Configuration();
+		List<ContainerOverlay> containerOverlays =
+			MesosEntrypointUtils.buildOverlays(new Configuration(), true);
+		List<Class> expectedClass =
+			Arrays.asList(HadoopConfOverlay.newBuilder().fromEnvironment(configuration).build().getClass(),
+				HadoopUserOverlay.newBuilder().fromEnvironment(configuration).build().getClass(),
+				KeytabOverlay.newBuilder().fromEnvironment(configuration).build().getClass(),
+				Krb5ConfOverlay.newBuilder().fromEnvironment(configuration).build().getClass(),
+				SSLStoreOverlay.newBuilder().fromEnvironment(configuration).build().getClass(),
+				FlinkJobOverlay.newBuilder().fromEnvironment(configuration).build().getClass()
+			);
+
+		List<Class> results = containerOverlays.stream().map(ContainerOverlay::getClass).collect(Collectors.toList());
+
+		assert(CollectionUtils.isEqualCollection(expectedClass, results));
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlay.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlay.java
@@ -52,7 +52,8 @@ public class FlinkDistributionOverlay extends AbstractContainerOverlay {
 
 	private static final Logger LOG = LoggerFactory.getLogger(FlinkDistributionOverlay.class);
 
-	static final Path TARGET_ROOT = new Path("flink");
+	static final String TARGET_ROOT_STR = "./";
+	static final Path TARGET_ROOT = new Path(TARGET_ROOT_STR);
 
 	final File flinkBinPath;
 	final File flinkConfPath;
@@ -69,7 +70,7 @@ public class FlinkDistributionOverlay extends AbstractContainerOverlay {
 	@Override
 	public void configure(ContainerSpecification container) throws IOException {
 
-		container.getEnvironmentVariables().put(ENV_FLINK_HOME_DIR, TARGET_ROOT.toString());
+		container.getEnvironmentVariables().put(ENV_FLINK_HOME_DIR, TARGET_ROOT_STR);
 
 		// add the paths to the container specification.
 		addPathRecursively(flinkBinPath, TARGET_ROOT, container);
@@ -108,7 +109,6 @@ public class FlinkDistributionOverlay extends AbstractContainerOverlay {
 			flinkConfPath = getObligatoryFileFromEnvironment(ENV_FLINK_CONF_DIR);
 			flinkLibPath = getObligatoryFileFromEnvironment(ENV_FLINK_LIB_DIR);
 			flinkPluginsPath = getObligatoryFileFromEnvironment(ENV_FLINK_PLUGINS_DIR);
-
 			return this;
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/FlinkJobOverlay.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/FlinkJobOverlay.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.clusterframework.overlays;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.clusterframework.ContainerSpecification;
+import org.apache.flink.runtime.entrypoint.component.AbstractUserClassPathJobGraphRetriever;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+
+
+/**
+ * Overlays Flink and Job into a container, based on supplied bin/conf/lib/plugins/job directories.
+ * The following files are copied to the container:
+ *  - bin/
+ *  - conf/
+ *  - lib/
+ *  - plugins/
+ *  - job/
+ */
+public class FlinkJobOverlay extends FlinkDistributionOverlay {
+
+	private static final Logger LOG = LoggerFactory.getLogger(FlinkJobOverlay.class);
+
+	private final File jobPath;
+
+	FlinkJobOverlay(File flinkBinPath, File flinkConfPath,
+					File flinkLibPath, File flinkPluginsPath, File jobPath) {
+		super(flinkBinPath, flinkConfPath, flinkLibPath, flinkPluginsPath);
+		this.jobPath = jobPath;
+	}
+
+	@Override
+	public void configure(ContainerSpecification container) throws IOException {
+		super.configure(container);
+		if (jobPath.isDirectory()) {
+			addPathRecursively(jobPath, TARGET_ROOT, container);
+		} else {
+			LOG.warn("The job directory '" + jobPath + "' doesn't exist.");
+		}
+	}
+
+	public static FlinkJobOverlay.Builder newBuilder() {
+		return new FlinkJobOverlay.Builder();
+	}
+
+	/**
+	 * A builder for the {@link FlinkJobOverlay}.
+	 */
+	public static class Builder extends FlinkDistributionOverlay.Builder {
+		File jobPath;
+
+		/**
+		 * Configures the overlay using the current environment.
+		 *
+		 * @param globalConfiguration the current configuration.
+		 */
+		public FlinkJobOverlay.Builder fromEnvironment(Configuration globalConfiguration) {
+			super.fromEnvironment(globalConfiguration);
+			jobPath = new File(
+				Paths.get(AbstractUserClassPathJobGraphRetriever.DEFAULT_JOB_DIR).toAbsolutePath().toUri());
+			return this;
+		}
+
+		public FlinkJobOverlay build() {
+			return new FlinkJobOverlay(flinkBinPath, flinkConfPath, flinkLibPath, flinkPluginsPath, jobPath);
+		}
+
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetriever.java
@@ -93,10 +93,16 @@ public abstract class AbstractUserClassPathJobGraphRetriever implements JobGraph
 				throws IOException {
 				FileVisitResult fileVisitResult = super.visitFile(file, attrs);
 				if (file.getFileName().toString().endsWith(".jar")) {
-					log.debug("add " + file.toUri().toURL() + " to user classpath");
-					jarURLs.add(file.toUri().toURL());
+					log.info("add " + file.toString() + " to user classpath");
+					if (file.isAbsolute()) {
+						jarURLs.add(file.toUri().toURL());
+					} else {
+						jarURLs.add(
+							new URL(new URL(file.getFileName().toUri().getScheme() + ":"), file.toString())
+						);
+					}
 				}
-					return fileVisitResult;
+				return fileVisitResult;
 			}
 		});
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetriever.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint.component;
+
+import org.apache.flink.core.fs.Path;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ *  Abstract class for the JobGraphRetriever, which wants to get classpath user's code depends on.
+ */
+
+public abstract class AbstractUserClassPathJobGraphRetriever implements JobGraphRetriever {
+
+	private final Logger log = LoggerFactory.getLogger(getClass());
+
+	public static final String DEFAULT_JOB_DIR = "job";
+
+	/** The directory contains all the jars, which user code depends on. */
+	@Nullable
+	private final String jobDir;
+
+	private List<URL> userClassPaths;
+
+	public AbstractUserClassPathJobGraphRetriever(String jobDir) {
+		this.jobDir = jobDir;
+	}
+
+	public List<URL> getUserClassPaths() throws IOException {
+		if (userClassPaths == null) {
+			userClassPaths = scanJarsInJobClassDir(jobDir);
+		}
+		return userClassPaths;
+	}
+
+	private List<URL> scanJarsInJobClassDir(String dir) throws IOException {
+
+		if (dir == null) {
+			return Collections.emptyList();
+		}
+
+		final File dirFile = new File(new Path(dir).toString());
+		final List<URL> jarURLs = new LinkedList<>();
+
+		if (!dirFile.exists()) {
+			log.warn("the job dir " + dirFile + " dose not exists.");
+			return Collections.emptyList();
+		}
+		if (!dirFile.isDirectory()) {
+			log.warn("the job dir " + dirFile + " is not a directory.");
+			return Collections.emptyList();
+		}
+
+		Files.walkFileTree(dirFile.toPath(),
+			EnumSet.of(FileVisitOption.FOLLOW_LINKS),
+			Integer.MAX_VALUE,
+			new SimpleFileVisitor<java.nio.file.Path>(){
+
+			@Override
+			public FileVisitResult visitFile(java.nio.file.Path file, BasicFileAttributes attrs)
+				throws IOException {
+				FileVisitResult fileVisitResult = super.visitFile(file, attrs);
+				if (file.getFileName().toString().endsWith(".jar")) {
+					log.debug("add " + file.toUri().toURL() + " to user classpath");
+					jarURLs.add(file.toUri().toURL());
+				}
+					return fileVisitResult;
+			}
+		});
+
+		if (jarURLs.isEmpty()) {
+			return Collections.emptyList();
+		} else {
+				return jarURLs;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -105,6 +106,42 @@ public class AbstractUserClassPathJobGraphRetrieverTest {
 			new TestJobGraphRetrieverTest(jobDir.toString());
 
 		assertTrue(CollectionUtils.isEqualCollection(expectedUrls, testJobGraphRetrieverTest.getUserClassPaths()));
+	}
+
+	@Test
+	public void testGetUserClassPathWithRelativeJobDir() throws IOException {
+		Path jobRelativeDir = Paths.get("_job_dir");
+		Path jobRelativeSubDir = Paths.get("_job_dir", "_sub_dir");
+		Path jarFile1 = Paths.get(jobRelativeDir.toString(), "file1.jar");
+		Path jarFile2 = Paths.get(jobRelativeSubDir.toString(), "file2.jar");
+
+		URL context = new URL(jobRelativeDir.toUri().getScheme() + ":");
+		List<URL> expectedURLs = Arrays.asList(
+			new URL(context, jarFile1.toString()), new URL(context, jarFile2.toString()));
+
+		try {
+			if (!Files.exists(jobRelativeDir)) {
+				Files.createDirectory(jobRelativeDir);
+			}
+			if (!Files.exists(jobRelativeSubDir)) {
+				Files.createDirectory(jobRelativeSubDir);
+			}
+			if (!Files.exists(jarFile1)) {
+				Files.createFile(jarFile1);
+			}
+			if (!Files.exists(jarFile2)) {
+				Files.createFile(jarFile2);
+			}
+
+			TestJobGraphRetrieverTest testJobGraphRetrieverTest =
+				new TestJobGraphRetrieverTest(jobRelativeDir.toString());
+			assertTrue(CollectionUtils.isEqualCollection(expectedURLs, testJobGraphRetrieverTest.getUserClassPaths()));
+		} finally {
+			Files.deleteIfExists(jarFile1);
+			Files.deleteIfExists(jarFile2);
+			Files.deleteIfExists(jobRelativeSubDir);
+			Files.deleteIfExists(jobRelativeDir);
+		}
 	}
 
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint.component;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the {@link AbstractUserClassPathJobGraphRetriever}.
+ */
+public class AbstractUserClassPathJobGraphRetrieverTest {
+
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	/**
+	 * Test class.
+	 */
+	public static class TestJobGraphRetrieverTest extends AbstractUserClassPathJobGraphRetriever {
+
+		public TestJobGraphRetrieverTest(String jobDir) {
+			super(jobDir);
+		}
+
+		@Override
+		public JobGraph retrieveJobGraph(Configuration configuration) {
+			return null;
+		}
+	}
+
+	@Test
+	public void testGetUserClassPathFromAFile() throws IOException {
+		final String fileName = "a.jar";
+		File file = temporaryFolder.newFile(fileName);
+
+		TestJobGraphRetrieverTest testJobGraphRetrieverTest = new TestJobGraphRetrieverTest(file.getAbsolutePath());
+
+		assertEquals(Collections.emptyList(), testJobGraphRetrieverTest.getUserClassPaths());
+	}
+
+	@Test
+	public void testGetUserClassPathFormADoesNotExistsFile() throws IOException {
+		final String fileName = "_does_not_exists_file";
+		final String doesNotExistsFilePath = temporaryFolder.getRoot() + "/" + fileName;
+
+		TestJobGraphRetrieverTest testJobGraphRetrieverTest = new TestJobGraphRetrieverTest(doesNotExistsFilePath);
+
+		assertEquals(Collections.emptyList(), testJobGraphRetrieverTest.getUserClassPaths());
+
+	}
+
+	@Test
+	public void testGetUserClassPath() throws IOException {
+
+		final Path jobDir = temporaryFolder.newFolder("_job_dir").toPath();
+		final Path jobSubDir1 = Files.createDirectory(jobDir.resolve("_sub_dir1"));
+		final Path jobSubDir2 = Files.createDirectory(jobDir.resolve("_sub_dir2"));
+		final Path jarFile1 = Files.createFile(jobDir.resolve("file1.jar"));
+		final Path jarFile2 = Files.createFile(jobDir.resolve("file2.jar"));
+		final Path jarFile3 = Files.createFile(jobSubDir1.resolve("file3.jar"));
+		final Path jarFile4 = Files.createFile(jobSubDir2.resolve("file4.jar"));
+
+		Files.createFile(jobDir.resolve("file1.txt"));
+		Files.createFile(jobSubDir2.resolve("file2.txt"));
+
+		List<URL> expectedUrls = Arrays.asList(jarFile1.toUri().toURL(),
+			jarFile2.toUri().toURL(),
+			jarFile3.toUri().toURL(),
+			jarFile4.toUri().toURL());
+
+		TestJobGraphRetrieverTest testJobGraphRetrieverTest =
+			new TestJobGraphRetrieverTest(jobDir.toString());
+
+		assertTrue(CollectionUtils.isEqualCollection(expectedUrls, testJobGraphRetrieverTest.getUserClassPaths()));
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/FileJobGraphRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/FileJobGraphRetrieverTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint.component;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.util.FlinkException;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.nio.file.StandardOpenOption.CREATE;
+import static org.junit.Assert.assertTrue;
+
+
+
+/**
+ * Tests for the {@link FileJobGraphRetriever}.
+ */
+public class FileJobGraphRetrieverTest {
+
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private Path jobGraphPath;
+	private Path jarFileInJobGraph;
+	private Configuration configuration;
+
+	@Before
+	public void init() throws IOException {
+		jobGraphPath = temporaryFolder.newFile("job.graph").toPath();
+		jarFileInJobGraph = temporaryFolder.newFile("jar_file_in_job_graph.jar").toPath();
+		JobVertex source = new JobVertex("source");
+		JobVertex target = new JobVertex("target");
+		target.connectNewDataSetAsInput(source, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
+		JobGraph jobGraph = new JobGraph(new JobID(), "test", source, target);
+		jobGraph.setClasspaths(Arrays.asList(jarFileInJobGraph.toUri().toURL()));
+
+		ObjectOutputStream objectOutputStream = new ObjectOutputStream(Files.newOutputStream(jobGraphPath, CREATE));
+		objectOutputStream.writeObject(jobGraph);
+		configuration = new Configuration();
+		configuration.setString(FileJobGraphRetriever.JOB_GRAPH_FILE_PATH.key(), jobGraphPath.toString());
+	}
+
+	@Test
+	public void testRetrieveJobGraphWithJarInJobDir() throws IOException, FlinkException {
+
+		Path jobDir = Paths.get("job");
+		Path jarFileInJobDir = Paths.get(jobDir.toString(), "jar_file_in_job_dir.jar");
+
+		final List<URL> expectedUrls = Arrays.asList(
+			jarFileInJobGraph.toUri().toURL(),
+			new URL(new URL(jarFileInJobDir.toUri().getScheme() + ":"), jarFileInJobDir.toString()));
+		try {
+			if (!Files.exists(jobDir)) {
+				Files.createDirectory(jobDir);
+			}
+			if (!Files.exists(jarFileInJobDir)) {
+				Files.createFile(jarFileInJobDir);
+			}
+
+			FileJobGraphRetriever fileJobGraphRetriever = FileJobGraphRetriever.createFrom(configuration);
+			JobGraph jobGraphFromFile = fileJobGraphRetriever.retrieveJobGraph(configuration);
+			assertTrue(CollectionUtils.isEqualCollection(expectedUrls, jobGraphFromFile.getClasspaths()));
+		} finally {
+			Files.deleteIfExists(jarFileInJobDir);
+			Files.deleteIfExists(jobDir);
+		}
+	}
+
+	@Test
+	public void testRetrieveJobGraphWithOutJobDir() throws IOException, FlinkException {
+		FileJobGraphRetriever fileJobGraphRetriever = FileJobGraphRetriever.createFrom(configuration);
+		List<URL> expectedUrls = Arrays.asList(jarFileInJobGraph.toUri().toURL());
+		JobGraph jobGraph = fileJobGraphRetriever.retrieveJobGraph(configuration);
+		assertTrue(CollectionUtils.isEqualCollection(expectedUrls, jobGraph.getClasspaths()));
+	}
+
+}

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -29,13 +29,13 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.yarn.configuration.YarnConfigOptions;
 import org.apache.flink.yarn.util.YarnTestUtils;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.client.api.YarnClient;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -44,6 +44,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 
+import static org.apache.flink.yarn.configuration.YarnConfigOptions.CLASSPATH_INCLUDE_USER_JAR;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -65,71 +66,80 @@ public class YARNITCase extends YarnTestBase {
 	}
 
 	@Test
-	public void testPerJobMode() throws Exception {
-		runTest(() -> {
-			Configuration configuration = new Configuration();
-			configuration.setString(AkkaOptions.ASK_TIMEOUT, "30 s");
-			final YarnClient yarnClient = getYarnClient();
+	public void testPerJobModeWithEnableSystemClassPathIncludeUserJar() throws Exception {
+		runTest(() -> deployPerjob(YarnConfigOptions.UserJarInclusion.FIRST));
+	}
 
-			try (final YarnClusterDescriptor yarnClusterDescriptor = new YarnClusterDescriptor(
-				configuration,
-				getYarnConfiguration(),
-				System.getenv(ConfigConstants.ENV_FLINK_CONF_DIR),
-				yarnClient,
-				true)) {
+	@Test
+	public void testPerJobModeWithDisableSystemClassPathIncludeUserJar() throws Exception {
+		runTest(() -> deployPerjob(YarnConfigOptions.UserJarInclusion.DISABLED));
+	}
 
-				yarnClusterDescriptor.setLocalJarPath(new Path(flinkUberjar.getAbsolutePath()));
-				yarnClusterDescriptor.addShipFiles(Arrays.asList(flinkLibFolder.listFiles()));
-				yarnClusterDescriptor.addShipFiles(Arrays.asList(flinkShadedHadoopDir.listFiles()));
+	private void deployPerjob(YarnConfigOptions.UserJarInclusion userJarInclusion) throws Exception {
+		Configuration configuration = new Configuration();
+		configuration.setString(AkkaOptions.ASK_TIMEOUT, "30 s");
+		configuration.setString(CLASSPATH_INCLUDE_USER_JAR, userJarInclusion.toString());
 
-				final ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
-					.setMasterMemoryMB(768)
-					.setTaskManagerMemoryMB(1024)
-					.setSlotsPerTaskManager(1)
-					.setNumberTaskManagers(1)
-					.createClusterSpecification();
+		final YarnClient yarnClient = getYarnClient();
 
-				StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-				env.setParallelism(2);
+		try (final YarnClusterDescriptor yarnClusterDescriptor = new YarnClusterDescriptor(
+			configuration,
+			getYarnConfiguration(),
+			System.getenv(ConfigConstants.ENV_FLINK_CONF_DIR),
+			yarnClient,
+			true)) {
 
-				env.addSource(new NoDataSource())
-					.shuffle()
-					.addSink(new DiscardingSink<>());
+			yarnClusterDescriptor.setLocalJarPath(new Path(flinkUberjar.getAbsolutePath()));
+			yarnClusterDescriptor.addShipFiles(Arrays.asList(flinkLibFolder.listFiles()));
+			yarnClusterDescriptor.addShipFiles(Arrays.asList(flinkShadedHadoopDir.listFiles()));
 
-				final JobGraph jobGraph = env.getStreamGraph().getJobGraph();
+			final ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
+				.setMasterMemoryMB(768)
+				.setTaskManagerMemoryMB(1024)
+				.setSlotsPerTaskManager(1)
+				.setNumberTaskManagers(1)
+				.createClusterSpecification();
 
-				File testingJar = YarnTestBase.findFile("..", new YarnTestUtils.TestJarFinder("flink-yarn-tests"));
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setParallelism(2);
 
-				jobGraph.addJar(new org.apache.flink.core.fs.Path(testingJar.toURI()));
+			env.addSource(new NoDataSource())
+				.shuffle()
+				.addSink(new DiscardingSink<>());
 
-				ApplicationId applicationId = null;
-				ClusterClient<ApplicationId> clusterClient = null;
+			final JobGraph jobGraph = env.getStreamGraph().getJobGraph();
 
-				try {
-					clusterClient = yarnClusterDescriptor.deployJobCluster(
-						clusterSpecification,
-						jobGraph,
-						false);
-					applicationId = clusterClient.getClusterId();
+			File testingJar = YarnTestBase.findFile("..", new YarnTestUtils.TestJarFinder("flink-yarn-tests"));
 
-					assertThat(clusterClient, is(instanceOf(RestClusterClient.class)));
-					final RestClusterClient<ApplicationId> restClusterClient = (RestClusterClient<ApplicationId>) clusterClient;
+			jobGraph.addJar(new org.apache.flink.core.fs.Path(testingJar.toURI()));
 
-					final CompletableFuture<JobResult> jobResultCompletableFuture = restClusterClient.requestJobResult(jobGraph.getJobID());
+			ApplicationId applicationId = null;
+			ClusterClient<ApplicationId> clusterClient = null;
 
-					final JobResult jobResult = jobResultCompletableFuture.get();
+			try {
+				clusterClient = yarnClusterDescriptor.deployJobCluster(
+					clusterSpecification,
+					jobGraph,
+					false);
+				applicationId = clusterClient.getClusterId();
 
-					assertThat(jobResult, is(notNullValue()));
-					assertThat(jobResult.getSerializedThrowable().isPresent(), is(false));
+				assertThat(clusterClient, is(instanceOf(RestClusterClient.class)));
+				final RestClusterClient<ApplicationId> restClusterClient = (RestClusterClient<ApplicationId>) clusterClient;
 
-					waitApplicationFinishedElseKillIt(applicationId, yarnAppTerminateTimeout, yarnClusterDescriptor);
-				} finally {
-					if (clusterClient != null) {
-						clusterClient.close();
-					}
+				final CompletableFuture<JobResult> jobResultCompletableFuture = restClusterClient.requestJobResult(jobGraph.getJobID());
+
+				final JobResult jobResult = jobResultCompletableFuture.get();
+
+				assertThat(jobResult, is(notNullValue()));
+				assertThat(jobResult.getSerializedThrowable().isPresent(), is(false));
+
+				waitApplicationFinishedElseKillIt(applicationId, yarnAppTerminateTimeout, yarnClusterDescriptor);
+			} finally {
+				if (clusterClient != null) {
+					clusterClient.close();
 				}
 			}
-		});
+		}
 	}
 
 	private void waitApplicationFinishedElseKillIt(

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -60,14 +60,15 @@ public class YarnConfigOptions {
 	/**
 	 * Defines whether user-jars are included in the system class path for per-job-clusters as well as their positioning
 	 * in the path. They can be positioned at the beginning ("FIRST"), at the end ("LAST"), or be positioned based on
-	 * their name ("ORDER").
+	 * their name ("ORDER"). "DISABLED" means the user-jars are excluded from the system class path.
 	 */
 	public static final ConfigOption<String> CLASSPATH_INCLUDE_USER_JAR =
 		key("yarn.per-job-cluster.include-user-jar")
 			.defaultValue("ORDER")
 			.withDescription("Defines whether user-jars are included in the system class path for per-job-clusters as" +
 				" well as their positioning in the path. They can be positioned at the beginning (\"FIRST\"), at the" +
-				" end (\"LAST\"), or be positioned based on their name (\"ORDER\").");
+				" end (\"LAST\"), or be positioned based on their name (\"ORDER\"). \"DISABLED\" means the user-jars " +
+				"are excluded from the system class path.");
 
 	/**
 	 * The vcores exposed by YARN.
@@ -211,6 +212,7 @@ public class YarnConfigOptions {
 
 	/** @see YarnConfigOptions#CLASSPATH_INCLUDE_USER_JAR */
 	public enum UserJarInclusion {
+		DISABLED,
 		FIRST,
 		LAST,
 		ORDER

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -91,23 +91,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 	public static void tearDownClass() {
 		yarnClient.stop();
 	}
-
-	/**
-	 * @see <a href="https://issues.apache.org/jira/browse/FLINK-11781">FLINK-11781</a>
-	 */
-	@Test
-	public void testThrowsExceptionIfUserTriesToDisableUserJarInclusionInSystemClassPath() {
-		final Configuration configuration = new Configuration();
-		configuration.setString(YarnConfigOptions.CLASSPATH_INCLUDE_USER_JAR, "DISABLED");
-
-		try {
-			createYarnClusterDescriptor(configuration);
-			fail("Expected exception not thrown");
-		} catch (final IllegalArgumentException e) {
-			assertThat(e.getMessage(), containsString("cannot be set to DISABLED anymore"));
-		}
-	}
-
+	
 	@Test
 	public void testFailIfTaskSlotsHigherThanMaxVcores() throws ClusterDeploymentException {
 		final Configuration flinkConfiguration = new Configuration();

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTestS3ITCase.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTestS3ITCase.java
@@ -157,7 +157,7 @@ public class YarnFileStageTestS3ITCase extends TestLogger {
 			final Path directory = new Path(basePath, pathSuffix);
 
 			YarnFileStageTest.testCopyFromLocalRecursive(fs.getHadoopFileSystem(),
-				new org.apache.hadoop.fs.Path(directory.toUri()), tempFolder, true);
+				new org.apache.hadoop.fs.Path(directory.toUri()), tempFolder, false, true);
 		} finally {
 			// clean up
 			fs.delete(basePath, true);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, Flink has the FlinkUserCodeClassLoader, which is using to load user’s class. However, the user class and the system class are all loaded by the system classloader in the perjob mode. This introduces some conflicts.

This pull request makes the FlinkUserClassLoader load the user class in perjob mode. 

## Brief change log
- *Introduce the `AbstractUserClassPathJobGraphRetriever`  to get the user classpath.*
- *`ClassPathJobGraphRetriever` sets the user classpath to JobGraph.*
- *`StandaloneJobClusterEntryPoint` use the "FLINK_HOME/job" as the default user classpath.*
- *`FlinkJobGraphRetirever` uses the "job" as the default user classpath.*
- *The system classpath does not include the user jars in yarn perjob mode if setting the yarn.per-job-cluster.include-user-jar to "DISABLE".*
- *`MesosJobClusterEntrypoint` uses the "job" directory as the default user classpath.*


## Verifying this change

This change added tests and can be verified as follows:
 - *Add some tests for the classloader.*
 - *The Standalone perjob mode can be covered by test_docker_embedded end-to-end test.*
 - *Add two integration tests for Yarn perjob mode.*
 - *Manually verifed Mesos perjob mode(Mesos/ Marathon).*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)