### PR TITLE
[FLINK-14288][legal] Add Py4J NOTICE for source release

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -34,6 +34,7 @@ See bundled license files for details.
 
 - d3:3.5.12
 - cloudpickle:1.2.2
+- net.sf.py4j:py4j:0.10.8.1
 
 This project bundles the following dependencies under SIL OFL 1.1 license (https://opensource.org/licenses/OFL-1.1).
 See bundled license files for details.


### PR DESCRIPTION

## What is the purpose of the change

*This pull request adds Py4J to the NOTICE as it's bundled in the source release*


## Brief change log

  - *Adds Py4J to the NOTICE file*

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
