### PR TITLE
[FLINK-14265][table-planner-blink] Don't use ContinuousFileReaderOperator to support multiple paths

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecTableSourceScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecTableSourceScan.scala
@@ -192,6 +192,8 @@ class StreamExecTableSourceScan(
       env: StreamExecutionEnvironment,
       format: InputFormat[IN, _ <: InputSplit],
       t: TypeInformation[IN]): Transformation[IN] = {
+    // See StreamExecutionEnvironment.createInput, it is better to deal with checkpoint.
+    // The disadvantage is that streaming not support multi-paths.
     env.createInput(format, t).name(tableSource.explainSource()).getTransformation
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecTableSourceScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecTableSourceScan.scala
@@ -18,8 +18,12 @@
 
 package org.apache.flink.table.planner.plan.nodes.physical.stream
 
+import org.apache.flink.api.common.io.InputFormat
+import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.dag.Transformation
+import org.apache.flink.core.io.InputSplit
 import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.functions.{AssignerWithPeriodicWatermarks, AssignerWithPunctuatedWatermarks}
 import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.table.api.{DataTypes, TableException}
@@ -182,6 +186,13 @@ class StreamExecTableSourceScan(
       tableSourceTable.selectedFields)
     ScanUtil.hasTimeAttributeField(fieldIndexes) ||
       ScanUtil.needsConversion(tableSource.getProducedDataType)
+  }
+
+  override def createInput[IN](
+      env: StreamExecutionEnvironment,
+      format: InputFormat[IN, _ <: InputSplit],
+      t: TypeInformation[IN]): Transformation[IN] = {
+    env.createInput(format, t).name(tableSource.explainSource()).getTransformation
   }
 }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSourceITCase.scala
@@ -29,7 +29,7 @@ import org.apache.flink.types.Row
 
 import org.junit.{Before, Test}
 
-import java.io.File
+import java.io.{File, FileWriter}
 import java.lang.{Boolean => JBool, Integer => JInt, Long => JLong}
 
 class TableSourceITCase extends BatchTestBase {
@@ -253,9 +253,11 @@ class TableSourceITCase extends BatchTestBase {
   def testMultiPaths(): Unit = {
     val tmpFile1 = File.createTempFile("flink-table-sink-test", ".tmp")
     tmpFile1.deleteOnExit()
+    new FileWriter(tmpFile1).append("t1\n").append("t2\n").close()
 
     val tmpFile2 = File.createTempFile("flink-table-sink-test", ".tmp")
     tmpFile2.deleteOnExit()
+    new FileWriter(tmpFile2).append("t3\n").append("t4\n").close()
 
     val schema = new TableSchema(Array("a"), Array(Types.STRING))
 
@@ -265,7 +267,12 @@ class TableSourceITCase extends BatchTestBase {
 
     checkResult(
       "select * from MyMultiPathTable",
-      Seq()
+      Seq(
+        row("t1"),
+        row("t2"),
+        row("t3"),
+        row("t4")
+      )
     )
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSourceITCase.scala
@@ -23,12 +23,13 @@ import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.table.api.{DataTypes, TableSchema, Types}
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.{BatchTestBase, TestData}
-import org.apache.flink.table.planner.utils.{TestDataTypeTableSource, TestFilterableTableSource, TestInputFormatTableSource, TestNestedProjectableTableSource, TestPartitionableTableSource, TestProjectableTableSource, TestTableSources}
+import org.apache.flink.table.planner.utils.{TestDataTypeTableSource, TestFileInputFormatTableSource, TestFilterableTableSource, TestInputFormatTableSource, TestNestedProjectableTableSource, TestPartitionableTableSource, TestProjectableTableSource, TestTableSources}
 import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter
 import org.apache.flink.types.Row
 
 import org.junit.{Before, Test}
 
+import java.io.File
 import java.lang.{Boolean => JBool, Integer => JInt, Long => JLong}
 
 class TableSourceITCase extends BatchTestBase {
@@ -245,6 +246,26 @@ class TableSourceITCase extends BatchTestBase {
         row(1, "5.10", "1", "1"),
         row(2, "6.10", "12", "12"),
         row(3, "7.10", "123", "123"))
+    )
+  }
+
+  @Test
+  def testMultiPaths(): Unit = {
+    val tmpFile1 = File.createTempFile("flink-table-sink-test", ".tmp")
+    tmpFile1.deleteOnExit()
+
+    val tmpFile2 = File.createTempFile("flink-table-sink-test", ".tmp")
+    tmpFile2.deleteOnExit()
+
+    val schema = new TableSchema(Array("a"), Array(Types.STRING))
+
+    val tableSource = new TestFileInputFormatTableSource(
+      Array(tmpFile1.getPath, tmpFile2.getPath), schema)
+    tEnv.registerTableSource("MyMultiPathTable", tableSource)
+
+    checkResult(
+      "select * from MyMultiPathTable",
+      Seq()
     )
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSourceITCase.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.runtime.batch.sql
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.table.api.{DataTypes, TableSchema, Types}
+import org.apache.flink.table.planner.runtime.utils.BatchAbstractTestBase.TEMPORARY_FOLDER
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.{BatchTestBase, TestData}
 import org.apache.flink.table.planner.utils.{TestDataTypeTableSource, TestFileInputFormatTableSource, TestFilterableTableSource, TestInputFormatTableSource, TestNestedProjectableTableSource, TestPartitionableTableSource, TestProjectableTableSource, TestTableSources}
@@ -251,12 +252,10 @@ class TableSourceITCase extends BatchTestBase {
 
   @Test
   def testMultiPaths(): Unit = {
-    val tmpFile1 = File.createTempFile("flink-table-sink-test", ".tmp")
-    tmpFile1.deleteOnExit()
+    val tmpFile1 = TEMPORARY_FOLDER.newFile("tmpFile1.tmp")
     new FileWriter(tmpFile1).append("t1\n").append("t2\n").close()
 
-    val tmpFile2 = File.createTempFile("flink-table-sink-test", ".tmp")
-    tmpFile2.deleteOnExit()
+    val tmpFile2 = TEMPORARY_FOLDER.newFile("tmpFile2.tmp")
     new FileWriter(tmpFile2).append("t3\n").append("t4\n").close()
 
     val schema = new TableSchema(Array("a"), Array(Types.STRING))

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/testTableSources.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/testTableSources.scala
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.io.InputFormat
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.common.typeutils.TypeSerializer
-import org.apache.flink.api.java.io.CollectionInputFormat
+import org.apache.flink.api.java.io.{CollectionInputFormat, RowCsvInputFormat}
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.core.io.InputSplit
 import org.apache.flink.streaming.api.datastream.DataStream
@@ -649,6 +649,21 @@ class TestStreamTableSource(
 
   override def getDataStream(execEnv: StreamExecutionEnvironment): DataStream[Row] = {
     execEnv.fromCollection(values, tableSchema.toRowType)
+  }
+
+  override def getReturnType: TypeInformation[Row] = tableSchema.toRowType
+
+  override def getTableSchema: TableSchema = tableSchema
+}
+
+class TestFileInputFormatTableSource(
+    paths: Array[String],
+    tableSchema: TableSchema) extends InputFormatTableSource[Row] {
+
+  override def getInputFormat: InputFormat[Row, _ <: InputSplit] = {
+    val format = new RowCsvInputFormat(null, tableSchema.getFieldTypes)
+    format.setFilePaths(paths: _*)
+    format
   }
 
   override def getReturnType: TypeInformation[Row] = tableSchema.toRowType


### PR DESCRIPTION
## What is the purpose of the change

Now, blink planner use ContinuousFileReaderOperator to support InputFormat, but ContinuousFileReaderOperator not support multiple paths.
If read partitioned source, after partition pruning, we need let InputFormat to read multiple partitions which are multiple paths.
We can use InputFormatSourceFunction directly to support InputFormat.

## Verifying this change

TableSourceITCase.testMultiPaths

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no