### PR TITLE
[FLINK-13983][runtime] Launch task executor with new memory calculation logics

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.configuration;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Time;
 
 import javax.annotation.Nonnull;
@@ -31,6 +32,7 @@ import java.util.Set;
 
 import static org.apache.flink.configuration.MetricOptions.SYSTEM_RESOURCE_METRICS;
 import static org.apache.flink.configuration.MetricOptions.SYSTEM_RESOURCE_METRICS_PROBING_INTERVAL;
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * Utility class for {@link Configuration} related helper functions.
@@ -172,6 +174,62 @@ public class ConfigurationUtils {
 	@Nonnull
 	private static String[] splitPaths(@Nonnull String separatedPaths) {
 		return separatedPaths.length() > 0 ? separatedPaths.split(",|" + File.pathSeparator) : EMPTY;
+	}
+
+	@VisibleForTesting
+	public static Map<String, String> parseTmResourceDynamicConfigs(String dynamicConfigsStr) {
+		Map<String, String> configs = new HashMap<>();
+		String[] configStrs = dynamicConfigsStr.split(" ");
+
+		checkArgument(configStrs.length % 2 == 0);
+		for (int i = 0; i < configStrs.length; ++i) {
+			String configStr = configStrs[i];
+			if (i % 2 == 0) {
+				checkArgument(configStr.equals("-D"));
+			} else {
+				String[] configKV = configStr.split("=");
+				checkArgument(configKV.length == 2);
+				configs.put(configKV[0], configKV[1]);
+			}
+		}
+
+		checkArgument(configs.containsKey(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY.key()));
+		checkArgument(configs.containsKey(TaskManagerOptions.TASK_HEAP_MEMORY.key()));
+		checkArgument(configs.containsKey(TaskManagerOptions.TASK_OFF_HEAP_MEMORY.key()));
+		checkArgument(configs.containsKey(TaskManagerOptions.SHUFFLE_MEMORY_MAX.key()));
+		checkArgument(configs.containsKey(TaskManagerOptions.SHUFFLE_MEMORY_MIN.key()));
+		checkArgument(configs.containsKey(TaskManagerOptions.MANAGED_MEMORY_SIZE.key()));
+		checkArgument(configs.containsKey(TaskManagerOptions.MANAGED_MEMORY_OFFHEAP_SIZE.key()));
+
+		return configs;
+	}
+
+	@VisibleForTesting
+	public static Map<String, String> parseTmResourceJvmParams(String jvmParamsStr) {
+		final String xmx = "-Xmx";
+		final String xms = "-Xms";
+		final String maxDirect = "-XX:MaxDirectMemorySize=";
+		final String maxMetadata = "-XX:MaxMetaspaceSize=";
+
+		Map<String, String> configs = new HashMap<>();
+		for (String paramStr : jvmParamsStr.split(" ")) {
+			if (paramStr.startsWith(xmx)) {
+				configs.put(xmx, paramStr.substring(xmx.length()));
+			} else if (paramStr.startsWith(xms)) {
+				configs.put(xms, paramStr.substring(xms.length()));
+			} else if (paramStr.startsWith(maxDirect)) {
+				configs.put(maxDirect, paramStr.substring(maxDirect.length()));
+			} else if (paramStr.startsWith(maxMetadata)) {
+				configs.put(maxMetadata, paramStr.substring(maxMetadata.length()));
+			}
+		}
+
+		checkArgument(configs.containsKey(xmx));
+		checkArgument(configs.containsKey(xms));
+		checkArgument(configs.containsKey(maxDirect));
+		checkArgument(configs.containsKey(maxMetadata));
+
+		return configs;
 	}
 
 	// Make sure that we cannot instantiate this class

--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -776,3 +776,17 @@ calculateTaskManagerHeapSizeMB() {
 
     echo ${tm_heap_size_mb}
 }
+
+runBashJavaUtilsCmd() {
+    local cmd=$1
+    local class_path=$2
+    local conf_dir=$3
+
+    local output="`${JAVA_RUN} -classpath ${class_path} org.apache.flink.runtime.util.BashJavaUtils ${cmd} --configDir ${conf_dir} 2> /dev/null`"
+    if [[ $? -ne 0 ]]; then
+        echo "[ERROR] Cannot run BashJavaUtils to execute command ${cmd}."
+        exit 1
+    fi
+
+    echo ${output}
+}

--- a/flink-dist/src/main/flink-bin/bin/taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/taskmanager.sh
@@ -44,32 +44,18 @@ if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
         export JVM_ARGS="$JVM_ARGS -XX:+UseG1GC"
     fi
 
-    if [ ! -z "${FLINK_TM_HEAP_MB}" ] && [ "${FLINK_TM_HEAP}" == 0 ]; then
-	    echo "used deprecated key \`${KEY_TASKM_MEM_MB}\`, please replace with key \`${KEY_TASKM_MEM_SIZE}\`"
-    else
-	    flink_tm_heap_bytes=$(parseBytes ${FLINK_TM_HEAP})
-	    FLINK_TM_HEAP_MB=$(getMebiBytes ${flink_tm_heap_bytes})
-    fi
-
-    if [[ ! ${FLINK_TM_HEAP_MB} =~ ${IS_NUMBER} ]] || [[ "${FLINK_TM_HEAP_MB}" -lt "0" ]]; then
-        echo "[ERROR] Configured TaskManager JVM heap size is not a number. Please set '${KEY_TASKM_MEM_SIZE}' in ${FLINK_CONF_FILE}."
-        exit 1
-    fi
-
-    if [ "${FLINK_TM_HEAP_MB}" -gt "0" ]; then
-
-        TM_HEAP_SIZE=$(calculateTaskManagerHeapSizeMB)
-        # Long.MAX_VALUE in TB: This is an upper bound, much less direct memory will be used
-        TM_MAX_OFFHEAP_SIZE="8388607T"
-
-        export JVM_ARGS="${JVM_ARGS} -Xms${TM_HEAP_SIZE}M -Xmx${TM_HEAP_SIZE}M -XX:MaxDirectMemorySize=${TM_MAX_OFFHEAP_SIZE}"
-
-    fi
-
     # Add TaskManager-specific JVM options
     export FLINK_ENV_JAVA_OPTS="${FLINK_ENV_JAVA_OPTS} ${FLINK_ENV_JAVA_OPTS_TM}"
 
     # Startup parameters
+    dynamic_configs_and_jvm_params=$(getTmResourceDynamicConfigsAndJvmParams)
+    IFS=$'\n' lines=(${dynamic_configs_and_jvm_params})
+
+    jvm_params=${lines[0]}
+    export JVM_ARGS="${JVM_ARGS} ${jvm_params}"
+
+    dynamic_configs=${lines[1]}
+    ARGS=(${ARGS[@]} ${dynamic_configs})
     ARGS+=("--configDir" "${FLINK_CONF_DIR}")
 fi
 

--- a/flink-dist/src/test/bin/runBashJavaUtilsCmd.sh
+++ b/flink-dist/src/test/bin/runBashJavaUtilsCmd.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Wrapper script to compare the TM heap size calculation of config.sh with Java
+USAGE="Usage: runBashJavaUtilsCmd.sh <command>"
+
+COMMAND=$1
+
+if [[ -z "${COMMAND}" ]]; then
+  echo "$USAGE"
+  exit 1
+fi
+
+bin=`dirname "$0"`
+bin=`cd "$bin"; pwd`
+
+FLINK_CLASSPATH=`find . -name 'flink-dist*.jar' | grep lib`
+FLINK_CONF_DIR=${bin}/../../main/resources
+
+. ${bin}/../../main/flink-bin/bin/config.sh > /dev/null
+
+runBashJavaUtilsCmd ${COMMAND} ${FLINK_CLASSPATH} ${FLINK_CONF_DIR}

--- a/flink-dist/src/test/java/org/apache/flink/dist/BashJavaUtilsTest.java
+++ b/flink-dist/src/test/java/org/apache/flink/dist/BashJavaUtilsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.dist;
+
+import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.runtime.util.BashJavaUtils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests for BashJavaUtils.
+ */
+public class BashJavaUtilsTest extends JavaBashTestBase {
+
+	private static final String RUN_BASH_JAVA_UTILS_CMD_SCRIPT = "src/test/bin/runBashJavaUtilsCmd.sh";
+
+	@Test
+	public void testGetTmResourceDynamicConfigs() throws Exception {
+		String[] command = {RUN_BASH_JAVA_UTILS_CMD_SCRIPT,
+			BashJavaUtils.Command.GET_TM_RESOURCE_DYNAMIC_CONFIGS.toString()};
+		String result = executeScript(command);
+
+		assertNotNull(result);
+		ConfigurationUtils.parseTmResourceDynamicConfigs(result);
+	}
+
+	@Test
+	public void testGetTmResourceJvmParams() throws Exception {
+		String[] command = {RUN_BASH_JAVA_UTILS_CMD_SCRIPT,
+			BashJavaUtils.Command.GET_TM_RESOURCE_JVM_PARAMS.toString()};
+		String result = executeScript(command);
+
+		assertNotNull(result);
+		ConfigurationUtils.parseTmResourceJvmParams(result);
+	}
+}

--- a/flink-dist/src/test/java/org/apache/flink/dist/JavaBashTestBase.java
+++ b/flink-dist/src/test/java/org/apache/flink/dist/JavaBashTestBase.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.dist;
+
+import org.apache.flink.util.OperatingSystem;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Assume;
+import org.junit.BeforeClass;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * Abstract test class for executing bash scripts.
+ */
+public abstract class JavaBashTestBase extends TestLogger {
+	@BeforeClass
+	public static void checkOperatingSystem() {
+		Assume.assumeTrue("This test checks shell scripts which are not available on Windows.",
+			!OperatingSystem.isWindows());
+	}
+
+	/**
+	 * Executes the given shell script wrapper and returns its output.
+	 *
+	 * @param command  command to run
+	 *
+	 * @return raw script output
+	 */
+	protected String executeScript(final String[] command) throws IOException {
+		ProcessBuilder pb = new ProcessBuilder(command);
+		pb.redirectErrorStream(true);
+		Process process = pb.start();
+		BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+		StringBuilder sb = new StringBuilder();
+		String s;
+		while ((s = reader.readLine()) != null) {
+			sb.append(s);
+		}
+		return sb.toString();
+	}
+}

--- a/flink-dist/src/test/java/org/apache/flink/dist/TaskManagerHeapSizeCalculationJavaBashTest.java
+++ b/flink-dist/src/test/java/org/apache/flink/dist/TaskManagerHeapSizeCalculationJavaBashTest.java
@@ -24,16 +24,10 @@ import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.taskexecutor.TaskManagerServices;
 import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration;
-import org.apache.flink.util.OperatingSystem;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Assume;
-import org.junit.Before;
 import org.junit.Test;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.util.Random;
 
 import static org.hamcrest.CoreMatchers.allOf;
@@ -51,7 +45,7 @@ import static org.junit.Assert.assertThat;
  * <tt>double</tt> precision but our Java code restrains to <tt>float</tt> because we actually do
  * not need high precision.
  */
-public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
+public class TaskManagerHeapSizeCalculationJavaBashTest extends JavaBashTestBase {
 
 	/** Key that is used by <tt>config.sh</tt>. */
 	private static final String KEY_TASKM_MEM_SIZE = "taskmanager.heap.size";
@@ -63,12 +57,6 @@ public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
 	 * testing.
 	 */
 	private static final int NUM_RANDOM_TESTS = 20;
-
-	@Before
-	public void checkOperatingSystem() {
-		Assume.assumeTrue("This test checks shell scripts which are not available on Windows.",
-			!OperatingSystem.isWindows());
-	}
 
 	/**
 	 * Tests that {@link NettyShuffleEnvironmentConfiguration#calculateNetworkBufferMemory(long, Configuration)}
@@ -308,26 +296,6 @@ public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
 				") with configuration: " + config.toString(), scriptHeapSizeMB,
 			allOf(greaterThanOrEqualTo(javaHeapSizeMB - absoluteTolerance),
 				lessThanOrEqualTo(javaHeapSizeMB + absoluteTolerance)));
-	}
-
-	/**
-	 * Executes the given shell script wrapper and returns its output.
-	 *
-	 * @param command  command to run
-	 *
-	 * @return raw script output
-	 */
-	private String executeScript(final String[] command) throws IOException {
-		ProcessBuilder pb = new ProcessBuilder(command);
-		pb.redirectErrorStream(true);
-		Process process = pb.start();
-		BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
-		StringBuilder sb = new StringBuilder();
-		String s;
-		while ((s = reader.readLine()) != null) {
-			sb.append(s);
-		}
-		return sb.toString();
 	}
 
 }

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -24,6 +24,8 @@ import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.description.Description;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
+import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
 import org.apache.flink.util.Preconditions;
 
 import com.netflix.fenzo.ConstraintEvaluator;
@@ -333,9 +335,16 @@ public class MesosTaskManagerParameters {
 	public static MesosTaskManagerParameters create(Configuration flinkConfig) {
 
 		List<ConstraintEvaluator> constraints = parseConstraints(flinkConfig.getString(MESOS_CONSTRAINTS_HARD_HOSTATTR));
+		TaskExecutorResourceSpec taskExecutorResourceSpec;
+		if (flinkConfig.getBoolean(TaskManagerOptions.ENABLE_FLIP_49_CONFIG)) {
+			taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(flinkConfig);
+		} else {
+			taskExecutorResourceSpec = null;
+		}
 		// parse the common parameters
 		ContaineredTaskManagerParameters containeredParameters = ContaineredTaskManagerParameters.create(
 			flinkConfig,
+			taskExecutorResourceSpec,
 			flinkConfig.getInteger(MESOS_RM_TASKS_MEMORY_MB),
 			flinkConfig.getInteger(MESOS_RM_TASKS_SLOTS));
 

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -271,7 +271,7 @@ public class MesosResourceManagerTest extends TestLogger {
 			// TaskExecutor templating
 			ContainerSpecification containerSpecification = new ContainerSpecification();
 			ContaineredTaskManagerParameters containeredParams =
-				new ContaineredTaskManagerParameters(1024, 768, 256, 4, new HashMap<String, String>());
+				new ContaineredTaskManagerParameters(null, 1024, 768, 256, 4, new HashMap<String, String>());
 			MesosTaskManagerParameters tmParams = new MesosTaskManagerParameters(
 				1.0, 1, 0, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams,
 				Collections.<Protos.Volume>emptyList(), Collections.<Protos.Parameter>emptyList(), false,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -472,7 +472,9 @@ public class BootstrapTools {
 		for (Map.Entry<String, String> variable : startCommandValues
 			.entrySet()) {
 			template = template
-				.replace("%" + variable.getKey() + "%", variable.getValue());
+				.replace("%" + variable.getKey() + "%", variable.getValue())
+				.replace("  ", " ")
+				.trim();
 		}
 		return template;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ContaineredTaskManagerParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ContaineredTaskManagerParameters.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.runtime.taskexecutor.TaskManagerServices;
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -48,13 +49,19 @@ public class ContaineredTaskManagerParameters implements java.io.Serializable {
 	/** Environment variables to add to the Java process. */
 	private final HashMap<String, String> taskManagerEnv;
 
+	@Nullable // should only be null when flip49 is disabled
+	private final TaskExecutorResourceSpec taskExecutorResourceSpec;
+
 	public ContaineredTaskManagerParameters(
+			@Nullable // should only be null when flip49 is disabled
+			TaskExecutorResourceSpec taskExecutorResourceSpec,
 			long totalContainerMemoryMB,
 			long taskManagerHeapSizeMB,
 			long taskManagerDirectMemoryLimitMB,
 			int numSlots,
 			HashMap<String, String> taskManagerEnv) {
 
+		this.taskExecutorResourceSpec = taskExecutorResourceSpec;
 		this.totalContainerMemoryMB = totalContainerMemoryMB;
 		this.taskManagerHeapSizeMB = taskManagerHeapSizeMB;
 		this.taskManagerDirectMemoryLimitMB = taskManagerDirectMemoryLimitMB;
@@ -63,6 +70,11 @@ public class ContaineredTaskManagerParameters implements java.io.Serializable {
 	}
 
 	// ------------------------------------------------------------------------
+
+	@Nullable // should only be null when flip49 is disabled
+	public TaskExecutorResourceSpec getTaskExecutorResourceSpec() {
+		return taskExecutorResourceSpec;
+	}
 
 	public long taskManagerTotalMemoryMB() {
 		return totalContainerMemoryMB;
@@ -90,7 +102,8 @@ public class ContaineredTaskManagerParameters implements java.io.Serializable {
 	@Override
 	public String toString() {
 		return "TaskManagerParameters {" +
-			"totalContainerMemory=" + totalContainerMemoryMB +
+			"taskExecutorResourceSpec=" + (taskExecutorResourceSpec == null ? "null" : taskExecutorResourceSpec) +
+			", totalContainerMemory=" + totalContainerMemoryMB +
 			", taskManagerHeapSize=" + taskManagerHeapSizeMB +
 			", taskManagerDirectMemoryLimit=" + taskManagerDirectMemoryLimitMB +
 			", numSlots=" + numSlots +
@@ -151,6 +164,8 @@ public class ContaineredTaskManagerParameters implements java.io.Serializable {
 	 */
 	public static ContaineredTaskManagerParameters create(
 			Configuration config,
+			@Nullable // should only be null when flip49 is disabled
+			TaskExecutorResourceSpec taskExecutorResourceSpec,
 			long containerMemoryMB,
 			int numSlots) {
 		// (1) try to compute how much memory used by container
@@ -175,6 +190,6 @@ public class ContaineredTaskManagerParameters implements java.io.Serializable {
 
 		// done
 		return new ContaineredTaskManagerParameters(
-			containerMemoryMB, heapSizeMB, offHeapSizeMB, numSlots, envVars);
+			taskExecutorResourceSpec, containerMemoryMB, heapSizeMB, offHeapSizeMB, numSlots, envVars);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceSpec.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceSpec.java
@@ -74,7 +74,7 @@ import org.apache.flink.configuration.MemorySize;
  *               └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
  * </pre>
  */
-public class TaskExecutorResourceSpec {
+public class TaskExecutorResourceSpec implements java.io.Serializable {
 
 	private final MemorySize frameworkHeapSize;
 
@@ -154,5 +154,19 @@ public class TaskExecutorResourceSpec {
 
 	public MemorySize getTotalProcessMemorySize() {
 		return getTotalFlinkMemorySize().add(jvmMetaspaceSize).add(jvmOverheadSize);
+	}
+
+	@Override
+	public String toString() {
+		return "TaskExecutorResourceSpec {"
+			+ "frameworkHeapSize=" + frameworkHeapSize.toString()
+			+ ", taskHeapSize=" + taskHeapSize.toString()
+			+ ", taskOffHeapSize=" + taskOffHeapSize.toString()
+			+ ", shuffleMemSize=" + shuffleMemSize.toString()
+			+ ", onHeapManagedMemorySize=" + onHeapManagedMemorySize.toString()
+			+ ", offHeapManagedMemorySize=" + offHeapManagedMemorySize.toString()
+			+ ", jvmMetaspaceSize=" + jvmMetaspaceSize.toString()
+			+ ", jvmOverheadSize=" + jvmOverheadSize.toString()
+			+ "}";
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -59,6 +59,7 @@ public class NettyShuffleServiceFactory implements ShuffleServiceFactory<NettySh
 		NettyShuffleEnvironmentConfiguration networkConfig = NettyShuffleEnvironmentConfiguration.fromConfiguration(
 			shuffleEnvironmentContext.getConfiguration(),
 			shuffleEnvironmentContext.getMaxJvmHeapMemory(),
+			shuffleEnvironmentContext.getShuffleMemorySize(),
 			shuffleEnvironmentContext.isLocalCommunicationOnly(),
 			shuffleEnvironmentContext.getHostAddress());
 		return createNettyShuffleEnvironment(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -27,6 +27,8 @@ import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
+import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
@@ -1209,6 +1211,16 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
 		final ResourceProfile resourceProfile = TaskManagerServices.computeSlotResourceProfile(numSlots, managedMemoryBytes);
 		return Collections.nCopies(numSlots, resourceProfile);
+	}
+
+	@Nullable // should only be null when flip49 is disabled
+	public static TaskExecutorResourceSpec createTaskExecutorResourceSpec(Configuration config) {
+		final boolean enableFlip49 = config.getBoolean(TaskManagerOptions.ENABLE_FLIP_49_CONFIG);
+		if (enableFlip49) {
+			return TaskExecutorResourceUtils.resourceSpecFromConfig(config);
+		} else {
+			return null;
+		}
 	}
 }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleEnvironmentContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleEnvironmentContext.java
@@ -19,9 +19,12 @@
 package org.apache.flink.runtime.shuffle;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.io.network.TaskEventPublisher;
+
+import javax.annotation.Nullable;
 
 import java.net.InetAddress;
 
@@ -34,6 +37,8 @@ public class ShuffleEnvironmentContext {
 	private final Configuration configuration;
 	private final ResourceID taskExecutorResourceId;
 	private final long maxJvmHeapMemory;
+	@Nullable // should only be null when flip49 is disabled
+	private final MemorySize shuffleMemorySize;
 	private final boolean localCommunicationOnly;
 	private final InetAddress hostAddress;
 	private final TaskEventPublisher eventPublisher;
@@ -43,6 +48,8 @@ public class ShuffleEnvironmentContext {
 			Configuration configuration,
 			ResourceID taskExecutorResourceId,
 			long maxJvmHeapMemory,
+			@Nullable // should only be null when flip49 is disabled
+			MemorySize shuffleMemorySize,
 			boolean localCommunicationOnly,
 			InetAddress hostAddress,
 			TaskEventPublisher eventPublisher,
@@ -50,6 +57,7 @@ public class ShuffleEnvironmentContext {
 		this.configuration = checkNotNull(configuration);
 		this.taskExecutorResourceId = checkNotNull(taskExecutorResourceId);
 		this.maxJvmHeapMemory = maxJvmHeapMemory;
+		this.shuffleMemorySize = shuffleMemorySize;
 		this.localCommunicationOnly = localCommunicationOnly;
 		this.hostAddress = checkNotNull(hostAddress);
 		this.eventPublisher = checkNotNull(eventPublisher);
@@ -66,6 +74,11 @@ public class ShuffleEnvironmentContext {
 
 	public long getMaxJvmHeapMemory() {
 		return maxJvmHeapMemory;
+	}
+
+	@Nullable // should only be null when flip49 is disabled
+	public MemorySize getShuffleMemorySize() {
+		return shuffleMemorySize;
 	}
 
 	public boolean isLocalCommunicationOnly() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.taskexecutor;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
@@ -305,8 +304,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 		}
 	}
 
-	@VisibleForTesting
-	static Configuration loadConfiguration(String[] args) throws FlinkParseException {
+	public static Configuration loadConfiguration(String[] args) throws FlinkParseException {
 		final CommandLineParser<ClusterConfiguration> commandLineParser = new CommandLineParser<>(new ClusterConfigurationParserFactory());
 
 		final ClusterConfiguration clusterConfiguration;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -311,6 +311,7 @@ public class TaskManagerServices {
 			taskManagerServicesConfiguration.getConfiguration(),
 			taskManagerServicesConfiguration.getResourceID(),
 			taskManagerServicesConfiguration.getMaxJvmHeapMemory(),
+			taskManagerServicesConfiguration.getShuffleMemorySize(),
 			taskManagerServicesConfiguration.isLocalCommunicationOnly(),
 			taskManagerServicesConfiguration.getTaskManagerAddress(),
 			taskEventDispatcher,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -51,7 +51,9 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
@@ -330,6 +332,19 @@ public class TaskManagerServices {
 	 */
 	private static MemoryManager createMemoryManager(
 			TaskManagerServicesConfiguration taskManagerServicesConfiguration) {
+		if (taskManagerServicesConfiguration.getOnHeapManagedMemorySize() != null &&
+			taskManagerServicesConfiguration.getOffHeapManagedMemorySize() != null) {
+			// flip49 enabled
+
+			final Map<MemoryType, Long> memorySizeByType = new HashMap<>();
+			memorySizeByType.put(MemoryType.HEAP, taskManagerServicesConfiguration.getOnHeapManagedMemorySize().getBytes());
+			memorySizeByType.put(MemoryType.OFF_HEAP, taskManagerServicesConfiguration.getOffHeapManagedMemorySize().getBytes());
+
+			return new MemoryManager(memorySizeByType,
+				taskManagerServicesConfiguration.getNumberOfSlots(),
+				taskManagerServicesConfiguration.getPageSize());
+		}
+
 		// computing the amount of memory to use depends on how much memory is available
 		// it strictly needs to happen AFTER the network stack has been initialized
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -222,6 +222,16 @@ public class TaskManagerServicesConfiguration {
 		return taskExecutorResourceSpec == null ? null : taskExecutorResourceSpec.getShuffleMemSize();
 	}
 
+	@Nullable // should only be null when flip49 is disabled
+	public MemorySize getOnHeapManagedMemorySize() {
+		return taskExecutorResourceSpec == null ? null : taskExecutorResourceSpec.getOnHeapManagedMemorySize();
+	}
+
+	@Nullable // should only be null when flip49 is disabled
+	public MemorySize getOffHeapManagedMemorySize() {
+		return taskExecutorResourceSpec == null ? null : taskExecutorResourceSpec.getOffHeapManagedMemorySize();
+	}
+
 	long getTimerServiceShutdownTimeout() {
 		return timerServiceShutdownTimeout;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -22,9 +22,12 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
@@ -85,6 +88,9 @@ public class TaskManagerServicesConfiguration {
 
 	private Optional<Time> systemResourceMetricsProbingInterval;
 
+	@Nullable // should only be null when flip49 is disabled
+	private final TaskExecutorResourceSpec taskExecutorResourceSpec;
+
 	public TaskManagerServicesConfiguration(
 			Configuration configuration,
 			ResourceID resourceID,
@@ -101,6 +107,8 @@ public class TaskManagerServicesConfiguration {
 			MemoryType memoryType,
 			float memoryFraction,
 			int pageSize,
+			@Nullable // should only be null when flip49 is disabled
+			TaskExecutorResourceSpec taskExecutorResourceSpec,
 			long timerServiceShutdownTimeout,
 			RetryingRegistrationConfiguration retryingRegistrationConfiguration,
 			Optional<Time> systemResourceMetricsProbingInterval) {
@@ -121,6 +129,8 @@ public class TaskManagerServicesConfiguration {
 		this.memoryType = checkNotNull(memoryType);
 		this.memoryFraction = memoryFraction;
 		this.pageSize = pageSize;
+
+		this.taskExecutorResourceSpec = taskExecutorResourceSpec;
 
 		checkArgument(timerServiceShutdownTimeout >= 0L, "The timer " +
 			"service shutdown timeout must be greater or equal to 0.");
@@ -207,6 +217,11 @@ public class TaskManagerServicesConfiguration {
 		return pageSize;
 	}
 
+	@Nullable // should only be null when flip49 is disabled
+	public MemorySize getShuffleMemorySize() {
+		return taskExecutorResourceSpec == null ? null : taskExecutorResourceSpec.getShuffleMemSize();
+	}
+
 	long getTimerServiceShutdownTimeout() {
 		return timerServiceShutdownTimeout;
 	}
@@ -259,6 +274,30 @@ public class TaskManagerServicesConfiguration {
 
 		final RetryingRegistrationConfiguration retryingRegistrationConfiguration = RetryingRegistrationConfiguration.fromConfiguration(configuration);
 
+		if (configuration.getBoolean(TaskManagerOptions.ENABLE_FLIP_49_CONFIG)) {
+			final TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(configuration);
+			return new TaskManagerServicesConfiguration(
+				configuration,
+				resourceID,
+				remoteAddress,
+				localCommunicationOnly,
+				tmpDirs,
+				localStateRootDir,
+				freeHeapMemoryWithDefrag,
+				maxJvmHeapMemory,
+				localRecoveryMode,
+				queryableStateConfig,
+				ConfigurationParserUtils.getSlot(configuration),
+				ConfigurationParserUtils.getManagedMemorySize(configuration),
+				ConfigurationParserUtils.getMemoryType(configuration),
+				ConfigurationParserUtils.getManagedMemoryFraction(configuration),
+				ConfigurationParserUtils.getPageSize(configuration),
+				taskExecutorResourceSpec,
+				timerServiceShutdownTimeout,
+				retryingRegistrationConfiguration,
+				ConfigurationUtils.getSystemResourceMetricsProbingInterval(configuration));
+		}
+
 		return new TaskManagerServicesConfiguration(
 			configuration,
 			resourceID,
@@ -275,6 +314,7 @@ public class TaskManagerServicesConfiguration {
 			ConfigurationParserUtils.getMemoryType(configuration),
 			ConfigurationParserUtils.getManagedMemoryFraction(configuration),
 			ConfigurationParserUtils.getPageSize(configuration),
+			null,
 			timerServiceShutdownTimeout,
 			retryingRegistrationConfiguration,
 			ConfigurationUtils.getSystemResourceMetricsProbingInterval(configuration));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/BashJavaUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/BashJavaUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.taskexecutor.TaskManagerRunner;
+
+import java.util.Arrays;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * Utility class for using java utilities in bash scripts.
+ */
+public class BashJavaUtils {
+
+	public static void main(String[] args) throws Exception {
+		checkArgument(args.length > 0, "Command not specified.");
+
+		switch (Command.valueOf(args[0])) {
+			case GET_TM_RESOURCE_DYNAMIC_CONFIGS:
+				getTmResourceDynamicConfigs(args);
+				break;
+			case GET_TM_RESOURCE_JVM_PARAMS:
+				getTmResourceJvmParams(args);
+				break;
+			default:
+				// unexpected, Command#valueOf should fail if a unknown command is passed in
+				throw new RuntimeException("Unexpected, something is wrong.");
+		}
+	}
+
+	private static void getTmResourceDynamicConfigs(String[] args) throws Exception {
+		Configuration configuration = TaskManagerRunner.loadConfiguration(Arrays.copyOfRange(args, 1, args.length));
+		TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(configuration);
+		System.out.println(TaskExecutorResourceUtils.generateDynamicConfigsStr(taskExecutorResourceSpec));
+	}
+
+	private static void getTmResourceJvmParams(String[] args) throws Exception {
+		Configuration configuration = TaskManagerRunner.loadConfiguration(Arrays.copyOfRange(args, 1, args.length));
+		TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(configuration);
+		System.out.println(TaskExecutorResourceUtils.generateJvmParametersStr(taskExecutorResourceSpec));
+	}
+
+	/**
+	 * Commands that BashJavaUtils supports.
+	 */
+	public enum Command {
+		/**
+		 * Get dynamic configs of task executor resources.
+		 */
+		GET_TM_RESOURCE_DYNAMIC_CONFIGS,
+
+		/**
+		 * Get JVM parameters of task executor resources.
+		 */
+		GET_TM_RESOURCE_JVM_PARAMS
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
@@ -165,8 +165,8 @@ public class BootstrapToolsTest extends TestLogger {
 
 		assertEquals(
 			java + " " + jvmmem +
-				" " + // jvmOpts
-				" " + // logging
+				"" + // jvmOpts
+				"" + // logging
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
 				.getTaskManagerShellCommand(cfg, containeredParams, "./conf", "./logs",
@@ -175,8 +175,8 @@ public class BootstrapToolsTest extends TestLogger {
 		final String krb5 = "-Djava.security.krb5.conf=krb5.conf";
 		assertEquals(
 			java + " " + jvmmem +
-				" " + " " + krb5 + // jvmOpts
-				" " + // logging
+				" " + krb5 + // jvmOpts
+				"" + // logging
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
 				.getTaskManagerShellCommand(cfg, containeredParams, "./conf", "./logs",
@@ -185,7 +185,7 @@ public class BootstrapToolsTest extends TestLogger {
 		// logback only, with/out krb5
 		assertEquals(
 			java + " " + jvmmem +
-				" " + // jvmOpts
+				"" + // jvmOpts
 				" " + logfile + " " + logback +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
@@ -194,7 +194,7 @@ public class BootstrapToolsTest extends TestLogger {
 
 		assertEquals(
 			java + " " + jvmmem +
-				" " + " " + krb5 + // jvmOpts
+				" " + krb5 + // jvmOpts
 				" " + logfile + " " + logback +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
@@ -204,7 +204,7 @@ public class BootstrapToolsTest extends TestLogger {
 		// log4j, with/out krb5
 		assertEquals(
 			java + " " + jvmmem +
-				" " + // jvmOpts
+				"" + // jvmOpts
 				" " + logfile + " " + log4j +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
@@ -213,7 +213,7 @@ public class BootstrapToolsTest extends TestLogger {
 
 		assertEquals(
 			java + " " + jvmmem +
-				" " + " " + krb5 + // jvmOpts
+				" " + krb5 + // jvmOpts
 				" " + logfile + " " + log4j +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
@@ -223,7 +223,7 @@ public class BootstrapToolsTest extends TestLogger {
 		// logback + log4j, with/out krb5
 		assertEquals(
 			java + " " + jvmmem +
-				" " + // jvmOpts
+				"" + // jvmOpts
 				" " + logfile + " " + logback + " " + log4j +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools
@@ -232,7 +232,7 @@ public class BootstrapToolsTest extends TestLogger {
 
 		assertEquals(
 			java + " " + jvmmem +
-				" " + " " + krb5 + // jvmOpts
+				" " + krb5 + // jvmOpts
 				" " + logfile + " " + logback + " " + log4j +
 				" " + mainClass + " " + args + " " + redirects,
 			BootstrapTools

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ContaineredTaskManagerParametersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ContaineredTaskManagerParametersTest.java
@@ -45,7 +45,7 @@ public class ContaineredTaskManagerParametersTest extends TestLogger {
 		Configuration conf = new Configuration();
 
 		ContaineredTaskManagerParameters params =
-			ContaineredTaskManagerParameters.create(conf, CONTAINER_MEMORY, 1);
+			ContaineredTaskManagerParameters.create(conf, null, CONTAINER_MEMORY, 1);
 
 		final float memoryCutoffRatio = conf.getFloat(
 			ConfigConstants.CONTAINERIZED_HEAP_CUTOFF_RATIO,
@@ -80,7 +80,7 @@ public class ContaineredTaskManagerParametersTest extends TestLogger {
 		conf.setBoolean(MEMORY_OFF_HEAP, false);
 
 		ContaineredTaskManagerParameters params =
-			ContaineredTaskManagerParameters.create(conf, CONTAINER_MEMORY, 1);
+			ContaineredTaskManagerParameters.create(conf, null, CONTAINER_MEMORY, 1);
 
 		assertTrue(params.taskManagerDirectMemoryLimitMB() > 0L);
 
@@ -98,7 +98,7 @@ public class ContaineredTaskManagerParametersTest extends TestLogger {
 		conf.setBoolean(MEMORY_OFF_HEAP, true);
 
 		ContaineredTaskManagerParameters params =
-			ContaineredTaskManagerParameters.create(conf, CONTAINER_MEMORY, 1);
+			ContaineredTaskManagerParameters.create(conf, null, CONTAINER_MEMORY, 1);
 
 		assertTrue(params.taskManagerDirectMemoryLimitMB() > 0L);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NettyShuffleEnvironmentConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NettyShuffleEnvironmentConfigurationTest.java
@@ -43,7 +43,7 @@ public class NettyShuffleEnvironmentConfigurationTest extends TestLogger {
 	private static final long MEM_SIZE_PARAM = 128L * 1024 * 1024;
 
 	/**
-	 * Verifies that {@link  NettyShuffleEnvironmentConfiguration#fromConfiguration(Configuration, long, boolean, InetAddress)}
+	 * Verifies that {@link  NettyShuffleEnvironmentConfiguration#fromConfiguration(Configuration, long, MemorySize, boolean, InetAddress)}
 	 * returns the correct result for new configurations via
 	 * {@link NettyShuffleEnvironmentOptions#NETWORK_REQUEST_BACKOFF_INITIAL},
 	 * {@link NettyShuffleEnvironmentOptions#NETWORK_REQUEST_BACKOFF_MAX},
@@ -63,6 +63,7 @@ public class NettyShuffleEnvironmentConfigurationTest extends TestLogger {
 		final  NettyShuffleEnvironmentConfiguration networkConfig =  NettyShuffleEnvironmentConfiguration.fromConfiguration(
 			config,
 			MEM_SIZE_PARAM,
+			null,
 			true,
 			InetAddress.getLoopbackAddress());
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/UtilsTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/UtilsTest.java
@@ -187,7 +187,7 @@ public class UtilsTest extends TestLogger {
 			hdfsDelegationTokenKind, service));
 		amCredentials.writeTokenStorageFile(new org.apache.hadoop.fs.Path(credentialFile.getAbsolutePath()), yarnConf);
 
-		ContaineredTaskManagerParameters tmParams = new ContaineredTaskManagerParameters(64,
+		ContaineredTaskManagerParameters tmParams = new ContaineredTaskManagerParameters(null, 64,
 			64, 16, 1, new HashMap<>(1));
 		Configuration taskManagerConf = new Configuration();
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
@@ -177,6 +177,7 @@ public class YarnConfigurationITCase extends YarnTestBase {
 
 					final ContaineredTaskManagerParameters containeredTaskManagerParameters = ContaineredTaskManagerParameters.create(
 						configuration,
+						null,
 						taskManagerMemory,
 						slotsPerTaskManager);
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -26,6 +26,8 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
+import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.FutureUtils;
@@ -129,6 +131,9 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 
 	private final Resource resource;
 
+	@Nullable // should only be null when flip49 is disabled
+	private final TaskExecutorResourceSpec taskExecutorResourceSpec;
+
 	public YarnResourceManager(
 			RpcService rpcService,
 			String resourceManagerEndpointId,
@@ -176,7 +181,14 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 
 		this.webInterfaceUrl = webInterfaceUrl;
 		this.numberOfTaskSlots = flinkConfig.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
-		this.defaultTaskManagerMemoryMB = ConfigurationUtils.getTaskManagerHeapMemory(flinkConfig).getMebiBytes();
+
+		this.taskExecutorResourceSpec = createTaskExecutorResourceSpec(flinkConfig);
+		if (taskExecutorResourceSpec != null) { // FLIP-49 enabled
+			final TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(flinkConfig);
+			this.defaultTaskManagerMemoryMB = taskExecutorResourceSpec.getTotalProcessMemorySize().getMebiBytes();
+		} else { // FLIP-49 disabled
+			this.defaultTaskManagerMemoryMB = ConfigurationUtils.getTaskManagerHeapMemory(flinkConfig).getMebiBytes();
+		}
 		this.defaultCpus = flinkConfig.getInteger(YarnConfigOptions.VCORES, numberOfTaskSlots);
 		this.resource = Resource.newInstance(defaultTaskManagerMemoryMB, defaultCpus);
 
@@ -403,6 +415,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 		try {
 			// Context information used to start a TaskExecutor Java process
 			ContainerLaunchContext taskExecutorLaunchContext = createTaskExecutorLaunchContext(
+				taskExecutorResourceSpec,
 				container.getResource(),
 				containerIdStr,
 				container.getNodeId().getHost());
@@ -539,20 +552,31 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 			RM_REQUEST_PRIORITY);
 	}
 
-	private ContainerLaunchContext createTaskExecutorLaunchContext(Resource resource, String containerId, String host)
-			throws Exception {
+	private ContainerLaunchContext createTaskExecutorLaunchContext(
+		@Nullable // should only be null when flip49 is disabled
+		TaskExecutorResourceSpec tmResourceSpec,
+		Resource resource,
+		String containerId,
+		String host) throws Exception {
+
 		// init the ContainerLaunchContext
 		final String currDir = env.get(ApplicationConstants.Environment.PWD.key());
 
 		final ContaineredTaskManagerParameters taskManagerParameters =
-				ContaineredTaskManagerParameters.create(flinkConfig, resource.getMemory(), numberOfTaskSlots);
+				ContaineredTaskManagerParameters.create(flinkConfig, tmResourceSpec, resource.getMemory(), numberOfTaskSlots);
 
-		log.debug("TaskExecutor {} will be started with container size {} MB, JVM heap size {} MB, " +
-				"JVM direct memory limit {} MB",
+		if (tmResourceSpec == null) { // FLIP-49 disabled
+			log.debug("TaskExecutor {} will be started with container size {} MB, JVM heap size {} MB, " +
+					"JVM direct memory limit {} MB",
 				containerId,
 				taskManagerParameters.taskManagerTotalMemoryMB(),
 				taskManagerParameters.taskManagerHeapSizeMB(),
 				taskManagerParameters.taskManagerDirectMemoryLimitMB());
+		} else { // Flip-49 enabled
+			log.debug("TaskExecutor {} will be started with {}.",
+				containerId,
+				tmResourceSpec);
+		}
 
 		Configuration taskManagerConfig = BootstrapTools.cloneConfiguration(flinkConfig);
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -189,7 +189,6 @@ public class YarnClusterDescriptorTest extends TestLogger {
 		final String log4j =
 			"-Dlog4j.configuration=file:" + FlinkYarnSessionCli.CONFIG_FILE_LOG4J_NAME; // if set
 		final String mainClass = clusterDescriptor.getYarnSessionClusterEntrypoint();
-		final String args = "";
 		final String redirects =
 			"1> " + ApplicationConstants.LOG_DIR_EXPANSION_VAR + "/jobmanager.out " +
 			"2> " + ApplicationConstants.LOG_DIR_EXPANSION_VAR + "/jobmanager.err";
@@ -199,9 +198,9 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			// no logging, with/out krb5
 			assertEquals(
 				java + " " + jvmmem +
-					" " + // jvmOpts
-					" " + // logging
-					" " + mainClass + " " + args + " " + redirects,
+					"" + // jvmOpts
+					"" + // logging
+					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
 						mainClass,
@@ -213,9 +212,9 @@ public class YarnClusterDescriptorTest extends TestLogger {
 
 			assertEquals(
 				java + " " + jvmmem +
-					" " + " " + krb5 + // jvmOpts
-					" " + // logging
-					" " + mainClass + " " + args + " " + redirects,
+					" " + krb5 + // jvmOpts
+					"" + // logging
+					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
 						mainClass,
@@ -228,9 +227,9 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			// logback only, with/out krb5
 			assertEquals(
 				java + " " + jvmmem +
-					" " + // jvmOpts
+					"" + // jvmOpts
 					" " + logfile + " " + logback +
-					" " + mainClass + " " + args + " " + redirects,
+					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
 						mainClass,
@@ -242,9 +241,9 @@ public class YarnClusterDescriptorTest extends TestLogger {
 
 			assertEquals(
 				java + " " + jvmmem +
-					" " + " " + krb5 + // jvmOpts
+					" " + krb5 + // jvmOpts
 					" " + logfile + " " + logback +
-					" " + mainClass + " " + args + " " + redirects,
+					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
 						mainClass,
@@ -257,9 +256,9 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			// log4j, with/out krb5
 			assertEquals(
 				java + " " + jvmmem +
-					" " + // jvmOpts
+					"" + // jvmOpts
 					" " + logfile + " " + log4j +
-					" " + mainClass + " " + args + " " + redirects,
+					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
 						mainClass,
@@ -271,9 +270,9 @@ public class YarnClusterDescriptorTest extends TestLogger {
 
 			assertEquals(
 				java + " " + jvmmem +
-					" " + " " + krb5 + // jvmOpts
+					" " + krb5 + // jvmOpts
 					" " + logfile + " " + log4j +
-					" " + mainClass + " " + args + " " + redirects,
+					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
 						mainClass,
@@ -286,9 +285,9 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			// logback + log4j, with/out krb5
 			assertEquals(
 				java + " " + jvmmem +
-					" " + // jvmOpts
+					"" + // jvmOpts
 					" " + logfile + " " + logback + " " + log4j +
-					" " + mainClass + " " + args + " " + redirects,
+					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
 						mainClass,
@@ -300,9 +299,9 @@ public class YarnClusterDescriptorTest extends TestLogger {
 
 			assertEquals(
 				java + " " + jvmmem +
-					" " + " " + krb5 + // jvmOpts
+					" " + krb5 + // jvmOpts
 					" " + logfile + " " + logback + " " + log4j +
-					" " + mainClass + " " + args + " " + redirects,
+					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
 						mainClass,
@@ -320,7 +319,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				java + " " + jvmmem +
 					" " + jvmOpts +
 					" " + logfile + " " + logback + " " + log4j +
-					" " + mainClass + " " + args + " " + redirects,
+					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
 						mainClass,
@@ -334,7 +333,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				java + " " + jvmmem +
 					" " + jvmOpts + " " + krb5 + // jvmOpts
 					" " + logfile + " " + logback + " " + log4j +
-					" " + mainClass + " " + args + " " + redirects,
+					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
 						mainClass,
@@ -351,7 +350,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				java + " " + jvmmem +
 					" " + jvmOpts + " " + jmJvmOpts +
 					" " + logfile + " " + logback + " " + log4j +
-					" " + mainClass + " " + args + " " + redirects,
+					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
 						mainClass,
@@ -365,7 +364,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				java + " " + jvmmem +
 					" " + jvmOpts + " " + jmJvmOpts + " " + krb5 + // jvmOpts
 					" " + logfile + " " + logback + " " + log4j +
-					" " + mainClass + " " + args + " " + redirects,
+					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
 						mainClass,
@@ -383,7 +382,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				java + " 1 " + jvmmem +
 					" 2 " + jvmOpts + " " + jmJvmOpts + " " + krb5 + // jvmOpts
 					" 3 " + logfile + " " + logback + " " + log4j +
-					" 4 " + mainClass + " 5 " + args + " 6 " + redirects,
+					" 4 " + mainClass + " 5 6 " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
 						mainClass,
@@ -401,7 +400,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 					" " + logfile + " " + logback + " " + log4j +
 					" " + jvmOpts + " " + jmJvmOpts + " " + krb5 + // jvmOpts
 					" " + jvmmem +
-					" " + mainClass + " " + args + " " + redirects,
+					" " + mainClass + " " + redirects,
 				clusterDescriptor
 					.setupApplicationMasterContainer(
 						mainClass,


### PR DESCRIPTION
## What is the purpose of the change
This PR is part of FLIP-49. It uses the new memory configuration and calculation logics for launching task executors.

NOTE: Changes to the Mesos deployment should be manually verified. This is not yet done due to lack of Mesos environment.

This PR is based on #9693 & #9760.

## Brief change log
- 723e82fb6058a96fc078d3147acb22ddf7332f01..c681c67b99d8afd714aa7e5afd75cf83a4ccb23b: Commits of previous PR #9693.
- 3529c027776e94031790c192cca3ea3e84cc86d0..27ae6ed6aaa27b2e8c5da941b33dbd8aad719f23: Commits of previous PR #9760.
- 42605e8d6106dff86031551e0e1e57c8667c3df2: Refactor `TaskManagerHeapSizeCalculationJavaBashTest`, extract common `JavaBashTestBase` for executing testing bash scripts from java test cases.
- b31f9802d89a4d07b48eae3fce8c7061e2f712a1: Remove heading/trailing/duplicated whitespaces from shell command generated by `BootstrapTools`. This simplifies relevant test cases from carefully dealing with white space counts.
- b6fd6ddaeb9179ebf9459025f66dceccf43caa3b: Introduce `BashJavaUtils`, which allows to call java implemented utils from bash scripts.
- 3a881444799e763544a75c3eb6d282df7a844ece: TM startup bash scripts use new memory configuration and calculation logics to launch task executors (when flip49 is enabled)
- c2487f6a6e87e958f33f1d145963062e2c60342a: Launch task executors on Yarn/Mesos with new memory configuration and calculation logics (when flip49 is enabled)
- 3cdeedcbc6f05fae27ab4f98765c044d67cca5ca: TM decide memory size of `ShuffleEnvironment` with new memory configuration and calculation logics (when flip49 is enabled)
- 768101e26760ce3dbdcaa6d216dc77ca86b4f96e: TM decide memory size of `MemoryManager` with new memory configuration and calculation logics (when flip49 is enabled)


## Verifying this change
- Add `BashJavaUtilsTest` to creating dynamic configs and JVM parameters by calling java codes from bash scripts.
- Manually test launching task executors with proper dynamic configs and JVM parameters when using FLIP-49 new configurations.
- Add `BootstrapTools#testGetTaskManagerShellCommand` to test generating task executor launching command with proper dynamic configs and JVM parameters on Yarn.
- **NOT YET**: Manually test launching task executors with proper dynamic configs and JVM parameters when using FLIP-49 new configurations.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
f