### PR TITLE
[FLINK-13971][rest]Add TaskManager ID in JobVertexTaskManagersInfo.TaskManagersInfo

### DIFF
--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -3509,6 +3509,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
             "additionalProperties" : {
               "type" : "integer"
             }
+          },
+          "taskmanager-id" : {
+            "type" : "string"
           }
         }
       }

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -1637,7 +1637,7 @@
           "type" : "array",
           "items" : {
             "type" : "object",
-            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobVertexDetailsInfo:SubtaskExecutionAttemptDetailsInfo",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:SubtaskExecutionAttemptDetailsInfo",
             "properties" : {
               "subtask" : {
                 "type" : "integer"

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexTaskManagersInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexTaskManagersInfo.java
@@ -105,6 +105,7 @@ public class JobVertexTaskManagersInfo implements ResponseBody {
 		public static final String TASK_MANAGERS_FIELD_DURATION = "duration";
 		public static final String TASK_MANAGERS_FIELD_METRICS = "metrics";
 		public static final String TASK_MANAGERS_FIELD_STATUS_COUNTS = "status-counts";
+		public static final String TASK_MANAGERS_FIELD_TASKMANAGER_ID = "taskmanager-id";
 
 		@JsonProperty(TASK_MANAGERS_FIELD_HOST)
 		private final String host;
@@ -127,6 +128,9 @@ public class JobVertexTaskManagersInfo implements ResponseBody {
 		@JsonProperty(TASK_MANAGERS_FIELD_STATUS_COUNTS)
 		private final Map<ExecutionState, Integer> statusCounts;
 
+		@JsonProperty(TASK_MANAGERS_FIELD_TASKMANAGER_ID)
+		private final String taskmanagerId;
+
 		@JsonCreator
 		public TaskManagersInfo(
 				@JsonProperty(TASK_MANAGERS_FIELD_HOST) String host,
@@ -135,7 +139,8 @@ public class JobVertexTaskManagersInfo implements ResponseBody {
 				@JsonProperty(TASK_MANAGERS_FIELD_END_TIME) long endTime,
 				@JsonProperty(TASK_MANAGERS_FIELD_DURATION) long duration,
 				@JsonProperty(TASK_MANAGERS_FIELD_METRICS) IOMetricsInfo metrics,
-				@JsonProperty(TASK_MANAGERS_FIELD_STATUS_COUNTS) Map<ExecutionState, Integer> statusCounts) {
+				@JsonProperty(TASK_MANAGERS_FIELD_STATUS_COUNTS) Map<ExecutionState, Integer> statusCounts,
+				@JsonProperty(TASK_MANAGERS_FIELD_TASKMANAGER_ID) String taskmanagerId) {
 			this.host = checkNotNull(host);
 			this.status = checkNotNull(status);
 			this.startTime = startTime;
@@ -143,6 +148,7 @@ public class JobVertexTaskManagersInfo implements ResponseBody {
 			this.duration = duration;
 			this.metrics = checkNotNull(metrics);
 			this.statusCounts = checkNotNull(statusCounts);
+			this.taskmanagerId = taskmanagerId;
 		}
 
 		@Override
@@ -160,12 +166,13 @@ public class JobVertexTaskManagersInfo implements ResponseBody {
 				endTime == that.endTime &&
 				duration == that.duration &&
 				Objects.equals(metrics, that.metrics) &&
-				Objects.equals(statusCounts, that.statusCounts);
+				Objects.equals(statusCounts, that.statusCounts) &&
+				Objects.equals(taskmanagerId, that.taskmanagerId);
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(host, status, startTime, endTime, duration, metrics, statusCounts);
+			return Objects.hash(host, status, startTime, endTime, duration, metrics, statusCounts, taskmanagerId);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobVertexTaskManagersInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobVertexTaskManagersInfoTest.java
@@ -58,7 +58,7 @@ public class JobVertexTaskManagersInfoTest extends RestResponseMarshallingTestBa
 		for (ExecutionState executionState : ExecutionState.values()) {
 			statusCounts.put(executionState, count++);
 		}
-		taskManagersInfoList.add(new TaskManagersInfo("host1", ExecutionState.CANCELING, 1L, 2L, 3L, jobVertexMetrics, statusCounts));
+		taskManagersInfoList.add(new TaskManagersInfo("host1", ExecutionState.CANCELING, 1L, 2L, 3L, jobVertexMetrics, statusCounts, "taskmanagerId"));
 
 		return new JobVertexTaskManagersInfo(new JobVertexID(), "test", System.currentTimeMillis(), taskManagersInfoList);
 	}


### PR DESCRIPTION


## What is the purpose of the change
- User could get taskmanager id from vertex's taskmanager



## Brief change log

- Add TaskManager ID in JobVertexTaskManagersInfo.TaskManagersInfo


## Verifying this change



This change is already covered by existing tests, such as JobVertexTaskManagersInfoTest.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (don't know)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
