### PR TITLE
[FLINK-14251] Add FutureUtils#forward utility

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -1066,4 +1066,21 @@ public class FutureUtils {
 			throw suppressedExceptions;
 		}
 	}
+
+	/**
+	 * Forwards the value from the source future to the target future.
+	 *
+	 * @param source future to forward the value from
+	 * @param target future to forward the value to
+	 * @param <T> type of the value
+	 */
+	public static <T> void forward(CompletableFuture<T> source, CompletableFuture<T> target) {
+		source.whenComplete((value, throwable) -> {
+			if (throwable != null) {
+				target.completeExceptionally(throwable);
+			} else {
+				target.complete(value);
+			}
+		});
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -172,11 +172,10 @@ public class ZooKeeperUtils {
 	 * @param client        The {@link CuratorFramework} ZooKeeper client to use
 	 * @param configuration {@link Configuration} object containing the configuration values
 	 * @return {@link ZooKeeperLeaderRetrievalService} instance.
-	 * @throws Exception
 	 */
 	public static ZooKeeperLeaderRetrievalService createLeaderRetrievalService(
 		final CuratorFramework client,
-		final Configuration configuration) throws Exception {
+		final Configuration configuration) {
 		return createLeaderRetrievalService(client, configuration, "");
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
@@ -48,6 +48,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.emptyArray;
@@ -764,5 +765,49 @@ public class FutureUtilsTest extends TestLogger {
 		private boolean hasBeenCalled() {
 			return exception != null;
 		}
+	}
+
+	@Test
+	public void testForwardNormal() throws Exception {
+		final CompletableFuture<String> source = new CompletableFuture<>();
+		final CompletableFuture<String> target = new CompletableFuture<>();
+
+		FutureUtils.forward(source, target);
+
+		assertThat(target.isDone(), is(source.isDone()));
+
+		source.complete("foobar");
+
+		assertThat(target.isDone(), is(source.isDone()));
+		assertThat(target.get(), is(equalTo(source.get())));
+	}
+
+	@Test
+	public void testForwardExceptionally() {
+		final CompletableFuture<String> source = new CompletableFuture<>();
+		final CompletableFuture<String> target = new CompletableFuture<>();
+
+		FutureUtils.forward(source, target);
+
+		assertThat(target.isDone(), is(source.isDone()));
+
+		source.completeExceptionally(new FlinkException("foobar"));
+
+		assertThat(target.isDone(), is(source.isDone()));
+
+		Throwable targetException = getThrowable(target);
+		Throwable actualException = getThrowable(source);
+
+		assertThat(targetException, is(equalTo(actualException)));
+	}
+
+	private static Throwable getThrowable(CompletableFuture<?> completableFuture) {
+		try {
+			completableFuture.join();
+		} catch (CompletionException e) {
+			return e.getCause();
+		}
+
+		throw new AssertionError("Future has not been completed exceptionally.");
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR is based on #9771. 

The forward function completes the second future with the result of the first
future.

## Verifying this change

- Added `FutureUtils#testForwardNormal`, `#testForwardExceptionally`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
