### PR TITLE
[FLINK-14118][benchmarks]Add network throughput benchmark for data skew scenario.

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/DataSkewStreamNetworkThroughputBenchmark.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/DataSkewStreamNetworkThroughputBenchmark.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io.benchmark;
+
+import org.apache.flink.core.io.IOReadableWritable;
+import org.apache.flink.runtime.io.network.api.writer.ChannelSelector;
+import org.apache.flink.runtime.io.network.api.writer.RecordWriterBuilder;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * Network throughput benchmarks for data skew scenario executed by the external
+ * <a href="https://github.com/dataArtisans/flink-benchmarks">flink-benchmarks</a> project.
+ */
+public class DataSkewStreamNetworkThroughputBenchmark extends StreamNetworkThroughputBenchmark {
+
+	@Override
+	protected void setChannelSelector(RecordWriterBuilder recordWriterBuilder, boolean broadcastMode) {
+		checkArgument(!broadcastMode, "Combining broadcasting with data skew doesn't make sense");
+		recordWriterBuilder.setChannelSelector(new DataSkewChannelSelector());
+	}
+
+	/**
+	 * A {@link ChannelSelector} which selects channel 0 for nearly all records. And all other channels
+	 * except for channel 0 will be only selected at most once.
+	 */
+	private static class DataSkewChannelSelector implements ChannelSelector {
+		private int numberOfChannels;
+		private int channelIndex = 0;
+
+		@Override
+		public void setup(int numberOfChannels) {
+			this.numberOfChannels = numberOfChannels;
+		}
+
+		@Override
+		public int selectChannel(IOReadableWritable record) {
+			if (channelIndex >= numberOfChannels) {
+				return 0;
+			}
+			return channelIndex++;
+		}
+
+		@Override
+		public boolean isBroadcast() {
+			return false;
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/DataSkewStreamNetworkThroughputBenchmarkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/DataSkewStreamNetworkThroughputBenchmarkTest.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io.benchmark;
+
+/**
+ * Tests for various network benchmarks based on {@link DataSkewStreamNetworkThroughputBenchmark}.
+ */
+public class DataSkewStreamNetworkThroughputBenchmarkTest extends StreamNetworkThroughputBenchmarkTest {
+	@Override
+	protected StreamNetworkThroughputBenchmark createBenchmark() {
+		return new DataSkewStreamNetworkThroughputBenchmark();
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmark.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmark.java
@@ -116,15 +116,19 @@ public class StreamNetworkThroughputBenchmark {
 		for (int writer = 0; writer < recordWriters; writer++) {
 			ResultPartitionWriter resultPartitionWriter = environment.createResultPartitionWriter(writer);
 			RecordWriterBuilder recordWriterBuilder = new RecordWriterBuilder().setTimeout(flushTimeout);
-			if (broadcastMode) {
-				recordWriterBuilder.setChannelSelector(new BroadcastPartitioner());
-			}
+			setChannelSelector(recordWriterBuilder, broadcastMode);
 			writerThreads[writer] = new LongRecordWriterThread(
 				recordWriterBuilder.build(resultPartitionWriter),
 				broadcastMode);
 			writerThreads[writer].start();
 		}
 		receiver = environment.createReceiver();
+	}
+
+	protected void setChannelSelector(RecordWriterBuilder recordWriterBuilder, boolean broadcastMode) {
+		if (broadcastMode) {
+			recordWriterBuilder.setChannelSelector(new BroadcastPartitioner());
+		}
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

The purpose of this pr is to add a network benchmark for data skew scenario in which most of the data will go to a few channels. The added benchmark simulates the most extreme scenario in which nearly all data goes to only one channel.


## Brief change log

  - Add DataSkewStreamNetworkThroughputBenchmark to simulate data skew scenario.
  - Add DataSkewStreamNetworkThroughputBenchmarkTest to verify the added benchmark.


## Verifying this change

A new DataSkewStreamNetworkThroughputBenchmarkTest was added to verify the change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
