### PR TITLE
[FLINK-14248][runtime] Let LazyFromSourcesSchedulingStrategy restart terminated tasks

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/LazyFromSourcesSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/LazyFromSourcesSchedulingStrategy.java
@@ -102,6 +102,7 @@ public class LazyFromSourcesSchedulingStrategy implements SchedulingStrategy {
 		final Set<SchedulingExecutionVertex> verticesToSchedule = schedulingTopology.getVertexOrThrow(executionVertexId)
 			.getProducedResultPartitions()
 			.stream()
+			.filter(partition -> partition.getPartitionType().isBlocking())
 			.flatMap(partition -> inputConstraintChecker.markSchedulingResultPartitionFinished(partition).stream())
 			.flatMap(partition -> partition.getConsumers().stream())
 			.collect(Collectors.toSet());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingExecutionVertex.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingExecutionVertex.java
@@ -41,6 +41,8 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
 
 	private InputDependencyConstraint inputDependencyConstraint;
 
+	private ExecutionState state = ExecutionState.CREATED;
+
 	public TestingSchedulingExecutionVertex(JobVertexID jobVertexId, int subtaskIndex) {
 		this(jobVertexId, subtaskIndex, InputDependencyConstraint.ANY);
 	}
@@ -70,7 +72,7 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
 
 	@Override
 	public ExecutionState getState() {
-		return ExecutionState.CREATED;
+		return state;
 	}
 
 	@Override
@@ -94,5 +96,10 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
 
 	void addProducedPartition(SchedulingResultPartition partition) {
 		producedPartitions.add(partition);
+	}
+
+	public TestingSchedulingExecutionVertex transitionState(ExecutionState state) {
+		this.state = state;
+		return this;
 	}
 }


### PR DESCRIPTION

## What is the purpose of the change

LazyFromSourcesSchedulingStrategy now will only schedule tasks in CREATED state.
However, the DefaultScheduler will reset failed tasks when actually restarting them.
This makes failed tasks not able to be restarted with LazyFromSourcesSchedulingStrategy.

This PR is to make LazyFromSourcesSchedulingStrategy restart a task when and only it's in terminal state. 


## Brief change log

  - *Make LazyFromSourcesSchedulingStrategy restart a task when and only it's in terminal state*


## Verifying this change

The existing task restart tests are reworked and they covers this change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
