### PR TITLE
[FLINK-14113][client] Remove class JobWithJars

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
@@ -16,99 +16,22 @@
  * limitations under the License.
  */
 
-package org.apache.flink.client.program;
+package org.apache.flink.client;
 
-import org.apache.flink.api.common.Plan;
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.jar.JarFile;
 
 /**
- * A JobWithJars is a Flink dataflow plan, together with a bunch of JAR files that contain
- * the classes of the functions and libraries necessary for the execution.
+ * Utility functions for Flink client.
  */
-public class JobWithJars {
-
-	private Plan plan;
-
-	private List<URL> jarFiles;
-
-	/**
-	 * classpaths that are needed during user code execution.
-	 */
-	private List<URL> classpaths;
-
-	private ClassLoader userCodeClassLoader;
-
-	public JobWithJars(Plan plan, List<URL> jarFiles, List<URL> classpaths) throws IOException {
-		this.plan = plan;
-		this.jarFiles = new ArrayList<URL>(jarFiles.size());
-		this.classpaths = new ArrayList<URL>(classpaths.size());
-
-		for (URL jarFile: jarFiles) {
-			checkJarFile(jarFile);
-			this.jarFiles.add(jarFile);
-		}
-
-		for (URL path: classpaths) {
-			this.classpaths.add(path);
-		}
-	}
-
-	public JobWithJars(Plan plan, URL jarFile) throws IOException {
-		this.plan = plan;
-
-		checkJarFile(jarFile);
-		this.jarFiles = Collections.singletonList(jarFile);
-		this.classpaths = Collections.<URL>emptyList();
-	}
-
-	JobWithJars(Plan plan, List<URL> jarFiles, List<URL> classpaths, ClassLoader userCodeClassLoader) {
-		this.plan = plan;
-		this.jarFiles = jarFiles;
-		this.classpaths = classpaths;
-		this.userCodeClassLoader = userCodeClassLoader;
-	}
-
-	/**
-	 * Returns the plan.
-	 */
-	public Plan getPlan() {
-		return this.plan;
-	}
-
-	/**
-	 * Returns list of jar files that need to be submitted with the plan.
-	 */
-	public List<URL> getJarFiles() {
-		return this.jarFiles;
-	}
-
-	/**
-	 * Returns list of classpaths that need to be submitted with the plan.
-	 */
-	public List<URL> getClasspaths() {
-		return classpaths;
-	}
-
-	/**
-	 * Gets the {@link java.lang.ClassLoader} that must be used to load user code classes.
-	 *
-	 * @return The user code ClassLoader.
-	 */
-	public ClassLoader getUserCodeClassLoader() {
-		if (this.userCodeClassLoader == null) {
-			this.userCodeClassLoader = buildUserCodeClassLoader(jarFiles, classpaths, getClass().getClassLoader());
-		}
-		return this.userCodeClassLoader;
-	}
+public enum ClientUtils {
+	;
 
 	public static void checkJarFile(URL jar) throws IOException {
 		File jarFile;
@@ -124,6 +47,7 @@ public class JobWithJars {
 			throw new IOException("JAR file can't be read '" + jarFile.getAbsolutePath() + '\'');
 		}
 
+		//noinspection EmptyTryBlock
 		try (JarFile ignored = new JarFile(jarFile)) {
 			// verify that we can open the Jar file
 		} catch (IOException e) {

--- a/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
@@ -47,7 +47,6 @@ public enum ClientUtils {
 			throw new IOException("JAR file can't be read '" + jarFile.getAbsolutePath() + '\'');
 		}
 
-		//noinspection EmptyTryBlock
 		try (JarFile ignored = new JarFile(jarFile)) {
 			// verify that we can open the Jar file
 		} catch (IOException e) {

--- a/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
@@ -22,11 +22,11 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.PlanExecutor;
 import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.client.program.JobWithJars;
 import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 
 import java.net.InetSocketAddress;
 import java.net.URL;
@@ -56,17 +56,23 @@ public class RemoteExecutor extends PlanExecutor {
 	private int defaultParallelism = 1;
 
 	public RemoteExecutor(String hostname, int port) {
-		this(hostname, port, new Configuration(), Collections.<URL>emptyList(),
-				Collections.<URL>emptyList());
+		this(hostname, port, new Configuration(), Collections.emptyList(), Collections.emptyList());
 	}
 
-	public RemoteExecutor(String hostname, int port, Configuration clientConfiguration,
-			List<URL> jarFiles, List<URL> globalClasspaths) {
+	public RemoteExecutor(
+		String hostname,
+		int port,
+		Configuration clientConfiguration,
+		List<URL> jarFiles,
+		List<URL> globalClasspaths) {
 		this(new InetSocketAddress(hostname, port), clientConfiguration, jarFiles, globalClasspaths);
 	}
 
-	public RemoteExecutor(InetSocketAddress inet, Configuration clientConfiguration,
-			List<URL> jarFiles, List<URL> globalClasspaths) {
+	public RemoteExecutor(
+		InetSocketAddress inet,
+		Configuration clientConfiguration,
+		List<URL> jarFiles,
+		List<URL> globalClasspaths) {
 		this.clientConfiguration = clientConfiguration;
 		this.jarFiles = jarFiles;
 		this.globalClasspaths = globalClasspaths;
@@ -111,15 +117,16 @@ public class RemoteExecutor extends PlanExecutor {
 	public JobExecutionResult executePlan(Plan plan) throws Exception {
 		checkNotNull(plan);
 
-		JobWithJars p = new JobWithJars(plan, this.jarFiles, this.globalClasspaths);
-		return executePlanWithJars(p);
-	}
+		try (ClusterClient<?> client = new RestClusterClient<>(clientConfiguration, "RemoteExecutor")) {
+			ClassLoader classLoader = ClientUtils.buildUserCodeClassLoader(jarFiles, globalClasspaths, getClass().getClassLoader());
 
-	private JobExecutionResult executePlanWithJars(JobWithJars program) throws Exception {
-		checkNotNull(program);
-
-		try (ClusterClient<?>  client = new RestClusterClient<>(clientConfiguration, "RemoteExecutor")) {
-			return client.run(program, defaultParallelism).getJobExecutionResult();
+			return client.run(
+				plan,
+				jarFiles,
+				globalClasspaths,
+				classLoader,
+				defaultParallelism,
+				SavepointRestoreSettings.none()).getJobExecutionResult();
 		}
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -65,8 +65,13 @@ public class ContextEnvironment extends ExecutionEnvironment {
 		verifyExecuteIsCalledOnceWhenInDetachedMode();
 
 		final Plan plan = createProgramPlan(jobName);
-		final JobWithJars job = new JobWithJars(plan, jarFilesToAttach, classpathsToAttach, userCodeClassLoader);
-		final JobSubmissionResult jobSubmissionResult = client.run(job, getParallelism(), savepointSettings);
+		final JobSubmissionResult jobSubmissionResult = client.run(
+			plan,
+			jarFilesToAttach,
+			classpathsToAttach,
+			userCodeClassLoader,
+			getParallelism(),
+			savepointSettings);
 
 		lastJobExecutionResult = jobSubmissionResult.getJobExecutionResult();
 		return lastJobExecutionResult;

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -19,6 +19,7 @@
 package org.apache.flink.client.program;
 
 import org.apache.flink.api.common.ProgramDescription;
+import org.apache.flink.client.ClientUtils;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.util.InstantiationUtil;
@@ -198,7 +199,7 @@ public class PackagedProgram {
 		// now that we have an entry point, we can extract the nested jar files (if any)
 		this.extractedTempLibraries = jarFileUrl == null ? Collections.emptyList() : extractContainedLibraries(jarFileUrl);
 		this.classpaths = classpaths;
-		this.userCodeClassLoader = JobWithJars.buildUserCodeClassLoader(getAllLibraries(), classpaths, getClass().getClassLoader());
+		this.userCodeClassLoader = ClientUtils.buildUserCodeClassLoader(getAllLibraries(), classpaths, getClass().getClassLoader());
 
 		// load the entry point class
 		this.mainClass = loadMainClass(entryPointClassName, userCodeClassLoader);
@@ -623,7 +624,7 @@ public class PackagedProgram {
 
 	private static void checkJarFile(URL jarfile) throws ProgramInvocationException {
 		try {
-			JobWithJars.checkJarFile(jarfile);
+			ClientUtils.checkJarFile(jarfile);
 		}
 		catch (IOException e) {
 			throw new ProgramInvocationException(e.getMessage(), e);

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroExternalJarProgramITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroExternalJarProgramITCase.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.formats.avro;
 
-import org.apache.flink.client.program.JobWithJars;
+import org.apache.flink.client.ClientUtils;
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.formats.avro.testjar.AvroExternalJarProgram;
@@ -68,7 +68,7 @@ public class AvroExternalJarProgramITCase extends TestLogger {
 
 		String jarFile = JAR_FILE;
 		try {
-			JobWithJars.checkJarFile(new File(jarFile).getAbsoluteFile().toURI().toURL());
+			ClientUtils.checkJarFile(new File(jarFile).getAbsoluteFile().toURI().toURL());
 		} catch (IOException e) {
 			jarFile = "target/".concat(jarFile);
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -23,8 +23,8 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.client.ClientUtils;
 import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.client.program.JobWithJars;
 import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
@@ -191,7 +191,7 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 			try {
 				URL jarFileUrl = new File(jarFile).getAbsoluteFile().toURI().toURL();
 				this.jarFiles.add(jarFileUrl);
-				JobWithJars.checkJarFile(jarFileUrl);
+				ClientUtils.checkJarFile(jarFileUrl);
 			} catch (MalformedURLException e) {
 				throw new IllegalArgumentException("JAR file path is invalid '" + jarFile + "'", e);
 			} catch (IOException e) {
@@ -255,7 +255,7 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 			LOG.info("Running remotely at {}:{}", host, port);
 		}
 
-		ClassLoader userCodeClassLoader = JobWithJars.buildUserCodeClassLoader(jarFiles, globalClasspaths, envClassLoader);
+		ClassLoader userCodeClassLoader = ClientUtils.buildUserCodeClassLoader(jarFiles, globalClasspaths, envClassLoader);
 
 		Configuration configuration = new Configuration();
 		configuration.addAll(clientConfiguration);

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -20,12 +20,12 @@ package org.apache.flink.table.client.gateway.local;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.client.ClientUtils;
 import org.apache.flink.client.cli.CliFrontend;
 import org.apache.flink.client.cli.CliFrontendParser;
 import org.apache.flink.client.cli.CustomCommandLine;
 import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.client.program.JobWithJars;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.core.fs.FileSystem;
@@ -581,7 +581,7 @@ public class LocalExecutor implements Executor {
 		try {
 			// find jar files
 			for (URL url : jars) {
-				JobWithJars.checkJarFile(url);
+				ClientUtils.checkJarFile(url);
 				dependencies.add(url);
 			}
 
@@ -601,7 +601,7 @@ public class LocalExecutor implements Executor {
 					// only consider jars
 					if (f.isFile() && f.getAbsolutePath().toLowerCase().endsWith(".jar")) {
 						final URL url = f.toURI().toURL();
-						JobWithJars.checkJarFile(url);
+						ClientUtils.checkJarFile(url);
 						dependencies.add(url);
 					}
 				}


### PR DESCRIPTION
## What is the purpose of the change

JobWithJars is a batch-only concept, acts as a POJO consists of Plan and {{URL}}s of libs. We can

1. inline the usage of Plan and {{URL}}s as we do in streaming case.
2. extract static methods into a utility class said ClientUtils.

The main purpose here is towards no batch specific concept that doesn't bring too much good.

## Verifying this change

*(Please pick either of the following options)*

This change is code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

@liupc you might also be interested in this pull request since it possibly conflict with your pull request #9683 . But let's say it just code location conflicts instead of logic conflicts.

@kl0u I notice that you're working on getting rid of `run`s and `getOptimizedPlan`s in `ClusterClient` so this one also possibly conflict with your diff. But again, there should not be logic conflicts.
