### PR TITLE
[FLINK-14351][metrics] Introduce DelimiterProvider

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DelimiterProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DelimiterProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics;
+
+/**
+ * Interface for retrieving the configured global and reporter-specific delimiters.
+ */
+public interface DelimiterProvider {
+
+	/**
+	 * Returns the global delimiter.
+	 *
+	 * @return global delimiter
+	 */
+	char getDelimiter();
+
+	/**
+	 * Returns the configured delimiter for the reporter with the given index.
+	 *
+	 * @param index index of the reporter whose delimiter should be used
+	 * @return configured reporter delimiter, or global delimiter if index is invalid
+	 */
+	char getDelimiter(int index);
+
+	/**
+	 * Returns the number of reporters whose delimiter can be retrieved.
+	 */
+	int getNumberReporters();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistry.java
@@ -28,27 +28,7 @@ import javax.annotation.Nullable;
 /**
  * Interface for a metric registry.
  */
-public interface MetricRegistry {
-
-	/**
-	 * Returns the global delimiter.
-	 *
-	 * @return global delimiter
-	 */
-	char getDelimiter();
-
-	/**
-	 * Returns the configured delimiter for the reporter with the given index.
-	 *
-	 * @param index index of the reporter whose delimiter should be used
-	 * @return configured reporter delimiter, or global delimiter if index is invalid
-	 */
-	char getDelimiter(int index);
-
-	/**
-	 * Returns the number of registered reporters.
-	 */
-	int getNumberReporters();
+public interface MetricRegistry extends DelimiterProvider {
 
 	/**
 	 * Registers a new {@link Metric} with this registry.


### PR DESCRIPTION
Introduce a dedicated interface for retrieving delimiters from the MetricRegistry.

Preparatory step for introducing the dedicated MetricScope in FLINK-14350, which requires these methods and will be the sole user.