### PR TITLE
[FLINK-14380][Flink-Core] Type Extractor Setter

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -1803,7 +1803,7 @@ public class TypeExtractor {
 					m.getParameterTypes().length == 1 && // one parameter of the field's type
 					(m.getGenericParameterTypes()[0].equals( fieldType ) || (fieldTypeWrapper != null && m.getParameterTypes()[0].equals( fieldTypeWrapper )) || (fieldTypeGeneric != null && m.getGenericParameterTypes()[0].equals(fieldTypeGeneric) ) )&&
 					// return type is void.
-					m.getReturnType().equals(Void.TYPE)
+					(m.getReturnType().equals(Void.TYPE) || m.getReturnType().equals(clazz))
 				) {
 					hasSetter = true;
 				}

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -1802,7 +1802,7 @@ public class TypeExtractor {
 				if((methodNameLow.equals("set"+fieldNameLow) || methodNameLow.equals(fieldNameLow+"_$eq")) &&
 					m.getParameterTypes().length == 1 && // one parameter of the field's type
 					(m.getGenericParameterTypes()[0].equals( fieldType ) || (fieldTypeWrapper != null && m.getParameterTypes()[0].equals( fieldTypeWrapper )) || (fieldTypeGeneric != null && m.getGenericParameterTypes()[0].equals(fieldTypeGeneric) ) )&&
-					// return type is void.
+					// return type is void or of type class for scala case class immutable setter.
 					(m.getReturnType().equals(Void.TYPE) || m.getReturnType().equals(clazz))
 				) {
 					hasSetter = true;


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->
https://issues.apache.org/jira/browse/FLINK-14380

## What is the purpose of the change
When deciding if a class conforms to POJO using the type extractor Flink checks that the class implements a setter and getter method. For the setter method Flink makes the assertion that the return type is `Void`. This is an issue if using a case class as often the return type of a case class setter is a copy of the objects class. Consider the following case class:


```scala
case class  SomeClass(x: Int) {
    x_=(newX: Int): SomeClass = { this.copy(x = newX) }
}
```


This class will be identified as not being valid POJO although getter (generated) and setter methods are provided because the return type of the setter is not void. 

This issue discourages immutabilaty and makes the usage of case classes not possible without falling back to Kryo Serializer.

The issue is located in https://github.com/apache/flink/blob/master/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java on line 1806. Here is a permalink to the line 

https://github.com/apache/flink/blob/80b27a150026b7b5cb707bd9fa3e17f565bb8112/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java#L1806


A copy of the if check is here
```java
if((methodNameLow.equals("set"+fieldNameLow) || methodNameLow.equals(fieldNameLow+"_$eq")) &&
					m.getParameterTypes().length == 1 && // one parameter of the field's type
					(m.getGenericParameterTypes()[0].equals( fieldType ) || (fieldTypeWrapper != null && m.getParameterTypes()[0].equals( fieldTypeWrapper )) || (fieldTypeGeneric != null && m.getGenericParameterTypes()[0].equals(fieldTypeGeneric) ) )&&
					// return type is void.
					m.getReturnType().equals(Void.TYPE)
				) {
					hasSetter = true;
				}
			}
```


I believe the 
```java
m.getReturnType().equals(Void.TYPE)
```

should be modified to 

```java
m.getReturnType().equals(Void.TYPE) || m.getReturnType().equals(clazz.Type)
```

This will allow for case class setters which return copies of the object enabling to use case classes. This allows us to maintain immutability without being forced to fall back to the Kryo Serializer.  


## Brief change log

```java
m.getReturnType().equals(Void.TYPE)
```

changed to

```java
m.getReturnType().equals(Void.TYPE) || m.getReturnType().equals(clazz)
```



## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.
TBD

## Does this pull request potentially affect one of the following parts:

- This pull request could potentially cause issues during deserialization. Really need core developers to confirm.

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
