### PR TITLE
[FLINK-14341][python] Support pip version of 7.1.x for gen_protos.py

### DIFF
--- a/flink-python/README.md
+++ b/flink-python/README.md
@@ -40,4 +40,4 @@ python pyflink/gen_protos.py
 PyFlink depends on the following libraries to execute the above script:
 1. grpcio-tools (>=1.3.5,<=1.14.2)
 2. setuptools (>=37.0.0)
-3. pip (>=8.0.0)
+3. pip (>=7.1.0)

--- a/flink-python/pyflink/gen_protos.py
+++ b/flink-python/pyflink/gen_protos.py
@@ -120,10 +120,17 @@ def _install_grpcio_tools_and_generate_proto_files(force, output_dir):
     logging.warning('Installing grpcio-tools into %s', install_path)
     try:
         start = time.time()
-        subprocess.check_call(
-            [sys.executable, '-m', 'pip', 'install',
-             '--install-option', "--prefix=" + install_path, '--build', build_path,
-             '--upgrade', GRPC_TOOLS, "-I"])
+        pip_version = pkg_resources.get_distribution("pip").version
+        if pip_version >= '8.0.0':
+            subprocess.check_call(
+                [sys.executable, '-m', 'pip', 'install',
+                 '--prefix', install_path, '--build', build_path,
+                 '--upgrade', GRPC_TOOLS, "-I"])
+        else:
+            subprocess.check_call(
+                [sys.executable, '-m', 'pip', 'install',
+                 '--install-option', '--prefix=' + install_path, '--build', build_path,
+                 '--upgrade', GRPC_TOOLS, "-I"])
         from distutils.dist import Distribution
         install_obj = Distribution().get_command_obj('install', create=True)
         install_obj.prefix = install_path

--- a/flink-python/pyflink/gen_protos.py
+++ b/flink-python/pyflink/gen_protos.py
@@ -122,7 +122,7 @@ def _install_grpcio_tools_and_generate_proto_files(force, output_dir):
         start = time.time()
         subprocess.check_call(
             [sys.executable, '-m', 'pip', 'install',
-             '--prefix', install_path, '--build', build_path,
+             '--install-option', "--prefix=" + install_path, '--build', build_path,
              '--upgrade', GRPC_TOOLS, "-I"])
         from distutils.dist import Distribution
         install_obj = Distribution().get_command_obj('install', create=True)

--- a/flink-python/pyflink/gen_protos.py
+++ b/flink-python/pyflink/gen_protos.py
@@ -120,8 +120,11 @@ def _install_grpcio_tools_and_generate_proto_files(force, output_dir):
     logging.warning('Installing grpcio-tools into %s', install_path)
     try:
         start = time.time()
+        # since '--prefix' option only supported for pip 8.0+, so here we fallback to
+        # use `--install-option` when the pip version is lower than 8.0.0.
         pip_version = pkg_resources.get_distribution("pip").version
-        if pip_version >= '8.0.0':
+        from pkg_resources import parse_version
+        if parse_version(pip_version) >= parse_version('8.0.0'):
             subprocess.check_call(
                 [sys.executable, '-m', 'pip', 'install',
                  '--prefix', install_path, '--build', build_path,


### PR DESCRIPTION

## What is the purpose of the change

Currently, it reported an error on flink-python module when build flink:

```
[INFO] --- protoc-jar-maven-plugin:3.7.1:run (default) @ flink-python_2.11 ---
Downloading from nexus: http://nexus.d.xiaomi.net/nexus/content/groups/public/com/github/os72/protoc-jar/3.7.1/protoc-jar-3.7.1.jar
Downloaded from nexus: http://nexus.d.xiaomi.net/nexus/content/groups/public/com/github/os72/protoc-jar/3.7.1/protoc-jar-3.7.1.jar (10 MB at 29 MB/s)
[INFO] Protoc version: 3.7.1
protoc-jar: protoc version: 3.7.1, detected platform: linux-x86_64 (linux/amd64)
protoc-jar: embedded: bin/3.7.1/protoc-3.7.1-linux-x86_64.exe
protoc-jar: executing: [/tmp/protocjar8378491914719706170/bin/protoc.exe, --version]
libprotoc 3.7.1
[INFO] Protoc command: /tmp/protocjar8378491914719706170/bin/protoc.exe
[INFO] Input directories:
[INFO]     /home/liupengcheng/work/git/xiaomi/flink/flink-python/pyflink/proto
[INFO] Output targets:
[INFO]     java: /home/liupengcheng/work/git/xiaomi/flink/flink-python/target/generated-sources (add: main, clean: false, plugin: null, outputOptions: null)
[INFO] /home/liupengcheng/work/git/xiaomi/flink/flink-python/target/generated-sources does not exist. Creating...
[INFO]     Processing (java): flink-fn-execution.proto
protoc-jar: executing: [/tmp/protocjar8378491914719706170/bin/protoc.exe, -I/home/liupengcheng/work/git/xiaomi/flink/flink-python/pyflink/proto, --java_out=/home/liupengcheng/work/git/xiaomi/flink/flink-python/target/generated-sources, /home/liupengcheng/work/git/xiaomi/flink/flink-python/pyflink/proto/flink-fn-execution.proto]
[INFO] Adding generated sources (java): /home/liupengcheng/work/git/xiaomi/flink/flink-python/target/generated-sources
[INFO] 
[INFO] --- exec-maven-plugin:1.5.0:exec (Protos Generation) @ flink-python_2.11 ---
/home/liupengcheng/work/git/xiaomi/flink/flink-python/pyflink/gen_protos.py:49: UserWarning: Installing grpcio-tools is recommended for development.
  warnings.warn('Installing grpcio-tools is recommended for development.')
WARNING:root:Installing grpcio-tools into /home/liupengcheng/work/git/xiaomi/flink/flink-python/pyflink/../.eggs/grpcio-wheelsUsage:   
  /usr/local/bin/python -m pip install [options] <requirement specifier> [package-index-options] ...
  /usr/local/bin/python -m pip install [options] -r <requirements file> [package-index-options] ...
  /usr/local/bin/python -m pip install [options] [-e] <vcs project url> ...
  /usr/local/bin/python -m pip install [options] [-e] <local project path> ...
  /usr/local/bin/python -m pip install [options] <archive url/path> ...no such option: --prefix
Process Process-1:
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/local/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/home/liupengcheng/work/git/xiaomi/flink/flink-python/pyflink/gen_protos.py", line 126, in _install_grpcio_tools_and_generate_proto_files
    '--upgrade', GRPC_TOOLS, "-I"])
  File "/usr/local/lib/python2.7/subprocess.py", line 540, in check_call
    raise CalledProcessError(retcode, cmd)
CalledProcessError: Command '['/usr/local/bin/python', '-m', 'pip', 'install', '--prefix', '/home/liupengcheng/work/git/xiaomi/flink/flink-python/pyflink/../.eggs/grpcio-wheels', '--build', '/home/liupengcheng/work/git/xiaomi/flink/flink-python/pyflink/../.eggs/grpcio-wheels-build', '--upgrade', 'grpcio-tools>=1.3.5,<=1.14.2', '-I']' returned non-zero exit status 2
Traceback (most recent call last):
  File "/home/liupengcheng/work/git/xiaomi/flink/flink-python/pyflink/gen_protos.py", line 146, in <module>
    generate_proto_files(force=True)
  File "/home/liupengcheng/work/git/xiaomi/flink/flink-python/pyflink/gen_protos.py", line 91, in generate_proto_files
    raise ValueError("Proto generation failed (see log for details).")
ValueError: Proto generation failed (see log for details).
[ERROR] Command execution failed.
```

The root cause s because the `–prefix` option is only supported since pip v8.0. See docs for details: https://pip.pypa.io/en/stable/news/.

This PR will use the `--install-option="–prefix=xxx"` for better compatibility.


## Brief change log

*(for example:)*
  - Fix pip command options

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
