### PR TITLE
[FLINK-14186][e2e] Skip Elastic Search 2.3.5 case when running with JDK11

### DIFF
--- a/tools/travis/splits/split_misc.sh
+++ b/tools/travis/splits/split_misc.sh
@@ -59,7 +59,9 @@ if [[ ${PROFILE} != *"jdk11"* ]]; then
 fi
 run_test "Stateful stream job upgrade end-to-end test" "$END_TO_END_DIR/test-scripts/test_stateful_stream_job_upgrade.sh 2 4"
 
-run_test "Elasticsearch (v2.3.5) sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 2 https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.3.5/elasticsearch-2.3.5.tar.gz"
+if [[ ${PROFILE} != *"jdk11"* ]]; then
+  run_test "Elasticsearch (v2.3.5) sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 2 https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.3.5/elasticsearch-2.3.5.tar.gz"
+fi
 run_test "Elasticsearch (v5.1.2) sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 5 https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.1.2.tar.gz"
 run_test "Elasticsearch (v6.3.1) sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 6 https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.3.1.tar.gz"
 


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the end-to-end test failure when testing elastic search link with ES 2.3.5 on JDK 11. Since Java has removed some GC options with the change on the GC algorithms, ES 2.3.5 will fail to start up with JDK 11 since it have included some removed GC options by default. Therefore, we should skip this case when testing with JDK 11.

## Brief change log

- 18531c05a028f98d44a072705392b3c966493416 skips the Elastic Search 2.3.5 case when running with JDK11.

## Verifying this change

This change is tested by manually run run-nightly-tests.sh under flink-end-to-end-tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature?**no**
  - If yes, how is the feature documented? **not applicable**
