### PR TITLE
[FLINK-13360][documentation] Add documentation for HBase connector for Table API & SQL

### DIFF
--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1101,6 +1101,29 @@ To use this connector, add the following dependency to your project:
 
 The connector can be defined as follows:
 
+<div class="codetabs" markdown="1">
+<div data-lang="YAML" markdown="1">
+{% highlight yaml %}
+connector:
+  type: hbase
+  version: 1.4.3                 # required: valid connector versions are "1.4.3"
+  
+  table-name: "hbase_table_name" # required: hbase table name
+  
+  zookeeper:
+    quorum: "localhost:2181"     # required: HBase Zookeeper quorum configuration
+    znode.parent: "/test"        # required: the root dir in Zookeeper for HBase cluster
+    
+  write.buffer-flush:
+    max-size: 1048576            # optional: Write option, sets when to flush a buffered request
+                                 # based on the memory size of rows currently added.
+    max-rows: 1                  # optional: Write option, sets when to flush buffered 
+                                 # request based on the number of rows currently added.
+    interval: 1                  # optional: Write option, sets a flush interval flushing buffered 
+                                 # requesting if the interval passes, in milliseconds.
+{% endhighlight %}
+</div>
+
 <div data-lang="DDL" markdown="1">
 {% highlight sql %}
 CREATE TABLE MyUserTable (
@@ -1115,7 +1138,7 @@ CREATE TABLE MyUserTable (
   'connector.table-name' = 'hbase_table_name',  -- required: hbase table name
   
   'connector.zookeeper.quorum' = 'localhost:2181', -- required: HBase Zookeeper quorum configuration
-  'connector.zookeeper.znode.parent' = '/test',  -- rquired: the root dir in Zookeeper for HBase cluster
+  'connector.zookeeper.znode.parent' = '/test',  -- required: the root dir in Zookeeper for HBase cluster
 
   'connector.write.buffer-flush.max-size' = '1048576', -- optional: Write option, sets when to flush a buffered request
                                                        -- based on the memory size of rows currently added.
@@ -1132,11 +1155,11 @@ CREATE TABLE MyUserTable (
 
 **Columns:** All the column families in HBase table must be declared as `ROW` type, the field name maps to the column family name, and the nested field names map to the column qualifier names. There is no need to declare all the families and qualifiers in the schema, users can declare what's necessary. Except the `ROW` type fields, the only one field of atomic type (e.g. `STRING`, `BIGINT`) will be recognized as row key of the table. There's no constraints on the name of row key field. 
 
-**HBase config:** If need to configure Config for HBase, create default configuration from current runtime env (`hbase-site.xml` in classpath) first, and overwrite configuration using serialized configuration from client-side env (`hbase-site.xml` in classpath).
-
 **Temporary join:** Lookup join against HBase do not use any caching; data is always queired directly through the HBase client.
 
 **Rowkey:** Empty string rowkey values are currently unsupported.
+
+**Java/Scala/Python API:** Java/Scala/Python APIs are not supported yet.
 
 {% top %}
 

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1075,6 +1075,69 @@ CREATE TABLE MyUserTable (
 
 {% top %}
 
+### HBase Connector
+
+<span class="label label-primary">Source: Batch</span>
+<span class="label label-primary">Sink: Batch</span>
+<span class="label label-primary">Sink: Streaming Append Mode</span>
+<span class="label label-primary">Sink: Streaming Upsert Mode</span>
+<span class="label label-primary">Temporal Join: Sync Mode</span>
+
+The HBase connector allows for writing into an HBase cluster.
+
+The connector can operate in [upsert mode](#update-modes) for exchanging UPSERT/DELETE messages with the external system using a [key defined by the query](./streaming/dynamic_tables.html#table-to-stream-conversion).
+
+For append-only queries, the connector can also operate in [append mode](#update-modes) for exchanging only INSERT messages with the external system.
+
+To use this connector, add the following dependency to your project:
+
+{% highlight xml %}
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-connector-hbase{{ site.scala_version_suffix }}</artifactId>
+  <version>{{site.version }}</version>
+</dependency>
+{% endhighlight %}
+
+The connector can be defined as follows:
+
+<div data-lang="DDL" markdown="1">
+{% highlight sql %}
+CREATE TABLE MyUserTable (
+  hbase_rowkey_name rowkey_type,
+  hbase_column_family_name1 ROW<...>,
+  hbase_column_family_name2 ROW<...>
+) WITH (
+  'connector.type' = 'hbase', -- required: specify this table type is hbase
+  
+  'connector.version' = '1.4.3',          -- required: valid connector versions are "1.4.3"
+  
+  'connector.table-name' = 'hbase_table_name',  -- required: hbase table name
+  
+  'connector.zookeeper.quorum' = 'quorum_url', -- required: hbase zookeeper config
+  'connector.zookeeper.znode.parent' = 'znode',
+
+  'connector.write.buffer-flush.max-size' = '1048576', -- required: Write option, sets when to flush a buffered request
+                                                       -- based on the memory size of rows currently added.
+
+  'connector.write.buffer-flush.max-rows' = '1', -- required: Write option, sets when to flush buffered 
+                                                    -- request based on the number of rows currently added.
+
+  'connector.write.buffer-flush.interval' = '1', -- required: Write option, sets a flush interval flushing buffered 
+                                                 -- requesting if the interval passes, in milliseconds.
+)
+{% endhighlight %}
+</div>
+</div>
+
+**Column family:** Values other than rowKey must be declared by column families. So need to wrap values with the SQL ROW function before inserting into hbase table.
+
+**HBase config:** If need to configure Config for HBase, create default configuration from current runtime env (`hbase-site.xml` in classpath) first, and overwrite configuration using serialized configuration from client-side env (`hbase-site.xml` in classpath).
+
+**Temporary join:** The Lookup Join of HBase does not use any caching, and every time the data is accessed directly to the client Api of HBase.
+
+{% top %}
+
 Table Formats
 -------------
 

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1083,8 +1083,7 @@ CREATE TABLE MyUserTable (
 <span class="label label-primary">Sink: Streaming Upsert Mode</span>
 <span class="label label-primary">Temporal Join: Sync Mode</span>
 
-The HBase connector allows for reading from an HBase cluster.
-The HBase connector allows for writing into an HBase cluster.
+The HBase connector allows for reading from and writing to an HBase cluster.
 
 The connector can operate in [upsert mode](#update-modes) for exchanging UPSERT/DELETE messages with the external system using a [key defined by the query](./streaming/dynamic_tables.html#table-to-stream-conversion).
 

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1131,7 +1131,7 @@ CREATE TABLE MyUserTable (
 </div>
 </div>
 
-**Column family:** Values other than rowKey must be declared by column families. So need to wrap values with the SQL ROW function before inserting into hbase table.
+**Column family:** Values other than `rowKey` must be declared as column families, and all column family values must be wrapped with the SQL ROW function before being inserted into HBase table.
 
 **HBase config:** If need to configure Config for HBase, create default configuration from current runtime env (`hbase-site.xml` in classpath) first, and overwrite configuration using serialized configuration from client-side env (`hbase-site.xml` in classpath).
 

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1137,7 +1137,7 @@ CREATE TABLE MyUserTable (
 
 **Temporary join:** Lookup join against HBase do not use any caching; data is always queired directly through the HBase client.
 
-**Rowkey:** User should confirm rowkey should not be empty string. (waiting for support)
+**Rowkey:** Empty string rowkey values are currently unsupported.
 
 {% top %}
 

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1096,7 +1096,7 @@ To use this connector, add the following dependency to your project:
 <dependency>
   <groupId>org.apache.flink</groupId>
   <artifactId>flink-connector-hbase{{ site.scala_version_suffix }}</artifactId>
-  <version>{{site.version }}</version>
+  <version>{{ site.version }}</version>
 </dependency>
 {% endhighlight %}
 

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1130,7 +1130,7 @@ CREATE TABLE MyUserTable (
 </div>
 </div>
 
-**Column family:** Values other than `rowKey` must be declared as column families, and all column family values must be wrapped with the SQL ROW function before being inserted into HBase table.
+**Columns:** All the column families in HBase table must be declared as `ROW` type, the field name maps to the column family name, and the nested field names map to the column qualifier names. There is no need to declare all the families and qualifiers in the schema, users can declare what's necessary. Except the `ROW` type fields, the only one field of atomic type (e.g. `STRING`, `BIGINT`) will be recognized as row key of the table. There's no constraints on the name of row key field. 
 
 **HBase config:** If need to configure Config for HBase, create default configuration from current runtime env (`hbase-site.xml` in classpath) first, and overwrite configuration using serialized configuration from client-side env (`hbase-site.xml` in classpath).
 

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1143,7 +1143,7 @@ CREATE TABLE MyUserTable (
   'connector.write.buffer-flush.max-size' = '10mb', -- optional: writing option, determines how many size in memory of buffered rows to insert per round trip. This can help performance on writing to JDBC database. The default value is "2mb".
                                                        -- based on the memory size of rows currently added.
 
-  'connector.write.buffer-flush.max-rows' = '1', -- optional: Write option, sets when to flush buffered 
+  'connector.write.buffer-flush.max-rows' = '1000', -- optional: writing option, determines how many rows to insert per round trip. This can help performance on writing to JDBC database. No default value, i.e. the default flushing is not depends on the number of buffered rows.
                                                     -- request based on the number of rows currently added.
 
   'connector.write.buffer-flush.interval' = '1', -- optional: Write option, sets a flush interval flushing buffered 

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1083,6 +1083,7 @@ CREATE TABLE MyUserTable (
 <span class="label label-primary">Sink: Streaming Upsert Mode</span>
 <span class="label label-primary">Temporal Join: Sync Mode</span>
 
+The HBase connector allows for reading from an HBase cluster.
 The HBase connector allows for writing into an HBase cluster.
 
 The connector can operate in [upsert mode](#update-modes) for exchanging UPSERT/DELETE messages with the external system using a [key defined by the query](./streaming/dynamic_tables.html#table-to-stream-conversion).
@@ -1117,13 +1118,13 @@ CREATE TABLE MyUserTable (
   'connector.zookeeper.quorum' = 'quorum_url', -- required: hbase zookeeper config
   'connector.zookeeper.znode.parent' = 'znode',
 
-  'connector.write.buffer-flush.max-size' = '1048576', -- required: Write option, sets when to flush a buffered request
+  'connector.write.buffer-flush.max-size' = '1048576', -- optional: Write option, sets when to flush a buffered request
                                                        -- based on the memory size of rows currently added.
 
-  'connector.write.buffer-flush.max-rows' = '1', -- required: Write option, sets when to flush buffered 
+  'connector.write.buffer-flush.max-rows' = '1', -- optional: Write option, sets when to flush buffered 
                                                     -- request based on the number of rows currently added.
 
-  'connector.write.buffer-flush.interval' = '1', -- required: Write option, sets a flush interval flushing buffered 
+  'connector.write.buffer-flush.interval' = '1', -- optional: Write option, sets a flush interval flushing buffered 
                                                  -- requesting if the interval passes, in milliseconds.
 )
 {% endhighlight %}
@@ -1135,6 +1136,8 @@ CREATE TABLE MyUserTable (
 **HBase config:** If need to configure Config for HBase, create default configuration from current runtime env (`hbase-site.xml` in classpath) first, and overwrite configuration using serialized configuration from client-side env (`hbase-site.xml` in classpath).
 
 **Temporary join:** The Lookup Join of HBase does not use any caching, and every time the data is accessed directly to the client Api of HBase.
+
+**Rowkey:** User should confirm rowkey should not be empty string. (waiting for support)
 
 {% top %}
 

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1135,7 +1135,7 @@ CREATE TABLE MyUserTable (
 
 **HBase config:** If need to configure Config for HBase, create default configuration from current runtime env (`hbase-site.xml` in classpath) first, and overwrite configuration using serialized configuration from client-side env (`hbase-site.xml` in classpath).
 
-**Temporary join:** The Lookup Join of HBase does not use any caching, and every time the data is accessed directly to the client Api of HBase.
+**Temporary join:** Lookup join against HBase do not use any caching; data is always queired directly through the HBase client.
 
 **Rowkey:** User should confirm rowkey should not be empty string. (waiting for support)
 

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1115,7 +1115,7 @@ CREATE TABLE MyUserTable (
   'connector.table-name' = 'hbase_table_name',  -- required: hbase table name
   
   'connector.zookeeper.quorum' = 'localhost:2181', -- required: HBase Zookeeper quorum configuration
-  'connector.zookeeper.znode.parent' = 'znode',
+  'connector.zookeeper.znode.parent' = '/test',  -- rquired: the root dir in Zookeeper for HBase cluster
 
   'connector.write.buffer-flush.max-size' = '1048576', -- optional: Write option, sets when to flush a buffered request
                                                        -- based on the memory size of rows currently added.

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1140,7 +1140,7 @@ CREATE TABLE MyUserTable (
   'connector.zookeeper.quorum' = 'localhost:2181', -- required: HBase Zookeeper quorum configuration
   'connector.zookeeper.znode.parent' = '/test',  -- required: the root dir in Zookeeper for HBase cluster
 
-  'connector.write.buffer-flush.max-size' = '1048576', -- optional: Write option, sets when to flush a buffered request
+  'connector.write.buffer-flush.max-size' = '10mb', -- optional: writing option, determines how many size in memory of buffered rows to insert per round trip. This can help performance on writing to JDBC database. The default value is "2mb".
                                                        -- based on the memory size of rows currently added.
 
   'connector.write.buffer-flush.max-rows' = '1', -- optional: Write option, sets when to flush buffered 

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1114,7 +1114,7 @@ CREATE TABLE MyUserTable (
   
   'connector.table-name' = 'hbase_table_name',  -- required: hbase table name
   
-  'connector.zookeeper.quorum' = 'quorum_url', -- required: hbase zookeeper config
+  'connector.zookeeper.quorum' = 'localhost:2181', -- required: HBase Zookeeper quorum configuration
   'connector.zookeeper.znode.parent' = 'znode',
 
   'connector.write.buffer-flush.max-size' = '1048576', -- optional: Write option, sets when to flush a buffered request

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1104,15 +1104,15 @@ connector:
   zookeeper:
     quorum: "localhost:2181"     # required: HBase Zookeeper quorum configuration
     znode.parent: "/test"        # required: the root dir in Zookeeper for HBase cluster
-    
+  
   write.buffer-flush:
-    max-size: 1048576            # optional: writing option, determines how many size in memory of buffered
+    max-size: "10mb"             # optional: writing option, determines how many size in memory of buffered
                                  # rows to insert per round trip. This can help performance on writing to JDBC
                                  # database. The default value is "2mb".
-    max-rows: 1                  # optional: writing option, determines how many rows to insert per round trip.
-                                 #This can help performance on writing to JDBC database. No default value,
+    max-rows: 1000               # optional: writing option, determines how many rows to insert per round trip.
+                                 # This can help performance on writing to JDBC database. No default value,
                                  # i.e. the default flushing is not depends on the number of buffered rows.
-    interval: 1                  # optional: writing option, sets a flush interval flushing buffered requesting
+    interval: "2s"               # optional: writing option, sets a flush interval flushing buffered requesting
                                  # if the interval passes, in milliseconds. Default value is "0s", which means
                                  # no asynchronous flush thread will be scheduled.
 {% endhighlight %}


### PR DESCRIPTION
## What is the purpose of the change

Add documentation for HBase connector for Table

## Verifying this change

without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no