### PR TITLE
[FLINK-14300][runtime, test] Add test making sure that RecordWriter is properly closed in case of early StreamTask failure

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.api.writer;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.SimpleCounter;
@@ -56,6 +57,10 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 public abstract class RecordWriter<T extends IOReadableWritable> {
 
+	/** Default name for the output flush thread, if no name with a task reference is given. */
+	@VisibleForTesting
+	public static final String DEFAULT_OUTPUT_FLUSH_THREAD_NAME = "OutputFlusher";
+
 	private static final Logger LOG = LoggerFactory.getLogger(RecordWriter.class);
 
 	protected final ResultPartitionWriter targetPartition;
@@ -71,9 +76,6 @@ public abstract class RecordWriter<T extends IOReadableWritable> {
 	private Counter numBuffersOut = new SimpleCounter();
 
 	private final boolean flushAlways;
-
-	/** Default name for teh output flush thread, if no name with a task reference is given. */
-	private static final String DEFAULT_OUTPUT_FLUSH_THREAD_NAME = "OutputFlusher";
 
 	/** The thread that periodically flushes the output, to give an upper latency bound. */
 	private final Optional<OutputFlusher> outputFlusher;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -58,6 +58,9 @@ public class StreamConfig implements Serializable {
 	//  Config Keys
 	// ------------------------------------------------------------------------
 
+	@VisibleForTesting
+	public static final String SERIALIZEDUDF = "serializedUDF";
+
 	private static final String NUMBER_OF_OUTPUTS = "numberOfOutputs";
 	private static final String NUMBER_OF_INPUTS = "numberOfInputs";
 	private static final String CHAINED_OUTPUTS = "chainedOutputs";
@@ -67,7 +70,6 @@ public class StreamConfig implements Serializable {
 	private static final String VERTEX_NAME = "vertexID";
 	private static final String ITERATION_ID = "iterationId";
 	private static final String OUTPUT_SELECTOR_WRAPPER = "outputSelectorWrapper";
-	private static final String SERIALIZEDUDF = "serializedUDF";
 	private static final String BUFFER_TIMEOUT = "bufferTimeout";
 	private static final String TYPE_SERIALIZER_IN_1 = "typeSerializer_in_1";
 	private static final String TYPE_SERIALIZER_IN_2 = "typeSerializer_in_2";

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
@@ -25,7 +25,9 @@ import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.graph.StreamNode;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
 
 import java.util.Collections;
@@ -42,22 +44,29 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class StreamConfigChainer {
 	private final StreamConfig headConfig;
 	private final Map<Integer, StreamConfig> chainedConfigs = new HashMap<>();
+	private final long bufferTimeout;
 
 	private StreamConfig tailConfig;
 	private int chainIndex = 0;
 
 	public StreamConfigChainer(OperatorID headOperatorID, StreamOperator<?> headOperator, StreamConfig headConfig) {
-		this.headConfig = checkNotNull(headConfig);
-		this.tailConfig = checkNotNull(headConfig);
-
-		head(headOperator, headOperatorID);
+		this(headOperatorID, SimpleOperatorFactory.of(headOperator), headConfig);
 	}
 
-	private void head(StreamOperator<?> headOperator, OperatorID headOperatorID) {
-		headConfig.setStreamOperator(headOperator);
+	public StreamConfigChainer(OperatorID headOperatorID, StreamOperatorFactory<?> headOperatorFactory, StreamConfig headConfig) {
+		this.headConfig = checkNotNull(headConfig);
+		this.tailConfig = checkNotNull(headConfig);
+		this.bufferTimeout = headConfig.getBufferTimeout();
+
+		head(headOperatorID, headOperatorFactory);
+	}
+
+	private void head(OperatorID headOperatorID, StreamOperatorFactory<?> headOperatorFactory) {
+		headConfig.setStreamOperatorFactory(headOperatorFactory);
 		headConfig.setOperatorID(headOperatorID);
 		headConfig.setChainStart();
 		headConfig.setChainIndex(chainIndex);
+		headConfig.setBufferTimeout(bufferTimeout);
 	}
 
 	public <T> StreamConfigChainer chain(
@@ -89,6 +98,20 @@ public class StreamConfigChainer {
 			TypeSerializer<IN> inputSerializer,
 			TypeSerializer<OUT> outputSerializer,
 			boolean createKeyedStateBackend) {
+		return chain(
+			operatorID,
+			SimpleOperatorFactory.of(operator),
+			inputSerializer,
+			outputSerializer,
+			createKeyedStateBackend);
+	}
+
+	public <IN, OUT> StreamConfigChainer chain(
+			OperatorID operatorID,
+			StreamOperatorFactory<OUT> operatorFactory,
+			TypeSerializer<IN> inputSerializer,
+			TypeSerializer<OUT> outputSerializer,
+			boolean createKeyedStateBackend) {
 		chainIndex++;
 
 		tailConfig.setChainedOutputs(Collections.singletonList(
@@ -100,7 +123,7 @@ public class StreamConfigChainer {
 				null,
 				null)));
 		tailConfig = new StreamConfig(new Configuration());
-		tailConfig.setStreamOperator(checkNotNull(operator));
+		tailConfig.setStreamOperatorFactory(checkNotNull(operatorFactory));
 		tailConfig.setOperatorID(checkNotNull(operatorID));
 		tailConfig.setTypeSerializerIn1(inputSerializer);
 		tailConfig.setTypeSerializerOut(outputSerializer);
@@ -109,6 +132,7 @@ public class StreamConfigChainer {
 			tailConfig.setStateKeySerializer(inputSerializer);
 		}
 		tailConfig.setChainIndex(chainIndex);
+		tailConfig.setBufferTimeout(bufferTimeout);
 
 		chainedConfigs.put(chainIndex, tailConfig);
 
@@ -116,7 +140,6 @@ public class StreamConfigChainer {
 	}
 
 	public void finish() {
-
 		List<StreamEdge> outEdgesInOrder = new LinkedList<StreamEdge>();
 		outEdgesInOrder.add(
 			new StreamEdge(
@@ -127,7 +150,6 @@ public class StreamConfigChainer {
 				new BroadcastPartitioner<Object>(),
 				null));
 
-		tailConfig.setBufferTimeout(0);
 		tailConfig.setChainEnd();
 		tailConfig.setOutputSelectors(Collections.emptyList());
 		tailConfig.setNumberOfOutputs(1);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
@@ -61,10 +61,10 @@ public class StreamConfigChainer {
 	}
 
 	public <T> StreamConfigChainer chain(
-		OperatorID operatorID,
-		OneInputStreamOperator<T, T> operator,
-		TypeSerializer<T> typeSerializer,
-		boolean createKeyedStateBackend) {
+			OperatorID operatorID,
+			OneInputStreamOperator<T, T> operator,
+			TypeSerializer<T> typeSerializer,
+			boolean createKeyedStateBackend) {
 		return chain(operatorID, operator, typeSerializer, typeSerializer, createKeyedStateBackend);
 	}
 
@@ -76,10 +76,10 @@ public class StreamConfigChainer {
 	}
 
 	public <IN, OUT> StreamConfigChainer chain(
-		OperatorID operatorID,
-		OneInputStreamOperator<IN, OUT> operator,
-		TypeSerializer<IN> inputSerializer,
-		TypeSerializer<OUT> outputSerializer) {
+			OperatorID operatorID,
+			OneInputStreamOperator<IN, OUT> operator,
+			TypeSerializer<IN> inputSerializer,
+			TypeSerializer<OUT> outputSerializer) {
 		return chain(operatorID, operator, inputSerializer, outputSerializer, false);
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -136,6 +136,7 @@ public class StreamTaskTestHarness<OUT> {
 		this.executionConfig = new ExecutionConfig();
 
 		streamConfig = new StreamConfig(taskConfig);
+		streamConfig.setBufferTimeout(0);
 
 		outputSerializer = outputType.createSerializer(executionConfig);
 		outputStreamRecordSerializer = new StreamElementSerializer<OUT>(outputSerializer);
@@ -184,7 +185,6 @@ public class StreamTaskTestHarness<OUT> {
 		Preconditions.checkState(!setupCalled, "This harness was already setup.");
 		setupCalled = true;
 		streamConfig.setChainStart();
-		streamConfig.setBufferTimeout(0);
 		streamConfig.setTimeCharacteristic(TimeCharacteristic.EventTime);
 		streamConfig.setOutputSelectors(Collections.<OutputSelector<?>>emptyList());
 		streamConfig.setNumberOfOutputs(1);


### PR DESCRIPTION
This adds a missing test coverage for the previously merged https://github.com/apache/flink/pull/9857 pull request.
## Verifying this change

This PR only adds a new test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

CC @mklein0 