### PR TITLE
[FLINK-14287] Decouple leader address from LeaderContender 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -896,7 +896,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 					recoveredJobsFuture,
 					BiFunctionWithException.unchecked((Boolean confirmLeadership, Collection<JobGraph> recoveredJobs) -> {
 						if (confirmLeadership) {
-							leaderElectionService.confirmLeaderSessionID(newLeaderSessionID);
+							leaderElectionService.confirmLeadership(newLeaderSessionID, getAddress());
 						} else {
 							for (JobGraph recoveredJob : recoveredJobs) {
 								jobGraphStore.releaseJobGraph(recoveredJob.getJobID());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
@@ -236,7 +236,10 @@ public class EmbeddedLeaderService {
 	/**
 	 * Callback from leader contenders when they confirm a leader grant.
 	 */
-	private void confirmLeader(final EmbeddedLeaderElectionService service, final UUID leaderSessionId) {
+	private void confirmLeader(
+			final EmbeddedLeaderElectionService service,
+			final UUID leaderSessionId,
+			final String leaderAddress) {
 		synchronized (lock) {
 			// if the service was shut down in the meantime, ignore this confirmation
 			if (!service.running || shutdown) {
@@ -246,16 +249,15 @@ public class EmbeddedLeaderService {
 			try {
 				// check if the confirmation is for the same grant, or whether it is a stale grant
 				if (service == currentLeaderProposed && currentLeaderSessionId.equals(leaderSessionId)) {
-					final String address = service.contender.getAddress();
-					LOG.info("Received confirmation of leadership for leader {} , session={}", address, leaderSessionId);
+					LOG.info("Received confirmation of leadership for leader {} , session={}", leaderAddress, leaderSessionId);
 
 					// mark leadership
 					currentLeaderConfirmed = service;
-					currentLeaderAddress = address;
+					currentLeaderAddress = leaderAddress;
 					currentLeaderProposed = null;
 
 					// notify all listeners
-					notifyAllListeners(address, leaderSessionId);
+					notifyAllListeners(leaderAddress, leaderSessionId);
 				}
 				else {
 					LOG.debug("Received confirmation of leadership for a stale leadership grant. Ignoring.");
@@ -434,9 +436,10 @@ public class EmbeddedLeaderService {
 		}
 
 		@Override
-		public void confirmLeaderSessionID(UUID leaderSessionID) {
+		public void confirmLeadership(UUID leaderSessionID, String leaderAddress) {
 			checkNotNull(leaderSessionID);
-			confirmLeader(this, leaderSessionID);
+			checkNotNull(leaderAddress);
+			confirmLeader(this, leaderSessionID, leaderAddress);
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/leaderelection/SingleLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/leaderelection/SingleLeaderElectionService.java
@@ -141,7 +141,7 @@ public class SingleLeaderElectionService implements LeaderElectionService {
 	}
 
 	@Override
-	public void confirmLeaderSessionID(UUID leaderSessionID) {
+	public void confirmLeadership(UUID leaderSessionID, String leaderAddress) {
 		checkNotNull(leaderSessionID, "leaderSessionID");
 		checkArgument(leaderSessionID.equals(leaderId), "confirmed wrong leader session id");
 
@@ -151,14 +151,13 @@ public class SingleLeaderElectionService implements LeaderElectionService {
 			checkState(leader == null, "leader already confirmed");
 
 			// accept the confirmation
-			final String address = proposedLeader.getAddress();
-			leaderAddress = address;
+			this.leaderAddress = leaderAddress;
 			leader = proposedLeader;
 
 			// notify all listeners
 			for (EmbeddedLeaderRetrievalService listener : listeners) {
 				notificationExecutor.execute(
-						new NotifyOfLeaderCall(address, leaderId, listener.listener, LOG));
+						new NotifyOfLeaderCall(leaderAddress, leaderId, listener.listener, LOG));
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionService.java
@@ -30,9 +30,9 @@ import java.util.UUID;
  * to instantiate its own leader election service.
  *
  * Once a contender has been granted leadership he has to confirm the received leader session ID
- * by calling the method confirmLeaderSessionID. This will notify the leader election service, that
- * the contender has received the new leader session ID and that it can now be published for
- * leader retrieval services.
+ * by calling the method {@link #confirmLeadership(UUID, String)}. This will notify the leader election
+ * service, that the contender has accepted the leadership specified and that the leader session id as
+ * well as the leader address can now be published for leader retrieval services.
  */
 public interface LeaderElectionService {
 
@@ -51,16 +51,18 @@ public interface LeaderElectionService {
 	void stop() throws Exception;
 
 	/**
-	 * Confirms that the new leader session ID has been successfully received by the new leader.
-	 * This method is usually called by the newly appointed {@link LeaderContender}.
+	 * Confirms that the {@link LeaderContender} has accepted the leadership identified by the
+	 * given leader session id. It also publishes the leader address under which the leader is
+	 * reachable.
 	 *
-	 * The rational behind this method is to establish an order between setting the new leader
-	 * session ID in the {@link LeaderContender} and publishing the new leader session ID to the
-	 * leader retrieval services.
+	 * <p>The rational behind this method is to establish an order between setting the new leader
+	 * session ID in the {@link LeaderContender} and publishing the new leader session ID as well
+	 * as the leader address to the leader retrieval services.
 	 *
 	 * @param leaderSessionID The new leader session ID
+	 * @param leaderAddress The address of the new leader
 	 */
-	void confirmLeaderSessionID(UUID leaderSessionID);
+	void confirmLeadership(UUID leaderSessionID, String leaderAddress);
 
 	/**
 	 * Returns true if the {@link LeaderContender} with which the service has been started owns

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionService.java
@@ -57,7 +57,7 @@ public class StandaloneLeaderElectionService implements LeaderElectionService {
 	}
 
 	@Override
-	public void confirmLeaderSessionID(UUID leaderSessionID) {}
+	public void confirmLeadership(UUID leaderSessionID, String leaderAddress) {}
 
 	@Override
 	public boolean hasLeadership(@Nonnull UUID leaderSessionId) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -897,7 +897,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 			(acceptLeadership) -> {
 				if (acceptLeadership) {
 					// confirming the leader session ID might be blocking,
-					leaderElectionService.confirmLeaderSessionID(newLeaderSessionID);
+					leaderElectionService.confirmLeadership(newLeaderSessionID, getAddress());
 				}
 			},
 			getRpcService().getExecutor());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/LeaderRetrievalUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/LeaderRetrievalUtils.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.util;
 
-import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalException;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
@@ -30,10 +29,8 @@ import org.slf4j.LoggerFactory;
 import java.net.InetAddress;
 import java.time.Duration;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-
-import scala.concurrent.Future;
-import scala.concurrent.Promise;
 
 /**
  * Utility class to work with {@link LeaderRetrievalService} class.
@@ -62,9 +59,7 @@ public class LeaderRetrievalUtils {
 		try {
 			leaderRetrievalService.start(listener);
 
-			Future<LeaderConnectionInfo> connectionInfoFuture = listener.getLeaderConnectionInfoFuture();
-
-			return FutureUtils.toJava(connectionInfoFuture).get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+			return listener.getLeaderConnectionInfoFuture().get(timeout.toMillis(), TimeUnit.MILLISECONDS);
 		} catch (Exception e) {
 			throw new LeaderRetrievalException("Could not retrieve the leader address and leader " +
 				"session ID.", e);
@@ -110,25 +105,23 @@ public class LeaderRetrievalUtils {
 	 * leader's akka URL and the current leader session ID.
 	 */
 	public static class LeaderConnectionInfoListener implements  LeaderRetrievalListener {
-		private final Promise<LeaderConnectionInfo> connectionInfo = new scala.concurrent.impl.Promise.DefaultPromise<>();
+		private final CompletableFuture<LeaderConnectionInfo> connectionInfoFuture = new CompletableFuture<>();
 
-		public Future<LeaderConnectionInfo> getLeaderConnectionInfoFuture() {
-			return connectionInfo.future();
+		public CompletableFuture<LeaderConnectionInfo> getLeaderConnectionInfoFuture() {
+			return connectionInfoFuture;
 		}
 
 		@Override
 		public void notifyLeaderAddress(String leaderAddress, UUID leaderSessionID) {
-			if (leaderAddress != null && !leaderAddress.equals("") && !connectionInfo.isCompleted()) {
+			if (leaderAddress != null && !leaderAddress.equals("") && !connectionInfoFuture.isDone()) {
 				final LeaderConnectionInfo leaderConnectionInfo = new LeaderConnectionInfo(leaderSessionID, leaderAddress);
-				connectionInfo.success(leaderConnectionInfo);
+				connectionInfoFuture.complete(leaderConnectionInfo);
 			}
 		}
 
 		@Override
 		public void handleError(Exception exception) {
-			if (!connectionInfo.isCompleted()) {
-				connectionInfo.failure(exception);
-			}
+			connectionInfoFuture.completeExceptionally(exception);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -710,7 +710,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 	@Override
 	public void grantLeadership(final UUID leaderSessionID) {
 		log.info("{} was granted leadership with leaderSessionID={}", getRestBaseUrl(), leaderSessionID);
-		leaderElectionService.confirmLeaderSessionID(leaderSessionID);
+		leaderElectionService.confirmLeadership(leaderSessionID, getRestBaseUrl());
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedHaServicesTest.java
@@ -137,7 +137,7 @@ public class EmbeddedHaServicesTest extends TestLogger {
 
 		final UUID leaderId = leaderIdArgumentCaptor.getValue();
 
-		leaderElectionService.confirmLeaderSessionID(leaderId);
+		leaderElectionService.confirmLeadership(leaderId, address);
 
 		verify(leaderRetrievalListener).notifyLeaderAddress(eq(address), eq(leaderId));
 	}
@@ -163,7 +163,7 @@ public class EmbeddedHaServicesTest extends TestLogger {
 
 		final UUID leaderId = leaderIdArgumentCaptor.getValue();
 
-		leaderElectionService.confirmLeaderSessionID(leaderId);
+		leaderElectionService.confirmLeadership(leaderId, address);
 
 		verify(leaderRetrievalListener).notifyLeaderAddress(eq(address), eq(leaderId));
 	}
@@ -191,8 +191,8 @@ public class EmbeddedHaServicesTest extends TestLogger {
 
 		assertThat(dispatcherLeaderElectionService.hasLeadership(newLeaderSessionId), is(true));
 
-		dispatcherLeaderElectionService.confirmLeaderSessionID(oldLeaderSessionId);
-		dispatcherLeaderElectionService.confirmLeaderSessionID(newLeaderSessionId);
+		dispatcherLeaderElectionService.confirmLeadership(oldLeaderSessionId, leaderContender.getAddress());
+		dispatcherLeaderElectionService.confirmLeadership(newLeaderSessionId, leaderContender.getAddress());
 
 		assertThat(dispatcherLeaderElectionService.hasLeadership(newLeaderSessionId), is(true));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/leaderelection/SingleLeaderElectionServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/leaderelection/SingleLeaderElectionServiceTest.java
@@ -216,7 +216,7 @@ public class SingleLeaderElectionServiceTest {
 				@Override
 				public Void answer(InvocationOnMock invocation) throws Throwable {
 					final UUID uuid = (UUID) invocation.getArguments()[0];
-					service.confirmLeaderSessionID(uuid);
+					service.confirmLeadership(uuid, address);
 					return null;
 				}
 		}).when(mockContender).grantLeadership(any(UUID.class));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
@@ -101,7 +101,7 @@ public class LeaderElectionTest extends TestLogger {
 			assertThat(leaderElectionService.hasLeadership(leaderSessionId), is(true));
 			assertThat(leaderElectionService.hasLeadership(UUID.randomUUID()), is(false));
 
-			leaderElectionService.confirmLeaderSessionID(leaderSessionId);
+			leaderElectionService.confirmLeadership(leaderSessionId, manualLeaderContender.getAddress());
 
 			assertThat(leaderElectionService.hasLeadership(leaderSessionId), is(true));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingContender.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingContender.java
@@ -118,7 +118,7 @@ public class TestingContender implements LeaderContender {
 
 			this.leaderSessionID = leaderSessionID;
 
-			leaderElectionService.confirmLeaderSessionID(leaderSessionID);
+			leaderElectionService.confirmLeadership(leaderSessionID, getAddress());
 
 			leader = true;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionService.java
@@ -67,7 +67,7 @@ public class TestingLeaderElectionService implements LeaderElectionService {
 	}
 
 	@Override
-	public synchronized void confirmLeaderSessionID(UUID leaderSessionID) {
+	public synchronized void confirmLeadership(UUID leaderSessionID, String leaderAddress) {
 		if (confirmationFuture != null) {
 			confirmationFuture.complete(leaderSessionID);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
@@ -52,7 +52,7 @@ public class ResourceManagerHATest extends TestLogger {
 
 		TestingLeaderElectionService leaderElectionService = new TestingLeaderElectionService() {
 			@Override
-			public void confirmLeaderSessionID(UUID leaderId) {
+			public void confirmLeadership(UUID leaderId, String leaderAddress) {
 				leaderSessionIdFuture.complete(leaderId);
 			}
 		};

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/DocumentingDispatcherRestEndpoint.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/DocumentingDispatcherRestEndpoint.java
@@ -110,7 +110,7 @@ public class DocumentingDispatcherRestEndpoint extends DispatcherRestEndpoint im
 		}
 
 		@Override
-		public void confirmLeaderSessionID(final UUID leaderSessionID) {
+		public void confirmLeadership(final UUID leaderSessionID, final String leaderAddress) {
 
 		}
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/highavailability/YarnIntraNonHaMasterServicesTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/highavailability/YarnIntraNonHaMasterServicesTest.java
@@ -156,7 +156,7 @@ public class YarnIntraNonHaMasterServicesTest extends TestLogger {
 			@Override
 			public Void answer(InvocationOnMock invocation) throws Throwable {
 				final UUID uuid = (UUID) invocation.getArguments()[0];
-				service.confirmLeaderSessionID(uuid);
+				service.confirmLeadership(uuid, address);
 				return null;
 			}
 		}).when(mockContender).grantLeadership(any(UUID.class));


### PR DESCRIPTION
## What is the purpose of the change

This PR is based on #9812.

Change LeaderElectionService#confirmLeadership to accept leader address so that
the LeaderContender does not need to know the address of the potential leader
before gaining leadership. This allows to decouple the leader election from the
actual leader component.

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
