### PR TITLE
[FLINK-14360][yarn] flink on yarn support obtain delegation token for multi hdfs.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -55,5 +55,4 @@ public class ClusterOptions {
 		.key("cluster.fs-servers")
 		.noDefaultValue()
         .withDescription("Multi filesystem list to obtain hdfs delegation tokens.");
-
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -50,4 +50,10 @@ public class ClusterOptions {
 		.key("cluster.services.shutdown-timeout")
 		.defaultValue(30000L)
 		.withDescription("The shutdown timeout for cluster services like executors in milliseconds.");
+
+	public static final ConfigOption<String> CLUSTER_FS_SERVERS = ConfigOptions
+		.key("cluster.fs-servers")
+		.noDefaultValue()
+        .withDescription("Multi filesystem list to obtain hdfs delegation tokens.");
+
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -686,6 +686,15 @@ public final class ConfigConstants {
 	public static final String FILESYSTEM_SCHEME = "fs.default-scheme";
 
 	/**
+	 * Key to specify a comma-separated list of the hdfs namespaces to
+	 * obtain their namenodes' delegation tokens.
+	 *
+	 * @deprecated Use {@link ClusterOptions#CLUSTER_FS_SERVERS} instead.
+	 */
+	@Deprecated
+    public static final String CLUSTER_FS_SERVERS = "cluster.fs-servers";
+
+	/**
 	 * Key to specify whether the file systems should simply overwrite existing files.
 	 *
 	 * @deprecated Use {@link CoreOptions#FILESYTEM_DEFAULT_OVERRIDE} instead.

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -692,7 +692,7 @@ public final class ConfigConstants {
 	 * @deprecated Use {@link ClusterOptions#CLUSTER_FS_SERVERS} instead.
 	 */
 	@Deprecated
-    public static final String CLUSTER_FS_SERVERS = "cluster.fs-servers";
+	public static final String CLUSTER_FS_SERVERS = "cluster.fs-servers";
 
 	/**
 	 * Key to specify whether the file systems should simply overwrite existing files.

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -952,7 +952,16 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		if (UserGroupInformation.isSecurityEnabled()) {
 			// set HDFS delegation tokens when security is enabled
 			LOG.info("Adding delegation token to the AM container..");
-			Utils.setTokensFor(amContainer, paths, yarnConfiguration);
+			String[] nameNodes = StringUtils.getStrings(flinkConfiguration.getString(ClusterOptions.CLUSTER_FS_SERVERS));
+			if (nameNodes != null && nameNodes.length > 0) {
+				List<Path> ps = new ArrayList<>();
+				for (int i = 0; i < nameNodes.length; i++) {
+					ps.add(new Path(nameNodes[i]));
+				}
+				Utils.setTokensFor(amContainer, ps, yarnConfiguration);
+			} else {
+				Utils.setTokensFor(amContainer, paths, yarnConfiguration);
+			}
 		}
 
 		amContainer.setLocalResources(localResources);


### PR DESCRIPTION
## What is the purpose of the change
Provide a optional config ` cluster.fs-servers` to set a list of multi hdfs scheme names, so that when deploy flink on yarn with multi hdfs clusters or with hdfs federation,we can obtain their delegation tokens.

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation
  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? ( JavaDocs)
