### PR TITLE
[FLINK-14076] Ensure CheckpointException can always be deserialized on JobManager

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseTest.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseTest.java
@@ -37,11 +37,13 @@ import org.junit.Test;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.LinkedList;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeoutException;
 
+import static org.apache.flink.util.ExceptionUtils.findSerializedThrowable;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
 import static org.mockito.Mockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -156,7 +158,8 @@ public class CassandraSinkBaseTest {
 
 				Assert.fail();
 			} catch (Exception e) {
-				Assert.assertTrue(e.getCause() instanceof IOException);
+				Optional<IOException> exCause = findSerializedThrowable(e, IOException.class, ClassLoader.getSystemClassLoader());
+				Assert.assertTrue(exCause.isPresent());
 			}
 		}
 	}

--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011ITCase.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011ITCase.java
@@ -49,7 +49,7 @@ import java.util.stream.IntStream;
 import static org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer011.Semantic;
 import static org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer011.Semantic.AT_LEAST_ONCE;
 import static org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer011.Semantic.EXACTLY_ONCE;
-import static org.apache.flink.util.ExceptionUtils.findThrowable;
+import static org.apache.flink.util.ExceptionUtils.findSerializedThrowable;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
@@ -160,7 +160,7 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBaseWithFlink {
 		}
 		catch (Exception ex) {
 			// testHarness1 will be fenced off after creating and closing testHarness2
-			if (!findThrowable(ex, ProducerFencedException.class).isPresent()) {
+			if (!findSerializedThrowable(ex, ProducerFencedException.class, ClassLoader.getSystemClassLoader()).isPresent()) {
 				throw ex;
 			}
 		}
@@ -664,7 +664,8 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBaseWithFlink {
 	}
 
 	private boolean isCausedBy(FlinkKafka011ErrorCode expectedErrorCode, Throwable ex) {
-		Optional<FlinkKafka011Exception> cause = findThrowable(ex, FlinkKafka011Exception.class);
+		// Extract the root cause kafka exception (if any) from the serialized throwable.
+		Optional<FlinkKafka011Exception> cause = findSerializedThrowable(ex, FlinkKafka011Exception.class, ClassLoader.getSystemClassLoader());
 		if (cause.isPresent()) {
 			return cause.get().getErrorCode().equals(expectedErrorCode);
 		}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
@@ -45,7 +45,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.apache.flink.util.ExceptionUtils.findThrowable;
+import static org.apache.flink.util.ExceptionUtils.findSerializedThrowable;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
@@ -156,7 +156,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 		}
 		catch (Exception ex) {
 			// testHarness1 will be fenced off after creating and closing testHarness2
-			if (!findThrowable(ex, ProducerFencedException.class).isPresent()) {
+			if (!findSerializedThrowable(ex, ProducerFencedException.class, ClassLoader.getSystemClassLoader()).isPresent()) {
 				throw ex;
 			}
 		}
@@ -662,7 +662,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 	}
 
 	private boolean isCausedBy(FlinkKafkaErrorCode expectedErrorCode, Throwable ex) {
-		Optional<FlinkKafkaException> cause = findThrowable(ex, FlinkKafkaException.class);
+		Optional<FlinkKafkaException> cause = findSerializedThrowable(ex, FlinkKafkaException.class, ClassLoader.getSystemClassLoader());
 		if (cause.isPresent()) {
 			return cause.get().getErrorCode().equals(expectedErrorCode);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointException.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.SerializedThrowable;
 
 /**
  * Base class for checkpoint related exceptions.
@@ -40,12 +41,20 @@ public class CheckpointException extends Exception {
 	}
 
 	public CheckpointException(CheckpointFailureReason failureReason, Throwable cause) {
-		super(failureReason.message(), cause);
+		// Defensively replace the cause with a SerializedThrowable in case it's a user-defined exception
+		// that doesn't exist on the JobManager's default classpath.
+		super(
+			failureReason.message(),
+			cause == null ? null : new SerializedThrowable(cause));
 		this.checkpointFailureReason = Preconditions.checkNotNull(failureReason);
 	}
 
 	public CheckpointException(String message, CheckpointFailureReason failureReason, Throwable cause) {
-		super(message + " Failure reason: " + failureReason.message(), cause);
+		// Defensively replace the cause with a SerializedThrowable in case it's a user-defined exception
+		// that doesn't exist on the JobManager's default classpath.
+		super(
+			message + " Failure reason: " + failureReason.message(),
+			cause == null ? null : new SerializedThrowable(cause));
 		this.checkpointFailureReason = Preconditions.checkNotNull(failureReason);
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunctionTest.java
@@ -47,6 +47,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.util.ExceptionUtils.findSerializedThrowable;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.junit.Assert.assertEquals;
@@ -167,7 +168,7 @@ public class TwoPhaseCommitSinkFunctionTest {
 			harness.snapshot(2, 5);
 			fail("something should fail");
 		} catch (Exception ex) {
-			if (!(ex.getCause() instanceof ContentDump.NotWritableException)) {
+			if (!findSerializedThrowable(ex, ContentDump.NotWritableException.class, ClassLoader.getSystemClassLoader()).isPresent()) {
 				throw ex;
 			}
 			// ignore

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
@@ -558,7 +558,7 @@ public class AbstractStreamOperatorTest {
 					new MemCheckpointStreamFactory(Integer.MAX_VALUE));
 			fail("Exception expected.");
 		} catch (Exception e) {
-			assertEquals(failingException, e.getCause());
+			assertEquals(failingException.getMessage(), e.getCause().getMessage());
 		}
 	}
 
@@ -636,7 +636,7 @@ public class AbstractStreamOperatorTest {
 					new MemCheckpointStreamFactory(Integer.MAX_VALUE));
 			fail("Exception expected.");
 		} catch (Exception e) {
-			assertEquals(failingException, e.getCause());
+			assertEquals(failingException.getMessage(), e.getCause().getMessage());
 		}
 
 		// verify that the context has been closed, the operator snapshot result has been cancelled

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/ContentDump.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/ContentDump.java
@@ -124,7 +124,7 @@ public class ContentDump {
 	/**
 	 * Exception thrown for an attempt to write into read-only {@link ContentDump}.
 	 */
-	public class NotWritableException extends RuntimeException {
+	public static class NotWritableException extends RuntimeException {
 		public NotWritableException(String name) {
 			super(String.format("File [%s] is not writable", name));
 		}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

JobManager would previously fail to deserialize a DeclineCheckpoint if it contained a CheckpointException with a root cause from user-defined code. For example, if a `org.apache.apache.kafka.KafkaException` caused a checkpoint to fail, it would get wrapped in a CheckpointException. The KafkaException is not on the JM classpath, so the (wrapped) KafkaException will cause deserialization to fail on the JM. Now CheckpointException always wraps its cause to ensure deserialization works.


## Brief change log
  - JM is guaranteed to be able to deserialize DeclineCheckpoint from TM


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: don't know
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
