### PR TITLE
[FLINK-14070] [runtime] Use TimeUtils to parse duration configs in flink-runtime

### DIFF
--- a/docs/_includes/generated/failure_rate_restart_strategy_configuration.html
+++ b/docs/_includes/generated/failure_rate_restart_strategy_configuration.html
@@ -10,12 +10,12 @@
         <tr>
             <td><h5>restart-strategy.failure-rate.delay</h5></td>
             <td style="word-wrap: break-word;">"1 s"</td>
-            <td>Delay between two consecutive restart attempts if <span markdown="span">`restart-strategy`</span> has been set to <span markdown="span">`failure-rate`</span>. It can be specified using Scala's <span markdown="span">`FiniteDuration`</span> notation: "1 min", "20 s"</td>
+            <td>Delay between two consecutive restart attempts if <span markdown="span">`restart-strategy`</span> has been set to <span markdown="span">`failure-rate`</span>. It can be specified using notation: "1 min", "20 s"</td>
         </tr>
         <tr>
             <td><h5>restart-strategy.failure-rate.failure-rate-interval</h5></td>
             <td style="word-wrap: break-word;">"1 min"</td>
-            <td>Time interval for measuring failure rate if <span markdown="span">`restart-strategy`</span> has been set to <span markdown="span">`failure-rate`</span>. It can be specified using Scala's <span markdown="span">`FiniteDuration`</span> notation: "1 min", "20 s"</td>
+            <td>Time interval for measuring failure rate if <span markdown="span">`restart-strategy`</span> has been set to <span markdown="span">`failure-rate`</span>. It can be specified using notation: "1 min", "20 s"</td>
         </tr>
         <tr>
             <td><h5>restart-strategy.failure-rate.max-failures-per-interval</h5></td>

--- a/docs/_includes/generated/fixed_delay_restart_strategy_configuration.html
+++ b/docs/_includes/generated/fixed_delay_restart_strategy_configuration.html
@@ -15,7 +15,7 @@
         <tr>
             <td><h5>restart-strategy.fixed-delay.delay</h5></td>
             <td style="word-wrap: break-word;">"1 s"</td>
-            <td>Delay between two consecutive restart attempts if <span markdown="span">`restart-strategy`</span> has been set to <span markdown="span">`fixed-delay`</span>. Delaying the retries can be helpful when the program interacts with external systems where for example connections or pending transactions should reach a timeout before re-execution is attempted. It can be specified using Scala's <span markdown="span">`FiniteDuration`</span> notation: "1 min", "20 s"</td>
+            <td>Delay between two consecutive restart attempts if <span markdown="span">`restart-strategy`</span> has been set to <span markdown="span">`fixed-delay`</span>. Delaying the retries can be helpful when the program interacts with external systems where for example connections or pending transactions should reach a timeout before re-execution is attempted. It can be specified using notation: "1 min", "20 s"</td>
         </tr>
     </tbody>
 </table>

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -73,6 +73,7 @@ import java.lang.reflect.UndeclaredThrowableException;
 import java.net.InetSocketAddress;
 import java.net.URL;
 import java.text.SimpleDateFormat;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -83,8 +84,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-
-import scala.concurrent.duration.FiniteDuration;
 
 /**
  * Implementation of a simple command line frontend for executing programs.
@@ -113,7 +112,7 @@ public class CliFrontend {
 
 	private final Options customCommandLineOptions;
 
-	private final FiniteDuration clientTimeout;
+	private final Duration clientTimeout;
 
 	private final int defaultParallelism;
 

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -52,12 +52,11 @@ import javax.annotation.Nullable;
 
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-
-import scala.concurrent.duration.FiniteDuration;
 
 /**
  * Encapsulates the functionality necessary to submit a program to a remote cluster.
@@ -75,7 +74,7 @@ public abstract class ClusterClient<T> implements AutoCloseable {
 	protected final Configuration flinkConfig;
 
 	/** Timeout for futures. */
-	protected final FiniteDuration timeout;
+	protected final Duration timeout;
 	/**
 	 * For interactive invocations, the job results are only available after the ContextEnvironment has
 	 * been run inside the user JAR. We pass the Client to every instance of the ContextEnvironment

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestartStrategyOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestartStrategyOptions.java
@@ -92,10 +92,9 @@ public class RestartStrategyOptions {
 					"Delay between two consecutive restart attempts if %s has been set to %s. " +
 						"Delaying the retries can be helpful when the program interacts with external systems where " +
 						"for example connections or pending transactions should reach a timeout before re-execution " +
-						"is attempted. It can be specified using Scala's %s notation: \"1 min\", \"20 s\"",
+						"is attempted. It can be specified using notation: \"1 min\", \"20 s\"",
 					code(RESTART_STRATEGY.key()),
-					code("fixed-delay"),
-					code("FiniteDuration"))
+					code("fixed-delay"))
 				.build());
 
 	public static final ConfigOption<Integer> RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL = ConfigOptions
@@ -116,10 +115,9 @@ public class RestartStrategyOptions {
 			Description.builder()
 				.text(
 					"Time interval for measuring failure rate if %s has been set to %s. " +
-						"It can be specified using Scala's %s notation: \"1 min\", \"20 s\"",
+						"It can be specified using notation: \"1 min\", \"20 s\"",
 					code(RESTART_STRATEGY.key()),
-					code("failure-rate"),
-					code("FiniteDuration"))
+					code("failure-rate"))
 				.build());
 
 	public static final ConfigOption<String> RESTART_STRATEGY_FAILURE_RATE_DELAY = ConfigOptions
@@ -129,10 +127,9 @@ public class RestartStrategyOptions {
 			Description.builder()
 				.text(
 					"Delay between two consecutive restart attempts if %s has been set to %s. " +
-						"It can be specified using Scala's %s notation: \"1 min\", \"20 s\"",
+						"It can be specified using notation: \"1 min\", \"20 s\"",
 					code(RESTART_STRATEGY.key()),
-					code("failure-rate"),
-					code("FiniteDuration"))
+					code("failure-rate"))
 				.build());
 
 	private RestartStrategyOptions() {

--- a/flink-core/src/main/java/org/apache/flink/util/TimeUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/TimeUtils.java
@@ -109,6 +109,14 @@ public class TimeUtils {
 	}
 
 	/**
+	 * @param duration to convert to string
+	 * @return duration string in millis
+	 */
+	public static String getStringInMillis(final Duration duration) {
+		return duration.toMillis() + TimeUnit.MILLISECONDS.labels.get(0);
+	}
+
+	/**
 	 * Enum which defines time unit, mostly used to parse value from configuration file.
 	 */
 	private enum TimeUnit {

--- a/flink-core/src/test/java/org/apache/flink/util/TimeUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/TimeUtilsTest.java
@@ -20,6 +20,9 @@ package org.apache.flink.util;
 
 import org.junit.Test;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -165,5 +168,12 @@ public class TimeUtilsTest {
 	@Test(expected = IllegalArgumentException.class)
 	public void testParseDurationNumberOverflow() {
 		TimeUtils.parseDuration("100000000000000000000000000000000 ms");
+	}
+
+	@Test
+	public void testGetStringInMillis() {
+		assertEquals("4567ms", TimeUtils.getStringInMillis(Duration.ofMillis(4567L)));
+		assertEquals("4567000ms", TimeUtils.getStringInMillis(Duration.ofSeconds(4567L)));
+		assertEquals("4ms", TimeUtils.getStringInMillis(Duration.of(4567L, ChronoUnit.MICROS)));
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FailureRateRestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FailureRateRestartStrategy.java
@@ -25,11 +25,11 @@ import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TimeUtils;
 
+import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.concurrent.CompletableFuture;
-
-import scala.concurrent.duration.Duration;
 
 /**
  * Restart strategy which tries to restart the given {@link ExecutionGraph} when failure rate exceeded
@@ -94,8 +94,8 @@ public class FailureRateRestartStrategy implements RestartStrategy {
 		String failuresIntervalString = configuration.getString(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL);
 		String delayString = configuration.getString(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_DELAY);
 
-		Duration failuresInterval = Duration.apply(failuresIntervalString);
-		Duration delay = Duration.apply(delayString);
+		Duration failuresInterval = TimeUtils.parseDuration(failuresIntervalString);
+		Duration delay = TimeUtils.parseDuration(delayString);
 
 		return new FailureRateRestartStrategyFactory(maxFailuresPerInterval, Time.milliseconds(failuresInterval.toMillis()), Time.milliseconds(delay.toMillis()));
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategy.java
@@ -25,10 +25,9 @@ import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TimeUtils;
 
 import java.util.concurrent.CompletableFuture;
-
-import scala.concurrent.duration.Duration;
 
 /**
  * Restart strategy which tries to restart the given {@link ExecutionGraph} a fixed number of times
@@ -82,11 +81,11 @@ public class FixedDelayRestartStrategy implements RestartStrategy {
 		long delay;
 
 		try {
-			delay = Duration.apply(delayString).toMillis();
-		} catch (NumberFormatException nfe) {
+			delay = TimeUtils.parseDuration(delayString).toMillis();
+		} catch (IllegalArgumentException ex) {
 			throw new Exception("Invalid config value for " +
 					RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY.key() + ": " + delayString +
-					". Value must be a valid duration (such as '100 milli' or '10 s')");
+					". Value must be a valid duration (such as '100 milli' or '10 s')", ex);
 		}
 
 		return new FixedDelayRestartStrategyFactory(maxAttempts, delay);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerSharedServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerSharedServices.java
@@ -39,11 +39,10 @@ import org.apache.flink.util.ExceptionUtils;
 
 import javax.annotation.Nonnull;
 
+import java.time.Duration;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-
-import scala.concurrent.duration.FiniteDuration;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -152,7 +151,7 @@ public class JobManagerSharedServices {
 				FlinkUserCodeClassLoaders.ResolveOrder.fromString(classLoaderResolveOrder),
 				alwaysParentFirstLoaderPatterns);
 
-		final FiniteDuration timeout;
+		final Duration timeout;
 		try {
 			timeout = AkkaUtils.getTimeout(config);
 		} catch (NumberFormatException e) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
@@ -30,8 +30,6 @@ import org.apache.flink.util.StringUtils;
 
 import javax.annotation.Nullable;
 
-import scala.concurrent.duration.FiniteDuration;
-
 import static org.apache.flink.runtime.minicluster.RpcServiceSharing.SHARED;
 
 /**
@@ -104,8 +102,7 @@ public class MiniClusterConfiguration {
 	}
 
 	public Time getRpcTimeout() {
-		FiniteDuration duration = AkkaUtils.getTimeout(configuration);
-		return Time.of(duration.length(), duration.unit());
+		return AkkaUtils.getTimeoutAsTime(configuration);
 	}
 
 	public UnmodifiableConfiguration getConfiguration() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServicesConfiguration.java
@@ -21,10 +21,10 @@ package org.apache.flink.runtime.resourcemanager;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ResourceManagerOptions;
-import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerConfiguration;
+import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.Preconditions;
-import scala.concurrent.duration.Duration;
+import org.apache.flink.util.TimeUtils;
 
 /**
  * Configuration class for the {@link ResourceManagerRuntimeServices} class.
@@ -56,8 +56,8 @@ public class ResourceManagerRuntimeServicesConfiguration {
 		final Time jobTimeout;
 
 		try {
-			jobTimeout = Time.milliseconds(Duration.apply(strJobTimeout).toMillis());
-		} catch (NumberFormatException e) {
+			jobTimeout = Time.milliseconds(TimeUtils.parseDuration(strJobTimeout).toMillis());
+		} catch (IllegalArgumentException e) {
 			throw new ConfigurationException("Could not parse the resource manager's job timeout " +
 				"value " + ResourceManagerOptions.JOB_TIMEOUT + '.', e);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -23,13 +23,12 @@ import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.ResourceManagerOptions;
+import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import scala.concurrent.duration.Duration;
 
 /**
  * Configuration for the {@link SlotManager}.
@@ -72,12 +71,10 @@ public class SlotManagerConfiguration {
 	}
 
 	public static SlotManagerConfiguration fromConfiguration(Configuration configuration) throws ConfigurationException {
-		final String strTimeout = configuration.getString(AkkaOptions.ASK_TIMEOUT);
 		final Time rpcTimeout;
-
 		try {
-			rpcTimeout = Time.milliseconds(Duration.apply(strTimeout).toMillis());
-		} catch (NumberFormatException e) {
+			rpcTimeout = AkkaUtils.getTimeoutAsTime(configuration);
+		} catch (IllegalArgumentException e) {
 			throw new ConfigurationException("Could not parse the resource manager's timeout " +
 				"value " + AkkaOptions.ASK_TIMEOUT + '.', e);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceConfiguration.java
@@ -23,8 +23,6 @@ import org.apache.flink.runtime.akka.AkkaUtils;
 
 import javax.annotation.Nonnull;
 
-import scala.concurrent.duration.FiniteDuration;
-
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
@@ -62,8 +60,7 @@ public class AkkaRpcServiceConfiguration {
 	}
 
 	public static AkkaRpcServiceConfiguration fromConfiguration(Configuration configuration) {
-		final FiniteDuration duration = AkkaUtils.getTimeout(configuration);
-		final Time timeout = Time.of(duration.length(), duration.unit());
+		final Time timeout = AkkaUtils.getTimeoutAsTime(configuration);
 
 		final long maximumFramesize = AkkaRpcServiceUtils.extractMaximumFramesize(configuration);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
@@ -31,13 +31,14 @@ import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders
 import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TimeUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import scala.concurrent.duration.Duration;
+import java.time.Duration;
 
 /**
  * Configuration object for {@link TaskExecutor}.
@@ -196,56 +197,39 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 
 		LOG.info("Messages have a max timeout of " + timeout);
 
-		final Time finiteRegistrationDuration;
-
+		Time finiteRegistrationDuration;
 		try {
-			Duration maxRegistrationDuration = Duration.create(configuration.getString(TaskManagerOptions.REGISTRATION_TIMEOUT));
-			if (maxRegistrationDuration.isFinite()) {
-				finiteRegistrationDuration = Time.milliseconds(maxRegistrationDuration.toMillis());
-			} else {
-				finiteRegistrationDuration = null;
-			}
-		} catch (NumberFormatException e) {
-			throw new IllegalArgumentException("Invalid format for parameter " +
-				TaskManagerOptions.REGISTRATION_TIMEOUT.key(), e);
+			Duration maxRegistrationDuration = TimeUtils.parseDuration(configuration.getString(TaskManagerOptions.REGISTRATION_TIMEOUT));
+			finiteRegistrationDuration = Time.milliseconds(maxRegistrationDuration.toMillis());
+		} catch (IllegalArgumentException e) {
+			LOG.warn("Invalid format for parameter {}. Set the timeout to be infinite.",
+				TaskManagerOptions.REGISTRATION_TIMEOUT.key());
+			finiteRegistrationDuration = null;
 		}
 
 		final Time initialRegistrationPause;
 		try {
-			Duration pause = Duration.create(configuration.getString(TaskManagerOptions.INITIAL_REGISTRATION_BACKOFF));
-			if (pause.isFinite()) {
-				initialRegistrationPause = Time.milliseconds(pause.toMillis());
-			} else {
-				throw new IllegalArgumentException("The initial registration pause must be finite: " + pause);
-			}
-		} catch (NumberFormatException e) {
+			Duration pause = TimeUtils.parseDuration(configuration.getString(TaskManagerOptions.INITIAL_REGISTRATION_BACKOFF));
+			initialRegistrationPause = Time.milliseconds(pause.toMillis());
+		} catch (IllegalArgumentException e) {
 			throw new IllegalArgumentException("Invalid format for parameter " +
 				TaskManagerOptions.INITIAL_REGISTRATION_BACKOFF.key(), e);
 		}
 
 		final Time maxRegistrationPause;
 		try {
-			Duration pause = Duration.create(configuration.getString(
-				TaskManagerOptions.REGISTRATION_MAX_BACKOFF));
-			if (pause.isFinite()) {
-				maxRegistrationPause = Time.milliseconds(pause.toMillis());
-			} else {
-				throw new IllegalArgumentException("The maximum registration pause must be finite: " + pause);
-			}
-		} catch (NumberFormatException e) {
+			Duration pause = TimeUtils.parseDuration(configuration.getString(TaskManagerOptions.REGISTRATION_MAX_BACKOFF));
+			maxRegistrationPause = Time.milliseconds(pause.toMillis());
+		} catch (IllegalArgumentException e) {
 			throw new IllegalArgumentException("Invalid format for parameter " +
 				TaskManagerOptions.INITIAL_REGISTRATION_BACKOFF.key(), e);
 		}
 
 		final Time refusedRegistrationPause;
 		try {
-			Duration pause = Duration.create(configuration.getString(TaskManagerOptions.REFUSED_REGISTRATION_BACKOFF));
-			if (pause.isFinite()) {
-				refusedRegistrationPause = Time.milliseconds(pause.toMillis());
-			} else {
-				throw new IllegalArgumentException("The refused registration pause must be finite: " + pause);
-			}
-		} catch (NumberFormatException e) {
+			Duration pause = TimeUtils.parseDuration(configuration.getString(TaskManagerOptions.REFUSED_REGISTRATION_BACKOFF));
+			refusedRegistrationPause = Time.milliseconds(pause.toMillis());
+		} catch (IllegalArgumentException e) {
 			throw new IllegalArgumentException("Invalid format for parameter " +
 				TaskManagerOptions.INITIAL_REGISTRATION_BACKOFF.key(), e);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
@@ -186,9 +186,8 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 		final String[] tmpDirPaths = ConfigurationUtils.parseTempDirectories(configuration);
 
 		final Time timeout;
-
 		try {
-			timeout = Time.milliseconds(AkkaUtils.getTimeout(configuration).toMillis());
+			timeout = AkkaUtils.getTimeoutAsTime(configuration);
 		} catch (Exception e) {
 			throw new IllegalArgumentException(
 				"Invalid format for '" + AkkaOptions.ASK_TIMEOUT.key() +

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -729,7 +729,7 @@ object AkkaUtils {
   }
 
   def getTimeout(config: Configuration): time.Duration = {
-    return TimeUtils.parseDuration(config.getString(AkkaOptions.ASK_TIMEOUT))
+    TimeUtils.parseDuration(config.getString(AkkaOptions.ASK_TIMEOUT))
   }
 
   def getTimeoutAsTime(config: Configuration): Time = {
@@ -750,11 +750,11 @@ object AkkaUtils {
   }
 
   def getLookupTimeout(config: Configuration): time.Duration = {
-    return TimeUtils.parseDuration(config.getString(AkkaOptions.LOOKUP_TIMEOUT))
+    TimeUtils.parseDuration(config.getString(AkkaOptions.LOOKUP_TIMEOUT))
   }
 
   def getClientTimeout(config: Configuration): time.Duration = {
-    return TimeUtils.parseDuration(config.getString(AkkaOptions.CLIENT_TIMEOUT))
+    TimeUtils.parseDuration(config.getString(AkkaOptions.CLIENT_TIMEOUT))
   }
 
   /** Returns the address of the given [[ActorSystem]]. The [[Address]] object contains

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.akka
 import java.io.IOException
 import java.net._
 import java.time
-import java.util.concurrent.{Callable, CompletableFuture, TimeUnit}
+import java.util.concurrent.{Callable, CompletableFuture}
 
 import akka.actor._
 import akka.pattern.{ask => akkaAsk}
@@ -367,9 +367,9 @@ object AkkaUtils {
                                 pauseValue: String,
                                 intervalParamName: String,
                                 intervalValue: String): Unit = {
-    if (Duration.apply(pauseValue).lteq(Duration.apply(intervalValue))) {
+    if (TimeUtils.parseDuration(pauseValue).compareTo(TimeUtils.parseDuration(intervalValue)) <= 0) {
       throw new IllegalConfigurationException(
-        "%s [%s] must greater then %s [%s]",
+        "%s [%s] must greater than %s [%s]",
         pauseParamName,
         pauseValue,
         intervalParamName,
@@ -397,11 +397,11 @@ object AkkaUtils {
 
     val normalizedExternalHostname = NetUtils.unresolvedHostToNormalizedString(externalHostname)
 
-    val akkaAskTimeout = Duration(configuration.getString(AkkaOptions.ASK_TIMEOUT))
+    val akkaAskTimeout = getTimeout(configuration)
 
     val startupTimeout = configuration.getString(
       AkkaOptions.STARTUP_TIMEOUT,
-      (akkaAskTimeout * 10).toString)
+      TimeUtils.getStringInMillis(akkaAskTimeout.multipliedBy(10L)))
 
     val transportHeartbeatInterval = configuration.getString(
       AkkaOptions.TRANSPORT_HEARTBEAT_INTERVAL)

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.akka
 
 import java.io.IOException
 import java.net._
+import java.time
 import java.util.concurrent.{Callable, CompletableFuture, TimeUnit}
 
 import akka.actor._
@@ -31,6 +32,7 @@ import org.apache.flink.runtime.clusterframework.BootstrapTools.{FixedThreadPool
 import org.apache.flink.runtime.concurrent.FutureUtils
 import org.apache.flink.runtime.net.SSLUtils
 import org.apache.flink.util.NetUtils
+import org.apache.flink.util.TimeUtils
 import org.apache.flink.util.function.FunctionUtils
 import org.jboss.netty.channel.ChannelException
 import org.jboss.netty.logging.{InternalLoggerFactory, Slf4JLoggerFactory}
@@ -48,8 +50,6 @@ import scala.language.postfixOps
  */
 object AkkaUtils {
   val LOG: Logger = LoggerFactory.getLogger(AkkaUtils.getClass)
-
-  val INF_TIMEOUT: FiniteDuration = 21474835 seconds
 
   val FLINK_ACTOR_SYSTEM_NAME = "flink"
 
@@ -728,15 +728,13 @@ object AkkaUtils {
     }
   }
 
-  def getTimeout(config: Configuration): FiniteDuration = {
-    val duration = Duration(config.getString(AkkaOptions.ASK_TIMEOUT))
-
-    new FiniteDuration(duration.toMillis, TimeUnit.MILLISECONDS)
+  def getTimeout(config: Configuration): time.Duration = {
+    return TimeUtils.parseDuration(config.getString(AkkaOptions.ASK_TIMEOUT))
   }
 
   def getTimeoutAsTime(config: Configuration): Time = {
     try {
-      val duration = Duration(config.getString(AkkaOptions.ASK_TIMEOUT))
+      val duration = getTimeout(config)
 
       Time.milliseconds(duration.toMillis)
     } catch {
@@ -746,38 +744,17 @@ object AkkaUtils {
   }
 
   def getDefaultTimeout: Time = {
-    val duration = Duration(AkkaOptions.ASK_TIMEOUT.defaultValue())
+    val duration = TimeUtils.parseDuration(AkkaOptions.ASK_TIMEOUT.defaultValue())
 
     Time.milliseconds(duration.toMillis)
   }
 
-  def getDefaultTimeoutAsFiniteDuration: FiniteDuration = {
-    val timeout = getDefaultTimeout
-
-    new FiniteDuration(timeout.toMilliseconds, TimeUnit.MILLISECONDS)
+  def getLookupTimeout(config: Configuration): time.Duration = {
+    return TimeUtils.parseDuration(config.getString(AkkaOptions.LOOKUP_TIMEOUT))
   }
 
-  def getLookupTimeout(config: Configuration): FiniteDuration = {
-    val duration = Duration(config.getString(AkkaOptions.LOOKUP_TIMEOUT))
-
-    new FiniteDuration(duration.toMillis, TimeUnit.MILLISECONDS)
-  }
-
-  def getDefaultLookupTimeout: FiniteDuration = {
-    val duration = Duration(AkkaOptions.LOOKUP_TIMEOUT.defaultValue())
-    new FiniteDuration(duration.toMillis, TimeUnit.MILLISECONDS)
-  }
-
-  def getClientTimeout(config: Configuration): FiniteDuration = {
-    val duration = Duration(config.getString(AkkaOptions.CLIENT_TIMEOUT))
-
-    new FiniteDuration(duration.toMillis, TimeUnit.MILLISECONDS)
-  }
-
-  def getDefaultClientTimeout: FiniteDuration = {
-    val duration = Duration(AkkaOptions.CLIENT_TIMEOUT.defaultValue())
-
-    new FiniteDuration(duration.toMillis, TimeUnit.MILLISECONDS)
+  def getClientTimeout(config: Configuration): time.Duration = {
+    return TimeUtils.parseDuration(config.getString(AkkaOptions.CLIENT_TIMEOUT))
   }
 
   /** Returns the address of the given [[ActorSystem]]. The [[Address]] object contains

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/AkkaUtilsTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/AkkaUtilsTest.scala
@@ -207,4 +207,14 @@ class AkkaUtilsTest
     akkaConfig.getString("akka.remote.netty.tcp.hostname") should
       equal(NetUtils.unresolvedHostToNormalizedString(ipv6AddressString))
   }
+
+  test("getAkkaConfig should set startup timeout to be 10 times of ask timeout by default") {
+    val configuration = new Configuration()
+    configuration.setString(AkkaOptions.ASK_TIMEOUT.key(), "100ms")
+
+    val akkaConfig = AkkaUtils.getAkkaConfig(configuration, Some(("localhost", 31337)))
+
+    akkaConfig.getString("akka.remote.startup-timeout") should
+      equal("1000ms")
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change

*TimeUtils now can parse all duration configs supported by scala FiniteDuration.
And we'd like to use it to replace scala Duration for duration config parsing.*
*This is one step to make flink-runtime scala free.*


## Brief change log

  - *The duration configs in flink-runtime are now parsed using TimeUtils#parseDuration*

## Verifying this change

This change is already covered by existing tests of changed components.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
