### PR TITLE
[FLINK-14347][test] Filter out expected exception string in YARN tests

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -131,6 +131,9 @@ public abstract class YarnTestBase extends TestLogger {
 		"Remote connection to [null] failed with java.nio.channels.NotYetConnectedException",
 		"java.io.IOException: Connection reset by peer",
 
+		// filter out expected ResourceManagerException caused by intended shutdown request
+		"Received shutdown request from YARN ResourceManager.",
+
 		// this can happen in Akka 2.4 on shutdown.
 		"java.util.concurrent.RejectedExecutionException: Worker has already been shutdown",
 


### PR DESCRIPTION
## What is the purpose of the change

Filter out expected exception string in YARN tests, especially `YARNSessionFIFOITCase.checkForProhibitedLogContents`.

The instability reported in FLINK-14347 depends on whether or not `jobmanager.log` has been dumped on the verification. Given that the "forbidden" string is actually expected[1] I propose we add the next line into whitelist. Locally verify when `jobmanager.log` dumped we find the "forbidden" string and filter out with the exclusion of expected Exception.

Received shutdown request from YARN ResourceManager

[1] Specifically, we call `YarnClient#killApplication` in `YARNSessionFIFOITCase#runDetachedModeTest` which always causes a shutdown request.

## Verifying this change

This change is itself about tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
