### PR TITLE
[FLINK-10995][benchmarks] Use BroadcastRecordWriter for network broadcast benchmarks

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -78,7 +78,6 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
 	protected NettyShuffleEnvironment receiverEnv;
 
 	protected int channels;
-	protected boolean broadcastMode = false;
 	protected boolean localMode = false;
 
 	protected ResultPartitionID[] partitionIds;
@@ -96,7 +95,6 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
 		setUp(
 			writers,
 			channels,
-			false,
 			localMode,
 			senderBufferPoolSize,
 			receiverBufferPoolSize,
@@ -120,12 +118,10 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
 	public void setUp(
 			int writers,
 			int channels,
-			boolean broadcastMode,
 			boolean localMode,
 			int senderBufferPoolSize,
 			int receiverBufferPoolSize,
 			Configuration config) throws Exception {
-		this.broadcastMode = broadcastMode;
 		this.localMode = localMode;
 		this.channels = channels;
 		this.partitionIds = new ResultPartitionID[writers];

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkPointToPointBenchmark.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkPointToPointBenchmark.java
@@ -20,6 +20,8 @@ package org.apache.flink.streaming.runtime.io.benchmark;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
+import org.apache.flink.runtime.io.network.api.writer.RecordWriterBuilder;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.types.LongValue;
 
 import java.util.concurrent.CompletableFuture;
@@ -77,7 +79,9 @@ public class StreamNetworkPointToPointBenchmark {
 		environment = new StreamNetworkBenchmarkEnvironment<>();
 		environment.setUp(1, 1, false, false, -1, -1, config);
 
-		recordWriter = environment.createRecordWriter(0, flushTimeout);
+		ResultPartitionWriter resultPartitionWriter = environment.createResultPartitionWriter(0);
+
+		recordWriter = new RecordWriterBuilder().setTimeout(flushTimeout).build(resultPartitionWriter);
 		receiver = environment.createReceiver();
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkPointToPointBenchmark.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkPointToPointBenchmark.java
@@ -77,7 +77,7 @@ public class StreamNetworkPointToPointBenchmark {
 	 */
 	public void setUp(long flushTimeout, Configuration config) throws Exception {
 		environment = new StreamNetworkBenchmarkEnvironment<>();
-		environment.setUp(1, 1, false, false, -1, -1, config);
+		environment.setUp(1, 1, false, -1, -1, config);
 
 		ResultPartitionWriter resultPartitionWriter = environment.createResultPartitionWriter(0);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmark.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmark.java
@@ -19,6 +19,8 @@
 package org.apache.flink.streaming.runtime.io.benchmark;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.io.network.api.writer.RecordWriterBuilder;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.types.LongValue;
 
 import java.util.concurrent.CompletableFuture;
@@ -112,8 +114,10 @@ public class StreamNetworkThroughputBenchmark {
 			config);
 		writerThreads = new LongRecordWriterThread[recordWriters];
 		for (int writer = 0; writer < recordWriters; writer++) {
+			ResultPartitionWriter resultPartitionWriter = environment.createResultPartitionWriter(writer);
+			RecordWriterBuilder recordWriterBuilder = new RecordWriterBuilder().setTimeout(flushTimeout);
 			writerThreads[writer] = new LongRecordWriterThread(
-				environment.createRecordWriter(writer, flushTimeout),
+				recordWriterBuilder.build(resultPartitionWriter),
 				broadcastMode);
 			writerThreads[writer].start();
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmark.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmark.java
@@ -107,7 +107,6 @@ public class StreamNetworkThroughputBenchmark {
 		environment.setUp(
 			recordWriters,
 			channels,
-			broadcastMode,
 			localMode,
 			senderBufferPoolSize,
 			receiverBufferPoolSize,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmark.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmark.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.runtime.io.benchmark;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriterBuilder;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
 import org.apache.flink.types.LongValue;
 
 import java.util.concurrent.CompletableFuture;
@@ -115,6 +116,9 @@ public class StreamNetworkThroughputBenchmark {
 		for (int writer = 0; writer < recordWriters; writer++) {
 			ResultPartitionWriter resultPartitionWriter = environment.createResultPartitionWriter(writer);
 			RecordWriterBuilder recordWriterBuilder = new RecordWriterBuilder().setTimeout(flushTimeout);
+			if (broadcastMode) {
+				recordWriterBuilder.setChannelSelector(new BroadcastPartitioner());
+			}
 			writerThreads[writer] = new LongRecordWriterThread(
 				recordWriterBuilder.build(resultPartitionWriter),
 				broadcastMode);


### PR DESCRIPTION
After merging https://github.com/apache/flink/pull/7713 we haven't observed the performance improvement in the benchmarks, because broadcasting was not properly configured in the `networkBroadcastThroughput` benchmark. This PR fixes that.

Local tests shows that the before mentioned PR when tested with this fix, improved the `networkBroadcastThroughput` throughput from `640 ops/ms`  to `950 ops/ms`.

## Verifying this change

This change is already covered by existing tests, such as `StreamNetworkThroughputBenchmarkTest` and `StreamNetworkBroadcastThroughputBenchmarkTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
