### PR TITLE
[FLINK-14300][Runtime / Task] Cleanup operator threads in case StreamTask fails to al…

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -514,6 +514,11 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 				synchronized (lock) {
 					operatorChain.releaseOutputs();
 				}
+			} else {
+				// failed to allocate operatorChain, clean up record writers
+				for (RecordWriter<SerializationDelegate<StreamRecord<OUT>>> writer: recordWriters) {
+					writer.close();
+				}
 			}
 
 			mailboxProcessor.close();


### PR DESCRIPTION
…locate operatorChain

## What is the purpose of the change

This pull request fixes a thread leak on the task manager when the StreamTask class fails to deserialize an operator when instantiating the operatorChain property. The error handling code cleans up all operator threads if the OperatorChain class is instantiated, but fails to clean up threads created before the OperatorChain class is instantiated if the operatorChain property is null.

An example of a deserialization exception thrown when instantiating the OperatorChain object is as follows:
```
org.apache.flink.streaming.runtime.tasks.StreamTaskException: Cannot instantiate user function.
        at org.apache.flink.streaming.api.graph.StreamConfig.getStreamOperator(StreamConfig.java:239)
        at org.apache.flink.streaming.runtime.tasks.OperatorChain.<init>(OperatorChain.java:104)
        at org.apache.flink.streaming.runtime.tasks.StreamTask.invoke(StreamTask.java:267)
        at org.apache.flink.runtime.taskmanager.Task.run(Task.java:711)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.io.InvalidClassException: com.example.DBWriter; local class incompatible: stream classdesc serialVersionUID = -3648304528349867488, local class serialVersionUID = -7371568206393076603
	at java.io.ObjectStreamClass.initNonProxy(ObjectStreamClass.java:699)
	at java.io.ObjectInputStream.readNonProxyDesc(ObjectInputStream.java:1885)
	at java.io.ObjectInputStream.readClassDesc(ObjectInputStream.java:1751)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2042)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1573)
	at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2287)
	at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2211)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2069)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1573)
	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:431)
	at org.apache.flink.util.InstantiationUtil.deserializeObject(InstantiationUtil.java:566)
	at org.apache.flink.util.InstantiationUtil.deserializeObject(InstantiationUtil.java:552)
	at org.apache.flink.util.InstantiationUtil.deserializeObject(InstantiationUtil.java:540)
	at org.apache.flink.util.InstantiationUtil.readObjectFromConfig(InstantiationUtil.java:501)
	at org.apache.flink.streaming.api.graph.StreamConfig.getStreamOperator(StreamConfig.java:224)
```

## Brief change log

  - Stop leaking OutputFlusher threads if a flink job fails to deserialize an intermediate operator in a StreamTask operator chain.

## Verifying this change

This change can be verified as follows:
  - Create a User Defined Function which can be serialized, but fails to deserialize. I think reusing the base class definition of `serialVersionUID` will do it.
  - Create a 2-3 operator stream with badly serialized operator in every position of the chain.
  - When the serialization exception occurs, the `recordWriters` property should be holding an *OutputFlusher* thread which will be left to run because the `operatorChain` instance is not there to clean it up.

## Does this pull request potentially affect one of the following parts:

  - Dependencies: no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes, should improve job restarts by stopping thread leak.
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
