### PR TITLE
[FLINK-14180][runtime]Enable config of maximum capacity of FileArchivedExecutionGraphStore.

### DIFF
--- a/docs/_includes/generated/job_manager_configuration.html
+++ b/docs/_includes/generated/job_manager_configuration.html
@@ -48,6 +48,11 @@
             <td>The time in seconds after which a completed job expires and is purged from the job store.</td>
         </tr>
         <tr>
+            <td><h5>jobstore.max-capacity</h5></td>
+            <td style="word-wrap: break-word;">2147483647</td>
+            <td>The max number of completed jobs that can be kept in the job store.</td>
+        </tr>
+        <tr>
             <td><h5>slot.idle.timeout</h5></td>
             <td style="word-wrap: break-word;">50000</td>
             <td>The timeout in milliseconds for a idle slot in Slot Pool.</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -157,6 +157,14 @@ public class JobManagerOptions {
 		.withDescription("The time in seconds after which a completed job expires and is purged from the job store.");
 
 	/**
+	 * The max number of completed jobs that can be kept in the job store.
+	 */
+	public static final ConfigOption<Integer> JOB_STORE_MAX_CAPACITY =
+		key("jobstore.max-capacity")
+			.defaultValue(Integer.MAX_VALUE)
+			.withDescription("The max number of completed jobs that can be kept in the job store.");
+
+	/**
 	 * The timeout in milliseconds for requesting a slot from Slot Pool.
 	 */
 	public static final ConfigOption<Long> SLOT_REQUEST_TIMEOUT =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/FileArchivedExecutionGraphStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/FileArchivedExecutionGraphStore.java
@@ -83,6 +83,7 @@ public class FileArchivedExecutionGraphStore implements ArchivedExecutionGraphSt
 	public FileArchivedExecutionGraphStore(
 			File rootDir,
 			Time expirationTime,
+			int maximumCapacity,
 			long maximumCacheSizeBytes,
 			ScheduledExecutor scheduledExecutor,
 			Ticker ticker) throws IOException {
@@ -102,6 +103,7 @@ public class FileArchivedExecutionGraphStore implements ArchivedExecutionGraphSt
 			"The storage directory must exist and be a directory.");
 		this.jobDetailsCache = CacheBuilder.newBuilder()
 			.expireAfterWrite(expirationTime.toMilliseconds(), TimeUnit.MILLISECONDS)
+			.maximumSize(maximumCapacity)
 			.removalListener(
 				(RemovalListener<JobID, JobDetails>) notification -> deleteExecutionGraphFile(notification.getKey()))
 			.ticker(ticker)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/SessionClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/SessionClusterEntrypoint.java
@@ -47,11 +47,13 @@ public abstract class SessionClusterEntrypoint extends ClusterEntrypoint {
 		final File tmpDir = new File(ConfigurationUtils.parseTempDirectories(configuration)[0]);
 
 		final Time expirationTime =  Time.seconds(configuration.getLong(JobManagerOptions.JOB_STORE_EXPIRATION_TIME));
+		final int maximumCapacity = configuration.getInteger(JobManagerOptions.JOB_STORE_MAX_CAPACITY);
 		final long maximumCacheSizeBytes = configuration.getLong(JobManagerOptions.JOB_STORE_CACHE_SIZE);
 
 		return new FileArchivedExecutionGraphStore(
 			tmpDir,
 			expirationTime,
+			maximumCapacity,
 			maximumCacheSizeBytes,
 			scheduledExecutor,
 			Ticker.systemTicker());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/FileArchivedExecutionGraphStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/FileArchivedExecutionGraphStoreTest.java
@@ -54,7 +54,9 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for the {@link FileArchivedExecutionGraphStore}.
@@ -136,7 +138,7 @@ public class FileArchivedExecutionGraphStoreTest extends TestLogger {
 		final int numberExecutionGraphs = 10;
 		final Collection<ArchivedExecutionGraph> executionGraphs = generateTerminalExecutionGraphs(numberExecutionGraphs);
 
-		final Collection<JobDetails> jobDetails = executionGraphs.stream().map(WebMonitorUtils::createDetailsForJob).collect(Collectors.toList());
+		final Collection<JobDetails> jobDetails = generateJobDetails(executionGraphs);
 
 		final File rootDir = temporaryFolder.newFolder();
 
@@ -165,6 +167,7 @@ public class FileArchivedExecutionGraphStoreTest extends TestLogger {
 		try (final FileArchivedExecutionGraphStore executionGraphStore = new FileArchivedExecutionGraphStore(
 			rootDir,
 			expirationTime,
+			Integer.MAX_VALUE,
 			10000L,
 			scheduledExecutor,
 			manualTicker)) {
@@ -227,6 +230,7 @@ public class FileArchivedExecutionGraphStoreTest extends TestLogger {
 		try (final FileArchivedExecutionGraphStore executionGraphStore = new FileArchivedExecutionGraphStore(
 			rootDir,
 			Time.hours(1L),
+			Integer.MAX_VALUE,
 			100L << 10,
 			TestingUtils.defaultScheduledExecutor(),
 			Ticker.systemTicker())) {
@@ -259,6 +263,47 @@ public class FileArchivedExecutionGraphStoreTest extends TestLogger {
 		}
 	}
 
+	/**
+	 * Tests that the size of {@link FileArchivedExecutionGraphStore} is no more than the configured max capacity
+	 * and the old execution graphs will be purged if the total added number exceeds the max capacity.
+	 */
+	@Test
+	public void testMaximumCapacity() throws IOException {
+		final File rootDir = temporaryFolder.newFolder();
+
+		final int maxCapacity = 10;
+		final int numberExecutionGraphs = 10;
+
+		final Collection<ArchivedExecutionGraph> oldExecutionGraphs = generateTerminalExecutionGraphs(numberExecutionGraphs);
+		final Collection<ArchivedExecutionGraph> newExecutionGraphs = generateTerminalExecutionGraphs(numberExecutionGraphs);
+
+		final Collection<JobDetails> jobDetails = generateJobDetails(newExecutionGraphs);
+
+		try (final FileArchivedExecutionGraphStore executionGraphStore = new FileArchivedExecutionGraphStore(
+			rootDir,
+			Time.hours(1L),
+			maxCapacity,
+			10000L,
+			TestingUtils.defaultScheduledExecutor(),
+			Ticker.systemTicker())) {
+
+			for (ArchivedExecutionGraph executionGraph : oldExecutionGraphs) {
+				executionGraphStore.put(executionGraph);
+				// no more than the configured maximum capacity
+				assertTrue(executionGraphStore.size() <= maxCapacity);
+			}
+
+			for (ArchivedExecutionGraph executionGraph : newExecutionGraphs) {
+				executionGraphStore.put(executionGraph);
+				// equals to the configured maximum capacity
+				assertEquals(maxCapacity, executionGraphStore.size());
+			}
+
+			// the older execution graphs are purged
+			assertThat(executionGraphStore.getAvailableJobDetails(), Matchers.containsInAnyOrder(jobDetails.toArray()));
+		}
+	}
+
 	private Collection<ArchivedExecutionGraph> generateTerminalExecutionGraphs(int number) {
 		final Collection<ArchivedExecutionGraph> executionGraphs = new ArrayList<>(number);
 
@@ -277,6 +322,7 @@ public class FileArchivedExecutionGraphStoreTest extends TestLogger {
 		return new FileArchivedExecutionGraphStore(
 			storageDirectory,
 			Time.hours(1L),
+			Integer.MAX_VALUE,
 			10000L,
 			TestingUtils.defaultScheduledExecutor(),
 			Ticker.systemTicker());
@@ -317,5 +363,9 @@ public class FileArchivedExecutionGraphStoreTest extends TestLogger {
 
 	private static Matcher<ArchivedExecutionGraph> matchesPartiallyWith(ArchivedExecutionGraph executionGraph) {
 		return new PartialArchivedExecutionGraphMatcher(executionGraph);
+	}
+
+	private static Collection<JobDetails> generateJobDetails(Collection<ArchivedExecutionGraph> executionGraphs) {
+		return executionGraphs.stream().map(WebMonitorUtils::createDetailsForJob).collect(Collectors.toList());
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change
The purpose of this pr to enable config of max capacity of FileArchivedExecutionGraphStore. Currently, Flink session cluster uses FileArchivedExecutionGraphStore to keep finished jobs for historic requests. The FileArchivedExecutionGraphStore purges archived ExecutionGraphs only by an expiration time. In a session cluster on which runs many batch jobs, it is hard to config the jobstore.expiration-time, if configured too short, the historical information may have been deleted when the user want to check it, and if configured too long, the web front end may response very slowly when the number of finished job is too large. This pr enables config of maximum capacity of FileArchivedExecutionGraphStore, after which, the expiration time can be set to a relative long value and the maximum capacity can be set to an appropriate value which does not make the web ui become too slow or consume too much memory.

## Brief change log

  - A new config option *jobstore.max-capacity* was added. The default value is *Integer.MAX_VALUE*, which means the capacity of job store is not limited and keeps the default behavior unchanged.
  - Set the maximum capacity of job detail cache through the *maximumSize* interface of Guava Cache.
  - Add a test case to verify the change.


## Verifying this change

This change added tests and can be verified as follows:

  - A ut case was added which works by putting more than the configured capacity number of the finished ExecutionGraphs to FileArchivedExecutionGraphStore and verifying that the size of the FileArchivedExecutionGraphStore is no more than the configured max capacity and the old execution graphs will be purged if the total added execution graph number exceeds the max capacity.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
