### PR TITLE
[FLINK-14158] Update Mesos scheduler to make leaseOfferExpiration and declinedOfferRefuse duration configurable

### DIFF
--- a/docs/_includes/generated/mesos_configuration.html
+++ b/docs/_includes/generated/mesos_configuration.html
@@ -28,6 +28,11 @@
             <td>Enables SSL for the Flink artifact server. Note that security.ssl.enabled also needs to be set to true encryption to enable encryption.</td>
         </tr>
         <tr>
+            <td><h5>mesos.resourcemanager.declined-offer-refuse-duration</h5></td>
+            <td style="word-wrap: break-word;">5000</td>
+            <td>Amount of time to ask the Mesos master to not resend a declined resource offer again. This ensures a declined resource offer isn't resent immediately after being declined</td>
+        </tr>
+        <tr>
             <td><h5>mesos.resourcemanager.framework.name</h5></td>
             <td style="word-wrap: break-word;">"Flink"</td>
             <td>Mesos framework name</td>
@@ -56,6 +61,11 @@
             <td><h5>mesos.resourcemanager.tasks.port-assignments</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Comma-separated list of configuration keys which represent a configurable port. All port keys will dynamically get a port assigned through Mesos.</td>
+        </tr>
+        <tr>
+            <td><h5>mesos.resourcemanager.unusedoffer-expiration</h5></td>
+            <td style="word-wrap: break-word;">120000</td>
+            <td>Amount of time to wait for unused expired offers before declining them. This ensures your scheduler will not hoard unuseful offers.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/configuration/MesosOptions.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/configuration/MesosOptions.java
@@ -118,4 +118,30 @@ public class MesosOptions {
 				"All port keys will dynamically get a port assigned through Mesos.")
 			.build());
 
+	/**
+	 * Config parameter to configure the amount of time to wait for unused expired Mesos
+	 * offers before they are declined.
+	 */
+	public static final ConfigOption<Long> UNUSED_OFFER_EXPIRATION =
+		key("mesos.resourcemanager.unusedoffer-expiration")
+			.defaultValue(120000L)
+			.withDescription(
+				Description.builder()
+					.text("Amount of time to wait for unused expired offers before declining them. " +
+						"This ensures your scheduler will not hoard unuseful offers.")
+					.build());
+
+	/**
+	 * Config parameter to configure the amount of time refuse a particular offer for.
+	 * This ensures the same resource offer isn't resent immediately after declining.
+	 */
+	public static final ConfigOption<Long> DECLINED_OFFER_REFUSE_DURATION =
+		key("mesos.resourcemanager.declined-offer-refuse-duration")
+			.defaultValue(5000L)
+			.withDescription(
+				Description.builder()
+					.text("Amount of time to ask the Mesos master to not resend a " +
+						"declined resource offer again. This ensures a declined resource offer " +
+						"isn't resent immediately after being declined")
+					.build());
 }

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
@@ -764,6 +764,12 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 			}
 
 			@Override
+			public TaskSchedulerBuilder withLeaseOfferExpirySecs(long leaseOfferExpirySecs) {
+				builder.withLeaseOfferExpirySecs(leaseOfferExpirySecs);
+				return this;
+			}
+
+			@Override
 			public TaskScheduler build() {
 				return builder.build();
 			}

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/scheduler/TaskSchedulerBuilder.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/scheduler/TaskSchedulerBuilder.java
@@ -40,6 +40,11 @@ public interface TaskSchedulerBuilder {
 	TaskSchedulerBuilder withRejectAllExpiredOffers();
 
 	/**
+	 * Specify the expiration time for unused resource offers.
+	 */
+	TaskSchedulerBuilder withLeaseOfferExpirySecs(long leaseOfferExpirySecs);
+
+	/**
 	 * Build a Fenzo task scheduler.
 	 */
 	TaskScheduler build();

--- a/flink-mesos/src/main/scala/org/apache/flink/mesos/scheduler/LaunchCoordinator.scala
+++ b/flink-mesos/src/main/scala/org/apache/flink/mesos/scheduler/LaunchCoordinator.scala
@@ -19,22 +19,24 @@
 package org.apache.flink.mesos.scheduler
 
 import java.util.Collections
+import java.util.concurrent.TimeUnit
 
 import akka.actor.{Actor, ActorRef, FSM, Props}
 import com.netflix.fenzo._
 import com.netflix.fenzo.functions.Action1
 import grizzled.slf4j.Logger
-import org.apache.flink.api.java.tuple.{Tuple2=>FlinkTuple2}
+import org.apache.flink.api.java.tuple.{Tuple2 => FlinkTuple2}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.mesos.Utils
 import org.apache.flink.mesos.scheduler.LaunchCoordinator._
 import org.apache.flink.mesos.scheduler.messages._
 import org.apache.flink.mesos.util.MesosResourceAllocation
-import org.apache.mesos.{SchedulerDriver, Protos}
+import org.apache.mesos.{Protos, SchedulerDriver}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.{Map => MutableMap}
 import scala.concurrent.duration._
+import org.apache.flink.mesos.configuration.MesosOptions._
 
 /**
   * The launch coordinator handles offer processing, including
@@ -54,6 +56,15 @@ class LaunchCoordinator(
 
   val LOG = Logger(getClass)
 
+  val declineOfferFilters: Protos.Filters =
+    Protos.Filters.newBuilder()
+      .setRefuseSeconds(
+        Duration(config.getLong(DECLINED_OFFER_REFUSE_DURATION), TimeUnit.MILLISECONDS).toSeconds)
+      .build()
+
+  val unusedOfferExpirationDuration: Long =
+    Duration(config.getLong(UNUSED_OFFER_EXPIRATION), TimeUnit.MILLISECONDS).toSeconds
+
   /**
     * The task placement optimizer.
     *
@@ -68,13 +79,13 @@ class LaunchCoordinator(
           LOG.info(s"Declined offer ${lease.getId} from ${lease.hostname()} "
             + s"of memory ${lease.memoryMB()} MB, ${lease.cpuCores()} cpus, "
             + s"${lease.getScalarValue("gpus")} gpus, "
-            + s"of disk: ${lease.diskMB()} MB, network: ${lease.networkMbps()} Mbps")
-          schedulerDriver.declineOffer(lease.getOffer.getId)
+            + s"of disk: ${lease.diskMB()} MB, network: ${lease.networkMbps()} Mbps "
+            + s"for the next ${declineOfferFilters.getRefuseSeconds} seconds")
+          schedulerDriver.declineOffer(lease.getOffer.getId, declineOfferFilters)
         }
       })
-      // avoid situations where we have lots of expired offers and we only expire a few at a time
-      .withRejectAllExpiredOffers()
-      .build
+      .withLeaseOfferExpirySecs(unusedOfferExpirationDuration)
+      .withRejectAllExpiredOffers().build
   }
 
   override def postStop(): Unit = {
@@ -114,7 +125,9 @@ class LaunchCoordinator(
     case Event(offers: ResourceOffers, data: GatherData) =>
       // decline any offers that come in
       schedulerDriver.suppressOffers()
-      for(offer <- offers.offers().asScala) { schedulerDriver.declineOffer(offer.getId) }
+      for(offer <- offers.offers().asScala) {
+        schedulerDriver.declineOffer(offer.getId, declineOfferFilters)
+      }
       stay()
 
     case Event(msg: Launch, data: GatherData) =>

--- a/flink-mesos/src/test/scala/org/apache/flink/mesos/scheduler/LaunchCoordinatorTest.scala
+++ b/flink-mesos/src/test/scala/org/apache/flink/mesos/scheduler/LaunchCoordinatorTest.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.mesos.scheduler
 
+import java.util.concurrent.TimeUnit
 import java.util.{Collections, UUID}
 import java.util.concurrent.atomic.AtomicReference
 
@@ -27,13 +28,13 @@ import akka.testkit._
 import com.netflix.fenzo.TaskRequest.{AssignedResources, NamedResourceSetRequest}
 import com.netflix.fenzo._
 import com.netflix.fenzo.functions.{Action1, Action2}
-import org.apache.flink.api.java.tuple.{Tuple2 => FlinkTuple2}
+import org.apache.flink.api.java.tuple.{Tuple2=>FlinkTuple2}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.mesos.scheduler.LaunchCoordinator._
 import org.apache.flink.mesos.scheduler.messages._
 import org.apache.flink.runtime.akka.AkkaUtils
 import org.apache.mesos.Protos.{SlaveID, TaskInfo}
-import org.apache.mesos.{Protos, SchedulerDriver}
+import org.apache.mesos.{SchedulerDriver, Protos}
 import org.junit.runner.RunWith
 import org.mockito.Mockito.{verify, _}
 import org.mockito.invocation.InvocationOnMock
@@ -47,7 +48,10 @@ import scala.collection.JavaConverters._
 import org.apache.flink.mesos.Utils.range
 import org.apache.flink.mesos.Utils.ranges
 import org.apache.flink.mesos.Utils.scalar
+import org.apache.flink.mesos.configuration.MesosOptions.DECLINED_OFFER_REFUSE_DURATION
 import org.apache.flink.mesos.util.MesosResourceAllocation
+
+import scala.concurrent.duration.Duration
 
 @RunWith(classOf[JUnitRunner])
 class LaunchCoordinatorTest
@@ -202,6 +206,9 @@ class LaunchCoordinatorTest
   def taskSchedulerBuilder(optimizer: TaskScheduler) = new TaskSchedulerBuilder {
     var leaseRejectAction: Action1[VirtualMachineLease] = null
     var rejectAllExpiredOffers: Boolean = false
+    var leaseOfferExpiry: Long = 0L
+    var offersToReject: Int = 0
+
     override def withLeaseRejectAction(
         action: Action1[VirtualMachineLease]): TaskSchedulerBuilder = {
       leaseRejectAction = action
@@ -212,7 +219,13 @@ class LaunchCoordinatorTest
       this
     }
 
+    override def withLeaseOfferExpirySecs(leaseOfferExpirySecs: Long): TaskSchedulerBuilder = {
+      leaseOfferExpiry = leaseOfferExpirySecs
+      this
+    }
+
     override def build(): TaskScheduler = optimizer
+
   }
 
   /**
@@ -239,6 +252,11 @@ class LaunchCoordinatorTest
     val trace = Mockito.inOrder(schedulerDriver)
     val fsm =
       TestFSMRef(new LaunchCoordinator(testActor, config, schedulerDriver, optimizerBuilder))
+    val refuseFilter =
+      Protos.Filters.newBuilder()
+        .setRefuseSeconds(
+          Duration(config.getLong(DECLINED_OFFER_REFUSE_DURATION), TimeUnit.MILLISECONDS).toSeconds)
+        .build()
 
     val framework = randomFramework
     val task1 = randomTask
@@ -321,8 +339,8 @@ class LaunchCoordinatorTest
         "stays in Idle with offers declined" in new Context {
           fsm.setState(Idle)
           fsm ! new ResourceOffers(Seq(slave1._3, slave1._4).asJava)
-          verify(schedulerDriver).declineOffer(slave1._3.getId)
-          verify(schedulerDriver).declineOffer(slave1._4.getId)
+          verify(schedulerDriver).declineOffer(slave1._3.getId, refuseFilter)
+          verify(schedulerDriver).declineOffer(slave1._4.getId, refuseFilter)
           fsm.stateName should be (Idle)
         }
       }
@@ -462,7 +480,7 @@ class LaunchCoordinatorTest
           fsm.setState(GatheringOffers,
             GatherData(tasks = Seq(task1._2), newLeases = Seq(lease(slave1._3))))
           fsm ! StateTimeout
-          verify(schedulerDriver).declineOffer(slave1._3.getId)
+          verify(schedulerDriver).declineOffer(slave1._3.getId, refuseFilter)
         }
       }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

While debugging some Flink on Mesos scheduling issues (tied to our use of Mesos quotas) we end up getting skewed offers that are useless fairly often. As we are not rejecting these offers fast enough and as we are not telling Mesos to not re-send for a long enough period, we end up not being able to schedule our job for upwards of an hour (~30 Mesos containers).

The Fenzo default is to reject expired and unused Mesos offers after 120s, this can be overridden using their TaskScheduler builder. Additionally, Mesos allows us to override the time for which it won't re-send offers (default is 5s). We found that updating to reject more aggressively (every 1s instead of 120s) and keeping rejected offers away for longer (60s instead of 5s) dramatically increases our chances of scheduling our jobs on Mesos.

(As the defaults, I've left the current values that Flink on Mesos users have as of today to not result in any surprises when they upgrade / pull in this change. )

This is a follow-up item that was discussed in https://github.com/apache/flink/pull/9652


## Brief change log

  - Add config options for unused offer expiry time and declined offer refuse duration
  - Plumb change through to Fenzo TaskScheduler and Mesos driver.

## Verifying this change


Existing unit tests + manually tested config options to verify that they work as expected. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: No
  - The serializers: No
  - The runtime per-record code paths (performance sensitive): No
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: Yes (Mesos)
  - The S3 file system connector: No

## Documentation

  - Does this pull request introduce a new feature? No just config options
  - If yes, how is the feature documented? Documented config options
