### PR TITLE
[FLINK-14059][core] Introduce option allVerticesInSameSlotSharingGroupByDefault in ExecutionConfig

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -160,6 +160,9 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	/** The default input dependency constraint to schedule tasks. */
 	private InputDependencyConstraint defaultInputDependencyConstraint = InputDependencyConstraint.ANY;
 
+	/** Flag to indicate whether to put all vertices into the same slot sharing group by default. */
+	private boolean allVerticesInSameSlotSharingGroupByDefault = true;
+
 	// ------------------------------- User code values --------------------------------------------
 
 	private GlobalJobParameters globalJobParameters = new GlobalJobParameters();
@@ -566,6 +569,32 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	@PublicEvolving
 	public InputDependencyConstraint getDefaultInputDependencyConstraint() {
 		return defaultInputDependencyConstraint;
+	}
+
+	/**
+	 * Enables to put all vertices into the same slot sharing group by default.
+	 */
+	@Internal
+	public void enableAllVerticesInSameSlotSharingGroupByDefault() {
+		this.allVerticesInSameSlotSharingGroupByDefault = true;
+	}
+
+	/**
+	 * Disables to put all vertices into the same slot sharing group by default.
+	 */
+	@Internal
+	public void disableAllVerticesInSameSlotSharingGroupByDefault() {
+		this.allVerticesInSameSlotSharingGroupByDefault = false;
+	}
+
+	/**
+	 * Gets whether to put all vertices into the same slot sharing group by default.
+	 *
+	 * @return whether to put all vertices into the same slot sharing group by default.
+	 */
+	@Internal
+	public boolean isAllVerticesInSameSlotSharingGroupByDefault() {
+		return allVerticesInSameSlotSharingGroupByDefault;
 	}
 
 	/**
@@ -996,7 +1025,8 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 				registeredPojoTypes.equals(other.registeredPojoTypes) &&
 				taskCancellationIntervalMillis == other.taskCancellationIntervalMillis &&
 				useSnapshotCompression == other.useSnapshotCompression &&
-				defaultInputDependencyConstraint == other.defaultInputDependencyConstraint;
+				defaultInputDependencyConstraint == other.defaultInputDependencyConstraint &&
+				allVerticesInSameSlotSharingGroupByDefault == other.allVerticesInSameSlotSharingGroupByDefault;
 
 		} else {
 			return false;
@@ -1024,7 +1054,8 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 			registeredPojoTypes,
 			taskCancellationIntervalMillis,
 			useSnapshotCompression,
-			defaultInputDependencyConstraint);
+			defaultInputDependencyConstraint,
+			allVerticesInSameSlotSharingGroupByDefault);
 	}
 
 	public boolean canEqual(Object obj) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/BatchExecutor.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/BatchExecutor.java
@@ -67,6 +67,7 @@ public class BatchExecutor extends ExecutorBase {
 		if (isShuffleModeAllBatch()) {
 			executionConfig.setDefaultInputDependencyConstraint(InputDependencyConstraint.ALL);
 		}
+		executionConfig.disableAllVerticesInSameSlotSharingGroupByDefault();
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/delegation/BatchExecutorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/delegation/BatchExecutorTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.delegation;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.environment.LocalStreamEnvironment;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.operators.StreamSource;
+import org.apache.flink.streaming.api.transformations.SourceTransformation;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Test for {@link BatchExecutor}.
+ */
+public class BatchExecutorTest extends TestLogger {
+
+	private final BatchExecutor batchExecutor;
+
+	private final StreamGraph streamGraph;
+
+	public BatchExecutorTest() {
+		batchExecutor = new BatchExecutor(LocalStreamEnvironment.getExecutionEnvironment());
+		batchExecutor.setTableConfig(new TableConfig());
+
+		final Transformation testTransform = new SourceTransformation<>(
+			"MockTransform",
+			new StreamSource<>(new SourceFunction<String>() {
+				@Override
+				public void run(SourceContext<String> ctx) {
+				}
+
+				@Override
+				public void cancel() {
+				}
+			}),
+			BasicTypeInfo.STRING_TYPE_INFO,
+			1);
+
+		streamGraph = batchExecutor.generateStreamGraph(Collections.singletonList(testTransform), "Test Job");
+	}
+
+	@Test
+	public void testAllVerticesInSameSlotSharingGroupByDefaultIsDisabled() {
+		assertFalse(streamGraph.getExecutionConfig().isAllVerticesInSameSlotSharingGroupByDefault());
+	}
+}


### PR DESCRIPTION

## What is the purpose of the change

This PR is to introduce option allVerticesInSameSlotSharingGroupByDefault in ExecutionConfig.
It's true by default for DataSet and streaming jobs so that tasks can be scheduled with slots not fewer than the max parallelism.
It's false for blink batch jobs so that vertices can we can have finer resource planning regarding pipelined regions.


## Brief change log

*(for example:)*
  - *Introduced option allVerticesInSameSlotSharingGroupByDefault in ExecutionConfig. The default value is true.*
  - *Set the option to false for blink batch jobs*


## Verifying this change


  - *Added unit tests for blink batch job generation*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
