### PR TITLE
[FLINK-14150][python] Clean up the __pycache__ directories and other empty directories in flink-python source code folder before packaging.

### DIFF
--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -197,9 +197,15 @@ under the License.
 						</goals>
 						<configuration>
 							<target>
-								<delete>
+								<delete includeEmptyDirs="true">
 									<fileset dir="${project.basedir}/pyflink"
-											 includes="**/*.pyc"/>
+											 includes="**/*.pyc,**/__pycache__"/>
+									<fileset dir="${project.basedir}/pyflink">
+										<and>
+											<size value="0"/>
+											<type type="dir"/>
+										</and>
+									</fileset>
 								</delete>
 								<delete file="${project.basedir}/lib/pyflink.zip"/>
 								<delete dir="${project.basedir}/target"/>
@@ -217,9 +223,15 @@ under the License.
 						</goals>
 						<configuration>
 							<target>
-								<delete>
+								<delete includeEmptyDirs="true">
 									<fileset dir="${project.basedir}/pyflink"
-											 includes="**/*.pyc"/>
+											 includes="**/*.pyc,**/__pycache__"/>
+									<fileset dir="${project.basedir}/pyflink">
+										<and>
+											<size value="0"/>
+											<type type="dir"/>
+										</and>
+									</fileset>
 								</delete>
 								<delete file="${project.basedir}/lib/pyflink.zip"/>
 								<zip destfile="${project.basedir}/lib/pyflink.zip">


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds configurations of maven-antrun-plugin to pom.xml of flink-python to clean up the __pycache__ directories and other empty directories in flink-python source code folder before packaging*


## Brief change log

  - *add configurations in pom.xml of flink-python to delete __pycache__ directories and empty directories.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
