### PR TITLE
[FLINK-14210][metrics]support connect timeout and write timeout confi…

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -659,6 +659,8 @@ Parameters:
 - `username` - (optional) InfluxDB username used for authentication
 - `password` - (optional) InfluxDB username's password used for authentication
 - `retentionPolicy` - (optional) InfluxDB retention policy, defaults to retention policy defined on the server for the db
+- `connectTimeout` - (optional) the InfluxDB connect timeout, defaults to connect timeout is 10000 ms
+- `writeTimeout` - (optional) the InfluxDB write timeout, defaults to write timeout is 10000 ms
 
 Example configuration:
 
@@ -671,6 +673,8 @@ metrics.reporter.influxdb.db: flink
 metrics.reporter.influxdb.username: flink-metrics
 metrics.reporter.influxdb.password: qwerty
 metrics.reporter.influxdb.retentionPolicy: one_hour
+metrics.reporter.influxdb.connectTimeout: 10000
+metrics.reporter.influxdb.writeTimeout: 10000
 
 {% endhighlight %}
 

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -659,8 +659,8 @@ Parameters:
 - `username` - (optional) InfluxDB username used for authentication
 - `password` - (optional) InfluxDB username's password used for authentication
 - `retentionPolicy` - (optional) InfluxDB retention policy, defaults to retention policy defined on the server for the db
-- `connectTimeout` - (optional) the InfluxDB connect timeout, defaults to connect timeout is 10000 ms
-- `writeTimeout` - (optional) the InfluxDB write timeout, defaults to write timeout is 10000 ms
+- `connectTimeout` - (optional) the InfluxDB client connect timeout in milliseconds, default is 10000 ms
+- `writeTimeout` - (optional) the InfluxDB client write timeout in milliseconds, default is 10000 ms
 
 Example configuration:
 
@@ -673,8 +673,8 @@ metrics.reporter.influxdb.db: flink
 metrics.reporter.influxdb.username: flink-metrics
 metrics.reporter.influxdb.password: qwerty
 metrics.reporter.influxdb.retentionPolicy: one_hour
-metrics.reporter.influxdb.connectTimeout: 10000
-metrics.reporter.influxdb.writeTimeout: 10000
+metrics.reporter.influxdb.connectTimeout: 60000
+metrics.reporter.influxdb.writeTimeout: 60000
 
 {% endhighlight %}
 

--- a/docs/monitoring/metrics.zh.md
+++ b/docs/monitoring/metrics.zh.md
@@ -659,6 +659,8 @@ Parameters:
 - `username` - (optional) InfluxDB username used for authentication
 - `password` - (optional) InfluxDB username's password used for authentication
 - `retentionPolicy` - (optional) InfluxDB retention policy, defaults to retention policy defined on the server for the db
+- `connectTimeout` - (optional) the InfluxDB connect timeout, defaults to connect timeout is 10000 ms
+- `writeTimeout` - (optional) the InfluxDB write timeout, defaults to write timeout is 10000 ms
 
 Example configuration:
 
@@ -671,6 +673,8 @@ metrics.reporter.influxdb.db: flink
 metrics.reporter.influxdb.username: flink-metrics
 metrics.reporter.influxdb.password: qwerty
 metrics.reporter.influxdb.retentionPolicy: one_hour
+metrics.reporter.influxdb.connectTimeout: 10000
+metrics.reporter.influxdb.writeTimeout: 10000
 
 {% endhighlight %}
 

--- a/docs/monitoring/metrics.zh.md
+++ b/docs/monitoring/metrics.zh.md
@@ -659,8 +659,8 @@ Parameters:
 - `username` - (optional) InfluxDB username used for authentication
 - `password` - (optional) InfluxDB username's password used for authentication
 - `retentionPolicy` - (optional) InfluxDB retention policy, defaults to retention policy defined on the server for the db
-- `connectTimeout` - (optional) the InfluxDB connect timeout, defaults to connect timeout is 10000 ms
-- `writeTimeout` - (optional) the InfluxDB write timeout, defaults to write timeout is 10000 ms
+- `connectTimeout` - (optional) the InfluxDB client connect timeout in milliseconds, default is 10000 ms
+- `writeTimeout` - (optional) the InfluxDB client write timeout in milliseconds, default is 10000 ms
 
 Example configuration:
 
@@ -673,8 +673,8 @@ metrics.reporter.influxdb.db: flink
 metrics.reporter.influxdb.username: flink-metrics
 metrics.reporter.influxdb.password: qwerty
 metrics.reporter.influxdb.retentionPolicy: one_hour
-metrics.reporter.influxdb.connectTimeout: 10000
-metrics.reporter.influxdb.writeTimeout: 10000
+metrics.reporter.influxdb.connectTimeout: 60000
+metrics.reporter.influxdb.writeTimeout: 60000
 
 {% endhighlight %}
 

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
@@ -27,6 +27,7 @@ import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.Scheduled;
 
+import okhttp3.OkHttpClient;
 import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDBFactory;
 import org.influxdb.dto.BatchPoints;
@@ -37,13 +38,16 @@ import java.time.Instant;
 import java.util.ConcurrentModificationException;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.concurrent.TimeUnit;
 
+import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.CONNECT_TIMEOUT;
 import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.DB;
 import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.HOST;
 import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.PASSWORD;
 import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.PORT;
 import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.RETENTION_POLICY;
 import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.USERNAME;
+import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.WRITE_TIMEOUT;
 import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.getInteger;
 import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.getString;
 
@@ -77,10 +81,15 @@ public class InfluxdbReporter extends AbstractReporter<MeasurementInfo> implemen
 
 		this.database = database;
 		this.retentionPolicy = getString(config, RETENTION_POLICY);
+
+		int connectTimeout = getInteger(config, CONNECT_TIMEOUT);
+		int writeTimeout = getInteger(config, WRITE_TIMEOUT);
+		OkHttpClient.Builder client = new OkHttpClient.Builder().connectTimeout(connectTimeout, TimeUnit.MICROSECONDS).writeTimeout(writeTimeout, TimeUnit.MICROSECONDS);
+
 		if (username != null && password != null) {
-			influxDB = InfluxDBFactory.connect(url, username, password);
+			influxDB = InfluxDBFactory.connect(url, username, password, client, InfluxDB.ResponseFormat.JSON);
 		} else {
-			influxDB = InfluxDBFactory.connect(url);
+			influxDB = InfluxDBFactory.connect(url, client);
 		}
 
 		log.info("Configured InfluxDBReporter with {host:{}, port:{}, db:{}, and retentionPolicy:{}}", host, port, database, retentionPolicy);

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
@@ -84,10 +84,12 @@ public class InfluxdbReporter extends AbstractReporter<MeasurementInfo> implemen
 
 		int connectTimeout = getInteger(config, CONNECT_TIMEOUT);
 		int writeTimeout = getInteger(config, WRITE_TIMEOUT);
-		OkHttpClient.Builder client = new OkHttpClient.Builder().connectTimeout(connectTimeout, TimeUnit.MICROSECONDS).writeTimeout(writeTimeout, TimeUnit.MICROSECONDS);
+		OkHttpClient.Builder client = new OkHttpClient.Builder()
+			.connectTimeout(connectTimeout, TimeUnit.MILLISECONDS)
+			.writeTimeout(writeTimeout, TimeUnit.MILLISECONDS);
 
 		if (username != null && password != null) {
-			influxDB = InfluxDBFactory.connect(url, username, password, client, InfluxDB.ResponseFormat.JSON);
+			influxDB = InfluxDBFactory.connect(url, username, password, client);
 		} else {
 			influxDB = InfluxDBFactory.connect(url, client);
 		}

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporterOptions.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporterOptions.java
@@ -57,6 +57,16 @@ public class InfluxdbReporterOptions {
 		.defaultValue("")
 		.withDescription("(optional) the InfluxDB retention policy for metrics");
 
+	public static final ConfigOption<Integer> CONNECT_TIMEOUT = ConfigOptions
+		.key("connectTimeout")
+		.defaultValue(10000)
+		.withDescription("(optional) the InfluxDB connect timeout for metrics");
+
+	public static final ConfigOption<Integer> WRITE_TIMEOUT = ConfigOptions
+		.key("writeTimeout")
+		.defaultValue(10000)
+		.withDescription("(optional) the InfluxDB write timeout for metrics");
+
 	static String getString(MetricConfig config, ConfigOption<String> key) {
 		return config.getString(key.key(), key.defaultValue());
 	}

--- a/flink-metrics/flink-metrics-influxdb/src/test/java/org/apache/flink/metrics/influxdb/InfluxdbReporterTest.java
+++ b/flink-metrics/flink-metrics-influxdb/src/test/java/org/apache/flink/metrics/influxdb/InfluxdbReporterTest.java
@@ -126,8 +126,6 @@ public class InfluxdbReporterTest extends TestLogger {
 		metricConfig.setProperty(InfluxdbReporterOptions.PORT.key(), String.valueOf(wireMockRule.port()));
 		metricConfig.setProperty(InfluxdbReporterOptions.DB.key(), TEST_INFLUXDB_DB);
 		metricConfig.setProperty(InfluxdbReporterOptions.RETENTION_POLICY.key(), retentionPolicy);
-		metricConfig.setProperty(InfluxdbReporterOptions.CONNECT_TIMEOUT.key(), "10000");
-		metricConfig.setProperty(InfluxdbReporterOptions.WRITE_TIMEOUT.key(), "10000");
 
 		return new MetricRegistryImpl(
 			MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),

--- a/flink-metrics/flink-metrics-influxdb/src/test/java/org/apache/flink/metrics/influxdb/InfluxdbReporterTest.java
+++ b/flink-metrics/flink-metrics-influxdb/src/test/java/org/apache/flink/metrics/influxdb/InfluxdbReporterTest.java
@@ -126,6 +126,8 @@ public class InfluxdbReporterTest extends TestLogger {
 		metricConfig.setProperty(InfluxdbReporterOptions.PORT.key(), String.valueOf(wireMockRule.port()));
 		metricConfig.setProperty(InfluxdbReporterOptions.DB.key(), TEST_INFLUXDB_DB);
 		metricConfig.setProperty(InfluxdbReporterOptions.RETENTION_POLICY.key(), retentionPolicy);
+		metricConfig.setProperty(InfluxdbReporterOptions.CONNECT_TIMEOUT.key(), "10000");
+		metricConfig.setProperty(InfluxdbReporterOptions.WRITE_TIMEOUT.key(), "10000");
 
 		return new MetricRegistryImpl(
 			MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),


### PR DESCRIPTION
## What is the purpose of the change

*Support optional connect timeout and write timeout for InfluxDB metric reporter (currently only default is allowed)*


## Brief change log

*Added support for r timeout and write timeout specification for InfluxDB metrics reporter along with supporting tests and documentation.*


## Verifying this change

*Running the unit test suite*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
