### PR TITLE
[FLINK-14276][quickstarts] Scala quickstart compiles on JDK 11

### DIFF
--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
@@ -171,6 +171,11 @@ under the License.
 						</goals>
 					</execution>
 				</executions>
+				<configuration>
+					<args>
+						<arg>-nobootcp</arg>
+					</args>
+				</configuration>
 			</plugin>
 
 			<!-- Eclipse Scala Integration -->


### PR DESCRIPTION
Fixes an issue where a scala quickstart project would not compile on Java 9+. Same approach as in #6623.