### PR TITLE
[FLINK-14247][runtime] Use NoResourceAvailableException to wrap TimeoutException on slot allocation timeout

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/NoResourceAvailableException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/NoResourceAvailableException.java
@@ -22,36 +22,19 @@ import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.throwable.ThrowableAnnotation;
 import org.apache.flink.runtime.throwable.ThrowableType;
 
+/**
+ * Indicates resource allocation failures.
+ */
 @ThrowableAnnotation(ThrowableType.NonRecoverableError)
 public class NoResourceAvailableException extends JobException {
 
 	private static final long serialVersionUID = -2249953165298717803L;
-	
+
 	private static final String BASE_MESSAGE = "Not enough free slots available to run the job. "
-			+ "You can decrease the operator parallelism or increase the number of slots per TaskManager in the configuration.";
+		+ "You can decrease the operator parallelism or increase the number of slots per TaskManager in the configuration.";
 
 	public NoResourceAvailableException() {
 		super(BASE_MESSAGE);
-	}
-	
-	public NoResourceAvailableException(ScheduledUnit unit) {
-		super("No resource available to schedule unit " + unit
-				+ ". You can decrease the operator parallelism or increase the number of slots per TaskManager in the configuration.");
-	}
-
-	public NoResourceAvailableException(int numInstances, int numSlotsTotal, int availableSlots) {
-		super(String.format("%s Resources available to scheduler: Number of instances=%d, total number of slots=%d, available slots=%d",
-				BASE_MESSAGE, numInstances, numSlotsTotal, availableSlots));
-	}
-	
-	NoResourceAvailableException(ScheduledUnit task, int numInstances, int numSlotsTotal, int availableSlots) {
-		super(String.format("%s Task to schedule: < %s > with groupID < %s > in sharing group < %s >. Resources available to scheduler: Number of instances=%d, total number of slots=%d, available slots=%d",
-				BASE_MESSAGE, task.getTaskToExecute(),
-				task.getCoLocationConstraint() == null ? task.getTaskToExecute().getVertex().getJobvertexId() : task.getCoLocationConstraint().getGroupId(),
-				task.getSlotSharingGroupId(),
-				numInstances,
-				numSlotsTotal,
-				availableSlots));
 	}
 
 	public NoResourceAvailableException(String message) {
@@ -63,14 +46,13 @@ public class NoResourceAvailableException extends JobException {
 	}
 
 	// --------------------------------------------------------------------------------------------
-	
+
 	@Override
 	public boolean equals(Object obj) {
-		return obj instanceof NoResourceAvailableException && 
-				getMessage().equals(((NoResourceAvailableException) obj).getMessage());
-
+		return obj instanceof NoResourceAvailableException &&
+			getMessage().equals(((NoResourceAvailableException) obj).getMessage());
 	}
-	
+
 	@Override
 	public int hashCode() {
 		return getMessage().hashCode();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/NoResourceAvailableException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/NoResourceAvailableException.java
@@ -19,13 +19,10 @@
 package org.apache.flink.runtime.jobmanager.scheduler;
 
 import org.apache.flink.runtime.JobException;
-import org.apache.flink.runtime.throwable.ThrowableAnnotation;
-import org.apache.flink.runtime.throwable.ThrowableType;
 
 /**
  * Indicates resource allocation failures.
  */
-@ThrowableAnnotation(ThrowableType.NonRecoverableError)
 public class NoResourceAvailableException extends JobException {
 
 	private static final long serialVersionUID = -2249953165298717803L;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -375,7 +375,7 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 		final Throwable strippedThrowable = ExceptionUtils.stripCompletionException(failure);
 		if (strippedThrowable instanceof TimeoutException) {
 			return new NoResourceAvailableException("Could not allocate the required slot within slot request timeout. " +
-				"Please make sure that the cluster has enough resources.");
+				"Please make sure that the cluster has enough resources.", failure);
 		} else {
 			return failure;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -371,7 +371,7 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 		};
 	}
 
-	private Throwable maybeWrapWithNoResourceAvailableException(final Throwable failure) {
+	private static Throwable maybeWrapWithNoResourceAvailableException(final Throwable failure) {
 		final Throwable strippedThrowable = ExceptionUtils.stripCompletionException(failure);
 		if (strippedThrowable instanceof TimeoutException) {
 			return new NoResourceAvailableException("Could not allocate the required slot within slot request timeout. " +

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.executiongraph.restart.ThrowingRestartStrategy;
 import org.apache.flink.runtime.io.network.partition.PartitionTracker;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
@@ -45,6 +46,7 @@ import org.apache.flink.runtime.scheduler.strategy.SchedulingStrategy;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingStrategyFactory;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.util.ExceptionUtils;
 
 import org.slf4j.Logger;
 
@@ -59,6 +61,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -362,10 +365,20 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 					.registerProducedPartitions(logicalSlot.getTaskManagerLocation(), sendScheduleOrUpdateConsumerMessage);
 				executionVertex.tryAssignResource(logicalSlot);
 			} else {
-				handleTaskFailure(executionVertexId, throwable);
+				handleTaskFailure(executionVertexId, maybeWrapWithNoResourceAvailableException(throwable));
 			}
 			return null;
 		};
+	}
+
+	private Throwable maybeWrapWithNoResourceAvailableException(final Throwable failure) {
+		final Throwable strippedThrowable = ExceptionUtils.stripCompletionException(failure);
+		if (strippedThrowable instanceof TimeoutException) {
+			return new NoResourceAvailableException("Could not allocate the required slot within slot request timeout. " +
+				"Please make sure that the cluster has enough resources.");
+		} else {
+			return failure;
+		}
 	}
 
 	private BiFunction<Object, Throwable, Void> deployOrHandleError(final DeploymentHandle deploymentHandle) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleSlotProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleSlotProvider.java
@@ -112,13 +112,10 @@ public class SimpleSlotProvider implements SlotProvider, SlotOwner {
 					.createTestingLogicalSlot();
 				allocatedSlots.put(slotRequestId, slot);
 				return CompletableFuture.completedFuture(result);
-			}
-			else {
-				if (allowQueued) {
-					return FutureUtils.completedExceptionally(new TimeoutException());
-				} else {
-					return FutureUtils.completedExceptionally(new NoResourceAvailableException());
-				}
+			} else if (allowQueued) {
+				return FutureUtils.completedExceptionally(new TimeoutException());
+			} else {
+				return FutureUtils.completedExceptionally(new NoResourceAvailableException());
 			}
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleSlotProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleSlotProvider.java
@@ -46,6 +46,7 @@ import java.net.InetAddress;
 import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -113,7 +114,11 @@ public class SimpleSlotProvider implements SlotProvider, SlotOwner {
 				return CompletableFuture.completedFuture(result);
 			}
 			else {
-				return FutureUtils.completedExceptionally(new NoResourceAvailableException());
+				if (allowQueued) {
+					return FutureUtils.completedExceptionally(new TimeoutException());
+				} else {
+					return FutureUtils.completedExceptionally(new NoResourceAvailableException());
+				}
 			}
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
@@ -61,7 +61,6 @@ import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 
 import org.hamcrest.Matchers;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -71,13 +70,13 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import static junit.framework.TestCase.assertTrue;
 import static org.apache.flink.util.ExceptionUtils.findThrowable;
 import static org.apache.flink.util.ExceptionUtils.findThrowableWithMessage;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link DefaultScheduler}.
@@ -249,7 +248,7 @@ public class DefaultSchedulerTest extends TestLogger {
 			.getException()
 			.deserializeError(DefaultSchedulerTest.class.getClassLoader());
 		assertTrue(findThrowable(failureCause, NoResourceAvailableException.class).isPresent());
-		Assert.assertTrue(
+		assertTrue(
 			findThrowableWithMessage(
 				failureCause,
 				"Could not allocate the required slot within slot request timeout.").isPresent());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/throwable/ThrowableClassifierTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/throwable/ThrowableClassifierTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.throwable;
 
 import org.apache.flink.runtime.execution.SuppressRestartsException;
-import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
@@ -37,9 +36,6 @@ public class ThrowableClassifierTest extends TestLogger {
 	public void testThrowableType_NonRecoverable() {
 		assertEquals(ThrowableType.NonRecoverableError,
 			ThrowableClassifier.getThrowableType(new SuppressRestartsException(new Exception(""))));
-
-		assertEquals(ThrowableType.NonRecoverableError,
-			ThrowableClassifier.getThrowableType(new NoResourceAvailableException()));
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/throwable/ThrowableClassifierTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/throwable/ThrowableClassifierTest.java
@@ -16,14 +16,12 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.executiongraph;
+package org.apache.flink.runtime.throwable;
 
 import org.apache.flink.runtime.execution.SuppressRestartsException;
 import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
-import org.apache.flink.runtime.throwable.ThrowableAnnotation;
-import org.apache.flink.runtime.throwable.ThrowableClassifier;
-import org.apache.flink.runtime.throwable.ThrowableType;
 import org.apache.flink.util.TestLogger;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -31,8 +29,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Test throwable classifier
- * */
+ * Test {@link ThrowableClassifier}.
+ */
 public class ThrowableClassifierTest extends TestLogger {
 
 	@Test
@@ -49,25 +47,25 @@ public class ThrowableClassifierTest extends TestLogger {
 		assertEquals(ThrowableType.RecoverableError,
 			ThrowableClassifier.getThrowableType(new Exception("")));
 		assertEquals(ThrowableType.RecoverableError,
-			ThrowableClassifier.getThrowableType(new ThrowableType_RecoverableFailure_Exception()));
+			ThrowableClassifier.getThrowableType(new TestRecoverableErrorException()));
 	}
 
 	@Test
 	public void testThrowableType_EnvironmentError() {
 		assertEquals(ThrowableType.EnvironmentError,
-			ThrowableClassifier.getThrowableType(new ThrowableType_EnvironmentError_Exception()));
+			ThrowableClassifier.getThrowableType(new TestEnvironmentErrorException()));
 	}
 
 	@Test
 	public void testThrowableType_PartitionDataMissingError() {
 		assertEquals(ThrowableType.PartitionDataMissingError,
-			ThrowableClassifier.getThrowableType(new ThrowableType_PartitionDataMissingError_Exception()));
+			ThrowableClassifier.getThrowableType(new TestPartitionDataMissingErrorException()));
 	}
 
 	@Test
 	public void testThrowableType_InheritError() {
 		assertEquals(ThrowableType.PartitionDataMissingError,
-			ThrowableClassifier.getThrowableType(new Sub_ThrowableType_PartitionDataMissingError_Exception()));
+			ThrowableClassifier.getThrowableType(new TestPartitionDataMissingErrorSubException()));
 	}
 
 	@Test
@@ -79,40 +77,40 @@ public class ThrowableClassifierTest extends TestLogger {
 
 		// no recoverable throwable type
 		assertFalse(ThrowableClassifier.findThrowableOfThrowableType(
-			new ThrowableType_PartitionDataMissingError_Exception(),
+			new TestPartitionDataMissingErrorException(),
 			ThrowableType.RecoverableError).isPresent());
 
 		// direct recoverable throwable
 		assertTrue(ThrowableClassifier.findThrowableOfThrowableType(
-			new ThrowableType_RecoverableFailure_Exception(),
+			new TestRecoverableErrorException(),
 			ThrowableType.RecoverableError).isPresent());
 
 		// nested recoverable throwable
 		assertTrue(ThrowableClassifier.findThrowableOfThrowableType(
-			new Exception(new ThrowableType_RecoverableFailure_Exception()),
+			new Exception(new TestRecoverableErrorException()),
 			ThrowableType.RecoverableError).isPresent());
 
 		// inherit recoverable throwable
 		assertTrue(ThrowableClassifier.findThrowableOfThrowableType(
-			new Sub_ThrowableType_RecoverableFailure_Exception(),
+			new TestRecoverableFailureSubException(),
 			ThrowableType.RecoverableError).isPresent());
 	}
 
 	@ThrowableAnnotation(ThrowableType.PartitionDataMissingError)
-	private class ThrowableType_PartitionDataMissingError_Exception extends Exception {
+	private class TestPartitionDataMissingErrorException extends Exception {
 	}
 
 	@ThrowableAnnotation(ThrowableType.EnvironmentError)
-	private class ThrowableType_EnvironmentError_Exception extends Exception {
+	private class TestEnvironmentErrorException extends Exception {
 	}
 
 	@ThrowableAnnotation(ThrowableType.RecoverableError)
-	private class ThrowableType_RecoverableFailure_Exception extends Exception {
+	private class TestRecoverableErrorException extends Exception {
 	}
 
-	private class Sub_ThrowableType_PartitionDataMissingError_Exception extends ThrowableType_PartitionDataMissingError_Exception {
+	private class TestPartitionDataMissingErrorSubException extends TestPartitionDataMissingErrorException {
 	}
 
-	private class Sub_ThrowableType_RecoverableFailure_Exception extends ThrowableType_RecoverableFailure_Exception {
+	private class TestRecoverableFailureSubException extends TestRecoverableErrorException {
 	}
 }


### PR DESCRIPTION

## What is the purpose of the change

This PR is to use NoResourceAvailableException to wrap TimeoutException on slot allocation timeout. This makes the error easier to understand for users.


## Brief change log

  - *Use NoResourceAvailableException to wrap TimeoutException on slot allocation timeout before triggering error handling*
  - *other hotfix changes see each commit*


## Verifying this change

  - *Added unit tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
