### PR TITLE
[FLINK-13515][test] Fix ClassLoaderITCase fails on Java 11

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
@@ -142,7 +142,7 @@ public class ClassLoaderITCase extends TestLogger {
 	}
 
 	@Test
-	public void testCustomSplitJobWithCustomClassLoaderJar() throws IOException, ProgramInvocationException {
+	public void testCustomSplitJobWithCustomClassLoaderJar() throws ProgramInvocationException {
 
 		PackagedProgram inputSplitTestProg = new PackagedProgram(new File(INPUT_SPLITS_PROG_JAR_FILE));
 
@@ -150,20 +150,20 @@ public class ClassLoaderITCase extends TestLogger {
 			miniClusterResource.getMiniCluster(),
 			parallelism,
 			Collections.singleton(new Path(INPUT_SPLITS_PROG_JAR_FILE)),
-			Collections.<URL>emptyList());
+			Collections.emptyList());
 
 		inputSplitTestProg.invokeInteractiveModeForExecution();
 	}
 
 	@Test
-	public void testStreamingCustomSplitJobWithCustomClassLoader() throws IOException, ProgramInvocationException {
+	public void testStreamingCustomSplitJobWithCustomClassLoader() throws ProgramInvocationException {
 		PackagedProgram streamingInputSplitTestProg = new PackagedProgram(new File(STREAMING_INPUT_SPLITS_PROG_JAR_FILE));
 
 		TestStreamEnvironment.setAsContext(
 			miniClusterResource.getMiniCluster(),
 			parallelism,
 			Collections.singleton(new Path(STREAMING_INPUT_SPLITS_PROG_JAR_FILE)),
-			Collections.<URL>emptyList());
+			Collections.emptyList());
 
 		streamingInputSplitTestProg.invokeInteractiveModeForExecution();
 	}
@@ -176,14 +176,14 @@ public class ClassLoaderITCase extends TestLogger {
 		TestEnvironment.setAsContext(
 			miniClusterResource.getMiniCluster(),
 			parallelism,
-			Collections.<Path>emptyList(),
+			Collections.emptyList(),
 			Collections.singleton(classpath));
 
 		inputSplitTestProg2.invokeInteractiveModeForExecution();
 	}
 
 	@Test
-	public void testStreamingClassloaderJobWithCustomClassLoader() throws IOException, ProgramInvocationException {
+	public void testStreamingClassloaderJobWithCustomClassLoader() throws ProgramInvocationException {
 		// regular streaming job
 		PackagedProgram streamingProg = new PackagedProgram(new File(STREAMING_PROG_JAR_FILE));
 
@@ -191,13 +191,13 @@ public class ClassLoaderITCase extends TestLogger {
 			miniClusterResource.getMiniCluster(),
 			parallelism,
 			Collections.singleton(new Path(STREAMING_PROG_JAR_FILE)),
-			Collections.<URL>emptyList());
+			Collections.emptyList());
 
 		streamingProg.invokeInteractiveModeForExecution();
 	}
 
 	@Test
-	public void testCheckpointedStreamingClassloaderJobWithCustomClassLoader() throws IOException, ProgramInvocationException {
+	public void testCheckpointedStreamingClassloaderJobWithCustomClassLoader() throws ProgramInvocationException {
 		// checkpointed streaming job with custom classes for the checkpoint (FLINK-2543)
 		// the test also ensures that user specific exceptions are serializable between JobManager <--> JobClient.
 		PackagedProgram streamingCheckpointedProg = new PackagedProgram(new File(STREAMING_CHECKPOINTED_PROG_JAR_FILE));
@@ -206,7 +206,7 @@ public class ClassLoaderITCase extends TestLogger {
 			miniClusterResource.getMiniCluster(),
 			parallelism,
 			Collections.singleton(new Path(STREAMING_CHECKPOINTED_PROG_JAR_FILE)),
-			Collections.<URL>emptyList());
+			Collections.emptyList());
 
 		try {
 			streamingCheckpointedProg.invokeInteractiveModeForExecution();
@@ -233,7 +233,7 @@ public class ClassLoaderITCase extends TestLogger {
 	}
 
 	@Test
-	public void testKMeansJobWithCustomClassLoader() throws IOException, ProgramInvocationException {
+	public void testKMeansJobWithCustomClassLoader() throws ProgramInvocationException {
 		PackagedProgram kMeansProg = new PackagedProgram(
 			new File(KMEANS_JAR_PATH),
 			new String[] {
@@ -246,20 +246,20 @@ public class ClassLoaderITCase extends TestLogger {
 			miniClusterResource.getMiniCluster(),
 			parallelism,
 			Collections.singleton(new Path(KMEANS_JAR_PATH)),
-			Collections.<URL>emptyList());
+			Collections.emptyList());
 
 		kMeansProg.invokeInteractiveModeForExecution();
 	}
 
 	@Test
-	public void testUserCodeTypeJobWithCustomClassLoader() throws IOException, ProgramInvocationException {
+	public void testUserCodeTypeJobWithCustomClassLoader() throws ProgramInvocationException {
 		PackagedProgram userCodeTypeProg = new PackagedProgram(new File(USERCODETYPE_JAR_PATH));
 
 		TestEnvironment.setAsContext(
 			miniClusterResource.getMiniCluster(),
 			parallelism,
 			Collections.singleton(new Path(USERCODETYPE_JAR_PATH)),
-			Collections.<URL>emptyList());
+			Collections.emptyList());
 
 		userCodeTypeProg.invokeInteractiveModeForExecution();
 	}
@@ -280,10 +280,10 @@ public class ClassLoaderITCase extends TestLogger {
 			miniClusterResource.getMiniCluster(),
 			parallelism,
 			Collections.singleton(new Path(CHECKPOINTING_CUSTOM_KV_STATE_JAR_PATH)),
-			Collections.<URL>emptyList());
+			Collections.emptyList());
 
 		expectedException.expectCause(
-			Matchers.<Throwable>hasProperty("cause", isA(SuccessException.class)));
+			Matchers.hasProperty("cause", isA(SuccessException.class)));
 
 		program.invokeInteractiveModeForExecution();
 	}
@@ -313,20 +313,17 @@ public class ClassLoaderITCase extends TestLogger {
 			miniClusterResource.getMiniCluster(),
 			parallelism,
 			Collections.singleton(new Path(CUSTOM_KV_STATE_JAR_PATH)),
-			Collections.<URL>emptyList()
+			Collections.emptyList()
 		);
 
 		// Execute detached
-		Thread invokeThread = new Thread(new Runnable() {
-			@Override
-			public void run() {
-				try {
-					program.invokeInteractiveModeForExecution();
-				} catch (ProgramInvocationException ignored) {
-					if (ignored.getCause() == null ||
-						!(ignored.getCause() instanceof JobCancellationException)) {
-						ignored.printStackTrace();
-					}
+		Thread invokeThread = new Thread(() -> {
+			try {
+				program.invokeInteractiveModeForExecution();
+			} catch (ProgramInvocationException ex) {
+				if (ex.getCause() == null ||
+					!(ex.getCause() instanceof JobCancellationException)) {
+					ex.printStackTrace();
 				}
 			}
 		});


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes the failure of `ClassLoaderITCase` on Java 11. For a nested class instance `x`, `x.getCanonicalName()` finds and loads the enclosing class of `x` by calling the methods of the classloader where `x` resides. Thus, it is incorrect to use `candidate.getClass().getCanonicalName()` to test whether there is `SuccessException` in the classpath of the class loader where the `ClassLoaderITCase` class resides, because `candidate.getClass().getCanonicalName()` will not find and load the related classes in the classloader where the `ClassLoaderITCase` class resides. We should use `Class.forName(...)` to test the expected result.


In addition, when calling `getCanonicalName()` , `NoClassDefFoundError` is reported in Java 8, not in Java 11,  for the following reason:

In Java 8, a class named `CheckpointedStreamingProgram$1` is generated at compiling ( because there are nested classes) , and when the nested classes are loaded, the dependent class loaded is `CheckpointedStreamingProgram$1` rather than `CheckpointedStreamingProgram`. Therefore, when `getCanonicalName()` is called in `ClassLoaderITCase`, the `CheckpointedStreamingProgram` class needs to be loaded, but at this time the `ChildFirstClassloader` (an `URLClassloader`) is closed and cannot load it, so `NoClassDefFoundError` is reported. But in Java 11, the `CheckpointedStreamingProgram$1` class is not generated and the `CheckpointedStreamingProgram` class is used directly (that is the `CheckpointedStreamingProgram` class has been loaded into `ChildFirstClassloader` before closing `ChildFirstClassloader`), so no errors are reported.


## Brief change log

  - Change the expected detection logic in `ClassLoaderITCase#testCheckpointedStreamingClassloaderJobWithCustomClassLoader`


## Verifying this change

This change is already covered by existing test.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
