### PR TITLE
[FLINK-14253][table-planner-blink] Add hash distribution and sort grouping only when dynamic partition insert

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/RelTimeIndicatorConverter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/RelTimeIndicatorConverter.scala
@@ -185,7 +185,8 @@ class RelTimeIndicatorConverter(rexBuilder: RexBuilder) extends RelShuttle {
         newInput,
         sink.sink,
         sink.sinkName,
-        sink.catalogTable)
+        sink.catalogTable,
+        sink.staticPartitions)
 
     case _ =>
       throw new TableException(s"Unsupported logical operator: ${other.getClass.getSimpleName}")

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/LogicalSink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/LogicalSink.scala
@@ -39,12 +39,13 @@ final class LogicalSink(
     input: RelNode,
     sink: TableSink[_],
     sinkName: String,
-    val catalogTable: CatalogTable)
+    val catalogTable: CatalogTable,
+    val staticPartitions: Map[String, String])
   extends Sink(cluster, traitSet, input, sink, sinkName) {
 
   override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
     new LogicalSink(
-      cluster, traitSet, inputs.head, sink, sinkName, catalogTable)
+      cluster, traitSet, inputs.head, sink, sinkName, catalogTable, staticPartitions)
   }
 
 }
@@ -54,9 +55,10 @@ object LogicalSink {
   def create(input: RelNode,
       sink: TableSink[_],
       sinkName: String,
-      catalogTable: CatalogTable = null): LogicalSink = {
+      catalogTable: CatalogTable = null,
+      staticPartitions: Map[String, String] = Map()): LogicalSink = {
     val traits = input.getCluster.traitSetOf(Convention.NONE)
     new LogicalSink(
-      input.getCluster, traits, input, sink, sinkName, catalogTable)
+      input.getCluster, traits, input, sink, sinkName, catalogTable, staticPartitions)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalSink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalSink.scala
@@ -41,13 +41,14 @@ class FlinkLogicalSink(
     input: RelNode,
     sink: TableSink[_],
     sinkName: String,
-    val catalogTable: CatalogTable)
+    val catalogTable: CatalogTable,
+    val staticPartitions: Map[String, String])
   extends Sink(cluster, traitSet, input, sink, sinkName)
   with FlinkLogicalRel {
 
   override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
     new FlinkLogicalSink(
-      cluster, traitSet, inputs.head, sink, sinkName, catalogTable)
+      cluster, traitSet, inputs.head, sink, sinkName, catalogTable, staticPartitions)
   }
 
 }
@@ -66,7 +67,8 @@ private class FlinkLogicalSinkConverter
       newInput,
       sink.sink,
       sink.sinkName,
-      sink.catalogTable)
+      sink.catalogTable,
+      sink.staticPartitions)
   }
 }
 
@@ -77,10 +79,11 @@ object FlinkLogicalSink {
       input: RelNode,
       sink: TableSink[_],
       sinkName: String,
-      catalogTable: CatalogTable = null): FlinkLogicalSink = {
+      catalogTable: CatalogTable = null,
+      staticPartitions: Map[String, String] = Map()): FlinkLogicalSink = {
     val cluster = input.getCluster
     val traitSet = cluster.traitSetOf(FlinkConventions.LOGICAL).simplify()
     new FlinkLogicalSink(
-      cluster, traitSet, input, sink, sinkName, catalogTable)
+      cluster, traitSet, input, sink, sinkName, catalogTable, staticPartitions)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecSinkRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecSinkRule.scala
@@ -45,18 +45,23 @@ class StreamExecSinkRule extends ConverterRule(
     if (sinkNode.catalogTable != null && sinkNode.catalogTable.isPartitioned) {
       sinkNode.sink match {
         case partitionSink: PartitionableTableSink =>
-          val partKeys = sinkNode.catalogTable.getPartitionKeys
-          val partitionIndices = partKeys
-              .map(partitionSink.getTableSchema.getFieldNames.indexOf(_))
+          partitionSink.setStaticPartition(sinkNode.staticPartitions)
+          val dynamicPartFields = sinkNode.catalogTable.getPartitionKeys
+              .filter(!sinkNode.staticPartitions.contains(_))
 
-          if (partitionSink.configurePartitionGrouping(false)) {
-            throw new TableException("Partition grouping in stream mode is not supported yet!")
-          }
+          if (dynamicPartFields.nonEmpty) {
+            val dynamicPartIndices =
+              dynamicPartFields.map(partitionSink.getTableSchema.getFieldNames.indexOf(_))
 
-          if (!partitionSink.isInstanceOf[DataStreamTableSink[_]]) {
-            requiredTraitSet = requiredTraitSet.plus(
-              FlinkRelDistribution.hash(partitionIndices
-                  .map(Integer.valueOf), requireStrict = false))
+            if (partitionSink.configurePartitionGrouping(false)) {
+              throw new TableException("Partition grouping in stream mode is not supported yet!")
+            }
+
+            if (!partitionSink.isInstanceOf[DataStreamTableSink[_]]) {
+              requiredTraitSet = requiredTraitSet.plus(
+                FlinkRelDistribution.hash(dynamicPartIndices
+                    .map(Integer.valueOf), requireStrict = false))
+            }
           }
         case _ => throw new TableException("We need PartitionableTableSink to write data to" +
             s" partitioned table: ${sinkNode.sinkName}")

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testDynamic">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO sink SELECT a, b, c FROM MyTable]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSink(name=[sink], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Sink(name=[sink], fields=[a, b, c])
++- Sort(orderBy=[b ASC, c ASC])
+   +- Exchange(distribution=[hash[b, c]])
+      +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartial">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO sink PARTITION (b=1) SELECT a, c FROM MyTable]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSink(name=[sink], fields=[a, b, c])
++- LogicalProject(a=[$0], EXPR$1=[1:BIGINT], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Sink(name=[sink], fields=[a, b, c])
++- Sort(orderBy=[c ASC])
+   +- Exchange(distribution=[hash[c]])
+      +- Calc(select=[a, 1:BIGINT AS EXPR$1, c])
+         +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testStatic">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO sink PARTITION (b=1, c=1) SELECT a FROM MyTable]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSink(name=[sink], fields=[a, b, c])
++- LogicalProject(a=[$0], EXPR$1=[1:BIGINT], EXPR$2=[1:BIGINT])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Sink(name=[sink], fields=[a, b, c])
++- Calc(select=[a, 1:BIGINT AS EXPR$1, 1:BIGINT AS EXPR$2])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testWrongFields">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO sink PARTITION (b=1) SELECT a, b, c FROM MyTable]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testWrongStatic">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO sink PARTITION (a=1) SELECT b, c FROM MyTable]]>
+
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.xml
@@ -23,7 +23,7 @@ limitations under the License.
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalSink(name=[sink], fields=[a, b, c])
+LogicalSink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c])
 +- LogicalProject(a=[$0], b=[$1], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
@@ -31,7 +31,7 @@ LogicalSink(name=[sink], fields=[a, b, c])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Sink(name=[sink], fields=[a, b, c])
+Sink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c])
 +- Sort(orderBy=[b ASC, c ASC])
    +- Exchange(distribution=[hash[b, c]])
       +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
@@ -46,7 +46,7 @@ Sink(name=[sink], fields=[a, b, c])
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalSink(name=[sink], fields=[a, b, c])
+LogicalSink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c])
 +- LogicalProject(a=[$0], EXPR$1=[1:BIGINT], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
@@ -54,7 +54,7 @@ LogicalSink(name=[sink], fields=[a, b, c])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Sink(name=[sink], fields=[a, b, c])
+Sink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c])
 +- Sort(orderBy=[c ASC])
    +- Exchange(distribution=[hash[c]])
       +- Calc(select=[a, 1:BIGINT AS EXPR$1, c])
@@ -70,7 +70,7 @@ Sink(name=[sink], fields=[a, b, c])
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalSink(name=[sink], fields=[a, b, c])
+LogicalSink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c])
 +- LogicalProject(a=[$0], EXPR$1=[1:BIGINT], EXPR$2=[1:BIGINT])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
@@ -78,7 +78,7 @@ LogicalSink(name=[sink], fields=[a, b, c])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Sink(name=[sink], fields=[a, b, c])
+Sink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c])
 +- Calc(select=[a, 1:BIGINT AS EXPR$1, 1:BIGINT AS EXPR$2])
    +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/PartitionableSinkTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/PartitionableSinkTest.xml
@@ -23,7 +23,7 @@ limitations under the License.
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalSink(name=[sink], fields=[a, b, c])
+LogicalSink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c])
 +- LogicalProject(a=[$0], b=[$1], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
@@ -31,7 +31,7 @@ LogicalSink(name=[sink], fields=[a, b, c])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Sink(name=[sink], fields=[a, b, c])
+Sink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c])
 +- Exchange(distribution=[hash[b, c]])
    +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
@@ -45,7 +45,7 @@ Sink(name=[sink], fields=[a, b, c])
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalSink(name=[sink], fields=[a, b, c])
+LogicalSink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c])
 +- LogicalProject(a=[$0], EXPR$1=[1:BIGINT], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
@@ -53,7 +53,7 @@ LogicalSink(name=[sink], fields=[a, b, c])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Sink(name=[sink], fields=[a, b, c])
+Sink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c])
 +- Exchange(distribution=[hash[c]])
    +- Calc(select=[a, 1:BIGINT AS EXPR$1, c])
       +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
@@ -68,7 +68,7 @@ Sink(name=[sink], fields=[a, b, c])
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalSink(name=[sink], fields=[a, b, c])
+LogicalSink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c])
 +- LogicalProject(a=[$0], EXPR$1=[1:BIGINT], EXPR$2=[1:BIGINT])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
@@ -76,7 +76,7 @@ LogicalSink(name=[sink], fields=[a, b, c])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Sink(name=[sink], fields=[a, b, c])
+Sink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c])
 +- Calc(select=[a, 1:BIGINT AS EXPR$1, 1:BIGINT AS EXPR$2])
    +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/PartitionableSinkTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/PartitionableSinkTest.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testDynamic">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO sink SELECT a, b, c FROM MyTable]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSink(name=[sink], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Sink(name=[sink], fields=[a, b, c])
++- Exchange(distribution=[hash[b, c]])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartial">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO sink PARTITION (b=1) SELECT a, c FROM MyTable]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSink(name=[sink], fields=[a, b, c])
++- LogicalProject(a=[$0], EXPR$1=[1:BIGINT], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Sink(name=[sink], fields=[a, b, c])
++- Exchange(distribution=[hash[c]])
+   +- Calc(select=[a, 1:BIGINT AS EXPR$1, c])
+      +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testStatic">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO sink PARTITION (b=1, c=1) SELECT a FROM MyTable]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSink(name=[sink], fields=[a, b, c])
++- LogicalProject(a=[$0], EXPR$1=[1:BIGINT], EXPR$2=[1:BIGINT])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Sink(name=[sink], fields=[a, b, c])
++- Calc(select=[a, 1:BIGINT AS EXPR$1, 1:BIGINT AS EXPR$2])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testWrongFields">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO sink PARTITION (b=1) SELECT a, b, c FROM MyTable]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testWrongStatic">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO sink PARTITION (a=1) SELECT b, c FROM MyTable]]>
+
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.batch.sql
+
+import org.apache.flink.api.common.typeinfo.{TypeInformation, Types}
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.api.{SqlDialect, TableConfig, ValidationException}
+import org.apache.flink.table.planner.runtime.batch.sql.PartitionableSinkITCase
+import org.apache.flink.table.planner.utils.TableTestBase
+
+import org.junit.Test
+
+class PartitionableSinkTest extends TableTestBase {
+
+  val conf = new TableConfig
+  conf.setSqlDialect(SqlDialect.HIVE)
+  private val util = batchTestUtil(conf)
+  util.addTableSource[(Long, Long, Long)]("MyTable", 'a, 'b, 'c)
+  PartitionableSinkITCase.registerTableSink(
+    util.tableEnv,
+    "sink",
+    new RowTypeInfo(
+      Array[TypeInformation[_]](Types.LONG, Types.LONG, Types.LONG),
+      Array("a", "b", "c")),
+    grouping = true,
+    Array("b", "c"))
+
+  @Test
+  def testStatic(): Unit = {
+    util.verifySqlUpdate("INSERT INTO sink PARTITION (b=1, c=1) SELECT a FROM MyTable")
+  }
+
+  @Test
+  def testDynamic(): Unit = {
+    util.verifySqlUpdate("INSERT INTO sink SELECT a, b, c FROM MyTable")
+  }
+
+  @Test
+  def testPartial(): Unit = {
+    util.verifySqlUpdate("INSERT INTO sink PARTITION (b=1) SELECT a, c FROM MyTable")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testWrongStatic(): Unit = {
+    util.verifySqlUpdate("INSERT INTO sink PARTITION (a=1) SELECT b, c FROM MyTable")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testWrongFields(): Unit = {
+    util.verifySqlUpdate("INSERT INTO sink PARTITION (b=1) SELECT a, b, c FROM MyTable")
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/PartitionableSinkTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/PartitionableSinkTest.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.stream.sql
+
+import org.apache.flink.api.common.typeinfo.{TypeInformation, Types}
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.api.{SqlDialect, TableConfig, ValidationException}
+import org.apache.flink.table.planner.runtime.batch.sql.PartitionableSinkITCase
+import org.apache.flink.table.planner.utils.TableTestBase
+
+import org.junit.Test
+
+class PartitionableSinkTest extends TableTestBase {
+
+  val conf = new TableConfig
+  conf.setSqlDialect(SqlDialect.HIVE)
+  private val util = streamTestUtil(conf)
+  util.addTableSource[(Long, Long, Long)]("MyTable", 'a, 'b, 'c)
+  PartitionableSinkITCase.registerTableSink(
+    util.tableEnv,
+    "sink",
+    new RowTypeInfo(
+      Array[TypeInformation[_]](Types.LONG, Types.LONG, Types.LONG),
+      Array("a", "b", "c")),
+    grouping = false,
+    Array("b", "c"))
+
+  @Test
+  def testStatic(): Unit = {
+    util.verifySqlUpdate("INSERT INTO sink PARTITION (b=1, c=1) SELECT a FROM MyTable")
+  }
+
+  @Test
+  def testDynamic(): Unit = {
+    util.verifySqlUpdate("INSERT INTO sink SELECT a, b, c FROM MyTable")
+  }
+
+  @Test
+  def testPartial(): Unit = {
+    util.verifySqlUpdate("INSERT INTO sink PARTITION (b=1) SELECT a, c FROM MyTable")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testWrongStatic(): Unit = {
+    util.verifySqlUpdate("INSERT INTO sink PARTITION (a=1) SELECT b, c FROM MyTable")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testWrongFields(): Unit = {
+    util.verifySqlUpdate("INSERT INTO sink PARTITION (b=1) SELECT a, b, c FROM MyTable")
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

Now in BatchExecSinkRule, we don't have static partitions, if it is a partitioned table, will add hash distribution and sort grouping. It is wrong:
1.  Group only when dynamic partition insert (not all partition fields are static partitions)
2.  We can just hash and sort dynamic partition fields instead of all partition fields.


## Verifying this change

stream and batch PartitionedSinkTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no