### PR TITLE
[FLINK-14178] Downgrade maven-shade-plugin to 3.1.0

### DIFF
--- a/docs/dev/projectsetup/dependencies.md
+++ b/docs/dev/projectsetup/dependencies.md
@@ -196,7 +196,7 @@ you can use the following shade plugin definition:
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>3.2.1</version>
+            <version>3.1.0</version>
             <executions>
                 <execution>
                     <phase>package</phase>

--- a/docs/dev/projectsetup/dependencies.zh.md
+++ b/docs/dev/projectsetup/dependencies.zh.md
@@ -159,7 +159,7 @@ Scala 版本(2.10、2.11、2.12等)互相是不兼容的。因此，依赖 Scala
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>3.2.1</version>
+            <version>3.1.0</version>
             <executions>
                 <execution>
                     <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -1686,7 +1686,7 @@ under the License.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>3.2.1</version>
+					<version>3.1.0</version>
 				</plugin>
 
 				<plugin>


### PR DESCRIPTION

## What is the purpose of the change

*This pull request downgrades maven-shade-plugin to 3.1.0 as 3.2.1 doesn't work on ARM for Flink*

## Brief change log

  - *Downgrade maven-shade-plugin to 3.1.0*


## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
