### PR TITLE
[FLINK-11405][rest]rest api can more exceptions by query parameter

### DIFF
--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -1894,6 +1894,16 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
       </td>
     </tr>
     <tr>
+        <td colspan="2">Query parameters</td>
+    </tr>
+    <tr>
+        <td colspan="2">
+            <ul>
+                <li><code>size</code> (optional): Comma-separated list of integer values that specifie the upper limit of exceptions to return.</li>
+            </ul>
+        </td>
+    </tr>
+    <tr>
       <td colspan="2">
         <button data-toggle="collapse" data-target="#-1011644505">Request</button>
         <div id="-1011644505" class="collapse">

--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -1899,7 +1899,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     <tr>
         <td colspan="2">
             <ul>
-                <li><code>size</code> (optional): Comma-separated list of integer values that specifie the upper limit of exceptions to return.</li>
+                <li><code>maxExceptions</code> (optional): Comma-separated list of integer values that specifies the upper limit of exceptions to return.</li>
             </ul>
         </td>
     </tr>

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -1302,7 +1302,10 @@
       } ]
     },
     "query-parameters" : {
-      "queryParameters" : [ ]
+      "queryParameters" : [ {
+        "key" : "size",
+        "mandatory" : false
+      } ]
     },
     "request" : {
       "type" : "any"

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -1303,7 +1303,7 @@
     },
     "query-parameters" : {
       "queryParameters" : [ {
-        "key" : "size",
+        "key" : "maxExceptions",
         "mandatory" : false
       } ]
     },

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
@@ -82,7 +82,7 @@ public class JobExceptionsHandler extends AbstractExecutionGraphHandler<JobExcep
 
 	@Override
 	public Collection<ArchivedJson> archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
-		ResponseBody json = createJobExceptionsInfo(graph, Iterables.size(graph.getAllExecutionVertices()));
+		ResponseBody json = createJobExceptionsInfo(graph, MAX_NUMBER_EXCEPTION_TO_REPORT);
 		String path = getMessageHeaders().getTargetRestEndpointURL()
 			.replace(':' + JobIDPathParameter.KEY, graph.getJobID().toString());
 		return Collections.singletonList(new ArchivedJson(path, json));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
@@ -39,8 +39,6 @@ import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.util.ExceptionUtils;
 
-import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
@@ -39,6 +39,8 @@ import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.util.ExceptionUtils;
 
+import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -80,7 +82,7 @@ public class JobExceptionsHandler extends AbstractExecutionGraphHandler<JobExcep
 
 	@Override
 	public Collection<ArchivedJson> archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
-		ResponseBody json = createJobExceptionsInfo(graph, MAX_NUMBER_EXCEPTION_TO_REPORT);
+		ResponseBody json = createJobExceptionsInfo(graph, Iterables.size(graph.getAllExecutionVertices()));
 		String path = getMessageHeaders().getTargetRestEndpointURL()
 			.replace(':' + JobIDPathParameter.KEY, graph.getJobID().toString());
 		return Collections.singletonList(new ArchivedJson(path, json));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsHeaders.java
@@ -20,13 +20,14 @@ package org.apache.flink.runtime.rest.messages;
 
 import org.apache.flink.runtime.rest.HttpMethodWrapper;
 import org.apache.flink.runtime.rest.handler.job.JobExceptionsHandler;
+import org.apache.flink.runtime.rest.messages.job.JobExceptionsMessageParameters;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 /**
  * Message headers for the {@link JobExceptionsHandler}.
  */
-public class JobExceptionsHeaders implements MessageHeaders<EmptyRequestBody, JobExceptionsInfo, JobMessageParameters> {
+public class JobExceptionsHeaders implements MessageHeaders<EmptyRequestBody, JobExceptionsInfo, JobExceptionsMessageParameters> {
 
 	private static final JobExceptionsHeaders INSTANCE = new JobExceptionsHeaders();
 
@@ -50,8 +51,8 @@ public class JobExceptionsHeaders implements MessageHeaders<EmptyRequestBody, Jo
 	}
 
 	@Override
-	public JobMessageParameters getUnresolvedMessageParameters() {
-		return new JobMessageParameters();
+	public JobExceptionsMessageParameters getUnresolvedMessageParameters() {
+		return new JobExceptionsMessageParameters();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfo.java
@@ -81,6 +81,22 @@ public class JobExceptionsInfo implements ResponseBody {
 		return Objects.hash(rootException, rootTimestamp, allExceptions, truncated);
 	}
 
+	public String getRootException() {
+		return rootException;
+	}
+
+	public Long getRootTimestamp() {
+		return rootTimestamp;
+	}
+
+	public List<ExecutionExceptionInfo> getAllExceptions() {
+		return allExceptions;
+	}
+
+	public boolean isTruncated() {
+		return truncated;
+	}
+
 	//---------------------------------------------------------------------------------
 	// Static helper classes
 	//---------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfo.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.rest.handler.job.JobExceptionsHandler;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -81,18 +82,22 @@ public class JobExceptionsInfo implements ResponseBody {
 		return Objects.hash(rootException, rootTimestamp, allExceptions, truncated);
 	}
 
+	@JsonIgnore
 	public String getRootException() {
 		return rootException;
 	}
 
+	@JsonIgnore
 	public Long getRootTimestamp() {
 		return rootTimestamp;
 	}
 
+	@JsonIgnore
 	public List<ExecutionExceptionInfo> getAllExceptions() {
 		return allExceptions;
 	}
 
+	@JsonIgnore
 	public boolean isTruncated() {
 		return truncated;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/ExceptionShowSizeParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/ExceptionShowSizeParameter.java
@@ -26,7 +26,7 @@ import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
  */
 public class ExceptionShowSizeParameter extends MessageQueryParameter<Integer> {
 
-	private static final String QUERY_PARAMETER_NAME = "size";
+	public static final String QUERY_PARAMETER_NAME = "size";
 
 	public ExceptionShowSizeParameter() {
 		super(QUERY_PARAMETER_NAME, MessageParameterRequisiteness.OPTIONAL);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/ExceptionShowSizeParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/ExceptionShowSizeParameter.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job;
+
+import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+
+/**
+ * @see org.apache.flink.runtime.rest.handler.job.JobExceptionsHandler
+ * show size for JobExceptionsHandler
+ */
+public class ExceptionShowSizeParameter extends MessageQueryParameter<Integer> {
+
+	private static final String QUERY_PARAMETER_NAME = "size";
+
+	public ExceptionShowSizeParameter() {
+		super(QUERY_PARAMETER_NAME, MessageParameterRequisiteness.OPTIONAL);
+	}
+
+	@Override
+	public Integer convertStringToValue(String value) {
+		return Integer.valueOf(value);
+	}
+
+	@Override
+	public String convertValueToString(Integer value) {
+		return value.toString();
+	}
+
+	@Override
+	public String getDescription() {
+		return "Show exception's size.";
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobExceptionsMessageParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobExceptionsMessageParameters.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job;
+
+import org.apache.flink.runtime.rest.handler.job.JobExceptionsHandler;
+import org.apache.flink.runtime.rest.messages.JobMessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * {@link MessageParameters} for {@link JobExceptionsHandler}.
+ */
+public class JobExceptionsMessageParameters extends JobMessageParameters {
+
+	private final ExceptionShowSizeParameter exceptionShowSizeParameter = new ExceptionShowSizeParameter();
+
+	@Override
+	public Collection<MessageQueryParameter<?>> getQueryParameters() {
+		return Collections.singletonList(exceptionShowSizeParameter);
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobExceptionsMessageParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobExceptionsMessageParameters.java
@@ -31,11 +31,11 @@ import java.util.Collections;
  */
 public class JobExceptionsMessageParameters extends JobMessageParameters {
 
-	private final ExceptionShowSizeParameter exceptionShowSizeParameter = new ExceptionShowSizeParameter();
+	private final UpperLimitExceptionParameter upperLimitExceptionParameter = new UpperLimitExceptionParameter();
 
 	@Override
 	public Collection<MessageQueryParameter<?>> getQueryParameters() {
-		return Collections.singletonList(exceptionShowSizeParameter);
+		return Collections.singletonList(upperLimitExceptionParameter);
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/UpperLimitExceptionParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/UpperLimitExceptionParameter.java
@@ -18,18 +18,19 @@
 
 package org.apache.flink.runtime.rest.messages.job;
 
+import org.apache.flink.runtime.rest.messages.MessageParameter;
 import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
 
 /**
  * @see org.apache.flink.runtime.rest.handler.job.JobExceptionsHandler
- * show size for JobExceptionsHandler
+ * Specifies the upper limit of exceptions to return for JobExceptionsHandler
  */
-public class ExceptionShowSizeParameter extends MessageQueryParameter<Integer> {
+public class UpperLimitExceptionParameter extends MessageQueryParameter<Integer> {
 
-	public static final String QUERY_PARAMETER_NAME = "size";
+	public static final String KEY = "size";
 
-	public ExceptionShowSizeParameter() {
-		super(QUERY_PARAMETER_NAME, MessageParameterRequisiteness.OPTIONAL);
+	public UpperLimitExceptionParameter() {
+		super(KEY, MessageParameter.MessageParameterRequisiteness.OPTIONAL);
 	}
 
 	@Override
@@ -44,6 +45,6 @@ public class ExceptionShowSizeParameter extends MessageQueryParameter<Integer> {
 
 	@Override
 	public String getDescription() {
-		return "Show exception's size.";
+		return "Integer value that specifies the upper limit of exceptions to return.";
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/UpperLimitExceptionParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/UpperLimitExceptionParameter.java
@@ -22,12 +22,12 @@ import org.apache.flink.runtime.rest.messages.MessageParameter;
 import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
 
 /**
+ * Specifies the upper limit of exceptions to return for JobExceptionsHandler.
  * @see org.apache.flink.runtime.rest.handler.job.JobExceptionsHandler
- * Specifies the upper limit of exceptions to return for JobExceptionsHandler
  */
 public class UpperLimitExceptionParameter extends MessageQueryParameter<Integer> {
 
-	public static final String KEY = "size";
+	public static final String KEY = "maxExceptions";
 
 	public UpperLimitExceptionParameter() {
 		super(KEY, MessageParameter.MessageParameterRequisiteness.OPTIONAL);
@@ -45,6 +45,6 @@ public class UpperLimitExceptionParameter extends MessageQueryParameter<Integer>
 
 	@Override
 	public String getDescription() {
-		return "Integer value that specifies the upper limit of exceptions to return.";
+		return "Comma-separated list of integer values that specifies the upper limit of exceptions to return.";
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
@@ -37,8 +37,8 @@ import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.JobExceptionsHeaders;
 import org.apache.flink.runtime.rest.messages.JobExceptionsInfo;
 import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
-import org.apache.flink.runtime.rest.messages.job.ExceptionShowSizeParameter;
 import org.apache.flink.runtime.rest.messages.job.JobExceptionsMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.UpperLimitExceptionParameter;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.util.EvictingBoundedList;
@@ -126,7 +126,7 @@ public class JobExceptionsHandlerTest extends TestLogger {
 		final Map<String, String> pathParameters = new HashMap<>();
 		pathParameters.put(JobIDPathParameter.KEY, jobId.toString());
 		final Map<String, List<String>> queryParameters = new HashMap<>();
-		queryParameters.put(ExceptionShowSizeParameter.QUERY_PARAMETER_NAME, Collections.singletonList("" + size));
+		queryParameters.put(UpperLimitExceptionParameter.KEY, Collections.singletonList("" + size));
 
 		return new HandlerRequest<>(
 			EmptyRequestBody.getInstance(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ArchivedExecution;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.HandlerRequestException;
+import org.apache.flink.runtime.rest.handler.legacy.ExecutionGraphCache;
+import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobExceptionsHeaders;
+import org.apache.flink.runtime.rest.messages.JobExceptionsInfo;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.job.ExceptionShowSizeParameter;
+import org.apache.flink.runtime.rest.messages.job.JobExceptionsMessageParameters;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.util.EvictingBoundedList;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * Test for the {@link JobExceptionsHandler}.
+ */
+public class JobExceptionsHandlerTest extends TestLogger {
+
+	@Test
+	public void testGetJobExceptionsInfo() throws HandlerRequestException {
+		final JobExceptionsHandler jobExceptionsHandler = new JobExceptionsHandler(
+			() -> null,
+			TestingUtils.TIMEOUT(),
+			Collections.emptyMap(),
+			JobExceptionsHeaders.getInstance(),
+			new ExecutionGraphCache(TestingUtils.TIMEOUT(), TestingUtils.TIMEOUT()),
+			TestingUtils.defaultExecutor());
+
+		Map<JobVertexID, ArchivedExecutionJobVertex> tasks = new HashMap<>();
+		final int exceptionSize = 50;
+		for (int i = 0; i < exceptionSize; i++) {
+			final JobVertexID jobVertexId = new JobVertexID();
+			tasks.put(jobVertexId, createArchivedExecutionJobVertex(jobVertexId));
+		}
+		final AccessExecutionGraph archivedExecutionGraph = new ArchivedExecutionGraphBuilder()
+			.setTasks(tasks)
+			.build();
+		final int querySize = 10;
+		int finalShowSize = exceptionSize >= querySize ? querySize : exceptionSize;
+		final HandlerRequest<EmptyRequestBody, JobExceptionsMessageParameters> handlerRequest = createRequest(archivedExecutionGraph.getJobID(), querySize);
+
+		final JobExceptionsInfo jobExceptionsInfo = jobExceptionsHandler.handleRequest(handlerRequest, archivedExecutionGraph);
+
+		assert(jobExceptionsInfo.getAllExceptions().size() == finalShowSize);
+	}
+
+	private ArchivedExecutionJobVertex createArchivedExecutionJobVertex(JobVertexID jobVertexID) {
+		final StringifiedAccumulatorResult[] emptyAccumulators = new StringifiedAccumulatorResult[0];
+		final long[] timestamps = new long[ExecutionState.values().length];
+		final ExecutionState expectedState = ExecutionState.RUNNING;
+
+		final LocalTaskManagerLocation assignedResourceLocation = new LocalTaskManagerLocation();
+		final AllocationID allocationID = new AllocationID();
+
+		final int subtaskIndex = 1;
+		final int attempt = 2;
+		return new ArchivedExecutionJobVertex(
+			new ArchivedExecutionVertex[]{
+				new ArchivedExecutionVertex(
+					subtaskIndex,
+					"test task",
+					new ArchivedExecution(
+						new StringifiedAccumulatorResult[0],
+						null,
+						new ExecutionAttemptID(),
+						attempt,
+						expectedState,
+						"error",
+						assignedResourceLocation,
+						allocationID,
+						subtaskIndex,
+						timestamps),
+					new EvictingBoundedList<>(0)
+				)
+			},
+			jobVertexID,
+			jobVertexID.toString(),
+			1,
+			1,
+			ResourceProfile.UNKNOWN,
+			emptyAccumulators);
+	}
+
+	private HandlerRequest<EmptyRequestBody, JobExceptionsMessageParameters> createRequest(JobID jobId, int size) throws HandlerRequestException {
+		final Map<String, String> pathParameters = new HashMap<>();
+		pathParameters.put(JobIDPathParameter.KEY, jobId.toString());
+		final Map<String, List<String>> queryParameters = new HashMap<>();
+		queryParameters.put(ExceptionShowSizeParameter.QUERY_PARAMETER_NAME, Collections.singletonList("" + size));
+
+		return new HandlerRequest<>(
+			EmptyRequestBody.getInstance(),
+			new JobExceptionsMessageParameters(),
+			pathParameters,
+			queryParameters);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change
This pull request makes rest api can show more exceptions by query parameter.
User could define exception's size  to view by  /jobs/:jobid/exceptions?size=[size]


## Brief change log
- Add JobExceptionsMessageParameters and ExceptionShowSizeParameter for define size in url.
- Update JobExceptionsHandler


## Verifying this change


Add JobExceptionsHandlerTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
