### PR TITLE
 [FLINK-14289][runtime] Remove Optional fields from RecordWriter relevant classes

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
@@ -33,8 +33,9 @@ import org.apache.flink.util.XORShiftRandom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
-import java.util.Optional;
 import java.util.Random;
 
 import static org.apache.flink.runtime.io.network.api.serialization.RecordSerializer.SerializationResult;
@@ -76,7 +77,8 @@ public abstract class RecordWriter<T extends IOReadableWritable> {
 	private static final String DEFAULT_OUTPUT_FLUSH_THREAD_NAME = "OutputFlusher";
 
 	/** The thread that periodically flushes the output, to give an upper latency bound. */
-	private final Optional<OutputFlusher> outputFlusher;
+	@Nullable
+	private final OutputFlusher outputFlusher;
 
 	/** To avoid synchronization overhead on the critical path, best-effort error tracking is enough here.*/
 	private Throwable flusherException;
@@ -90,14 +92,14 @@ public abstract class RecordWriter<T extends IOReadableWritable> {
 		checkArgument(timeout >= -1);
 		this.flushAlways = (timeout == 0);
 		if (timeout == -1 || timeout == 0) {
-			outputFlusher = Optional.empty();
+			outputFlusher = null;
 		} else {
 			String threadName = taskName == null ?
 				DEFAULT_OUTPUT_FLUSH_THREAD_NAME :
 				DEFAULT_OUTPUT_FLUSH_THREAD_NAME + " for " + taskName;
 
-			outputFlusher = Optional.of(new OutputFlusher(threadName, timeout));
-			outputFlusher.get().start();
+			outputFlusher = new OutputFlusher(threadName, timeout);
+			outputFlusher.start();
 		}
 	}
 
@@ -235,10 +237,10 @@ public abstract class RecordWriter<T extends IOReadableWritable> {
 	public void close() {
 		clearBuffers();
 		// make sure we terminate the thread in any case
-		if (outputFlusher.isPresent()) {
-			outputFlusher.get().terminate();
+		if (outputFlusher != null) {
+			outputFlusher.terminate();
 			try {
-				outputFlusher.get().join();
+				outputFlusher.join();
 			} catch (InterruptedException e) {
 				// ignore on close
 				// restore interrupt flag to fast exit further blocking calls

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterBuilder.java
@@ -18,37 +18,39 @@
 
 package org.apache.flink.runtime.io.network.api.writer;
 
+import org.apache.flink.core.io.IOReadableWritable;
+
 /**
  * Utility class to encapsulate the logic of building a {@link RecordWriter} instance.
  */
-public class RecordWriterBuilder {
+public class RecordWriterBuilder<T extends IOReadableWritable> {
 
-	private ChannelSelector selector = new RoundRobinChannelSelector();
+	private ChannelSelector<T> selector = new RoundRobinChannelSelector<>();
 
 	private long timeout = -1;
 
 	private String taskName = "test";
 
-	public RecordWriterBuilder setChannelSelector(ChannelSelector selector) {
+	public RecordWriterBuilder<T> setChannelSelector(ChannelSelector<T> selector) {
 		this.selector = selector;
 		return this;
 	}
 
-	public RecordWriterBuilder setTimeout(long timeout) {
+	public RecordWriterBuilder<T> setTimeout(long timeout) {
 		this.timeout = timeout;
 		return this;
 	}
 
-	public RecordWriterBuilder setTaskName(String taskName) {
+	public RecordWriterBuilder<T> setTaskName(String taskName) {
 		this.taskName = taskName;
 		return this;
 	}
 
-	public RecordWriter build(ResultPartitionWriter writer) {
+	public RecordWriter<T> build(ResultPartitionWriter writer) {
 		if (selector.isBroadcast()) {
-			return new BroadcastRecordWriter(writer, timeout, taskName);
+			return new BroadcastRecordWriter<>(writer, timeout, taskName);
 		} else {
-			return new ChannelSelectorRecordWriter(writer, selector, timeout, taskName);
+			return new ChannelSelectorRecordWriter<>(writer, selector, timeout, taskName);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/IterationHeadTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/IterationHeadTask.java
@@ -143,7 +143,7 @@ public class IterationHeadTask<X, Y, S extends Function, OT> extends AbstractIte
 			throw new Exception("Error: Inconsistent head task setup - wrong mapping of output gates.");
 		}
 		// now, we can instantiate the sync gate
-		this.toSync = new RecordWriterBuilder().build(getEnvironment().getWriter(syncGateIndex));
+		this.toSync = new RecordWriterBuilder<>().build(getEnvironment().getWriter(syncGateIndex));
 		this.toSyncPartitionId = getEnvironment().getWriter(syncGateIndex).getPartitionId();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/SlotCountExceedingParallelismTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/SlotCountExceedingParallelismTest.java
@@ -141,7 +141,7 @@ public class SlotCountExceedingParallelismTest extends TestLogger {
 
 		@Override
 		public void invoke() throws Exception {
-			RecordWriter<IntValue> writer = new RecordWriterBuilder().build(getEnvironment().getWriter(0));
+			RecordWriter<IntValue> writer = new RecordWriterBuilder<IntValue>().build(getEnvironment().getWriter(0));
 			final int numberOfTimesToSend = getTaskConfiguration().getInteger(CONFIG_KEY, 0);
 
 			final IntValue subtaskIndex = new IntValue(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduleOrUpdateConsumersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduleOrUpdateConsumersTest.java
@@ -148,8 +148,8 @@ public class ScheduleOrUpdateConsumersTest extends TestLogger {
 
 			// The order of intermediate result creation in the job graph specifies which produced
 			// result partition is pipelined/blocking.
-			final RecordWriter<IntValue> pipelinedWriter = new RecordWriterBuilder().build(getEnvironment().getWriter(0));
-			final RecordWriter<IntValue> blockingWriter = new RecordWriterBuilder().build(getEnvironment().getWriter(1));
+			final RecordWriter<IntValue> pipelinedWriter = new RecordWriterBuilder<IntValue>().build(getEnvironment().getWriter(0));
+			final RecordWriter<IntValue> blockingWriter = new RecordWriterBuilder<IntValue>().build(getEnvironment().getWriter(1));
 			writers.add(pipelinedWriter);
 			writers.add(blockingWriter);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingAbstractInvokables.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingAbstractInvokables.java
@@ -47,7 +47,7 @@ public class TestingAbstractInvokables {
 
 		@Override
 		public void invoke() throws Exception {
-			final RecordWriter<IntValue> writer = new RecordWriterBuilder().build(getEnvironment().getWriter(0));
+			final RecordWriter<IntValue> writer = new RecordWriterBuilder<IntValue>().build(getEnvironment().getWriter(0));
 
 			try {
 				writer.emit(new IntValue(42));
@@ -97,7 +97,7 @@ public class TestingAbstractInvokables {
 		@Override
 		public void invoke() throws Exception {
 			final Object o = new Object();
-			RecordWriter<IntValue> recordWriter = new RecordWriterBuilder().build(getEnvironment().getWriter(0));
+			RecordWriter<IntValue> recordWriter = new RecordWriterBuilder<IntValue>().build(getEnvironment().getWriter(0));
 			for (int i = 0; i < 1024; i++) {
 				recordWriter.emit(new IntValue(42));
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskCancelAsyncProducerConsumerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskCancelAsyncProducerConsumerITCase.java
@@ -215,7 +215,7 @@ public class TaskCancelAsyncProducerConsumerITCase extends TestLogger {
 			private final RecordWriter<LongValue> recordWriter;
 
 			public ProducerThread(ResultPartitionWriter partitionWriter) {
-				this.recordWriter = new RecordWriterBuilder().build(partitionWriter);
+				this.recordWriter = new RecordWriterBuilder<LongValue>().build(partitionWriter);
 			}
 
 			@Override

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/Tasks.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/Tasks.scala
@@ -35,8 +35,8 @@ object Tasks {
         classOf[IntValue],
         getEnvironment.getTaskManagerInfo.getTmpDirectories)
       
-      val writer = new RecordWriterBuilder().build(
-        getEnvironment.getWriter(0)).asInstanceOf[RecordWriter[IntValue]]
+      val writer = new RecordWriterBuilder[IntValue]().build(
+        getEnvironment.getWriter(0))
 
       try {
         while (true) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -1413,7 +1413,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			}
 		}
 
-		RecordWriter<SerializationDelegate<StreamRecord<OUT>>> output = new RecordWriterBuilder()
+		RecordWriter<SerializationDelegate<StreamRecord<OUT>>> output = new RecordWriterBuilder<SerializationDelegate<StreamRecord<OUT>>>()
 			.setChannelSelector(outputPartitioner)
 			.setTimeout(bufferTimeout)
 			.setTaskName(taskName)

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/FileBufferReaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/FileBufferReaderITCase.java
@@ -146,7 +146,7 @@ public class FileBufferReaderITCase extends TestLogger {
 
 		@Override
 		public void invoke() throws Exception {
-			final RecordWriter<ByteArrayType> writer = new RecordWriterBuilder().build(getEnvironment().getWriter(0));
+			final RecordWriter<ByteArrayType> writer = new RecordWriterBuilder<ByteArrayType>().build(getEnvironment().getWriter(0));
 
 			final ByteArrayType bytes = new ByteArrayType(dataSource);
 			int counter = 0;

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/NetworkStackThroughputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/NetworkStackThroughputITCase.java
@@ -78,7 +78,7 @@ public class NetworkStackThroughputITCase extends TestLogger {
 
 		@Override
 		public void invoke() throws Exception {
-			RecordWriter<SpeedTestRecord> writer = new RecordWriterBuilder().build(getEnvironment().getWriter(0));
+			RecordWriter<SpeedTestRecord> writer = new RecordWriterBuilder<SpeedTestRecord>().build(getEnvironment().getWriter(0));
 
 			try {
 				// Determine the amount of data to send per subtask
@@ -128,7 +128,7 @@ public class NetworkStackThroughputITCase extends TestLogger {
 					SpeedTestRecord.class,
 					getEnvironment().getTaskManagerInfo().getTmpDirectories());
 
-			RecordWriter<SpeedTestRecord> writer = new RecordWriterBuilder().build(getEnvironment().getWriter(0));
+			RecordWriter<SpeedTestRecord> writer = new RecordWriterBuilder<SpeedTestRecord>().build(getEnvironment().getWriter(0));
 
 			try {
 				SpeedTestRecord record;


### PR DESCRIPTION
## What is the purpose of the change

*Based on the code style guides for Jave Optional , it should not be used for class fields. So we remove the optional usages from `RecordWriter`, `BroadcastRecordWriter` and `ChannelSelectorRecordWriter`.*

## Brief change log

  - *Refactor the usages of Optional in `RecordWriter` relevant classes*
  - *Add missing generics in `RecordWriterBuilder` for avoiding unchecked warning*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)