### PR TITLE
[FLINK-14098] Support multiple statements for TableEnvironment.

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
@@ -52,7 +52,7 @@ public final class CliStrings {
 		.append(formatCommand(SqlCommand.RESET, "Resets all session configuration properties."))
 		.append(formatCommand(SqlCommand.SELECT, "Executes a SQL SELECT query on the Flink cluster."))
 		.append(formatCommand(SqlCommand.SET, "Sets a session configuration property. Syntax: 'SET <key>=<value>;'. Use 'SET;' for listing all properties."))
-		.append(formatCommand(SqlCommand.SHOW_FUNCTIONS, "Shows all registered user-defined functions."))
+		.append(formatCommand(SqlCommand.SHOW_FUNCTIONS, "Shows all system-defined and registered user-defined functions."))
 		.append(formatCommand(SqlCommand.SHOW_TABLES, "Shows all registered tables."))
 		.append(formatCommand(SqlCommand.SOURCE, "Reads a SQL SELECT query from a file and executes it on the Flink cluster."))
 		.append(formatCommand(SqlCommand.USE_CATALOG, "Sets the current catalog. The current database is set to the catalog's default one. Experimental! Syntax: 'USE CATALOG <name>;'"))

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
@@ -52,7 +52,7 @@ public final class CliStrings {
 		.append(formatCommand(SqlCommand.RESET, "Resets all session configuration properties."))
 		.append(formatCommand(SqlCommand.SELECT, "Executes a SQL SELECT query on the Flink cluster."))
 		.append(formatCommand(SqlCommand.SET, "Sets a session configuration property. Syntax: 'SET <key>=<value>;'. Use 'SET;' for listing all properties."))
-		.append(formatCommand(SqlCommand.SHOW_FUNCTIONS, "Shows all system-defined and registered user-defined functions."))
+		.append(formatCommand(SqlCommand.SHOW_FUNCTIONS, "Shows all registered user-defined functions."))
 		.append(formatCommand(SqlCommand.SHOW_TABLES, "Shows all registered tables."))
 		.append(formatCommand(SqlCommand.SOURCE, "Reads a SQL SELECT query from a file and executes it on the Flink cluster."))
 		.append(formatCommand(SqlCommand.USE_CATALOG, "Sets the current catalog. The current database is set to the catalog's default one. Experimental! Syntax: 'USE CATALOG <name>;'"))

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/api/java/internal/StreamTableEnvironmentImplTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/api/java/internal/StreamTableEnvironmentImplTest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -111,7 +112,7 @@ public class StreamTableEnvironmentImplTest {
 		}
 
 		@Override
-		public List<Operation> parse(String statement) {
+		public List<Operation> parse(String statement, Consumer<Operation> operationPreConsumer) {
 			throw new AssertionError("Should not be called");
 		}
 

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/api/java/internal/StreamTableEnvironmentImplTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/api/java/internal/StreamTableEnvironmentImplTest.java
@@ -112,7 +112,7 @@ public class StreamTableEnvironmentImplTest {
 		}
 
 		@Override
-		public List<Operation> parse(String statement, Consumer<Operation> operationPreConsumer) {
+		public Iterable<Operation> parse(String statement, Consumer<Operation> operationPreConsumer) {
 			throw new AssertionError("Should not be called");
 		}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
@@ -62,7 +62,7 @@ public interface Planner {
 	 * <p>The produced Operation trees should already be validated.
 	 *
 	 * @param statement the sql statement to evaluate
-	 * @param operationPreConsumer pre consumer for specific operations 
+	 * @param operationPreConsumer pre consumer for specific operations
 	 * @return parsed queries as trees of relational {@link Operation}s
 	 */
 	List<Operation> parse(String statement, Consumer<Operation> operationPreConsumer);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * This interface serves two purposes:
@@ -43,7 +44,7 @@ import java.util.List;
  * of {@link Planner#translate(List)} will strip any execution configuration from
  * the DataStream information.
  *
- * <p>All Tables referenced in either {@link Planner#parse(String)} or
+ * <p>All Tables referenced in either {@link Planner#parse(String, Consumer)} or
  * {@link Planner#translate(List)} should be previously registered in a
  * {@link org.apache.flink.table.catalog.CatalogManager}, which will be provided during
  * instantiation of the {@link Planner}.
@@ -61,9 +62,10 @@ public interface Planner {
 	 * <p>The produced Operation trees should already be validated.
 	 *
 	 * @param statement the sql statement to evaluate
+	 * @param operationPreConsumer pre consumer for specific operations
 	 * @return parsed queries as trees of relational {@link Operation}s
 	 */
-	List<Operation> parse(String statement);
+	List<Operation> parse(String statement, Consumer<Operation> operationPreConsumer);
 
 	/**
 	 * Converts a relational tree of {@link ModifyOperation}s into a set of runnable

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
@@ -65,7 +65,7 @@ public interface Planner {
 	 * @param operationPreConsumer pre consumer for specific operations
 	 * @return parsed queries as trees of relational {@link Operation}s
 	 */
-	List<Operation> parse(String statement, Consumer<Operation> operationPreConsumer);
+	Iterable<Operation> parse(String statement, Consumer<Operation> operationPreConsumer);
 
 	/**
 	 * Converts a relational tree of {@link ModifyOperation}s into a set of runnable

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
@@ -62,7 +62,7 @@ public interface Planner {
 	 * <p>The produced Operation trees should already be validated.
 	 *
 	 * @param statement the sql statement to evaluate
-	 * @param operationPreConsumer pre consumer for specific operations
+	 * @param operationPreConsumer pre consumer for specific operations 
 	 * @return parsed queries as trees of relational {@link Operation}s
 	 */
 	List<Operation> parse(String statement, Consumer<Operation> operationPreConsumer);

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/PlannerMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/PlannerMock.java
@@ -32,7 +32,7 @@ import java.util.function.Consumer;
 public class PlannerMock implements Planner {
 
 	@Override
-	public List<Operation> parse(String statement, Consumer<Operation> operationPreConsumer) {
+	public Iterable<Operation> parse(String statement, Consumer<Operation> operationPreConsumer) {
 		return null;
 	}
 

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/PlannerMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/PlannerMock.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.operations.ModifyOperation;
 import org.apache.flink.table.operations.Operation;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * Mocking {@link Planner} for tests.
@@ -31,7 +32,7 @@ import java.util.List;
 public class PlannerMock implements Planner {
 
 	@Override
-	public List<Operation> parse(String statement) {
+	public List<Operation> parse(String statement, Consumer<Operation> operationPreConsumer) {
 		return null;
 	}
 

--- a/flink-table/flink-table-api-scala-bridge/src/test/scala/org/apache/flink/table/api/scala/internal/StreamTableEnvironmentImplTest.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/test/scala/org/apache/flink/table/api/scala/internal/StreamTableEnvironmentImplTest.scala
@@ -32,6 +32,7 @@ import org.junit.Assert.assertThat
 import org.junit.Test
 
 import java.util.{Collections, List => JList}
+import java.util.function.Consumer
 
 /**
  * Tests for [[StreamTableEnvironmentImpl]].
@@ -94,7 +95,8 @@ class StreamTableEnvironmentImplTest {
   }
 
   private class TestPlanner(transformation: Transformation[_]) extends Planner {
-    override def parse(statement: String) = throw new AssertionError("Should not be called")
+    def parse(statement: String, operationPreConsumer: Consumer[Operation]) =
+      throw new AssertionError("Should not be called")
 
     override def translate(modifyOperations: JList[ModifyOperation])
       : JList[Transformation[_]] = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
@@ -31,7 +31,7 @@ import org.apache.calcite.rel.{RelFieldCollation, RelRoot}
 import org.apache.calcite.sql.advise.{SqlAdvisor, SqlAdvisorValidator}
 import org.apache.calcite.sql.parser.{SqlParser, SqlParseException => CSqlParseException}
 import org.apache.calcite.sql.validate.SqlValidator
-import org.apache.calcite.sql.{SqlKind, SqlNode, SqlOperatorTable}
+import org.apache.calcite.sql.{SqlKind, SqlNode, SqlNodeList, SqlOperatorTable}
 import org.apache.calcite.sql2rel.{RelDecorrelator, SqlRexConvertletTable, SqlToRelConverter}
 import org.apache.calcite.tools.{FrameworkConfig, RelConversionException}
 
@@ -109,12 +109,12 @@ class FlinkPlannerImpl(
     validator
   }
 
-  def parse(sql: String): SqlNode = {
+  def parse(sql: String): SqlNodeList = {
     try {
       ready()
       val parser: SqlParser = SqlParser.create(sql, parserConfig)
-      val sqlNode: SqlNode = parser.parseStmt
-      sqlNode
+      val sqlNodeList: SqlNodeList = parser.parseStmtList()
+      sqlNodeList
     } catch {
       case e: CSqlParseException =>
         throw new SqlParserException(s"SQL parse failed. ${e.getMessage}", e)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.catalog
 
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.api.internal.TableEnvironmentImpl
-import org.apache.flink.table.api.{EnvironmentSettings, TableEnvironment, TableException, ValidationException}
+import org.apache.flink.table.api.{EnvironmentSettings, TableEnvironment, ValidationException}
 import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory
 import org.apache.flink.types.Row
 
@@ -49,12 +49,6 @@ class CatalogTableITCase(isStreamingMode: Boolean) {
     toRow(1, "a"),
     toRow(2, "b"),
     toRow(3, "c")
-  )
-
-  private val DIM_DATA = List(
-    toRow(1, "aDim"),
-    toRow(2, "bDim"),
-    toRow(3, "cDim")
   )
 
   implicit def rowOrdering: Ordering[Row] = Ordering.by((r : Row) => {
@@ -94,7 +88,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) {
       toRow(2, "3000", 3)
     )
     TestCollectionTableFactory.initData(sourceData)
-    val sourceDDL =
+    val sql =
       """
         |create table t1(
         |  a int,
@@ -102,26 +96,18 @@ class CatalogTableITCase(isStreamingMode: Boolean) {
         |  c int
         |) with (
         |  'connector' = 'COLLECTION'
-        |)
-      """.stripMargin
-    val sinkDDL =
-      """
+        |);
         |create table t2(
         |  a int,
         |  b varchar,
         |  c int
         |) with (
         |  'connector' = 'COLLECTION'
-        |)
-      """.stripMargin
-    val query =
-      """
+        |);
         |insert into t2
         |select t1.a, t1.b, (t1.a + 1) as c from t1
       """.stripMargin
-    tableEnv.sqlUpdate(sourceDDL)
-    tableEnv.sqlUpdate(sinkDDL)
-    tableEnv.sqlUpdate(query)
+    tableEnv.sqlUpdate(sql)
     execJob("testJob")
     assertEquals(sourceData.sorted, TestCollectionTableFactory.RESULT.sorted)
   }
@@ -179,7 +165,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) {
       toRow(2, 3000, 1, 2)
     )
     TestCollectionTableFactory.initData(sourceData)
-    val sourceDDL =
+    val sql =
       """
         |create table t1(
         |  a int,
@@ -187,10 +173,8 @@ class CatalogTableITCase(isStreamingMode: Boolean) {
         |  c int
         |) with (
         |  'connector' = 'COLLECTION'
-        |)
-      """.stripMargin
-    val sinkDDL =
-      """
+        |);
+        |
         |create table t2(
         |  a int,
         |  b int,
@@ -198,19 +182,14 @@ class CatalogTableITCase(isStreamingMode: Boolean) {
         |  d int
         |) with (
         |  'connector' = 'COLLECTION'
-        |)
-      """.stripMargin
-    val query =
-      """
+        |);
         |insert into t2
         |select a.a, a.b, b.a, b.b
         |  from t1 a
         |  join t1 b
-        |  on a.a = b.b
+        |  on a.a = b.b;
       """.stripMargin
-    tableEnv.sqlUpdate(sourceDDL)
-    tableEnv.sqlUpdate(sinkDDL)
-    tableEnv.sqlUpdate(query)
+    tableEnv.sqlUpdate(sql)
     execJob("testJob")
     assertEquals(expected.sorted, TestCollectionTableFactory.RESULT.sorted)
   }
@@ -468,7 +447,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) {
         |  c varchar
         |) with (
         | 'connector' = 'COLLECTION'
-        |)
+        |);
       """.stripMargin
     val ddl2 =
       """

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/ExpressionTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/ExpressionTestBase.scala
@@ -180,7 +180,7 @@ abstract class ExpressionTestBase {
   private def addSqlTestExpr(sqlExpr: String, expected: String): Unit = {
     // create RelNode from SQL expression
     val parsed = calcitePlanner.parse(s"SELECT $sqlExpr FROM $tableName")
-    val validated = calcitePlanner.validate(parsed)
+    val validated = calcitePlanner.validate(parsed.get(0))
     val converted = calcitePlanner.rel(validated).rel
     addTestExpr(converted, expected, sqlExpr)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/match/PatternTranslatorTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/match/PatternTranslatorTestBase.scala
@@ -86,7 +86,7 @@ abstract class PatternTranslatorTestBase extends TestLogger {
          |FROM $tableName
          |$matchRecognize
          |""".stripMargin)
-    val validated = calcitePlanner.validate(parsed)
+    val validated = calcitePlanner.validate(parsed.get(0))
     val converted = calcitePlanner.rel(validated).rel
 
     val plannerBase = context._2

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -972,7 +972,7 @@ class TestingTableEnvironment private(
       throw new TableException(
         "Unsupported SQL query! sqlUpdate() only accepts a single SQL statement of type INSERT.")
     }
-    val operation = operations.get(0)
+    val operation = operations.iterator.next()
     operation match {
       case modifyOperation: ModifyOperation =>
         val modifyOperations = List(modifyOperation)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -39,7 +39,7 @@ import org.apache.flink.table.delegation.{Executor, ExecutorFactory, PlannerFact
 import org.apache.flink.table.expressions.Expression
 import org.apache.flink.table.factories.ComponentFactoryService
 import org.apache.flink.table.functions.{AggregateFunction, ScalarFunction, TableAggregateFunction, TableFunction, UserDefinedAggregateFunction, UserFunctionsTypeHelper}
-import org.apache.flink.table.operations.{CatalogSinkModifyOperation, ModifyOperation, QueryOperation}
+import org.apache.flink.table.operations.{CatalogSinkModifyOperation, ModifyOperation, Operation, QueryOperation}
 import org.apache.flink.table.planner.calcite.CalciteConfig
 import org.apache.flink.table.planner.delegation.PlannerBase
 import org.apache.flink.table.planner.operations.{DataStreamQueryOperation, PlannerQueryOperation, RichTableSourceQueryOperation}
@@ -66,6 +66,7 @@ import org.junit.Rule
 import org.junit.rules.{ExpectedException, TestName}
 
 import _root_.java.util
+import _root_.java.util.function.Consumer
 
 import _root_.scala.collection.JavaConversions._
 import _root_.scala.io.Source
@@ -964,7 +965,9 @@ class TestingTableEnvironment private(
   }
 
   override def sqlUpdate(stmt: String): Unit = {
-    val operations = planner.parse(stmt)
+    val operations = planner.parse(stmt, new Consumer[Operation] {
+      override def accept(t: Operation): Unit = {}
+    })
     if (operations.size != 1) {
       throw new TableException(
         "Unsupported SQL query! sqlUpdate() only accepts a single SQL statement of type INSERT.")

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -363,8 +363,16 @@ abstract class TableEnvImpl(
 
   override def sqlQuery(query: String): Table = {
     val planner = getFlinkPlanner
+
     // parse the sql query
-    val parsed = planner.parse(query)
+    val parsedList = planner.parse(query)
+    if (parsedList.size != 1) {
+      throw new ValidationException("Unsupported SQL query! " +
+        "sqlQuery() only accepts a single SQL query.")
+    }
+
+    val parsed = parsedList.get(0)
+
     if (null != parsed && parsed.getKind.belongsTo(SqlKind.QUERY)) {
       // validate the sql query
       val validated = planner.validate(parsed)
@@ -381,8 +389,8 @@ abstract class TableEnvImpl(
   override def sqlUpdate(stmt: String): Unit = {
     val planner = getFlinkPlanner
     // parse the sql query
-    val parsed = planner.parse(stmt)
-    parsed match {
+    val parsedList = planner.parse(stmt)
+    parsedList.foreach {
       case insert: RichSqlInsert =>
         // validate the insert
         val validatedInsert = planner.validate(insert).asInstanceOf[RichSqlInsert]

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/FlinkPlannerImpl.scala
@@ -34,7 +34,7 @@ import org.apache.calcite.schema.SchemaPlus
 import org.apache.calcite.sql.advise.{SqlAdvisor, SqlAdvisorValidator}
 import org.apache.calcite.sql.parser.{SqlParser, SqlParseException => CSqlParseException}
 import org.apache.calcite.sql.validate.SqlValidator
-import org.apache.calcite.sql.{SqlKind, SqlNode, SqlOperatorTable}
+import org.apache.calcite.sql.{SqlKind, SqlNode, SqlNodeList, SqlOperatorTable}
 import org.apache.calcite.sql2rel.{RelDecorrelator, SqlRexConvertletTable, SqlToRelConverter}
 import org.apache.calcite.tools.{FrameworkConfig, RelBuilder, RelConversionException}
 
@@ -111,12 +111,12 @@ class FlinkPlannerImpl(
     validator
   }
 
-  def parse(sql: String): SqlNode = {
+  def parse(sql: String): SqlNodeList = {
     try {
       ready()
       val parser: SqlParser = SqlParser.create(sql, parserConfig)
-      val sqlNode: SqlNode = parser.parseStmt
-      sqlNode
+      val sqlNodeList: SqlNodeList = parser.parseStmtList()
+      sqlNodeList
     } catch {
       case e: CSqlParseException =>
         throw new SqlParserException(s"SQL parse failed. ${e.getMessage}", e)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
@@ -124,7 +124,7 @@ public class SqlToOperationConverterTest {
 			"    'kafka.topic' = 'log.test'\n" +
 			")\n";
 		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
-		SqlNode node = planner.parse(sql);
+		SqlNode node = planner.parse(sql).get(0);
 		assert node instanceof SqlCreateTable;
 		Operation operation = SqlToOperationConverter.convert(planner, node);
 		assert operation instanceof CreateTableOperation;
@@ -153,7 +153,7 @@ public class SqlToOperationConverterTest {
 			"  'a.b-c-d.e-f1231.g' = 'ada',\n" +
 			"  'a.b-c-d.*' = 'adad')\n";
 		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
-		SqlNode node = planner.parse(sql);
+		SqlNode node = planner.parse(sql).get(0);
 		assert node instanceof SqlCreateTable;
 		Operation operation = SqlToOperationConverter.convert(planner, node);
 		assert operation instanceof CreateTableOperation;
@@ -187,7 +187,7 @@ public class SqlToOperationConverterTest {
 			"    'kafka.topic' = 'log.test'\n" +
 			")\n";
 		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
-		SqlNode node = planner.parse(sql);
+		SqlNode node = planner.parse(sql).get(0);
 		assert node instanceof SqlCreateTable;
 		SqlToOperationConverter.convert(planner, node);
 	}
@@ -196,7 +196,7 @@ public class SqlToOperationConverterTest {
 	public void testSqlInsertWithStaticPartition() {
 		final String sql = "insert into t1 partition(a=1) select b, c, d from t2";
 		FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.HIVE);
-		SqlNode node = planner.parse(sql);
+		SqlNode node = planner.parse(sql).get(0);
 		assert node instanceof RichSqlInsert;
 		Operation operation = SqlToOperationConverter.convert(planner, node);
 		assert operation instanceof CatalogSinkModifyOperation;
@@ -367,7 +367,7 @@ public class SqlToOperationConverterTest {
 		}
 		final String sql = buffer.toString();
 		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
-		SqlNode node = planner.parse(sql);
+		SqlNode node = planner.parse(sql).get(0);
 		assert node instanceof SqlCreateTable;
 		Operation operation = SqlToOperationConverter.convert(planner, node);
 		TableSchema schema = ((CreateTableOperation) operation).getCatalogTable().getSchema();
@@ -395,7 +395,7 @@ public class SqlToOperationConverterTest {
 		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
 		for (TestItem item : testItems) {
 			String sql = String.format(sqlTemplate, item.testExpr);
-			SqlNode node = planner.parse(sql);
+			SqlNode node = planner.parse(sql).get(0);
 			assert node instanceof SqlCreateTable;
 			expectedEx.expect(TableException.class);
 			expectedEx.expectMessage(item.expectedError);

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/utils/ExpressionTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/utils/ExpressionTestBase.scala
@@ -179,7 +179,7 @@ abstract class ExpressionTestBase {
 
   private def addSqlTestExpr(sqlExpr: String, expected: String): Unit = {
     // create RelNode from SQL expression
-    val parsed = planner.parse(s"SELECT $sqlExpr FROM $tableName")
+    val parsed = planner.parse(s"SELECT $sqlExpr FROM $tableName").get(0)
     val validated = planner.validate(parsed)
     val converted = planner.rel(validated).rel
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/match/PatternTranslatorTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/match/PatternTranslatorTestBase.scala
@@ -79,7 +79,7 @@ abstract class PatternTranslatorTestBase extends TestLogger{
         override def accept(t: Operation): Unit = {}
       })
 
-    val queryOperation = parsed.get(0).asInstanceOf[QueryOperation]
+    val queryOperation = parsed.iterator.next().asInstanceOf[QueryOperation]
     val relNode = context._3.getRelBuilder.tableOperation(queryOperation).build()
 
     val optimized = context._3.optimizer

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/match/PatternTranslatorTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/match/PatternTranslatorTestBase.scala
@@ -26,7 +26,7 @@ import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironm
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.scala.internal.StreamTableEnvironmentImpl
-import org.apache.flink.table.operations.QueryOperation
+import org.apache.flink.table.operations.{Operation, QueryOperation}
 import org.apache.flink.table.plan.nodes.datastream.{DataStreamMatch, DataStreamScan}
 import org.apache.flink.table.planner.StreamPlanner
 import org.apache.flink.types.Row
@@ -35,6 +35,8 @@ import org.junit.Assert._
 import org.junit.rules.ExpectedException
 import org.junit.{ComparisonFailure, Rule}
 import org.mockito.Mockito.{mock, when}
+
+import java.util.function.Consumer
 
 abstract class PatternTranslatorTestBase extends TestLogger{
 
@@ -73,7 +75,9 @@ abstract class PatternTranslatorTestBase extends TestLogger{
          |SELECT *
          |FROM $tableName
          |$matchRecognize
-         |""".stripMargin)
+         |""".stripMargin, new Consumer[Operation] {
+        override def accept(t: Operation): Unit = {}
+      })
 
     val queryOperation = parsed.get(0).asInstanceOf[QueryOperation]
     val relNode = context._3.getRelBuilder.tableOperation(queryOperation).build()


### PR DESCRIPTION
Currently TableEnvironment.sqlUpdate supports single sql statement parsing by invoking SqlParser.parseStmt. Actually, Calcite’s SqlParser is able to parse multiple sql statements split by semicolon, It’s user-friendly to refactor TableEnvironment.sqlUpdate to support multiple sql statements too, by invoking SqlParser.parseStmtList instead.

@wuchong Appreciate if you get time to take a look into this MR.