### PR TITLE
[FLINK-13985] Use unsafe memory for managed memory

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/HybridMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/HybridMemorySegment.java
@@ -57,20 +57,6 @@ public final class HybridMemorySegment extends MemorySegment {
 	 * Note that the given ByteBuffer must be direct {@link java.nio.ByteBuffer#allocateDirect(int)},
 	 * otherwise this method with throw an IllegalArgumentException.
 	 *
-	 * <p>The owner referenced by this memory segment is null.
-	 *
-	 * @param buffer The byte buffer whose memory is represented by this memory segment.
-	 * @throws IllegalArgumentException Thrown, if the given ByteBuffer is not direct.
-	 */
-	HybridMemorySegment(ByteBuffer buffer) {
-		this(buffer, null);
-	}
-
-	/**
-	 * Creates a new memory segment that represents the memory backing the given direct byte buffer.
-	 * Note that the given ByteBuffer must be direct {@link java.nio.ByteBuffer#allocateDirect(int)},
-	 * otherwise this method with throw an IllegalArgumentException.
-	 *
 	 * <p>The memory segment references the given owner.
 	 *
 	 * @param buffer The byte buffer whose memory is represented by this memory segment.
@@ -80,17 +66,6 @@ public final class HybridMemorySegment extends MemorySegment {
 	HybridMemorySegment(ByteBuffer buffer, Object owner) {
 		super(checkBufferAndGetAddress(buffer), buffer.capacity(), owner);
 		this.offHeapBuffer = buffer;
-	}
-
-	/**
-	 * Creates a new memory segment that represents the memory of the byte array.
-	 *
-	 * <p>The owner referenced by this memory segment is null.
-	 *
-	 * @param buffer The byte array whose memory is represented by this memory segment.
-	 */
-	HybridMemorySegment(byte[] buffer) {
-		this(buffer, null);
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentFactory.java
@@ -42,7 +42,7 @@ public final class MemorySegmentFactory {
 	 * @return A new memory segment that targets the given heap memory region.
 	 */
 	public static MemorySegment wrap(byte[] buffer) {
-		return new HybridMemorySegment(buffer);
+		return new HybridMemorySegment(buffer, null);
 	}
 
 	/**
@@ -79,40 +79,22 @@ public final class MemorySegmentFactory {
 	 * represents that memory.
 	 *
 	 * @param size The size of the off-heap memory segment to allocate.
+	 * @return A new memory segment, backed by unpooled off-heap memory.
+	 */
+	public static MemorySegment allocateUnpooledOffHeapMemory(int size) {
+		return allocateUnpooledOffHeapMemory(size, null);
+	}
+
+	/**
+	 * Allocates some unpooled off-heap memory and creates a new memory segment that
+	 * represents that memory.
+	 *
+	 * @param size The size of the off-heap memory segment to allocate.
 	 * @param owner The owner to associate with the off-heap memory segment.
 	 * @return A new memory segment, backed by unpooled off-heap memory.
 	 */
 	public static MemorySegment allocateUnpooledOffHeapMemory(int size, Object owner) {
 		ByteBuffer memory = ByteBuffer.allocateDirect(size);
-		return wrapPooledOffHeapMemory(memory, owner);
-	}
-
-	/**
-	 * Creates a memory segment that wraps the given byte array.
-	 *
-	 * <p>This method is intended to be used for components which pool memory and create
-	 * memory segments around long-lived memory regions.
-	 *
-	 * @param memory The heap memory to be represented by the memory segment.
-	 * @param owner The owner to associate with the memory segment.
-	 * @return A new memory segment representing the given heap memory.
-	 */
-	public static MemorySegment wrapPooledHeapMemory(byte[] memory, Object owner) {
-		return new HybridMemorySegment(memory, owner);
-	}
-
-	/**
-	 * Creates a memory segment that wraps the off-heap memory backing the given ByteBuffer.
-	 * Note that the ByteBuffer needs to be a <i>direct ByteBuffer</i>.
-	 *
-	 * <p>This method is intended to be used for components which pool memory and create
-	 * memory segments around long-lived memory regions.
-	 *
-	 * @param memory The byte buffer with the off-heap memory to be represented by the memory segment.
-	 * @param owner The owner to associate with the memory segment.
-	 * @return A new memory segment representing the given off-heap memory.
-	 */
-	public static MemorySegment wrapPooledOffHeapMemory(ByteBuffer memory, Object owner) {
 		return new HybridMemorySegment(memory, owner);
 	}
 
@@ -127,7 +109,7 @@ public final class MemorySegmentFactory {
 	 * @return A new memory segment representing the given off-heap memory.
 	 */
 	public static MemorySegment wrapOffHeapMemory(ByteBuffer memory) {
-		return new HybridMemorySegment(memory);
+		return new HybridMemorySegment(memory, null);
 	}
 
 }

--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemoryUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemoryUtils.java
@@ -19,8 +19,11 @@
 package org.apache.flink.core.memory;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.ExceptionUtils;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 /**
@@ -35,6 +38,8 @@ public class MemoryUtils {
 
 	/** The native byte order of the platform on which the system currently runs. */
 	public static final ByteOrder NATIVE_BYTE_ORDER = ByteOrder.nativeOrder();
+
+	private static final Constructor<?> DIRECT_BUFFER_CONSTRUCTOR = getDirectBufferPrivateConstructor();
 
 	@SuppressWarnings("restriction")
 	private static sun.misc.Unsafe getUnsafe() {
@@ -57,4 +62,80 @@ public class MemoryUtils {
 
 	/** Should not be instantiated. */
 	private MemoryUtils() {}
+
+	private static Constructor<? extends ByteBuffer> getDirectBufferPrivateConstructor() {
+		//noinspection OverlyBroadCatchBlock
+		try {
+			Constructor<? extends ByteBuffer> constructor =
+				ByteBuffer.allocateDirect(1).getClass().getDeclaredConstructor(long.class, int.class);
+			constructor.setAccessible(true);
+			return constructor;
+		} catch (NoSuchMethodException e) {
+			ExceptionUtils.rethrow(
+				e,
+				"The private constructor java.nio.DirectByteBuffer.<init>(long, int) is not available.");
+		} catch (SecurityException e) {
+			ExceptionUtils.rethrow(
+				e,
+				"The private constructor java.nio.DirectByteBuffer.<init>(long, int) is not available, " +
+					"permission denied by security manager");
+		} catch (Throwable t) {
+			ExceptionUtils.rethrow(
+				t,
+				"Unclassified error while trying to access private constructor " +
+					"java.nio.DirectByteBuffer.<init>(long, int).");
+		}
+		throw new RuntimeException("unexpected to avoid returning null");
+	}
+
+	/**
+	 * Allocates unsafe native memory.
+	 *
+	 * @param size size of the unsafe memory to allocate.
+	 * @return address of the allocated unsafe memory
+	 */
+	static long allocateUnsafe(long size) {
+		return UNSAFE.allocateMemory(Math.max(1L, size));
+	}
+
+	/**
+	 * Creates a cleaner to release the unsafe memory by VM GC.
+	 *
+	 * <p>When memory owner becomes <a href="package-summary.html#reachability">phantom reachable</a>,
+	 * GC will release the underlying unsafe memory if not released yet.
+	 *
+	 * @param owner memory owner which phantom reaching is to monitor by GC and release the unsafe memory
+	 * @param address address of the unsafe memory to release
+	 * @return action to run to release the unsafe memory manually
+	 */
+	@SuppressWarnings("UseOfSunClasses")
+	static Runnable createMemoryGcCleaner(Object owner, long address) {
+		// The release call is wrapped with the sun.misc.Cleaner
+		// which will schedule it before GC is run for the owner object (not reachable in user code).
+		// but only if sun.misc.Cleaner::clean has not been already called explicitly by user before.
+		// If sun.misc.Cleaner::clean is called after GC it will not call the release.
+		// This way we guarantee that there will always be a release at some point but only once.
+		return sun.misc.Cleaner.create(owner, () -> releaseUnsafe(address))::clean;
+	}
+
+	private static void releaseUnsafe(long address) {
+		UNSAFE.freeMemory(address);
+	}
+
+	/**
+	 * Wraps the unsafe native memory with a {@link ByteBuffer}.
+	 *
+	 * @param address address of the unsafe memory to wrap
+	 * @param size size of the unsafe memory to wrap
+	 * @return a {@link ByteBuffer} which is a view of the given unsafe memory
+	 */
+	static ByteBuffer wrapUnsafeMemoryWithByteBuffer(long address, int size) {
+		//noinspection OverlyBroadCatchBlock
+		try {
+			return (ByteBuffer) DIRECT_BUFFER_CONSTRUCTOR.newInstance(address, size);
+		} catch (Throwable t) {
+			ExceptionUtils.rethrow(t, "Failed to wrap unsafe off-heap memory with ByteBuffer");
+		}
+		throw new RuntimeException("unexpected to avoid returning null");
+	}
 }

--- a/flink-core/src/test/java/org/apache/flink/core/memory/CrossSegmentTypeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/CrossSegmentTypeTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.core.memory;
 
 import org.junit.Test;
 
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Random;
 
@@ -43,17 +42,8 @@ public class CrossSegmentTypeTest {
 
 	@Test
 	public void testCompareBytesMixedSegments() {
-		MemorySegment[] segs1 = {
-				new HeapMemorySegment(new byte[pageSize]),
-				new HybridMemorySegment(new byte[pageSize]),
-				new HybridMemorySegment(ByteBuffer.allocateDirect(pageSize))
-		};
-
-		MemorySegment[] segs2 = {
-				new HeapMemorySegment(new byte[pageSize]),
-				new HybridMemorySegment(new byte[pageSize]),
-				new HybridMemorySegment(ByteBuffer.allocateDirect(pageSize))
-		};
+		MemorySegment[] segs1 = createSegments(pageSize);
+		MemorySegment[] segs2 = createSegments(pageSize);
 
 		Random rnd = new Random();
 
@@ -107,18 +97,8 @@ public class CrossSegmentTypeTest {
 	@Test
 	public void testSwapBytesMixedSegments() {
 		final int halfPageSize = pageSize / 2;
-
-		MemorySegment[] segs1 = {
-				new HeapMemorySegment(new byte[pageSize]),
-				new HybridMemorySegment(new byte[pageSize]),
-				new HybridMemorySegment(ByteBuffer.allocateDirect(pageSize))
-		};
-
-		MemorySegment[] segs2 = {
-				new HeapMemorySegment(new byte[halfPageSize]),
-				new HybridMemorySegment(new byte[halfPageSize]),
-				new HybridMemorySegment(ByteBuffer.allocateDirect(halfPageSize))
-		};
+		MemorySegment[] segs1 = createSegments(pageSize);
+		MemorySegment[] segs2 = createSegments(halfPageSize);
 
 		Random rnd = new Random();
 
@@ -162,17 +142,8 @@ public class CrossSegmentTypeTest {
 
 	@Test
 	public void testCopyMixedSegments() {
-		MemorySegment[] segs1 = {
-				new HeapMemorySegment(new byte[pageSize]),
-				new HybridMemorySegment(new byte[pageSize]),
-				new HybridMemorySegment(ByteBuffer.allocateDirect(pageSize))
-		};
-
-		MemorySegment[] segs2 = {
-				new HeapMemorySegment(new byte[pageSize]),
-				new HybridMemorySegment(new byte[pageSize]),
-				new HybridMemorySegment(ByteBuffer.allocateDirect(pageSize))
-		};
+		MemorySegment[] segs1 = createSegments(pageSize);
+		MemorySegment[] segs2 = createSegments(pageSize);
 
 		Random rnd = new Random();
 
@@ -181,6 +152,15 @@ public class CrossSegmentTypeTest {
 				testCopy(seg1, seg2, rnd);
 			}
 		}
+	}
+
+	private static MemorySegment[] createSegments(int size) {
+		MemorySegment[] segments = {
+			new HeapMemorySegment(new byte[size]),
+			MemorySegmentFactory.allocateUnpooledSegment(size),
+			MemorySegmentFactory.allocateUnpooledOffHeapMemory(size)
+		};
+		return segments;
 	}
 
 	private void testCopy(MemorySegment seg1, MemorySegment seg2, Random random) {

--- a/flink-core/src/test/java/org/apache/flink/core/memory/CrossSegmentTypeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/CrossSegmentTypeTest.java
@@ -158,7 +158,8 @@ public class CrossSegmentTypeTest {
 		MemorySegment[] segments = {
 			new HeapMemorySegment(new byte[size]),
 			MemorySegmentFactory.allocateUnpooledSegment(size),
-			MemorySegmentFactory.allocateUnpooledOffHeapMemory(size)
+			MemorySegmentFactory.allocateUnpooledOffHeapMemory(size),
+			MemorySegmentFactory.allocateOffHeapUnsafeMemory(size, null)
 		};
 		return segments;
 	}

--- a/flink-core/src/test/java/org/apache/flink/core/memory/EndiannessAccessChecks.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/EndiannessAccessChecks.java
@@ -20,7 +20,6 @@ package org.apache.flink.core.memory;
 
 import org.junit.Test;
 
-import java.nio.ByteBuffer;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
@@ -38,12 +37,12 @@ public class EndiannessAccessChecks {
 
 	@Test
 	public void testHybridOnHeapSegment() {
-		testBigAndLittleEndianAccessUnaligned(new HybridMemorySegment(new byte[11111]));
+		testBigAndLittleEndianAccessUnaligned(MemorySegmentFactory.wrap(new byte[11111]));
 	}
 
 	@Test
 	public void testHybridOffHeapSegment() {
-		testBigAndLittleEndianAccessUnaligned(new HybridMemorySegment(ByteBuffer.allocateDirect(11111)));
+		testBigAndLittleEndianAccessUnaligned(MemorySegmentFactory.allocateUnpooledOffHeapMemory(11111));
 	}
 
 	private void testBigAndLittleEndianAccessUnaligned(MemorySegment segment) {

--- a/flink-core/src/test/java/org/apache/flink/core/memory/EndiannessAccessChecks.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/EndiannessAccessChecks.java
@@ -45,6 +45,11 @@ public class EndiannessAccessChecks {
 		testBigAndLittleEndianAccessUnaligned(MemorySegmentFactory.allocateUnpooledOffHeapMemory(11111));
 	}
 
+	@Test
+	public void testHybridOffHeapUnsafeSegment() {
+		testBigAndLittleEndianAccessUnaligned(MemorySegmentFactory.allocateOffHeapUnsafeMemory(11111, null));
+	}
+
 	private void testBigAndLittleEndianAccessUnaligned(MemorySegment segment) {
 		final Random rnd = new Random();
 

--- a/flink-core/src/test/java/org/apache/flink/core/memory/HybridOffHeapDirectMemorySegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/HybridOffHeapDirectMemorySegmentTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.memory;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ * Tests for the {@link HybridMemorySegment} in off-heap mode using direct memory.
+ */
+@RunWith(Parameterized.class)
+public class HybridOffHeapDirectMemorySegmentTest extends HybridOffHeapMemorySegmentTest {
+
+	public HybridOffHeapDirectMemorySegmentTest(int pageSize) {
+		super(pageSize);
+	}
+
+	@Override
+	MemorySegment createSegment(int size) {
+		return MemorySegmentFactory.allocateUnpooledOffHeapMemory(size);
+	}
+
+	@Override
+	MemorySegment createSegment(int size, Object owner) {
+		return MemorySegmentFactory.allocateUnpooledOffHeapMemory(size, owner);
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/core/memory/HybridOffHeapMemorySegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/HybridOffHeapMemorySegmentTest.java
@@ -41,18 +41,18 @@ public class HybridOffHeapMemorySegmentTest extends MemorySegmentTestBase {
 
 	@Override
 	MemorySegment createSegment(int size) {
-		return new HybridMemorySegment(ByteBuffer.allocateDirect(size));
+		return MemorySegmentFactory.allocateUnpooledOffHeapMemory(size);
 	}
 
 	@Override
 	MemorySegment createSegment(int size, Object owner) {
-		return new HybridMemorySegment(ByteBuffer.allocateDirect(size), owner);
+		return MemorySegmentFactory.allocateUnpooledOffHeapMemory(size, owner);
 	}
 
 	@Test
 	public void testHybridHeapSegmentSpecifics() {
 		final ByteBuffer buffer = ByteBuffer.allocateDirect(411);
-		HybridMemorySegment seg = new HybridMemorySegment(buffer);
+		HybridMemorySegment seg = new HybridMemorySegment(buffer, null);
 
 		assertFalse(seg.isFreed());
 		assertTrue(seg.isOffHeap());

--- a/flink-core/src/test/java/org/apache/flink/core/memory/HybridOffHeapMemorySegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/HybridOffHeapMemorySegmentTest.java
@@ -19,8 +19,6 @@
 package org.apache.flink.core.memory;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.nio.ByteBuffer;
 
@@ -32,27 +30,16 @@ import static org.junit.Assert.fail;
 /**
  * Tests for the {@link HybridMemorySegment} in off-heap mode.
  */
-@RunWith(Parameterized.class)
-public class HybridOffHeapMemorySegmentTest extends MemorySegmentTestBase {
+public abstract class HybridOffHeapMemorySegmentTest extends MemorySegmentTestBase {
 
-	public HybridOffHeapMemorySegmentTest(int pageSize) {
+	HybridOffHeapMemorySegmentTest(int pageSize) {
 		super(pageSize);
-	}
-
-	@Override
-	MemorySegment createSegment(int size) {
-		return MemorySegmentFactory.allocateUnpooledOffHeapMemory(size);
-	}
-
-	@Override
-	MemorySegment createSegment(int size, Object owner) {
-		return MemorySegmentFactory.allocateUnpooledOffHeapMemory(size, owner);
 	}
 
 	@Test
 	public void testHybridHeapSegmentSpecifics() {
-		final ByteBuffer buffer = ByteBuffer.allocateDirect(411);
-		HybridMemorySegment seg = new HybridMemorySegment(buffer, null);
+		HybridMemorySegment seg = (HybridMemorySegment) createSegment(411);
+		ByteBuffer buffer = seg.getOffHeapBuffer();
 
 		assertFalse(seg.isFreed());
 		assertTrue(seg.isOffHeap());

--- a/flink-core/src/test/java/org/apache/flink/core/memory/HybridOffHeapUnsafeMemorySegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/HybridOffHeapUnsafeMemorySegmentTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.memory;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ * Tests for the {@link HybridMemorySegment} in off-heap mode using unsafe memory.
+ */
+@RunWith(Parameterized.class)
+public class HybridOffHeapUnsafeMemorySegmentTest extends HybridOffHeapMemorySegmentTest {
+
+	public HybridOffHeapUnsafeMemorySegmentTest(int pageSize) {
+		super(pageSize);
+	}
+
+	@Override
+	MemorySegment createSegment(int size) {
+		return MemorySegmentFactory.allocateOffHeapUnsafeMemory(size, null);
+	}
+
+	@Override
+	MemorySegment createSegment(int size, Object owner) {
+		return MemorySegmentFactory.allocateOffHeapUnsafeMemory(size, owner);
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/core/memory/HybridOnHeapMemorySegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/HybridOnHeapMemorySegmentTest.java
@@ -41,18 +41,18 @@ public class HybridOnHeapMemorySegmentTest extends MemorySegmentTestBase {
 
 	@Override
 	MemorySegment createSegment(int size) {
-		return new HybridMemorySegment(new byte[size]);
+		return MemorySegmentFactory.allocateUnpooledSegment(size);
 	}
 
 	@Override
 	MemorySegment createSegment(int size, Object owner) {
-		return new HybridMemorySegment(new byte[size], owner);
+		return MemorySegmentFactory.allocateUnpooledSegment(size, owner);
 	}
 
 	@Test
 	public void testHybridHeapSegmentSpecifics() {
 		final byte[] buffer = new byte[411];
-		HybridMemorySegment seg = new HybridMemorySegment(buffer);
+		HybridMemorySegment seg = new HybridMemorySegment(buffer, null);
 
 		assertFalse(seg.isFreed());
 		assertFalse(seg.isOffHeap());

--- a/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentChecksTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentChecksTest.java
@@ -40,18 +40,8 @@ public class MemorySegmentChecksTest {
 	}
 
 	@Test(expected = NullPointerException.class)
-	public void testHybridHeapNullBuffer1() {
-		new HybridMemorySegment((byte[]) null);
-	}
-
-	@Test(expected = NullPointerException.class)
 	public void testHybridHeapNullBuffer2() {
 		new HybridMemorySegment((byte[]) null, new Object());
-	}
-
-	@Test(expected = NullPointerException.class)
-	public void testHybridOffHeapNullBuffer1() {
-		new HybridMemorySegment((ByteBuffer) null);
 	}
 
 	@Test(expected = NullPointerException.class)
@@ -61,7 +51,7 @@ public class MemorySegmentChecksTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testHybridNonDirectBuffer() {
-		new HybridMemorySegment(ByteBuffer.allocate(1024));
+		new HybridMemorySegment(ByteBuffer.allocate(1024), new Object());
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentChecksTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentChecksTest.java
@@ -46,12 +46,12 @@ public class MemorySegmentChecksTest {
 
 	@Test(expected = NullPointerException.class)
 	public void testHybridOffHeapNullBuffer2() {
-		new HybridMemorySegment((ByteBuffer) null, new Object());
+		new HybridMemorySegment(null, new Object(), () -> {});
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testHybridNonDirectBuffer() {
-		new HybridMemorySegment(ByteBuffer.allocate(1024), new Object());
+		new HybridMemorySegment(ByteBuffer.allocate(1024), new Object(), () -> {});
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentTestBase.java
@@ -326,6 +326,10 @@ public abstract class MemorySegmentTestBase {
 		MemorySegment seg1 = createSegment(pageSize);
 		MemorySegment seg2 = createSegment(pageSize);
 
+		byte[] referenceArray = new byte[pageSize];
+		seg1.put(0, referenceArray);
+		seg2.put(0, referenceArray);
+
 		int i = new Random().nextInt(pageSize - 8);
 
 		seg1.put(i, (byte) 10);
@@ -1665,6 +1669,7 @@ public abstract class MemorySegmentTestBase {
 		{
 			final MemorySegment segment = createSegment(pageSize);
 			byte[] expected = new byte[pageSize];
+			segment.put(0, expected, 0, pageSize);
 
 			for (int i = 0; i < 200; i++) {
 				int numBytes = random.nextInt(pageSize - 10) + 1;

--- a/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentUndersizedTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentUndersizedTest.java
@@ -47,7 +47,7 @@ public class MemorySegmentUndersizedTest {
 
 	@Test
 	public void testZeroSizeHeapHybridSegment() {
-		MemorySegment segment = new HybridMemorySegment(new byte[0]);
+		MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(0);
 
 		testZeroSizeBuffer(segment);
 		testSegmentWithSizeLargerZero(segment);
@@ -55,7 +55,7 @@ public class MemorySegmentUndersizedTest {
 
 	@Test
 	public void testZeroSizeOffHeapHybridSegment() {
-		MemorySegment segment = new HybridMemorySegment(ByteBuffer.allocateDirect(0));
+		MemorySegment segment = MemorySegmentFactory.allocateUnpooledOffHeapMemory(0);
 
 		testZeroSizeBuffer(segment);
 		testSegmentWithSizeLargerZero(segment);
@@ -68,12 +68,12 @@ public class MemorySegmentUndersizedTest {
 
 	@Test
 	public void testSizeOneHeapHybridSegment() {
-		testSegmentWithSizeLargerZero(new HybridMemorySegment(new byte[1]));
+		testSegmentWithSizeLargerZero(MemorySegmentFactory.allocateUnpooledSegment(1));
 	}
 
 	@Test
 	public void testSizeOneOffHeapHybridSegment() {
-		testSegmentWithSizeLargerZero(new HybridMemorySegment(ByteBuffer.allocateDirect(1)));
+		testSegmentWithSizeLargerZero(MemorySegmentFactory.allocateUnpooledOffHeapMemory(1));
 	}
 
 	private static void testZeroSizeBuffer(MemorySegment segment) {

--- a/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentUndersizedTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentUndersizedTest.java
@@ -62,6 +62,14 @@ public class MemorySegmentUndersizedTest {
 	}
 
 	@Test
+	public void testZeroSizeOffHeapUnsafeHybridSegment() {
+		MemorySegment segment = MemorySegmentFactory.allocateOffHeapUnsafeMemory(0, null);
+
+		testZeroSizeBuffer(segment);
+		testSegmentWithSizeLargerZero(segment);
+	}
+
+	@Test
 	public void testSizeOneHeapSegment() {
 		testSegmentWithSizeLargerZero(new HeapMemorySegment(new byte[1]));
 	}
@@ -74,6 +82,11 @@ public class MemorySegmentUndersizedTest {
 	@Test
 	public void testSizeOneOffHeapHybridSegment() {
 		testSegmentWithSizeLargerZero(MemorySegmentFactory.allocateUnpooledOffHeapMemory(1));
+	}
+
+	@Test
+	public void testSizeOneOffHeapUnsafeHybridSegment() {
+		testSegmentWithSizeLargerZero(MemorySegmentFactory.allocateOffHeapUnsafeMemory(1, null));
 	}
 
 	private static void testZeroSizeBuffer(MemorySegment segment) {

--- a/flink-core/src/test/java/org/apache/flink/core/memory/OperationsOnFreedSegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/OperationsOnFreedSegmentTest.java
@@ -42,19 +42,19 @@ public class OperationsOnFreedSegmentTest {
 	@Test
 	public void testSingleSegmentOperationsHeapSegment() throws Exception {
 		testOpsOnFreedSegment(new HeapMemorySegment(new byte[PAGE_SIZE]));
-		testOpsOnFreedSegment(new HybridMemorySegment(new byte[PAGE_SIZE]));
-		testOpsOnFreedSegment(new HybridMemorySegment(ByteBuffer.allocateDirect(PAGE_SIZE)));
+		testOpsOnFreedSegment(MemorySegmentFactory.wrap(new byte[PAGE_SIZE]));
+		testOpsOnFreedSegment(MemorySegmentFactory.allocateUnpooledOffHeapMemory(PAGE_SIZE));
 	}
 
 	@Test
 	public void testCompare() {
 		MemorySegment aliveHeap = new HeapMemorySegment(new byte[PAGE_SIZE]);
-		MemorySegment aliveHybridHeap = new HybridMemorySegment(new byte[PAGE_SIZE]);
-		MemorySegment aliveHybridOffHeap = new HybridMemorySegment(ByteBuffer.allocateDirect(PAGE_SIZE));
+		MemorySegment aliveHybridHeap = MemorySegmentFactory.wrap(new byte[PAGE_SIZE]);
+		MemorySegment aliveHybridOffHeap = MemorySegmentFactory.allocateUnpooledOffHeapMemory(PAGE_SIZE);
 
 		MemorySegment freedHeap = new HeapMemorySegment(new byte[PAGE_SIZE]);
-		MemorySegment freedHybridHeap = new HybridMemorySegment(new byte[PAGE_SIZE]);
-		MemorySegment freedHybridOffHeap = new HybridMemorySegment(ByteBuffer.allocateDirect(PAGE_SIZE));
+		MemorySegment freedHybridHeap = MemorySegmentFactory.wrap(new byte[PAGE_SIZE]);
+		MemorySegment freedHybridOffHeap = MemorySegmentFactory.allocateUnpooledOffHeapMemory(PAGE_SIZE);
 		freedHeap.free();
 		freedHybridHeap.free();
 		freedHybridOffHeap.free();
@@ -87,12 +87,12 @@ public class OperationsOnFreedSegmentTest {
 	@Test
 	public void testCopyTo() {
 		MemorySegment aliveHeap = new HeapMemorySegment(new byte[PAGE_SIZE]);
-		MemorySegment aliveHybridHeap = new HybridMemorySegment(new byte[PAGE_SIZE]);
-		MemorySegment aliveHybridOffHeap = new HybridMemorySegment(ByteBuffer.allocateDirect(PAGE_SIZE));
+		MemorySegment aliveHybridHeap = MemorySegmentFactory.wrap(new byte[PAGE_SIZE]);
+		MemorySegment aliveHybridOffHeap = MemorySegmentFactory.allocateUnpooledOffHeapMemory(PAGE_SIZE);
 
 		MemorySegment freedHeap = new HeapMemorySegment(new byte[PAGE_SIZE]);
-		MemorySegment freedHybridHeap = new HybridMemorySegment(new byte[PAGE_SIZE]);
-		MemorySegment freedHybridOffHeap = new HybridMemorySegment(ByteBuffer.allocateDirect(PAGE_SIZE));
+		MemorySegment freedHybridHeap = MemorySegmentFactory.wrap(new byte[PAGE_SIZE]);
+		MemorySegment freedHybridOffHeap = MemorySegmentFactory.allocateUnpooledOffHeapMemory(PAGE_SIZE);
 		freedHeap.free();
 		freedHybridHeap.free();
 		freedHybridOffHeap.free();
@@ -125,12 +125,12 @@ public class OperationsOnFreedSegmentTest {
 	@Test
 	public void testSwap() {
 		MemorySegment aliveHeap = new HeapMemorySegment(new byte[PAGE_SIZE]);
-		MemorySegment aliveHybridHeap = new HybridMemorySegment(new byte[PAGE_SIZE]);
-		MemorySegment aliveHybridOffHeap = new HybridMemorySegment(ByteBuffer.allocateDirect(PAGE_SIZE));
+		MemorySegment aliveHybridHeap = MemorySegmentFactory.wrap(new byte[PAGE_SIZE]);
+		MemorySegment aliveHybridOffHeap = MemorySegmentFactory.allocateUnpooledOffHeapMemory(PAGE_SIZE);
 
 		MemorySegment freedHeap = new HeapMemorySegment(new byte[PAGE_SIZE]);
-		MemorySegment freedHybridHeap = new HybridMemorySegment(new byte[PAGE_SIZE]);
-		MemorySegment freedHybridOffHeap = new HybridMemorySegment(ByteBuffer.allocateDirect(PAGE_SIZE));
+		MemorySegment freedHybridHeap = MemorySegmentFactory.wrap(new byte[PAGE_SIZE]);
+		MemorySegment freedHybridOffHeap = MemorySegmentFactory.allocateUnpooledOffHeapMemory(PAGE_SIZE);
 		freedHeap.free();
 		freedHybridHeap.free();
 		freedHybridOffHeap.free();

--- a/flink-core/src/test/java/org/apache/flink/core/memory/OperationsOnFreedSegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/OperationsOnFreedSegmentTest.java
@@ -128,8 +128,9 @@ public class OperationsOnFreedSegmentTest {
 		MemorySegment heap = new HeapMemorySegment(new byte[PAGE_SIZE]);
 		MemorySegment hybridHeap = MemorySegmentFactory.wrap(new byte[PAGE_SIZE]);
 		MemorySegment hybridOffHeap = MemorySegmentFactory.allocateUnpooledOffHeapMemory(PAGE_SIZE);
+		MemorySegment hybridOffHeapUnsafe = MemorySegmentFactory.allocateOffHeapUnsafeMemory(PAGE_SIZE, null);
 
-		MemorySegment[] segments = { heap, hybridHeap, hybridOffHeap };
+		MemorySegment[] segments = { heap, hybridHeap, hybridOffHeap, hybridOffHeapUnsafe };
 
 		return segments;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -48,7 +48,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.apache.flink.core.memory.MemorySegmentFactory.allocateUnpooledOffHeapMemory;
+import static org.apache.flink.core.memory.MemorySegmentFactory.allocateOffHeapUnsafeMemory;
 import static org.apache.flink.core.memory.MemorySegmentFactory.allocateUnpooledSegment;
 
 /**
@@ -601,7 +601,7 @@ public class MemoryManager {
 			case HEAP:
 				return allocateUnpooledSegment(getPageSize(), owner);
 			case OFF_HEAP:
-				return allocateUnpooledOffHeapMemory(getPageSize(), owner);
+				return allocateOffHeapUnsafeMemory(getPageSize(), owner);
 			default:
 				throw new IllegalArgumentException("unrecognized memory type: " + memoryType);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/KeyedBudgetManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/KeyedBudgetManagerTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.util;
 import org.apache.flink.runtime.util.KeyedBudgetManager.AcquisitionResult;
 import org.apache.flink.util.Preconditions;
 
+import org.apache.flink.util.TestLogger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,7 +46,7 @@ import static org.junit.Assert.fail;
  * Test suite for {@link KeyedBudgetManager}.
  */
 @SuppressWarnings("MagicNumber")
-public class KeyedBudgetManagerTest {
+public class KeyedBudgetManagerTest extends TestLogger {
 	private static final String[] TEST_KEYS = {"k1", "k2", "k3", "k4"};
 	private static final long[] TEST_BUDGETS = {15, 17, 22, 11};
 	private static final Executor NEW_THREAD_EXECUTOR = r -> new Thread(r).start();


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces allocation of off-heap memory independent of direct buffers and limiting option `-XX:MaxDirectMemorySize`. This implementation uses `sun.misc.Unsafe` for that purpose.

## Brief change log

 - Make tests use `MemorySegmentFactory` to create `MemorySegment` and remove shorthand constructors of `HybridMemorySegment` in favour of `MemorySegmentFactory` methods.
 - Add allocate/release unsafe memory methods to `MemoryUtils`
  - Add a `MemoryUtils#createMemoryGcCleaner` to release memory in phantom reference queue upon GC of the memory owning object (based on `sun.misc.Cleaner` similar to `java.nio.DirectByteBuffer(int cap)`).
  - Add `MemoryUtils#wrapUnsafeMemoryWithByteBuffer` which uses the private constructor `java.nio.DirectByteBuffer(long address, int cap)` to wrap unsafe memory but w/o checking `-XX:MaxDirectMemorySize`.
 - Add an optional custom action to call in `HybridMemorySegment#free` for memory cleanup
 - Change `MemorySegmentFactory#allocateUnpooledOffHeapMemory` to allocate unsafe memory, wrap it with ByteBuffer with `MemoryUtils#wrapUnsafeMemoryWithByteBuffer`, hook a phantom reference queue cleaner upon the buffer GC and create `HybridMemorySegment` with this buffer and its custom cleaner.

## Verifying this change

Units tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
