### PR TITLE
[FLINK-13982][runtime] Implement memory calculation logics

### DIFF
--- a/docs/_includes/generated/common_section.html
+++ b/docs/_includes/generated/common_section.html
@@ -13,9 +13,9 @@
             <td>JVM heap size for the JobManager.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.heap.size</h5></td>
-            <td style="word-wrap: break-word;">"1024m"</td>
-            <td>JVM heap size for the TaskManagers, which are the parallel workers of the system. On YARN setups, this value is automatically configured to the size of the TaskManager's YARN container, minus a certain tolerance value.</td>
+            <td><h5>taskmanager.memory.total-flink.size</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Total Flink Memory size for the TaskExecutors. This includes all the memory that a TaskExecutor consumes, except for JVM Metaspace and JVM Overhead. It consists of Framework Heap Memory, Task Heap Memory, Task Off-Heap Memory, Managed Memory, and Shuffle Memory.</td>
         </tr>
         <tr>
             <td><h5>parallelism.default</h5></td>

--- a/docs/_includes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/_includes/generated/netty_shuffle_environment_configuration.html
@@ -33,21 +33,6 @@
             <td>Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate). In credit-based flow control mode, this indicates how many floating credits are shared among all the input channels. The floating buffers are distributed based on backlog (real-time output buffers in the subpartition) feedback, and can help relieve back-pressure caused by unbalanced data distribution among the subpartitions. This value should be increased in case of higher round trip times between nodes and/or larger number of machines in the cluster.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.network.memory.fraction</h5></td>
-            <td style="word-wrap: break-word;">0.1</td>
-            <td>Fraction of JVM memory to use for network buffers. This determines how many streaming data exchange channels a TaskManager can have at the same time and how well buffered the channels are. If a job is rejected or you get a warning that the system has not enough buffers available, increase this value or the min/max values below. Also note, that "taskmanager.network.memory.min"` and "taskmanager.network.memory.max" may override this fraction.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.memory.max</h5></td>
-            <td style="word-wrap: break-word;">"1gb"</td>
-            <td>Maximum memory size for network buffers.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.memory.min</h5></td>
-            <td style="word-wrap: break-word;">"64mb"</td>
-            <td>Minimum memory size for network buffers.</td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.network.request-backoff.initial</h5></td>
             <td style="word-wrap: break-word;">100</td>
             <td>Minimum backoff in milliseconds for partition requests of input channels.</td>

--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -43,11 +43,6 @@
             <td>Whether the quarantine monitor for task managers shall be started. The quarantine monitor shuts down the actor system if it detects that it has quarantined another actor system or if it has been quarantined by another actor system.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.heap.size</h5></td>
-            <td style="word-wrap: break-word;">"1024m"</td>
-            <td>JVM heap size for the TaskManagers, which are the parallel workers of the system. On YARN setups, this value is automatically configured to the size of the TaskManager's YARN container, minus a certain tolerance value.</td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.host</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>The address of the network interface that the TaskManager binds to. This option can be used to define explicitly a binding address. Because different TaskManagers need different values for this option, usually it is specified in an additional non-shared TaskManager-specific config file.</td>

--- a/docs/_includes/generated/task_manager_memory_configuration.html
+++ b/docs/_includes/generated/task_manager_memory_configuration.html
@@ -8,14 +8,49 @@
     </thead>
     <tbody>
         <tr>
-            <td><h5>taskmanager.memory.fraction</h5></td>
-            <td style="word-wrap: break-word;">0.7</td>
-            <td>The relative amount of memory (after subtracting the amount of memory used by network buffers) that the task manager reserves for sorting, hash tables, and caching of intermediate results. For example, a value of <span markdown="span">`0.8`</span> means that a task manager reserves 80% of its memory (on-heap or off-heap depending on taskmanager.memory.off-heap) for internal data buffers, leaving 20% of free memory for the task manager's heap for objects created by user-defined functions. This parameter is only evaluated, if taskmanager.memory.size is not set.</td>
+            <td><h5>taskmanager.memory.framework.heap.size</h5></td>
+            <td style="word-wrap: break-word;">"128m"</td>
+            <td>Framework Heap Memory size for TaskExecutors. This is the size of JVM heap memory reserved for TaskExecutor framework, which will not be allocated to task slots.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.memory.off-heap</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Memory allocation method (JVM heap or off-heap), used for managed memory of the TaskManager. For setups with larger quantities of memory, this can improve the efficiency of the operations performed on the memory.<br />When set to true, then it is advised that <span markdown="span">`taskmanager.memory.preallocate`</span> is also set to true.</td>
+            <td><h5>taskmanager.memory.jvm-metaspace.size</h5></td>
+            <td style="word-wrap: break-word;">"192m"</td>
+            <td>JVM Metaspace Size for the TaskExecutors.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.memory.jvm-overhead.fraction</h5></td>
+            <td style="word-wrap: break-word;">0.1</td>
+            <td>Fraction of Total Process Memory to be reserved for JVM Overhead. This is off-heap memory reserved for JVM overhead, such as thread stack space, I/O direct memory, compile cache, etc. The size of JVM Overhead is derived to make up the configured fraction of the Total Process Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of JVM Overhead can be explicitly specified by setting the min/max size to the same value.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.memory.jvm-overhead.max</h5></td>
+            <td style="word-wrap: break-word;">"1g"</td>
+            <td>Max JVM Overhead size for the TaskExecutors. This is off-heap memory reserved for JVM overhead, such as thread stack space, I/O direct memory, compile cache, etc. The size of JVM Overhead is derived to make up the configured fraction of the Total Process Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of JVM Overhead can be explicitly specified by setting the min/max size to the same value.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.memory.jvm-overhead.min</h5></td>
+            <td style="word-wrap: break-word;">"128m"</td>
+            <td>Min JVM Overhead size for the TaskExecutors. This is off-heap memory reserved for JVM overhead, such as thread stack space, I/O direct memory, compile cache, etc. The size of JVM Overhead is derived to make up the configured fraction of the Total Process Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of JVM Overhead can be explicitly specified by setting the min/max size to the same value.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.memory.managed.fraction</h5></td>
+            <td style="word-wrap: break-word;">0.5</td>
+            <td>Fraction of Total Flink Memory to be used as Managed Memory, if Managed Memory size is not explicitly specified.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.memory.managed.off-heap.fraction</h5></td>
+            <td style="word-wrap: break-word;">-1.0</td>
+            <td>Fraction of Managed Memory that Off-Heap Managed Memory takes, if Off-Heap Managed Memory size is not explicitly specified. If the fraction is not explicitly specified (or configured with negative values), it will be derived from the legacy config option 'taskmanager.memory.off-heap', to use either all on-heap memory or all off-heap memory for Managed Memory.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.memory.managed.off-heap.size</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Off-Heap Managed Memory size for TaskExecutors. This is the part of Managed Memory that is off-heap, while the remaining is on-heap. If unspecified, it will be derived to make up the configured fraction of the Managed Memory size.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.memory.managed.size</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Managed Memory size for TaskExecutors. This is the size of memory managed by the memory manager, including both On-Heap Managed Memory and Off-Heap Managed Memory, reserved for sorting, hash tables, caching of intermediate results and state backends. Memory consumers can either allocate memory from the memory manager in the form of MemorySegments, or reserve bytes from the memory manager and keep their memory usage within that boundary. If unspecified, it will be derived to make up the configured fraction of the Total Flink Memory.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.preallocate</h5></td>
@@ -28,9 +63,39 @@
             <td>Size of memory buffers used by the network stack and the memory manager.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.memory.size</h5></td>
-            <td style="word-wrap: break-word;">"0"</td>
-            <td>The amount of memory (in megabytes) that the task manager reserves on-heap or off-heap (depending on taskmanager.memory.off-heap) for sorting, hash tables, and caching of intermediate results. If unspecified, the memory manager will take a fixed ratio with respect to the size of the task manager JVM as specified by taskmanager.memory.fraction.</td>
+            <td><h5>taskmanager.memory.shuffle.fraction</h5></td>
+            <td style="word-wrap: break-word;">0.1</td>
+            <td>Fraction of Total Flink Memory to be used as Shuffle Memory. Shuffle Memory is off-heap memory reserved for ShuffleEnvironment (e.g., network buffers). Shuffle Memory size is derived to make up the configured fraction of the Total Flink Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of Shuffle Memory can be explicitly specified by setting the min/max size to the same value.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.memory.shuffle.max</h5></td>
+            <td style="word-wrap: break-word;">"1g"</td>
+            <td>Max Shuffle Memory size for TaskExecutors. Shuffle Memory is off-heap memory reserved for ShuffleEnvironment (e.g., network buffers). Shuffle Memory size is derived to make up the configured fraction of the Total Flink Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of Shuffle Memory can be explicitly specified by setting the min/max to the same value.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.memory.shuffle.min</h5></td>
+            <td style="word-wrap: break-word;">"64m"</td>
+            <td>Min Shuffle Memory size for TaskExecutors. Shuffle Memory is off-heap memory reserved for ShuffleEnvironment (e.g., network buffers). Shuffle Memory size is derived to make up the configured fraction of the Total Flink Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of Shuffle Memory can be explicitly specified by setting the min/max to the same value.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.memory.task.heap.size</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Task Heap Memory size for TaskExecutors. This is the size of JVM heap memory reserved for user code. If not specified, it will be derived as Total Flink Memory minus Framework Heap Memory, Task Off-Heap Memory, (On-Heap and Off-Heap) Managed Memory and Shuffle Memory.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.memory.task.off-heap.size</h5></td>
+            <td style="word-wrap: break-word;">"0b"</td>
+            <td>Task Heap Memory size for TaskExecutors. This is the size of off heap memory (JVM direct memory or native memory) reserved for user code.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.memory.total-flink.size</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Total Flink Memory size for the TaskExecutors. This includes all the memory that a TaskExecutor consumes, except for JVM Metaspace and JVM Overhead. It consists of Framework Heap Memory, Task Heap Memory, Task Off-Heap Memory, Managed Memory, and Shuffle Memory.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.memory.total-process.size</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Total Process Memory size for the TaskExecutors. This includes all the memory that a TaskExecutor consumes, consisting of Total Flink Memory, JVM Metaspace, and JVM Overhead. On containerized setups, this should be set to the container memory.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
@@ -82,7 +82,7 @@ public class KafkaShortRetentionTestBase implements Serializable {
 
 	private static Configuration getConfiguration() {
 		Configuration flinkConfig = new Configuration();
-		flinkConfig.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "16m");
+		flinkConfig.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "16m");
 		return flinkConfig;
 	}
 

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
@@ -117,7 +117,7 @@ public abstract class KafkaTestBase extends TestLogger {
 
 	protected static Configuration getFlinkConfiguration() {
 		Configuration flinkConfig = new Configuration();
-		flinkConfig.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "16m");
+		flinkConfig.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "16m");
 		flinkConfig.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "my_reporter." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, JMXReporter.class.getName());
 		return flinkConfig;
 	}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/manualtests/ManualExactlyOnceTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/manualtests/ManualExactlyOnceTest.java
@@ -78,7 +78,7 @@ public class ManualExactlyOnceTest {
 		}
 
 		final Configuration flinkConfig = new Configuration();
-		flinkConfig.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "16m");
+		flinkConfig.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "16m");
 		flinkConfig.setString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY, "0 s");
 
 		MiniClusterResource flink = new MiniClusterResource(new MiniClusterResourceConfiguration.Builder()

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/manualtests/ManualExactlyOnceWithStreamReshardingTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/manualtests/ManualExactlyOnceWithStreamReshardingTest.java
@@ -90,7 +90,7 @@ public class ManualExactlyOnceWithStreamReshardingTest {
 		}
 
 		final Configuration flinkConfig = new Configuration();
-		flinkConfig.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "16m");
+		flinkConfig.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "16m");
 		flinkConfig.setString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY, "0 s");
 
 		MiniClusterResource flink = new MiniClusterResource(new MiniClusterResourceConfiguration.Builder()

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -252,7 +252,7 @@ public final class ConfigConstants {
 	 * memory manager (in megabytes). If not set, a relative fraction will be allocated, as defined
 	 * by {@link #TASK_MANAGER_MEMORY_FRACTION_KEY}.
 	 *
-	 * @deprecated Use {@link TaskManagerOptions#MANAGED_MEMORY_SIZE} instead
+	 * @deprecated Use {@link TaskManagerOptions#LEGACY_MANAGED_MEMORY_SIZE} instead
 	 */
 	@Deprecated
 	public static final String TASK_MANAGER_MEMORY_SIZE_KEY = "taskmanager.memory.size";
@@ -260,7 +260,7 @@ public final class ConfigConstants {
 	/**
 	 * The config parameter defining the fraction of free memory allocated by the memory manager.
 	 *
-	 * @deprecated Use {@link TaskManagerOptions#MANAGED_MEMORY_FRACTION} instead
+	 * @deprecated Use {@link TaskManagerOptions#LEGACY_MANAGED_MEMORY_FRACTION} instead
 	 */
 	@Deprecated
 	public static final String TASK_MANAGER_MEMORY_FRACTION_KEY = "taskmanager.memory.fraction";
@@ -1427,7 +1427,7 @@ public final class ConfigConstants {
 	/**
 	 * Config key has been deprecated. Therefore, no default value required.
 	 *
-	 * @deprecated {@link TaskManagerOptions#MANAGED_MEMORY_FRACTION} provides the default value now
+	 * @deprecated {@link TaskManagerOptions#LEGACY_MANAGED_MEMORY_FRACTION} provides the default value now
 	 */
 	@Deprecated
 	public static final float DEFAULT_MEMORY_MANAGER_MEMORY_FRACTION = 0.7f;

--- a/flink-core/src/main/java/org/apache/flink/configuration/MemorySize.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/MemorySize.java
@@ -20,6 +20,7 @@ package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.PublicEvolving;
 
+import java.math.BigDecimal;
 import java.util.Locale;
 
 import static org.apache.flink.configuration.MemorySize.MemoryUnit.BYTES;
@@ -113,6 +114,28 @@ public class MemorySize implements java.io.Serializable {
 	@Override
 	public String toString() {
 		return bytes + " bytes";
+	}
+
+	// ------------------------------------------------------------------------
+	//  Calculations
+	// ------------------------------------------------------------------------
+
+	public MemorySize add(MemorySize that) {
+		return new MemorySize(Math.addExact(this.bytes, that.bytes));
+	}
+
+	public MemorySize subtract(MemorySize that) {
+		return new MemorySize(Math.subtractExact(this.bytes, that.bytes));
+	}
+
+	public MemorySize multiply(double multiplier) {
+		checkArgument(multiplier >= 0, "multiplier must be >= 0");
+
+		BigDecimal product = BigDecimal.valueOf(this.bytes).multiply(BigDecimal.valueOf(multiplier));
+		if (product.compareTo(BigDecimal.valueOf(Long.MAX_VALUE)) > 0) {
+			throw new ArithmeticException("long overflow");
+		}
+		return new MemorySize(product.longValue());
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -80,8 +80,8 @@ public class NettyShuffleEnvironmentOptions {
 	 * Number of buffers used in the network stack. This defines the number of possible tasks and
 	 * shuffles.
 	 *
-	 * @deprecated use {@link #NETWORK_BUFFERS_MEMORY_FRACTION}, {@link #NETWORK_BUFFERS_MEMORY_MIN},
-	 * and {@link #NETWORK_BUFFERS_MEMORY_MAX} instead
+	 * @deprecated use {@link TaskManagerOptions#SHUFFLE_MEMORY_FRACTION}, {@link TaskManagerOptions#SHUFFLE_MEMORY_MIN},
+	 * and {@link TaskManagerOptions#SHUFFLE_MEMORY_MAX} instead
 	 */
 	@Deprecated
 	public static final ConfigOption<Integer> NETWORK_NUM_BUFFERS =
@@ -90,7 +90,10 @@ public class NettyShuffleEnvironmentOptions {
 
 	/**
 	 * Fraction of JVM memory to use for network buffers.
+	 *
+	 * @deprecated use {@link TaskManagerOptions#SHUFFLE_MEMORY_FRACTION} instead
 	 */
+	@Deprecated
 	public static final ConfigOption<Float> NETWORK_BUFFERS_MEMORY_FRACTION =
 		key("taskmanager.network.memory.fraction")
 			.defaultValue(0.1f)
@@ -102,7 +105,10 @@ public class NettyShuffleEnvironmentOptions {
 
 	/**
 	 * Minimum memory size for network buffers.
+	 *
+	 * @deprecated use {@link TaskManagerOptions#SHUFFLE_MEMORY_MIN} instead
 	 */
+	@Deprecated
 	public static final ConfigOption<String> NETWORK_BUFFERS_MEMORY_MIN =
 		key("taskmanager.network.memory.min")
 			.defaultValue("64mb")
@@ -110,7 +116,10 @@ public class NettyShuffleEnvironmentOptions {
 
 	/**
 	 * Maximum memory size for network buffers.
+	 *
+	 * @deprecated use {@link TaskManagerOptions#SHUFFLE_MEMORY_MAX} instead
 	 */
+	@Deprecated
 	public static final ConfigOption<String> NETWORK_BUFFERS_MEMORY_MAX =
 		key("taskmanager.network.memory.max")
 			.defaultValue("1gb")

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -189,9 +189,9 @@ public class TaskManagerOptions {
 
 	/**
 	 * Amount of memory to be allocated by the task manager's memory manager. If not
-	 * set, a relative fraction will be allocated, as defined by {@link #MANAGED_MEMORY_FRACTION}.
+	 * set, a relative fraction will be allocated, as defined by {@link #LEGACY_MANAGED_MEMORY_FRACTION}.
 	 */
-	public static final ConfigOption<String> MANAGED_MEMORY_SIZE =
+	public static final ConfigOption<String> LEGACY_MANAGED_MEMORY_SIZE =
 			key("taskmanager.memory.size")
 			.defaultValue("0")
 			.withDescription("The amount of memory (in megabytes) that the task manager reserves on-heap or off-heap" +
@@ -200,10 +200,10 @@ public class TaskManagerOptions {
 				" the task manager JVM as specified by taskmanager.memory.fraction.");
 
 	/**
-	 * Fraction of free memory allocated by the memory manager if {@link #MANAGED_MEMORY_SIZE} is
+	 * Fraction of free memory allocated by the memory manager if {@link #LEGACY_MANAGED_MEMORY_SIZE} is
 	 * not set.
 	 */
-	public static final ConfigOption<Float> MANAGED_MEMORY_FRACTION =
+	public static final ConfigOption<Float> LEGACY_MANAGED_MEMORY_FRACTION =
 			key("taskmanager.memory.fraction")
 			.defaultValue(0.7f)
 			.withDescription(new Description.DescriptionBuilder()
@@ -212,8 +212,8 @@ public class TaskManagerOptions {
 					" For example, a value of %s means that a task manager reserves 80% of its memory" +
 					" (on-heap or off-heap depending on taskmanager.memory.off-heap)" +
 					" for internal data buffers, leaving 20% of free memory for the task manager's heap for objects" +
-					" created by user-defined functions. This parameter is only evaluated, if " + MANAGED_MEMORY_SIZE.key() +
-					" is not set.", code("0.8"))
+					" created by user-defined functions. This parameter is only evaluated, if " +
+					LEGACY_MANAGED_MEMORY_SIZE.key() + " is not set.", code("0.8"))
 				.build());
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -44,7 +44,7 @@ public class TaskManagerOptions {
 	/**
 	 * JVM heap size for the TaskManagers with memory size.
 	 */
-	@Documentation.CommonOption(position = Documentation.CommonOption.POSITION_MEMORY)
+	@Deprecated
 	public static final ConfigOption<String> TASK_MANAGER_HEAP_MEMORY =
 			key("taskmanager.heap.size")
 			.defaultValue("1024m")
@@ -191,6 +191,7 @@ public class TaskManagerOptions {
 	 * Amount of memory to be allocated by the task manager's memory manager. If not
 	 * set, a relative fraction will be allocated, as defined by {@link #LEGACY_MANAGED_MEMORY_FRACTION}.
 	 */
+	@Deprecated
 	public static final ConfigOption<String> LEGACY_MANAGED_MEMORY_SIZE =
 			key("taskmanager.memory.size")
 			.defaultValue("0")
@@ -203,6 +204,7 @@ public class TaskManagerOptions {
 	 * Fraction of free memory allocated by the memory manager if {@link #LEGACY_MANAGED_MEMORY_SIZE} is
 	 * not set.
 	 */
+	@Deprecated
 	public static final ConfigOption<Float> LEGACY_MANAGED_MEMORY_FRACTION =
 			key("taskmanager.memory.fraction")
 			.defaultValue(0.7f)
@@ -220,6 +222,7 @@ public class TaskManagerOptions {
 	 * Memory allocation method (JVM heap or off-heap), used for managed memory of the TaskManager
 	 * as well as the network buffers.
 	 **/
+	@Deprecated
 	public static final ConfigOption<Boolean> MEMORY_OFF_HEAP =
 			key("taskmanager.memory.off-heap")
 			.defaultValue(false)
@@ -259,6 +262,189 @@ public class TaskManagerOptions {
 					text("\"name\" - uses hostname as binding address"),
 					text("\"ip\" - uses host's ip address as binding address"))
 				.build());
+
+	// ------------------------------------------------------------------------
+	//  Memory Options
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Total Process Memory size for the TaskExecutors.
+	 */
+	public static final ConfigOption<String> TOTAL_PROCESS_MEMORY =
+		key("taskmanager.memory.total-process.size")
+			.noDefaultValue()
+			.withDescription("Total Process Memory size for the TaskExecutors. This includes all the memory that a"
+				+ " TaskExecutor consumes, consisting of Total Flink Memory, JVM Metaspace, and JVM Overhead. On"
+				+ " containerized setups, this should be set to the container memory.");
+
+	/**
+	 * Total Flink Memory size for the TaskExecutors.
+	 */
+	@Documentation.CommonOption(position = Documentation.CommonOption.POSITION_MEMORY)
+	public static final ConfigOption<String> TOTAL_FLINK_MEMORY =
+		key("taskmanager.memory.total-flink.size")
+		.noDefaultValue()
+		.withDeprecatedKeys(TASK_MANAGER_HEAP_MEMORY.key())
+		.withDescription("Total Flink Memory size for the TaskExecutors. This includes all the memory that a"
+			+ " TaskExecutor consumes, except for JVM Metaspace and JVM Overhead. It consists of Framework Heap Memory,"
+			+ " Task Heap Memory, Task Off-Heap Memory, Managed Memory, and Shuffle Memory.");
+
+	/**
+	 * Framework Heap Memory size for TaskExecutors.
+	 */
+	public static final ConfigOption<String> FRAMEWORK_HEAP_MEMORY =
+		key("taskmanager.memory.framework.heap.size")
+			.defaultValue("128m")
+			.withDescription("Framework Heap Memory size for TaskExecutors. This is the size of JVM heap memory reserved"
+				+ " for TaskExecutor framework, which will not be allocated to task slots.");
+
+	/**
+	 * Task Heap Memory size for TaskExecutors.
+	 */
+	public static final ConfigOption<String> TASK_HEAP_MEMORY =
+		key("taskmanager.memory.task.heap.size")
+			.noDefaultValue()
+			.withDescription("Task Heap Memory size for TaskExecutors. This is the size of JVM heap memory reserved for"
+				+ " user code. If not specified, it will be derived as Total Flink Memory minus Framework Heap Memory,"
+				+ " Task Off-Heap Memory, (On-Heap and Off-Heap) Managed Memory and Shuffle Memory.");
+
+	/**
+	 * Task Off-Heap Memory size for TaskExecutors.
+	 */
+	public static final ConfigOption<String> TASK_OFF_HEAP_MEMORY =
+		key("taskmanager.memory.task.off-heap.size")
+			.defaultValue("0b")
+			.withDescription("Task Heap Memory size for TaskExecutors. This is the size of off heap memory (JVM direct"
+				+ " memory or native memory) reserved for user code.");
+
+	/**
+	 * Managed Memory size for TaskExecutors.
+	 */
+	public static final ConfigOption<String> MANAGED_MEMORY_SIZE =
+		key("taskmanager.memory.managed.size")
+			.noDefaultValue()
+			.withDeprecatedKeys(LEGACY_MANAGED_MEMORY_SIZE.key())
+			.withDescription("Managed Memory size for TaskExecutors. This is the size of memory managed by the memory"
+				+ " manager, including both On-Heap Managed Memory and Off-Heap Managed Memory, reserved for sorting,"
+				+ " hash tables, caching of intermediate results and state backends. Memory consumers can either"
+				+ " allocate memory from the memory manager in the form of MemorySegments, or reserve bytes from the"
+				+ " memory manager and keep their memory usage within that boundary. If unspecified, it will be derived"
+				+ " to make up the configured fraction of the Total Flink Memory.");
+
+	/**
+	 * Fraction of Total Flink Memory to be used as Managed Memory, if {@link #MANAGED_MEMORY_SIZE} is not specified.
+	 */
+	public static final ConfigOption<Float> MANAGED_MEMORY_FRACTION =
+		key("taskmanager.memory.managed.fraction")
+			.defaultValue(0.5f)
+			.withDescription("Fraction of Total Flink Memory to be used as Managed Memory, if Managed Memory size is not"
+				+ " explicitly specified.");
+
+	/**
+	 * Off-Heap Managed Memory size for TaskExecutors.
+	 */
+	public static final ConfigOption<String> MANAGED_MEMORY_OFFHEAP_SIZE =
+		key("taskmanager.memory.managed.off-heap.size")
+			.noDefaultValue()
+			.withDescription("Off-Heap Managed Memory size for TaskExecutors. This is the part of Managed Memory that is"
+				+ " off-heap, while the remaining is on-heap. If unspecified, it will be derived to make up the"
+				+ " configured fraction of the Managed Memory size.");
+
+	/**
+	 * Fraction of Managed Memory that Off-Heap Managed Memory takes.
+	 */
+	public static final ConfigOption<Float> MANAGED_MEMORY_OFFHEAP_FRACTION =
+		key("taskmanager.memory.managed.off-heap.fraction")
+			.defaultValue(-1.0f)
+			.withDescription("Fraction of Managed Memory that Off-Heap Managed Memory takes, if Off-Heap Managed Memory"
+				+ " size is not explicitly specified. If the fraction is not explicitly specified (or configured with"
+				+ " negative values), it will be derived from the legacy config option '"
+				+ TaskManagerOptions.MEMORY_OFF_HEAP.key() + "', to use either all on-heap memory or all off-heap memory"
+				+ " for Managed Memory.");
+
+	/**
+	 * Min Shuffle Memory size for TaskExecutors.
+	 */
+	public static final ConfigOption<String> SHUFFLE_MEMORY_MIN =
+		key("taskmanager.memory.shuffle.min")
+			.defaultValue("64m")
+			.withDeprecatedKeys(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MIN.key())
+			.withDescription("Min Shuffle Memory size for TaskExecutors. Shuffle Memory is off-heap memory reserved for"
+				+ " ShuffleEnvironment (e.g., network buffers). Shuffle Memory size is derived to make up the configured"
+				+ " fraction of the Total Flink Memory. If the derived size is less/greater than the configured min/max"
+				+ " size, the min/max size will be used. The exact size of Shuffle Memory can be explicitly specified by"
+				+ " setting the min/max to the same value.");
+
+	/**
+	 * Max Shuffle Memory size for TaskExecutors.
+	 */
+	public static final ConfigOption<String> SHUFFLE_MEMORY_MAX =
+		key("taskmanager.memory.shuffle.max")
+			.defaultValue("1g")
+			.withDeprecatedKeys(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MAX.key())
+			.withDescription("Max Shuffle Memory size for TaskExecutors. Shuffle Memory is off-heap memory reserved for"
+				+ " ShuffleEnvironment (e.g., network buffers). Shuffle Memory size is derived to make up the configured"
+				+ " fraction of the Total Flink Memory. If the derived size is less/greater than the configured min/max"
+				+ " size, the min/max size will be used. The exact size of Shuffle Memory can be explicitly specified by"
+				+ " setting the min/max to the same value.");
+
+	/**
+	 * Fraction of Total Flink Memory to be used as Shuffle Memory.
+	 */
+	public static final ConfigOption<Float> SHUFFLE_MEMORY_FRACTION =
+		key("taskmanager.memory.shuffle.fraction")
+			.defaultValue(0.1f)
+			.withDeprecatedKeys(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_FRACTION.key())
+			.withDescription("Fraction of Total Flink Memory to be used as Shuffle Memory. Shuffle Memory is off-heap"
+				+ " memory reserved for ShuffleEnvironment (e.g., network buffers). Shuffle Memory size is derived to"
+				+ " make up the configured fraction of the Total Flink Memory. If the derived size is less/greater than"
+				+ " the configured min/max size, the min/max size will be used. The exact size of Shuffle Memory can be"
+				+ " explicitly specified by setting the min/max size to the same value.");
+
+	/**
+	 * JVM Metaspace Size for the TaskExecutors.
+	 */
+	public static final ConfigOption<String> JVM_METASPACE =
+		key("taskmanager.memory.jvm-metaspace.size")
+			.defaultValue("192m")
+			.withDescription("JVM Metaspace Size for the TaskExecutors.");
+
+	/**
+	 * Min JVM Overhead size for the TaskExecutors.
+	 */
+	public static final ConfigOption<String> JVM_OVERHEAD_MIN =
+		key("taskmanager.memory.jvm-overhead.min")
+			.defaultValue("128m")
+			.withDescription("Min JVM Overhead size for the TaskExecutors. This is off-heap memory reserved for JVM"
+				+ " overhead, such as thread stack space, I/O direct memory, compile cache, etc. The size of JVM"
+				+ " Overhead is derived to make up the configured fraction of the Total Process Memory. If the derived"
+				+ " size is less/greater than the configured min/max size, the min/max size will be used. The exact size"
+				+ " of JVM Overhead can be explicitly specified by setting the min/max size to the same value.");
+
+	/**
+	 * Max JVM Overhead size for the TaskExecutors.
+	 */
+	public static final ConfigOption<String> JVM_OVERHEAD_MAX =
+		key("taskmanager.memory.jvm-overhead.max")
+			.defaultValue("1g")
+			.withDescription("Max JVM Overhead size for the TaskExecutors. This is off-heap memory reserved for JVM"
+				+ " overhead, such as thread stack space, I/O direct memory, compile cache, etc. The size of JVM"
+				+ " Overhead is derived to make up the configured fraction of the Total Process Memory. If the derived"
+				+ " size is less/greater than the configured min/max size, the min/max size will be used. The exact size"
+				+ " of JVM Overhead can be explicitly specified by setting the min/max size to the same value.");
+
+	/**
+	 * Fraction of Total Process Memory to be reserved for JVM Overhead.
+	 */
+	public static final ConfigOption<Float> JVM_OVERHEAD_FRACTION =
+		key("taskmanager.memory.jvm-overhead.fraction")
+			.defaultValue(0.1f)
+			.withDescription("Fraction of Total Process Memory to be reserved for JVM Overhead. This is off-heap memory"
+				+ " reserved for JVM overhead, such as thread stack space, I/O direct memory, compile cache, etc. The"
+				+ " size of JVM Overhead is derived to make up the configured fraction of the Total Process Memory. If"
+				+ " the derived size is less/greater than the configured min/max size, the min/max size will be used."
+				+ " The exact size of JVM Overhead can be explicitly specified by setting the min/max size to the same"
+				+ " value.");
 
 	// ------------------------------------------------------------------------
 	//  Task Options

--- a/flink-dist/src/test/java/org/apache/flink/dist/TaskManagerHeapSizeCalculationJavaBashTest.java
+++ b/flink-dist/src/test/java/org/apache/flink/dist/TaskManagerHeapSizeCalculationJavaBashTest.java
@@ -80,8 +80,8 @@ public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
 		final long networkBufMin = 64L << 20; // 64MB
 		final long networkBufMax = 1L << 30; // 1GB
 
-		int managedMemSize = Integer.valueOf(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue());
-		float managedMemFrac = TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue();
+		int managedMemSize = Integer.valueOf(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE.defaultValue());
+		float managedMemFrac = TaskManagerOptions.LEGACY_MANAGED_MEMORY_FRACTION.defaultValue();
 
 		// manual tests from org.apache.flink.runtime.taskexecutor.TaskManagerServices.calculateHeapSizeMB()
 
@@ -119,8 +119,8 @@ public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
 		final long networkBufMin = 64L << 20; // 64MB
 		final long networkBufMax = 1L << 30; // 1GB
 
-		int managedMemSize = Integer.valueOf(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue());
-		float managedMemFrac = TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue();
+		int managedMemSize = Integer.valueOf(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE.defaultValue());
+		float managedMemFrac = TaskManagerOptions.LEGACY_MANAGED_MEMORY_FRACTION.defaultValue();
 
 		// manual tests from org.apache.flink.runtime.taskexecutor.TaskManagerServices.calculateHeapSizeMB()
 
@@ -184,11 +184,11 @@ public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
 		config.setString(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MAX, String.valueOf(netBufMemMax));
 
 		if (managedMemSizeMB == 0) {
-			config.removeConfig(TaskManagerOptions.MANAGED_MEMORY_SIZE);
+			config.removeConfig(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE);
 		} else {
-			config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, managedMemSizeMB + "m");
+			config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, managedMemSizeMB + "m");
 		}
-		config.setFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION, managedMemFrac);
+		config.setFloat(TaskManagerOptions.LEGACY_MANAGED_MEMORY_FRACTION, managedMemFrac);
 
 		return config;
 	}
@@ -214,8 +214,8 @@ public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
 		int javaMemMB = Math.max((int) (max >> 20), ran.nextInt(Integer.MAX_VALUE)) + 1;
 		boolean useOffHeap = ran.nextBoolean();
 
-		int managedMemSize = Integer.valueOf(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue());
-		float managedMemFrac = TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue();
+		int managedMemSize = Integer.valueOf(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE.defaultValue());
+		float managedMemFrac = TaskManagerOptions.LEGACY_MANAGED_MEMORY_FRACTION.defaultValue();
 
 		if (ran.nextBoolean()) {
 			// use fixed-size managed memory
@@ -295,8 +295,8 @@ public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
 			String.valueOf(config.getFloat(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_FRACTION)),
 			config.getString(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MIN),
 			config.getString(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MAX),
-			config.getString(TaskManagerOptions.MANAGED_MEMORY_SIZE),
-			String.valueOf(config.getFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION))};
+			config.getString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE),
+			String.valueOf(config.getFloat(TaskManagerOptions.LEGACY_MANAGED_MEMORY_FRACTION))};
 		String scriptOutput = executeScript(command);
 
 		// we need a tolerance of at least one, to compensate for MB/byte conversion rounding errors

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateFsBackendITCase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateFsBackendITCase.java
@@ -96,7 +96,7 @@ public class HAQueryableStateFsBackendITCase extends AbstractQueryableStateTestB
 
 		Configuration config = new Configuration();
 		config.setBoolean(QueryableStateOptions.ENABLE_QUERYABLE_STATE_PROXY_SERVER, true);
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "4m");
 		config.setInteger(ConfigConstants.LOCAL_NUMBER_JOB_MANAGER, NUM_JMS);
 		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, NUM_TMS);
 		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, NUM_SLOTS_PER_TM);

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateRocksDBBackendITCase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateRocksDBBackendITCase.java
@@ -96,7 +96,7 @@ public class HAQueryableStateRocksDBBackendITCase extends AbstractQueryableState
 
 		Configuration config = new Configuration();
 		config.setBoolean(QueryableStateOptions.ENABLE_QUERYABLE_STATE_PROXY_SERVER, true);
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "4m");
 		config.setInteger(ConfigConstants.LOCAL_NUMBER_JOB_MANAGER, NUM_JMS);
 		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, NUM_TMS);
 		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, NUM_SLOTS_PER_TM);

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/NonHAQueryableStateFsBackendITCase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/NonHAQueryableStateFsBackendITCase.java
@@ -80,7 +80,7 @@ public class NonHAQueryableStateFsBackendITCase extends AbstractQueryableStateTe
 	private static Configuration getConfig() {
 		Configuration config = new Configuration();
 		config.setBoolean(QueryableStateOptions.ENABLE_QUERYABLE_STATE_PROXY_SERVER, true);
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "4m");
 		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, NUM_TMS);
 		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, NUM_SLOTS_PER_TM);
 		config.setInteger(QueryableStateOptions.CLIENT_NETWORK_THREADS, 1);

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/NonHAQueryableStateRocksDBBackendITCase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/NonHAQueryableStateRocksDBBackendITCase.java
@@ -79,7 +79,7 @@ public class NonHAQueryableStateRocksDBBackendITCase extends AbstractQueryableSt
 	private static Configuration getConfig() {
 		Configuration config = new Configuration();
 		config.setBoolean(QueryableStateOptions.ENABLE_QUERYABLE_STATE_PROXY_SERVER, true);
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "4m");
 		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, NUM_TMS);
 		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, NUM_SLOTS_PER_TM);
 		config.setInteger(QueryableStateOptions.CLIENT_NETWORK_THREADS, 1);

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
@@ -102,7 +102,7 @@ public class WebFrontendITCase extends TestLogger {
 		}
 
 		// !!DO NOT REMOVE!! next line is required for tests
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "12m");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "12m");
 
 		return config;
 	}
@@ -224,8 +224,8 @@ public class WebFrontendITCase extends TestLogger {
 		String config = TestBaseUtils.getFromHTTP("http://localhost:" + getRestPort() + "/jobmanager/config");
 		Map<String, String> conf = WebMonitorUtils.fromKeyValueJsonArray(config);
 
-		String expected = CLUSTER_CONFIGURATION.getString(TaskManagerOptions.MANAGED_MEMORY_SIZE);
-		String actual = conf.get(TaskManagerOptions.MANAGED_MEMORY_SIZE.key());
+		String expected = CLUSTER_CONFIGURATION.getString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE);
+		String actual = conf.get(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE.key());
 
 		assertEquals(expected, actual);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceSpec.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceSpec.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.clusterframework;
+
+import org.apache.flink.configuration.MemorySize;
+
+/**
+ * Describe the specifics of different resource dimensions of the TaskExecutor.
+ *
+ * <p>A TaskExecutor's memory consists of the following components.
+ * <ul>
+ *     <li>Framework Heap Memory</li>
+ *     <li>Task Heap Memory</li>
+ *     <li>Task Off-Heap Memory</li>
+ *     <li>Shuffle Memory</li>
+ *     <li>Managed Memory</li>
+ *     <ul>
+ *         <li>On-Heap Managed Memory</li>
+ *         <li>Off-Heap Managed Memory</li>
+ *     </ul>
+ *     <li>JVM Metaspace</li>
+ *     <li>JVM Overhead</li>
+ * </ul>
+ * Among all the components, Framework Heap Memory, Task Heap Memory and On-Heap Managed Memory use on heap memory,
+ * while the rest use off heap memory. We use Total Process Memory to refer to all the memory components, while Total
+ * Flink Memory refering to all the components except JVM Metaspace and JVM Overhead.
+ *
+ * <p>The relationships of TaskExecutor memory components are shown below.
+ * <pre>
+ *               ┌ ─ ─ Total Process Memory  ─ ─ ┐
+ *                ┌ ─ ─ Total Flink Memory  ─ ─ ┐
+ *               │ ┌───────────────────────────┐ │
+ *                ││   Framework Heap Memory   ││  ─┐
+ *               │ └───────────────────────────┘ │  │
+ *                │┌───────────────────────────┐│   │
+ *               │ │     Task Heap Memory      │ │ ─┤
+ *                │└───────────────────────────┘│   │
+ *               │ ┌───────────────────────────┐ │  │
+ *            ┌─  ││   Task Off-Heap Memory    ││   │
+ *            │  │ └───────────────────────────┘ │  ├─ On-Heap
+ *            │   │┌───────────────────────────┐│   │
+ *            ├─ │ │      Shuffle Memory       │ │  │
+ *            │   │└───────────────────────────┘│   │
+ *            │  │ ┌───── Managed Memory ──────┐ │  │
+ *            │   ││┌─────────────────────────┐││   │
+ *            │  │ ││ On-Heap Managed Memory  ││ │ ─┘
+ *            │   ││├─────────────────────────┤││
+ *  Off-Heap ─┼─ │ ││ Off-Heap Managed Memory ││ │
+ *            │   ││└─────────────────────────┘││
+ *            │  │ └───────────────────────────┘ │
+ *            │   └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
+ *            │  │┌─────────────────────────────┐│
+ *            ├─  │        JVM Metaspace        │
+ *            │  │└─────────────────────────────┘│
+ *            │   ┌─────────────────────────────┐
+ *            └─ ││        JVM Overhead         ││
+ *                └─────────────────────────────┘
+ *               └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
+ * </pre>
+ */
+public class TaskExecutorResourceSpec {
+
+	private final MemorySize frameworkHeapSize;
+
+	private final MemorySize taskHeapSize;
+
+	private final MemorySize taskOffHeapSize;
+
+	private final MemorySize shuffleMemSize;
+
+	private final MemorySize onHeapManagedMemorySize;
+
+	private final MemorySize offHeapManagedMemorySize;
+
+	private final MemorySize jvmMetaspaceSize;
+
+	private final MemorySize jvmOverheadSize;
+
+	public TaskExecutorResourceSpec(
+		MemorySize frameworkHeapSize,
+		MemorySize taskHeapSize,
+		MemorySize taskOffHeapSize,
+		MemorySize shuffleMemSize,
+		MemorySize onHeapManagedMemorySize,
+		MemorySize offHeapManagedMemorySize,
+		MemorySize jvmMetaspaceSize,
+		MemorySize jvmOverheadSize) {
+
+		this.frameworkHeapSize = frameworkHeapSize;
+		this.taskHeapSize = taskHeapSize;
+		this.taskOffHeapSize = taskOffHeapSize;
+		this.shuffleMemSize = shuffleMemSize;
+		this.onHeapManagedMemorySize = onHeapManagedMemorySize;
+		this.offHeapManagedMemorySize = offHeapManagedMemorySize;
+		this.jvmMetaspaceSize = jvmMetaspaceSize;
+		this.jvmOverheadSize = jvmOverheadSize;
+	}
+
+	public MemorySize getFrameworkHeapSize() {
+		return frameworkHeapSize;
+	}
+
+	public MemorySize getTaskHeapSize() {
+		return taskHeapSize;
+	}
+
+	public MemorySize getTaskOffHeapSize() {
+		return taskOffHeapSize;
+	}
+
+	public MemorySize getShuffleMemSize() {
+		return shuffleMemSize;
+	}
+
+	public MemorySize getOnHeapManagedMemorySize() {
+		return onHeapManagedMemorySize;
+	}
+
+	public MemorySize getOffHeapManagedMemorySize() {
+		return offHeapManagedMemorySize;
+	}
+
+	public MemorySize getManagedMemorySize() {
+		return onHeapManagedMemorySize.add(offHeapManagedMemorySize);
+	}
+
+	public MemorySize getJvmMetaspaceSize() {
+		return jvmMetaspaceSize;
+	}
+
+	public MemorySize getJvmOverheadSize() {
+		return jvmOverheadSize;
+	}
+
+	public MemorySize getTotalFlinkMemorySize() {
+		return frameworkHeapSize.add(taskHeapSize).add(taskOffHeapSize).add(shuffleMemSize).add(getManagedMemorySize());
+	}
+
+	public MemorySize getTotalProcessMemorySize() {
+		return getTotalFlinkMemorySize().add(jvmMetaspaceSize).add(jvmOverheadSize);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
@@ -1,0 +1,565 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.clusterframework;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.util.ConfigurationParserUtils;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Utility class for TaskExecutor memory configurations.
+ *
+ * <p>See {@link TaskExecutorResourceSpec} for details about memory components of TaskExecutor and their relationships.
+ */
+public class TaskExecutorResourceUtils {
+
+	private TaskExecutorResourceUtils() {}
+
+	// ------------------------------------------------------------------------
+	//  Memory Configuration Calculations
+	// ------------------------------------------------------------------------
+
+	public static TaskExecutorResourceSpec resourceSpecFromConfig(final Configuration config) {
+		if (isTaskHeapMemorySizeExplicitlyConfigured(config) && isManagedMemorySizeExplicitlyConfigured(config)) {
+			// both task heap memory and managed memory are configured, use these to derive total flink memory
+			return deriveResourceSpecWithExplicitTaskAndManagedMemory(config);
+		} else if (isTotalFlinkMemorySizeExplicitlyConfigured(config)) {
+			// either of task heap memory and managed memory is not configured, total flink memory is configured,
+			// derive from total flink memory
+			return deriveResourceSpecWithTotalFlinkMemory(config);
+		} else if (isTotalProcessMemorySizeExplicitlyConfigured(config)) {
+			// total flink memory is not configured, total process memory is configured,
+			// derive from total process memory
+			return deriveResourceSpecWithTotalProcessMemory(config);
+		} else {
+			throw new IllegalConfigurationException("Either Task Heap Memory size and Managed Memory size, or Total Flink"
+				+ " Memory size, or Total Process Memory size need to be configured explicitly.");
+		}
+	}
+
+	private static TaskExecutorResourceSpec deriveResourceSpecWithExplicitTaskAndManagedMemory(final Configuration config) {
+		// derive flink internal memory from explicitly configure task heap memory size and managed memory size
+
+		final MemorySize taskHeapMemorySize = getTaskHeapMemorySize(config);
+		final MemorySize managedMemorySize = getManagedMemorySize(config);
+
+		final MemorySize frameworkHeapMemorySize = getFrameworkHeapMemorySize(config);
+		final MemorySize taskOffHeapMemorySize = getTaskOffHeapMemorySize(config);
+
+		final OnHeapAndOffHeapManagedMemory onHeapAndOffHeapManagedMemory = deriveOnHeapAndOffHeapMemoryFromManagedMemory(config, managedMemorySize);
+
+		final MemorySize shuffleMemorySize;
+		final MemorySize totalFlinkExcludeShuffleMemorySize =
+			frameworkHeapMemorySize.add(taskHeapMemorySize).add(taskOffHeapMemorySize).add(managedMemorySize);
+
+		if (isTotalFlinkMemorySizeExplicitlyConfigured(config)) {
+			// derive shuffle memory from total flink memory, and check against shuffle min/max
+			final MemorySize totalFlinkMemorySize = getTotalFlinkMemorySize(config);
+			if (totalFlinkExcludeShuffleMemorySize.getBytes() > totalFlinkMemorySize.getBytes()) {
+				throw new IllegalConfigurationException(
+					"Sum of configured Framework Heap Memory (" + frameworkHeapMemorySize.toString()
+					+ "), Task Heap Memory (" + taskHeapMemorySize.toString()
+					+ "), Task Off-Heap Memory (" + taskOffHeapMemorySize.toString()
+					+ ") and Managed Memory (" + managedMemorySize.toString()
+					+ ") exceed configured Total Flink Memory (" + totalFlinkMemorySize.toString() + ").");
+			}
+			shuffleMemorySize = totalFlinkMemorySize.subtract(totalFlinkExcludeShuffleMemorySize);
+			sanityCheckShuffleMemory(config, shuffleMemorySize, totalFlinkMemorySize);
+		} else {
+			// derive shuffle memory from shuffle configs
+			if (isUsingLegacyShuffleConfigs(config)) {
+				shuffleMemorySize = getShuffleMemorySizeWithLegacyConfig(config);
+			} else {
+				shuffleMemorySize = deriveShuffleMemoryWithInverseFraction(config, totalFlinkExcludeShuffleMemorySize);
+			}
+		}
+
+		final FlinkInternalMemory flinkInternalMemory = new FlinkInternalMemory(
+			frameworkHeapMemorySize,
+			taskHeapMemorySize,
+			taskOffHeapMemorySize,
+			shuffleMemorySize,
+			onHeapAndOffHeapManagedMemory.onHeap,
+			onHeapAndOffHeapManagedMemory.offHeap);
+		sanityCheckTotalFlinkMemory(config, flinkInternalMemory);
+
+		// derive jvm metaspace and overhead
+
+		final JvmMetaspaceAndOverhead jvmMetaspaceAndOverhead = deriveJvmMetaspaceAndOverheadFromTotalFlinkMemory(config, flinkInternalMemory.getTotalFlinkMemorySize());
+		sanityCheckTotalProcessMemory(config, flinkInternalMemory.getTotalFlinkMemorySize(), jvmMetaspaceAndOverhead);
+
+		return createTaskExecutorResourceSpec(flinkInternalMemory, jvmMetaspaceAndOverhead);
+	}
+
+	private static TaskExecutorResourceSpec deriveResourceSpecWithTotalFlinkMemory(final Configuration config) {
+		// derive flink internal memory from explicitly configured total flink memory
+
+		final MemorySize totalFlinkMemorySize = getTotalFlinkMemorySize(config);
+		final FlinkInternalMemory flinkInternalMemory = deriveInternalMemoryFromTotalFlinkMemory(config, totalFlinkMemorySize);
+
+		// derive jvm metaspace and overhead
+
+		final JvmMetaspaceAndOverhead jvmMetaspaceAndOverhead = deriveJvmMetaspaceAndOverheadFromTotalFlinkMemory(config, totalFlinkMemorySize);
+		sanityCheckTotalProcessMemory(config, totalFlinkMemorySize, jvmMetaspaceAndOverhead);
+
+		return createTaskExecutorResourceSpec(flinkInternalMemory, jvmMetaspaceAndOverhead);
+	}
+
+	private static TaskExecutorResourceSpec deriveResourceSpecWithTotalProcessMemory(final Configuration config) {
+		// derive total flink memory from explicitly configured total process memory size
+
+		final MemorySize totalProcessMemorySize = getTotalProcessMemorySize(config);
+		final MemorySize jvmMetaspaceSize = getJvmMetaspaceSize(config);
+		final MemorySize jvmOverheadSize = deriveJvmOverheadWithFraction(config, totalProcessMemorySize);
+		final JvmMetaspaceAndOverhead jvmMetaspaceAndOverhead = new JvmMetaspaceAndOverhead(jvmMetaspaceSize, jvmOverheadSize);
+
+		if (jvmMetaspaceAndOverhead.getTotalJvmMetaspaceAndOverheadSize().getBytes() > totalProcessMemorySize.getBytes()) {
+			throw new IllegalConfigurationException(
+				"Sum of configured JVM Metaspace (" + jvmMetaspaceAndOverhead.metaspace.toString()
+				+ ") and JVM Overhead (" + jvmMetaspaceAndOverhead.overhead.toString()
+				+ ") exceed configured Total Process Memory (" + totalProcessMemorySize.toString() + ").");
+		}
+		final MemorySize totalFlinkMemorySize = totalProcessMemorySize.subtract(jvmMetaspaceAndOverhead.getTotalJvmMetaspaceAndOverheadSize());
+
+		// derive flink internal memory
+
+		final FlinkInternalMemory flinkInternalMemory = deriveInternalMemoryFromTotalFlinkMemory(config, totalFlinkMemorySize);
+
+		return createTaskExecutorResourceSpec(flinkInternalMemory, jvmMetaspaceAndOverhead);
+	}
+
+	private static JvmMetaspaceAndOverhead deriveJvmMetaspaceAndOverheadFromTotalFlinkMemory(
+		final Configuration config, final MemorySize totalFlinkMemorySize) {
+		final MemorySize jvmMetaspaceSize = getJvmMetaspaceSize(config);
+		final MemorySize jvmOverheadSize = deriveJvmOverheadWithInverseFraction(config,
+			totalFlinkMemorySize.add(jvmMetaspaceSize));
+		return new JvmMetaspaceAndOverhead(jvmMetaspaceSize, jvmOverheadSize);
+	}
+
+	private static FlinkInternalMemory deriveInternalMemoryFromTotalFlinkMemory(
+		final Configuration config, final MemorySize totalFlinkMemorySize) {
+		final MemorySize frameworkHeapMemorySize = getFrameworkHeapMemorySize(config);
+		final MemorySize taskOffHeapMemorySize = getTaskOffHeapMemorySize(config);
+
+		final MemorySize taskHeapMemorySize;
+		final MemorySize shuffleMemorySize;
+		final MemorySize managedMemorySize;
+
+		if (isTaskHeapMemorySizeExplicitlyConfigured(config)) {
+			// task heap memory is configured,
+			// derive managed memory first, leave the remaining to shuffle memory and check against shuffle min/max
+			taskHeapMemorySize = getTaskHeapMemorySize(config);
+			managedMemorySize = deriveManagedMemoryAbsoluteOrWithFraction(config, totalFlinkMemorySize);
+			final MemorySize totalFlinkExcludeShuffleMemorySize =
+				frameworkHeapMemorySize.add(taskHeapMemorySize).add(taskOffHeapMemorySize).add(managedMemorySize);
+			if (totalFlinkExcludeShuffleMemorySize.getBytes() > totalFlinkMemorySize.getBytes()) {
+				throw new IllegalConfigurationException(
+					"Sum of configured Framework Heap Memory (" + frameworkHeapMemorySize.toString()
+						+ "), Task Heap Memory (" + taskHeapMemorySize.toString()
+						+ "), Task Off-Heap Memory (" + taskOffHeapMemorySize.toString()
+						+ ") and Managed Memory (" + managedMemorySize.toString()
+						+ ") exceed configured Total Flink Memory (" + totalFlinkMemorySize.toString() + ").");
+			}
+			shuffleMemorySize = totalFlinkMemorySize.subtract(totalFlinkExcludeShuffleMemorySize);
+			sanityCheckShuffleMemory(config, shuffleMemorySize, totalFlinkMemorySize);
+		} else {
+			// task heap memory is not configured
+			// derive managed memory and shuffle memory, leave the remaining to task heap memory
+			if (isManagedMemorySizeExplicitlyConfigured(config)) {
+				managedMemorySize = getManagedMemorySize(config);
+			} else {
+				managedMemorySize = deriveManagedMemoryAbsoluteOrWithFraction(config, totalFlinkMemorySize);
+			}
+			shuffleMemorySize = deriveShuffleMemoryWithFraction(config, totalFlinkMemorySize);
+			final MemorySize totalFlinkExcludeTaskHeapMemorySize =
+				frameworkHeapMemorySize.add(taskOffHeapMemorySize).add(managedMemorySize).add(shuffleMemorySize);
+			if (totalFlinkExcludeTaskHeapMemorySize.getBytes() > totalFlinkMemorySize.getBytes()) {
+				throw new IllegalConfigurationException(
+					"Sum of configured Framework Heap Memory (" + frameworkHeapMemorySize.toString()
+						+ "), Task Off-Heap Memory (" + taskOffHeapMemorySize.toString()
+						+ "), Managed Memory (" + managedMemorySize.toString()
+						+ ") and Shuffle Memory (" + shuffleMemorySize.toString()
+						+ ") exceed configured Total Flink Memory (" + totalFlinkMemorySize.toString() + ").");
+			}
+			taskHeapMemorySize = totalFlinkMemorySize.subtract(totalFlinkExcludeTaskHeapMemorySize);
+		}
+
+		final OnHeapAndOffHeapManagedMemory onHeapAndOffHeapManagedMemory = deriveOnHeapAndOffHeapMemoryFromManagedMemory(config, managedMemorySize);
+		final FlinkInternalMemory flinkInternalMemory = new FlinkInternalMemory(
+			frameworkHeapMemorySize,
+			taskHeapMemorySize,
+			taskOffHeapMemorySize,
+			shuffleMemorySize,
+			onHeapAndOffHeapManagedMemory.onHeap,
+			onHeapAndOffHeapManagedMemory.offHeap);
+		sanityCheckTotalFlinkMemory(config, flinkInternalMemory);
+
+		return flinkInternalMemory;
+	}
+
+	private static OnHeapAndOffHeapManagedMemory deriveOnHeapAndOffHeapMemoryFromManagedMemory(
+		final Configuration config, final MemorySize managedMemorySize) {
+
+		final MemorySize offHeapSize;
+
+		if (isManagedMemoryOffHeapSizeExplicitlyConfigured(config)) {
+			offHeapSize = getManagedMemoryOffHeapSize(config);
+			// sanity check
+			if (offHeapSize.getBytes() > managedMemorySize.getBytes()) {
+				throw new IllegalConfigurationException("Configured Off-Heap Managed Memory size (" + offHeapSize.toString()
+					+ ") is larger than configured/derived total Managed Memory size (" + managedMemorySize.toString() + ").");
+			}
+		} else {
+			final double offHeapFraction;
+			if (isManagedMemoryOffHeapFractionExplicitlyConfigured(config)) {
+				offHeapFraction = getManagedMemoryOffHeapFraction(config);
+			} else {
+				@SuppressWarnings("deprecation")
+				final boolean legacyManagedMemoryOffHeap = config.getBoolean(TaskManagerOptions.MEMORY_OFF_HEAP);
+				offHeapFraction = legacyManagedMemoryOffHeap ? 1.0 : 0.0;
+			}
+			offHeapSize = managedMemorySize.multiply(offHeapFraction);
+		}
+
+		final MemorySize onHeapSize = managedMemorySize.subtract(offHeapSize);
+		return new OnHeapAndOffHeapManagedMemory(onHeapSize, offHeapSize);
+	}
+
+	private static MemorySize deriveManagedMemoryAbsoluteOrWithFraction(final Configuration config, final MemorySize base) {
+		if (isManagedMemorySizeExplicitlyConfigured(config)) {
+			return getManagedMemorySize(config);
+		} else {
+			return deriveWithFraction(base, getManagedMemoryRangeFraction(config));
+		}
+	}
+
+	private static MemorySize deriveShuffleMemoryWithFraction(final Configuration config, final MemorySize base) {
+		return deriveWithFraction(base, getShuffleMemoryRangeFraction(config));
+	}
+
+	private static MemorySize deriveShuffleMemoryWithInverseFraction(final Configuration config, final MemorySize base) {
+		return deriveWithInverseFraction(base, getShuffleMemoryRangeFraction(config));
+	}
+
+	private static MemorySize deriveJvmOverheadWithFraction(final Configuration config, final MemorySize base) {
+		return deriveWithFraction(base, getJvmOverheadRangeFraction(config));
+	}
+
+	private static MemorySize deriveJvmOverheadWithInverseFraction(final Configuration config, final MemorySize base) {
+		return deriveWithInverseFraction(base, getJvmOverheadRangeFraction(config));
+	}
+
+	private static MemorySize deriveWithFraction(final MemorySize base, final RangeFraction rangeFraction) {
+		final long relative = (long) (rangeFraction.fraction * base.getBytes());
+		return new MemorySize(Math.max(rangeFraction.minSize.getBytes(), Math.min(rangeFraction.maxSize.getBytes(), relative)));
+	}
+
+	private static MemorySize deriveWithInverseFraction(final MemorySize base, final RangeFraction rangeFraction) {
+		checkArgument(rangeFraction.fraction < 1);
+		final long relative = (long) (rangeFraction.fraction / (1 - rangeFraction.fraction) * base.getBytes());
+		return new MemorySize(Math.max(rangeFraction.minSize.getBytes(), Math.min(rangeFraction.maxSize.getBytes(), relative)));
+	}
+
+	private static MemorySize getFrameworkHeapMemorySize(final Configuration config) {
+		return MemorySize.parse(config.getString(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY));
+	}
+
+	private static MemorySize getTaskHeapMemorySize(final Configuration config) {
+		checkArgument(isTaskHeapMemorySizeExplicitlyConfigured(config));
+		return MemorySize.parse(config.getString(TaskManagerOptions.TASK_HEAP_MEMORY));
+	}
+
+	private static MemorySize getTaskOffHeapMemorySize(final Configuration config) {
+		return MemorySize.parse(config.getString(TaskManagerOptions.TASK_OFF_HEAP_MEMORY));
+	}
+
+	private static MemorySize getManagedMemorySize(final Configuration config) {
+		checkArgument(isManagedMemorySizeExplicitlyConfigured(config));
+		return MemorySize.parse(config.getString(TaskManagerOptions.MANAGED_MEMORY_SIZE));
+	}
+
+	private static RangeFraction getManagedMemoryRangeFraction(final Configuration config) {
+		final MemorySize minSize = new MemorySize(0);
+		final MemorySize maxSize = new MemorySize(Long.MAX_VALUE);
+		final double fraction = config.getFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION);
+		if (fraction >= 1 || fraction < 0) {
+			throw new IllegalConfigurationException("Configured Managed Memory fraction ("
+				+ fraction + ") must be in [0, 1).");
+		}
+		return new RangeFraction(minSize, maxSize, fraction);
+	}
+
+	private static double getManagedMemoryOffHeapFraction(final Configuration config) {
+		checkArgument(isManagedMemoryOffHeapFractionExplicitlyConfigured(config));
+		final double offHeapFraction = config.getFloat(TaskManagerOptions.MANAGED_MEMORY_OFFHEAP_FRACTION);
+		if (offHeapFraction > 1 || offHeapFraction < 0) {
+			throw new IllegalConfigurationException("Configured Off-Heap Managed Memory fraction ("
+				+ offHeapFraction + ") must be in [0, 1].");
+		}
+		return offHeapFraction;
+	}
+
+	private static MemorySize getManagedMemoryOffHeapSize(final Configuration config) {
+		checkArgument(isManagedMemoryOffHeapSizeExplicitlyConfigured(config));
+		return MemorySize.parse(config.getString(TaskManagerOptions.MANAGED_MEMORY_OFFHEAP_SIZE));
+	}
+
+	private static MemorySize getShuffleMemorySizeWithLegacyConfig(final Configuration config) {
+		checkArgument(isUsingLegacyShuffleConfigs(config));
+		@SuppressWarnings("deprecation")
+		final long numOfBuffers = config.getInteger(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS);
+		final long pageSize =  ConfigurationParserUtils.getPageSize(config);
+		return new MemorySize(numOfBuffers * pageSize);
+	}
+
+	private static RangeFraction getShuffleMemoryRangeFraction(final Configuration config) {
+		final MemorySize minSize = MemorySize.parse(config.getString(TaskManagerOptions.SHUFFLE_MEMORY_MIN));
+		final MemorySize maxSize = MemorySize.parse(config.getString(TaskManagerOptions.SHUFFLE_MEMORY_MAX));
+		final double fraction = config.getFloat(TaskManagerOptions.SHUFFLE_MEMORY_FRACTION);
+		if (fraction >= 1 || fraction < 0) {
+			throw new IllegalConfigurationException("Configured Shuffle Memory fraction ("
+				+ fraction + ") must be in [0, 1).");
+		}
+		return new RangeFraction(minSize, maxSize, fraction);
+	}
+
+	private static MemorySize getJvmMetaspaceSize(final Configuration config) {
+		return MemorySize.parse(config.getString(TaskManagerOptions.JVM_METASPACE));
+	}
+
+	private static RangeFraction getJvmOverheadRangeFraction(final Configuration config) {
+		final MemorySize minSize = MemorySize.parse(config.getString(TaskManagerOptions.JVM_OVERHEAD_MIN));
+		final MemorySize maxSize = MemorySize.parse(config.getString(TaskManagerOptions.JVM_OVERHEAD_MAX));
+		final double fraction = config.getFloat(TaskManagerOptions.JVM_OVERHEAD_FRACTION);
+		if (fraction >= 1 || fraction < 0) {
+			throw new IllegalConfigurationException("Configured JVM Overhead fraction ("
+				+ fraction + ") must be in [0, 1).");
+		}
+		return new RangeFraction(minSize, maxSize, fraction);
+	}
+
+	private static MemorySize getTotalFlinkMemorySize(final Configuration config) {
+		checkArgument(isTotalFlinkMemorySizeExplicitlyConfigured(config));
+		if (config.contains(TaskManagerOptions.TOTAL_FLINK_MEMORY)) {
+			return MemorySize.parse(config.getString(TaskManagerOptions.TOTAL_FLINK_MEMORY));
+		} else {
+			@SuppressWarnings("deprecation")
+			final long legacyHeapMemoryMB = config.getInteger(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY_MB);
+			return new MemorySize(legacyHeapMemoryMB << 20); // megabytes to bytes
+		}
+	}
+
+	private static MemorySize getTotalProcessMemorySize(final Configuration config) {
+		checkArgument(isTotalProcessMemorySizeExplicitlyConfigured(config));
+		return MemorySize.parse(config.getString(TaskManagerOptions.TOTAL_PROCESS_MEMORY));
+	}
+
+	private static boolean isTaskHeapMemorySizeExplicitlyConfigured(final Configuration config) {
+		return config.contains(TaskManagerOptions.TASK_HEAP_MEMORY);
+	}
+
+	private static boolean isManagedMemorySizeExplicitlyConfigured(final Configuration config) {
+		return config.contains(TaskManagerOptions.MANAGED_MEMORY_SIZE);
+	}
+
+	private static boolean isManagedMemoryOffHeapFractionExplicitlyConfigured(final Configuration config) {
+		return config.getFloat(TaskManagerOptions.MANAGED_MEMORY_OFFHEAP_FRACTION) >= 0;
+	}
+
+	private static boolean isManagedMemoryOffHeapSizeExplicitlyConfigured(final Configuration config) {
+		return config.contains(TaskManagerOptions.MANAGED_MEMORY_OFFHEAP_SIZE);
+	}
+
+	private static boolean isUsingLegacyShuffleConfigs(final Configuration config) {
+		// use the legacy number-of-buffer config option only when it is explicitly configured and
+		// none of new config options is explicitly configured
+		@SuppressWarnings("deprecation")
+		final boolean legacyConfigured = config.contains(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS);
+		return !config.contains(TaskManagerOptions.SHUFFLE_MEMORY_MIN) &&
+			!config.contains(TaskManagerOptions.SHUFFLE_MEMORY_MAX) &&
+			!config.contains(TaskManagerOptions.SHUFFLE_MEMORY_FRACTION) &&
+			legacyConfigured;
+	}
+
+	private static boolean isShuffleMemoryFractionExplicitlyConfigured(final Configuration config) {
+		return config.contains(TaskManagerOptions.SHUFFLE_MEMORY_FRACTION);
+	}
+
+	private static boolean isTotalFlinkMemorySizeExplicitlyConfigured(final Configuration config) {
+		// backward compatible with the deprecated config option TASK_MANAGER_HEAP_MEMORY_MB only when it's explicitly
+		// configured by the user
+		@SuppressWarnings("deprecation")
+		final boolean legacyConfigured = config.contains(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY_MB);
+		return config.contains(TaskManagerOptions.TOTAL_FLINK_MEMORY) || legacyConfigured;
+	}
+
+	private static boolean isTotalProcessMemorySizeExplicitlyConfigured(final Configuration config) {
+		return config.contains(TaskManagerOptions.TOTAL_PROCESS_MEMORY);
+	}
+
+	private static void sanityCheckTotalFlinkMemory(final Configuration config, final FlinkInternalMemory flinkInternalMemory) {
+		if (isTotalFlinkMemorySizeExplicitlyConfigured(config)) {
+			final MemorySize configuredTotalFlinkMemorySize = getTotalFlinkMemorySize(config);
+			if (!configuredTotalFlinkMemorySize.equals(flinkInternalMemory.getTotalFlinkMemorySize())) {
+				throw new IllegalConfigurationException(
+					"Configured/Derived Flink internal memory sizes (total " + flinkInternalMemory.getTotalFlinkMemorySize().toString()
+						+ ") do not add up to the configured Total Flink Memory size (" + configuredTotalFlinkMemorySize.toString()
+						+ "). Configured/Derived Flink internal memory sizes are: "
+						+ "Framework Heap Memory (" + flinkInternalMemory.frameworkHeap.toString()
+						+ "), Task Heap Memory (" + flinkInternalMemory.taskHeap.toString()
+						+ "), Task Off-Heap Memory (" + flinkInternalMemory.taskOffHeap.toString()
+						+ "), Shuffle Memory (" + flinkInternalMemory.shuffle.toString()
+						+ "), Managed Memory (" + flinkInternalMemory.getManagedMemorySize().toString() + ").");
+			}
+		}
+	}
+
+	private static void sanityCheckTotalProcessMemory(final Configuration config, final MemorySize totalFlinkMemory, final JvmMetaspaceAndOverhead jvmMetaspaceAndOverhead) {
+		final MemorySize derivedTotalProcessMemorySize =
+			totalFlinkMemory.add(jvmMetaspaceAndOverhead.metaspace).add(jvmMetaspaceAndOverhead.overhead);
+		if (isTotalProcessMemorySizeExplicitlyConfigured(config)) {
+			final MemorySize configuredTotalProcessMemorySize = getTotalProcessMemorySize(config);
+			if (!configuredTotalProcessMemorySize.equals(derivedTotalProcessMemorySize)) {
+				throw new IllegalConfigurationException(
+					"Configured/Derived memory sizes (total " + derivedTotalProcessMemorySize.toString()
+						+ ") do not add up to the configured Total Process Memory size (" + configuredTotalProcessMemorySize.toString()
+						+ "). Configured/Derived memory sizes are: "
+						+ "Total Flink Memory (" + totalFlinkMemory.toString()
+						+ "), JVM Metaspace (" + jvmMetaspaceAndOverhead.metaspace.toString()
+						+ "), JVM Overhead (" + jvmMetaspaceAndOverhead.overhead.toString() + ").");
+			}
+		}
+	}
+
+	private static void sanityCheckShuffleMemory(final Configuration config, final MemorySize derivedShuffleMemorySize, final MemorySize totalFlinkMemorySize) {
+		if (isUsingLegacyShuffleConfigs(config)) {
+			final MemorySize configuredShuffleMemorySize = getShuffleMemorySizeWithLegacyConfig(config);
+			if (!configuredShuffleMemorySize.equals(derivedShuffleMemorySize)) {
+				throw new IllegalConfigurationException(
+					"Derived Shuffle Memory size (" + derivedShuffleMemorySize.toString()
+					+ ") does not match configured Shuffle Memory size (" + configuredShuffleMemorySize.toString() + ").");
+			}
+		} else {
+			final RangeFraction shuffleRangeFraction = getShuffleMemoryRangeFraction(config);
+			if (derivedShuffleMemorySize.getBytes() > shuffleRangeFraction.maxSize.getBytes() ||
+				derivedShuffleMemorySize.getBytes() < shuffleRangeFraction.minSize.getBytes()) {
+				throw new IllegalConfigurationException("Derived Shuffle Memory size ("
+					+ derivedShuffleMemorySize.toString() + ") is not in configured Shuffle Memory range ["
+					+ shuffleRangeFraction.minSize.toString() + ", "
+					+ shuffleRangeFraction.maxSize.toString() + "].");
+			}
+			if (isShuffleMemoryFractionExplicitlyConfigured(config) &&
+				!derivedShuffleMemorySize.equals(totalFlinkMemorySize.multiply(shuffleRangeFraction.fraction))) {
+				throw new IllegalConfigurationException("Derived Shuffle Memory size("
+					+ derivedShuffleMemorySize.toString() + ") does not match configured Shuffle Memory fraction ("
+					+ shuffleRangeFraction.fraction + ").");
+			}
+		}
+	}
+
+	private static TaskExecutorResourceSpec createTaskExecutorResourceSpec(
+		final FlinkInternalMemory flinkInternalMemory, final JvmMetaspaceAndOverhead jvmMetaspaceAndOverhead) {
+		return new TaskExecutorResourceSpec(
+			flinkInternalMemory.frameworkHeap,
+			flinkInternalMemory.taskHeap,
+			flinkInternalMemory.taskOffHeap,
+			flinkInternalMemory.shuffle,
+			flinkInternalMemory.onHeapManaged,
+			flinkInternalMemory.offHeapManaged,
+			jvmMetaspaceAndOverhead.metaspace,
+			jvmMetaspaceAndOverhead.overhead);
+	}
+
+	private static class RangeFraction {
+		final MemorySize minSize;
+		final MemorySize maxSize;
+		final double fraction;
+
+		RangeFraction(final MemorySize minSize, final MemorySize maxSize, final double fraction) {
+			this.minSize = minSize;
+			this.maxSize = maxSize;
+			this.fraction = fraction;
+			checkArgument(minSize.getBytes() <= maxSize.getBytes());
+			checkArgument(fraction >= 0 && fraction <= 1);
+		}
+	}
+
+	private static class FlinkInternalMemory {
+		final MemorySize frameworkHeap;
+		final MemorySize taskHeap;
+		final MemorySize taskOffHeap;
+		final MemorySize shuffle;
+		final MemorySize onHeapManaged;
+		final MemorySize offHeapManaged;
+
+		FlinkInternalMemory(
+			final MemorySize frameworkHeap,
+			final MemorySize taskHeap,
+			final MemorySize taskOffHeap,
+			final MemorySize shuffle,
+			final MemorySize onHeapManaged,
+			final MemorySize offHeapManaged) {
+
+			this.frameworkHeap = checkNotNull(frameworkHeap);
+			this.taskHeap = checkNotNull(taskHeap);
+			this.taskOffHeap = checkNotNull(taskOffHeap);
+			this.shuffle = checkNotNull(shuffle);
+			this.onHeapManaged = checkNotNull(onHeapManaged);
+			this.offHeapManaged = checkNotNull(offHeapManaged);
+		}
+
+		MemorySize getTotalFlinkMemorySize() {
+			return frameworkHeap.add(taskHeap).add(taskOffHeap).add(shuffle).add(getManagedMemorySize());
+		}
+
+		MemorySize getManagedMemorySize() {
+			return onHeapManaged.add(offHeapManaged);
+		}
+	}
+
+	private static class OnHeapAndOffHeapManagedMemory {
+		final MemorySize onHeap;
+		final MemorySize offHeap;
+
+		OnHeapAndOffHeapManagedMemory(final MemorySize onHeap, final MemorySize offHeap) {
+			this.onHeap = onHeap;
+			this.offHeap = offHeap;
+		}
+	}
+
+	private static class JvmMetaspaceAndOverhead {
+		final MemorySize metaspace;
+		final MemorySize overhead;
+
+		JvmMetaspaceAndOverhead(final MemorySize jvmMetaspace, final MemorySize jvmOverhead) {
+			this.metaspace = checkNotNull(jvmMetaspace);
+			this.overhead = checkNotNull(jvmOverhead);
+		}
+
+		MemorySize getTotalJvmMetaspaceAndOverheadSize() {
+			return metaspace.add(overhead);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManagerFactory.java
@@ -75,7 +75,7 @@ public abstract class ActiveResourceManagerFactory<T extends ResourceIDRetrievab
 		final long managedMemoryBytes = TaskManagerServices.getManagedMemoryFromProcessMemory(originalConfiguration, processMemoryBytes);
 
 		final Configuration resourceManagerConfig = new Configuration(originalConfiguration);
-		resourceManagerConfig.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, managedMemoryBytes + "b");
+		resourceManagerConfig.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, managedMemoryBytes + "b");
 
 		return resourceManagerConfig;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -1204,7 +1204,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
 	public static Collection<ResourceProfile> createWorkerSlotProfiles(Configuration config) {
 		final int numSlots = config.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
-		final long managedMemoryBytes = MemorySize.parse(config.getString(TaskManagerOptions.MANAGED_MEMORY_SIZE)).getBytes();
+		final long managedMemoryBytes = MemorySize.parse(config.getString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE)).getBytes();
 
 		final ResourceProfile resourceProfile = TaskManagerServices.computeSlotResourceProfile(numSlots, managedMemoryBytes);
 		return Collections.nCopies(numSlots, resourceProfile);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -433,7 +433,7 @@ public class TaskManagerServices {
 			final long managedMemorySize = getManagedMemoryFromHeapAndManaged(config, heapAndManagedMemory);
 
 			ConfigurationParserUtils.checkConfigParameter(managedMemorySize < heapAndManagedMemory, managedMemorySize,
-				TaskManagerOptions.MANAGED_MEMORY_SIZE.key(),
+				TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE.key(),
 					"Managed memory size too large for " + (networkReservedMemory >> 20) +
 						" MB network buffer memory and a total of " + totalJavaMemorySizeMB +
 						" MB JVM memory");
@@ -460,20 +460,20 @@ public class TaskManagerServices {
 	 * All values are in bytes.
 	 */
 	public static long getManagedMemoryFromHeapAndManaged(Configuration config, long heapAndManagedMemory) {
-		if (config.contains(TaskManagerOptions.MANAGED_MEMORY_SIZE)) {
+		if (config.contains(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE)) {
 			// take the configured absolute value
-			final String sizeValue = config.getString(TaskManagerOptions.MANAGED_MEMORY_SIZE);
+			final String sizeValue = config.getString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE);
 			try {
 				return MemorySize.parse(sizeValue, MEGA_BYTES).getBytes();
 			}
 			catch (IllegalArgumentException e) {
 				throw new IllegalConfigurationException(
-					"Could not read " + TaskManagerOptions.MANAGED_MEMORY_SIZE.key(), e);
+					"Could not read " + TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE.key(), e);
 			}
 		}
 		else {
 			// calculate managed memory size via fraction
-			final float fraction = config.getFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION);
+			final float fraction = config.getFloat(TaskManagerOptions.LEGACY_MANAGED_MEMORY_FRACTION);
 			return (long) (fraction * heapAndManagedMemory);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -67,7 +67,7 @@ public class TaskManagerServicesConfiguration {
 	/**
 	 * Managed memory (in megabytes).
 	 *
-	 * @see TaskManagerOptions#MANAGED_MEMORY_SIZE
+	 * @see TaskManagerOptions#LEGACY_MANAGED_MEMORY_SIZE
 	 */
 	private final long configuredMemory;
 
@@ -201,7 +201,7 @@ public class TaskManagerServicesConfiguration {
 	 *
 	 * @return managed memory or a default value (currently <tt>-1</tt>) if not configured
 	 *
-	 * @see TaskManagerOptions#MANAGED_MEMORY_SIZE
+	 * @see TaskManagerOptions#LEGACY_MANAGED_MEMORY_SIZE
 	 */
 	long getConfiguredMemory() {
 		return configuredMemory;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -231,8 +231,8 @@ public class NettyShuffleEnvironmentConfiguration {
 	 *
 	 * <p>The following configuration parameters are involved:
 	 * <ul>
-	 *  <li>{@link TaskManagerOptions#MANAGED_MEMORY_SIZE},</li>
-	 *  <li>{@link TaskManagerOptions#MANAGED_MEMORY_FRACTION},</li>
+	 *  <li>{@link TaskManagerOptions#LEGACY_MANAGED_MEMORY_SIZE},</li>
+	 *  <li>{@link TaskManagerOptions#LEGACY_MANAGED_MEMORY_FRACTION},</li>
 	 *  <li>{@link NettyShuffleEnvironmentOptions#NETWORK_BUFFERS_MEMORY_FRACTION},</li>
 	 * 	<li>{@link NettyShuffleEnvironmentOptions#NETWORK_BUFFERS_MEMORY_MIN},</li>
 	 * 	<li>{@link NettyShuffleEnvironmentOptions#NETWORK_BUFFERS_MEMORY_MAX}, and</li>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ConfigurationParserUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ConfigurationParserUtils.java
@@ -43,21 +43,23 @@ public class ConfigurationParserUtils {
 	 */
 	public static long getManagedMemorySize(Configuration configuration) {
 		long managedMemorySize;
-		String managedMemorySizeDefaultVal = TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue();
-		if (!configuration.getString(TaskManagerOptions.MANAGED_MEMORY_SIZE).equals(managedMemorySizeDefaultVal)) {
+		String managedMemorySizeDefaultVal = TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE.defaultValue();
+		if (!configuration.getString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE).equals(managedMemorySizeDefaultVal)) {
 			try {
 				managedMemorySize = MemorySize.parse(
-					configuration.getString(TaskManagerOptions.MANAGED_MEMORY_SIZE), MEGA_BYTES).getMebiBytes();
+					configuration.getString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE), MEGA_BYTES).getMebiBytes();
 			} catch (IllegalArgumentException e) {
-				throw new IllegalConfigurationException("Could not read " + TaskManagerOptions.MANAGED_MEMORY_SIZE.key(), e);
+				throw new IllegalConfigurationException("Could not read " + TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE
+
+					.key(), e);
 			}
 		} else {
 			managedMemorySize = Long.valueOf(managedMemorySizeDefaultVal);
 		}
 
 		checkConfigParameter(configuration.getString(
-			TaskManagerOptions.MANAGED_MEMORY_SIZE).equals(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue()) || managedMemorySize > 0,
-			managedMemorySize, TaskManagerOptions.MANAGED_MEMORY_SIZE.key(),
+			TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE).equals(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE.defaultValue()) || managedMemorySize > 0,
+			managedMemorySize, TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE.key(),
 			"MemoryManager needs at least one MB of memory. " +
 				"If you leave this config parameter empty, the system automatically pick a fraction of the available memory.");
 
@@ -71,10 +73,10 @@ public class ConfigurationParserUtils {
 	 * @return fraction of managed memory
 	 */
 	public static float getManagedMemoryFraction(Configuration configuration) {
-		float managedMemoryFraction = configuration.getFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION);
+		float managedMemoryFraction = configuration.getFloat(TaskManagerOptions.LEGACY_MANAGED_MEMORY_FRACTION);
 
 		checkConfigParameter(managedMemoryFraction > 0.0f && managedMemoryFraction < 1.0f, managedMemoryFraction,
-			TaskManagerOptions.MANAGED_MEMORY_FRACTION.key(),
+			TaskManagerOptions.LEGACY_MANAGED_MEMORY_FRACTION.key(),
 			"MemoryManager fraction of the free memory must be between 0.0 and 1.0");
 
 		return managedMemoryFraction;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtilsTest.java
@@ -1,0 +1,655 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.clusterframework;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.function.Consumer;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link TaskExecutorResourceUtils}.
+ */
+public class TaskExecutorResourceUtilsTest extends TestLogger {
+
+	private static final MemorySize TASK_HEAP_SIZE = MemorySize.parse("100m");
+	private static final MemorySize MANAGED_MEM_SIZE = MemorySize.parse("200m");
+	private static final MemorySize TOTAL_FLINK_MEM_SIZE = MemorySize.parse("800m");
+	private static final MemorySize TOTAL_PROCESS_MEM_SIZE = MemorySize.parse("1g");
+
+	@Test
+	public void testConfigFrameworkHeapMemory() {
+		final MemorySize frameworkHeapSize = MemorySize.parse("100m");
+
+		Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY, frameworkHeapSize.getMebiBytes() + "m");
+
+		validateInAllConfigurations(conf, taskExecutorResourceSpec -> assertThat(taskExecutorResourceSpec.getFrameworkHeapSize(), is(frameworkHeapSize)));
+	}
+
+	@Test
+	public void testConfigTaskHeapMemory() {
+		final MemorySize taskHeapSize = MemorySize.parse("50m");
+
+		Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.TASK_HEAP_MEMORY, taskHeapSize.getMebiBytes() + "m");
+
+		// validate in configurations without explicit task heap memory size,
+		// to avoid checking against overwritten task heap memory size
+		validateInConfigurationsWithoutExplicitTaskHeapMem(conf, taskExecutorResourceSpec -> assertThat(taskExecutorResourceSpec.getTaskHeapSize(), is(taskHeapSize)));
+	}
+
+	@Test
+	public void testConfigTaskOffheapMemory() {
+		final MemorySize taskOffHeapSize = MemorySize.parse("50m");
+
+		Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.TASK_OFF_HEAP_MEMORY, taskOffHeapSize.getMebiBytes() + "m");
+
+		validateInAllConfigurations(conf, taskExecutorResourceSpec -> assertThat(taskExecutorResourceSpec.getTaskOffHeapSize(), is(taskOffHeapSize)));
+	}
+
+	@Test
+	public void testConfigShuffleMemoryRange() {
+		final MemorySize shuffleMin = MemorySize.parse("50m");
+		final MemorySize shuffleMax = MemorySize.parse("200m");
+
+		Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.SHUFFLE_MEMORY_MAX, shuffleMax.getMebiBytes() + "m");
+		conf.setString(TaskManagerOptions.SHUFFLE_MEMORY_MIN, shuffleMin.getMebiBytes() + "m");
+
+		validateInAllConfigurations(conf, taskExecutorResourceSpec -> {
+			assertThat(taskExecutorResourceSpec.getShuffleMemSize().getBytes(), greaterThanOrEqualTo(shuffleMin.getBytes()));
+			assertThat(taskExecutorResourceSpec.getShuffleMemSize().getBytes(), lessThanOrEqualTo(shuffleMax.getBytes()));
+		});
+	}
+
+	@Test
+	public void testConfigShuffleMemoryRangeFailure() {
+		final MemorySize shuffleMin = MemorySize.parse("200m");
+		final MemorySize shuffleMax = MemorySize.parse("50m");
+
+		Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.SHUFFLE_MEMORY_MAX, shuffleMax.getMebiBytes() + "m");
+		conf.setString(TaskManagerOptions.SHUFFLE_MEMORY_MIN, shuffleMin.getMebiBytes() + "m");
+
+		validateFailInAllConfigurations(conf);
+	}
+
+	@Test
+	public void testConfigShuffleMemoryFraction() {
+		final MemorySize shuffleMin = MemorySize.parse("0m");
+		final MemorySize shuffleMax = MemorySize.parse("1t");
+		final float fraction = 0.2f;
+
+		Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.SHUFFLE_MEMORY_MAX, shuffleMax.getMebiBytes() + "m");
+		conf.setString(TaskManagerOptions.SHUFFLE_MEMORY_MIN, shuffleMin.getMebiBytes() + "m");
+		conf.setFloat(TaskManagerOptions.SHUFFLE_MEMORY_FRACTION, fraction);
+
+		// validate in configurations without explicit total flink/process memory, otherwise explicit configured
+		// shuffle memory fraction might conflict with total flink/process memory minus other memory sizes
+		validateInConfigWithExplicitTaskHeapAndManagedMem(conf, taskExecutorResourceSpec ->
+			assertThat(taskExecutorResourceSpec.getShuffleMemSize(), is(taskExecutorResourceSpec.getTotalFlinkMemorySize().multiply(fraction))));
+	}
+
+	@Test
+	public void testConfigShuffleMemoryFractionFailure() {
+		Configuration conf = new Configuration();
+		conf.setFloat(TaskManagerOptions.SHUFFLE_MEMORY_FRACTION, -0.1f);
+		validateFailInAllConfigurations(conf);
+
+		conf.setFloat(TaskManagerOptions.SHUFFLE_MEMORY_FRACTION, 1.0f);
+		validateFailInAllConfigurations(conf);
+	}
+
+	@Test
+	public void testConfigShuffleMemoryLegacyRangeFraction() {
+		final MemorySize shuffleMin = MemorySize.parse("50m");
+		final MemorySize shuffleMax = MemorySize.parse("200m");
+		final float fraction = 0.2f;
+
+		@SuppressWarnings("deprecation")
+		final ConfigOption<String> legacyOptionMin = NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MIN;
+		@SuppressWarnings("deprecation")
+		final ConfigOption<String> legacyOptionMax = NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MAX;
+		@SuppressWarnings("deprecation")
+		final ConfigOption<Float> legacyOptionFraction = NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_FRACTION;
+
+		Configuration conf = new Configuration();
+		conf.setString(legacyOptionMin, shuffleMin.getMebiBytes() + "m");
+		conf.setString(legacyOptionMax, shuffleMax.getMebiBytes() + "m");
+
+		validateInAllConfigurations(conf, taskExecutorResourceSpec -> {
+			assertThat(taskExecutorResourceSpec.getShuffleMemSize().getBytes(), greaterThanOrEqualTo(shuffleMin.getBytes()));
+			assertThat(taskExecutorResourceSpec.getShuffleMemSize().getBytes(), lessThanOrEqualTo(shuffleMax.getBytes()));
+		});
+
+		conf.setString(legacyOptionMin, "0m");
+		conf.setString(legacyOptionMax, "1t");
+		conf.setFloat(legacyOptionFraction, fraction);
+
+		validateInConfigWithExplicitTaskHeapAndManagedMem(conf, taskExecutorResourceSpec ->
+			assertThat(taskExecutorResourceSpec.getShuffleMemSize(), is(taskExecutorResourceSpec.getTotalFlinkMemorySize().multiply(fraction))));
+	}
+
+	@Test
+	public void testConfigShuffleMemoryLegacyNumOfBuffers() {
+		final MemorySize pageSize = MemorySize.parse("32k");
+		final int numOfBuffers = 1024;
+		final MemorySize shuffleSize = pageSize.multiply(numOfBuffers);
+
+		@SuppressWarnings("deprecation")
+		final ConfigOption<Integer> legacyOption = NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS;
+
+		Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.MEMORY_SEGMENT_SIZE, pageSize.getKibiBytes() + "k");
+		conf.setInteger(legacyOption, numOfBuffers);
+
+		// validate in configurations without explicit total flink/process memory, otherwise explicit configured
+		// shuffle memory size might conflict with total flink/process memory minus other memory sizes
+		validateInConfigWithExplicitTaskHeapAndManagedMem(conf, taskExecutorResourceSpec ->
+			assertThat(taskExecutorResourceSpec.getShuffleMemSize(), is(shuffleSize)));
+	}
+
+	@Test
+	public void testConfigManagedMemorySize() {
+		final MemorySize managedMemSize = MemorySize.parse("100m");
+
+		Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, managedMemSize.getMebiBytes() + "m");
+
+		// validate in configurations without explicit managed memory size,
+		// to avoid checking against overwritten managed memory size
+		validateInConfigurationsWithoutExplicitManagedMem(conf, taskExecutorResourceSpec -> assertThat(taskExecutorResourceSpec.getManagedMemorySize(), is(managedMemSize)));
+	}
+
+	@Test
+	public void testConfigManagedMemoryLegacySize() {
+		final MemorySize managedMemSize = MemorySize.parse("100m");
+
+		@SuppressWarnings("deprecation")
+		final ConfigOption<String> legacyOption = TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE;
+
+		Configuration conf = new Configuration();
+		conf.setString(legacyOption, managedMemSize.getMebiBytes() + "m");
+
+		// validate in configurations without explicit managed memory size,
+		// to avoid checking against overwritten managed memory size
+		validateInConfigurationsWithoutExplicitManagedMem(conf, taskExecutorResourceSpec -> assertThat(taskExecutorResourceSpec.getManagedMemorySize(), is(managedMemSize)));
+	}
+
+	@Test
+	public void testConfigManagedMemoryFraction() {
+		final float fraction = 0.5f;
+
+		Configuration conf = new Configuration();
+		conf.setFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION, fraction);
+
+		// managed memory fraction is only used when managed memory size is not explicitly configured
+		validateInConfigurationsWithoutExplicitManagedMem(conf, taskExecutorResourceSpec ->
+			assertThat(taskExecutorResourceSpec.getManagedMemorySize(), is(taskExecutorResourceSpec.getTotalFlinkMemorySize().multiply(fraction))));
+	}
+
+	@Test
+	public void testConfigManagedMemoryFractionFailure() {
+		final Configuration conf = new Configuration();
+		conf.setFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION, -0.1f);
+		validateFailInConfigurationsWithoutExplicitManagedMem(conf);
+
+		conf.setFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION, 1.0f);
+		validateFailInConfigurationsWithoutExplicitManagedMem(conf);
+	}
+
+	@Test
+	public void testConfigManagedMemoryLegacyFraction() {
+		final float fraction = 0.5f;
+
+		@SuppressWarnings("deprecation")
+		final ConfigOption<Float> legacyOption = TaskManagerOptions.LEGACY_MANAGED_MEMORY_FRACTION;
+
+		Configuration conf = new Configuration();
+		conf.setFloat(legacyOption, fraction);
+
+		// managed memory fraction is only used when managed memory size is not explicitly configured
+		validateInConfigurationsWithoutExplicitManagedMem(conf, taskExecutorResourceSpec ->
+			assertThat(taskExecutorResourceSpec.getManagedMemorySize(), is(taskExecutorResourceSpec.getTotalFlinkMemorySize().multiply(fraction))));
+	}
+
+	@Test
+	public void testConfigOffHeapManagedMemorySize() {
+		final MemorySize offHeapSize = MemorySize.parse("20m");
+
+		Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.MANAGED_MEMORY_OFFHEAP_SIZE, offHeapSize.getMebiBytes() + "m");
+
+		validateInAllConfigurations(conf, taskExecutorResourceSpec -> {
+			assertThat(taskExecutorResourceSpec.getOffHeapManagedMemorySize(), is(offHeapSize));
+			assertThat(taskExecutorResourceSpec.getOnHeapManagedMemorySize(), is(taskExecutorResourceSpec.getManagedMemorySize().subtract(taskExecutorResourceSpec.getOffHeapManagedMemorySize())));
+		});
+	}
+
+	@Test
+	public void testConfigOffHeapManagedMemorySizeFailure() {
+		final MemorySize offHeapSize = MemorySize.parse("1t");
+
+		Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.MANAGED_MEMORY_OFFHEAP_SIZE, offHeapSize.getMebiBytes() + "m");
+
+		validateFailInAllConfigurations(conf);
+	}
+
+	@Test
+	public void testConfigOffHeapManagedMemoryFraction() {
+		final float fraction = 0.5f;
+
+		Configuration conf = new Configuration();
+		conf.setFloat(TaskManagerOptions.MANAGED_MEMORY_OFFHEAP_FRACTION, fraction);
+
+		validateInAllConfigurations(conf, taskExecutorResourceSpec -> {
+			assertThat(taskExecutorResourceSpec.getOffHeapManagedMemorySize(), is(taskExecutorResourceSpec.getManagedMemorySize().multiply(fraction)));
+			assertThat(taskExecutorResourceSpec.getOnHeapManagedMemorySize(), is(taskExecutorResourceSpec.getManagedMemorySize().subtract(taskExecutorResourceSpec.getOffHeapManagedMemorySize())));
+		});
+	}
+
+	@Test
+	public void testConfigOffHeapManagedMemoryFractionFailure() {
+		Configuration conf = new Configuration();
+		conf.setFloat(TaskManagerOptions.MANAGED_MEMORY_OFFHEAP_FRACTION, 1.1f);
+		validateFailInAllConfigurations(conf);
+	}
+
+	@Test
+	public void testConfigOffHeapManagedMemoryLegacyOffHeap() {
+		@SuppressWarnings("deprecation")
+		final ConfigOption<Boolean> legacyOption = TaskManagerOptions.MEMORY_OFF_HEAP;
+
+		// negative off-heap managed memory fraction means not configured, if off-heap managed memory size is also not configured,
+		// legacy 'taskmanager.memory.off-heap' will be used to set managed memory to either all on-heap or all off-heap
+		Configuration conf = new Configuration();
+		conf.setFloat(TaskManagerOptions.MANAGED_MEMORY_OFFHEAP_FRACTION, -1.0f);
+
+		conf.setBoolean(legacyOption, true);
+		validateInAllConfigurations(conf, taskExecutorResourceSpec -> {
+			assertThat(taskExecutorResourceSpec.getOffHeapManagedMemorySize(), is(taskExecutorResourceSpec.getManagedMemorySize()));
+			assertThat(taskExecutorResourceSpec.getOnHeapManagedMemorySize(), is(new MemorySize(0L)));
+		});
+	}
+
+	@Test
+	public void testConfigOffHeapManagedMemoryLegacyOnHeap() {
+		@SuppressWarnings("deprecation")
+		final ConfigOption<Boolean> legacyOption = TaskManagerOptions.MEMORY_OFF_HEAP;
+
+		// negative off-heap managed memory fraction means not configured, if off-heap managed memory size is also not configured,
+		// legacy 'taskmanager.memory.off-heap' will be used to set managed memory to either all on-heap or all off-heap
+		Configuration conf = new Configuration();
+		conf.setFloat(TaskManagerOptions.MANAGED_MEMORY_OFFHEAP_FRACTION, -1.0f);
+
+		conf.setBoolean(legacyOption, false);
+		validateInAllConfigurations(conf, taskExecutorResourceSpec -> {
+			assertThat(taskExecutorResourceSpec.getOnHeapManagedMemorySize(), is(taskExecutorResourceSpec.getManagedMemorySize()));
+			assertThat(taskExecutorResourceSpec.getOffHeapManagedMemorySize(), is(new MemorySize(0L)));
+		});
+	}
+
+	@Test
+	public void testConfigJvmMetaspaceSize() {
+		final MemorySize jvmMetaspaceSize = MemorySize.parse("50m");
+
+		Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.JVM_METASPACE, jvmMetaspaceSize.getMebiBytes() + "m");
+
+		validateInAllConfigurations(conf, taskExecutorResourceSpec -> assertThat(taskExecutorResourceSpec.getJvmMetaspaceSize(), is(jvmMetaspaceSize)));
+	}
+
+	@Test
+	public void testConfigJvmOverheadRange() {
+		final MemorySize minSize = MemorySize.parse("50m");
+		final MemorySize maxSize = MemorySize.parse("200m");
+
+		Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.JVM_OVERHEAD_MAX, maxSize.getMebiBytes() + "m");
+		conf.setString(TaskManagerOptions.JVM_OVERHEAD_MIN, minSize.getMebiBytes() + "m");
+
+		validateInAllConfigurations(conf, taskExecutorResourceSpec -> {
+			assertThat(taskExecutorResourceSpec.getJvmOverheadSize().getBytes(),
+				greaterThanOrEqualTo(minSize.getBytes()));
+			assertThat(taskExecutorResourceSpec.getJvmOverheadSize().getBytes(), lessThanOrEqualTo(maxSize.getBytes()));
+		});
+	}
+
+	@Test
+	public void testConfigJvmOverheadRangeFailure() {
+		final MemorySize minSize = MemorySize.parse("200m");
+		final MemorySize maxSize = MemorySize.parse("50m");
+
+		Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.JVM_OVERHEAD_MAX, maxSize.getMebiBytes() + "m");
+		conf.setString(TaskManagerOptions.JVM_OVERHEAD_MIN, minSize.getMebiBytes() + "m");
+
+		validateFailInAllConfigurations(conf);
+	}
+
+	@Test
+	public void testConfigJvmOverheadFraction() {
+		final MemorySize minSize = MemorySize.parse("0m");
+		final MemorySize maxSize = MemorySize.parse("1t");
+		final float fraction = 0.2f;
+
+		Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.JVM_OVERHEAD_MAX, maxSize.getMebiBytes() + "m");
+		conf.setString(TaskManagerOptions.JVM_OVERHEAD_MIN, minSize.getMebiBytes() + "m");
+		conf.setFloat(TaskManagerOptions.JVM_OVERHEAD_FRACTION, fraction);
+
+		validateInAllConfigurations(conf, taskExecutorResourceSpec ->
+			assertThat(taskExecutorResourceSpec.getJvmOverheadSize(), is(taskExecutorResourceSpec.getTotalProcessMemorySize().multiply(fraction))));
+	}
+
+	@Test
+	public void testConfigJvmOverheadFractionFailureNegative() {
+		final Configuration conf = new Configuration();
+		conf.setFloat(TaskManagerOptions.JVM_OVERHEAD_FRACTION, -0.1f);
+		validateFailInConfigurationsWithoutExplicitManagedMem(conf);
+	}
+
+	@Test
+	public void testConfigJvmOverheadFractionFailureNoLessThanOne() {
+		final Configuration conf = new Configuration();
+		conf.setFloat(TaskManagerOptions.JVM_OVERHEAD_FRACTION, 1.0f);
+		validateFailInConfigurationsWithoutExplicitManagedMem(conf);
+	}
+
+	@Test
+	public void testConfigTotalFlinkMemory() {
+		final MemorySize totalFlinkMemorySize = MemorySize.parse("1g");
+
+		Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.TOTAL_FLINK_MEMORY, totalFlinkMemorySize.getMebiBytes() + "m");
+
+		TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(conf);
+		assertThat(taskExecutorResourceSpec.getTotalFlinkMemorySize(), is(totalFlinkMemorySize));
+	}
+
+	@Test
+	public void testFlinkInternalMemorySizeAddUpFailure() {
+		final MemorySize totalFlinkMemory = MemorySize.parse("499m");
+		final MemorySize frameworkHeap = MemorySize.parse("100m");
+		final MemorySize taskHeap = MemorySize.parse("100m");
+		final MemorySize taskOffHeap = MemorySize.parse("100m");
+		final MemorySize shuffle = MemorySize.parse("100m");
+		final MemorySize managed = MemorySize.parse("100m");
+
+		Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.TOTAL_FLINK_MEMORY, totalFlinkMemory.getMebiBytes() + "m");
+		conf.setString(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY, frameworkHeap.getMebiBytes() + "m");
+		conf.setString(TaskManagerOptions.TASK_HEAP_MEMORY, taskHeap.getMebiBytes() + "m");
+		conf.setString(TaskManagerOptions.TASK_OFF_HEAP_MEMORY, taskOffHeap.getMebiBytes() + "m");
+		conf.setString(TaskManagerOptions.SHUFFLE_MEMORY_MIN, shuffle.getMebiBytes() + "m");
+		conf.setString(TaskManagerOptions.SHUFFLE_MEMORY_MAX, shuffle.getMebiBytes() + "m");
+		conf.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, managed.getMebiBytes() + "m");
+
+		validateFail(conf);
+	}
+
+	@Test
+	public void testConfigTotalFlinkMemoryLegacyMB() {
+		final MemorySize totalFlinkMemorySize = MemorySize.parse("1g");
+
+		@SuppressWarnings("deprecation")
+		final ConfigOption<Integer> legacyOption = TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY_MB;
+
+		Configuration conf = new Configuration();
+		conf.setInteger(legacyOption, totalFlinkMemorySize.getMebiBytes());
+
+		TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(conf);
+		assertThat(taskExecutorResourceSpec.getTotalFlinkMemorySize(), is(totalFlinkMemorySize));
+	}
+
+	@Test
+	public void testConfigTotalProcessMemorySize() {
+		final MemorySize totalProcessMemorySize = MemorySize.parse("1g");
+
+		Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.TOTAL_PROCESS_MEMORY, totalProcessMemorySize.getMebiBytes() + "m");
+
+		TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(conf);
+		assertThat(taskExecutorResourceSpec.getTotalProcessMemorySize(), is(totalProcessMemorySize));
+	}
+
+	@Test
+	public void testFlinkInternalMemoryFractionAddUpFailure() {
+		final float shuffleFraction = 0.6f;
+		final float managedFraction = 0.6f;
+
+		Configuration conf = new Configuration();
+		conf.setFloat(TaskManagerOptions.SHUFFLE_MEMORY_FRACTION, shuffleFraction);
+		conf.setFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION, managedFraction);
+
+		// if managed memory size is explicitly configured, then managed memory fraction will be ignored
+		validateFailInConfigurationsWithoutExplicitManagedMem(conf);
+	}
+
+	@Test
+	public void testConfigTotalFlinkMemoryLegacySize() {
+		final MemorySize totalFlinkMemorySize = MemorySize.parse("1g");
+
+		@SuppressWarnings("deprecation")
+		final ConfigOption<String> legacyOption = TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY;
+
+		Configuration conf = new Configuration();
+		conf.setString(legacyOption, totalFlinkMemorySize.getMebiBytes() + "m");
+
+		TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(conf);
+		assertThat(taskExecutorResourceSpec.getTotalFlinkMemorySize(), is(totalFlinkMemorySize));
+	}
+
+	@Test
+	public void testConfigTotalProcessMemoryAddUpFailure() {
+		final MemorySize totalProcessMemory = MemorySize.parse("699m");
+		final MemorySize totalFlinkMemory = MemorySize.parse("500m");
+		final MemorySize jvmMetaspace = MemorySize.parse("100m");
+		final MemorySize jvmOverhead = MemorySize.parse("100m");
+
+		Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.TOTAL_PROCESS_MEMORY, totalProcessMemory.getMebiBytes() + "m");
+		conf.setString(TaskManagerOptions.TOTAL_FLINK_MEMORY, totalFlinkMemory.getMebiBytes() + "m");
+		conf.setString(TaskManagerOptions.JVM_METASPACE, jvmMetaspace.getMebiBytes() + "m");
+		conf.setString(TaskManagerOptions.JVM_OVERHEAD_MIN, jvmOverhead.getMebiBytes() + "m");
+		conf.setString(TaskManagerOptions.JVM_OVERHEAD_MAX, jvmOverhead.getMebiBytes() + "m");
+
+		validateFail(conf);
+	}
+
+	private void validateInAllConfigurations(final Configuration customConfig, Consumer<TaskExecutorResourceSpec> validateFunc) {
+		validateInConfigWithExplicitTaskHeapAndManagedMem(customConfig, validateFunc);
+		validateInConfigWithExplicitTotalFlinkMem(customConfig, validateFunc);
+		validateInConfigWithExplicitTotalFlinkAndTaskHeapMem(customConfig, validateFunc);
+		validateInConfigWithExplicitTotalFlinkAndManagedMem(customConfig, validateFunc);
+		validateInConfigWithExplicitTotalProcessMem(customConfig, validateFunc);
+	}
+
+	private void validateFailInAllConfigurations(final Configuration customConfig) {
+		validateFailInConfigWithExplicitTaskHeapAndManagedMem(customConfig);
+		validateFailInConfigWithExplicitTotalFlinkMem(customConfig);
+		validateFailInConfigWithExplicitTotalFlinkAndTaskHeapMem(customConfig);
+		validateFailInConfigWithExplicitTotalFlinkAndManagedMem(customConfig);
+		validateFailInConfigWithExplicitTotalProcessMem(customConfig);
+	}
+
+	private void validateInConfigurationsWithoutExplicitTaskHeapMem(final Configuration customConfig, Consumer<TaskExecutorResourceSpec> validateFunc) {
+		validateInConfigWithExplicitTotalFlinkMem(customConfig, validateFunc);
+		validateInConfigWithExplicitTotalFlinkAndManagedMem(customConfig, validateFunc);
+		validateInConfigWithExplicitTotalProcessMem(customConfig, validateFunc);
+	}
+
+	private void validateInConfigurationsWithoutExplicitManagedMem(final Configuration customConfig, Consumer<TaskExecutorResourceSpec> validateFunc) {
+		validateInConfigWithExplicitTotalFlinkMem(customConfig, validateFunc);
+		validateInConfigWithExplicitTotalFlinkAndTaskHeapMem(customConfig, validateFunc);
+		validateInConfigWithExplicitTotalProcessMem(customConfig, validateFunc);
+	}
+
+	private void validateFailInConfigurationsWithoutExplicitManagedMem(final Configuration customConfig) {
+		validateFailInConfigWithExplicitTotalFlinkMem(customConfig);
+		validateFailInConfigWithExplicitTotalFlinkAndTaskHeapMem(customConfig);
+		validateFailInConfigWithExplicitTotalProcessMem(customConfig);
+	}
+
+	private void validateInConfigWithExplicitTaskHeapAndManagedMem(
+		final Configuration customConfig, Consumer<TaskExecutorResourceSpec> validateFunc) {
+		log.info("Validating in configuration with explicit task heap and managed memory size.");
+		final Configuration config = configWithExplicitTaskHeapAndManageMem();
+		config.addAll(customConfig);
+		TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(config);
+		assertThat(taskExecutorResourceSpec.getTaskHeapSize(), is(TASK_HEAP_SIZE));
+		assertThat(taskExecutorResourceSpec.getManagedMemorySize(), is(MANAGED_MEM_SIZE));
+		validateFunc.accept(taskExecutorResourceSpec);
+	}
+
+	private void validateFailInConfigWithExplicitTaskHeapAndManagedMem(final Configuration customConfig) {
+		log.info("Validating failing in configuration with explicit task heap and managed memory size.");
+		final Configuration config = configWithExplicitTaskHeapAndManageMem();
+		config.addAll(customConfig);
+		validateFail(config);
+	}
+
+	private void validateInConfigWithExplicitTotalFlinkMem(
+		final Configuration customConfig, Consumer<TaskExecutorResourceSpec> validateFunc) {
+		log.info("Validating in configuration with explicit total flink memory size.");
+		final Configuration config = configWithExplicitTotalFlinkMem();
+		config.addAll(customConfig);
+		TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(config);
+		assertThat(taskExecutorResourceSpec.getTotalFlinkMemorySize(), is(TOTAL_FLINK_MEM_SIZE));
+		validateFunc.accept(taskExecutorResourceSpec);
+	}
+
+	private void validateFailInConfigWithExplicitTotalFlinkMem(final Configuration customConfig) {
+		log.info("Validating failing in configuration with explicit total flink memory size.");
+		final Configuration config = configWithExplicitTotalFlinkMem();
+		config.addAll(customConfig);
+		validateFail(config);
+	}
+
+	private void validateInConfigWithExplicitTotalFlinkAndTaskHeapMem(
+		final Configuration customConfig, Consumer<TaskExecutorResourceSpec> validateFunc) {
+		log.info("Validating in configuration with explicit total flink and task heap memory size.");
+		final Configuration config = configWithExplicitTotalFlinkAndTaskHeapMem();
+		config.addAll(customConfig);
+		TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(config);
+		assertThat(taskExecutorResourceSpec.getTotalFlinkMemorySize(), is(TOTAL_FLINK_MEM_SIZE));
+		assertThat(taskExecutorResourceSpec.getTaskHeapSize(), is(TASK_HEAP_SIZE));
+		validateFunc.accept(taskExecutorResourceSpec);
+	}
+
+	private void validateFailInConfigWithExplicitTotalFlinkAndTaskHeapMem(final Configuration customConfig) {
+		log.info("Validating failing in configuration with explicit total flink and task heap memory size.");
+		final Configuration config = configWithExplicitTotalFlinkAndTaskHeapMem();
+		config.addAll(customConfig);
+		validateFail(config);
+	}
+
+	private void validateInConfigWithExplicitTotalFlinkAndManagedMem(
+		final Configuration customConfig, Consumer<TaskExecutorResourceSpec> validateFunc) {
+		log.info("Validating in configuration with explicit total flink and managed memory size.");
+		final Configuration config = configWithExplicitTotalFlinkAndManagedMem();
+		config.addAll(customConfig);
+		TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(config);
+		assertThat(taskExecutorResourceSpec.getTotalFlinkMemorySize(), is(TOTAL_FLINK_MEM_SIZE));
+		assertThat(taskExecutorResourceSpec.getManagedMemorySize(), is(MANAGED_MEM_SIZE));
+		validateFunc.accept(taskExecutorResourceSpec);
+	}
+
+	private void validateFailInConfigWithExplicitTotalFlinkAndManagedMem(final Configuration customConfig) {
+		log.info("Validating failing in configuration with explicit total flink and managed memory size.");
+		final Configuration config = configWithExplicitTotalFlinkAndManagedMem();
+		config.addAll(customConfig);
+		validateFail(config);
+	}
+
+	private void validateInConfigWithExplicitTotalProcessMem(
+		final Configuration customConfig, Consumer<TaskExecutorResourceSpec> validateFunc) {
+		log.info("Validating in configuration with explicit total process memory size.");
+		final Configuration config = configWithExplicitTotalProcessMem();
+		config.addAll(customConfig);
+		TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(config);
+		assertThat(taskExecutorResourceSpec.getTotalProcessMemorySize(), is(TOTAL_PROCESS_MEM_SIZE));
+		validateFunc.accept(taskExecutorResourceSpec);
+	}
+
+	private void validateFailInConfigWithExplicitTotalProcessMem(final Configuration customConfig) {
+		log.info("Validating failing in configuration with explicit total process memory size.");
+		final Configuration config = configWithExplicitTotalProcessMem();
+		config.addAll(customConfig);
+		validateFail(config);
+	}
+
+	private void validateFail(final Configuration config) {
+		try {
+			TaskExecutorResourceUtils.resourceSpecFromConfig(config);
+			fail("Configuration did not fail as expected.");
+		} catch (Throwable t) {
+			// expected
+		}
+	}
+
+	private static Configuration configWithExplicitTaskHeapAndManageMem() {
+		final Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.TASK_HEAP_MEMORY, TASK_HEAP_SIZE.getMebiBytes() + "m");
+		conf.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, MANAGED_MEM_SIZE.getMebiBytes() + "m");
+		return conf;
+	}
+
+	private static Configuration configWithExplicitTotalFlinkMem() {
+		final Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.TOTAL_FLINK_MEMORY, TOTAL_FLINK_MEM_SIZE.getMebiBytes() + "m");
+		return conf;
+	}
+
+	private static Configuration configWithExplicitTotalFlinkAndTaskHeapMem() {
+		final Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.TOTAL_FLINK_MEMORY, TOTAL_FLINK_MEM_SIZE.getMebiBytes() + "m");
+		conf.setString(TaskManagerOptions.TASK_HEAP_MEMORY, TASK_HEAP_SIZE.getMebiBytes() + "m");
+		return conf;
+	}
+
+	private static Configuration configWithExplicitTotalFlinkAndManagedMem() {
+		final Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.TOTAL_FLINK_MEMORY, TOTAL_FLINK_MEM_SIZE.getMebiBytes() + "m");
+		conf.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, MANAGED_MEM_SIZE.getMebiBytes() + "m");
+		return conf;
+	}
+
+	private static Configuration configWithExplicitTotalProcessMem() {
+		final Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.TOTAL_PROCESS_MEMORY, TOTAL_PROCESS_MEM_SIZE.getMebiBytes() + "m");
+		return conf;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManagerFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManagerFactoryTest.java
@@ -89,7 +89,7 @@ public class ActiveResourceManagerFactoryTest extends TestLogger {
 				ClusterInformation clusterInformation,
 				@Nullable String webInterfaceUrl,
 				ResourceManagerMetricGroup resourceManagerMetricGroup) {
-			assertThat(configuration.contains(TaskManagerOptions.MANAGED_MEMORY_SIZE), is(true));
+			assertThat(configuration.contains(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE), is(true));
 
 			return null;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -280,7 +280,7 @@ public class ResourceManagerTest extends TestLogger {
 	@Test
 	public void testCreateWorkerSlotProfiles() {
 		final Configuration config = new Configuration();
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "100m");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "100m");
 		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 5);
 
 		final ResourceProfile rmCalculatedResourceProfile =
@@ -289,7 +289,7 @@ public class ResourceManagerTest extends TestLogger {
 		final ResourceProfile tmCalculatedResourceProfile =
 			TaskManagerServices.computeSlotResourceProfile(
 				config.getInteger(TaskManagerOptions.NUM_TASK_SLOTS),
-				MemorySize.parse(config.getString(TaskManagerOptions.MANAGED_MEMORY_SIZE)).getBytes());
+				MemorySize.parse(config.getString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE)).getBytes());
 
 		assertEquals(rmCalculatedResourceProfile, tmCalculatedResourceProfile);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NettyShuffleEnvironmentConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NettyShuffleEnvironmentConfigurationTest.java
@@ -247,15 +247,15 @@ public class NettyShuffleEnvironmentConfigurationTest extends TestLogger {
 
 		config.setBoolean(TaskManagerOptions.MEMORY_OFF_HEAP, true);
 		config.setFloat(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.1f);
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "10m"); // 10MB
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "10m"); // 10MB
 		assertEquals(890, TaskManagerServices.calculateHeapSizeMB(1000, config));
 
 		config.setFloat(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.6f);
 		assertEquals(390, TaskManagerServices.calculateHeapSizeMB(1000, config));
 
-		config.removeConfig(TaskManagerOptions.MANAGED_MEMORY_SIZE); // use fraction of given memory
+		config.removeConfig(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE); // use fraction of given memory
 		config.setFloat(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.1f);
-		config.setFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION, 0.1f); // 10%
+		config.setFloat(TaskManagerOptions.LEGACY_MANAGED_MEMORY_FRACTION, 0.1f); // 10%
 		assertEquals(810, TaskManagerServices.calculateHeapSizeMB(1000, config));
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NetworkBufferCalculationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NetworkBufferCalculationTest.java
@@ -46,32 +46,32 @@ public class NetworkBufferCalculationTest extends TestLogger {
 		final long networkBufMax = 1L << 30; // 1GB
 
 		config = getConfig(
-			Long.valueOf(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue()),
-			TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
+			Long.valueOf(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE.defaultValue()),
+			TaskManagerOptions.LEGACY_MANAGED_MEMORY_FRACTION.defaultValue(),
 			0.1f, networkBufMin, networkBufMax, MemoryType.HEAP);
 		assertEquals(100L << 20,
 			NettyShuffleEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 900L << 20)); // 900MB
 
 		config = getConfig(
-			Long.valueOf(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue()),
-			TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
+			Long.valueOf(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE.defaultValue()),
+			TaskManagerOptions.LEGACY_MANAGED_MEMORY_FRACTION.defaultValue(),
 			0.2f, networkBufMin, networkBufMax, MemoryType.HEAP);
 		assertEquals(200L << 20,
 			NettyShuffleEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 800L << 20)); // 800MB
 
 		config = getConfig(
-			Long.valueOf(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue()),
-			TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
+			Long.valueOf(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE.defaultValue()),
+			TaskManagerOptions.LEGACY_MANAGED_MEMORY_FRACTION.defaultValue(),
 			0.6f, networkBufMin, networkBufMax, MemoryType.HEAP);
 		assertEquals(600L << 20,
 			NettyShuffleEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 400L << 20)); // 400MB
 
-		config = getConfig(10, TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
+		config = getConfig(10, TaskManagerOptions.LEGACY_MANAGED_MEMORY_FRACTION.defaultValue(),
 			0.1f, networkBufMin, networkBufMax, MemoryType.OFF_HEAP);
 		assertEquals(100L << 20,
 			NettyShuffleEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 890L << 20)); // 890MB
 
-		config = getConfig(10, TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
+		config = getConfig(10, TaskManagerOptions.LEGACY_MANAGED_MEMORY_FRACTION.defaultValue(),
 				0.6f, networkBufMin, networkBufMax, MemoryType.OFF_HEAP);
 		assertEquals(615L << 20,
 			NettyShuffleEnvironmentConfiguration.calculateNewNetworkBufferMemory(config, 400L << 20)); // 400MB
@@ -84,8 +84,8 @@ public class NetworkBufferCalculationTest extends TestLogger {
 	/**
 	 * Returns a configuration for the tests.
 	 *
-	 * @param managedMemory         see {@link TaskManagerOptions#MANAGED_MEMORY_SIZE}
-	 * @param managedMemoryFraction see {@link TaskManagerOptions#MANAGED_MEMORY_FRACTION}
+	 * @param managedMemory         see {@link TaskManagerOptions#LEGACY_MANAGED_MEMORY_SIZE}
+	 * @param managedMemoryFraction see {@link TaskManagerOptions#LEGACY_MANAGED_MEMORY_FRACTION}
 	 * @param networkBufFraction	see {@link NettyShuffleEnvironmentOptions#NETWORK_BUFFERS_MEMORY_FRACTION}
 	 * @param networkBufMin			see {@link NettyShuffleEnvironmentOptions#NETWORK_BUFFERS_MEMORY_MIN}
 	 * @param networkBufMax			see {@link NettyShuffleEnvironmentOptions#NETWORK_BUFFERS_MEMORY_MAX}
@@ -103,8 +103,8 @@ public class NetworkBufferCalculationTest extends TestLogger {
 
 		final Configuration configuration = new Configuration();
 
-		configuration.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE.key(), managedMemory);
-		configuration.setFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION.key(), managedMemoryFraction);
+		configuration.setLong(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE.key(), managedMemory);
+		configuration.setFloat(TaskManagerOptions.LEGACY_MANAGED_MEMORY_FRACTION.key(), managedMemoryFraction);
 		configuration.setFloat(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_FRACTION.key(), networkBufFraction);
 		configuration.setLong(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MIN.key(), networkBufMin);
 		configuration.setLong(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MAX.key(), networkBufMax);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
@@ -123,7 +123,7 @@ public class TaskManagerRunnerStartupTest extends TestLogger {
 		cfg.setBoolean(TaskManagerOptions.MANAGED_MEMORY_PRE_ALLOCATE, true);
 
 		// something invalid
-		cfg.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "-42m");
+		cfg.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "-42m");
 		try {
 
 			startTaskManager(
@@ -139,7 +139,7 @@ public class TaskManagerRunnerStartupTest extends TestLogger {
 		// something ridiculously high
 		final long memSize = (((long) Integer.MAX_VALUE - 1) *
 			MemorySize.parse(TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue()).getBytes()) >> 20;
-		cfg.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, memSize + "m");
+		cfg.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, memSize + "m");
 		try {
 
 			startTaskManager(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/MiniClusterResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/MiniClusterResource.java
@@ -159,8 +159,8 @@ public class MiniClusterResource extends ExternalResource {
 			configuration.setBoolean(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, true);
 		}
 
-		if (!configuration.contains(TaskManagerOptions.MANAGED_MEMORY_SIZE)) {
-			configuration.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, DEFAULT_MANAGED_MEMORY_SIZE);
+		if (!configuration.contains(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE)) {
+			configuration.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, DEFAULT_MANAGED_MEMORY_SIZE);
 		}
 
 		// set rest and rpc port to 0 to avoid clashes with concurrent MiniClusters

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
@@ -88,7 +88,7 @@ public class LocalStreamEnvironment extends StreamExecutionEnvironment {
 
 		Configuration configuration = new Configuration();
 		configuration.addAll(jobGraph.getJobConfiguration());
-		configuration.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "0");
+		configuration.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "0");
 
 		// add (and override) the settings with what the user defined
 		configuration.addAll(this.configuration);

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -119,7 +119,7 @@ public class LocalExecutorITCase extends TestLogger {
 
 	private static Configuration getConfig() {
 		Configuration config = new Configuration();
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "4m");
 		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, NUM_TMS);
 		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, NUM_SLOTS_PER_TM);
 		config.setBoolean(WebOptions.SUBMIT_ENABLE, false);

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/BatchAbstractTestBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/BatchAbstractTestBase.java
@@ -47,7 +47,7 @@ public class BatchAbstractTestBase {
 
 	private static Configuration getConfiguration() {
 		Configuration config = new Configuration();
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "100m");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "100m");
 		return config;
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorErrorITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorErrorITCase.java
@@ -58,7 +58,7 @@ public class AccumulatorErrorITCase extends TestLogger {
 
 	public static Configuration getConfiguration() {
 		Configuration config = new Configuration();
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "12m");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "12m");
 		return config;
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeAllWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeAllWindowCheckpointingITCase.java
@@ -67,7 +67,7 @@ public class EventTimeAllWindowCheckpointingITCase extends TestLogger {
 
 	private static Configuration getConfiguration() {
 		Configuration config = new Configuration();
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "48m");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "48m");
 		config.setString(AkkaOptions.LOOKUP_TIMEOUT, "60 s");
 		config.setString(AkkaOptions.ASK_TIMEOUT, "60 s");
 		return config;

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
@@ -209,7 +209,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 		final File haDir = temporaryFolder.newFolder();
 
 		Configuration config = new Configuration();
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "48m");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "48m");
 		// the default network buffers size (10% of heap max =~ 150MB) seems to much for this test case
 		config.setString(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MAX, String.valueOf(80L << 20)); // 80 MB
 		config.setString(AkkaOptions.FRAMESIZE, String.valueOf(MAX_MEM_STATE_SIZE) + "b");

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/KeyedStateCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/KeyedStateCheckpointingITCase.java
@@ -88,7 +88,7 @@ public class KeyedStateCheckpointingITCase extends TestLogger {
 
 	private static Configuration getConfiguration() {
 		Configuration config = new Configuration();
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "12m");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "12m");
 		return config;
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -664,7 +664,7 @@ public class SavepointITCase extends TestLogger {
 
 		Configuration config = getFileBasedCheckpointsConfig();
 		config.addAll(jobGraph.getJobConfiguration());
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "0");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "0");
 
 		MiniClusterWithClientResource cluster = new MiniClusterWithClientResource(
 			new MiniClusterResourceConfiguration.Builder()

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/WindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/WindowCheckpointingITCase.java
@@ -80,7 +80,7 @@ public class WindowCheckpointingITCase extends TestLogger {
 
 	private static Configuration getConfiguration() {
 		Configuration config = new Configuration();
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "48m");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "48m");
 		return config;
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
@@ -116,7 +116,7 @@ public class ClassLoaderITCase extends TestLogger {
 				FOLDER.newFolder().getAbsoluteFile().toURI().toString());
 
 		// required as we otherwise run out of memory
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "80m");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "80m");
 
 		miniClusterResource = new MiniClusterResource(
 			new MiniClusterResourceConfiguration.Builder()

--- a/flink-tests/src/test/java/org/apache/flink/test/example/failing/JobSubmissionFailsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/failing/JobSubmissionFailsITCase.java
@@ -64,7 +64,7 @@ public class JobSubmissionFailsITCase extends TestLogger {
 
 	private static Configuration getConfiguration() {
 		Configuration config = new Configuration();
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "4m");
 		return config;
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/manual/StreamingScalabilityAndLatency.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/manual/StreamingScalabilityAndLatency.java
@@ -50,7 +50,7 @@ public class StreamingScalabilityAndLatency {
 
 		try {
 			Configuration config = new Configuration();
-			config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "80m");
+			config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "80m");
 			config.setInteger(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS, 20000);
 
 			config.setInteger("taskmanager.net.server.numThreads", 1);

--- a/flink-tests/src/test/java/org/apache/flink/test/misc/CustomSerializationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/CustomSerializationITCase.java
@@ -59,7 +59,7 @@ public class CustomSerializationITCase extends TestLogger {
 
 	public static Configuration getConfiguration() {
 		Configuration config = new Configuration();
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "30m");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "30m");
 		return config;
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
@@ -62,7 +62,7 @@ public class SuccessAfterNetworkBuffersFailureITCase extends TestLogger {
 
 	private static Configuration getConfiguration() {
 		Configuration config = new Configuration();
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "80m");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "80m");
 		config.setInteger(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS, 800);
 		return config;
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -102,7 +102,7 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 		config.setString(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperResource.getConnectString());
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.newFolder().getAbsolutePath());
 		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 2);
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "4m");
 		config.setInteger(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS, 100);
 
 		try (final StandaloneSessionClusterEntrypoint clusterEntrypoint = new StandaloneSessionClusterEntrypoint(config)) {

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
@@ -249,7 +249,7 @@ public class JobManagerHAProcessFailureRecoveryITCase extends TestLogger {
 		Configuration config = ZooKeeperTestUtils.createZooKeeperHAConfig(
 			zooKeeper.getConnectString(), zookeeperStoragePath.getPath());
 		// Task manager configuration
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "4m");
 		config.setInteger(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS, 100);
 		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 2);
 

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -115,7 +115,7 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 		config.setString(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperResource.getConnectString());
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.newFolder().getAbsolutePath());
 		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 2);
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "4m");
 		config.setInteger(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS, 100);
 		config.setInteger(RestOptions.PORT, 0);
 

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/IPv6HostnamesITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/IPv6HostnamesITCase.java
@@ -77,7 +77,7 @@ public class IPv6HostnamesITCase extends TestLogger {
 		Configuration config = new Configuration();
 		config.setString(JobManagerOptions.ADDRESS, addressString);
 		config.setString(TaskManagerOptions.HOST, addressString);
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "16m");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "16m");
 		return config;
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/TimestampITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/TimestampITCase.java
@@ -89,7 +89,7 @@ public class TimestampITCase extends TestLogger {
 
 	private static Configuration getConfiguration() {
 		Configuration config = new Configuration();
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "12m");
+		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "12m");
 		return config;
 	}
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
@@ -218,6 +218,6 @@ public class YarnConfigurationITCase extends YarnTestBase {
 
 	private static int calculateManagedMemorySizeMB(Configuration configuration) {
 		Configuration resourceManagerConfig = ActiveResourceManagerFactory.createActiveResourceManagerConfiguration(configuration);
-		return MemorySize.parse(resourceManagerConfig.getString(TaskManagerOptions.MANAGED_MEMORY_SIZE)).getMebiBytes();
+		return MemorySize.parse(resourceManagerConfig.getString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE)).getMebiBytes();
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change
This PR is part of FLIP-49. It implements the new task executor memory configuration and calculation logics.

## Brief change log
- adc4fb2acd7ae0ab2a03cc1e847f0add38d63f48: Rename constant names for managed memory size and fraction config options. This is to avoid naming conflicts in the next commit.
- 97057237606f35581b0ac5b53c4e5807e0ea0376: Introduce task executor memory config options for FLIP-49.
- 119fa285da71d191dcd4ebbd34f8f668c446f8b6: Introduce arithmetic operations (add, subtract and multiply) for MemorySize. These are used for memory calculations in following commits.
- 3acadf1377e10c2e817702e32960ca71d9c62d5c: Introduce 'TaskExecutorResourceSpec' as the data structure for storing calculated memory sizes.
- 652135947866e0d8d10d5081f106213f30287898: Introduce 'TaskExecutorResourceUtils' for calculating memory sizes from configurations, as well as 'TaskExecutorResourceUtilsTest' that validates the memory calculation logics.
- 1ae6e405a644fb981e1066163688bc147338e583: Implement generating JVM parameters and dynamic configurations ('-D' options) from 'TaskExecutorResourceSpec' in 'TaskExecutorResourceUtils'. JVM parameters will be used for launching task executor JVM with calculated memory sizes. Dynamic configurations will be used for passing calculated memory sizes into task executors. 

## Verifying this change
This change added tests and can be verified as follows:
- Add 'TaskExecutorResourceUtilsTest' that validates:
  - Memory calculation logics
    - Success and failure cases
    - Backwards compatibility
  - Generating dynamic configurations
  - Generating JVM parameters

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
