### PR TITLE
[FLINK-14139][rest]Fix potential memory leak problem of rest server.

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/FileUploadHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/FileUploadHandlerTest.java
@@ -38,8 +38,12 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.lang.reflect.Field;
+import java.util.LinkedHashSet;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for the {@link FileUploadHandler}. Ensures that multipart http messages containing files and/or json are properly
@@ -136,6 +140,8 @@ public class FileUploadHandlerTest extends TestLogger {
 		try (Response response = client.newCall(fileRequest).execute()) {
 			assertEquals(fileHandler.getMessageHeaders().getResponseStatusCode().code(), response.code());
 		}
+
+		verifyNoFileIsRegisteredToDeleteOnExitHook();
 	}
 
 	@Test
@@ -162,6 +168,8 @@ public class FileUploadHandlerTest extends TestLogger {
 			assertEquals(mixedHandler.getMessageHeaders().getResponseStatusCode().code(), response.code());
 			assertEquals(json, mixedHandler.lastReceivedRequest);
 		}
+
+		verifyNoFileIsRegisteredToDeleteOnExitHook();
 	}
 
 	@Test
@@ -188,6 +196,8 @@ public class FileUploadHandlerTest extends TestLogger {
 			// FileUploads are outright forbidden
 			assertEquals(HttpResponseStatus.BAD_REQUEST.code(), response.code());
 		}
+
+		verifyNoFileIsRegisteredToDeleteOnExitHook();
 	}
 
 	@Test
@@ -212,6 +222,8 @@ public class FileUploadHandlerTest extends TestLogger {
 			// JSON payload did not match expected format
 			assertEquals(HttpResponseStatus.BAD_REQUEST.code(), response.code());
 		}
+
+		verifyNoFileIsRegisteredToDeleteOnExitHook();
 	}
 
 	@Test
@@ -223,6 +235,8 @@ public class FileUploadHandlerTest extends TestLogger {
 			assertEquals(HttpResponseStatus.BAD_REQUEST.code(), response.code());
 		}
 		MULTIPART_UPLOAD_RESOURCE.assertUploadDirectoryIsEmpty();
+
+		verifyNoFileIsRegisteredToDeleteOnExitHook();
 	}
 
 	/**
@@ -238,5 +252,25 @@ public class FileUploadHandlerTest extends TestLogger {
 			assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR.code(), response.code());
 		}
 		MULTIPART_UPLOAD_RESOURCE.assertUploadDirectoryIsEmpty();
+
+		verifyNoFileIsRegisteredToDeleteOnExitHook();
+	}
+
+	/**
+	 * DiskAttribute and DiskFileUpload class of netty store post chunks and file chunks as temp files on local disk.
+	 * By default, netty will register these temp files to java.io.DeleteOnExitHook which may lead to memory leak.
+	 * {@link FileUploadHandler} disables the shutdown hook registration so no file should be registered. Note that
+	 * clean up of temp files is handed over to {@link org.apache.flink.runtime.entrypoint.ClusterEntrypoint}.
+	 */
+	private void verifyNoFileIsRegisteredToDeleteOnExitHook() {
+		try {
+			Class<?> clazz = Class.forName("java.io.DeleteOnExitHook");
+			Field field = clazz.getDeclaredField("files");
+			field.setAccessible(true);
+			LinkedHashSet files = (LinkedHashSet) field.get(null);
+			assertTrue(files.isEmpty());
+		} catch (ClassNotFoundException | IllegalAccessException | NoSuchFieldException e) {
+			fail("This should never happen.");
+		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

The purpose of this pr is to fix the potential memory leak problem of rest server when using session/standalone cluster. More specifically, Flink's rest server uses netty decoder for http request processing and file uploading. However io.netty.handler.codec.http.multipart.DiskAttribute and io.netty.handler.codec.http.multipart.DiskFileUpload class of netty would register some temp files, including post chunks and upload file chunks, to java.io.DeleteOnExitHook which has a potential of memory leak, because the registered file names will never be deleted before the cluster stops. This pr attempts to solve the problem by disabling the registration of temp files to java.io.DeleteOnExitHook and makes Flink's shutdown hook to take the responsibility of temp file clean up.

## Brief change log

  - *The deleteOnExitTemporaryFile filed of io.netty.handler.codec.http.multipart.DiskAttribute and io.netty.handler.codec.http.multipart.DiskFileUpload is set to false to disable netty to register the shutdown hook.*
  - *Set the baseDirectory of io.netty.handler.codec.http.multipart.DiskAttribute to the file upload directory (shares the same directory with file upload), which will be cleaned up by Flink's shutdown hook when jvm exits.*
  - *Add tests to verify that no temp files will be registered to java.io.DeleteOnExitHook after the fix.*


## Verifying this change

This change added tests and can be verified as follows:

  - *Based on the existing FileUploadHandlerTest which will register temp file (both post chunks and uploaded file chunks) to java.io.DeleteOnExitHook, after file uploading, each test case verifies that no file is register to java.io.DeleteOnExitHook. Before the fix, the test will fail and after the fix, the test will pass.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
