### PR TITLE
[FLINK-14208][python] Optimize Python UDFs with parameters of constant values

### DIFF
--- a/flink-python/pyflink/fn_execution/flink_fn_execution_pb2.py
+++ b/flink-python/pyflink/fn_execution/flink_fn_execution_pb2.py
@@ -36,7 +36,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='flink-fn-execution.proto',
   package='org.apache.flink.fn_execution.v1',
   syntax='proto3',
-  serialized_pb=_b('\n\x18\x66link-fn-execution.proto\x12 org.apache.flink.fn_execution.v1\"\xe2\x01\n\x13UserDefinedFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12K\n\x06inputs\x18\x02 \x03(\x0b\x32;.org.apache.flink.fn_execution.v1.UserDefinedFunction.Input\x1am\n\x05Input\x12\x44\n\x03udf\x18\x01 \x01(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunctionH\x00\x12\x15\n\x0binputOffset\x18\x02 \x01(\x05H\x00\x42\x07\n\x05input\"[\n\x14UserDefinedFunctions\x12\x43\n\x04udfs\x18\x01 \x03(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunction\"\x8d\x07\n\x06Schema\x12>\n\x06\x66ields\x18\x01 \x03(\x0b\x32..org.apache.flink.fn_execution.v1.Schema.Field\x1a\x97\x01\n\x07MapType\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\xcd\x02\n\tFieldType\x12\x44\n\ttype_name\x18\x01 \x01(\x0e\x32\x31.org.apache.flink.fn_execution.v1.Schema.TypeName\x12\x10\n\x08nullable\x18\x02 \x01(\x08\x12U\n\x17\x63ollection_element_type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeH\x00\x12\x44\n\x08map_type\x18\x04 \x01(\x0b\x32\x30.org.apache.flink.fn_execution.v1.Schema.MapTypeH\x00\x12>\n\nrow_schema\x18\x05 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.SchemaH\x00\x42\x0b\n\ttype_info\x1al\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12@\n\x04type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\"\xea\x01\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\x0b\n\x07TINYINT\x10\x01\x12\x0c\n\x08SMALLINT\x10\x02\x12\x07\n\x03INT\x10\x03\x12\n\n\x06\x42IGINT\x10\x04\x12\x0b\n\x07\x44\x45\x43IMAL\x10\x05\x12\t\n\x05\x46LOAT\x10\x06\x12\n\n\x06\x44OUBLE\x10\x07\x12\x08\n\x04\x44\x41TE\x10\x08\x12\x08\n\x04TIME\x10\t\x12\x0c\n\x08\x44\x41TETIME\x10\n\x12\x0b\n\x07\x42OOLEAN\x10\x0b\x12\n\n\x06\x42INARY\x10\x0c\x12\r\n\tVARBINARY\x10\r\x12\x08\n\x04\x43HAR\x10\x0e\x12\x0b\n\x07VARCHAR\x10\x0f\x12\t\n\x05\x41RRAY\x10\x10\x12\x07\n\x03MAP\x10\x11\x12\x0c\n\x08MULTISET\x10\x12\x42-\n\x1forg.apache.flink.fnexecution.v1B\nFlinkFnApib\x06proto3')
+  serialized_pb=_b('\n\x18\x66link-fn-execution.proto\x12 org.apache.flink.fn_execution.v1\"\xfc\x01\n\x13UserDefinedFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12K\n\x06inputs\x18\x02 \x03(\x0b\x32;.org.apache.flink.fn_execution.v1.UserDefinedFunction.Input\x1a\x86\x01\n\x05Input\x12\x44\n\x03udf\x18\x01 \x01(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunctionH\x00\x12\x15\n\x0binputOffset\x18\x02 \x01(\x05H\x00\x12\x17\n\rinputConstant\x18\x03 \x01(\x0cH\x00\x42\x07\n\x05input\"[\n\x14UserDefinedFunctions\x12\x43\n\x04udfs\x18\x01 \x03(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunction\"\x8d\x07\n\x06Schema\x12>\n\x06\x66ields\x18\x01 \x03(\x0b\x32..org.apache.flink.fn_execution.v1.Schema.Field\x1a\x97\x01\n\x07MapType\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\xcd\x02\n\tFieldType\x12\x44\n\ttype_name\x18\x01 \x01(\x0e\x32\x31.org.apache.flink.fn_execution.v1.Schema.TypeName\x12\x10\n\x08nullable\x18\x02 \x01(\x08\x12U\n\x17\x63ollection_element_type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeH\x00\x12\x44\n\x08map_type\x18\x04 \x01(\x0b\x32\x30.org.apache.flink.fn_execution.v1.Schema.MapTypeH\x00\x12>\n\nrow_schema\x18\x05 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.SchemaH\x00\x42\x0b\n\ttype_info\x1al\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12@\n\x04type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\"\xea\x01\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\x0b\n\x07TINYINT\x10\x01\x12\x0c\n\x08SMALLINT\x10\x02\x12\x07\n\x03INT\x10\x03\x12\n\n\x06\x42IGINT\x10\x04\x12\x0b\n\x07\x44\x45\x43IMAL\x10\x05\x12\t\n\x05\x46LOAT\x10\x06\x12\n\n\x06\x44OUBLE\x10\x07\x12\x08\n\x04\x44\x41TE\x10\x08\x12\x08\n\x04TIME\x10\t\x12\x0c\n\x08\x44\x41TETIME\x10\n\x12\x0b\n\x07\x42OOLEAN\x10\x0b\x12\n\n\x06\x42INARY\x10\x0c\x12\r\n\tVARBINARY\x10\r\x12\x08\n\x04\x43HAR\x10\x0e\x12\x0b\n\x07VARCHAR\x10\x0f\x12\t\n\x05\x41RRAY\x10\x10\x12\x07\n\x03MAP\x10\x11\x12\x0c\n\x08MULTISET\x10\x12\x42-\n\x1forg.apache.flink.fnexecution.v1B\nFlinkFnApib\x06proto3')
 )
 
 
@@ -126,8 +126,8 @@ _SCHEMA_TYPENAME = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1060,
-  serialized_end=1294,
+  serialized_start=1086,
+  serialized_end=1320,
 )
 _sym_db.RegisterEnumDescriptor(_SCHEMA_TYPENAME)
 
@@ -153,6 +153,13 @@ _USERDEFINEDFUNCTION_INPUT = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='inputConstant', full_name='org.apache.flink.fn_execution.v1.UserDefinedFunction.Input.inputConstant', index=2,
+      number=3, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -168,8 +175,8 @@ _USERDEFINEDFUNCTION_INPUT = _descriptor.Descriptor(
       name='input', full_name='org.apache.flink.fn_execution.v1.UserDefinedFunction.Input.input',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=180,
-  serialized_end=289,
+  serialized_start=181,
+  serialized_end=315,
 )
 
 _USERDEFINEDFUNCTION = _descriptor.Descriptor(
@@ -206,7 +213,7 @@ _USERDEFINEDFUNCTION = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=63,
-  serialized_end=289,
+  serialized_end=315,
 )
 
 
@@ -236,8 +243,8 @@ _USERDEFINEDFUNCTIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=291,
-  serialized_end=382,
+  serialized_start=317,
+  serialized_end=408,
 )
 
 
@@ -274,8 +281,8 @@ _SCHEMA_MAPTYPE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=460,
-  serialized_end=611,
+  serialized_start=486,
+  serialized_end=637,
 )
 
 _SCHEMA_FIELDTYPE = _descriptor.Descriptor(
@@ -335,8 +342,8 @@ _SCHEMA_FIELDTYPE = _descriptor.Descriptor(
       name='type_info', full_name='org.apache.flink.fn_execution.v1.Schema.FieldType.type_info',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=614,
-  serialized_end=947,
+  serialized_start=640,
+  serialized_end=973,
 )
 
 _SCHEMA_FIELD = _descriptor.Descriptor(
@@ -379,8 +386,8 @@ _SCHEMA_FIELD = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=949,
-  serialized_end=1057,
+  serialized_start=975,
+  serialized_end=1083,
 )
 
 _SCHEMA = _descriptor.Descriptor(
@@ -410,8 +417,8 @@ _SCHEMA = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=385,
-  serialized_end=1294,
+  serialized_start=411,
+  serialized_end=1320,
 )
 
 _USERDEFINEDFUNCTION_INPUT.fields_by_name['udf'].message_type = _USERDEFINEDFUNCTION
@@ -422,6 +429,9 @@ _USERDEFINEDFUNCTION_INPUT.fields_by_name['udf'].containing_oneof = _USERDEFINED
 _USERDEFINEDFUNCTION_INPUT.oneofs_by_name['input'].fields.append(
   _USERDEFINEDFUNCTION_INPUT.fields_by_name['inputOffset'])
 _USERDEFINEDFUNCTION_INPUT.fields_by_name['inputOffset'].containing_oneof = _USERDEFINEDFUNCTION_INPUT.oneofs_by_name['input']
+_USERDEFINEDFUNCTION_INPUT.oneofs_by_name['input'].fields.append(
+  _USERDEFINEDFUNCTION_INPUT.fields_by_name['inputConstant'])
+_USERDEFINEDFUNCTION_INPUT.fields_by_name['inputConstant'].containing_oneof = _USERDEFINEDFUNCTION_INPUT.oneofs_by_name['input']
 _USERDEFINEDFUNCTION.fields_by_name['inputs'].message_type = _USERDEFINEDFUNCTION_INPUT
 _USERDEFINEDFUNCTIONS.fields_by_name['udfs'].message_type = _USERDEFINEDFUNCTION
 _SCHEMA_MAPTYPE.fields_by_name['key_type'].message_type = _SCHEMA_FIELDTYPE

--- a/flink-python/pyflink/fn_execution/operations.py
+++ b/flink-python/pyflink/fn_execution/operations.py
@@ -82,29 +82,48 @@ class ScalarFunctionInputGetter(InputGetter):
         return self.scalar_function_invoker.invoke_eval(value)
 
 
-serializer = PickleSerializer()
-
-
 class ConstantInputGetter(InputGetter):
     """
-    InputGetter for the input argument which is the constant value.
+    InputGetter for the input argument which is a constant value.
 
-    :param constant_value: the constant value of the column in the input row
+    :param constant_value: the constant value of the column
     """
 
     def __init__(self, constant_value):
-        j_type = constant_value.value[0]
-        pickled_data = serializer.loads(constant_value.value[1:])
+        j_type = constant_value[0]
+        serializer = PickleSerializer()
+        pickled_data = serializer.loads(constant_value[1:])
+        # the type set contains
+        # TINYINT,SMALLINT,INTEGER,BIGINT,FLOAT,DOUBLE,DECIMAL,CHAR,VARCHAR,NULL
+        # the pickled_data doesn't need to transfer to anther python object
         if j_type == '\x00' or j_type == 0:
             self._constant_value = pickled_data
+        # the type is BOOLEAN
         elif j_type == '\x01' or j_type == 1:
-            self._constant_value = datetime.date(year=0, month=0, day=pickled_data)
+            self._constant_value = True if pickled_data == 'true' else False
+        # the type is DATE
         elif j_type == '\x02' or j_type == 2:
-            self._constant_value = datetime.time(microsecond=pickled_data * 1000)
+            self._constant_value = \
+                datetime.date(year=1970, month=1, day=1) + datetime.timedelta(days=pickled_data)
+        # the type is TIME
         elif j_type == '\x03' or j_type == 3:
-            self._constant_value = relativedelta(months=pickled_data)
+            seconds, milliseconds = divmod(pickled_data, 1000)
+            minutes, seconds = divmod(seconds, 60)
+            hours, minutes = divmod(minutes, 60)
+            self._constant_value = datetime.time(hours, minutes, seconds, milliseconds * 1000)
+        # the type set contains TIMESTAMP
         elif j_type == '\x04' or j_type == 4:
-            self._constant_value = datetime.timedelta(seconds=pickled_data)
+            self._constant_value = \
+                datetime.datetime(year=1970, month=1, day=1, hour=0, minute=0, second=0) \
+                + datetime.timedelta(milliseconds=pickled_data)
+        # the type set is YEAR_INTERVAL_TYPES
+        elif j_type == '\x05' or j_type == 5:
+            self._constant_value = relativedelta(months=pickled_data)
+        # the type set is DAY_INTERVAL_TYPES
+        elif j_type == '\x06' or j_type == 6:
+            self._constant_value = datetime.timedelta(milliseconds=pickled_data)
+        else:
+            raise Exception("Unknown type %s, it may be encode/decode error" % str(j_type))
 
     def get(self, value):
         return self._constant_value

--- a/flink-python/pyflink/fn_execution/operations.py
+++ b/flink-python/pyflink/fn_execution/operations.py
@@ -18,7 +18,6 @@
 
 import datetime
 from abc import abstractmethod, ABCMeta
-from dateutil.relativedelta import relativedelta
 
 from apache_beam.runners.worker import operation_specs
 from apache_beam.runners.worker import bundle_processor
@@ -113,12 +112,6 @@ class ConstantInputGetter(InputGetter):
             self._constant_value = \
                 datetime.datetime(year=1970, month=1, day=1, hour=0, minute=0, second=0) \
                 + datetime.timedelta(milliseconds=pickled_data)
-        # the type is YearMonthInterval
-        elif j_type == '\x04' or j_type == 4:
-            self._constant_value = relativedelta(months=pickled_data)
-        # the type is DayTimeInterval
-        elif j_type == '\x05' or j_type == 5:
-            self._constant_value = datetime.timedelta(milliseconds=pickled_data)
         else:
             raise Exception("Unknown type %s, should never happen" % str(j_type))
 

--- a/flink-python/pyflink/fn_execution/operations.py
+++ b/flink-python/pyflink/fn_execution/operations.py
@@ -95,15 +95,15 @@ class ConstantInputGetter(InputGetter):
     def __init__(self, constant_value):
         j_type = constant_value.value[0]
         pickled_data = serializer.loads(constant_value.value[1:])
-        if j_type == '\x00':
+        if j_type == '\x00' or j_type == 0:
             self._constant_value = pickled_data
-        elif j_type == '\x01':
+        elif j_type == '\x01' or j_type == 1:
             self._constant_value = datetime.date(year=0, month=0, day=pickled_data)
-        elif j_type == '\x02':
+        elif j_type == '\x02' or j_type == 2:
             self._constant_value = datetime.time(microsecond=pickled_data * 1000)
-        elif j_type == '\x03':
+        elif j_type == '\x03' or j_type == 3:
             self._constant_value = relativedelta(months=pickled_data)
-        elif j_type == '\x04':
+        elif j_type == '\x04' or j_type == 4:
             self._constant_value = datetime.timedelta(seconds=pickled_data)
 
     def get(self, value):

--- a/flink-python/pyflink/fn_execution/operations.py
+++ b/flink-python/pyflink/fn_execution/operations.py
@@ -94,36 +94,33 @@ class ConstantInputGetter(InputGetter):
         serializer = PickleSerializer()
         pickled_data = serializer.loads(constant_value[1:])
         # the type set contains
-        # TINYINT,SMALLINT,INTEGER,BIGINT,FLOAT,DOUBLE,DECIMAL,CHAR,VARCHAR,NULL
+        # TINYINT,SMALLINT,INTEGER,BIGINT,FLOAT,DOUBLE,DECIMAL,CHAR,VARCHAR,NULL,BOOLEAN
         # the pickled_data doesn't need to transfer to anther python object
         if j_type == '\x00' or j_type == 0:
             self._constant_value = pickled_data
-        # the type is BOOLEAN
-        elif j_type == '\x01' or j_type == 1:
-            self._constant_value = True if pickled_data == 'true' else False
         # the type is DATE
-        elif j_type == '\x02' or j_type == 2:
+        elif j_type == '\x01' or j_type == 1:
             self._constant_value = \
                 datetime.date(year=1970, month=1, day=1) + datetime.timedelta(days=pickled_data)
         # the type is TIME
-        elif j_type == '\x03' or j_type == 3:
+        elif j_type == '\x02' or j_type == 2:
             seconds, milliseconds = divmod(pickled_data, 1000)
             minutes, seconds = divmod(seconds, 60)
             hours, minutes = divmod(minutes, 60)
             self._constant_value = datetime.time(hours, minutes, seconds, milliseconds * 1000)
-        # the type set contains TIMESTAMP
-        elif j_type == '\x04' or j_type == 4:
+        # the type is TIMESTAMP
+        elif j_type == '\x03' or j_type == 3:
             self._constant_value = \
                 datetime.datetime(year=1970, month=1, day=1, hour=0, minute=0, second=0) \
                 + datetime.timedelta(milliseconds=pickled_data)
-        # the type set is YEAR_INTERVAL_TYPES
-        elif j_type == '\x05' or j_type == 5:
+        # the type is YearMonthInterval
+        elif j_type == '\x04' or j_type == 4:
             self._constant_value = relativedelta(months=pickled_data)
-        # the type set is DAY_INTERVAL_TYPES
-        elif j_type == '\x06' or j_type == 6:
+        # the type is DayTimeInterval
+        elif j_type == '\x05' or j_type == 5:
             self._constant_value = datetime.timedelta(milliseconds=pickled_data)
         else:
-            raise Exception("Unknown type %s, it may be encode/decode error" % str(j_type))
+            raise Exception("Unknown type %s, should never happen" % str(j_type))
 
     def get(self, value):
         return self._constant_value

--- a/flink-python/pyflink/proto/flink-fn-execution.proto
+++ b/flink-python/pyflink/proto/flink-fn-execution.proto
@@ -28,15 +28,12 @@ option java_outer_classname = "FlinkFnApi";
 // User-defined function definition. It supports chaining functions, that's, the execution
 // result of one user-defined function as the input of another user-defined function.
 message UserDefinedFunction {
-  message Constant {
-    bytes value = 1;
-  }
 
   message Input {
     oneof input {
       UserDefinedFunction udf = 1;
       int32 inputOffset = 2;
-      Constant inputConstant = 3;
+      bytes inputConstant = 3;
     }
   }
 
@@ -46,6 +43,7 @@ message UserDefinedFunction {
   // The input arguments of the user-defined function, it could be one of the following:
   // 1. A column from the input row
   // 2. The result of another user-defined function
+  // 3. The constant value of the column
   repeated Input inputs = 2;
 }
 

--- a/flink-python/pyflink/proto/flink-fn-execution.proto
+++ b/flink-python/pyflink/proto/flink-fn-execution.proto
@@ -28,10 +28,15 @@ option java_outer_classname = "FlinkFnApi";
 // User-defined function definition. It supports chaining functions, that's, the execution
 // result of one user-defined function as the input of another user-defined function.
 message UserDefinedFunction {
+  message Constant {
+    bytes value = 1;
+  }
+
   message Input {
     oneof input {
       UserDefinedFunction udf = 1;
       int32 inputOffset = 2;
+      Constant inputConstant = 3;
     }
   }
 

--- a/flink-python/pyflink/proto/flink-fn-execution.proto
+++ b/flink-python/pyflink/proto/flink-fn-execution.proto
@@ -28,7 +28,6 @@ option java_outer_classname = "FlinkFnApi";
 // User-defined function definition. It supports chaining functions, that's, the execution
 // result of one user-defined function as the input of another user-defined function.
 message UserDefinedFunction {
-
   message Input {
     oneof input {
       UserDefinedFunction udf = 1;

--- a/flink-python/pyflink/table/tests/test_udf.py
+++ b/flink-python/pyflink/table/tests/test_udf.py
@@ -96,6 +96,18 @@ class UserDefinedFunctionTests(PyFlinkStreamTableTestCase):
         actual = source_sink_utils.results()
         self.assert_equals(actual, ["2,Hi,2,Flink"])
 
+    def test_udf_with_constant_param(self):
+        self.t_env.register_function("add", add)
+
+        table_sink = source_sink_utils.TestAppendSink(['a'], [DataTypes.BIGINT()])
+        self.t_env.register_table_sink("Results", table_sink)
+
+        t = self.t_env.from_elements([(1, 2, 3), (2, 5, 6), (3, 1, 9)], ['a', 'b', 'c'])
+        t.select("add(a, 20l)").insert_into("Results")
+        self.t_env.execute("test")
+        actual = source_sink_utils.results()
+        self.assert_equals(actual, ["21", "22", "23"])
+
     def test_udf_in_join_condition_2(self):
         t1 = self.t_env.from_elements([(1, "Hi"), (2, "Hi")], ['a', 'b'])
         t2 = self.t_env.from_elements([(2, "Flink")], ['c', 'd'])

--- a/flink-python/pyflink/table/tests/test_udf.py
+++ b/flink-python/pyflink/table/tests/test_udf.py
@@ -117,6 +117,10 @@ class UserDefinedFunctionTests(PyFlinkStreamTableTestCase):
                                      bigint_param, decimal_param, float_param, double_param,
                                      boolean_param, str_param,
                                      date_param, time_param, timestamp_param):
+            # decide two float whether equals
+            def float_equal(a, b, rel_tol=1e-09, abs_tol=0.0):
+                return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
+
             from decimal import Decimal
             import datetime
 
@@ -134,16 +138,19 @@ class UserDefinedFunctionTests(PyFlinkStreamTableTestCase):
             assert isinstance(bigint_param, int), 'bigint_param of wrong type %s !' \
                                                   % type(bigint_param)
             p += bigint_param
-            assert isinstance(decimal_param, Decimal), 'decimal_param of wrong type %s !' \
-                                                       % type(decimal_param)
+            assert decimal_param == Decimal('1.05'), \
+                'decimal_param is wrong value %s ' % decimal_param
+
             p += int(decimal_param)
 
-            assert isinstance(float_param, float), 'float_param of wrong type %s !' \
-                                                   % type(float_param)
-            p += float_param
-            assert isinstance(double_param, float), 'double_param of wrong type %s !' \
-                                                    % type(double_param)
-            p += double_param
+            assert isinstance(float_param, float) and float_equal(float_param, 1.23, 1e-06), \
+                'float_param is wrong value %s ' % float_param
+
+            p += int(float_param)
+            assert isinstance(double_param, float) and float_equal(double_param, 1.98932, 1e-07), \
+                'double_param is wrong value %s ' % double_param
+
+            p += int(double_param)
 
             assert boolean_param is True, 'boolean_param is wrong value %s' % boolean_param
 
@@ -189,9 +196,9 @@ class UserDefinedFunctionTests(PyFlinkStreamTableTestCase):
                              "cast (1 as SMALLINT),"
                              "cast (1 as INT),"
                              "cast (1 as BIGINT),"
-                             "cast (1 as DECIMAL),"
-                             "cast (1.0 as FLOAT),"
-                             "cast (1.00 as DOUBLE),"
+                             "cast (1.05 as DECIMAL),"
+                             "cast (1.23 as FLOAT),"
+                             "cast (1.98932 as DOUBLE),"
                              "true,"
                              "'flink',"
                              "cast ('2014-09-13' as DATE),"

--- a/flink-python/src/main/java/org/apache/flink/api/common/python/PythonBridgeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/api/common/python/PythonBridgeUtils.java
@@ -129,25 +129,6 @@ public final class PythonBridgeUtils {
 					type = 3;
 					value = o.getValue3();
 					break;
-				case INTERVAL_YEAR:
-				case INTERVAL_YEAR_MONTH:
-				case INTERVAL_MONTH:
-					type = 4;
-					value = ((BigDecimal) o.getValue3()).intValueExact();
-					break;
-				case INTERVAL_DAY:
-				case INTERVAL_DAY_HOUR:
-				case INTERVAL_DAY_MINUTE:
-				case INTERVAL_DAY_SECOND:
-				case INTERVAL_HOUR:
-				case INTERVAL_HOUR_MINUTE:
-				case INTERVAL_HOUR_SECOND:
-				case INTERVAL_MINUTE:
-				case INTERVAL_MINUTE_SECOND:
-				case INTERVAL_SECOND:
-					type = 5;
-					value = ((BigDecimal) o.getValue3()).longValueExact();
-					break;
 				default:
 					throw new RuntimeException("Unsupported type " + typeName);
 			}

--- a/flink-python/src/main/java/org/apache/flink/api/common/python/PythonBridgeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/api/common/python/PythonBridgeUtils.java
@@ -74,7 +74,7 @@ public final class PythonBridgeUtils {
 		return unpickledData;
 	}
 
-	public static byte[] literalToPythonObject(RexLiteral o, SqlTypeName typeName) {
+	public static byte[] convertLiteralToPython(RexLiteral o, SqlTypeName typeName) {
 		byte type;
 		Object value;
 		Pickler pickler = new Pickler();
@@ -108,6 +108,7 @@ public final class PythonBridgeUtils {
 					value = ((BigDecimal) o.getValue3()).doubleValue();
 					break;
 				case DECIMAL:
+				case BOOLEAN:
 					type = 0;
 					value = o.getValue3();
 					break;
@@ -116,26 +117,22 @@ public final class PythonBridgeUtils {
 					type = 0;
 					value = o.getValue3().toString();
 					break;
-				case BOOLEAN:
-					type = 1;
-					value = o.getValue3().toString();
-					break;
 				case DATE:
-					type = 2;
+					type = 1;
 					value = o.getValue3();
 					break;
 				case TIME:
-					type = 3;
+					type = 2;
 					value = o.getValue3();
 					break;
 				case TIMESTAMP:
-					type = 4;
+					type = 3;
 					value = o.getValue3();
 					break;
 				case INTERVAL_YEAR:
 				case INTERVAL_YEAR_MONTH:
 				case INTERVAL_MONTH:
-					type = 5;
+					type = 4;
 					value = ((BigDecimal) o.getValue3()).intValueExact();
 					break;
 				case INTERVAL_DAY:
@@ -148,7 +145,7 @@ public final class PythonBridgeUtils {
 				case INTERVAL_MINUTE:
 				case INTERVAL_MINUTE_SECOND:
 				case INTERVAL_SECOND:
-					type = 6;
+					type = 5;
 					value = ((BigDecimal) o.getValue3()).longValueExact();
 					break;
 				default:

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/AbstractPythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/AbstractPythonScalarFunctionRunner.java
@@ -186,10 +186,7 @@ public abstract class AbstractPythonScalarFunctionRunner<IN, OUT> extends Abstra
 			} else if (input instanceof Integer) {
 				inputProto.setInputOffset((Integer) input);
 			} else {
-				FlinkFnApi.UserDefinedFunction.Constant.Builder constantBuilder =
-					FlinkFnApi.UserDefinedFunction.Constant.newBuilder();
-				constantBuilder.setValue(ByteString.copyFrom((byte[]) input));
-				inputProto.setInputConstant(constantBuilder.build());
+				inputProto.setInputConstant(ByteString.copyFrom((byte[]) input));
 			}
 			builder.addInputs(inputProto);
 		}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/AbstractPythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/AbstractPythonScalarFunctionRunner.java
@@ -183,8 +183,13 @@ public abstract class AbstractPythonScalarFunctionRunner<IN, OUT> extends Abstra
 				FlinkFnApi.UserDefinedFunction.Input.newBuilder();
 			if (input instanceof PythonFunctionInfo) {
 				inputProto.setUdf(getUserDefinedFunctionProto((PythonFunctionInfo) input));
-			} else {
+			} else if (input instanceof Integer) {
 				inputProto.setInputOffset((Integer) input);
+			} else {
+				FlinkFnApi.UserDefinedFunction.Constant.Builder constantBuilder =
+					FlinkFnApi.UserDefinedFunction.Constant.newBuilder();
+				constantBuilder.setValue(ByteString.copyFrom((byte[]) input));
+				inputProto.setInputConstant(constantBuilder.build());
 			}
 			builder.addInputs(inputProto);
 		}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
@@ -28,9 +28,9 @@ import scala.collection.mutable
 
 trait CommonPythonCalc {
 
-  private[flink] lazy val literalToPythonObject = {
+  private[flink] lazy val convertLiteralToPython = {
     val clazz = Class.forName("org.apache.flink.api.common.python.PythonBridgeUtils")
-    clazz.getMethod("literalToPythonObject", classOf[RexLiteral], classOf[SqlTypeName])
+    clazz.getMethod("convertLiteralToPython", classOf[RexLiteral], classOf[SqlTypeName])
   }
 
   private[flink] def extractPythonScalarFunctionInfos(
@@ -60,7 +60,7 @@ trait CommonPythonCalc {
 
         case literal: RexLiteral =>
           inputs.append(
-            literalToPythonObject.invoke(null, literal, literal.getType.getSqlTypeName))
+            convertLiteralToPython.invoke(null, literal, literal.getType.getSqlTypeName))
 
         case argNode: RexNode =>
           // For input arguments of RexInputRef, it's replaced with an offset into the input row

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
@@ -58,7 +58,8 @@ trait CommonPythonCalc {
           inputs.append(argPythonInfo)
 
         case literal: RexLiteral =>
-          inputs.append(rexLiteralToPythonObject.invoke(null, literal.getValue3, literal.getTypeName))
+          inputs.append(
+            rexLiteralToPythonObject.invoke(null, literal.getValue3, literal.getTypeName))
 
         case argNode: RexNode =>
           // For input arguments of RexInputRef, it's replaced with an offset into the input row

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
@@ -28,9 +28,9 @@ import scala.collection.mutable
 
 trait CommonPythonCalc {
 
-  private[flink] lazy val rexLiteralToPythonObject = {
+  private[flink] lazy val literalToPythonObject = {
     val clazz = Class.forName("org.apache.flink.api.common.python.PythonBridgeUtils")
-    clazz.getMethod("rexLiteralToPythonObject", classOf[Object], classOf[SqlTypeName])
+    clazz.getMethod("literalToPythonObject", classOf[RexLiteral], classOf[SqlTypeName])
   }
 
   private[flink] def extractPythonScalarFunctionInfos(
@@ -40,7 +40,8 @@ trait CommonPythonCalc {
     val pythonFunctionInfos = rexCalls.map(createPythonScalarFunctionInfo(_, inputNodes))
 
     val udfInputOffsets = inputNodes.toArray
-      .map(_._1).filter(_.isInstanceOf[RexInputRef])
+      .map(_._1)
+      .filter(_.isInstanceOf[RexInputRef])
       .map(_.asInstanceOf[RexInputRef].getIndex)
     (udfInputOffsets, pythonFunctionInfos)
   }
@@ -59,7 +60,7 @@ trait CommonPythonCalc {
 
         case literal: RexLiteral =>
           inputs.append(
-            rexLiteralToPythonObject.invoke(null, literal.getValue3, literal.getTypeName))
+            literalToPythonObject.invoke(null, literal, literal.getType.getSqlTypeName))
 
         case argNode: RexNode =>
           // For input arguments of RexInputRef, it's replaced with an offset into the input row

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
@@ -28,7 +28,7 @@ import scala.collection.mutable
 
 trait CommonPythonCalc {
 
-  private[flink] lazy val convertLiteralToPython = {
+  private lazy val convertLiteralToPython = {
     val clazz = Class.forName("org.apache.flink.api.common.python.PythonBridgeUtils")
     clazz.getMethod("convertLiteralToPython", classOf[RexLiteral], classOf[SqlTypeName])
   }


### PR DESCRIPTION
## What is the purpose of the change

This pull request optimize Python UDFS with parameters of constant values.The constant parameters are not needed to be transferred between the Java operator and the Python worker.


## Brief change log

  - *Adds Constant message in flink-fn-execution.proto*
  - *Adds translate rexLiteral object to python object logic*

## Verifying this change
This change added tests and can be verified as follows:

  - *Added test test_udf_with_constant_param*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
