### PR TITLE
[FLINK-14337][hs] Better handling of failed fetches

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
@@ -163,7 +163,7 @@ class HistoryServerArchiveFetcher {
 								refreshDir, jobID, iae);
 							continue;
 						}
-						if (cachedArchives.add(jobID)) {
+						if (!cachedArchives.contains(jobID)) {
 							try {
 								for (ArchivedJson archive : FsJobArchivist.getArchivedJsons(jobArchive.getPath())) {
 									String path = archive.getPath();
@@ -200,11 +200,10 @@ class HistoryServerArchiveFetcher {
 										fw.flush();
 									}
 								}
+								cachedArchives.add(jobID);
 								numFetchedArchives++;
 							} catch (IOException e) {
 								LOG.error("Failure while fetching/processing job archive for job {}.", jobID, e);
-								// Make sure we attempt to fetch the archive again
-								cachedArchives.remove(jobID);
 								// Make sure we do not include this job in the overview
 								try {
 									Files.delete(new File(webOverviewDir, jobID + JSON_FILE_ENDING).toPath());

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
@@ -152,7 +152,6 @@ class HistoryServerArchiveFetcher {
 					if (jobArchives == null) {
 						continue;
 					}
-					boolean updateOverview = false;
 					int numFetchedArchives = 0;
 					for (FileStatus jobArchive : jobArchives) {
 						Path jobArchivePath = jobArchive.getPath();
@@ -200,7 +199,6 @@ class HistoryServerArchiveFetcher {
 										fw.flush();
 									}
 								}
-								updateOverview = true;
 								numFetchedArchives++;
 							} catch (IOException e) {
 								LOG.error("Failure while fetching/processing job archive for job {}.", jobID, e);
@@ -223,7 +221,7 @@ class HistoryServerArchiveFetcher {
 							}
 						}
 					}
-					if (updateOverview) {
+					if (numFetchedArchives > 0) {
 						updateJobOverview(webOverviewDir, webDir);
 						for (int x = 0; x < numFetchedArchives; x++) {
 							numArchivedJobs.countDown();

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
@@ -176,6 +176,7 @@ class HistoryServerArchiveFetcher {
 										json = convertLegacyJobOverview(json);
 										target = new File(webOverviewDir, jobID + JSON_FILE_ENDING);
 									} else {
+										// this implicitly writes into webJobDir
 										target = new File(webDir, path + JSON_FILE_ENDING);
 									}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/history/FsJobArchivist.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/history/FsJobArchivist.java
@@ -109,15 +109,20 @@ public class FsJobArchivist {
 			ByteArrayOutputStream output = new ByteArrayOutputStream()) {
 			IOUtils.copyBytes(input, output);
 
-			JsonNode archive = mapper.readTree(output.toByteArray());
+			try {
+				JsonNode archive = mapper.readTree(output.toByteArray());
 
-			Collection<ArchivedJson> archives = new ArrayList<>();
-			for (JsonNode archivePart : archive.get(ARCHIVE)) {
-				String path = archivePart.get(PATH).asText();
-				String json = archivePart.get(JSON).asText();
-				archives.add(new ArchivedJson(path, json));
+				Collection<ArchivedJson> archives = new ArrayList<>();
+				for (JsonNode archivePart : archive.get(ARCHIVE)) {
+					String path = archivePart.get(PATH).asText();
+					String json = archivePart.get(JSON).asText();
+					archives.add(new ArchivedJson(path, json));
+				}
+				return archives;
+			} catch (NullPointerException npe) {
+				// occurs if the archive is empty or any of the expected fields are not present
+				throw new IOException("Job archive (" + file.getPath() + ") did not conform to expected format.");
 			}
-			return archives;
 		}
 	}
 }


### PR DESCRIPTION
Some small adjustments to the HistoryServer to prevent NPEs when processing empty/partial/corrupted archives, and ensure that archive fetches are retried unless the fetch was completed successfully.

Tests weren't added intentionally. The NPE issue is difficult to test without exposing details about the JSON structure to the test, while the other issue is simply difficult to test without larger refactorings.