### PR TITLE
[FLINK-14042] [flink-table-planner] Fix TemporalTable row schema always inferred as nullable

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/schema/FlinkTableFunctionImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/schema/FlinkTableFunctionImpl.scala
@@ -80,8 +80,15 @@ class FlinkTableFunctionImpl[T](
     val builder = flinkTypeFactory.builder
     fieldNames
       .zip(fieldTypes)
-      .foreach { f =>
-        builder.add(f._1, flinkTypeFactory.createTypeFromTypeInfo(f._2, isNullable = true))
+      .foreach {
+        case (fieldName, typeInfo) =>
+          val isNullable = !FlinkTypeFactory.isTimeIndicatorType(typeInfo)
+          builder
+            .add(
+              fieldName,
+              flinkTypeFactory
+                .createTypeFromTypeInfo(typeInfo, isNullable = isNullable)
+            )
       }
     builder.build
   }


### PR DESCRIPTION
## What is the purpose of the change
This fixes [FLINK-14042](https://issues.apache.org/jira/browse/FLINK-14042).

Fix a bug in the table planner where `FlinkTableFunctionImpl.getRow` would generate an incorrect type for schemas created for Temporal Tables 

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / **don't know**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
