### PR TITLE
!VERIFY ONLY! Upgrade ZK to 3.5.5

### DIFF
--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -3379,6 +3379,12 @@ WebSocket and HTTP server:
   * HOMEPAGE:
     * https://github.com/joewalnes/webbit
 
+Apache ZooKeeper - Server
+Copyright 2008-2019 The Apache Software Foundation
+
+Apache ZooKeeper - Jute
+Copyright 2008-2019 The Apache Software Foundation
+
 flink-shaded-curator
 Copyright 2014-2019 The Apache Software Foundation
 
@@ -7920,6 +7926,44 @@ Copyright 2011-2017 The Apache Software Foundation
 
 Curator Recipes
 Copyright 2011-2017 The Apache Software Foundation
+
+Copyright 2011 The Netty Project
+
+This product contains a modified version of 'JZlib', a re-implementation of
+zlib in pure Java, which can be obtained at:
+
+  * LICENSE:
+    * license/LICENSE.jzlib.txt (BSD Style License)
+  * HOMEPAGE:
+    * http://www.jcraft.com/jzlib/
+
+This product contains a modified version of 'Webbit', a Java event based
+WebSocket and HTTP server:
+
+This product optionally depends on 'Protocol Buffers', Google's data
+interchange format, which can be obtained at:
+
+This product optionally depends on 'SLF4J', a simple logging facade for Java,
+which can be obtained at:
+
+This product optionally depends on 'Apache Log4J', a logging framework,
+which can be obtained at:
+
+This product optionally depends on 'JBoss Logging', a logging framework,
+which can be obtained at:
+
+  * LICENSE:
+    * license/LICENSE.jboss-logging.txt (GNU LGPL 2.1)
+  * HOMEPAGE:
+    * http://anonsvn.jboss.org/repos/common/common-logging-spi/
+
+This product optionally depends on 'Apache Felix', an open source OSGi
+framework implementation, which can be obtained at:
+
+  * LICENSE:
+    * license/LICENSE.felix.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * http://felix.apache.org/
 
 Kerb Simple Kdc
 Copyright 2014-2017 The Apache Software Foundation

--- a/flink-connectors/flink-connector-kafka-0.8/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.8/pom.xml
@@ -149,6 +149,12 @@ under the License.
 			<artifactId>curator-test</artifactId>
 			<version>${curator.version}</version>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.zookeeper</groupId>
+					<artifactId>zookeeper</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/flink-connectors/flink-connector-kafka-base/pom.xml
+++ b/flink-connectors/flink-connector-kafka-base/pom.xml
@@ -142,6 +142,12 @@ under the License.
 			<artifactId>curator-test</artifactId>
 			<version>${curator.version}</version>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.zookeeper</groupId>
+					<artifactId>zookeeper</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/flink-formats/flink-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-avro-confluent-registry/pom.xml
@@ -50,6 +50,10 @@ under the License.
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-log4j12</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.zookeeper</groupId>
+					<artifactId>zookeeper</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>

--- a/flink-mesos/pom.xml
+++ b/flink-mesos/pom.xml
@@ -117,6 +117,12 @@ under the License.
 			<artifactId>curator-test</artifactId>
 			<version>${curator.version}</version>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.zookeeper</groupId>
+					<artifactId>zookeeper</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/flink-queryable-state/flink-queryable-state-runtime/pom.xml
+++ b/flink-queryable-state/flink-queryable-state-runtime/pom.xml
@@ -87,6 +87,12 @@ under the License.
 			<artifactId>curator-test</artifactId>
 			<version>${curator.version}</version>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.zookeeper</groupId>
+					<artifactId>zookeeper</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/flink-queryable-state/flink-queryable-state-runtime/pom.xml
+++ b/flink-queryable-state/flink-queryable-state-runtime/pom.xml
@@ -83,6 +83,13 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.zookeeper</groupId>
+			<artifactId>zookeeper</artifactId>
+			<scope>test</scope>
+			<version>${zookeeper.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.curator</groupId>
 			<artifactId>curator-test</artifactId>
 			<version>${curator.version}</version>

--- a/flink-runtime-web/pom.xml
+++ b/flink-runtime-web/pom.xml
@@ -101,6 +101,12 @@ under the License.
 			<artifactId>curator-test</artifactId>
 			<version>${curator.version}</version>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.zookeeper</groupId>
+					<artifactId>zookeeper</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -34,10 +34,6 @@ under the License.
 
 	<packaging>jar</packaging>
 
-	<properties>
-		<zookeeper.version>3.5.5</zookeeper.version>
-	</properties>
-
 	<dependencies>
 
 		<!-- core dependencies -->

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -313,6 +313,12 @@ under the License.
 			<artifactId>curator-test</artifactId>
 			<version>${curator.version}</version>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.zookeeper</groupId>
+					<artifactId>zookeeper</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -34,6 +34,10 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<zookeeper.version>3.5.5</zookeeper.version>
+	</properties>
+
 	<dependencies>
 
 		<!-- core dependencies -->
@@ -246,6 +250,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.zookeeper</groupId>
 			<artifactId>zookeeper</artifactId>
+			<version>${zookeeper.version}</version>
 		</dependency>
 
 		<dependency>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -251,6 +251,26 @@ under the License.
 			<groupId>org.apache.zookeeper</groupId>
 			<artifactId>zookeeper</artifactId>
 			<version>${zookeeper.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+				<!-- Netty is only needed for ZK servers, not clients -->
+				<exclusion>
+					<groupId>io.netty</groupId>
+					<artifactId>netty</artifactId>
+				</exclusion>
+				<!-- jline is optional for ZK console shell -->
+				<exclusion>
+					<groupId>jline</groupId>
+					<artifactId>jline</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -337,6 +357,48 @@ under the License.
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
+
+	<profiles>
+		<profile>
+			<!--
+				MapR build profile. This build profile must be used together with "vendor-repos"
+				to be able to locate the MapR Zookeeper dependencies.
+			-->
+			<id>mapr</id>
+			<activation>
+				<property>
+					<name>mapr</name>
+				</property>
+			</activation>
+
+			<!--
+				use MapR Zookeeper dependencies appropriate for MapR 5.2.0;
+				users of different MapR versions should simply override these versions
+				with appropriate values.
+			-->
+			<properties>
+				<zookeeper.version>3.4.5-mapr-1604</zookeeper.version>
+			</properties>
+
+			<dependencies>
+				<dependency>
+					<groupId>org.apache.zookeeper</groupId>
+					<artifactId>zookeeper</artifactId>
+					<version>${zookeeper.version}</version>
+					<exclusions>
+						<!--
+							exclude netty, because MapR's Zookeeper distribution has
+							a conflicting Netty version with Flink's Netty dependency
+						-->
+						<exclusion>
+							<groupId>org.jboss.netty</groupId>
+							<artifactId>netty</artifactId>
+						</exclusion>
+					</exclusions>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 
 	<build>
 		<plugins>

--- a/flink-shaded-curator/pom.xml
+++ b/flink-shaded-curator/pom.xml
@@ -40,6 +40,12 @@ under the License.
 			<groupId>org.apache.curator</groupId>
 			<artifactId>curator-recipes</artifactId>
 			<version>${curator.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.zookeeper</groupId>
+					<artifactId>zookeeper</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 

--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -473,6 +473,10 @@ under the License.
 					<groupId>org.codehaus.jackson</groupId>
 					<artifactId>jackson-mapper-asl</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.zookeeper</groupId>
+					<artifactId>zookeeper</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -497,6 +501,10 @@ under the License.
 				<exclusion>
 					<groupId>org.codehaus.jackson</groupId>
 					<artifactId>jackson-core-asl</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.zookeeper</groupId>
+					<artifactId>zookeeper</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/flink-test-utils-parent/flink-test-utils/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils/pom.xml
@@ -91,6 +91,12 @@ under the License.
 			<artifactId>curator-test</artifactId>
 			<version>${curator.version}</version>
 			<scope>compile</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.zookeeper</groupId>
+					<artifactId>zookeeper</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -57,6 +57,12 @@ under the License.
 			<artifactId>flink-shaded-hadoop-2</artifactId>
 			<version>${hadoop.version}-${flink.shaded.version}</version>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.zookeeper</groupId>
+					<artifactId>zookeeper</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -187,6 +193,13 @@ under the License.
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.zookeeper</groupId>
+			<artifactId>zookeeper</artifactId>
+			<scope>test</scope>
+			<version>${zookeeper.version}</version>
 		</dependency>
 
 		<dependency>

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -194,6 +194,12 @@ under the License.
 			<artifactId>curator-test</artifactId>
 			<version>${curator.version}</version>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.zookeeper</groupId>
+					<artifactId>zookeeper</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/flink-yarn-tests/pom.xml
+++ b/flink-yarn-tests/pom.xml
@@ -62,6 +62,13 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.zookeeper</groupId>
+			<artifactId>zookeeper</artifactId>
+			<scope>test</scope>
+			<version>${zookeeper.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@ under the License.
 		<scala.version>2.11.12</scala.version>
 		<scala.binary.version>2.11</scala.binary.version>
 		<chill.version>0.7.6</chill.version>
+		<zookeeper.version>3.5.5</zookeeper.version>
 		<curator.version>2.12.0</curator.version>
 		<jackson.version>2.9.8</jackson.version>
 		<metrics.version>3.1.5</metrics.version>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,6 @@ under the License.
 		<scala.version>2.11.12</scala.version>
 		<scala.binary.version>2.11</scala.binary.version>
 		<chill.version>0.7.6</chill.version>
-		<zookeeper.version>3.4.10</zookeeper.version>
 		<curator.version>2.12.0</curator.version>
 		<jackson.version>2.9.8</jackson.version>
 		<metrics.version>3.1.5</metrics.version>
@@ -582,32 +581,6 @@ under the License.
 				</exclusions>
 			</dependency>
 
-			<dependency>
-				<groupId>org.apache.zookeeper</groupId>
-				<artifactId>zookeeper</artifactId>
-				<version>${zookeeper.version}</version>
-				<exclusions>
-					<exclusion>
-						<groupId>log4j</groupId>
-						<artifactId>log4j</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>org.slf4j</groupId>
-						<artifactId>slf4j-log4j12</artifactId>
-					</exclusion>
-					<!-- Netty is only needed for ZK servers, not clients -->
-					<exclusion>
-						<groupId>io.netty</groupId>
-						<artifactId>netty</artifactId>
-					</exclusion>
-					<!-- jline is optional for ZK console shell -->
-					<exclusion>
-						<groupId>jline</groupId>
-						<artifactId>jline</artifactId>
-					</exclusion>
-				</exclusions>
-			</dependency>
-
 			<!-- We have to define the versions for httpcore and httpclient here such that a consistent
 			 version is used by the shaded hadoop jars and the flink-yarn-test project because of MNG-5899.
 
@@ -1050,32 +1023,13 @@ under the License.
 			</activation>
 
 			<!--
-				use MapR Hadoop / Zookeeper dependencies appropriate for MapR 5.2.0;
+				use MapR Hadoop dependencies appropriate for MapR 5.2.0;
 				users of different MapR versions should simply override these versions
 				with appropriate values.
 			-->
 			<properties>
 				<hadoop.version>2.7.0-mapr-1607</hadoop.version>
-				<zookeeper.version>3.4.5-mapr-1604</zookeeper.version>
 			</properties>
-
-			<dependencies>
-				<dependency>
-					<groupId>org.apache.zookeeper</groupId>
-					<artifactId>zookeeper</artifactId>
-					<version>${zookeeper.version}</version>
-					<exclusions>
-						<!--
-							exclude netty, because MapR's Zookeeper distribution has
-							a conflicting Netty version with Flink's Netty dependency
-						-->
-						<exclusion>
-							<groupId>org.jboss.netty</groupId>
-							<artifactId>netty</artifactId>
-						</exclusion>
-					</exclusions>
-				</dependency>
-			</dependencies>
 		</profile>
 
 		<profile>


### PR DESCRIPTION
CC @StephanEwen @zentol @lamber-ken 

We explicit depends on zk in flink-queryable-state-runtime, flink-tests and flink-yarn-tests for a proper zk dependencies in curator-tests resolver(by default it uses 3.4.x but we need a 3.5.x server for recognize message like create container). bump curator-tests to 4.2.0 collaborate with FLINK-10052 can eliminate dependencies to zk outside of flink-runtime IMO.