### PR TITLE
[FLINK-14317] make hadoop history server logs accessible through flink ui

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -180,6 +180,22 @@ public class JobManagerOptions {
 			// default matches heartbeat.timeout so that sticky allocation is not lost on timeouts for local recovery
 			.defaultValue(HeartbeatManagerOptions.HEARTBEAT_TIMEOUT.defaultValue())
 			.withDescription("The timeout in milliseconds for a idle slot in Slot Pool.");
+
+	/**
+	 * Hadoop job history server URL.
+	 */
+	public static final ConfigOption<String> JOB_MANAGER_HADOOP_HISTORYSERVER_URL =
+		key("jobmanager.hadoop.historyserver.url")
+			.noDefaultValue()
+			.withDescription("Hadoop history server url.");
+
+	/**
+	 * Hosts FQDN suffix. this information is needed in composing the hadoop history server url for job logs.
+	 */
+	public static final ConfigOption<String> JOB_MANAGER_HOST_FQDN_SUFFIX =
+		key("jobmanager.host.fqdn.suffix")
+			.noDefaultValue()
+			.withDescription("Hosts fqdn suffix");
 	/**
 	 * Config parameter determining the scheduler implementation.
 	 */

--- a/flink-runtime-web/web-dashboard/old-version/partials/jobs/job.plan.node.subtasks.html
+++ b/flink-runtime-web/web-dashboard/old-version/partials/jobs/job.plan.node.subtasks.html
@@ -43,7 +43,7 @@ limitations under the License.
       <td><span ng-if="subtask.metrics['write-bytes-complete']">{{ subtask.metrics['write-bytes'] | humanizeBytes }}</span><i ng-if="!subtask.metrics['write-bytes-complete']" aria-hidden="true" class="fa fa-spinner fa-spin fa-fw"></i></td>
       <td><span ng-if="subtask.metrics['write-records-complete']">{{ subtask.metrics['write-records'] | number }}</span><i ng-if="!subtask.metrics['write-records-complete']" aria-hidden="true" class="fa fa-spinner fa-spin fa-fw"></i></td>
       <td>{{ subtask.attempt + 1 }}</td>
-      <td>{{ subtask.host }}</td>
+      <td><a href="{{ subtask.host }}" target="_blank">{{ subtask.host }}</a></td>
       <td> 
         <bs-label status="{{subtask.status}}">{{subtask.status}}</bs-label>
       </td>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobExecutionHistory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobExecutionHistory.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.util.EnvironmentInformation;
+import org.apache.flink.shaded.guava18.com.google.common.base.Strings;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonAutoDetect;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedWriter;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.PropertyAccessor.FIELD;
+
+/**
+ * JobExecutionHistory is used to capture [flink job id --> application id & container id] mapping
+ * when we deploy jobs through Yarn. The following is an example on what JobExecutionHistory may capture.
+ * <p>
+ * {
+ * "clusterId" : "application_1560449379756_1548",
+ * "jobId" : "7fd4d6fe0baa53bfec4c278f18188ee6",
+ * "archivePath" : "hdfs:///flink/completed-jobs",
+ * "containers" : {
+ * "container_1560449379756_1548_01_000002" : "hadoo-data-slave-dev-0a025632.sample.com:8042"
+ * },
+ * "attempts" : {
+ * "8c39493bc486784f62c582c646b1c02e" : "Reduce (SUM(1), at main(WordCount.java:79) (1/1)",
+ * "95899b08e08e6e9d051654ffb67f8f64" : "DataSink (collect()) (1/1)",
+ * "39138b3e6df1c083b170525faf2bf80e" : "CHAIN DataSource (at getDefaultTextLineDataSet(WordCountData.java:70)))\
+ * -> FlatMap (FlatMap at main(WordCount.java:76)) -> Combine (SUM(1), at main(WordCount.java:79) (1/1)"
+ * }
+ */
+public class JobExecutionHistory {
+
+	protected static final Logger log = LoggerFactory.getLogger(JobExecutionHistory.class);
+	protected static JobExecutionHistory INSTANCE;
+
+	private static final String LOG_FILE_ENV = "log.file";
+
+	public static String hadoopUser = EnvironmentInformation.getHadoopUser();
+
+	// clusterId will be yarn application id, if the job is deployed through yarn
+	private String clusterId;
+	private String resourceManagerEpoch;
+	private String jobId;
+	private String archivePath;
+	private String historyServerUrl;
+
+	private Map<String, String> containers;
+
+	// [host:port --> container id] mapping
+	private Map<String, String> taskManagerLocationsToContainersMap;
+
+	private Map<String, Set<String>> vertexToAttemptIdsMap;
+
+	private Map<String, String> attemptsInfo;
+
+	public static JobExecutionHistory getInstance() {
+		if (INSTANCE == null) {
+			synchronized (JobExecutionHistory.class) {
+				if (INSTANCE == null) {
+					INSTANCE = new JobExecutionHistory();
+				}
+			}
+		}
+		return INSTANCE;
+	}
+
+	/**
+	 * In this method, we try to infer flink config directory based on 'log.file' jvm option parameters.
+	 * After finding the log file configuration jvm option, we replace `userlogs` substring with
+	 * 'nm-local-dir/usercache/$hadoopUser/appcache' to get the flink configuration file that is generated
+	 * on the fly.
+	 * <p>
+	 * Sample JVM Options:
+	 * -Xmx424m
+	 * -Dlog.file=/data/nvme1n1/userlogs/application_15756_1549/container_e02_15756_1549_01_000001/jobmanager.log
+	 * -Dlogback.configurationFile=file:logback.xml
+	 * -Dlog4j.configuration=file:log4j.properties
+	 */
+
+	public static String getFlinkConfDirectory(String[] jvmOptions) {
+		for (String jvmOption : jvmOptions) {
+			if (jvmOption.startsWith("-D" + LOG_FILE_ENV)) {
+				String logFilePath = jvmOption.split("=")[1];
+				String logFileDir = logFilePath.substring(0, logFilePath.lastIndexOf("/"));
+				String result = logFileDir.replace("userlogs", "nm-local-dir/usercache/" + hadoopUser + "/appcache");
+				return result;
+			}
+		}
+		// return null if jvmOptions does not have the right settings
+		return null;
+	}
+
+	/**
+	 *  This method infers yarn resource manager epoch number based on flink config directory.
+	 *  The reason that we need this method is that in yarn the container id is like
+	 *   `container_e02_1560449379756_1860_01_000002`. However, flink container id does not have `e02` substring.
+	 */
+	public static String getResourceManagerEpoch(String flinkConfDir) {
+		String[] dirStrs = flinkConfDir.split("/");
+		for (String dirStr : dirStrs) {
+			if (dirStr.startsWith("container_")) {
+				String[] strs= dirStr.split("_");
+				if (strs.length > 2) {
+					return strs[1];
+				}
+				break;
+			}
+		}
+		log.error("Failed to find resource manager epoch from {}", flinkConfDir);
+		return "";
+	}
+
+	JobExecutionHistory() {
+		String[] jvmOptions = EnvironmentInformation.getJvmStartupOptionsArray();
+		String flinkConfDir = getFlinkConfDirectory(jvmOptions);
+		log.info("Flink configuration dir: {}", flinkConfDir);
+
+		Configuration configuration = GlobalConfiguration.loadConfiguration(flinkConfDir);
+		this.clusterId = configuration.getString(HighAvailabilityOptions.HA_CLUSTER_ID);
+		this.resourceManagerEpoch = getResourceManagerEpoch(flinkConfDir);
+		this.archivePath = configuration.getString(JobManagerOptions.ARCHIVE_DIR);
+		this.historyServerUrl = configuration.getString(JobManagerOptions.JOB_MANAGER_HADOOP_HISTORYSERVER_URL);
+		this.containers = new HashMap<>();
+		this.attemptsInfo = new HashMap<>();
+		this.vertexToAttemptIdsMap = new HashMap<>();
+		this.taskManagerLocationsToContainersMap = new HashMap<>();
+	}
+
+	public void setClusterId(String clusterId) {
+		this.clusterId = clusterId;
+	}
+
+	public String getClusterId() {
+		return clusterId;
+	}
+
+	public String getResourceManagerEpoch() {
+		return resourceManagerEpoch;
+	}
+
+	public String getHistoryServerUrl() {
+		return historyServerUrl;
+	}
+
+	public void setJobId(String jobId) {
+		this.jobId = jobId;
+	}
+
+	public synchronized void addContainerInfo(String containerId, String hostInfo) {
+		containers.put(containerId, hostInfo);
+	}
+
+	public synchronized void addTaskManagerLocationToContainerInfo(String taskManagerLocation, String containerId) {
+		taskManagerLocationsToContainersMap.put(taskManagerLocation, containerId);
+	}
+
+	public String getContainerInfo(String taskManagerHostPort) {
+		return taskManagerLocationsToContainersMap.getOrDefault(taskManagerHostPort, "(unknown)");
+	}
+
+	public synchronized void addVertextToAttemptIdInfo(String vertexId, String attemptId) {
+		if (!vertexToAttemptIdsMap.containsKey(vertexId)) {
+			vertexToAttemptIdsMap.put(vertexId, new HashSet<>());
+		}
+		vertexToAttemptIdsMap.get(vertexId).add(attemptId);
+	}
+
+	public synchronized void addAttemptInfo(String attemptId, String vertexInfo) {
+		attemptsInfo.put(attemptId, vertexInfo);
+	}
+
+	public void saveToArchiveDir() {
+		try {
+			if (!Strings.isNullOrEmpty(archivePath)) {
+				org.apache.hadoop.conf.Configuration configuration = new org.apache.hadoop.conf.Configuration();
+				FileSystem fileSystem = FileSystem.get(new URI(archivePath), configuration);
+				Path file = new Path(archivePath + "/" + jobId + ".execution_history");
+				if (fileSystem.exists(file)) {
+					fileSystem.delete(file, true);
+				}
+				OutputStream os = fileSystem.create(file, true);
+				BufferedWriter br = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
+				br.write(this.toString());
+				br.close();
+			}
+		} catch (Exception e) {
+			log.error("Failed to write to archive directory : {}", jobId, e);
+		}
+	}
+
+	public String toString() {
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.setVisibility(FIELD, JsonAutoDetect.Visibility.ANY);
+		String result = "";
+		try {
+			result = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(this);
+		} catch (Exception e) {
+			log.error("Failed to generate json string", e);
+		}
+		return result;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobExecutionHistoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobExecutionHistoryTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster;
+
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class JobExecutionHistoryTest {
+
+	@Test
+	public void testJobCompletion() throws Exception {
+		String[] jvmOptions = {
+			"-Xmx424m",
+			"-Dlog.file=/data/nvme1n1/userlogs/application_1560449379756_1548/container_e02_1560449379756_1548_01_000001/jobmanager.log",
+			"-Dlogback.configurationFile=file:logback.xml",
+			"-Dlog4j.configuration=file:log4j.properties"
+		};
+		String dirPath = JobExecutionHistory.getFlinkConfDirectory(jvmOptions);
+
+		String expectedPath= "/data/nvme1n1/nm-local-dir/usercache/" + System.getProperty("user.name")
+			+ "/appcache/application_1560449379756_1548/container_e02_1560449379756_1548_01_000001";
+		assertEquals(dirPath, expectedPath);
+	}
+}


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This change is to add hadoop history server url to flink runtime web ui.  This will simplify task manager logs access, reducing the time that developers spend on finding logs for specific subtasks, and ultimately improve developer productivity.

## Brief change log

- add `JobExecutionHistory` to keep track of cluster id (yarn application id), and taskManagerId (yarn container id) --> taskManagerLocation mapping. We can use the information stored in JobExecutionHisotry to reconstruct hadoop history server url for taskmanager logs, and store the info in archived execution graph. The flink history server reads archived execution graph and renders hadoop history server url.

- updated `SubtaskExecutionAttemptDetailsInfo.create` to render proper hadoop history server url 

## Verifying this change

This change is already covered by existing tests, such as *JobMasterTests*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no 
  - The S3 file system connector:  no

## Documentation
  - Does this pull request introduce a new feature? yes 
  - If yes, how is the feature documented? JavaDocs
