### PR TITLE
[FLINK-14349][hbase] Create a Connector Descriptor for HBase so that user can connect HBase by TableEnvironment#connect

### DIFF
--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1098,16 +1098,20 @@ The connector can be defined as follows:
 {% highlight java %}
 .connect(
   new HBase()
-    .version("1.4.3")                      // required: valid connector versions are "1.4.3"
-    .tableName("hbase_table_name")         // required: HBase table to connect to
-    .zookeeperQuorum("localhost:2181")     // required: Zookeeper quorum address of HBase
-    .zookeeperNodeParent("/test")          // optional: zookeeper node parent path of HBase
-    .writeBufferFlushMaxSize("10mb")       // optional: threshold when to flush buffered request based on
-                                           // the memory byte size of rows currently added.
-    .writeBufferFlushMaxRows(1000)         // optional: threshold when to flush buffered request based on
-                                           // the number of rows currently added.
-    .writeBufferFlushInterval("2s")        // optional: an interval when to flushing buffered requesting
-                                           // if the interval passes, in milliseconds.
+    .version("1.4.3")                      // required: currently only support "1.4.3"
+    .tableName("hbase_table_name")         // required: HBase table name
+    .zookeeperQuorum("localhost:2181")     // required: HBase Zookeeper quorum configuration
+    .zookeeperNodeParent("/test")          // optional: the root dir in Zookeeper for HBase cluster.
+                                           // The default value is "/hbase".
+    .writeBufferFlushMaxSize("10mb")       // optional: writing option, determines how many size in memory of buffered
+                                           // rows to insert per round trip. This can help performance on writing to JDBC
+                                           // database. The default value is "2mb".
+    .writeBufferFlushMaxRows(1000)         // optional: writing option, determines how many rows to insert per round trip.
+                                           // This can help performance on writing to JDBC database. No default value,
+                                           // i.e. the default flushing is not depends on the number of buffered rows.
+    .writeBufferFlushInterval("2s")        // optional: writing option, sets a flush interval flushing buffered requesting
+                                           // if the interval passes, in milliseconds. Default value is "0s", which means
+                                           // no asynchronous flush thread will be scheduled.
 )
 {% endhighlight %}
 </div>
@@ -1115,7 +1119,7 @@ The connector can be defined as follows:
 {% highlight yaml %}
 connector:
   type: hbase
-  version: "1.4.3"                 # required: currently only support "1.4.3"
+  version: "1.4.3"               # required: currently only support "1.4.3"
   
   table-name: "hbase_table_name" # required: HBase table name
   

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1094,6 +1094,23 @@ For append-only queries, the connector can also operate in [append mode](#update
 The connector can be defined as follows:
 
 <div class="codetabs" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+.connect(
+  new HBase()
+    .version("1.4.3")                      // required: valid connector versions are "1.4.3"
+    .tableName("hbase_table_name")         // required: HBase table to connect to
+    .zookeeperQuorum("localhost:2181")     // required: Zookeeper quorum address of HBase
+    .zookeeperNodeParent("/test")          // optional: zookeeper node parent path of HBase
+    .writeBufferFlushMaxSize("10mb")       // optional: threshold when to flush buffered request based on
+                                           // the memory byte size of rows currently added.
+    .writeBufferFlushMaxRows(1000)         // optional: threshold when to flush buffered request based on
+                                           // the number of rows currently added.
+    .writeBufferFlushInterval("2s")        // optional: an interval when to flushing buffered requesting
+                                           // if the interval passes, in milliseconds.
+)
+{% endhighlight %}
+</div>
 <div data-lang="YAML" markdown="1">
 {% highlight yaml %}
 connector:
@@ -1156,8 +1173,6 @@ CREATE TABLE MyUserTable (
 **Columns:** All the column families in HBase table must be declared as `ROW` type, the field name maps to the column family name, and the nested field names map to the column qualifier names. There is no need to declare all the families and qualifiers in the schema, users can declare what's necessary. Except the `ROW` type fields, the only one field of atomic type (e.g. `STRING`, `BIGINT`) will be recognized as row key of the table. There's no constraints on the name of row key field. 
 
 **Temporary join:** Lookup join against HBase do not use any caching; data is always queired directly through the HBase client.
-
-**Java/Scala/Python API:** Java/Scala/Python APIs are not supported yet.
 
 {% top %}
 

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/table/descriptors/Elasticsearch.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/table/descriptors/Elasticsearch.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.descriptors;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.streaming.connectors.elasticsearch.ActionRequestFailureHandler;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchUpsertTableSinkBase.Host;
@@ -54,6 +55,7 @@ import static org.apache.flink.table.descriptors.ElasticsearchValidator.CONNECTO
 /**
  * Connector descriptor for the Elasticsearch search engine.
  */
+@PublicEvolving
 public class Elasticsearch extends ConnectorDescriptor {
 
 	private DescriptorProperties internalProperties = new DescriptorProperties(true);

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/Kafka.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/Kafka.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.descriptors;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumerBase;
 import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
@@ -50,6 +51,7 @@ import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_TYPE_V
 /**
  * Connector descriptor for the Apache Kafka message queue.
  */
+@PublicEvolving
 public class Kafka extends ConnectorDescriptor {
 
 	private String version;

--- a/flink-connectors/flink-hbase/pom.xml
+++ b/flink-connectors/flink-hbase/pom.xml
@@ -289,6 +289,13 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-common</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>

--- a/flink-connectors/flink-hbase/src/main/java/org/apache/flink/table/descriptors/HBase.java
+++ b/flink-connectors/flink-hbase/src/main/java/org/apache/flink/table/descriptors/HBase.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.descriptors;
 
+import org.apache.flink.configuration.MemorySize;
+
 import java.util.Map;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_VERSION;
@@ -40,7 +42,7 @@ public class HBase extends ConnectorDescriptor {
 	}
 
 	/**
-	 * Set the Apache HBase version to be used. Optional.
+	 * Set the Apache HBase version to be used. Required.
 	 *
 	 * @param version HBase version. E.g., "1.4.3".
 	 */
@@ -82,10 +84,10 @@ public class HBase extends ConnectorDescriptor {
 	/**
 	 * Set threshold when to flush buffered request based on the memory byte size of rows currently added . Default to <code>2mb</code>. Optional.
 	 *
-	 * @param writeBufferFlushMaxSize threshold (Byte size) to flush a buffered request. E.g, 2097152 (2MB).
+	 * @param maxSize threshold (Byte size) to flush a buffered request. E.g, "2097152", "2mb", "4kb".
 	 */
-	public HBase writeBufferFlushMaxSize(long writeBufferFlushMaxSize) {
-		properties.putLong(CONNECTOR_WRITE_BUFFER_FLUSH_MAX_SIZE, writeBufferFlushMaxSize);
+	public HBase writeBufferFlushMaxSize(String maxSize) {
+		properties.putMemorySize(CONNECTOR_WRITE_BUFFER_FLUSH_MAX_SIZE, MemorySize.parse(maxSize, MemorySize.MemoryUnit.BYTES));
 		return this;
 	}
 
@@ -95,14 +97,14 @@ public class HBase extends ConnectorDescriptor {
 	 *
 	 * @param writeBufferFlushMaxRows number of added rows when begin the request flushing.
 	 */
-	public HBase writeBufferFlushMaxRows(long writeBufferFlushMaxRows) {
-		properties.putLong(CONNECTOR_WRITE_BUFFER_FLUSH_MAX_ROWS, writeBufferFlushMaxRows);
+	public HBase writeBufferFlushMaxRows(int writeBufferFlushMaxRows) {
+		properties.putInt(CONNECTOR_WRITE_BUFFER_FLUSH_MAX_ROWS, writeBufferFlushMaxRows);
 		return this;
 	}
 
 	/**
 	 * Set a flush interval flushing buffered requesting if the interval passes, in milliseconds.
-	 * Defaults to not set, i.e. won't flush based on flush interval. Optionla.
+	 * Defaults to not set, i.e. won't flush based on flush interval. Optional.
 	 *
 	 * @param writeBufferFlushInterval flush interval in milliseconds.
 	 */

--- a/flink-connectors/flink-hbase/src/main/java/org/apache/flink/table/descriptors/HBase.java
+++ b/flink-connectors/flink-hbase/src/main/java/org/apache/flink/table/descriptors/HBase.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.util.TimeUtils;
 
-import java.time.Duration;
 import java.util.Map;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_VERSION;

--- a/flink-connectors/flink-hbase/src/main/java/org/apache/flink/table/descriptors/HBase.java
+++ b/flink-connectors/flink-hbase/src/main/java/org/apache/flink/table/descriptors/HBase.java
@@ -118,8 +118,7 @@ public class HBase extends ConnectorDescriptor {
 	 *                 {@link TimeUtils#parseDuration(String)}}.
 	 */
 	public HBase writeBufferFlushInterval(String interval) {
-		Duration duration = TimeUtils.parseDuration(interval);
-		properties.putLong(CONNECTOR_WRITE_BUFFER_FLUSH_INTERVAL, duration.toMillis());
+		properties.putString(CONNECTOR_WRITE_BUFFER_FLUSH_INTERVAL, interval);
 		return this;
 	}
 

--- a/flink-connectors/flink-hbase/src/main/java/org/apache/flink/table/descriptors/HBase.java
+++ b/flink-connectors/flink-hbase/src/main/java/org/apache/flink/table/descriptors/HBase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.descriptors;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.util.TimeUtils;
 
@@ -36,6 +37,7 @@ import static org.apache.flink.table.descriptors.HBaseValidator.CONNECTOR_ZK_QUO
 /**
  * Connector descriptor for Apache HBase.
  */
+@PublicEvolving
 public class HBase extends ConnectorDescriptor {
 	private DescriptorProperties properties = new DescriptorProperties();
 

--- a/flink-connectors/flink-hbase/src/main/java/org/apache/flink/table/descriptors/HBase.java
+++ b/flink-connectors/flink-hbase/src/main/java/org/apache/flink/table/descriptors/HBase.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.descriptors;
+
+import java.util.Map;
+
+import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_VERSION;
+import static org.apache.flink.table.descriptors.HBaseValidator.CONNECTOR_TABLE_NAME;
+import static org.apache.flink.table.descriptors.HBaseValidator.CONNECTOR_TYPE_VALUE_HBASE;
+import static org.apache.flink.table.descriptors.HBaseValidator.CONNECTOR_WRITE_BUFFER_FLUSH_INTERVAL;
+import static org.apache.flink.table.descriptors.HBaseValidator.CONNECTOR_WRITE_BUFFER_FLUSH_MAX_ROWS;
+import static org.apache.flink.table.descriptors.HBaseValidator.CONNECTOR_WRITE_BUFFER_FLUSH_MAX_SIZE;
+import static org.apache.flink.table.descriptors.HBaseValidator.CONNECTOR_ZK_NODE_PARENT;
+import static org.apache.flink.table.descriptors.HBaseValidator.CONNECTOR_ZK_QUORUM;
+
+/**
+ * Connector descriptor for Apache HBase.
+ */
+public class HBase extends ConnectorDescriptor {
+	private DescriptorProperties properties = new DescriptorProperties();
+
+	public HBase() {
+		super(CONNECTOR_TYPE_VALUE_HBASE, 1, true);
+	}
+
+	/**
+	 * Set the Apache HBase version to be used. Optional.
+	 *
+	 * @param version HBase version. E.g., "1.4.3".
+	 */
+	public HBase version(String version) {
+		properties.putString(CONNECTOR_VERSION, version);
+		return this;
+	}
+
+	/**
+	 * Set the HBase table name, Required.
+	 *
+	 * @param tableName Name of HBase table.  E.g., "testNamespace:testTable", "testDefaultTable"
+	 */
+	public HBase tableName(String tableName) {
+		properties.putString(CONNECTOR_TABLE_NAME, tableName);
+		return this;
+	}
+
+	/**
+	 * Set the zookeeper quorum address to connect the HBase cluster. Required.
+	 *
+	 * @param zookeeperQuorum zookeeper quorum address to connect the HBase cluster. E.g., "localhost:2181,localhost:2182,localhost:2183".
+	 */
+	public HBase zookeeperQuorum(String zookeeperQuorum) {
+		properties.putString(CONNECTOR_ZK_QUORUM, zookeeperQuorum);
+		return this;
+	}
+
+	/**
+	 * Set the zookeeper node parent path of HBase cluster. Optional.
+	 *
+	 * @param zookeeperNodeParent zookeeper node path of hbase cluster. E.g, "/hbase/example-root-znode".
+	 */
+	public HBase zookeeperNodeParent(String zookeeperNodeParent) {
+		properties.putString(CONNECTOR_ZK_NODE_PARENT, zookeeperNodeParent);
+		return this;
+	}
+
+	/**
+	 * Set threshold when to flush buffered request based on the memory byte size of rows currently added . Default to <code>2mb</code>. Optional.
+	 *
+	 * @param writeBufferFlushMaxSize threshold (Byte size) to flush a buffered request. E.g, 2097152 (2MB).
+	 */
+	public HBase writeBufferFlushMaxSize(long writeBufferFlushMaxSize) {
+		properties.putLong(CONNECTOR_WRITE_BUFFER_FLUSH_MAX_SIZE, writeBufferFlushMaxSize);
+		return this;
+	}
+
+	/**
+	 * Set threshold when to flush buffered request based on the number of rows currently added.
+	 * Defaults to not set, i.e. won't flush based on the number of buffered rows. Optional.
+	 *
+	 * @param writeBufferFlushMaxRows number of added rows when begin the request flushing.
+	 */
+	public HBase writeBufferFlushMaxRows(long writeBufferFlushMaxRows) {
+		properties.putLong(CONNECTOR_WRITE_BUFFER_FLUSH_MAX_ROWS, writeBufferFlushMaxRows);
+		return this;
+	}
+
+	/**
+	 * Set a flush interval flushing buffered requesting if the interval passes, in milliseconds.
+	 * Defaults to not set, i.e. won't flush based on flush interval. Optionla.
+	 *
+	 * @param writeBufferFlushInterval flush interval in milliseconds.
+	 */
+	public HBase writeBufferFlushInterval(long writeBufferFlushInterval) {
+		properties.putLong(CONNECTOR_WRITE_BUFFER_FLUSH_INTERVAL, writeBufferFlushInterval);
+		return this;
+	}
+
+	@Override
+	protected Map<String, String> toConnectorProperties() {
+		return properties.asMap();
+	}
+}

--- a/flink-connectors/flink-hbase/src/main/java/org/apache/flink/table/descriptors/HBase.java
+++ b/flink-connectors/flink-hbase/src/main/java/org/apache/flink/table/descriptors/HBase.java
@@ -19,7 +19,9 @@
 package org.apache.flink.table.descriptors;
 
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.util.TimeUtils;
 
+import java.time.Duration;
 import java.util.Map;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_VERSION;
@@ -64,7 +66,8 @@ public class HBase extends ConnectorDescriptor {
 	/**
 	 * Set the zookeeper quorum address to connect the HBase cluster. Required.
 	 *
-	 * @param zookeeperQuorum zookeeper quorum address to connect the HBase cluster. E.g., "localhost:2181,localhost:2182,localhost:2183".
+	 * @param zookeeperQuorum zookeeper quorum address to connect the HBase cluster.
+	 *                        E.g., "localhost:2181,localhost:2182,localhost:2183".
 	 */
 	public HBase zookeeperQuorum(String zookeeperQuorum) {
 		properties.putString(CONNECTOR_ZK_QUORUM, zookeeperQuorum);
@@ -72,7 +75,7 @@ public class HBase extends ConnectorDescriptor {
 	}
 
 	/**
-	 * Set the zookeeper node parent path of HBase cluster. Optional.
+	 * Set the zookeeper node parent path of HBase cluster. Default to use "/hbase", Optional.
 	 *
 	 * @param zookeeperNodeParent zookeeper node path of hbase cluster. E.g, "/hbase/example-root-znode".
 	 */
@@ -82,9 +85,10 @@ public class HBase extends ConnectorDescriptor {
 	}
 
 	/**
-	 * Set threshold when to flush buffered request based on the memory byte size of rows currently added . Default to <code>2mb</code>. Optional.
+	 * Set threshold when to flush buffered request based on the memory byte size of rows currently added.
+	 * Default to <code>2mb</code>. Optional.
 	 *
-	 * @param maxSize threshold (Byte size) to flush a buffered request. E.g, "2097152", "2mb", "4kb".
+	 * @param maxSize the maximum size (using the syntax of {@link MemorySize}).
 	 */
 	public HBase writeBufferFlushMaxSize(String maxSize) {
 		properties.putMemorySize(CONNECTOR_WRITE_BUFFER_FLUSH_MAX_SIZE, MemorySize.parse(maxSize, MemorySize.MemoryUnit.BYTES));
@@ -106,10 +110,14 @@ public class HBase extends ConnectorDescriptor {
 	 * Set a flush interval flushing buffered requesting if the interval passes, in milliseconds.
 	 * Defaults to not set, i.e. won't flush based on flush interval. Optional.
 	 *
-	 * @param writeBufferFlushInterval flush interval in milliseconds.
+	 * @param interval flush interval. The string should be in format "{length value}{time unit label}"
+	 *                 E.g, "123ms", "1 s", If no time unit label is specified, it will be considered as
+	 *                 milliseconds. For more details about the format, please see
+	 *                 {@link TimeUtils#parseDuration(String)}}.
 	 */
-	public HBase writeBufferFlushInterval(long writeBufferFlushInterval) {
-		properties.putLong(CONNECTOR_WRITE_BUFFER_FLUSH_INTERVAL, writeBufferFlushInterval);
+	public HBase writeBufferFlushInterval(String interval) {
+		Duration duration = TimeUtils.parseDuration(interval);
+		properties.putLong(CONNECTOR_WRITE_BUFFER_FLUSH_INTERVAL, duration.toMillis());
 		return this;
 	}
 

--- a/flink-connectors/flink-hbase/src/main/java/org/apache/flink/table/descriptors/HBase.java
+++ b/flink-connectors/flink-hbase/src/main/java/org/apache/flink/table/descriptors/HBase.java
@@ -109,7 +109,7 @@ public class HBase extends ConnectorDescriptor {
 	}
 
 	/**
-	 * Set a flush interval flushing buffered requesting if the interval passes, in milliseconds.
+	 * Set an interval when to flushing buffered requesting if the interval passes, in milliseconds.
 	 * Defaults to not set, i.e. won't flush based on flush interval. Optional.
 	 *
 	 * @param interval flush interval. The string should be in format "{length value}{time unit label}"

--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseDescriptorTest.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseDescriptorTest.java
@@ -49,7 +49,7 @@ public class HBaseDescriptorTest extends DescriptorTestBase {
 			.tableName("testNs:table1")
 			.zookeeperQuorum("localhost:2181")
 			.zookeeperNodeParent("/hbase/root")
-			.writeBufferFlushInterval(2 * 1000L)
+			.writeBufferFlushInterval("2s")
 			.writeBufferFlushMaxRows(100)
 			.writeBufferFlushMaxSize("1mb");
 

--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseDescriptorTest.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseDescriptorTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.descriptors.DescriptorTestBase;
 import org.apache.flink.table.descriptors.DescriptorValidator;
 import org.apache.flink.table.descriptors.HBase;
 import org.apache.flink.table.descriptors.HBaseValidator;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -50,7 +51,7 @@ public class HBaseDescriptorTest extends DescriptorTestBase {
 			.zookeeperNodeParent("/hbase/root")
 			.writeBufferFlushInterval(2 * 1000L)
 			.writeBufferFlushMaxRows(100)
-			.writeBufferFlushMaxSize(1024 * 1024L);
+			.writeBufferFlushMaxSize("1mb");
 
 		return Arrays.asList(hbaseDesc0, hbaseDesc1);
 	}
@@ -74,7 +75,7 @@ public class HBaseDescriptorTest extends DescriptorTestBase {
 		prop1.put("connector.property-version", "1");
 		prop1.put("connector.write.buffer-flush.interval", "2000");
 		prop1.put("connector.write.buffer-flush.max-rows", "100");
-		prop1.put("connector.write.buffer-flush.max-size", "1048576");
+		prop1.put("connector.write.buffer-flush.max-size", "1048576 bytes");
 
 		return Arrays.asList(prop0, prop1);
 	}

--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseDescriptorTest.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseDescriptorTest.java
@@ -76,7 +76,7 @@ public class HBaseDescriptorTest extends DescriptorTestBase {
 		prop1.put("connector.zookeeper.quorum", "localhost:2181");
 		prop1.put("connector.zookeeper.znode.parent", "/hbase/root");
 		prop1.put("connector.property-version", "1");
-		prop1.put("connector.write.buffer-flush.interval", "2000");
+		prop1.put("connector.write.buffer-flush.interval", "2s");
 		prop1.put("connector.write.buffer-flush.max-rows", "100");
 		prop1.put("connector.write.buffer-flush.max-size", "1048576 bytes");
 

--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseDescriptorTest.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseDescriptorTest.java
@@ -34,6 +34,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Test case for {@link HBase} descriptor.
+ */
 public class HBaseDescriptorTest extends DescriptorTestBase {
 
 	@Override

--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseDescriptorTest.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseDescriptorTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.addons.hbase;
+
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.descriptors.Descriptor;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.descriptors.DescriptorTestBase;
+import org.apache.flink.table.descriptors.DescriptorValidator;
+import org.apache.flink.table.descriptors.HBase;
+import org.apache.flink.table.descriptors.HBaseValidator;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class HBaseDescriptorTest extends DescriptorTestBase {
+
+	@Override
+	protected List<Descriptor> descriptors() {
+		HBase hbaseDesc0 = new HBase()
+			.version("1.4.3")
+			.tableName("testNs:table0")
+			.zookeeperQuorum("localhost:2181,localhost:2182,localhost:2183")
+			.zookeeperNodeParent("/hbase/root-dir");
+
+		HBase hbaseDesc1 = new HBase()
+			.version("1.4.3")
+			.tableName("testNs:table1")
+			.zookeeperQuorum("localhost:2181")
+			.zookeeperNodeParent("/hbase/root")
+			.writeBufferFlushInterval(2 * 1000L)
+			.writeBufferFlushMaxRows(100)
+			.writeBufferFlushMaxSize(1024 * 1024L);
+
+		return Arrays.asList(hbaseDesc0, hbaseDesc1);
+	}
+
+	@Override
+	protected List<Map<String, String>> properties() {
+		Map<String, String> prop0 = new HashMap<>();
+		prop0.put("connector.version", "1.4.3");
+		prop0.put("connector.type", "hbase");
+		prop0.put("connector.table-name", "testNs:table0");
+		prop0.put("connector.zookeeper.quorum", "localhost:2181,localhost:2182,localhost:2183");
+		prop0.put("connector.zookeeper.znode.parent", "/hbase/root-dir");
+		prop0.put("connector.property-version", "1");
+
+		Map<String, String> prop1 = new HashMap<>();
+		prop1.put("connector.version", "1.4.3");
+		prop1.put("connector.type", "hbase");
+		prop1.put("connector.table-name", "testNs:table1");
+		prop1.put("connector.zookeeper.quorum", "localhost:2181");
+		prop1.put("connector.zookeeper.znode.parent", "/hbase/root");
+		prop1.put("connector.property-version", "1");
+		prop1.put("connector.write.buffer-flush.interval", "2000");
+		prop1.put("connector.write.buffer-flush.max-rows", "100");
+		prop1.put("connector.write.buffer-flush.max-size", "1048576");
+
+		return Arrays.asList(prop0, prop1);
+	}
+
+	@Override
+	protected DescriptorValidator validator() {
+		return new HBaseValidator();
+	}
+
+	@Test
+	public void testRequiredFields() {
+		HBase hbaseDesc0 = new HBase();
+		HBase hbaseDesc1 = new HBase()
+			.version("1.4.3")
+			.zookeeperQuorum("localhost:2181")
+			.zookeeperNodeParent("/hbase/root"); // no table name
+		HBase hbaseDesc2 = new HBase()
+			.version("1.4.3")
+			.tableName("ns:table")
+			.zookeeperNodeParent("/hbase/root"); // no zookeeper quorum
+		HBase hbaseDesc3 = new HBase()
+			.tableName("ns:table")
+			.zookeeperQuorum("localhost:2181"); // no version
+
+		HBase[] testCases = new HBase[]{hbaseDesc0, hbaseDesc1, hbaseDesc2, hbaseDesc3};
+		for (int i = 0; i < testCases.length; i++) {
+			HBase hbaseDesc = testCases[i];
+			DescriptorProperties properties = new DescriptorProperties();
+			properties.putProperties(hbaseDesc.toProperties());
+			boolean caughtExpectedException = false;
+			try {
+				validator().validate(properties);
+			} catch (ValidationException e) {
+				caughtExpectedException = true;
+			}
+			Assert.assertTrue("The case#" + i + " didn't get the expected error", caughtExpectedException);
+		}
+	}
+}

--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/example/HBaseFlinkTestConstants.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/example/HBaseFlinkTestConstants.java
@@ -18,12 +18,12 @@
 
 package org.apache.flink.addons.hbase.example;
 
-import org.apache.flink.configuration.ConfigConstants;
+import org.apache.hadoop.hbase.util.Bytes;
 
 class HBaseFlinkTestConstants {
 
-	static final byte[] CF_SOME = "someCf".getBytes(ConfigConstants.DEFAULT_CHARSET);
-	static final byte[] Q_SOME = "someQual".getBytes(ConfigConstants.DEFAULT_CHARSET);
+	static final byte[] CF_SOME = Bytes.toBytes("someCf");
+	static final byte[] Q_SOME = Bytes.toBytes("someQual");
 	static final String TEST_TABLE_NAME = "test-table";
 	static final String TMP_DIR = "/tmp/test";
 


### PR DESCRIPTION
## What is the purpose of the change

Let Java/Scala users can do a TableEnvironment#connect to hbase by the newly introduced HBase connector descriptor.


## Brief change log

Introduced a new connector descriptor named HBase, also provided some UT to address the change.


## Verifying this change

See HBaseDescriptorTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
