### PR TITLE
[FLINK-14182][core] Make TimeUtils able to parse duration string with plural form labels

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/TimeUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/TimeUtils.java
@@ -23,6 +23,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -112,24 +113,47 @@ public class TimeUtils {
 	 */
 	private enum TimeUnit {
 
-		DAYS(ChronoUnit.DAYS, "d", "day"),
-		HOURS(ChronoUnit.HOURS, "h", "hour"),
-		MINUTES(ChronoUnit.MINUTES, "min", "minute"),
-		SECONDS(ChronoUnit.SECONDS, "s", "sec", "second"),
-		MILLISECONDS(ChronoUnit.MILLIS, "ms", "milli", "millisecond"),
-		MICROSECONDS(ChronoUnit.MICROS, "µs", "micro", "microsecond"),
-		NANOSECONDS(ChronoUnit.NANOS, "ns", "nano", "nanosecond");
+		DAYS(ChronoUnit.DAYS, singular("d"), plural("day")),
+		HOURS(ChronoUnit.HOURS, singular("h"), plural("hour")),
+		MINUTES(ChronoUnit.MINUTES, singular("min"), plural("minute")),
+		SECONDS(ChronoUnit.SECONDS, singular("s"), plural("sec"), plural("second")),
+		MILLISECONDS(ChronoUnit.MILLIS, singular("ms"), plural("milli"), plural("millisecond")),
+		MICROSECONDS(ChronoUnit.MICROS, singular("µs"), plural("micro"), plural("microsecond")),
+		NANOSECONDS(ChronoUnit.NANOS, singular("ns"), plural("nano"), plural("nanosecond"));
 
-		private String[] labels;
+		private static final String PLURAL_SUFFIX = "s";
 
-		private ChronoUnit unit;
+		private final List<String> labels;
 
-		TimeUnit(ChronoUnit unit, String... labels) {
+		private final ChronoUnit unit;
+
+		TimeUnit(ChronoUnit unit, String[]... labels) {
 			this.unit = unit;
-			this.labels = labels;
+			this.labels = Arrays.stream(labels).flatMap(ls -> Arrays.stream(ls)).collect(Collectors.toList());
 		}
 
-		public String[] getLabels() {
+		/**
+		 * @param label the original label
+		 * @return the singular format of the original label
+		 */
+		private static String[] singular(String label) {
+			return new String[] {
+				label
+			};
+		}
+
+		/**
+		 * @param label the original label
+		 * @return both the singular format and plural format of the original label
+		 */
+		private static String[] plural(String label) {
+			return new String[] {
+				label,
+				label + PLURAL_SUFFIX
+			};
+		}
+
+		public List<String> getLabels() {
 			return labels;
 		}
 

--- a/flink-core/src/test/java/org/apache/flink/util/TimeUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/TimeUtilsTest.java
@@ -32,7 +32,9 @@ public class TimeUtilsTest {
 	public void testParseDurationNanos() {
 		assertEquals(424562, TimeUtils.parseDuration("424562ns").getNano());
 		assertEquals(424562, TimeUtils.parseDuration("424562nano").getNano());
+		assertEquals(424562, TimeUtils.parseDuration("424562nanos").getNano());
 		assertEquals(424562, TimeUtils.parseDuration("424562nanosecond").getNano());
+		assertEquals(424562, TimeUtils.parseDuration("424562nanoseconds").getNano());
 		assertEquals(424562, TimeUtils.parseDuration("424562 ns").getNano());
 	}
 
@@ -40,7 +42,9 @@ public class TimeUtilsTest {
 	public void testParseDurationMicros() {
 		assertEquals(565731 * 1000L, TimeUtils.parseDuration("565731µs").getNano());
 		assertEquals(565731 * 1000L, TimeUtils.parseDuration("565731micro").getNano());
+		assertEquals(565731 * 1000L, TimeUtils.parseDuration("565731micros").getNano());
 		assertEquals(565731 * 1000L, TimeUtils.parseDuration("565731microsecond").getNano());
+		assertEquals(565731 * 1000L, TimeUtils.parseDuration("565731microseconds").getNano());
 		assertEquals(565731 * 1000L, TimeUtils.parseDuration("565731 µs").getNano());
 	}
 
@@ -49,14 +53,19 @@ public class TimeUtilsTest {
 		assertEquals(1234, TimeUtils.parseDuration("1234").toMillis());
 		assertEquals(1234, TimeUtils.parseDuration("1234ms").toMillis());
 		assertEquals(1234, TimeUtils.parseDuration("1234milli").toMillis());
+		assertEquals(1234, TimeUtils.parseDuration("1234millis").toMillis());
 		assertEquals(1234, TimeUtils.parseDuration("1234millisecond").toMillis());
+		assertEquals(1234, TimeUtils.parseDuration("1234milliseconds").toMillis());
 		assertEquals(1234, TimeUtils.parseDuration("1234 ms").toMillis());
 	}
 
 	@Test
 	public void testParseDurationSeconds() {
 		assertEquals(667766, TimeUtils.parseDuration("667766s").getSeconds());
+		assertEquals(667766, TimeUtils.parseDuration("667766sec").getSeconds());
+		assertEquals(667766, TimeUtils.parseDuration("667766secs").getSeconds());
 		assertEquals(667766, TimeUtils.parseDuration("667766second").getSeconds());
+		assertEquals(667766, TimeUtils.parseDuration("667766seconds").getSeconds());
 		assertEquals(667766, TimeUtils.parseDuration("667766 s").getSeconds());
 	}
 
@@ -64,6 +73,7 @@ public class TimeUtilsTest {
 	public void testParseDurationMinutes() {
 		assertEquals(7657623, TimeUtils.parseDuration("7657623min").toMinutes());
 		assertEquals(7657623, TimeUtils.parseDuration("7657623minute").toMinutes());
+		assertEquals(7657623, TimeUtils.parseDuration("7657623minutes").toMinutes());
 		assertEquals(7657623, TimeUtils.parseDuration("7657623 min").toMinutes());
 	}
 
@@ -71,6 +81,7 @@ public class TimeUtilsTest {
 	public void testParseDurationHours() {
 		assertEquals(987654, TimeUtils.parseDuration("987654h").toHours());
 		assertEquals(987654, TimeUtils.parseDuration("987654hour").toHours());
+		assertEquals(987654, TimeUtils.parseDuration("987654hours").toHours());
 		assertEquals(987654, TimeUtils.parseDuration("987654 h").toHours());
 	}
 
@@ -78,6 +89,7 @@ public class TimeUtilsTest {
 	public void testParseDurationDays() {
 		assertEquals(987654, TimeUtils.parseDuration("987654d").toDays());
 		assertEquals(987654, TimeUtils.parseDuration("987654day").toDays());
+		assertEquals(987654, TimeUtils.parseDuration("987654days").toDays());
 		assertEquals(987654, TimeUtils.parseDuration("987654 d").toDays());
 	}
 


### PR DESCRIPTION

## What is the purpose of the change


Scala Duration supports parsing plural form time unit label except for the shortest label of a TimeUnit. Namely:
{ 
  "d day days", 
  "h hour s", 
  "min minute minutes", 
  "s sec secs second seconds", 
  "ms milli millis millisecond milliseconds", 
  "µs micro micros microsecond microseconds", 
  "ns nano nanos nanosecond nanoseconds"
}

TimeUtils should support them as well.

## Brief change log

  - *Each label now can be marked as singular or plural for a time unit*

## Verifying this change

This change added tests and can be verified as follows:
  - *Unit tests in TimeUtilsTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
