### PR TITLE
[FLINK-14237][yarn] No need to rename shipped Flink jar

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -482,10 +482,12 @@ public final class Utils {
 		}
 
 		// register Flink Jar with remote HDFS
+		final String flinkJarPath;
 		final LocalResource flinkJar;
 		{
 			Path remoteJarPath = new Path(remoteFlinkJarPath);
 			FileSystem fs = remoteJarPath.getFileSystem(yarnConfig);
+			flinkJarPath = remoteJarPath.getName();
 			flinkJar = registerLocalResource(fs, remoteJarPath);
 		}
 
@@ -521,7 +523,8 @@ public final class Utils {
 		}
 
 		Map<String, LocalResource> taskManagerLocalResources = new HashMap<>();
-		taskManagerLocalResources.put("flink.jar", flinkJar);
+
+		taskManagerLocalResources.put(flinkJarPath, flinkJar);
 		taskManagerLocalResources.put("flink-conf.yaml", flinkConf);
 
 		//To support Yarn Secure Integration Test Scenario

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -813,7 +813,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
 		// Setup jar for ApplicationMaster
 		Path remotePathJar = setupSingleLocalResource(
-				"flink.jar",
+				flinkJarPath.getName(),
 				fs,
 				appId,
 				flinkJarPath,
@@ -846,7 +846,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 				"");
 
 		paths.add(remotePathJar);
-		classPathBuilder.append("flink.jar").append(File.pathSeparator);
+		classPathBuilder.append(flinkJarPath.getName()).append(File.pathSeparator);
 		paths.add(remotePathConf);
 		classPathBuilder.append("flink-conf.yaml").append(File.pathSeparator);
 


### PR DESCRIPTION
## What is the purpose of the change

Currently, when we ship Flink jar configured by `-yj`, we always rename it as `flink.jar`. It seems a redundant operation since we can always use the exact name of the real jar. It also causes some confusion to our users who should not be required to know about Flink internal implementation that they configure a specific Flink jar(said `flink-private-suffix`.jar) but cannot find it on YARN container, because it is now `flink.jar`.

## Brief change log

ship flink jar with its original name.

## Verifying this change

This change is already covered by existing YARN tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive):(no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes, on YARN we now always ship flink jar with its original name)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
