### PR TITLE
[FLINK-14309] [test-stability] Add retries and acks config in producer test

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
@@ -340,8 +340,6 @@ public abstract class KafkaProducerTestBase extends KafkaTestBaseWithFlink {
 		Properties properties = new Properties();
 		properties.putAll(standardProps);
 		properties.putAll(secureProps);
-		// kafka producer messages guarantee
-		properties.setProperty("retries", "0");
 
 		// process exactly failAfterElements number of elements and then shutdown Kafka broker and fail application
 		List<Integer> expectedElements = getIntegersSequence(numElements);

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
@@ -247,6 +247,9 @@ public abstract class KafkaProducerTestBase extends KafkaTestBaseWithFlink {
 		// increase batch.size and linger.ms - this tells KafkaProducer to batch produced events instead of flushing them immediately
 		properties.setProperty("batch.size", "10240000");
 		properties.setProperty("linger.ms", "10000");
+		// kafka producer messages guarantee
+		properties.setProperty("retries", "3");
+		properties.setProperty("acks", "all");
 
 		BrokerRestartingMapper.resetState(kafkaServer::blockProxyTraffic);
 
@@ -337,6 +340,8 @@ public abstract class KafkaProducerTestBase extends KafkaTestBaseWithFlink {
 		Properties properties = new Properties();
 		properties.putAll(standardProps);
 		properties.putAll(secureProps);
+		// kafka producer messages guarantee
+		properties.setProperty("retries", "0");
 
 		// process exactly failAfterElements number of elements and then shutdown Kafka broker and fail application
 		List<Integer> expectedElements = getIntegersSequence(numElements);


### PR DESCRIPTION
## What is the purpose of the change

Fix unit test: KafkaProducerTestBase.testOneToOneAtLeastOnceRegularSink

## Brief change log

Add retries and acks config to reduce the risk of failure of flush() method.


## Verifying this change

Unit Testing.

## Does this pull request potentially affect one of the following parts:

## Documentation
