### PR TITLE
[FLINK-7958][metrics] Reporters provide default delimiter

### DIFF
--- a/docs/_includes/generated/metric_configuration.html
+++ b/docs/_includes/generated/metric_configuration.html
@@ -53,6 +53,11 @@
             <td>The reporter interval to use for the reporter named &lt;name&gt;.</td>
         </tr>
         <tr>
+            <td><h5>metrics.reporter.&lt;name&gt;.scope.delimiter</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>The delimiter used to assemble the metric identifier the reporter named &lt;name&gt;.</td>
+        </tr>
+        <tr>
             <td><h5>metrics.reporters</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>An optional list of reporter names. If configured, only reporters whose name matches any of the names in the list will be started. Otherwise, all reporters that could be found in the configuration will be started.</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
@@ -70,7 +70,7 @@ public class MetricOptions {
 
 	/** The delimiter used to assemble the metric identifier. */
 	public static final ConfigOption<String> SCOPE_DELIMITER =
-		key("metrics.scope.delimiter")
+		key("metrics." + ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER)
 			.defaultValue(".")
 			.withDescription("Delimiter used to assemble the metric identifier.");
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
@@ -52,16 +52,19 @@ public class MetricOptions {
 				" any of the names in the list will be started. Otherwise, all reporters that could be found in" +
 				" the configuration will be started.");
 
+	// this option only exists for documentation purposes
 	public static final ConfigOption<String> REPORTER_CLASS =
 		key("metrics.reporter.<name>.class")
 			.noDefaultValue()
 			.withDescription("The reporter class to use for the reporter named <name>.");
 
+	// this option only exists for documentation purposes
 	public static final ConfigOption<String> REPORTER_INTERVAL =
 		key("metrics.reporter.<name>.interval")
 			.noDefaultValue()
 			.withDescription("The reporter interval to use for the reporter named <name>.");
 
+	// this option only exists for documentation purposes
 	public static final ConfigOption<String> REPORTER_SCOPE_DELIMITER =
 		key("metrics.reporter.<name>." + ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER)
 			.noDefaultValue()

--- a/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
@@ -62,6 +62,11 @@ public class MetricOptions {
 			.noDefaultValue()
 			.withDescription("The reporter interval to use for the reporter named <name>.");
 
+	public static final ConfigOption<String> REPORTER_SCOPE_DELIMITER =
+		key("metrics.reporter.<name>." + ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER)
+			.noDefaultValue()
+			.withDescription("The delimiter used to assemble the metric identifier the reporter named <name>.");
+
 	public static final ConfigOption<String> REPORTER_CONFIG_PARAMETER =
 		key("metrics.reporter.<name>.<parameter>")
 			.noDefaultValue()

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/MetricReporter.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/MetricReporter.java
@@ -76,4 +76,15 @@ public interface MetricReporter {
 	 * @param group       the group that contains the metric
 	 */
 	void notifyOfRemovedMetric(Metric metric, String metricName, MetricGroup group);
+
+	/**
+	 * Returns the delimiter used for assembly of the metric scope.
+	 *
+	 * <p>Note: This method is only called once.
+	 *
+	 * @return delimiter used for the metric scope
+	 */
+	default char getDefaultScopeDelimiter() {
+		return '.';
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
@@ -147,7 +147,7 @@ public class MetricRegistryImpl implements MetricRegistry {
 					}
 					reporters.add(reporterInstance);
 
-					String delimiterForReporter = reporterSetup.getDelimiter().orElse(String.valueOf(globalDelimiter));
+					String delimiterForReporter = reporterSetup.getDelimiter().orElse(String.valueOf(reporterInstance.getDefaultScopeDelimiter()));
 					if (delimiterForReporter.length() != 1) {
 						LOG.warn("Failed to parse delimiter '{}' for reporter '{}', using global delimiter '{}'.", delimiterForReporter, namedReporter, globalDelimiter);
 						delimiterForReporter = String.valueOf(globalDelimiter);


### PR DESCRIPTION
Currently, the delimiter used for assembling the metric identifier is either based on a delimiter configured for the reporter, or the globally configured delimiter (default: '.').
Additionally (just for context), there are some instances around logicalScopes where reporters themselves can decide on the delimiter.

External systems usually have well-defined requirements on what the delimiter should be, and it thus seems reasonable to allow reporters to provide a default delimiter, instead of using a global default across all reporters.

This PR adds a method for retrieving this delimiter from the reporter. This delimiter is used as the default, and can be overwritten by explicitly configuring a delimiter for this reporter.

This means that the global delimiter is no longer used in the context of a reporter, which is a slight change in behavior that must be documented in the release notes.

While useful on it's own this PR is primarily a preparatory step for properly exposing the logical scope; which currently is tricky to do since reporters using this currently inject a non-default delimiter that isn't controllable. Due to not being controllable the used methods should not be exposed publicly, but this in turn requires a different mechanism for reporters to define a delimiter.