### PR TITLE
[FLINK-14335] [docs] Java version of ExampleIntegrationTest in testing docs …

### DIFF
--- a/docs/dev/stream/testing.md
+++ b/docs/dev/stream/testing.md
@@ -44,7 +44,7 @@ public class IncrementMapFunction implements MapFunction<Long, Long> {
 
     @Override
     public Long map(Long record) throws Exception {
-        return record +1 ;
+        return record + 1;
     }
 }
 {% endhighlight %}
@@ -112,7 +112,7 @@ public class IncrementFlatMapFunctionTest {
         Collector<Integer> collector = mock(Collector.class);
 
         // call the methods that you have implemented
-        incrementer.flatMap(2L, collector)
+        incrementer.flatMap(2L, collector);
 
         //verify collector was called with the right output
         Mockito.verify(collector, times(1)).collect(3L);
@@ -216,7 +216,7 @@ public class StatefulFlatMapTest {
         testHarness.setProcessingTime(100L);
 
         //retrieve list of emitted records for assertions
-        assertThat(testHarness.getOutput(), containsInExactlyThisOrder(3L))
+        assertThat(testHarness.getOutput(), containsInExactlyThisOrder(3L));
 
         //retrieve list of records emitted to a specific side output for assertions (ProcessFunction only)
         //assertThat(testHarness.getSideOutput(new OutputTag<>("invalidRecords")), hasSize(0))
@@ -358,7 +358,7 @@ public class IncrementMapFunction implements MapFunction<Long, Long> {
 
     @Override
     public Long map(Long record) throws Exception {
-        return record +1 ;
+        return record + 1;
     }
 }
 {% endhighlight %}
@@ -410,7 +410,7 @@ public class ExampleIntegrationTest {
         env.execute();
 
         // verify your results
-        assertTrue(CollectSink.values.containsAll(1L, 22L, 23L));
+        assertTrue(CollectSink.values.containsAll(2L, 22L, 23L));
     }
 
     // create a testing sink
@@ -465,7 +465,7 @@ class StreamingJobIntegrationTest extends FlatSpec with Matchers with BeforeAndA
     env.execute()
 
     // verify your results
-    CollectSink.values should contain allOf (1,22,23)
+    CollectSink.values should contain allOf (2, 22, 23)
     }
 }
 // create a testing sink

--- a/docs/dev/stream/testing.md
+++ b/docs/dev/stream/testing.md
@@ -410,7 +410,7 @@ public class ExampleIntegrationTest {
         env.execute();
 
         // verify your results
-        assertEquals(Lists.newArrayList(2L, 42L, 44L), CollectSink.values);
+        assertTrue(CollectSink.values.containsAll(1L, 22L, 23L));
     }
 
     // create a testing sink

--- a/docs/dev/stream/testing.zh.md
+++ b/docs/dev/stream/testing.zh.md
@@ -44,7 +44,7 @@ public class IncrementMapFunction implements MapFunction<Long, Long> {
 
     @Override
     public Long map(Long record) throws Exception {
-        return record +1 ;
+        return record + 1;
     }
 }
 {% endhighlight %}
@@ -112,7 +112,7 @@ public class IncrementFlatMapFunctionTest {
         Collector<Integer> collector = mock(Collector.class);
 
         // call the methods that you have implemented
-        incrementer.flatMap(2L, collector)
+        incrementer.flatMap(2L, collector);
 
         //verify collector was called with the right output
         Mockito.verify(collector, times(1)).collect(3L);
@@ -216,7 +216,7 @@ public class StatefulFlatMapTest {
         testHarness.setProcessingTime(100L);
 
         //retrieve list of emitted records for assertions
-        assertThat(testHarness.getOutput(), containsInExactlyThisOrder(3L))
+        assertThat(testHarness.getOutput(), containsInExactlyThisOrder(3L));
 
         //retrieve list of records emitted to a specific side output for assertions (ProcessFunction only)
         //assertThat(testHarness.getSideOutput(new OutputTag<>("invalidRecords")), hasSize(0))
@@ -358,7 +358,7 @@ public class IncrementMapFunction implements MapFunction<Long, Long> {
 
     @Override
     public Long map(Long record) throws Exception {
-        return record +1 ;
+        return record + 1;
     }
 }
 {% endhighlight %}
@@ -410,7 +410,7 @@ public class ExampleIntegrationTest {
         env.execute();
 
         // verify your results
-        assertTrue(CollectSink.values.containsAll(1L, 22L, 23L));
+        assertTrue(CollectSink.values.containsAll(2L, 22L, 23L));
     }
 
     // create a testing sink
@@ -465,7 +465,7 @@ class StreamingJobIntegrationTest extends FlatSpec with Matchers with BeforeAndA
     env.execute()
 
     // verify your results
-    CollectSink.values should contain allOf (1,22,23)
+    CollectSink.values should contain allOf (2, 22, 23)
     }
 }
 // create a testing sink

--- a/docs/dev/stream/testing.zh.md
+++ b/docs/dev/stream/testing.zh.md
@@ -410,7 +410,7 @@ public class ExampleIntegrationTest {
         env.execute();
 
         // verify your results
-        assertEquals(Lists.newArrayList(2L, 42L, 44L), CollectSink.values);
+        assertTrue(CollectSink.values.containsAll(1L, 22L, 23L));
     }
 
     // create a testing sink


### PR DESCRIPTION
…is incorrect

## What is the purpose of the change

Fix the Java version of ExampleIntegrationTest. 

## Brief change log

Change the Java version of ExampleIntegrationTest in both EN and ZH version.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

cc @zentol 
