### PR TITLE
[FLINK-14302] [kafka] FlinkKafkaInternalProducer should not send `ADD_PARTITIONS_TO_TXN` request if `newPartitionsInTransaction` is empty when enable EoS

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
@@ -22,12 +22,15 @@ import org.apache.flink.streaming.connectors.kafka.internal.FlinkKafkaProducer;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 
+import kafka.server.KafkaServer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.InvalidTxnStateException;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -44,6 +47,21 @@ import static org.junit.Assert.assertEquals;
 public class FlinkKafkaProducerITCase extends KafkaTestBase {
 	protected String transactionalId;
 	protected Properties extraProperties;
+
+	@BeforeClass
+	public static void prepare() throws Exception {
+		LOG.info("-------------------------------------------------------------------------");
+		LOG.info("    Starting KafkaTestBase ");
+		LOG.info("-------------------------------------------------------------------------");
+
+		Properties serverProperties = new Properties();
+		serverProperties.put("transaction.state.log.num.partitions", Integer.toString(1));
+		startClusters(KafkaTestEnvironment.createConfig()
+			.setKafkaServersNumber(NUMBER_OF_KAFKA_SERVERS)
+			.setSecureMode(false)
+			.setHideKafkaBehindProxy(true)
+			.setKafkaServerProperties(serverProperties));
+	}
 
 	@Before
 	public void before() {
@@ -152,6 +170,20 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 		kafkaProducer.flush();
 	}
 
+	@Test(timeout = 30000L, expected = InvalidTxnStateException.class)
+	public void testProducerWhenCommitEmptyPartitionsToOutdatedTxnCoordinator() throws Exception {
+		String topic = "flink-kafka-producer-txn-coordinator-changed";
+		createTestTopic(topic, 1, 2);
+		try (Producer<String, String> kafkaProducer = new FlinkKafkaProducer<>(extraProperties)) {
+			kafkaProducer.initTransactions();
+			kafkaProducer.beginTransaction();
+			restartBroker(kafkaServer.getLeaderToShutDown("__transaction_state"));
+			kafkaProducer.flush();
+			kafkaProducer.commitTransaction();
+		}
+		deleteTestTopic(topic);
+	}
+
 	private FlinkKafkaProducer<String, String> getClosedProducer(String topicName) {
 		FlinkKafkaProducer<String, String> kafkaProducer = new FlinkKafkaProducer<>(extraProperties);
 		kafkaProducer.initTransactions();
@@ -169,6 +201,30 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 			ConsumerRecord<String, String> record = Iterables.getOnlyElement(records);
 			assertEquals(expectedKey, record.key());
 			assertEquals(expectedValue, record.value());
+		}
+	}
+
+	private void restartBroker(int brokerId) {
+		KafkaServer toRestart = null;
+		for (KafkaServer server : kafkaServer.getBrokers()) {
+			if (kafkaServer.getBrokerId(server) == brokerId) {
+				toRestart = server;
+			}
+		}
+
+		if (toRestart == null) {
+			StringBuilder listOfBrokers = new StringBuilder();
+			for (KafkaServer server : kafkaServer.getBrokers()) {
+				listOfBrokers.append(kafkaServer.getBrokerId(server));
+				listOfBrokers.append(" ; ");
+			}
+
+			throw new IllegalArgumentException("Cannot find broker to restart: " + brokerId
+				+ " ; available brokers: " + listOfBrokers.toString());
+		} else {
+			toRestart.shutdown();
+			toRestart.awaitShutdown();
+			toRestart.startup();
 		}
 	}
 }

--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
@@ -55,6 +55,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 
 		Properties serverProperties = new Properties();
 		serverProperties.put("transaction.state.log.num.partitions", Integer.toString(1));
+		serverProperties.put("auto.leader.rebalance.enable", Boolean.toString(false));
 		startClusters(KafkaTestEnvironment.createConfig()
 			.setKafkaServersNumber(NUMBER_OF_KAFKA_SERVERS)
 			.setSecureMode(false)

--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
@@ -28,7 +28,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.errors.InvalidTxnStateException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -170,7 +169,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 		kafkaProducer.flush();
 	}
 
-	@Test(timeout = 30000L, expected = InvalidTxnStateException.class)
+	@Test(timeout = 30000L)
 	public void testProducerWhenCommitEmptyPartitionsToOutdatedTxnCoordinator() throws Exception {
 		String topic = "flink-kafka-producer-txn-coordinator-changed";
 		createTestTopic(topic, 1, 2);

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/FlinkKafkaInternalProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/FlinkKafkaInternalProducer.java
@@ -269,9 +269,17 @@ public class FlinkKafkaInternalProducer<K, V> implements Producer<K, V> {
 	private TransactionalRequestResult enqueueNewPartitions() {
 		Object transactionManager = getValue(kafkaProducer, "transactionManager");
 		synchronized (transactionManager) {
-			Object txnRequestHandler = invoke(transactionManager, "addPartitionsToTransactionHandler");
-			invoke(transactionManager, "enqueueRequest", new Class[]{txnRequestHandler.getClass().getSuperclass()}, new Object[]{txnRequestHandler});
-			TransactionalRequestResult result = (TransactionalRequestResult) getValue(txnRequestHandler, txnRequestHandler.getClass().getSuperclass(), "result");
+			Object newPartitionsInTransaction = getValue(transactionManager, "newPartitionsInTransaction");
+			Object newPartitionsInTransactionIsEmpty = invoke(newPartitionsInTransaction, "isEmpty");
+			TransactionalRequestResult result;
+			if (newPartitionsInTransactionIsEmpty instanceof Boolean && !((Boolean) newPartitionsInTransactionIsEmpty)) {
+				Object txnRequestHandler = invoke(transactionManager, "addPartitionsToTransactionHandler");
+				invoke(transactionManager, "enqueueRequest", new Class[]{txnRequestHandler.getClass().getSuperclass()}, new Object[]{txnRequestHandler});
+				result = (TransactionalRequestResult) getValue(txnRequestHandler, txnRequestHandler.getClass().getSuperclass(), "result");
+			} else {
+				result = new TransactionalRequestResult();
+				result.done();
+			}
 			return result;
 		}
 	}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaInternalProducerITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaInternalProducerITCase.java
@@ -28,7 +28,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.errors.InvalidTxnStateException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -170,7 +169,7 @@ public class FlinkKafkaInternalProducerITCase extends KafkaTestBase {
 		kafkaProducer.flush();
 	}
 
-	@Test(timeout = 30000L, expected = InvalidTxnStateException.class)
+	@Test(timeout = 30000L)
 	public void testProducerWhenCommitEmptyPartitionsToOutdatedTxnCoordinator() throws Exception {
 		String topic = "flink-kafka-producer-txn-coordinator-changed";
 		createTestTopic(topic, 1, 2);

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaInternalProducerITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaInternalProducerITCase.java
@@ -22,12 +22,15 @@ import org.apache.flink.streaming.connectors.kafka.internal.FlinkKafkaInternalPr
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 
+import kafka.server.KafkaServer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.InvalidTxnStateException;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -44,6 +47,21 @@ import static org.junit.Assert.assertEquals;
 public class FlinkKafkaInternalProducerITCase extends KafkaTestBase {
 	protected String transactionalId;
 	protected Properties extraProperties;
+
+	@BeforeClass
+	public static void prepare() throws Exception {
+		LOG.info("-------------------------------------------------------------------------");
+		LOG.info("    Starting KafkaTestBase ");
+		LOG.info("-------------------------------------------------------------------------");
+
+		Properties serverProperties = new Properties();
+		serverProperties.put("transaction.state.log.num.partitions", Integer.toString(1));
+		startClusters(KafkaTestEnvironment.createConfig()
+			.setKafkaServersNumber(NUMBER_OF_KAFKA_SERVERS)
+			.setSecureMode(false)
+			.setHideKafkaBehindProxy(true)
+			.setKafkaServerProperties(serverProperties));
+	}
 
 	@Before
 	public void before() {
@@ -152,6 +170,20 @@ public class FlinkKafkaInternalProducerITCase extends KafkaTestBase {
 		kafkaProducer.flush();
 	}
 
+	@Test(timeout = 30000L, expected = InvalidTxnStateException.class)
+	public void testProducerWhenCommitEmptyPartitionsToOutdatedTxnCoordinator() throws Exception {
+		String topic = "flink-kafka-producer-txn-coordinator-changed";
+		createTestTopic(topic, 1, 2);
+		try (Producer<String, String> kafkaProducer = new FlinkKafkaInternalProducer<>(extraProperties)) {
+			kafkaProducer.initTransactions();
+			kafkaProducer.beginTransaction();
+			restartBroker(kafkaServer.getLeaderToShutDown("__transaction_state"));
+			kafkaProducer.flush();
+			kafkaProducer.commitTransaction();
+		}
+		deleteTestTopic(topic);
+	}
+
 	private FlinkKafkaInternalProducer<String, String> getClosedProducer(String topicName) {
 		FlinkKafkaInternalProducer<String, String> kafkaProducer = new FlinkKafkaInternalProducer<>(extraProperties);
 		kafkaProducer.initTransactions();
@@ -169,6 +201,30 @@ public class FlinkKafkaInternalProducerITCase extends KafkaTestBase {
 			ConsumerRecord<String, String> record = Iterables.getOnlyElement(records);
 			assertEquals(expectedKey, record.key());
 			assertEquals(expectedValue, record.value());
+		}
+	}
+
+	private void restartBroker(int brokerId) {
+		KafkaServer toRestart = null;
+		for (KafkaServer server : kafkaServer.getBrokers()) {
+			if (kafkaServer.getBrokerId(server) == brokerId) {
+				toRestart = server;
+			}
+		}
+
+		if (toRestart == null) {
+			StringBuilder listOfBrokers = new StringBuilder();
+			for (KafkaServer server : kafkaServer.getBrokers()) {
+				listOfBrokers.append(kafkaServer.getBrokerId(server));
+				listOfBrokers.append(" ; ");
+			}
+
+			throw new IllegalArgumentException("Cannot find broker to restart: " + brokerId
+				+ " ; available brokers: " + listOfBrokers.toString());
+		} else {
+			toRestart.shutdown();
+			toRestart.awaitShutdown();
+			toRestart.startup();
 		}
 	}
 }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaInternalProducerITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaInternalProducerITCase.java
@@ -55,6 +55,7 @@ public class FlinkKafkaInternalProducerITCase extends KafkaTestBase {
 
 		Properties serverProperties = new Properties();
 		serverProperties.put("transaction.state.log.num.partitions", Integer.toString(1));
+		serverProperties.put("auto.leader.rebalance.enable", Boolean.toString(false));
 		startClusters(KafkaTestEnvironment.createConfig()
 			.setKafkaServersNumber(NUMBER_OF_KAFKA_SERVERS)
 			.setSecureMode(false)


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

FlinkKafkaProducer will failed when commit without any data and its transaction coordinator changed. It is due to that client didn't get error message from kafka cluster. However, the root cause is that we shouldn't send `ADD_PARTITIONS_TO_TXN` request if `newPartitionsInTransaction` is empty. So, this PR aims to fix that.

## Brief change log
- Check `newPartitionsInTransaction` in kafka producer is empty before sending `ADD_PARTITIONS_TO_TXN` request to kafka cluster.

## Verifying this change

 - Introduce a new IT case to reproduce this bug, and make sure this patch can pass this test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: don't know
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
