### PR TITLE
[FLINK-14278] Extend DispatcherResourceManagerComponentFactory.create to take ioExecutor

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DispatcherRunnerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DispatcherRunnerFactory.java
@@ -21,10 +21,15 @@ package org.apache.flink.runtime.dispatcher.runner;
 import org.apache.flink.runtime.dispatcher.PartialDispatcherServices;
 import org.apache.flink.runtime.rpc.RpcService;
 
+import java.util.concurrent.Executor;
+
 /**
  * Factory interface for the {@link DispatcherRunner}.
  */
 public interface DispatcherRunnerFactory {
 
-	DispatcherRunner createDispatcherRunner(RpcService rpcService, PartialDispatcherServices partialDispatcherServices) throws Exception;
+	DispatcherRunner createDispatcherRunner(
+		RpcService rpcService,
+		Executor ioExecutor,
+		PartialDispatcherServices partialDispatcherServices) throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DispatcherRunnerFactoryImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DispatcherRunnerFactoryImpl.java
@@ -23,6 +23,8 @@ import org.apache.flink.runtime.dispatcher.PartialDispatcherServices;
 import org.apache.flink.runtime.dispatcher.StandaloneDispatcher;
 import org.apache.flink.runtime.rpc.RpcService;
 
+import java.util.concurrent.Executor;
+
 /**
  * Factory which creates a {@link DispatcherRunnerImpl} which runs a {@link StandaloneDispatcher}.
  */
@@ -37,6 +39,7 @@ public class DispatcherRunnerFactoryImpl implements DispatcherRunnerFactory {
 	@Override
 	public DispatcherRunnerImpl createDispatcherRunner(
 			RpcService rpcService,
+			Executor ioExecutor,
 			PartialDispatcherServices partialDispatcherServices) throws Exception {
 		return new DispatcherRunnerImpl(dispatcherFactory, rpcService, partialDispatcherServices);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -214,6 +214,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 
 			clusterComponent = dispatcherResourceManagerComponentFactory.create(
 				configuration,
+				ioExecutor,
 				commonRpcService,
 				haServices,
 				blobServer,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultDispatcherResourceManagerComponentFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultDispatcherResourceManagerComponentFactory.java
@@ -71,6 +71,7 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -101,6 +102,7 @@ public class DefaultDispatcherResourceManagerComponentFactory implements Dispatc
 	@Override
 	public DispatcherResourceManagerComponent create(
 			Configuration configuration,
+			Executor ioExecutor,
 			RpcService rpcService,
 			HighAvailabilityServices highAvailabilityServices,
 			BlobServer blobServer,
@@ -199,6 +201,7 @@ public class DefaultDispatcherResourceManagerComponentFactory implements Dispatc
 			log.debug("Starting Dispatcher.");
 			dispatcherRunner = dispatcherRunnerFactory.createDispatcherRunner(
 				rpcService,
+				ioExecutor,
 				partialDispatcherServices);
 
 			log.debug("Starting ResourceManager.");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponentFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponentFactory.java
@@ -28,6 +28,8 @@ import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
 
+import java.util.concurrent.Executor;
+
 /**
  * Factory for the {@link DispatcherResourceManagerComponent}.
  */
@@ -35,6 +37,7 @@ public interface DispatcherResourceManagerComponentFactory {
 
 	DispatcherResourceManagerComponent create(
 		Configuration configuration,
+		Executor ioExecutor,
 		RpcService rpcService,
 		HighAvailabilityServices highAvailabilityServices,
 		BlobServer blobServer,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -227,6 +227,10 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 		}
 	}
 
+	protected Executor getIOExecutor() {
+		return ioExecutor;
+	}
+
 	@VisibleForTesting
 	@Nonnull
 	protected Collection<DispatcherResourceManagerComponent> getDispatcherResourceManagerComponents() {
@@ -388,6 +392,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 		return Collections.singleton(
 			dispatcherResourceManagerComponentFactory.create(
 				configuration,
+				ioExecutor,
 				rpcServiceFactory.createRpcService(),
 				haServices,
 				blobServer,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/TestingMiniCluster.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/TestingMiniCluster.java
@@ -116,6 +116,7 @@ public class TestingMiniCluster extends MiniCluster {
 			result.add(
 				dispatcherResourceManagerComponentFactory.create(
 					configuration,
+					getIOExecutor(),
 					rpcServiceFactory.createRpcService(),
 					haServices,
 					blobServer,

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -75,6 +75,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.runtime.testutils.CommonTestUtils.getJavaCommandPath;
@@ -127,9 +128,10 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 			StandaloneResourceManagerFactory.INSTANCE);
 		DispatcherResourceManagerComponent dispatcherResourceManagerComponent = null;
 
+		final ScheduledExecutorService ioExecutor = TestingUtils.defaultExecutor();
 		final HighAvailabilityServices haServices = HighAvailabilityServicesUtils.createHighAvailabilityServices(
 			config,
-			TestingUtils.defaultExecutor(),
+			ioExecutor,
 			HighAvailabilityServicesUtils.AddressResolution.NO_ADDRESS_RESOLUTION);
 
 		try {
@@ -143,6 +145,7 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 
 			dispatcherResourceManagerComponent = resourceManagerComponentFactory.create(
 				config,
+				ioExecutor,
 				rpcService,
 				haServices,
 				blobServerResource.getBlobServer(),


### PR DESCRIPTION
## What is the purpose of the change

Pass in the `ioExecutor` from the `ClusterEntrypoint` to the `DispatcherRunnerFactory` via `DispatcherResourceManagerComponentFactory.create`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
