### PR TITLE
[FLINK-14206][runtime] Let fullRestart metric count both full restarts and fine grained restarts

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -455,8 +455,6 @@ public class ExecutionGraph implements AccessExecutionGraph {
 			ScheduleMode scheduleMode,
 			boolean allowQueuedScheduling) throws IOException {
 
-		checkNotNull(futureExecutor);
-
 		this.jobInformation = Preconditions.checkNotNull(jobInformation);
 
 		this.blobWriter = Preconditions.checkNotNull(blobWriter);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -737,18 +737,6 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	}
 
 	/**
-	 * Gets the number of full restarts that the execution graph went through.
-	 * If a full restart recovery is currently pending, this recovery is included in the
-	 * count.
-	 *
-	 * @return The number of full restarts so far
-	 */
-	public long getNumberOfFullRestarts() {
-		// subtract one, because the version starts at one
-		return globalModVersion - 1;
-	}
-
-	/**
 	 * Gets the number of restarts, including full restarts and fine grained restarts.
 	 * If a recovery is currently pending, this recovery is included in the count.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -27,6 +27,8 @@ import org.apache.flink.api.common.accumulators.AccumulatorHelper;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
@@ -263,6 +265,9 @@ public class ExecutionGraph implements AccessExecutionGraph {
 
 	@Nullable
 	private InternalTaskFailuresListener internalTaskFailuresListener;
+
+	/** Counts all restarts. Used by other Gauges/Meters and does not register to metric group. */
+	private final Counter numberOfRestartsCounter = new SimpleCounter();
 
 	// ------ Configuration of the Execution -------
 
@@ -741,6 +746,16 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	public long getNumberOfFullRestarts() {
 		// subtract one, because the version starts at one
 		return globalModVersion - 1;
+	}
+
+	/**
+	 * Gets the number of restarts, including full restarts and fine grained restarts.
+	 * If a recovery is currently pending, this recovery is included in the count.
+	 *
+	 * @return The number of restarts so far
+	 */
+	public long getNumberOfRestarts() {
+		return numberOfRestartsCounter.getCount();
 	}
 
 	@Override
@@ -1365,7 +1380,12 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	}
 
 	private long incrementGlobalModVersion() {
+		incrementRestarts();
 		return GLOBAL_VERSION_UPDATER.incrementAndGet(this);
+	}
+
+	public void incrementRestarts() {
+		numberOfRestartsCounter.inc();
 	}
 
 	private void initFailureCause(Throwable t) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/AdaptedRestartPipelinedRegionStrategyNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/AdaptedRestartPipelinedRegionStrategyNG.java
@@ -107,6 +107,8 @@ public class AdaptedRestartPipelinedRegionStrategyNG extends FailoverStrategy {
 		final Set<ExecutionVertexVersion> vertexVersions = new HashSet<>(
 			executionVertexVersioner.recordVertexModifications(verticesToRestart).values());
 
+		executionGraph.incrementRestarts();
+
 		FutureUtils.assertNoException(
 			cancelTasks(verticesToRestart)
 				.thenComposeAsync(resetAndRescheduleTasks(globalModVersion, vertexVersions), executionGraph.getJobMasterMainThreadExecutor())

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/metrics/NumberOfFullRestartsGauge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/metrics/NumberOfFullRestartsGauge.java
@@ -42,6 +42,6 @@ public class NumberOfFullRestartsGauge implements Gauge<Long> {
 
 	@Override
 	public Long getValue() {
-		return eg.getNumberOfFullRestarts();
+		return eg.getNumberOfRestarts();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGFailoverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGFailoverTest.java
@@ -294,6 +294,23 @@ public class AdaptedRestartPipelinedRegionStrategyNGFailoverTest extends TestLog
 		assertNotEquals(globalModVersionBeforeFailure, globalModVersionAfterFailure);
 	}
 
+	@Test
+	public void testCountingRestarts() throws Exception {
+		final JobGraph jobGraph = createStreamingJobGraph();
+		final ExecutionGraph eg = createExecutionGraph(jobGraph);
+
+		final Iterator<ExecutionVertex> vertexIterator = eg.getAllExecutionVertices().iterator();
+		final ExecutionVertex ev11 = vertexIterator.next();
+
+		// trigger task failure for fine grained recovery
+		ev11.getCurrentExecutionAttempt().fail(new Exception("Test Exception"));
+		assertEquals(1, eg.getNumberOfRestarts());
+
+		// trigger global failover
+		eg.failGlobal(new Exception("Force failover global"));
+		assertEquals(2, eg.getNumberOfRestarts());
+	}
+
 	// ------------------------------- Test Utils -----------------------------------------
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -69,7 +69,6 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
 
-import org.junit.After;
 import org.junit.Test;
 
 import javax.annotation.Nonnull;
@@ -80,9 +79,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.Consumer;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.completeCancellingForAllVertices;
@@ -104,17 +100,10 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
 	private static final int NUM_TASKS = 31;
 
-	private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(4);
-
 	private static final ComponentMainThreadExecutor mainThreadExecutor =
 		ComponentMainThreadExecutorServiceAdapter.forMainThread();
 
 	private static final JobID TEST_JOB_ID = new JobID();
-
-	@After
-	public void shutdown() {
-		executor.shutdownNow();
-	}
 
 	// ------------------------------------------------------------------------
 
@@ -593,9 +582,6 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
 	@Test
 	public void testRestartWithEagerSchedulingAndSlotSharing() throws Exception {
-		// this test is inconclusive if not used with a proper multi-threaded executor
-		assertTrue("test assumptions violated", ((ThreadPoolExecutor) executor).getCorePoolSize() > 1);
-
 		final int parallelism = 20;
 
 		try (SlotPool slotPool = createSlotPoolImpl()) {
@@ -618,8 +604,6 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
 			final ExecutionGraph eg = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(TEST_JOB_ID, source, sink)
 				.setSlotProvider(scheduler)
-				.setIoExecutor(executor)
-				.setFutureExecutor(executor)
 				.setRestartStrategy(restartStrategy)
 				.setScheduleMode(ScheduleMode.EAGER)
 				.build();
@@ -650,9 +634,6 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
 	@Test
 	public void testRestartWithSlotSharingAndNotEnoughResources() throws Exception {
-		// this test is inconclusive if not used with a proper multi-threaded executor
-		assertTrue("test assumptions violated", ((ThreadPoolExecutor) executor).getCorePoolSize() > 1);
-
 		final int numRestarts = 10;
 		final int parallelism = 20;
 
@@ -679,8 +660,6 @@ public class ExecutionGraphRestartTest extends TestLogger {
 			final ExecutionGraph eg = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(TEST_JOB_ID, source, sink)
 				.setSlotProvider(scheduler)
 				.setRestartStrategy(restartStrategy)
-				.setIoExecutor(executor)
-				.setFutureExecutor(executor)
 				.setScheduleMode(ScheduleMode.EAGER)
 				.build();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -90,12 +90,12 @@ import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.cr
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.finishAllVertices;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.switchToRunning;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Tests the restart behaviour of the {@link ExecutionGraph}.
@@ -549,9 +549,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		eg.waitUntilTerminal();
 		assertEquals(JobStatus.FINISHED, eg.getState());
 
-		if (eg.getNumberOfFullRestarts() > 2) {
-			fail("Too many restarts: " + eg.getNumberOfFullRestarts());
-		}
+		assertThat("Too many restarts", eg.getNumberOfRestarts(), is(lessThanOrEqualTo(2L)));
 	}
 
 	/**
@@ -689,10 +687,8 @@ public class ExecutionGraphRestartTest extends TestLogger {
 			eg.start(mainThreadExecutor);
 			eg.scheduleForExecution();
 
-			// wait until no more changes happen
-			while (eg.getNumberOfFullRestarts() < numRestarts) {
-				Thread.sleep(1);
-			}
+			// the last suppressed restart is also counted
+			assertEquals(numRestarts + 1, eg.getNumberOfRestarts());
 
 			assertEquals(JobStatus.FAILED, eg.getState());
 


### PR DESCRIPTION

## What is the purpose of the change

With fine grained recovery introduced in 1.9.0, the fullRestart metric only counts how many times the entire graph has been restarted, not including the number of fine grained failure restarts.

As many users leverage this metric for failure detecting monitoring and alerting, this PR is to make it also count fine grained restarts.


## Brief change log

- Add a counter numberOfRestartsCounter in ExecutionGraph to count all restarts. The counter is not to be registered to metric groups.
- Let NumberOfFullRestartsGauge query the value of the counter, instead of ExecutionGraph#globalModVersion
- increment numberOfRestartCounter in ExecutionGraph#incrementGlobalModVersion()
- increment numberOfRestartCounter in AdaptedRestartPipelinedRegionStrategyNG#restartTasks


## Verifying this change

  - *Added tests for the new counter*
  - *This change to NumberOfFullRestartsGauge is already covered by existing tests.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
