### PR TITLE
[FLINK-14040][travis] Enable MiniCluster tests based on schedulerNG in Flink cron build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,14 @@ jobs:
       env: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11"
       name: tests
     - if: type in (pull_request, push)
+      script: ./tools/travis_controller.sh scheduler_ng_core
+      env: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11"
+      name: core - scheduler_ng
+    - if: type in (pull_request, push)
+      script: ./tools/travis_controller.sh scheduler_ng_tests
+      env: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11"
+      name: tests - scheduler_ng
+    - if: type in (pull_request, push)
       script: ./tools/travis_controller.sh misc
       env: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11"
       name: misc

--- a/tools/travis/stage.sh
+++ b/tools/travis/stage.sh
@@ -25,6 +25,8 @@ STAGE_BLINK_PLANNER="blink_planner"
 STAGE_CONNECTORS="connectors"
 STAGE_KAFKA_GELLY="kafka/gelly"
 STAGE_TESTS="tests"
+STAGE_SCHEDULER_NG_CORE="scheduler_ng_core"
+STAGE_SCHEDULER_NG_TESTS="scheduler_ng_tests"
 STAGE_MISC="misc"
 STAGE_CLEANUP="cleanup"
 
@@ -158,6 +160,12 @@ function get_compile_modules_for_stage() {
         (${STAGE_TESTS})
             echo "-pl $MODULES_TESTS -am"
         ;;
+        (${STAGE_SCHEDULER_NG_CORE})
+            echo "-pl $MODULES_CORE -am"
+        ;;
+        (${STAGE_SCHEDULER_NG_TESTS})
+            echo "-pl $MODULES_TESTS -am"
+        ;;
         (${STAGE_MISC})
             # compile everything; using the -am switch does not work with negated module lists!
             # the negation takes precedence, thus not all required modules would be built
@@ -200,6 +208,12 @@ function get_test_modules_for_stage() {
         ;;
         (${STAGE_TESTS})
             echo "-pl $modules_tests"
+        ;;
+        (${STAGE_SCHEDULER_NG_CORE})
+            echo "-Dscheduler-ng -pl $MODULES_CORE"
+        ;;
+        (${STAGE_SCHEDULER_NG_TESTS})
+            echo "-Dscheduler-ng -pl $MODULES_TESTS"
         ;;
         (${STAGE_MISC})
             echo "-pl $modules_misc"


### PR DESCRIPTION

## What is the purpose of the change

Before making SchedulerNG the default scheduler, we need to guarantee all the MiniCluster tests can pass with it.
This PR is to enabled MiniCluster tests based on schedulerNG in Flink cron build.

## Brief change log

  - *Add a new stage in Flink travis and run it in cron builds*


## Verifying this change

This change is manually verified by triggering Flink cron build and checking its running results.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
