### PR TITLE
[FLINK-14298] Replace LeaderContender#getAddress with #getDescription

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
@@ -299,8 +299,7 @@ public class EmbeddedLeaderService {
 				currentLeaderProposed = leaderService;
 				currentLeaderProposed.isLeader = true;
 
-				LOG.info("Proposing leadership to contender {} @ {}",
-						leaderService.contender, leaderService.contender.getAddress());
+				LOG.info("Proposing leadership to contender {}", leaderService.contender.getDescription());
 
 				return execute(new GrantLeadershipCall(leaderService.contender, leaderSessionId, LOG));
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImpl.java
@@ -315,7 +315,7 @@ public class JobManagerRunnerImpl implements LeaderContender, OnCompletionAction
 
 	private CompletionStage<Void> startJobMaster(UUID leaderSessionId) {
 		log.info("JobManager runner for job {} ({}) was granted leadership with session id {} at {}.",
-			jobGraph.getName(), jobGraph.getJobID(), leaderSessionId, getAddress());
+			jobGraph.getName(), jobGraph.getJobID(), leaderSessionId, jobMasterService.getAddress());
 
 		try {
 			runningJobsRegistry.setJobRunning(jobGraph.getJobID());
@@ -370,7 +370,7 @@ public class JobManagerRunnerImpl implements LeaderContender, OnCompletionAction
 			currentLeaderGatewayFuture.complete(jobMasterService.getGateway());
 			leaderElectionService.confirmLeadership(leaderSessionId, leaderAddress);
 		} else {
-			log.debug("Ignoring confirmation of leader session id because {} is no longer the leader.", getAddress());
+			log.debug("Ignoring confirmation of leader session id because {} is no longer the leader.", getDescription());
 		}
 	}
 
@@ -394,8 +394,8 @@ public class JobManagerRunnerImpl implements LeaderContender, OnCompletionAction
 	}
 
 	private CompletableFuture<Void> revokeJobMasterLeadership() {
-		log.info("JobManager for job {} ({}) was revoked leadership at {}.",
-			jobGraph.getName(), jobGraph.getJobID(), getAddress());
+		log.info("JobManager for job {} ({}) at {} was revoked leadership.",
+			jobGraph.getName(), jobGraph.getJobID(), jobMasterService.getAddress());
 
 		setNewLeaderGatewayFuture();
 
@@ -431,7 +431,7 @@ public class JobManagerRunnerImpl implements LeaderContender, OnCompletionAction
 	}
 
 	@Override
-	public String getAddress() {
+	public String getDescription() {
 		return jobMasterService.getAddress();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderContender.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderContender.java
@@ -42,18 +42,19 @@ public interface LeaderContender {
 	void revokeLeadership();
 
 	/**
-	 * Returns the address of the {@link LeaderContender} under which other instances can connect
-	 * to it.
-	 *
-	 * @return Address of this contender.
-	 */
-	String getAddress();
-
-	/**
 	 * Callback method which is called by {@link LeaderElectionService} in case of an error in the
 	 * service thread.
 	 *
 	 * @param exception Caught exception
 	 */
 	void handleError(Exception exception);
+
+	/**
+	 * Returns the description of the {@link LeaderContender} for logging purposes.
+	 *
+	 * @return Description of this contender.
+	 */
+	default String getDescription() {
+		return "LeaderContender: " + getClass().getSimpleName();
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionService.java
@@ -25,11 +25,11 @@ import java.util.UUID;
 /**
  * Interface for a service which allows to elect a leader among a group of contenders.
  *
- * Prior to using this service, it has to be started calling the start method. The start method
+ * <p>Prior to using this service, it has to be started calling the start method. The start method
  * takes the contender as a parameter. If there are multiple contenders, then each contender has
  * to instantiate its own leader election service.
  *
- * Once a contender has been granted leadership he has to confirm the received leader session ID
+ * <p>Once a contender has been granted leadership he has to confirm the received leader session ID
  * by calling the method {@link #confirmLeadership(UUID, String)}. This will notify the leader election
  * service, that the contender has accepted the leadership specified and that the leader session id as
  * well as the leader address can now be published for leader retrieval services.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionService.java
@@ -229,7 +229,7 @@ public class ZooKeeperLeaderElectionService implements LeaderElectionService, Le
 				if (LOG.isDebugEnabled()) {
 					LOG.debug(
 						"Grant leadership to contender {} with session ID {}.",
-						leaderContender.getAddress(),
+						leaderContender.getDescription(),
 						issuedLeaderSessionID);
 				}
 
@@ -252,7 +252,7 @@ public class ZooKeeperLeaderElectionService implements LeaderElectionService, Le
 			if (running) {
 				LOG.debug(
 					"Revoke leadership of {} ({}@{}).",
-					leaderContender,
+					leaderContender.getDescription(),
 					confirmedLeaderSessionID,
 					confirmedLeaderAddress);
 
@@ -277,7 +277,7 @@ public class ZooKeeperLeaderElectionService implements LeaderElectionService, Le
 						if (LOG.isDebugEnabled()) {
 							LOG.debug(
 								"Leader node changed while {} is the leader with session ID {}.",
-								leaderContender.getAddress(),
+								leaderContender.getDescription(),
 								confirmedLeaderSessionID);
 						}
 
@@ -288,7 +288,7 @@ public class ZooKeeperLeaderElectionService implements LeaderElectionService, Le
 								if (LOG.isDebugEnabled()) {
 									LOG.debug(
 										"Writing leader information into empty node by {}.",
-										leaderContender.getAddress());
+										leaderContender.getDescription());
 								}
 								writeLeaderInformation();
 							} else {
@@ -299,7 +299,7 @@ public class ZooKeeperLeaderElectionService implements LeaderElectionService, Le
 									if (LOG.isDebugEnabled()) {
 										LOG.debug(
 											"Writing leader information into node with empty data field by {}.",
-											leaderContender.getAddress());
+											leaderContender.getDescription());
 									}
 									writeLeaderInformation();
 								} else {
@@ -315,7 +315,7 @@ public class ZooKeeperLeaderElectionService implements LeaderElectionService, Le
 										if (LOG.isDebugEnabled()) {
 											LOG.debug(
 												"Correcting leader information by {}.",
-												leaderContender.getAddress());
+												leaderContender.getDescription());
 										}
 										writeLeaderInformation();
 									}
@@ -410,7 +410,7 @@ public class ZooKeeperLeaderElectionService implements LeaderElectionService, Le
 				LOG.debug("Connected to ZooKeeper quorum. Leader election can start.");
 				break;
 			case SUSPENDED:
-				LOG.warn("Connection to ZooKeeper suspended. The contender " + leaderContender.getAddress()
+				LOG.warn("Connection to ZooKeeper suspended. The contender " + leaderContender.getDescription()
 					+ " no longer participates in the leader election.");
 				break;
 			case RECONNECTED:
@@ -418,7 +418,7 @@ public class ZooKeeperLeaderElectionService implements LeaderElectionService, Le
 				break;
 			case LOST:
 				// Maybe we have to throw an exception here to terminate the JobManager
-				LOG.warn("Connection to ZooKeeper lost. The contender " + leaderContender.getAddress()
+				LOG.warn("Connection to ZooKeeper lost. The contender " + leaderContender.getDescription()
 					+ " no longer participates in the leader election.");
 				break;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/LeaderConnectionInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/LeaderConnectionInfo.java
@@ -28,7 +28,7 @@ public class LeaderConnectionInfo {
 
 	private final String address;
 
-	LeaderConnectionInfo(UUID leaderSessionId, String address) {
+	public LeaderConnectionInfo(UUID leaderSessionId, String address) {
 		this.leaderSessionId = leaderSessionId;
 		this.address = address;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -719,7 +719,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 	}
 
 	@Override
-	public String getAddress() {
+	public String getDescription() {
 		return getRestBaseUrl();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedHaServicesTest.java
@@ -22,8 +22,9 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.leaderelection.LeaderContender;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
-import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.runtime.util.LeaderConnectionInfo;
+import org.apache.flink.runtime.util.LeaderRetrievalUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
@@ -37,16 +38,16 @@ import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests for the {@link EmbeddedHaServices}.
  */
 public class EmbeddedHaServicesTest extends TestLogger {
+
+	private static final String ADDRESS = "foobar";
 
 	private EmbeddedHaServices embeddedHaServices;
 
@@ -120,26 +121,29 @@ public class EmbeddedHaServicesTest extends TestLogger {
 	 */
 	@Test
 	public void testJobManagerLeaderRetrieval() throws Exception {
-		final String address = "foobar";
 		JobID jobId = new JobID();
-		LeaderRetrievalListener leaderRetrievalListener = mock(LeaderRetrievalListener.class);
-		LeaderContender leaderContender = mock(LeaderContender.class);
-		when(leaderContender.getAddress()).thenReturn(address);
 
 		LeaderElectionService leaderElectionService = embeddedHaServices.getJobManagerLeaderElectionService(jobId);
 		LeaderRetrievalService leaderRetrievalService = embeddedHaServices.getJobManagerLeaderRetriever(jobId);
 
+		runLeaderRetrievalTest(leaderElectionService, leaderRetrievalService);
+	}
+
+	private void runLeaderRetrievalTest(LeaderElectionService leaderElectionService, LeaderRetrievalService leaderRetrievalService) throws Exception {
+		LeaderRetrievalUtils.LeaderConnectionInfoListener leaderRetrievalListener = new LeaderRetrievalUtils.LeaderConnectionInfoListener();
+		TestingLeaderContender leaderContender = new TestingLeaderContender();
+
 		leaderRetrievalService.start(leaderRetrievalListener);
 		leaderElectionService.start(leaderContender);
 
-		ArgumentCaptor<UUID> leaderIdArgumentCaptor = ArgumentCaptor.forClass(UUID.class);
-		verify(leaderContender).grantLeadership(leaderIdArgumentCaptor.capture());
+		final UUID leaderId = leaderContender.getLeaderSessionFuture().get();
 
-		final UUID leaderId = leaderIdArgumentCaptor.getValue();
+		leaderElectionService.confirmLeadership(leaderId, ADDRESS);
 
-		leaderElectionService.confirmLeadership(leaderId, address);
+		final LeaderConnectionInfo leaderConnectionInfo = leaderRetrievalListener.getLeaderConnectionInfoFuture().get();
 
-		verify(leaderRetrievalListener).notifyLeaderAddress(eq(address), eq(leaderId));
+		assertThat(leaderConnectionInfo.getAddress(), is(ADDRESS));
+		assertThat(leaderConnectionInfo.getLeaderSessionId(), is(leaderId));
 	}
 
 	/**
@@ -147,25 +151,10 @@ public class EmbeddedHaServicesTest extends TestLogger {
 	 */
 	@Test
 	public void testResourceManagerLeaderRetrieval() throws Exception {
-		final String address = "foobar";
-		LeaderRetrievalListener leaderRetrievalListener = mock(LeaderRetrievalListener.class);
-		LeaderContender leaderContender = mock(LeaderContender.class);
-		when(leaderContender.getAddress()).thenReturn(address);
-
 		LeaderElectionService leaderElectionService = embeddedHaServices.getResourceManagerLeaderElectionService();
 		LeaderRetrievalService leaderRetrievalService = embeddedHaServices.getResourceManagerLeaderRetriever();
 
-		leaderRetrievalService.start(leaderRetrievalListener);
-		leaderElectionService.start(leaderContender);
-
-		ArgumentCaptor<UUID> leaderIdArgumentCaptor = ArgumentCaptor.forClass(UUID.class);
-		verify(leaderContender).grantLeadership(leaderIdArgumentCaptor.capture());
-
-		final UUID leaderId = leaderIdArgumentCaptor.getValue();
-
-		leaderElectionService.confirmLeadership(leaderId, address);
-
-		verify(leaderRetrievalListener).notifyLeaderAddress(eq(address), eq(leaderId));
+		runLeaderRetrievalTest(leaderElectionService, leaderRetrievalService);
 	}
 
 	/**
@@ -191,8 +180,8 @@ public class EmbeddedHaServicesTest extends TestLogger {
 
 		assertThat(dispatcherLeaderElectionService.hasLeadership(newLeaderSessionId), is(true));
 
-		dispatcherLeaderElectionService.confirmLeadership(oldLeaderSessionId, leaderContender.getAddress());
-		dispatcherLeaderElectionService.confirmLeadership(newLeaderSessionId, leaderContender.getAddress());
+		dispatcherLeaderElectionService.confirmLeadership(oldLeaderSessionId, ADDRESS);
+		dispatcherLeaderElectionService.confirmLeadership(newLeaderSessionId, ADDRESS);
 
 		assertThat(dispatcherLeaderElectionService.hasLeadership(newLeaderSessionId), is(true));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/TestingLeaderContender.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/TestingLeaderContender.java
@@ -58,7 +58,7 @@ final class TestingLeaderContender implements LeaderContender {
 	}
 
 	@Override
-	public String getAddress() {
+	public String getDescription() {
 		return "foobar";
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/leaderelection/SingleLeaderElectionServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/leaderelection/SingleLeaderElectionServiceTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.util.StringUtils;
 
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.util.Random;
@@ -34,7 +33,12 @@ import java.util.UUID;
 import java.util.concurrent.Executor;
 
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 /**
  * Tests for the {@link SingleLeaderElectionService}.
@@ -165,7 +169,7 @@ public class SingleLeaderElectionServiceTest {
 		service.shutdown();
 
 		final LeaderContender contender = mock(LeaderContender.class);
-		
+
 		// should not be possible to start
 		try {
 			service.start(contender);
@@ -210,15 +214,10 @@ public class SingleLeaderElectionServiceTest {
 	private static LeaderContender mockContender(final LeaderElectionService service, final String address) {
 		LeaderContender mockContender = mock(LeaderContender.class);
 
-		when(mockContender.getAddress()).thenReturn(address);
-
-		doAnswer(new Answer<Void>() {
-				@Override
-				public Void answer(InvocationOnMock invocation) throws Throwable {
-					final UUID uuid = (UUID) invocation.getArguments()[0];
-					service.confirmLeadership(uuid, address);
-					return null;
-				}
+		doAnswer((Answer<Void>) invocation -> {
+			final UUID uuid = (UUID) invocation.getArguments()[0];
+			service.confirmLeadership(uuid, address);
+			return null;
 		}).when(mockContender).grantLeadership(any(UUID.class));
 
 		return mockContender;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
@@ -101,7 +101,7 @@ public class LeaderElectionTest extends TestLogger {
 			assertThat(leaderElectionService.hasLeadership(leaderSessionId), is(true));
 			assertThat(leaderElectionService.hasLeadership(UUID.randomUUID()), is(false));
 
-			leaderElectionService.confirmLeadership(leaderSessionId, manualLeaderContender.getAddress());
+			leaderElectionService.confirmLeadership(leaderSessionId, "foobar");
 
 			assertThat(leaderElectionService.hasLeadership(leaderSessionId), is(true));
 
@@ -132,7 +132,7 @@ public class LeaderElectionTest extends TestLogger {
 		}
 
 		@Override
-		public String getAddress() {
+		public String getDescription() {
 			return "foobar";
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingContender.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingContender.java
@@ -118,7 +118,7 @@ public class TestingContender implements LeaderContender {
 
 			this.leaderSessionID = leaderSessionID;
 
-			leaderElectionService.confirmLeadership(leaderSessionID, getAddress());
+			leaderElectionService.confirmLeadership(leaderSessionID, address);
 
 			leader = true;
 
@@ -139,7 +139,7 @@ public class TestingContender implements LeaderContender {
 	}
 
 	@Override
-	public String getAddress() {
+	public String getDescription() {
 		return address;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionService.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.leaderelection;
 
+import org.apache.flink.runtime.util.LeaderConnectionInfo;
+
 import javax.annotation.Nonnull;
 
 import java.util.UUID;
@@ -31,7 +33,7 @@ public class TestingLeaderElectionService implements LeaderElectionService {
 
 	private LeaderContender contender = null;
 	private boolean hasLeadership = false;
-	private CompletableFuture<UUID> confirmationFuture = null;
+	private CompletableFuture<LeaderConnectionInfo> confirmationFuture = null;
 	private CompletableFuture<Void> startFuture = new CompletableFuture<>();
 	private UUID issuedLeaderSessionId = null;
 
@@ -40,7 +42,7 @@ public class TestingLeaderElectionService implements LeaderElectionService {
 	 *
 	 * <p>Note: the future is created upon calling {@link #isLeader(UUID)}.
 	 */
-	public synchronized CompletableFuture<UUID> getConfirmationFuture() {
+	public synchronized CompletableFuture<LeaderConnectionInfo> getConfirmationFuture() {
 		return confirmationFuture;
 	}
 
@@ -69,7 +71,7 @@ public class TestingLeaderElectionService implements LeaderElectionService {
 	@Override
 	public synchronized void confirmLeadership(UUID leaderSessionID, String leaderAddress) {
 		if (confirmationFuture != null) {
-			confirmationFuture.complete(leaderSessionID);
+			confirmationFuture.complete(new LeaderConnectionInfo(leaderSessionID, leaderAddress));
 		}
 	}
 
@@ -90,7 +92,7 @@ public class TestingLeaderElectionService implements LeaderElectionService {
 			contender.grantLeadership(leaderSessionID);
 		}
 
-		return confirmationFuture;
+		return confirmationFuture.thenApply(LeaderConnectionInfo::getLeaderSessionId);
 	}
 
 	public synchronized void notLeader() {
@@ -102,8 +104,8 @@ public class TestingLeaderElectionService implements LeaderElectionService {
 	}
 
 	public synchronized String getAddress() {
-		if (contender != null) {
-			return contender.getAddress();
+		if (confirmationFuture.isDone()) {
+			return confirmationFuture.join().getAddress();
 		} else {
 			throw new IllegalStateException("TestingLeaderElectionService has not been started.");
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -43,6 +43,8 @@ import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
@@ -175,7 +177,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
 
 			for (int i = 0; i < num; i++) {
 				leaderElectionService[i] = ZooKeeperUtils.createLeaderElectionService(client, configuration);
-				contenders[i] = new TestingContender(TEST_URL + "_" + i, leaderElectionService[i]);
+				contenders[i] = new TestingContender(createAddress(i), leaderElectionService[i]);
 
 				LOG.debug("Start leader election service for contender #{}.", i);
 
@@ -199,7 +201,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
 					TestingContender contender = contenders[index];
 
 					// check that the retrieval service has retrieved the correct leader
-					if (address.equals(contender.getAddress()) && listener.getLeaderSessionID().equals(contender.getLeaderSessionID())) {
+					if (address.equals(createAddress(index)) && listener.getLeaderSessionID().equals(contender.getLeaderSessionID())) {
 						// kill the election service of the leader
 						LOG.debug("Stop leader election service of contender #{}.", numberSeenLeaders);
 						leaderElectionService[index].stop();
@@ -226,6 +228,11 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
 				}
 			}
 		}
+	}
+
+	@Nonnull
+	private String createAddress(int i) {
+		return TEST_URL + "_" + i;
 	}
 
 	/**
@@ -367,7 +374,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
 			}
 
 			assertEquals(listener2.getLeaderSessionID(), contender.getLeaderSessionID());
-			assertEquals(listener2.getAddress(), contender.getAddress());
+			assertEquals(listener2.getAddress(), TEST_URL);
 
 		} finally {
 			if (leaderElectionService != null) {

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/highavailability/YarnIntraNonHaMasterServicesTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/highavailability/YarnIntraNonHaMasterServicesTest.java
@@ -49,7 +49,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests for YarnIntraNonHaMasterServices.
@@ -149,8 +148,6 @@ public class YarnIntraNonHaMasterServicesTest extends TestLogger {
 
 	private static LeaderContender mockContender(final LeaderElectionService service, final String address) {
 		LeaderContender mockContender = mock(LeaderContender.class);
-
-		when(mockContender.getAddress()).thenReturn(address);
 
 		doAnswer(new Answer<Void>() {
 			@Override


### PR DESCRIPTION
## What is the purpose of the change

This PR is based on #9813.

This commit changes the LeaderContender to only require implementations to
report a description of the contender used for logging purposes instead of
the actual leader address.

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
