### PR TITLE
[FLINK-14086][test][core] Add OperatingArchitecture Enum

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/ProcessorArchitecture.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ProcessorArchitecture.java
@@ -26,10 +26,16 @@ import java.util.List;
  * Note that this might be different than the actual operating system's architecture, for example
  * when installing a 32 bit JRE in a 64 bit OS.
  */
-public enum MemoryArchitecture {
+public enum ProcessorArchitecture {
+	/**
+	 * X86 platform.
+	 */
+	X86,
 
-	// constants here start with an underscore because Java identifier cannot start with a
-	// numeric character and alternatives like 'BIT_64' are not as readable
+	/**
+	 * arm platform.
+	 */
+	ARM,
 
 	/**
 	 * 32 bit memory address size.
@@ -46,18 +52,25 @@ public enum MemoryArchitecture {
 	 */
 	UNKNOWN;
 
-	// ------------------------------------------------------------------------
 
-	private static final MemoryArchitecture current = getInternal();
+	private static final ProcessorArchitecture arch = readArchFromSystemProperties();
+	private static final ProcessorArchitecture size = readSizeFromSystemProperties();
 
-	/**
-	 * Gets the processor architecture of this process.
-	 */
-	public static MemoryArchitecture get() {
-		return current;
+	private static ProcessorArchitecture readArchFromSystemProperties() {
+		final List<String> namesX86 = Arrays.asList("amd64", "x86_64", "x86", "i386", "i486", "i586", "i686");
+		final List<String> namesArm = Arrays.asList("arm", "aarch64");
+		final String arch = System.getProperty("os.arch");
+
+		if (namesX86.contains(arch)) {
+			return X86;
+		} else if (namesArm.contains(arch)) {
+			return ARM;
+		} else {
+			return UNKNOWN;
+		}
 	}
 
-	private static MemoryArchitecture getInternal() {
+	private static ProcessorArchitecture readSizeFromSystemProperties() {
 		// putting these into the method to avoid having objects on the heap that are not needed
 		// any more after initialization
 		final List<String> names64bit = Arrays.asList("amd64", "x86_64", "aarch64");
@@ -66,12 +79,19 @@ public enum MemoryArchitecture {
 
 		if (names64bit.contains(arch)) {
 			return _64_BIT;
-		}
-		else if (names32bit.contains(arch)) {
+		} else if (names32bit.contains(arch)) {
 			return _32_BIT;
-		}
-		else {
+		} else {
 			return UNKNOWN;
 		}
 	}
+
+	public static ProcessorArchitecture getCurrentOperatingSystemArch() {
+		return arch;
+	}
+
+	public static ProcessorArchitecture getCurrentOperatingSystemSize() {
+		return size;
+	}
+
 }

--- a/flink-core/src/test/java/org/apache/flink/util/ProcessorArchitectureTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/ProcessorArchitectureTest.java
@@ -23,14 +23,16 @@ import org.junit.Test;
 import static org.junit.Assert.assertNotEquals;
 
 /**
- * Tests for the {@link MemoryArchitecture}.
+ * Tests for the {@link ProcessorArchitecture}.
  */
-public class MemoryArchitectureTest {
+public class ProcessorArchitectureTest {
 
 	@Test
 	public void testArchitectureNotUnknown() {
-		final MemoryArchitecture arch = MemoryArchitecture.get();
+		final ProcessorArchitecture arch = ProcessorArchitecture.getCurrentOperatingSystemArch();
+		final ProcessorArchitecture size = ProcessorArchitecture.getCurrentOperatingSystemSize();
 
-		assertNotEquals(MemoryArchitecture.UNKNOWN, arch);
+		assertNotEquals(ProcessorArchitecture.UNKNOWN, arch);
+		assertNotEquals(ProcessorArchitecture.UNKNOWN, size);
 	}
 }

--- a/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/src/test/java/org/apache/flink/metrics/prometheus/tests/PrometheusReporterEndToEndITCase.java
+++ b/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/src/test/java/org/apache/flink/metrics/prometheus/tests/PrometheusReporterEndToEndITCase.java
@@ -27,6 +27,7 @@ import org.apache.flink.tests.util.FlinkDistribution;
 import org.apache.flink.tests.util.categories.TravisGroup1;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.OperatingSystem;
+import org.apache.flink.util.ProcessorArchitecture;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
@@ -68,17 +69,52 @@ public class PrometheusReporterEndToEndITCase extends TestLogger {
 
 	static {
 		final String base = "prometheus-" + PROMETHEUS_VERSION + '.';
+		final String os;
+		final String platform;
 		switch (OperatingSystem.getCurrentOperatingSystem()) {
 			case MAC_OS:
-				PROMETHEUS_FILE_NAME = base + "darwin-amd64";
+				os = "darwin";
 				break;
 			case WINDOWS:
-				PROMETHEUS_FILE_NAME = base + "windows-amd64";
+				os = "windows";
 				break;
 			default:
-				PROMETHEUS_FILE_NAME = base + "linux-amd64";
+				os = "linux";
 				break;
 		}
+		switch (ProcessorArchitecture.getCurrentOperatingSystemArch()) {
+			case X86:
+				switch (ProcessorArchitecture.getCurrentOperatingSystemSize()) {
+					case _32_BIT:
+						platform = "386";
+						break;
+					case _64_BIT:
+						platform = "amd64";
+						break;
+					default:
+						platform = "Unknown";
+						break;
+				}
+				break;
+			case ARM:
+				switch (ProcessorArchitecture.getCurrentOperatingSystemSize()) {
+					case _32_BIT:
+						platform = "armv7";
+						break;
+					case _64_BIT:
+						platform = "arm64";
+						break;
+					default:
+						platform = "Unknown";
+						break;
+				}
+				break;
+			default:
+				platform = "Unknown";
+				break;
+		}
+
+		PROMETHEUS_FILE_NAME = base + os + "-" + platform;
 	}
 
 	private static final Pattern LOG_REPORTER_PORT_PATTERN = Pattern.compile(".*Started PrometheusReporter HTTP server on port ([0-9]+).*");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -28,7 +28,7 @@ import org.apache.flink.runtime.io.network.buffer.BufferPoolFactory;
 import org.apache.flink.runtime.io.network.buffer.BufferPoolOwner;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
-import org.apache.flink.util.MemoryArchitecture;
+import org.apache.flink.util.ProcessorArchitecture;
 import org.apache.flink.util.function.FunctionWithException;
 
 import org.slf4j.Logger;
@@ -225,7 +225,7 @@ public class ResultPartitionFactory {
 	}
 
 	static BoundedBlockingSubpartitionType getBoundedBlockingType() {
-		switch (MemoryArchitecture.get()) {
+		switch (ProcessorArchitecture.getCurrentOperatingSystemSize()) {
 			case _64_BIT:
 				return BoundedBlockingSubpartitionType.FILE_MMAP;
 			case _32_BIT:


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

There is no way to distinguish operating system architecture in Flink.  So that Flink always runs in X86 ways even the platform is other architecture.

For example, PrometheusReporterEndToEndITCase fails on ARM, because when download prometheus package, it should get aarch64 package but actually it always download amd64 package.

This PR aims to add a common function that provide operating system architecture. So that Flink can do different thing on different platform.

## Brief change log

- Rename `MemoryArchitecture ` to  `OperatingArchitecture`.
- Update `OperatingArchitecture` to support arch check.
- Updated PrometheusReporterEndToEndITCase to adjust ARM platform.


## Verifying this change

This change is already covered by existing tests, such as *PrometheusReporterEndToEndITCase *.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
