### PR TITLE
[FLINK-14134][table] Introduce LimitableTableSource for optimizing limit

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/LimitableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/LimitableTableSource.java
@@ -24,8 +24,8 @@ import org.apache.flink.annotation.Experimental;
  * Adds support for limiting push-down to a {@link TableSource}.
  * A {@link TableSource} extending this interface is able to limit the number of records.
  *
- * <p>After pushing down, source only needs to try its best to limit, and does not need to
- * guarantee that the number of output lines must be less than or equal to the limit number.
+ * <p>After pushing down, source only needs to try its best to limit the number of output records,
+ * but does not need to guarantee that the number must be less than or equal to the limit.
  */
 @Experimental
 public interface LimitableTableSource<T> {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/LimitableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/LimitableTableSource.java
@@ -24,8 +24,8 @@ import org.apache.flink.annotation.Experimental;
  * Adds support for limiting push-down to a {@link TableSource}.
  * A {@link TableSource} extending this interface is able to limit the number of records.
  *
- * <p>After pushing down, if the total record number of source is greater than the limit number,
- * source should emit record number greater than or equal to the limit number.
+ * <p>After pushing down, source only needs to try its best to limit, and does not need to
+ * guarantee that the number of output lines must be less than or equal to the limit number.
  */
 @Experimental
 public interface LimitableTableSource<T> {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/LimitableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/LimitableTableSource.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sources;
+
+import org.apache.flink.annotation.Experimental;
+
+/**
+ * Adds support for limiting push-down to a {@link TableSource}.
+ * A {@link TableSource} extending this interface is able to limit the number of records.
+ */
+@Experimental
+public interface LimitableTableSource<T> {
+
+	/**
+	 * Return the flag to indicate whether limit push down has been tried. Must return true on
+	 * the returned instance of {@link #applyLimit(long)}.
+	 */
+	boolean isLimitPushedDown();
+
+	/**
+	 * Check and push down the limit to the table source.
+	 *
+	 * @param limit the value which limit the number of records.
+	 * @return A new cloned instance of {@link TableSource}.
+	 */
+	TableSource<T> applyLimit(long limit);
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/LimitableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/LimitableTableSource.java
@@ -23,6 +23,9 @@ import org.apache.flink.annotation.Experimental;
 /**
  * Adds support for limiting push-down to a {@link TableSource}.
  * A {@link TableSource} extending this interface is able to limit the number of records.
+ *
+ * <p>After pushing down, if the total record number of source is greater than the limit number,
+ * source should emit record number greater than or equal to the limit number.
  */
 @Experimental
 public interface LimitableTableSource<T> {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -90,6 +90,10 @@ object FlinkBatchRuleSets {
     RewriteCoalesceRule.CALC_INSTANCE
   )
 
+  private val LIMIT_RULES: RuleSet = RuleSets.ofList(
+    //push down localLimit
+    PushLimitIntoTableSourceScanRule.INSTANCE)
+
   /**
     * RuleSet to simplify predicate expressions in filters and joins
     */
@@ -338,7 +342,8 @@ object FlinkBatchRuleSets {
     * RuleSet to do logical optimize for batch
     */
   val LOGICAL_OPT_RULES: RuleSet = RuleSets.ofList((
-    FILTER_RULES.asScala ++
+    LIMIT_RULES.asScala ++
+      FILTER_RULES.asScala ++
       PROJECT_RULES.asScala ++
       PRUNE_EMPTY_RULES.asScala ++
       LOGICAL_RULES.asScala ++

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoTableSourceScanRule.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical
+
+import org.apache.flink.table.plan.stats.TableStats
+import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalSort, FlinkLogicalTableSourceScan}
+import org.apache.flink.table.planner.plan.schema.{FlinkRelOptTable, TableSourceTable}
+import org.apache.flink.table.planner.plan.stats.FlinkStatistic
+import org.apache.flink.table.sources.LimitableTableSource
+
+import org.apache.calcite.plan.RelOptRule.{none, operand}
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
+import org.apache.calcite.rel.core.{Sort, TableScan}
+import org.apache.calcite.rex.RexLiteral
+import org.apache.calcite.tools.RelBuilder
+
+/**
+  * Planner rule that tries to push limit into a [[LimitableTableSource]].
+  * The original limit will still be retained.
+  */
+class PushLimitIntoTableSourceScanRule extends RelOptRule(
+  operand(classOf[FlinkLogicalSort],
+    operand(classOf[FlinkLogicalTableSourceScan], none)), "PushLimitIntoTableSourceScanRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val sort = call.rel(0).asInstanceOf[Sort]
+    val fetch = sort.fetch
+    val offset = sort.offset
+    // Only push-down the limit whose offset equal zero. Because it is difficult to source based
+    // push to handle the non-zero offset. And the non-zero offset usually appear together with
+    // sort.
+    val onlyLimit = sort.getCollation.getFieldCollations.isEmpty &&
+        (offset == null || RexLiteral.intValue(offset) == 0) &&
+        fetch != null
+
+    var supportPushDown = false
+    if (onlyLimit) {
+      supportPushDown = call.rel(1).asInstanceOf[TableScan]
+          .getTable.unwrap(classOf[TableSourceTable[_]]) match {
+        case table: TableSourceTable[_] =>
+          table.tableSource match {
+            case source: LimitableTableSource[_] => !source.isLimitPushedDown
+            case _ => false
+          }
+        case _ => false
+      }
+    }
+    supportPushDown
+  }
+
+  override def onMatch(call: RelOptRuleCall): Unit = {
+    val sort = call.rel(0).asInstanceOf[Sort]
+    val scan = call.rel(1).asInstanceOf[FlinkLogicalTableSourceScan]
+    val relOptTable = scan.getTable.asInstanceOf[FlinkRelOptTable]
+    val limit = RexLiteral.intValue(sort.fetch)
+    val relBuilder = call.builder()
+    val newRelOptTable = applyLimit(limit, relOptTable, relBuilder)
+    val newScan = scan.copy(scan.getTraitSet, newRelOptTable)
+    call.transformTo(newScan)
+  }
+
+  private def applyLimit(
+      limit: Long,
+      relOptTable: FlinkRelOptTable,
+      relBuilder: RelBuilder): FlinkRelOptTable = {
+    val tableSourceTable = relOptTable.unwrap(classOf[TableSourceTable[Any]])
+    val limitedSource = tableSourceTable.tableSource.asInstanceOf[LimitableTableSource[Any]]
+    val newTableSource = limitedSource.applyLimit(limit)
+
+    val statistic = relOptTable.getFlinkStatistic
+    val newRowCount = if (statistic.getRowCount != null) {
+      Math.min(limit, statistic.getRowCount.toLong)
+    } else {
+      limit
+    }
+    // Update TableStats after limit push down
+    val newTableStats = new TableStats(newRowCount)
+    val newStatistic = FlinkStatistic.builder()
+        .statistic(statistic)
+        .tableStats(newTableStats)
+        .build()
+    val newTableSourceTable = tableSourceTable.replaceTableSource(newTableSource).copy(newStatistic)
+    relOptTable.copy(newTableSourceTable, relOptTable.getRowType)
+  }
+}
+
+object PushLimitIntoTableSourceScanRule {
+  val INSTANCE: RelOptRule = new PushLimitIntoTableSourceScanRule
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoTableSourceScanRule.scala
@@ -36,6 +36,14 @@ import java.util.Collections
 /**
   * Planner rule that tries to push limit into a [[LimitableTableSource]].
   * The original limit will still be retained.
+  *
+  * The reasons why the limit still be retained:
+  * 1.If the source is required to return the exact number of limit number, the implementation
+  * of the source is highly required. The source is required to accurately control the record
+  * number of split, and the parallelism setting also need to be adjusted accordingly.
+  * 2.When remove the limit, maybe filter will be pushed down to the source after limit pushed
+  * down. The source need know it should do limit first and do the filter later, it is hard to
+  * implement.
   */
 class PushLimitIntoTableSourceScanRule extends RelOptRule(
   operand(classOf[FlinkLogicalSort],

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoTableSourceScanRule.scala
@@ -31,6 +31,8 @@ import org.apache.calcite.rel.core.{Sort, TableScan}
 import org.apache.calcite.rex.RexLiteral
 import org.apache.calcite.tools.RelBuilder
 
+import java.util.Collections
+
 /**
   * Planner rule that tries to push limit into a [[LimitableTableSource]].
   * The original limit will still be retained.
@@ -83,7 +85,8 @@ class PushLimitIntoTableSourceScanRule extends RelOptRule(
           + "table source with pushdown capability must override and change "
           + "explainSource() API to explain the pushdown applied!")
     }
-    call.transformTo(newScan)
+
+    call.transformTo(sort.copy(sort.getTraitSet, Collections.singletonList(newScan)))
   }
 
   private def applyLimit(

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/LimitTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/LimitTest.xml
@@ -19,7 +19,6 @@ limitations under the License.
   <TestCase name="testFetch0WithoutOffset">
     <Resource name="sql">
       <![CDATA[SELECT a, c FROM MyTable FETCH FIRST 0 ROWS ONLY]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -27,40 +26,34 @@ LogicalSort(fetch=[0])
 +- LogicalProject(a=[$0], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Values(type=[RecordType(INTEGER a, VARCHAR(2147483647) c)], tuples=[[]], values=[a, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testFetchWithLimitSource">
     <Resource name="sql">
       <![CDATA[SELECT a, c FROM LimitTable FETCH FIRST 10 ROWS ONLY]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalSort(fetch=[10])
 +- LogicalProject(a=[$0], c=[$2])
-   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 10]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a, c])
 +- TableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 10]]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testFetchWithOffset">
     <Resource name="sql">
       <![CDATA[SELECT a, c FROM MyTable OFFSET 10 ROWS FETCH NEXT 10 ROWS ONLY]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -68,7 +61,6 @@ LogicalSort(offset=[10], fetch=[10])
 +- LogicalProject(a=[$0], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -78,13 +70,11 @@ Calc(select=[a, c])
       +- Limit(offset=[0], fetch=[20], global=[false])
          +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testFetchWithOffsetAndLimitSource">
     <Resource name="sql">
       <![CDATA[SELECT a, c FROM LimitTable OFFSET 10 ROWS FETCH NEXT 10 ROWS ONLY]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -92,7 +82,6 @@ LogicalSort(offset=[10], fetch=[10])
 +- LogicalProject(a=[$0], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -102,13 +91,11 @@ Calc(select=[a, c])
       +- Limit(offset=[0], fetch=[20], global=[false])
          +- TableSourceScan(table=[[default_catalog, default_database, LimitTable]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testFetchWithoutOffset">
     <Resource name="sql">
       <![CDATA[SELECT a, c FROM MyTable FETCH FIRST 10 ROWS ONLY]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -116,7 +103,6 @@ LogicalSort(fetch=[10])
 +- LogicalProject(a=[$0], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -126,13 +112,11 @@ Calc(select=[a, c])
       +- Limit(offset=[0], fetch=[10], global=[false])
          +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testLimit0WithOffset">
     <Resource name="sql">
       <![CDATA[SELECT a, c FROM MyTable LIMIT 0 OFFSET 10]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -140,19 +124,16 @@ LogicalSort(offset=[10], fetch=[0])
 +- LogicalProject(a=[$0], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Values(type=[RecordType(INTEGER a, VARCHAR(2147483647) c)], tuples=[[]], values=[a, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testLimitWithOffset">
     <Resource name="sql">
       <![CDATA[SELECT a, c FROM MyTable LIMIT 10 OFFSET 1]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -160,7 +141,6 @@ LogicalSort(offset=[1], fetch=[10])
 +- LogicalProject(a=[$0], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -170,13 +150,11 @@ Calc(select=[a, c])
       +- Limit(offset=[0], fetch=[11], global=[false])
          +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testLimit0WithOffset0">
     <Resource name="sql">
       <![CDATA[SELECT a, c FROM MyTable LIMIT 0 OFFSET 0]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -184,19 +162,16 @@ LogicalSort(offset=[0], fetch=[0])
 +- LogicalProject(a=[$0], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Values(type=[RecordType(INTEGER a, VARCHAR(2147483647) c)], tuples=[[]], values=[a, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testLimit0WithoutOffset">
     <Resource name="sql">
       <![CDATA[SELECT * FROM MyTable LIMIT 0]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -204,40 +179,34 @@ LogicalSort(fetch=[0])
 +- LogicalProject(a=[$0], b=[$1], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Values(type=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c)], tuples=[[]], values=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testLimitWithLimitSource">
     <Resource name="sql">
       <![CDATA[SELECT a, c FROM LimitTable LIMIT 10]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalSort(fetch=[10])
 +- LogicalProject(a=[$0], c=[$2])
-   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 10]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a, c])
 +- TableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 10]]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testLimitWithOffset0">
     <Resource name="sql">
       <![CDATA[SELECT a, c FROM MyTable LIMIT 10 OFFSET 0]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -245,7 +214,6 @@ LogicalSort(offset=[0], fetch=[10])
 +- LogicalProject(a=[$0], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -255,13 +223,11 @@ Calc(select=[a, c])
       +- Limit(offset=[0], fetch=[10], global=[false])
          +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testOnlyOffset">
     <Resource name="sql">
       <![CDATA[SELECT a, c FROM MyTable OFFSET 10 ROWS]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -269,7 +235,6 @@ LogicalSort(offset=[10])
 +- LogicalProject(a=[$0], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -278,13 +243,11 @@ Calc(select=[a, c])
    +- Exchange(distribution=[single])
       +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testLimitWithOffsetAndLimitSource">
     <Resource name="sql">
       <![CDATA[SELECT a, c FROM LimitTable LIMIT 10 OFFSET 1]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -292,7 +255,6 @@ LogicalSort(offset=[1], fetch=[10])
 +- LogicalProject(a=[$0], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -302,13 +264,11 @@ Calc(select=[a, c])
       +- Limit(offset=[0], fetch=[11], global=[false])
          +- TableSourceScan(table=[[default_catalog, default_database, LimitTable]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testLimitWithoutOffset">
     <Resource name="sql">
       <![CDATA[SELECT * FROM MyTable LIMIT 5]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -316,7 +276,6 @@ LogicalSort(fetch=[5])
 +- LogicalProject(a=[$0], b=[$1], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -325,7 +284,27 @@ Limit(offset=[0], fetch=[5], global=[true])
    +- Limit(offset=[0], fetch=[5], global=[false])
       +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
-
+    </Resource>
+  </TestCase>
+  <TestCase name="testOrderByWithLimitSource">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM LimitTable ORDER BY c LIMIT 10]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(sort0=[$1], dir0=[ASC-nulls-first], fetch=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, c])
++- SortLimit(orderBy=[c ASC], offset=[0], fetch=[10], global=[true])
+   +- Exchange(distribution=[single])
+      +- SortLimit(orderBy=[c ASC], offset=[0], fetch=[10], global=[false])
+         +- TableSourceScan(table=[[default_catalog, default_database, LimitTable]], fields=[a, b, c])
+]]>
     </Resource>
   </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/LimitTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/LimitTest.xml
@@ -92,7 +92,7 @@ Calc(select=[a, c])
 +- Limit(offset=[10], fetch=[10], global=[true])
    +- Exchange(distribution=[single])
       +- Limit(offset=[0], fetch=[20], global=[false])
-         +- TableSourceScan(table=[[default_catalog, default_database, LimitTable]], fields=[a, b, c])
+         +- TableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 20]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -268,7 +268,7 @@ Calc(select=[a, c])
 +- Limit(offset=[1], fetch=[10], global=[true])
    +- Exchange(distribution=[single])
       +- Limit(offset=[0], fetch=[11], global=[false])
-         +- TableSourceScan(table=[[default_catalog, default_database, LimitTable]], fields=[a, b, c])
+         +- TableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 11]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/LimitTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/LimitTest.xml
@@ -47,7 +47,10 @@ LogicalSort(fetch=[10])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a, c])
-+- TableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 10]]], fields=[a, b, c])
++- Limit(offset=[0], fetch=[10], global=[true])
+   +- Exchange(distribution=[single])
+      +- Limit(offset=[0], fetch=[10], global=[false])
+         +- TableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 10]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -200,7 +203,10 @@ LogicalSort(fetch=[10])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a, c])
-+- TableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 10]]], fields=[a, b, c])
++- Limit(offset=[0], fetch=[10], global=[true])
+   +- Exchange(distribution=[single])
+      +- Limit(offset=[0], fetch=[10], global=[false])
+         +- TableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 10]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/LimitTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/LimitTest.xml
@@ -19,6 +19,7 @@ limitations under the License.
   <TestCase name="testFetch0WithoutOffset">
     <Resource name="sql">
       <![CDATA[SELECT a, c FROM MyTable FETCH FIRST 0 ROWS ONLY]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -26,16 +27,40 @@ LogicalSort(fetch=[0])
 +- LogicalProject(a=[$0], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Values(type=[RecordType(INTEGER a, VARCHAR(2147483647) c)], tuples=[[]], values=[a, c])
 ]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testFetchWithLimitSource">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM LimitTable FETCH FIRST 10 ROWS ONLY]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(fetch=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 10]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, c])
++- TableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 10]]], fields=[a, b, c])
+]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testFetchWithOffset">
     <Resource name="sql">
       <![CDATA[SELECT a, c FROM MyTable OFFSET 10 ROWS FETCH NEXT 10 ROWS ONLY]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -43,6 +68,7 @@ LogicalSort(offset=[10], fetch=[10])
 +- LogicalProject(a=[$0], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -52,11 +78,37 @@ Calc(select=[a, c])
       +- Limit(offset=[0], fetch=[20], global=[false])
          +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testFetchWithOffsetAndLimitSource">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM LimitTable OFFSET 10 ROWS FETCH NEXT 10 ROWS ONLY]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(offset=[10], fetch=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, c])
++- Limit(offset=[10], fetch=[10], global=[true])
+   +- Exchange(distribution=[single])
+      +- Limit(offset=[0], fetch=[20], global=[false])
+         +- TableSourceScan(table=[[default_catalog, default_database, LimitTable]], fields=[a, b, c])
+]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testFetchWithoutOffset">
     <Resource name="sql">
       <![CDATA[SELECT a, c FROM MyTable FETCH FIRST 10 ROWS ONLY]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -64,6 +116,7 @@ LogicalSort(fetch=[10])
 +- LogicalProject(a=[$0], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -73,11 +126,13 @@ Calc(select=[a, c])
       +- Limit(offset=[0], fetch=[10], global=[false])
          +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testLimit0WithOffset">
     <Resource name="sql">
       <![CDATA[SELECT a, c FROM MyTable LIMIT 0 OFFSET 10]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -85,16 +140,19 @@ LogicalSort(offset=[10], fetch=[0])
 +- LogicalProject(a=[$0], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Values(type=[RecordType(INTEGER a, VARCHAR(2147483647) c)], tuples=[[]], values=[a, c])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testLimitWithOffset">
     <Resource name="sql">
       <![CDATA[SELECT a, c FROM MyTable LIMIT 10 OFFSET 1]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -102,6 +160,7 @@ LogicalSort(offset=[1], fetch=[10])
 +- LogicalProject(a=[$0], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -111,11 +170,13 @@ Calc(select=[a, c])
       +- Limit(offset=[0], fetch=[11], global=[false])
          +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testLimit0WithOffset0">
     <Resource name="sql">
       <![CDATA[SELECT a, c FROM MyTable LIMIT 0 OFFSET 0]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -123,16 +184,19 @@ LogicalSort(offset=[0], fetch=[0])
 +- LogicalProject(a=[$0], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Values(type=[RecordType(INTEGER a, VARCHAR(2147483647) c)], tuples=[[]], values=[a, c])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testLimit0WithoutOffset">
     <Resource name="sql">
       <![CDATA[SELECT * FROM MyTable LIMIT 0]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -140,16 +204,40 @@ LogicalSort(fetch=[0])
 +- LogicalProject(a=[$0], b=[$1], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Values(type=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c)], tuples=[[]], values=[a, b, c])
 ]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testLimitWithLimitSource">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM LimitTable LIMIT 10]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(fetch=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 10]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, c])
++- TableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 10]]], fields=[a, b, c])
+]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testLimitWithOffset0">
     <Resource name="sql">
       <![CDATA[SELECT a, c FROM MyTable LIMIT 10 OFFSET 0]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -157,6 +245,7 @@ LogicalSort(offset=[0], fetch=[10])
 +- LogicalProject(a=[$0], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -166,11 +255,13 @@ Calc(select=[a, c])
       +- Limit(offset=[0], fetch=[10], global=[false])
          +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testOnlyOffset">
     <Resource name="sql">
       <![CDATA[SELECT a, c FROM MyTable OFFSET 10 ROWS]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -178,6 +269,7 @@ LogicalSort(offset=[10])
 +- LogicalProject(a=[$0], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -186,11 +278,37 @@ Calc(select=[a, c])
    +- Exchange(distribution=[single])
       +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testLimitWithOffsetAndLimitSource">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM LimitTable LIMIT 10 OFFSET 1]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(offset=[1], fetch=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, c])
++- Limit(offset=[1], fetch=[10], global=[true])
+   +- Exchange(distribution=[single])
+      +- Limit(offset=[0], fetch=[11], global=[false])
+         +- TableSourceScan(table=[[default_catalog, default_database, LimitTable]], fields=[a, b, c])
+]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testLimitWithoutOffset">
     <Resource name="sql">
       <![CDATA[SELECT * FROM MyTable LIMIT 5]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -198,6 +316,7 @@ LogicalSort(fetch=[5])
 +- LogicalProject(a=[$0], b=[$1], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -206,6 +325,7 @@ Limit(offset=[0], fetch=[5], global=[true])
    +- Limit(offset=[0], fetch=[5], global=[false])
       +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
+
     </Resource>
   </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/LimitTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/LimitTest.scala
@@ -18,10 +18,13 @@
 
 package org.apache.flink.table.planner.plan.batch.sql
 
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo.{INT_TYPE_INFO, LONG_TYPE_INFO, STRING_TYPE_INFO}
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.SqlParserException
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.planner.utils.TableTestBase
+import org.apache.flink.table.planner.utils.{TableTestBase, TestLimitableTableSource}
 
 import org.junit.Test
 
@@ -29,6 +32,9 @@ class LimitTest extends TableTestBase {
 
   private val util = batchTestUtil()
   util.addTableSource[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
+  util.addTableSource("LimitTable", new TestLimitableTableSource(null, new RowTypeInfo(
+    Array[TypeInformation[_]](INT_TYPE_INFO, LONG_TYPE_INFO, STRING_TYPE_INFO),
+    Array("a", "b", "c"))))
 
   @Test
   def testLimitWithoutOffset(): Unit = {
@@ -88,6 +94,30 @@ class LimitTest extends TableTestBase {
   @Test
   def testOnlyOffset(): Unit = {
     util.verifyPlan("SELECT a, c FROM MyTable OFFSET 10 ROWS")
+  }
+
+  @Test
+  def testFetchWithLimitSource(): Unit = {
+    val sqlQuery = "SELECT a, c FROM LimitTable FETCH FIRST 10 ROWS ONLY"
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testLimitWithLimitSource(): Unit = {
+    val sqlQuery = "SELECT a, c FROM LimitTable LIMIT 10"
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testLimitWithOffsetAndLimitSource(): Unit = {
+    val sqlQuery = "SELECT a, c FROM LimitTable LIMIT 10 OFFSET 1"
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testFetchWithOffsetAndLimitSource(): Unit = {
+    val sqlQuery = "SELECT a, c FROM LimitTable OFFSET 10 ROWS FETCH NEXT 10 ROWS ONLY"
+    util.verifyPlan(sqlQuery)
   }
 
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/LimitTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/LimitTest.scala
@@ -103,6 +103,12 @@ class LimitTest extends TableTestBase {
   }
 
   @Test
+  def testOrderByWithLimitSource(): Unit = {
+    val sqlQuery = "SELECT a, c FROM LimitTable ORDER BY c LIMIT 10"
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
   def testLimitWithLimitSource(): Unit = {
     val sqlQuery = "SELECT a, c FROM LimitTable LIMIT 10"
     util.verifyPlan(sqlQuery)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/LimitITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/LimitITCase.scala
@@ -18,8 +18,10 @@
 
 package org.apache.flink.table.planner.runtime.batch.sql
 
+import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.TestData._
+import org.apache.flink.table.planner.utils.TestLimitableTableSource
 
 import org.junit._
 
@@ -30,9 +32,8 @@ class LimitITCase extends BatchTestBase {
     super.before()
     registerCollection("Table3", data3, type3, "a, b, c", nullablesOfData3)
 
-    // TODO support LimitableTableSource
-//    val rowType = new RowTypeInfo(type3.getFieldTypes, Array("a", "b", "c"))
-//    tEnv.registerTableSource("LimitTable", new TestLimitableTableSource(data3, rowType))
+    val rowType = new RowTypeInfo(type3.getFieldTypes, Array("a", "b", "c"))
+    tEnv.registerTableSource("LimitTable", new TestLimitableTableSource(data3, rowType))
   }
 
   @Test
@@ -56,7 +57,6 @@ class LimitITCase extends BatchTestBase {
       10)
   }
 
-  @Ignore
   @Test
   def testFetchWithLimitTable(): Unit = {
     checkSize(
@@ -71,7 +71,6 @@ class LimitITCase extends BatchTestBase {
       10)
   }
 
-  @Ignore
   @Test
   def testFetchFirstWithLimitTable(): Unit = {
     checkSize(
@@ -86,7 +85,6 @@ class LimitITCase extends BatchTestBase {
       5)
   }
 
-  @Ignore
   @Test
   def testLimitWithLimitTable(): Unit = {
     checkSize(
@@ -94,7 +92,7 @@ class LimitITCase extends BatchTestBase {
       5)
   }
 
-  @Ignore
+  @Ignore // TODO support limit without sort in table api.
   @Test
   def testTableLimitWithLimitTable(): Unit = {
     Assert.assertEquals(
@@ -109,7 +107,6 @@ class LimitITCase extends BatchTestBase {
       19)
   }
 
-  @Ignore
   @Test(expected = classOf[AssertionError])
   def testLessThanOffsetWithLimitSource(): Unit = {
     checkSize(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/LimitITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/LimitITCase.scala
@@ -86,6 +86,13 @@ class LimitITCase extends BatchTestBase {
   }
 
   @Test
+  def testLimit0WithLimitTable(): Unit = {
+    checkSize(
+      "SELECT * FROM LimitTable LIMIT 0",
+      0)
+  }
+
+  @Test
   def testLimitWithLimitTable(): Unit = {
     checkSize(
       "SELECT * FROM LimitTable LIMIT 5",

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/LimitITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/LimitITCase.scala
@@ -107,7 +107,7 @@ class LimitITCase extends BatchTestBase {
       19)
   }
 
-  @Test(expected = classOf[AssertionError])
+  @Test
   def testLessThanOffsetWithLimitSource(): Unit = {
     checkSize(
       "SELECT * FROM LimitTable OFFSET 2 ROWS FETCH NEXT 50 ROWS ONLY",

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TestLimitableTableSource.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TestLimitableTableSource.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.utils
+
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.io.CollectionInputFormat
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.table.api.TableSchema
+import org.apache.flink.table.sources._
+import org.apache.flink.types.Row
+
+import scala.collection.JavaConverters._
+
+/**
+  * The table source which support push-down the limit to the source.
+  */
+class TestLimitableTableSource(
+    data: Seq[Row],
+    rowType: RowTypeInfo,
+    var limit: Long = -1,
+    var limitablePushedDown: Boolean = false)
+  extends StreamTableSource[Row]
+  with LimitableTableSource[Row] {
+
+  override def isBounded = true
+
+  override def getDataStream(execEnv: StreamExecutionEnvironment): DataStream[Row] = {
+    if (limit == 0 && limit >= 0) {
+      throw new RuntimeException("This source can't generate data due abnormal limit " + limit)
+    }
+    val dataSet = if (limit > 0) {
+      data.take(limit.toInt).asJava
+    } else {
+      new java.util.ArrayList[Row]
+    }
+    execEnv.createInput(
+      new CollectionInputFormat(dataSet, rowType.createSerializer(new ExecutionConfig)),
+      rowType)
+  }
+
+  override def applyLimit(limit: Long): TableSource[Row] = {
+    this.limit = limit
+    limitablePushedDown = true
+    new TestLimitableTableSource(data, rowType, limit, limitablePushedDown)
+  }
+
+  override def isLimitPushedDown: Boolean = limitablePushedDown
+
+  override def getReturnType: TypeInformation[Row] = rowType
+
+  override def explainSource(): String = {
+    if (limit > 0 && limit < Long.MaxValue) "limit: " + limit else ""
+  }
+
+  override def getTableSchema: TableSchema = TableSchema.fromTypeInfo(rowType)
+}
+

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TestLimitableTableSource.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TestLimitableTableSource.scala
@@ -44,7 +44,7 @@ class TestLimitableTableSource(
   override def isBounded = true
 
   override def getDataStream(execEnv: StreamExecutionEnvironment): DataStream[Row] = {
-    if (limit == 0 && limit >= 0) {
+    if (limit < 0) {
       throw new RuntimeException("This source can't generate data due abnormal limit " + limit)
     }
     val dataSet = if (limit > 0) {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TestLimitableTableSource.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TestLimitableTableSource.scala
@@ -44,6 +44,9 @@ class TestLimitableTableSource(
   override def isBounded = true
 
   override def getDataStream(execEnv: StreamExecutionEnvironment): DataStream[Row] = {
+    if (limit == 0) {
+      throw new RuntimeException("limit 0 should be optimize to single values.")
+    }
     val dataSet = if (limit > 0) {
       data.take(limit.toInt).asJava
     } else {
@@ -63,10 +66,8 @@ class TestLimitableTableSource(
   override def getReturnType: TypeInformation[Row] = rowType
 
   override def explainSource(): String = {
-    if (limit > 0 && limit < Long.MaxValue) {
+    if (limit > 0) {
       "limit: " + limit
-    } else if (limitablePushedDown) {
-      "limitablePushedDown"
     } else {
       ""
     }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TestLimitableTableSource.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TestLimitableTableSource.scala
@@ -44,13 +44,10 @@ class TestLimitableTableSource(
   override def isBounded = true
 
   override def getDataStream(execEnv: StreamExecutionEnvironment): DataStream[Row] = {
-    if (limit < 0) {
-      throw new RuntimeException("This source can't generate data due abnormal limit " + limit)
-    }
     val dataSet = if (limit > 0) {
       data.take(limit.toInt).asJava
     } else {
-      new java.util.ArrayList[Row]
+      data.asJava
     }
     execEnv.createInput(
       new CollectionInputFormat(dataSet, rowType.createSerializer(new ExecutionConfig)),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TestLimitableTableSource.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TestLimitableTableSource.scala
@@ -58,8 +58,6 @@ class TestLimitableTableSource(
   }
 
   override def applyLimit(limit: Long): TableSource[Row] = {
-    this.limit = limit
-    limitablePushedDown = true
     new TestLimitableTableSource(data, rowType, limit, limitablePushedDown)
   }
 
@@ -68,7 +66,13 @@ class TestLimitableTableSource(
   override def getReturnType: TypeInformation[Row] = rowType
 
   override def explainSource(): String = {
-    if (limit > 0 && limit < Long.MaxValue) "limit: " + limit else ""
+    if (limit > 0 && limit < Long.MaxValue) {
+      "limit: " + limit
+    } else if (limitablePushedDown) {
+      "limitablePushedDown"
+    } else {
+      ""
+    }
   }
 
   override def getTableSchema: TableSchema = TableSchema.fromTypeInfo(rowType)


### PR DESCRIPTION
## What is the purpose of the change

SQL: select *from t1 limit 1
Now source will scan full table, if we can introduce LimitableTableSource, let source know the limit line, source can just read one row is OK.

Adds support for limiting push-down to a TableSource. A TableSource extending this interface is able to limit the number of records.

## Verifying this change

LimitTest for plan test.
LimitITCase for it case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs