### PR TITLE
[FLINK-14031][examples][table]Added the blink planner dependency and …

### DIFF
--- a/flink-examples/flink-examples-table/pom.xml
+++ b/flink-examples/flink-examples-table/pom.xml
@@ -51,6 +51,11 @@ under the License.
 			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/StreamSQLExample.java
+++ b/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/StreamSQLExample.java
@@ -18,15 +18,20 @@
 
 package org.apache.flink.table.examples.java;
 
+import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * Simple example for demonstrating the use of SQL on a Stream Table in Java.
+ *
+ * <p>Usage: <code>StreamSQLExample --planner &lt;blink|flink&gt;</code><br>
  *
  * <p>This example shows how to:
  *  - Convert DataStreams to Tables
@@ -42,9 +47,26 @@ public class StreamSQLExample {
 
 	public static void main(String[] args) throws Exception {
 
+		final ParameterTool params = ParameterTool.fromArgs(args);
+		String planner = params.has("planner") ? params.get("planner") : "flink";
+
 		// set up execution environment
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+		StreamTableEnvironment tEnv;
+		if (Objects.equals(planner, "blink")) {	// use blink planner in streaming mode
+			EnvironmentSettings settings = EnvironmentSettings.newInstance()
+				.useBlinkPlanner()
+				.inStreamingMode()
+				.build();
+			tEnv = StreamTableEnvironment.create(env, settings);
+		} else if (Objects.equals(planner, "flink")) {	// use flink planner in streaming mode
+			tEnv = StreamTableEnvironment.create(env);
+		} else {
+			System.err.println("The planner is incorrect. Please run 'StreamSQLExample --planner <planner>', " +
+				"where planner (it is either flink or blink, and the default is flink) indicates whether the " +
+				"example uses flink planner or blink planner.");
+			return;
+		}
 
 		DataStream<Order> orderA = env.fromCollection(Arrays.asList(
 			new Order(1L, "beer", 3),

--- a/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/StreamSQLExample.scala
+++ b/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/StreamSQLExample.scala
@@ -17,14 +17,18 @@
  */
 package org.apache.flink.table.examples.scala
 
+import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
+import org.apache.flink.table.api.EnvironmentSettings
 import org.apache.flink.table.api.scala._
 
 /**
   * Simple example for demonstrating the use of SQL on a Stream Table in Scala.
   *
-  * This example shows how to:
+  * <p>Usage: <code>StreamSQLExample --planner &lt;blink|flink&gt;</code><br>
+  *
+  * <p>This example shows how to:
   *  - Convert DataStreams to Tables
   *  - Register a Table under a name
   *  - Run a StreamSQL query on the registered Table
@@ -38,9 +42,25 @@ object StreamSQLExample {
 
   def main(args: Array[String]): Unit = {
 
+    val params = ParameterTool.fromArgs(args)
+    val planner = if (params.has("planner")) params.get("planner") else "flink"
+
     // set up execution environment
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = StreamTableEnvironment.create(env)
+    val tEnv = if (planner == "blink") {  // use blink planner in streaming mode
+      val settings = EnvironmentSettings.newInstance()
+        .useBlinkPlanner()
+        .inStreamingMode()
+        .build()
+      StreamTableEnvironment.create(env, settings)
+    } else if (planner == "flink") {  // use flink planner in streaming mode
+      StreamTableEnvironment.create(env)
+    } else {
+      System.err.println("The planner is incorrect. Please run 'StreamSQLExample --planner <planner>', " +
+        "where planner (it is either flink or blink, and the default is flink) indicates whether the " +
+        "example uses flink planner or blink planner.")
+      return
+    }
 
     val orderA: DataStream[Order] = env.fromCollection(Seq(
       Order(1L, "beer", 3),
@@ -53,14 +73,17 @@ object StreamSQLExample {
       Order(4L, "beer", 1)))
 
     // convert DataStream to Table
-    var tableA = tEnv.fromDataStream(orderA, 'user, 'product, 'amount)
+    val tableA = tEnv.fromDataStream(orderA, 'user, 'product, 'amount)
     // register DataStream as Table
     tEnv.registerDataStream("OrderB", orderB, 'user, 'product, 'amount)
 
     // union the two tables
     val result = tEnv.sqlQuery(
-      s"SELECT * FROM $tableA WHERE amount > 2 UNION ALL " +
-        "SELECT * FROM OrderB WHERE amount < 2")
+      s"""
+         |SELECT * FROM $tableA WHERE amount > 2
+         |UNION ALL
+         |SELECT * FROM OrderB WHERE amount < 2
+        """.stripMargin)
 
     result.toAppendStream[Order].print()
 


### PR DESCRIPTION
## What is the purpose of the change
Added the blink planner dependency and examples which use blink planner to flink-examples-table.

## Brief change log
- Add the blink planner dependency.
- Add examples which use blink planner.

## Verifying this change
Manually verified. Ran examples on idea and a local cluster.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
