### PR TITLE
[FLINK-14120][API/Datastream] Fix testImmediateShutdown

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeServiceTest.java
@@ -136,7 +136,7 @@ public class SystemProcessingTimeServiceTest extends TestLogger {
 		}
 	}
 
-	@Test(timeout = 10000)
+	@Test
 	public void testImmediateShutdown() throws Exception {
 		final CompletableFuture<Throwable> errorFuture = new CompletableFuture<>();
 
@@ -178,7 +178,7 @@ public class SystemProcessingTimeServiceTest extends TestLogger {
 			}
 
 			// check that the task eventually responded to interruption
-			assertThat(errorFuture.get(), instanceOf(InterruptedException.class));
+			assertThat(errorFuture.get(5, TimeUnit.SECONDS), instanceOf(InterruptedException.class));
 		}
 		finally {
 			timer.shutdownService();


### PR DESCRIPTION
##  What is the purpose of the change

The subtle asynchronous bug appearing in `testImmediateShutdown()` in `SystemProcessingTimeServiceTest` is fixed.

## Brief change log

  - ensured thread synchronization using CompletableFuture (instead of using synchronized blocks). 
  - refactored assertions to make test intention more clear.

## Verifying this change

This change is already covered by existing test (verified by 10k runs with 0 fails). 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable** 
