### PR TITLE
[FLINK-14176][web]Web Ui add log url for taskmanager of vertex

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-vertex-task-manager.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-vertex-task-manager.ts
@@ -50,4 +50,5 @@ export interface VertexTaskManagerDetailInterface {
     RUNNING: number;
     SCHEDULED: number;
   };
+  'taskmanager-id': string;
 }

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/taskmanagers/job-overview-drawer-taskmanagers.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/taskmanagers/job-overview-drawer-taskmanagers.component.html
@@ -21,12 +21,13 @@
   [nzSize]="'small'"
   [nzLoading]="isLoading"
   [nzData]="listOfTaskManager"
-  [nzScroll]="{x:'1450px',y:'calc( 100% - 35px )'}"
+  [nzScroll]="{x:'1460px',y:'calc( 100% - 35px )'}"
   [nzFrontPagination]="false"
   [nzShowPagination]="false">
   <thead (nzSortChange)="sort($event)" nzSingleSort>
     <tr>
-      <th nzWidth="160px" nzLeft="0px" nzShowSort nzSortKey="host">Host</th>
+      <th nzWidth="120px" nzLeft="0px" nzShowSort nzSortKey="host">Host</th>
+      <th nzWidth="50px" nzLeft="120px">LOG</th>
       <th nzWidth="150px" nzShowSort nzSortKey="metrics.read-bytes">Bytes received</th>
       <th nzWidth="150px" nzShowSort nzSortKey="metrics.read-records">Records received</th>
       <th nzWidth="120px" nzShowSort nzSortKey="metrics.write-bytes">Bytes sent</th>
@@ -40,7 +41,13 @@
   </thead>
   <tbody>
     <tr *ngFor="let taskManager of listOfTaskManager; trackBy:trackTaskManagerBy;">
-      <td nzLeft="0px">{{ taskManager.host }}</td>
+      <td nzLeft="0px" nzWidth="120px">{{ taskManager.host }}</td>
+      <td nzLeft="120px">
+        <span *ngIf="!taskManager['taskmanager-id'] || taskManager['taskmanager-id'] === '(unassigned)'; else hrefTpl">-</span>
+        <ng-template #hrefTpl>
+          <a [routerLink]="['/task-manager',taskManager['taskmanager-id'],'logs']" target="_blank">LOG</a>
+        </ng-template>
+      </td>
       <td>
         <span *ngIf="taskManager.metrics['read-bytes-complete'];else loadingTemplate">
           {{ taskManager.metrics['read-bytes'] | humanizeBytes }}


### PR DESCRIPTION
## What is the purpose of the change
This pull request adds log link for taskmanager in the page of job's vertex. Then it's easy for user seeing log.


## Brief change log
- The VertexTaskManagerDetailInterface in job-vertex-task-manager.ts add taskmanager-id.
- job-overview-drawer-taskmanagers.component.html add log logic.



## Verifying this change
no


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable)