### PR TITLE
[FLINK-14183][runtime] Remove unnecessary scala Duration usages in flink-runtime

### DIFF
--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/LeaderRetrievalHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/LeaderRetrievalHandlerTest.java
@@ -84,18 +84,18 @@ public class LeaderRetrievalHandlerTest extends TestLogger {
 
 		try (HttpTestClient httpClient = new HttpTestClient("localhost", bootstrap.getServerPort())) {
 			// 1. no leader gateway available --> Service unavailable
-			httpClient.sendGetRequest(restPath, FutureUtils.toFiniteDuration(timeout));
+			httpClient.sendGetRequest(restPath, FutureUtils.toDuration(timeout));
 
-			HttpTestClient.SimpleHttpResponse response = httpClient.getNextResponse(FutureUtils.toFiniteDuration(timeout));
+			HttpTestClient.SimpleHttpResponse response = httpClient.getNextResponse(FutureUtils.toDuration(timeout));
 
 			Assert.assertEquals(HttpResponseStatus.SERVICE_UNAVAILABLE, response.getStatus());
 
 			// 2. with leader
 			gatewayFuture.complete(gateway);
 
-			httpClient.sendGetRequest(restPath, FutureUtils.toFiniteDuration(timeout));
+			httpClient.sendGetRequest(restPath, FutureUtils.toDuration(timeout));
 
-			response = httpClient.getNextResponse(FutureUtils.toFiniteDuration(timeout));
+			response = httpClient.getNextResponse(FutureUtils.toDuration(timeout));
 
 			Assert.assertEquals(HttpResponseStatus.OK, response.getStatus());
 			Assert.assertEquals(RESPONSE_MESSAGE, response.getContent());

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/testutils/HttpTestClient.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/testutils/HttpTestClient.java
@@ -47,12 +47,11 @@ import org.apache.flink.shaded.netty4.io.netty.util.CharsetUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import scala.concurrent.duration.FiniteDuration;
 
 /**
  * A simple HTTP client.
@@ -130,7 +129,7 @@ public class HttpTestClient implements AutoCloseable {
 	 *
 	 * @param request The {@link HttpRequest} to send to the server
 	 */
-	public void sendRequest(HttpRequest request, FiniteDuration timeout) throws InterruptedException, TimeoutException {
+	public void sendRequest(HttpRequest request, Duration timeout) throws InterruptedException, TimeoutException {
 		LOG.debug("Writing {}.", request);
 
 		// Make the connection attempt.
@@ -153,7 +152,7 @@ public class HttpTestClient implements AutoCloseable {
 	 *
 	 * @param path The $path to GET (http://$host:$host/$path)
 	 */
-	public void sendGetRequest(String path, FiniteDuration timeout) throws TimeoutException, InterruptedException {
+	public void sendGetRequest(String path, Duration timeout) throws TimeoutException, InterruptedException {
 		if (!path.startsWith("/")) {
 			path = "/" + path;
 		}
@@ -172,7 +171,7 @@ public class HttpTestClient implements AutoCloseable {
 	 *
 	 * @param path The $path to DELETE (http://$host:$host/$path)
 	 */
-	public void sendDeleteRequest(String path, FiniteDuration timeout) throws TimeoutException, InterruptedException {
+	public void sendDeleteRequest(String path, Duration timeout) throws TimeoutException, InterruptedException {
 		if (!path.startsWith("/")) {
 			path = "/" + path;
 		}
@@ -191,7 +190,7 @@ public class HttpTestClient implements AutoCloseable {
 	 *
 	 * @param path The $path to PATCH (http://$host:$host/$path)
 	 */
-	public void sendPatchRequest(String path, FiniteDuration timeout) throws TimeoutException, InterruptedException {
+	public void sendPatchRequest(String path, Duration timeout) throws TimeoutException, InterruptedException {
 		if (!path.startsWith("/")) {
 			path = "/" + path;
 		}
@@ -221,7 +220,7 @@ public class HttpTestClient implements AutoCloseable {
 	 * @param timeout Timeout in milliseconds for the next response to become available
 	 * @return The next available {@link SimpleHttpResponse}
 	 */
-	public SimpleHttpResponse getNextResponse(FiniteDuration timeout) throws InterruptedException,
+	public SimpleHttpResponse getNextResponse(Duration timeout) throws InterruptedException,
 			TimeoutException {
 
 		SimpleHttpResponse response = responses.poll(timeout.toMillis(), TimeUnit.MILLISECONDS);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -30,6 +30,7 @@ import akka.dispatch.OnComplete;
 
 import javax.annotation.Nonnull;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -55,7 +56,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import scala.concurrent.Future;
-import scala.concurrent.duration.FiniteDuration;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -833,23 +833,13 @@ public class FutureUtils {
 	}
 
 	/**
-	 * Converts Flink time into a {@link FiniteDuration}.
+	 * Converts Flink time into a {@link Duration}.
 	 *
-	 * @param time to convert into a FiniteDuration
-	 * @return FiniteDuration with the length of the given time
+	 * @param time to convert into a Duration
+	 * @return Duration with the length of the given time
 	 */
-	public static FiniteDuration toFiniteDuration(Time time) {
-		return new FiniteDuration(time.toMilliseconds(), TimeUnit.MILLISECONDS);
-	}
-
-	/**
-	 * Converts {@link FiniteDuration} into Flink time.
-	 *
-	 * @param finiteDuration to convert into Flink time
-	 * @return Flink time with the length of the given finite duration
-	 */
-	public static Time toTime(FiniteDuration finiteDuration) {
-		return Time.milliseconds(finiteDuration.toMillis());
+	public static Duration toDuration(Time time) {
+		return Duration.ofMillis(time.toMilliseconds());
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/ConnectionUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/ConnectionUtils.java
@@ -32,14 +32,12 @@ import java.net.NetworkInterface;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-
-import scala.concurrent.duration.FiniteDuration;
 
 /**
  * Utilities to determine the network interface and address that should be used to bind the
@@ -342,7 +340,7 @@ public class ConnectionUtils {
 	 */
 	public static class LeaderConnectingAddressListener implements LeaderRetrievalListener {
 
-		private static final FiniteDuration defaultLoggingDelay = new FiniteDuration(400, TimeUnit.MILLISECONDS);
+		private static final Duration defaultLoggingDelay = Duration.ofMillis(400);
 
 		private enum LeaderRetrievalState {
 			NOT_RETRIEVED,
@@ -357,14 +355,13 @@ public class ConnectionUtils {
 		private Exception exception;
 
 		public InetAddress findConnectingAddress(
-				FiniteDuration timeout) throws LeaderRetrievalException {
+				Duration timeout) throws LeaderRetrievalException {
 			return findConnectingAddress(timeout, defaultLoggingDelay);
 		}
 
 		public InetAddress findConnectingAddress(
-				FiniteDuration timeout,
-				FiniteDuration startLoggingAfter)
-			throws LeaderRetrievalException {
+				Duration timeout,
+				Duration startLoggingAfter) throws LeaderRetrievalException {
 
 			final long startTimeNanos = System.nanoTime();
 			long currentSleepTime = MIN_SLEEP_TIME;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -69,6 +69,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.UndeclaredThrowableException;
 import java.net.InetAddress;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.Callable;
@@ -426,7 +427,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 			final Configuration configuration,
 			final HighAvailabilityServices haServices) throws LeaderRetrievalException {
 
-		final Time lookupTimeout = Time.milliseconds(AkkaUtils.getLookupTimeout(configuration).toMillis());
+		final Duration lookupTimeout = AkkaUtils.getLookupTimeout(configuration);
 
 		final InetAddress taskManagerAddress = LeaderRetrievalUtils.findConnectingAddress(
 			haServices.getResourceManagerLeaderRetriever(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/LeaderRetrievalUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/LeaderRetrievalUtils.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.util;
 
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalException;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
@@ -30,12 +29,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
+import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import scala.concurrent.Future;
 import scala.concurrent.Promise;
-import scala.concurrent.duration.FiniteDuration;
 
 /**
  * Utility class to work with {@link LeaderRetrievalService} class.
@@ -57,7 +56,7 @@ public class LeaderRetrievalUtils {
 	 */
 	public static LeaderConnectionInfo retrieveLeaderConnectionInfo(
 			LeaderRetrievalService leaderRetrievalService,
-			Time timeout) throws LeaderRetrievalException {
+			Duration timeout) throws LeaderRetrievalException {
 
 		LeaderConnectionInfoListener listener = new LeaderConnectionInfoListener();
 
@@ -66,7 +65,7 @@ public class LeaderRetrievalUtils {
 
 			Future<LeaderConnectionInfo> connectionInfoFuture = listener.getLeaderConnectionInfoFuture();
 
-			return FutureUtils.toJava(connectionInfoFuture).get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+			return FutureUtils.toJava(connectionInfoFuture).get(timeout.toMillis(), TimeUnit.MILLISECONDS);
 		} catch (Exception e) {
 			throw new LeaderRetrievalException("Could not retrieve the leader address and leader " +
 				"session ID.", e);
@@ -81,28 +80,23 @@ public class LeaderRetrievalUtils {
 
 	public static InetAddress findConnectingAddress(
 			LeaderRetrievalService leaderRetrievalService,
-			Time timeout) throws LeaderRetrievalException {
-		return findConnectingAddress(leaderRetrievalService, new FiniteDuration(timeout.getSize(), timeout.getUnit()));
-	}
+			Duration timeout) throws LeaderRetrievalException {
 
-	public static InetAddress findConnectingAddress(
-			LeaderRetrievalService leaderRetrievalService,
-			FiniteDuration timeout) throws LeaderRetrievalException {
 		ConnectionUtils.LeaderConnectingAddressListener listener = new ConnectionUtils.LeaderConnectingAddressListener();
 
 		try {
 			leaderRetrievalService.start(listener);
 
 			LOG.info("Trying to select the network interface and address to use " +
-					"by connecting to the leading JobManager.");
+				"by connecting to the leading JobManager.");
 
 			LOG.info("TaskManager will try to connect for " + timeout +
-					" before falling back to heuristics");
+				" before falling back to heuristics");
 
 			return listener.findConnectingAddress(timeout);
 		} catch (Exception e) {
 			throw new LeaderRetrievalException("Could not find the connecting address by " +
-					"connecting to the current leader.", e);
+				"connecting to the current leader.", e);
 		} finally {
 			try {
 				leaderRetrievalService.stop();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/ZooKeeperHADispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/ZooKeeperHADispatcherTest.java
@@ -62,6 +62,7 @@ import org.junit.rules.TestName;
 import javax.annotation.Nonnull;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -293,7 +294,9 @@ public class ZooKeeperHADispatcherTest extends TestLogger {
 				dispatcher1.start();
 				dispatcher2.start();
 
-				final LeaderConnectionInfo leaderConnectionInfo = LeaderRetrievalUtils.retrieveLeaderConnectionInfo(haServices.getDispatcherLeaderRetriever(), TIMEOUT);
+				final LeaderConnectionInfo leaderConnectionInfo = LeaderRetrievalUtils.retrieveLeaderConnectionInfo(
+					haServices.getDispatcherLeaderRetriever(),
+					Duration.ofMillis(TIMEOUT.toMilliseconds()));
 
 				final DispatcherGateway dispatcherGateway = rpcService.connect(leaderConnectionInfo.getAddress(), DispatcherId.fromUuid(leaderConnectionInfo.getLeaderSessionID()), DispatcherGateway.class).get();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderChangeClusterComponentsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderChangeClusterComponentsTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.leaderelection;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.api.common.time.Deadline;
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.highavailability.nonha.embedded.TestingEmbeddedHaServices;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -157,7 +156,11 @@ public class LeaderChangeClusterComponentsTest extends TestLogger {
 		highAvailabilityServices.grantResourceManagerLeadership();
 
 		// wait for the ResourceManager to confirm the leadership
-		assertThat(LeaderRetrievalUtils.retrieveLeaderConnectionInfo(highAvailabilityServices.getResourceManagerLeaderRetriever(), Time.minutes(TESTING_TIMEOUT.toMinutes())).getLeaderSessionID(), is(notNullValue()));
+		assertThat(
+			LeaderRetrievalUtils.retrieveLeaderConnectionInfo(
+				highAvailabilityServices.getResourceManagerLeaderRetriever(),
+				TESTING_TIMEOUT).getLeaderSessionID(),
+			is(notNullValue()));
 
 		waitUntilTaskExecutorsHaveConnected(NUM_TMS, deadline);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderRetrievalTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderRetrievalTest.java
@@ -45,9 +45,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
-import java.util.concurrent.TimeUnit;
-
-import scala.concurrent.duration.FiniteDuration;
+import java.time.Duration;
 
 import static org.junit.Assert.assertEquals;
 
@@ -102,7 +100,7 @@ public class ZooKeeperLeaderRetrievalTest extends TestLogger{
 	 */
 	@Test
 	public void testConnectingAddressRetrievalWithDelayedLeaderElection() throws Exception {
-		FiniteDuration timeout = new FiniteDuration(1, TimeUnit.MINUTES);
+		Duration timeout = Duration.ofMinutes(1L);
 
 		long sleepingTime = 1000;
 
@@ -197,7 +195,7 @@ public class ZooKeeperLeaderRetrievalTest extends TestLogger{
 	 */
 	@Test
 	public void testTimeoutOfFindConnectingAddress() throws Exception {
-		FiniteDuration timeout = new FiniteDuration(1L, TimeUnit.SECONDS);
+		Duration timeout = Duration.ofSeconds(1L);
 
 		LeaderRetrievalService leaderRetrievalService = highAvailabilityServices.getJobManagerLeaderRetriever(HighAvailabilityServices.DEFAULT_JOB_ID);
 		InetAddress result = LeaderRetrievalUtils.findConnectingAddress(leaderRetrievalService, timeout);
@@ -207,14 +205,14 @@ public class ZooKeeperLeaderRetrievalTest extends TestLogger{
 
 	static class FindConnectingAddress implements Runnable {
 
-		private final FiniteDuration timeout;
+		private final Duration timeout;
 		private final LeaderRetrievalService leaderRetrievalService;
 
 		private InetAddress result;
 		private Exception exception;
 
 		public FindConnectingAddress(
-				FiniteDuration timeout,
+				Duration timeout,
 				LeaderRetrievalService leaderRetrievalService) {
 			this.timeout = timeout;
 			this.leaderRetrievalService = leaderRetrievalService;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryImplTest.java
@@ -45,12 +45,11 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
-import scala.concurrent.duration.FiniteDuration;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.junit.Assert.assertEquals;
@@ -366,7 +365,7 @@ public class MetricRegistryImplTest extends TestLogger {
 	 */
 	@Test
 	public void testQueryActorShutdown() throws Exception {
-		final FiniteDuration timeout = new FiniteDuration(10L, TimeUnit.SECONDS);
+		final Duration timeout = Duration.ofSeconds(10L);
 
 		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
@@ -51,8 +51,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import scala.concurrent.Await;
-
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -272,7 +270,7 @@ public class AkkaRpcActorTest extends TestLogger {
 			terminationFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 		} finally {
 			rpcActorSystem.terminate();
-			Await.ready(rpcActorSystem.whenTerminated(), FutureUtils.toFiniteDuration(timeout));
+			FutureUtils.toJava(rpcActorSystem.whenTerminated()).get(timeout.getSize(), timeout.getUnit());
 		}
 	}
 

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.testingUtils
 
+import java.time.Duration
 import java.util
 import java.util.Collections
 import java.util.concurrent._
@@ -28,7 +29,6 @@ import org.apache.flink.api.common.time.Time
 import org.apache.flink.runtime.akka.AkkaUtils
 import org.apache.flink.runtime.concurrent.{ScheduledExecutor, ScheduledExecutorServiceAdapter}
 
-import scala.concurrent.duration.{TimeUnit, _}
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 import scala.language.postfixOps
 
@@ -41,9 +41,9 @@ object TestingUtils {
 
   val testConfig = ConfigFactory.parseString(getDefaultTestingActorSystemConfigString)
   
-  val TESTING_DURATION = 2 minute
+  val TESTING_DURATION = Duration.ofMinutes(2L);
 
-  val TESTING_TIMEOUT = 1 minute
+  val TESTING_TIMEOUT = Duration.ofMinutes(1L);
 
   val TIMEOUT = Time.minutes(1L)
 

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -265,7 +265,9 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 	 * @throws Exception if something goes wrong
 	 */
 	static DispatcherGateway retrieveDispatcherGateway(RpcService rpcService, HighAvailabilityServices haServices) throws Exception {
-		final LeaderConnectionInfo leaderConnectionInfo = LeaderRetrievalUtils.retrieveLeaderConnectionInfo(haServices.getDispatcherLeaderRetriever(), Time.seconds(10L));
+		final LeaderConnectionInfo leaderConnectionInfo = LeaderRetrievalUtils.retrieveLeaderConnectionInfo(
+			haServices.getDispatcherLeaderRetriever(),
+			Duration.ofSeconds(10L));
 
 		return rpcService.connect(
 			leaderConnectionInfo.getAddress(),


### PR DESCRIPTION
## What is the purpose of the change

This PR is to remove all usages of scala Duration/FiniteDuration in flink-runtime, except for those usages for Akka components (in AkkaUtils, AkkaRpcActor and ActorSystemScheduledExecutorAdapter).
This is one step towards a scala free flink-runtime.

## Brief change log

  - *Usages of scala Duration are replaced with java.time.Duration. Details see each commit.*

## Verifying this change

Most changes are trivial rework / code cleanup without any test coverage.
And some changes are already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
