### PR TITLE
[FLINK-14156][runtime] Submit timer trigger letters to task's mailbox with operator's precedence

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/KeyedStateInputFormat.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/KeyedStateInputFormat.java
@@ -216,13 +216,13 @@ public class KeyedStateInputFormat<K, OUT> extends RichInputFormat<OUT, KeyGroup
 	private StreamOperatorStateContext getStreamOperatorStateContext(Environment environment) throws IOException {
 		StreamTaskStateInitializer initializer = new StreamTaskStateInitializerImpl(
 			environment,
-			stateBackend,
-			new NeverFireProcessingTimeService());
+			stateBackend);
 
 		try {
 			return initializer.streamOperatorStateContext(
 				operatorState.getOperatorID(),
 				operatorState.getOperatorID().toString(),
+				new NeverFireProcessingTimeService(),
 				this,
 				keySerializer,
 				registry,

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/NeverFireProcessingTimeService.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/NeverFireProcessingTimeService.java
@@ -23,7 +23,6 @@ import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.util.concurrent.NeverCompleteFuture;
 
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -76,11 +75,4 @@ public final class NeverFireProcessingTimeService extends ProcessingTimeService 
 		shutdown.set(true);
 		return shutdown.get();
 	}
-
-	@Override
-	public boolean shutdownAndAwaitPending(long time, TimeUnit timeUnit) throws InterruptedException {
-		shutdown.set(true);
-		return shutdown.get();
-	}
 }
-

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/NeverFireProcessingTimeService.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/NeverFireProcessingTimeService.java
@@ -19,7 +19,7 @@ package org.apache.flink.state.api.runtime;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeCallback;
-import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.TimerService;
 import org.apache.flink.util.concurrent.NeverCompleteFuture;
 
 import java.util.concurrent.ScheduledFuture;
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * A processing time service whose timers never fire so all timers are included in savepoints.
  */
 @Internal
-public final class NeverFireProcessingTimeService extends ProcessingTimeService {
+public final class NeverFireProcessingTimeService implements TimerService {
 	private static final NeverCompleteFuture FUTURE = new NeverCompleteFuture(Long.MAX_VALUE);
 
 	private AtomicBoolean shutdown = new AtomicBoolean(true);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
@@ -69,7 +69,6 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTaskTestHarness;
 import org.apache.flink.streaming.runtime.tasks.StreamMockEnvironment;
-import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.TestLogger;
 
@@ -85,7 +84,6 @@ import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -216,18 +214,9 @@ public class RocksDBAsyncSnapshotTest extends TestLogger {
 		AtomicReference<Throwable> errorRef = new AtomicReference<>();
 		mockEnv.setExternalExceptionHandler(errorRef::set);
 		testHarness.invoke(mockEnv);
+		testHarness.waitForTaskRunning();
 
 		final OneInputStreamTask<String, String> task = testHarness.getTask();
-
-		// wait for the task to be running
-		for (Field field: StreamTask.class.getDeclaredFields()) {
-			if (field.getName().equals("isRunning")) {
-				field.setAccessible(true);
-				while (!field.getBoolean(task)) {
-					Thread.sleep(10);
-				}
-			}
-		}
 
 		task.triggerCheckpointAsync(new CheckpointMetaData(42, 17), CheckpointOptions.forCheckpointWithDefaultLocation(), false)
 			.get();
@@ -331,18 +320,9 @@ public class RocksDBAsyncSnapshotTest extends TestLogger {
 		blockerCheckpointStreamFactory.setWaiterLatch(new OneShotLatch());
 
 		testHarness.invoke(mockEnv);
+		testHarness.waitForTaskRunning();
 
 		final OneInputStreamTask<String, String> task = testHarness.getTask();
-
-		// wait for the task to be running
-		for (Field field: StreamTask.class.getDeclaredFields()) {
-			if (field.getName().equals("isRunning")) {
-				field.setAccessible(true);
-				while (!field.getBoolean(task)) {
-					Thread.sleep(10);
-				}
-			}
-		}
 
 		task.triggerCheckpointAsync(
 			new CheckpointMetaData(42, 17),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -155,6 +155,7 @@ public abstract class AbstractStreamOperator<OUT>
 
 	// ---------------- time handler ------------------
 
+	private transient ProcessingTimeService processingTimeService;
 	protected transient InternalTimeServiceManager<?> timeServiceManager;
 
 	// ---------------- two-input operator watermarks ------------------
@@ -173,6 +174,7 @@ public abstract class AbstractStreamOperator<OUT>
 	public void setup(StreamTask<?, ?> containingTask, StreamConfig config, Output<StreamRecord<OUT>> output) {
 		final Environment environment = containingTask.getEnvironment();
 		this.container = containingTask;
+		this.processingTimeService = containingTask.getProcessingTimeService();
 		this.config = config;
 		try {
 			OperatorMetricGroup operatorMetricGroup = environment.getMetricGroup().getOrAddOperator(config.getOperatorID(), config.getOperatorName());
@@ -253,6 +255,7 @@ public abstract class AbstractStreamOperator<OUT>
 			streamTaskStateManager.streamOperatorStateContext(
 				getOperatorID(),
 				getClass().getSimpleName(),
+				getProcessingTimeService(),
 				this,
 				keySerializer,
 				streamTaskCloseableRegistry,
@@ -552,11 +555,11 @@ public abstract class AbstractStreamOperator<OUT>
 	}
 
 	/**
-	 * Returns the {@link ProcessingTimeService} responsible for getting  the current
+	 * Returns the {@link ProcessingTimeService} responsible for getting the current
 	 * processing time and registering timers.
 	 */
 	protected ProcessingTimeService getProcessingTimeService() {
-		return container.getProcessingTimeService();
+		return processingTimeService;
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -174,7 +174,7 @@ public abstract class AbstractStreamOperator<OUT>
 	public void setup(StreamTask<?, ?> containingTask, StreamConfig config, Output<StreamRecord<OUT>> output) {
 		final Environment environment = containingTask.getEnvironment();
 		this.container = containingTask;
-		this.processingTimeService = containingTask.getProcessingTimeService();
+		this.processingTimeService = containingTask.getProcessingTimeService(config.getChainIndex());
 		this.config = config;
 		try {
 			OperatorMetricGroup operatorMetricGroup = environment.getMetricGroup().getOrAddOperator(config.getOperatorID(), config.getOperatorName());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImpl.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.runtime.state.InternalPriorityQueue;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
-import org.apache.flink.streaming.runtime.tasks.ProcessingTimeCallback;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -43,7 +42,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * {@link InternalTimerService} that stores timers on the Java heap.
  */
-public class InternalTimerServiceImpl<K, N> implements InternalTimerService<N>, ProcessingTimeCallback {
+public class InternalTimerServiceImpl<K, N> implements InternalTimerService<N> {
 
 	private final ProcessingTimeService processingTimeService;
 
@@ -175,7 +174,7 @@ public class InternalTimerServiceImpl<K, N> implements InternalTimerService<N>, 
 			// re-register the restored timers (if any)
 			final InternalTimer<K, N> headTimer = processingTimeTimersQueue.peek();
 			if (headTimer != null) {
-				nextTimer = processingTimeService.registerTimer(headTimer.getTimestamp(), this);
+				nextTimer = processingTimeService.registerTimer(headTimer.getTimestamp(), this::onProcessingTime);
 			}
 			this.isInitialized = true;
 		} else {
@@ -206,7 +205,7 @@ public class InternalTimerServiceImpl<K, N> implements InternalTimerService<N>, 
 				if (nextTimer != null) {
 					nextTimer.cancel(false);
 				}
-				nextTimer = processingTimeService.registerTimer(time, this);
+				nextTimer = processingTimeService.registerTimer(time, this::onProcessingTime);
 			}
 		}
 	}
@@ -246,8 +245,7 @@ public class InternalTimerServiceImpl<K, N> implements InternalTimerService<N>, 
 		}
 	}
 
-	@Override
-	public void onProcessingTime(long time) throws Exception {
+	private void onProcessingTime(long time) throws Exception {
 		// null out the timer in case the Triggerable calls registerProcessingTimeTimer()
 		// inside the callback.
 		nextTimer = null;
@@ -261,7 +259,7 @@ public class InternalTimerServiceImpl<K, N> implements InternalTimerService<N>, 
 		}
 
 		if (timer != null && nextTimer == null) {
-			nextTimer = processingTimeService.registerTimer(timer.getTimestamp(), this);
+			nextTimer = processingTimeService.registerTimer(timer.getTimestamp(), this::onProcessingTime);
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializer.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -39,6 +40,7 @@ public interface StreamTaskStateInitializer {
 	 *
 	 * @param operatorID the id of the operator for which the context is created. Cannot be null.
 	 * @param operatorClassName the classname of the operator instance for which the context is created. Cannot be null.
+	 * @param processingTimeService
 	 * @param keyContext the key context of the operator instance for which the context is created Cannot be null.
 	 * @param keySerializer the key-serializer for the operator. Can be null.
 	 * @param streamTaskCloseableRegistry the closeable registry to which created closeable objects will be registered.
@@ -49,6 +51,7 @@ public interface StreamTaskStateInitializer {
 	StreamOperatorStateContext streamOperatorStateContext(
 		@Nonnull OperatorID operatorID,
 		@Nonnull String operatorClassName,
+		@Nonnull ProcessingTimeService processingTimeService,
 		@Nonnull KeyContext keyContext,
 		@Nullable TypeSerializer<?> keySerializer,
 		@Nonnull CloseableRegistry streamTaskCloseableRegistry,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -69,7 +69,7 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 	/**
 	 * Constructor for initialization, possibly with initial state (recovery / savepoint / etc).
 	 *
-	 * <p>This constructor accepts a special {@link ProcessingTimeService}. By default (and if
+	 * <p>This constructor accepts a special {@link TimerService}. By default (and if
 	 * null is passes for the time provider) a {@link SystemProcessingTimeService DefaultTimerService}
 	 * will be used.
 	 *
@@ -79,7 +79,7 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 	@VisibleForTesting
 	public OneInputStreamTask(
 			Environment env,
-			@Nullable ProcessingTimeService timeProvider) {
+			@Nullable TimerService timeProvider) {
 		super(env, timeProvider);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeService.java
@@ -18,7 +18,6 @@
 package org.apache.flink.streaming.runtime.tasks;
 
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Defines the current processing time and handles all related actions,
@@ -105,15 +104,4 @@ public abstract class ProcessingTimeService {
 	 * @return returns true iff the shutdown was completed.
 	 */
 	public abstract boolean shutdownServiceUninterruptible(long timeoutMs);
-
-	/**
-	 * Shuts down and clean up the timer service provider hard and immediately. This does wait
-	 * for all timers to complete or until the time limit is exceeded. Any call to
-	 * {@link #registerTimer(long, ProcessingTimeCallback)} will result in a hard exception after calling this method.
-	 * @param time time to wait for termination.
-	 * @param timeUnit time unit of parameter time.
-	 * @return {@code true} if this timer service and all pending timers are terminated and
-	 *         {@code false} if the timeout elapsed before this happened.
-	 */
-	public abstract boolean shutdownAndAwaitPending(long time, TimeUnit timeUnit) throws InterruptedException;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeService.java
@@ -25,24 +25,13 @@ import java.util.concurrent.ScheduledFuture;
  *
  * <p>The access to the time via {@link #getCurrentProcessingTime()} is always available, regardless of
  * whether the timer service has been shut down.
- *
- * <p>The registration of timers follows a life cycle of three phases:
- * <ol>
- *     <li>In the initial state, it accepts timer registrations and triggers when the time is reached.</li>
- *     <li>After calling {@link #quiesce()}, further calls to
- *         {@link #registerTimer(long, ProcessingTimeCallback)} will not register any further timers, and will
- *         return a "dummy" future as a result. This is used for clean shutdown, where currently firing
- *         timers are waited for and no future timers can be scheduled, without causing hard exceptions.</li>
- *     <li>After a call to {@link #shutdownService()}, all calls to {@link #registerTimer(long, ProcessingTimeCallback)}
- *         will result in a hard exception.</li>
- * </ol>
  */
-public abstract class ProcessingTimeService {
+public interface ProcessingTimeService {
 
 	/**
 	 * Returns the current processing time.
 	 */
-	public abstract long getCurrentProcessingTime();
+	long getCurrentProcessingTime();
 
 	/**
 	 * Registers a task to be executed when (processing) time is {@code timestamp}.
@@ -53,7 +42,7 @@ public abstract class ProcessingTimeService {
 	 * @return The future that represents the scheduled task. This always returns some future,
 	 *         even if the timer was shut down
 	 */
-	public abstract ScheduledFuture<?> registerTimer(long timestamp, ProcessingTimeCallback target);
+	ScheduledFuture<?> registerTimer(long timestamp, ProcessingTimeCallback target);
 
 	/**
 	 * Registers a task to be executed repeatedly at a fixed rate.
@@ -63,45 +52,5 @@ public abstract class ProcessingTimeService {
 	 * @param period after the initial delay after which the callback is executed
 	 * @return Scheduled future representing the task to be executed repeatedly
 	 */
-	public abstract ScheduledFuture<?> scheduleAtFixedRate(ProcessingTimeCallback callback, long initialDelay, long period);
-
-	/**
-	 * Returns <tt>true</tt> if the service has been shut down, <tt>false</tt> otherwise.
-	 */
-	public abstract boolean isTerminated();
-
-	/**
-	 * This method puts the service into a state where it does not register new timers, but
-	 * returns for each call to {@link #registerTimer(long, ProcessingTimeCallback)} only a "mock" future.
-	 * Furthermore, the method clears all not yet started timers.
-	 *
-	 * <p>This method can be used to cleanly shut down the timer service. The using components
-	 * will not notice that the service is shut down (as for example via exceptions when registering
-	 * a new timer), but the service will simply not fire any timer any more.
-	 */
-	public abstract void quiesce() throws InterruptedException;
-
-	/**
-	 * This method can be used after calling {@link #quiesce()}, and awaits the completion
-	 * of currently executing timers.
-	 */
-	public abstract void awaitPendingAfterQuiesce() throws InterruptedException;
-
-	/**
-	 * Shuts down and clean up the timer service provider hard and immediately. This does not wait
-	 * for any timer to complete. Any further call to {@link #registerTimer(long, ProcessingTimeCallback)}
-	 * will result in a hard exception.
-	 */
-	public abstract void shutdownService();
-
-	/**
-	 * Shuts down and clean up the timer service provider hard and immediately. This does not wait
-	 * for any timer to complete. Any further call to {@link #registerTimer(long, ProcessingTimeCallback)}
-	 * will result in a hard exception. This call cannot be interrupted and will block until the shutdown is completed
-	 * or the timeout is exceeded.
-	 *
-	 * @param timeoutMs timeout for blocking on the service shutdown in milliseconds.
-	 * @return returns true iff the shutdown was completed.
-	 */
-	public abstract boolean shutdownServiceUninterruptible(long timeoutMs);
+	ScheduledFuture<?> scheduleAtFixedRate(ProcessingTimeCallback callback, long initialDelay, long period);
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeServiceImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeServiceImpl.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.function.Function;
+
+class ProcessingTimeServiceImpl implements ProcessingTimeService {
+	private final TimerService timerService;
+	private final Function<ProcessingTimeCallback, ProcessingTimeCallback> processingTimeCallbackWrapper;
+
+	ProcessingTimeServiceImpl(
+			TimerService timerService,
+			Function<ProcessingTimeCallback, ProcessingTimeCallback> processingTimeCallbackWrapper) {
+		this.timerService = timerService;
+		this.processingTimeCallbackWrapper = processingTimeCallbackWrapper;
+	}
+
+	@Override
+	public long getCurrentProcessingTime() {
+		return timerService.getCurrentProcessingTime();
+	}
+
+	@Override
+	public ScheduledFuture<?> registerTimer(long timestamp, ProcessingTimeCallback target) {
+		return timerService.registerTimer(timestamp, processingTimeCallbackWrapper.apply(target));
+	}
+
+	@Override
+	public ScheduledFuture<?> scheduleAtFixedRate(ProcessingTimeCallback callback, long initialDelay, long period) {
+		return timerService.scheduleAtFixedRate(processingTimeCallbackWrapper.apply(callback), initialDelay, period);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -349,8 +349,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	public StreamTaskStateInitializer createStreamTaskStateInitializer() {
 		return new StreamTaskStateInitializerImpl(
 			getEnvironment(),
-			stateBackend,
-			timerService);
+			stateBackend);
 	}
 
 	protected Counter setupNumRecordsInCounter(StreamOperator streamOperator) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -172,11 +172,11 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	private CheckpointStorageWorkerView checkpointStorage;
 
 	/**
-	 * The internal {@link ProcessingTimeService} used to define the current
+	 * The internal {@link TimerService} used to define the current
 	 * processing time (default = {@code System.currentTimeMillis()}) and
 	 * register timers for tasks to be executed in the future.
 	 */
-	protected ProcessingTimeService timerService;
+	protected TimerService timerService;
 
 	private final Thread.UncaughtExceptionHandler uncaughtExceptionHandler;
 
@@ -221,31 +221,31 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	 * Constructor for initialization, possibly with initial state (recovery / savepoint / etc).
 	 *
 	 * @param env The task environment for this task.
-	 * @param timeProvider Optionally, a specific time provider to use.
+	 * @param timerService Optionally, a specific timer service to use.
 	 */
-	protected StreamTask(Environment env, @Nullable ProcessingTimeService timeProvider) {
-		this(env, timeProvider, FatalExitExceptionHandler.INSTANCE);
+	protected StreamTask(Environment env, @Nullable TimerService timerService) {
+		this(env, timerService, FatalExitExceptionHandler.INSTANCE);
 	}
 
 	/**
 	 * Constructor for initialization, possibly with initial state (recovery / savepoint / etc).
 	 *
-	 * <p>This constructor accepts a special {@link ProcessingTimeService}. By default (and if
-	 * null is passes for the time provider) a {@link SystemProcessingTimeService DefaultTimerService}
+	 * <p>This constructor accepts a special {@link TimerService}. By default (and if
+	 * null is passes for the timer service) a {@link SystemProcessingTimeService DefaultTimerService}
 	 * will be used.
 	 *
 	 * @param environment The task environment for this task.
-	 * @param timeProvider Optionally, a specific time provider to use.
+	 * @param timerService Optionally, a specific timer service to use.
 	 * @param uncaughtExceptionHandler to handle uncaught exceptions in the async operations thread pool
 	 */
 	protected StreamTask(
 			Environment environment,
-			@Nullable ProcessingTimeService timeProvider,
+			@Nullable TimerService timerService,
 			Thread.UncaughtExceptionHandler uncaughtExceptionHandler) {
 
 		super(environment);
 
-		this.timerService = timeProvider;
+		this.timerService = timerService;
 		this.uncaughtExceptionHandler = Preconditions.checkNotNull(uncaughtExceptionHandler);
 		this.configuration = new StreamConfig(getTaskConfiguration());
 		this.accumulatorMap = getEnvironment().getAccumulatorRegistry().getUserMap();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeService.java
@@ -38,11 +38,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * A {@link ProcessingTimeService} which assigns as current processing time the result of calling
+ * A {@link TimerService} which assigns as current processing time the result of calling
  * {@link System#currentTimeMillis()} and registers timers using a {@link ScheduledThreadPoolExecutor}.
  */
 @Internal
-public class SystemProcessingTimeService extends ProcessingTimeService {
+public class SystemProcessingTimeService implements TimerService {
 
 	private static final Logger LOG = LoggerFactory.getLogger(SystemProcessingTimeService.class);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeService.java
@@ -190,8 +190,17 @@ public class SystemProcessingTimeService extends ProcessingTimeService {
 		}
 	}
 
-	@Override
-	public boolean shutdownAndAwaitPending(long time, TimeUnit timeUnit) throws InterruptedException {
+	/**
+	 * Shuts down and clean up the timer service provider hard and immediately. This does wait
+	 * for all timers to complete or until the time limit is exceeded. Any call to
+	 * {@link #registerTimer(long, ProcessingTimeCallback)} will result in a hard exception after calling this method.
+	 * @param time time to wait for termination.
+	 * @param timeUnit time unit of parameter time.
+	 * @return {@code true} if this timer service and all pending timers are terminated and
+	 *         {@code false} if the timeout elapsed before this happened.
+	 */
+	@VisibleForTesting
+	boolean shutdownAndAwaitPending(long time, TimeUnit timeUnit) throws InterruptedException {
 		shutdownService();
 		return timerService.awaitTermination(time, timeUnit);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TestProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TestProcessingTimeService.java
@@ -32,10 +32,10 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * This is a {@link ProcessingTimeService} used <b>strictly for testing</b> the
+ * This is a {@link TimerService} used <b>strictly for testing</b> the
  * processing time functionality.
- * */
-public class TestProcessingTimeService extends ProcessingTimeService {
+ */
+public class TestProcessingTimeService implements TimerService {
 
 	private volatile long currentTime = Long.MIN_VALUE;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TestProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TestProcessingTimeService.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * This is a {@link TimerService} used <b>strictly for testing</b> the
+ * This is a {@link TimerService} and {@link ProcessingTimeService} used <b>strictly for testing</b> the
  * processing time functionality.
  */
 public class TestProcessingTimeService implements TimerService {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TestProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TestProcessingTimeService.java
@@ -140,12 +140,6 @@ public class TestProcessingTimeService extends ProcessingTimeService {
 		return true;
 	}
 
-	@Override
-	public boolean shutdownAndAwaitPending(long time, TimeUnit timeUnit) throws InterruptedException {
-		shutdownService();
-		return true;
-	}
-
 	public int getNumActiveTimers() {
 		int count = 0;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TimerService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TimerService.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * A common timer service interface with life cycle methods.
+ *
+ * <p>The registration of timers follows a life cycle of three phases:
+ * <ol>
+ *     <li>In the initial state, it accepts timer registrations and triggers when the time is reached.</li>
+ *     <li>After calling {@link #quiesce()}, further calls to
+ *         {@link #registerTimer(long, ProcessingTimeCallback)} will not register any further timers, and will
+ *         return a "dummy" future as a result. This is used for clean shutdown, where currently firing
+ *         timers are waited for and no future timers can be scheduled, without causing hard exceptions.</li>
+ *     <li>After a call to {@link #shutdownService()}, all calls to {@link #registerTimer(long, ProcessingTimeCallback)}
+ *         will result in a hard exception.</li>
+ * </ol>
+ */
+@Internal
+public interface TimerService extends ProcessingTimeService {
+
+	/**
+	 * Returns <tt>true</tt> if the service has been shut down, <tt>false</tt> otherwise.
+	 */
+	boolean isTerminated();
+
+	/**
+	 * This method puts the service into a state where it does not register new timers, but
+	 * returns for each call to {@link #registerTimer(long, ProcessingTimeCallback)} only a "mock" future.
+	 * Furthermore, the method clears all not yet started timers.
+	 *
+	 * <p>This method can be used to cleanly shut down the timer service. The using components
+	 * will not notice that the service is shut down (as for example via exceptions when registering
+	 * a new timer), but the service will simply not fire any timer any more.
+	 */
+	void quiesce() throws InterruptedException;
+
+	/**
+	 * This method can be used after calling {@link #quiesce()}, and awaits the completion
+	 * of currently executing timers.
+	 */
+	void awaitPendingAfterQuiesce() throws InterruptedException;
+
+	/**
+	 * Shuts down and clean up the timer service provider hard and immediately. This does not wait
+	 * for any timer to complete. Any further call to {@link #registerTimer(long, ProcessingTimeCallback)}
+	 * will result in a hard exception.
+	 */
+	void shutdownService();
+
+	/**
+	 * Shuts down and clean up the timer service provider hard and immediately. This does not wait
+	 * for any timer to complete. Any further call to {@link #registerTimer(long, ProcessingTimeCallback)}
+	 * will result in a hard exception. This call cannot be interrupted and will block until the shutdown is completed
+	 * or the timeout is exceeded.
+	 *
+	 * @param timeoutMs timeout for blocking on the service shutdown in milliseconds.
+	 * @return returns true iff the shutdown was completed.
+	 */
+	boolean shutdownServiceUninterruptible(long timeoutMs);
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
@@ -171,13 +171,13 @@ public class StateInitializationContextImplTest {
 		StateBackend stateBackend = new MemoryStateBackend(1024);
 		StreamTaskStateInitializer streamTaskStateManager = new StreamTaskStateInitializerImpl(
 			environment,
-			stateBackend,
-			mock(ProcessingTimeService.class)) {
+			stateBackend) {
 
 			@Override
 			protected <K> InternalTimeServiceManager<K> internalTimeServiceManager(
 				AbstractKeyedStateBackend<K> keyedStatedBackend,
 				KeyContext keyContext,
+				ProcessingTimeService processingTimeService,
 				Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws Exception {
 
 				// We do not initialize a timer service manager here, because it would already consume the raw keyed
@@ -193,6 +193,7 @@ public class StateInitializationContextImplTest {
 		StreamOperatorStateContext stateContext = streamTaskStateManager.streamOperatorStateContext(
 			operatorID,
 			"TestOperatorClass",
+			mock(ProcessingTimeService.class),
 			mockOperator,
 			// notice that this essentially disables the previous test of the keyed stream because it was and is always
 			// consumed by the timer service.

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
@@ -93,6 +93,7 @@ public class StreamTaskStateInitializerImplTest {
 		StreamOperatorStateContext stateContext = streamTaskStateManager.streamOperatorStateContext(
 			streamOperator.getOperatorID(),
 			streamOperator.getClass().getSimpleName(),
+			new TestProcessingTimeService(),
 			streamOperator,
 			typeSerializer,
 			closeableRegistry,
@@ -201,6 +202,7 @@ public class StreamTaskStateInitializerImplTest {
 		StreamOperatorStateContext stateContext = streamTaskStateManager.streamOperatorStateContext(
 			streamOperator.getOperatorID(),
 			streamOperator.getClass().getSimpleName(),
+			new TestProcessingTimeService(),
 			streamOperator,
 			typeSerializer,
 			closeableRegistry,
@@ -268,22 +270,19 @@ public class StreamTaskStateInitializerImplTest {
 		DummyEnvironment dummyEnvironment = new DummyEnvironment("test-task", 1, 0);
 		dummyEnvironment.setTaskStateManager(taskStateManager);
 
-		ProcessingTimeService processingTimeService = new TestProcessingTimeService();
-
 		if (createTimerServiceManager) {
 			return new StreamTaskStateInitializerImpl(
 				dummyEnvironment,
-				stateBackend,
-				processingTimeService);
+				stateBackend);
 		} else {
 			return new StreamTaskStateInitializerImpl(
 				dummyEnvironment,
-				stateBackend,
-				processingTimeService) {
+				stateBackend) {
 				@Override
 				protected <K> InternalTimeServiceManager<K> internalTimeServiceManager(
 					AbstractKeyedStateBackend<K> keyedStatedBackend,
 					KeyContext keyContext,
+					ProcessingTimeService processingTimeService,
 					Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws Exception {
 					return null;
 				}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
@@ -36,9 +36,9 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.streaming.runtime.tasks.OperatorChain;
-import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.TimerService;
 import org.apache.flink.streaming.util.CollectorOutput;
 import org.apache.flink.streaming.util.MockStreamTask;
 import org.apache.flink.streaming.util.MockStreamTaskBuilder;
@@ -210,7 +210,7 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
 			StreamSource<T, ?> operator,
 			ExecutionConfig executionConfig,
 			Environment env,
-			ProcessingTimeService timeProvider) {
+			TimerService timerService) {
 
 		StreamConfig cfg = new StreamConfig(new Configuration());
 		cfg.setStateBackend(new MemoryStateBackend());
@@ -222,7 +222,7 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
 			MockStreamTask mockTask = new MockStreamTaskBuilder(env)
 				.setConfig(cfg)
 				.setExecutionConfig(executionConfig)
-				.setProcessingTimeService(timeProvider)
+				.setTimerService(timerService)
 				.build();
 
 			operator.setup(mockTask, cfg, (Output<StreamRecord<T>>) mock(Output.class));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorWatermarksTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorWatermarksTest.java
@@ -157,7 +157,7 @@ public class StreamSourceOperatorWatermarksTest {
 
 		StreamSourceContexts.getSourceContext(
 			TimeCharacteristic.IngestionTime,
-			operator.getContainingTask().getProcessingTimeService(),
+			processingTimeService,
 			operator.getContainingTask().getCheckpointLock(),
 			operator.getContainingTask().getStreamStatusMaintainer(),
 			new CollectorOutput<String>(output),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorWatermarksTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorWatermarksTest.java
@@ -38,9 +38,9 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.streaming.runtime.tasks.OperatorChain;
-import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.TimerService;
 import org.apache.flink.streaming.util.CollectorOutput;
 import org.apache.flink.streaming.util.MockStreamTask;
 import org.apache.flink.streaming.util.MockStreamTaskBuilder;
@@ -197,7 +197,7 @@ public class StreamSourceOperatorWatermarksTest {
 			StreamSource<T, ?> operator,
 			TimeCharacteristic timeChar,
 			long watermarkInterval,
-			final ProcessingTimeService timeProvider) throws Exception {
+			final TimerService timeProvider) throws Exception {
 
 		ExecutionConfig executionConfig = new ExecutionConfig();
 		executionConfig.setAutoWatermarkInterval(watermarkInterval);
@@ -217,7 +217,7 @@ public class StreamSourceOperatorWatermarksTest {
 			.setConfig(cfg)
 			.setExecutionConfig(executionConfig)
 			.setStreamStatusMaintainer(streamStatusMaintainer)
-			.setProcessingTimeService(timeProvider)
+			.setTimerService(timeProvider)
 			.build();
 
 		operator.setup(mockTask, cfg, (Output<StreamRecord<T>>) mock(Output.class));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorWatermarksTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorWatermarksTest.java
@@ -155,7 +155,8 @@ public class StreamSourceOperatorWatermarksTest {
 
 		final List<StreamElement> output = new ArrayList<>();
 
-		StreamSourceContexts.getSourceContext(TimeCharacteristic.IngestionTime,
+		StreamSourceContexts.getSourceContext(
+			TimeCharacteristic.IngestionTime,
 			operator.getContainingTask().getProcessingTimeService(),
 			operator.getContainingTask().getCheckpointLock(),
 			operator.getContainingTask().getStreamStatusMaintainer(),
@@ -184,17 +185,19 @@ public class StreamSourceOperatorWatermarksTest {
 	// ------------------------------------------------------------------------
 
 	@SuppressWarnings("unchecked")
-	private static <T> void setupSourceOperator(StreamSource<T, ?> operator,
+	private static <T> void setupSourceOperator(
+			StreamSource<T, ?> operator,
 			TimeCharacteristic timeChar,
 			long watermarkInterval) throws Exception {
 		setupSourceOperator(operator, timeChar, watermarkInterval, new TestProcessingTimeService());
 	}
 
 	@SuppressWarnings("unchecked")
-	private static <T> void setupSourceOperator(StreamSource<T, ?> operator,
-												TimeCharacteristic timeChar,
-												long watermarkInterval,
-												final ProcessingTimeService timeProvider) throws Exception {
+	private static <T> void setupSourceOperator(
+			StreamSource<T, ?> operator,
+			TimeCharacteristic timeChar,
+			long watermarkInterval,
+			final ProcessingTimeService timeProvider) throws Exception {
 
 		ExecutionConfig executionConfig = new ExecutionConfig();
 		executionConfig.setAutoWatermarkInterval(watermarkInterval);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamTaskOperatorTimerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamTaskOperatorTimerTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.YieldingOperatorFactory;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
+import org.apache.flink.streaming.runtime.tasks.OneInputStreamTaskTestHarness;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.streaming.runtime.tasks.mailbox.execution.MailboxExecutor;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Test to verify that timer triggers are run according to operator precedence (combined with yield() at operator level).
+ */
+public class StreamTaskOperatorTimerTest extends TestLogger {
+	private static List<String> events;
+
+	@Test
+	public void testOperatorYieldExecutesSelectedTimers() throws Exception {
+		events = new ArrayList<>();
+		final OneInputStreamTaskTestHarness<Integer, Integer> testHarness = new OneInputStreamTaskTestHarness<>(
+				OneInputStreamTask::new,
+				BasicTypeInfo.INT_TYPE_INFO,
+				BasicTypeInfo.INT_TYPE_INFO);
+
+		testHarness.setupOperatorChain(new OperatorID(), new TestOperatorFactory<>())
+				.chain(new OperatorID(), new TestOperatorFactory<>(), IntSerializer.INSTANCE)
+				.finish();
+
+		testHarness.invoke();
+		testHarness.waitForTaskRunning();
+
+		testHarness.processElement(new StreamRecord<>(42));
+
+		testHarness.endInput();
+		testHarness.waitForTaskCompletion();
+
+		assertThat(events, is(Arrays.asList("Timer:1:0", "Timer:0:0")));
+	}
+
+	private static class TestOperatorFactory<T> implements OneInputStreamOperatorFactory<T, T>, YieldingOperatorFactory<T> {
+		private MailboxExecutor mailboxExecutor;
+
+		@Override
+		public void setMailboxExecutor(MailboxExecutor mailboxExecutor) {
+			this.mailboxExecutor = mailboxExecutor;
+		}
+
+		@Override
+		public <Operator extends StreamOperator<T>> Operator createStreamOperator(
+				StreamTask<?, ?> containingTask,
+				StreamConfig config,
+				Output<StreamRecord<T>> output) {
+			TestOperator<T> operator = new TestOperator<>(config.getChainIndex(), mailboxExecutor);
+			operator.setup(containingTask, config, output);
+			return (Operator) operator;
+		}
+
+		@Override
+		public void setChainingStrategy(ChainingStrategy strategy) {
+		}
+
+		@Override
+		public ChainingStrategy getChainingStrategy() {
+			return ChainingStrategy.ALWAYS;
+		}
+
+		@Override
+		public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+			return TestOperator.class;
+		}
+	}
+
+	private static class TestOperator<T>
+			extends AbstractStreamOperator<T>
+			implements OneInputStreamOperator<T, T> {
+
+		private final transient MailboxExecutor mailboxExecutor;
+		private final int chainIndex;
+		private transient int count;
+
+		TestOperator(int chainIndex, MailboxExecutor mailboxExecutor) {
+			this.chainIndex = chainIndex;
+			this.mailboxExecutor = mailboxExecutor;
+		}
+
+		@Override
+		public void processElement(StreamRecord<T> element) throws Exception {
+			// The test operator creates a one-time timer (per input element) and passes the input element further
+			// (to the next operator or to the output).
+			// The execution is yielded until the operator's timer trigger is confirmed.
+
+			int index = count;
+			ProcessingTimeService processingTimeService = getProcessingTimeService();
+			processingTimeService
+				.registerTimer(
+					processingTimeService.getCurrentProcessingTime() + 1000L,
+					timestamp -> {
+						events.add("Timer:" + chainIndex + ":" + index);
+						--count;
+					});
+
+			++count;
+			output.collect(element);
+
+			while (count > 0) {
+				mailboxExecutor.yield();
+			}
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamTaskTimerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamTaskTimerTest.java
@@ -57,7 +57,7 @@ public class StreamTaskTimerTest extends TestLogger {
 	@Before
 	public void setup() throws Exception {
 		testHarness = startTestHarness();
-		timeService = testHarness.getProcessingTimeService();
+		timeService = testHarness.getTask().getProcessingTimeService(0);
 	}
 
 	@After

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TestProcessingTimeServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TestProcessingTimeServiceTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.streaming.api.operators.StreamMap;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTaskTestHarness;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeCallback;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 
 import org.junit.Test;
@@ -55,26 +56,26 @@ public class TestProcessingTimeServiceTest {
 
 		testHarness.invoke();
 
-		final OneInputStreamTask<String, String> mapTask = testHarness.getTask();
+		ProcessingTimeService processingTimeService = testHarness.getTask().getProcessingTimeService(0);
 
-		assertEquals(Long.MIN_VALUE, testHarness.getProcessingTimeService().getCurrentProcessingTime());
+		assertEquals(Long.MIN_VALUE, processingTimeService.getCurrentProcessingTime());
 
 		tp.setCurrentTime(11);
-		assertEquals(testHarness.getProcessingTimeService().getCurrentProcessingTime(), 11);
+		assertEquals(processingTimeService.getCurrentProcessingTime(), 11);
 
 		tp.setCurrentTime(15);
 		tp.setCurrentTime(16);
-		assertEquals(testHarness.getProcessingTimeService().getCurrentProcessingTime(), 16);
+		assertEquals(processingTimeService.getCurrentProcessingTime(), 16);
 
 		// register 2 tasks
-		mapTask.getProcessingTimeService().registerTimer(30, new ProcessingTimeCallback() {
+		processingTimeService.registerTimer(30, new ProcessingTimeCallback() {
 			@Override
 			public void onProcessingTime(long timestamp) {
 
 			}
 		});
 
-		mapTask.getProcessingTimeService().registerTimer(40, new ProcessingTimeCallback() {
+		processingTimeService.registerTimer(40, new ProcessingTimeCallback() {
 			@Override
 			public void onProcessingTime(long timestamp) {
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -587,7 +587,7 @@ public class OneInputStreamTaskTest extends TestLogger {
 		testHarness.waitForTaskRunning();
 
 		SystemProcessingTimeService timeService = (SystemProcessingTimeService)
-				testHarness.getTask().getProcessingTimeService();
+				testHarness.getTimerService();
 
 		// verify that the timer service is running
 		Assert.assertTrue(timeService.isAlive());
@@ -647,7 +647,7 @@ public class OneInputStreamTaskTest extends TestLogger {
 
 			// verify that the timer service is still running
 			Assert.assertTrue(
-					((SystemProcessingTimeService) getContainingTask().getProcessingTimeService())
+					((SystemProcessingTimeService) getContainingTask().getTimerService())
 					.isAlive());
 			super.close();
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OperatorChainTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OperatorChainTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.streaming.runtime.streamstatus.StreamStatusProvider;
 import org.apache.flink.streaming.runtime.tasks.OperatorChain.BroadcastingOutputCollector;
 import org.apache.flink.streaming.runtime.tasks.OperatorChain.ChainingOutput;
 import org.apache.flink.streaming.runtime.tasks.OperatorChain.WatermarkGaugeExposingOutput;
+import org.apache.flink.streaming.util.MockStreamTaskBuilder;
 
 import org.junit.Test;
 
@@ -78,8 +79,7 @@ public class OperatorChainTest {
 		checkArgument(operators.length > 0);
 
 		try (MockEnvironment env = MockEnvironment.builder().build()) {
-
-		final StreamTask<?, ?> containingTask = new OneInputStreamTask<T, OneInputStreamOperator<T, T>>(env);
+			final StreamTask<?, ?> containingTask = new MockStreamTaskBuilder(env).build();
 
 			final StreamStatusProvider statusProvider = mock(StreamStatusProvider.class);
 			final StreamConfig cfg = new StreamConfig(new Configuration());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -849,9 +849,10 @@ public class StreamTaskTest extends TestLogger {
 	public void testRecordWriterClosedOnStreamOperatorFactoryDeserializationError() throws Exception {
 		Configuration taskConfiguration = new Configuration();
 		StreamConfig streamConfig = new StreamConfig(taskConfiguration);
+		streamConfig.setStreamOperatorFactory(new UnusedOperatorFactory());
 
 		// Make sure that there is some output edge in the config so that some RecordWriter is created
-		StreamConfigChainer cfg = new StreamConfigChainer(new OperatorID(42, 42), new UnusedOperatorFactory(), streamConfig);
+		StreamConfigChainer cfg = new StreamConfigChainer(new OperatorID(42, 42), streamConfig);
 		cfg.chain(
 			new OperatorID(44, 44),
 			new UnusedOperatorFactory(),
@@ -1442,11 +1443,11 @@ public class StreamTaskTest extends TestLogger {
 			checkTaskThreadInfo();
 
 			// Create a time trigger to validate that it would also be invoked in the task's thread.
-			getProcessingTimeService().registerTimer(0, new ProcessingTimeCallback() {
+			getProcessingTimeService(0).registerTimer(0, new ProcessingTimeCallback() {
 				@Override
 				public void onProcessingTime(long timestamp) throws Exception {
-					hasTimerTriggered = true;
 					checkTaskThreadInfo();
+					hasTimerTriggered = true;
 				}
 			});
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -975,7 +975,7 @@ public class StreamTaskTest extends TestLogger {
 	public static class NoOpStreamTask<T, OP extends StreamOperator<T>> extends StreamTask<T, OP> {
 
 		public NoOpStreamTask(Environment environment) {
-			super(environment, null);
+			super(environment);
 		}
 
 		@Override
@@ -1257,11 +1257,12 @@ public class StreamTaskTest extends TestLogger {
 		@Override
 		public StreamTaskStateInitializer createStreamTaskStateInitializer() {
 			final StreamTaskStateInitializer streamTaskStateManager = super.createStreamTaskStateInitializer();
-			return (operatorID, operatorClassName, keyContext, keySerializer, closeableRegistry, metricGroup) -> {
+			return (operatorID, operatorClassName, processingTimeService, keyContext, keySerializer, closeableRegistry, metricGroup) -> {
 
 				final StreamOperatorStateContext context = streamTaskStateManager.streamOperatorStateContext(
 					operatorID,
 					operatorClassName,
+					processingTimeService,
 					keyContext,
 					keySerializer,
 					closeableRegistry,
@@ -1425,7 +1426,7 @@ public class StreamTaskTest extends TestLogger {
 		private transient boolean hasTimerTriggered;
 
 		ThreadInspectingTask(Environment env) {
-			super(env, null);
+			super(env);
 			Thread currentThread = Thread.currentThread();
 			taskThreadId = currentThread.getId();
 			taskClassLoader = currentThread.getContextClassLoader();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -42,7 +42,9 @@ import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.graph.StreamNode;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
@@ -148,8 +150,8 @@ public class StreamTaskTestHarness<OUT> {
 		return mockEnv;
 	}
 
-	public ProcessingTimeService getProcessingTimeService() {
-		return taskThread.task.getProcessingTimeService();
+	public TimerService getTimerService() {
+		return taskThread.task.getTimerService();
 	}
 
 	/**
@@ -418,9 +420,15 @@ public class StreamTaskTestHarness<OUT> {
 	}
 
 	public StreamConfigChainer setupOperatorChain(OperatorID headOperatorId, StreamOperator<?> headOperator) {
+		return setupOperatorChain(headOperatorId, SimpleOperatorFactory.of(headOperator));
+	}
+
+	public StreamConfigChainer setupOperatorChain(OperatorID headOperatorId, StreamOperatorFactory<?> headOperatorFactory) {
 		Preconditions.checkState(!setupCalled, "This harness was already setup.");
 		setupCalled = true;
-		return new StreamConfigChainer(headOperatorId, headOperator, getStreamConfig());
+		StreamConfig streamConfig = getStreamConfig();
+		streamConfig.setStreamOperatorFactory(headOperatorFactory);
+		return new StreamConfigChainer(headOperatorId, streamConfig);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -66,7 +66,6 @@ import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
-import org.apache.flink.streaming.runtime.tasks.mailbox.execution.MailboxExecutorFactory;
 import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.Preconditions;
 
@@ -255,7 +254,7 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 			.setStreamTaskStateInitializer(streamTaskStateInitializer)
 			.setClosableRegistry(closableRegistry)
 			.setCheckpointStorage(checkpointStorage)
-			.setProcessingTimeService(processingTimeService)
+			.setTimerService(processingTimeService)
 			.setHandleAsyncException(handleAsyncException)
 			.build();
 	}
@@ -342,10 +341,6 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 			setupCalled = true;
 			this.mockTask.init();
 		}
-	}
-
-	private MailboxExecutorFactory getMailboxExecutorFactory() {
-		return mockTask.getMailboxExecutorFactory();
 	}
 
 	/**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -266,8 +266,7 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 		ProcessingTimeService processingTimeService) {
 		return new StreamTaskStateInitializerImpl(
 			env,
-			stateBackend,
-			processingTimeService);
+			stateBackend);
 	}
 
 	public void setStateBackend(StateBackend stateBackend) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
@@ -29,8 +29,8 @@ import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.streaming.runtime.tasks.TimerService;
 import org.apache.flink.streaming.runtime.tasks.mailbox.execution.DefaultActionContext;
-import org.apache.flink.streaming.runtime.tasks.mailbox.execution.MailboxExecutor;
 
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -62,11 +62,11 @@ public class MockStreamTask<OUT, OP extends StreamOperator<OUT>> extends StreamT
 		CloseableRegistry closableRegistry,
 		StreamStatusMaintainer streamStatusMaintainer,
 		CheckpointStorageWorkerView checkpointStorage,
-		ProcessingTimeService processingTimeService,
+		TimerService timerService,
 		BiConsumer<String, Throwable> handleAsyncException,
 		Map<String, Accumulator<?, ?>> accumulatorMap
 	) {
-		super(environment);
+		super(environment, timerService);
 		this.name = name;
 		this.checkpointLock = checkpointLock;
 		this.config = config;
@@ -75,7 +75,7 @@ public class MockStreamTask<OUT, OP extends StreamOperator<OUT>> extends StreamT
 		this.closableRegistry = closableRegistry;
 		this.streamStatusMaintainer = streamStatusMaintainer;
 		this.checkpointStorage = checkpointStorage;
-		this.processingTimeService = processingTimeService;
+		this.processingTimeService = timerService;
 		this.handleAsyncException = handleAsyncException;
 		this.accumulatorMap = accumulatorMap;
 	}
@@ -144,11 +144,6 @@ public class MockStreamTask<OUT, OP extends StreamOperator<OUT>> extends StreamT
 	}
 
 	@Override
-	public ProcessingTimeService getProcessingTimeService() {
-		return processingTimeService;
-	}
-
-	@Override
 	public void handleAsyncException(String message, Throwable exception) {
 		handleAsyncException.accept(message, exception);
 	}
@@ -158,13 +153,8 @@ public class MockStreamTask<OUT, OP extends StreamOperator<OUT>> extends StreamT
 		return accumulatorMap;
 	}
 
-	/**
-	 * Creates the mailbox executor for the operator with the given configuration.
-	 *
-	 * @param config the config of the operator.
-	 * @return the mailbox executor of the operator.
-	 */
-	public MailboxExecutor getMailboxExecutor(StreamConfig config) {
-		return getMailboxExecutorFactory().createExecutor(config.getChainIndex());
+	@Override
+	public ProcessingTimeService getProcessingTimeService(int operatorIndex) {
+		return processingTimeService;
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTaskBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTaskBuilder.java
@@ -62,7 +62,7 @@ public class MockStreamTaskBuilder {
 
 		StateBackend stateBackend = new MemoryStateBackend();
 		this.checkpointStorage = stateBackend.createCheckpointStorage(new JobID());
-		this.streamTaskStateInitializer = new StreamTaskStateInitializerImpl(environment, stateBackend, processingTimeService);
+		this.streamTaskStateInitializer = new StreamTaskStateInitializerImpl(environment, stateBackend);
 	}
 
 	public MockStreamTaskBuilder setName(String name) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTaskBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTaskBuilder.java
@@ -33,8 +33,8 @@ import org.apache.flink.streaming.api.operators.MockStreamStatusMaintainer;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializerImpl;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
-import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.TimerService;
 
 import java.util.Collections;
 import java.util.Map;
@@ -52,7 +52,7 @@ public class MockStreamTaskBuilder {
 	private CloseableRegistry closableRegistry = new CloseableRegistry();
 	private StreamStatusMaintainer streamStatusMaintainer = new MockStreamStatusMaintainer();
 	private CheckpointStorageWorkerView checkpointStorage;
-	private ProcessingTimeService processingTimeService = new TestProcessingTimeService();
+	private TimerService timerService = new TestProcessingTimeService();
 	private StreamTaskStateInitializer streamTaskStateInitializer;
 	private BiConsumer<String, Throwable> handleAsyncException = (message, throwable) -> { };
 	private Map<String, Accumulator<?, ?>> accumulatorMap = Collections.emptyMap();
@@ -105,8 +105,8 @@ public class MockStreamTaskBuilder {
 		return this;
 	}
 
-	public MockStreamTaskBuilder setProcessingTimeService(ProcessingTimeService processingTimeService) {
-		this.processingTimeService = processingTimeService;
+	public MockStreamTaskBuilder setTimerService(TimerService timerService) {
+		this.timerService = timerService;
 		return this;
 	}
 
@@ -126,7 +126,7 @@ public class MockStreamTaskBuilder {
 			closableRegistry,
 			streamStatusMaintainer,
 			checkpointStorage,
-			processingTimeService,
+			timerService,
 			handleAsyncException,
 			accumulatorMap);
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/StreamOperatorSnapshotRestoreTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/StreamOperatorSnapshotRestoreTest.java
@@ -235,11 +235,12 @@ public class StreamOperatorSnapshotRestoreTest extends TestLogger {
 				StateBackend stateBackend,
 				ProcessingTimeService processingTimeService) {
 
-				return new StreamTaskStateInitializerImpl(env, stateBackend, processingTimeService) {
+				return new StreamTaskStateInitializerImpl(env, stateBackend) {
 					@Override
 					protected <K> InternalTimeServiceManager<K> internalTimeServiceManager(
 						AbstractKeyedStateBackend<K> keyedStatedBackend,
 						KeyContext keyContext,
+						ProcessingTimeService processingTimeService,
 						Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws Exception {
 
 						return null;


### PR DESCRIPTION
## What is the purpose of the change

This change submits `StreamTask`'s timer trigger mailbox action with the priority of the operator that the trigger originate from. This should allow chaining multiple operators that use `mailboxExecutor.yield()` internally.

## Brief change log

  - set once and access `ProcessingTimeService` instance at operator level (a new field in `AbstractStreamOperator`);
  - instantiate `ProcessingTimeService` instance with mailbox executor using operator precedence .

## Verifying this change

All existing tests should pass. This change needs to add more tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
