### PR TITLE
[FLINK-14344][checkpointing] A preparation for snapshotting master hook state asynchronously

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -665,7 +665,7 @@ public class CheckpointCoordinator {
 							.get(checkpointTimeout, TimeUnit.MILLISECONDS);
 					checkpoint.acknowledgeMasterState(masterHook.getIdentifier(), masterState);
 				}
-				Preconditions.checkState(checkpoint.isMasterStatesFullyAcknowledged());
+				Preconditions.checkState(checkpoint.areMasterStatesFullyAcknowledged());
 			}
 			// end of lock scope
 
@@ -811,7 +811,7 @@ public class CheckpointCoordinator {
 						LOG.debug("Received acknowledge message for checkpoint {} from task {} of job {} at {}.",
 							checkpointId, message.getTaskExecutionId(), message.getJob(), taskManagerLocationInfo);
 
-						if (checkpoint.isTasksFullyAcknowledged()) {
+						if (checkpoint.areTasksFullyAcknowledged()) {
 							completePendingCheckpoint(checkpoint);
 						}
 						break;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/MasterTriggerRestoreHook.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/MasterTriggerRestoreHook.java
@@ -95,13 +95,16 @@ public interface MasterTriggerRestoreHook<T> {
 	 * the checkpoint metadata under the hooks identifier (see {@link #getIdentifier()}).
 	 *
 	 * <p>If the action by this hook needs to be executed synchronously, then this method should
-	 * directly execute the action synchronously and block until it is complete. The returned future
-	 * (if any) would typically be a completed future.
+	 * directly execute the action synchronously. The returned future (if any) would typically be a
+	 * completed future.
 	 *
 	 * <p>If the action should be executed asynchronously and only needs to complete before the
 	 * checkpoint is considered completed, then the method may use the given executor to execute the
 	 * actual action and would signal its completion by completing the future. For hooks that do not
 	 * need to store data, the future would be completed with null.
+	 *
+	 * <p>Please note that this method should be non-blocking. Any heavy operation like IO operation
+	 * should be executed asynchronously with given executor.
 	 *
 	 * @param checkpointId The ID (logical timestamp, monotonously increasing) of the checkpoint
 	 * @param timestamp The wall clock timestamp when the checkpoint was triggered, for

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/MasterTriggerRestoreHook.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/MasterTriggerRestoreHook.java
@@ -29,7 +29,7 @@ import java.util.concurrent.Executor;
  * The interface for hooks that can be called by the checkpoint coordinator when triggering or
  * restoring a checkpoint. Such a hook is useful for example when preparing external systems for
  * taking or restoring checkpoints.
- * 
+ *
  * <p>The {@link #triggerCheckpoint(long, long, Executor)} method (called when triggering a checkpoint)
  * can return a result (via a future) that will be stored as part of the checkpoint metadata.
  * When restoring a checkpoint, that stored result will be given to the {@link #restoreCheckpoint(long, Object)}
@@ -44,7 +44,7 @@ import java.util.concurrent.Executor;
  * <p>The MasterTriggerRestoreHook is defined when creating the streaming dataflow graph. It is attached
  * to the job graph, which gets sent to the cluster for execution. To avoid having to make the hook
  * itself serializable, these hooks are attached to the job graph via a {@link MasterTriggerRestoreHook.Factory}.
- * 
+ *
  * @param <T> The type of the data produced by the hook and stored as part of the checkpoint metadata.
  *            If the hook never stores any data, this can be typed to {@code Void}.
  */
@@ -53,17 +53,17 @@ public interface MasterTriggerRestoreHook<T> {
 	/**
 	 * Gets the identifier of this hook. The identifier is used to identify a specific hook in the
 	 * presence of multiple hooks and to give it the correct checkpointed data upon checkpoint restoration.
-	 * 
+	 *
 	 * <p>The identifier should be unique between different hooks of a job, but deterministic/constant
 	 * so that upon resuming a savepoint, the hook will get the correct data.
 	 * For example, if the hook calls into another storage system and persists namespace/schema specific
 	 * information, then the name of the storage system, together with the namespace/schema name could
 	 * be an appropriate identifier.
-	 * 
+	 *
 	 * <p>When multiple hooks of the same name are created and attached to a job graph, only the first
 	 * one is actually used. This can be exploited to deduplicate hooks that would do the same thing.
-	 * 
-	 * @return The identifier of the hook. 
+	 *
+	 * @return The identifier of the hook.
 	 */
 	String getIdentifier();
 
@@ -89,28 +89,28 @@ public interface MasterTriggerRestoreHook<T> {
 	/**
 	 * This method is called by the checkpoint coordinator prior when triggering a checkpoint, prior
 	 * to sending the "trigger checkpoint" messages to the source tasks.
-	 * 
+	 *
 	 * <p>If the hook implementation wants to store data as part of the checkpoint, it may return
 	 * that data via a future, otherwise it should return null. The data is stored as part of
 	 * the checkpoint metadata under the hooks identifier (see {@link #getIdentifier()}).
-	 * 
+	 *
 	 * <p>If the action by this hook needs to be executed synchronously, then this method should
 	 * directly execute the action synchronously and block until it is complete. The returned future
 	 * (if any) would typically be a completed future.
-	 * 
+	 *
 	 * <p>If the action should be executed asynchronously and only needs to complete before the
 	 * checkpoint is considered completed, then the method may use the given executor to execute the
 	 * actual action and would signal its completion by completing the future. For hooks that do not
 	 * need to store data, the future would be completed with null.
-	 * 
+	 *
 	 * @param checkpointId The ID (logical timestamp, monotonously increasing) of the checkpoint
 	 * @param timestamp The wall clock timestamp when the checkpoint was triggered, for
-	 *                  info/logging purposes. 
+	 *                  info/logging purposes.
 	 * @param executor The executor for asynchronous actions
-	 * 
+	 *
 	 * @return Optionally, a future that signals when the hook has completed and that contains
 	 *         data to be stored with the checkpoint.
-	 * 
+	 *
 	 * @throws Exception Exceptions encountered when calling the hook will cause the checkpoint to abort.
 	 */
 	@Nullable
@@ -118,13 +118,13 @@ public interface MasterTriggerRestoreHook<T> {
 
 	/**
 	 * This method is called by the checkpoint coordinator prior to restoring the state of a checkpoint.
-	 * If the checkpoint did store data from this hook, that data will be passed to this method. 
-	 * 
+	 * If the checkpoint did store data from this hook, that data will be passed to this method.
+	 *
 	 * @param checkpointId The ID (logical timestamp) of the restored checkpoint
-	 * @param checkpointData The data originally stored in the checkpoint by this hook, possibly null. 
-	 * 
+	 * @param checkpointData The data originally stored in the checkpoint by this hook, possibly null.
+	 *
 	 * @throws Exception Exceptions thrown while restoring the checkpoint will cause the restore
-	 *                   operation to fail and to possibly fall back to another checkpoint. 
+	 *                   operation to fail and to possibly fall back to another checkpoint.
 	 */
 	void restoreCheckpoint(long checkpointId, @Nullable T checkpointData) throws Exception;
 
@@ -132,11 +132,11 @@ public interface MasterTriggerRestoreHook<T> {
 	 * Creates a the serializer to (de)serializes the data stored by this hook. The serializer
 	 * serializes the result of the Future returned by the {@link #triggerCheckpoint(long, long, Executor)}
 	 * method, and deserializes the data stored in the checkpoint into the object passed to the
-	 * {@link #restoreCheckpoint(long, Object)} method. 
-	 * 
+	 * {@link #restoreCheckpoint(long, Object)} method.
+	 *
 	 * <p>If the hook never returns any data to be stored, then this method may return null as the
 	 * serializer.
-	 * 
+	 *
 	 * @return The serializer to (de)serializes the data stored by this hook
 	 */
 	@Nullable
@@ -148,8 +148,8 @@ public interface MasterTriggerRestoreHook<T> {
 
 	/**
 	 * A factory to instantiate a {@code MasterTriggerRestoreHook}.
-	 * 
-	 * The hooks are defined when creating the streaming dataflow graph and are attached
+	 *
+	 * <p>The hooks are defined when creating the streaming dataflow graph and are attached
 	 * to the job graph, which gets sent to the cluster for execution. To avoid having to make
 	 * the hook implementation serializable, a serializable hook factory is actually attached to the
 	 * job graph instead of the hook implementation itself.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -182,11 +182,11 @@ public class PendingCheckpoint {
 		return masterStates;
 	}
 
-	public boolean isMasterStatesFullyAcknowledged() {
+	public boolean areMasterStatesFullyAcknowledged() {
 		return notYetAcknowledgedMasterStates.isEmpty() && !discarded;
 	}
 
-	public boolean isTasksFullyAcknowledged() {
+	public boolean areTasksFullyAcknowledged() {
 		return notYetAcknowledgedTasks.isEmpty() && !discarded;
 	}
 
@@ -260,9 +260,9 @@ public class PendingCheckpoint {
 	public CompletedCheckpoint finalizeCheckpoint() throws IOException {
 
 		synchronized (lock) {
-			checkState(isMasterStatesFullyAcknowledged(),
+			checkState(areMasterStatesFullyAcknowledged(),
 				"Pending checkpoint has not been fully acknowledged by master states yet.");
-			checkState(isTasksFullyAcknowledged(),
+			checkState(areTasksFullyAcknowledged(),
 				"Pending checkpoint has not been fully acknowledged by tasks yet.");
 
 			// make sure we fulfill the promise with an exception if something fails

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -38,6 +38,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -88,7 +89,9 @@ public class PendingCheckpoint {
 
 	private final Map<ExecutionAttemptID, ExecutionVertex> notYetAcknowledgedTasks;
 
-	private final List<MasterState> masterState;
+	private final List<MasterState> masterStates;
+
+	private final Set<String> notYetAcknowledgedMasterStates;
 
 	/** Set of acknowledged tasks. */
 	private final Set<ExecutionAttemptID> acknowledgedTasks;
@@ -122,6 +125,7 @@ public class PendingCheckpoint {
 			long checkpointId,
 			long checkpointTimestamp,
 			Map<ExecutionAttemptID, ExecutionVertex> verticesToConfirm,
+			Collection<String> masterStateIdentifiers,
 			CheckpointProperties props,
 			CheckpointStorageLocation targetLocation,
 			Executor executor) {
@@ -138,7 +142,8 @@ public class PendingCheckpoint {
 		this.executor = Preconditions.checkNotNull(executor);
 
 		this.operatorStates = new HashMap<>();
-		this.masterState = new ArrayList<>();
+		this.masterStates = new ArrayList<>(masterStateIdentifiers.size());
+		this.notYetAcknowledgedMasterStates = new HashSet<>(masterStateIdentifiers);
 		this.acknowledgedTasks = new HashSet<>(verticesToConfirm.size());
 		this.onCompletionPromise = new CompletableFuture<>();
 	}
@@ -173,8 +178,16 @@ public class PendingCheckpoint {
 		return operatorStates;
 	}
 
-	public boolean isFullyAcknowledged() {
-		return this.notYetAcknowledgedTasks.isEmpty() && !discarded;
+	public List<MasterState> getMasterStates() {
+		return masterStates;
+	}
+
+	public boolean isMasterStatesFullyAcknowledged() {
+		return notYetAcknowledgedMasterStates.isEmpty() && !discarded;
+	}
+
+	public boolean isTasksFullyAcknowledged() {
+		return notYetAcknowledgedTasks.isEmpty() && !discarded;
 	}
 
 	public boolean isAcknowledgedBy(ExecutionAttemptID executionAttemptId) {
@@ -247,12 +260,15 @@ public class PendingCheckpoint {
 	public CompletedCheckpoint finalizeCheckpoint() throws IOException {
 
 		synchronized (lock) {
-			checkState(isFullyAcknowledged(), "Pending checkpoint has not been fully acknowledged yet.");
+			checkState(isMasterStatesFullyAcknowledged(),
+				"Pending checkpoint has not been fully acknowledged by master states yet.");
+			checkState(isTasksFullyAcknowledged(),
+				"Pending checkpoint has not been fully acknowledged by tasks yet.");
 
 			// make sure we fulfill the promise with an exception if something fails
 			try {
 				// write out the metadata
-				final Savepoint savepoint = new SavepointV2(checkpointId, operatorStates.values(), masterState);
+				final Savepoint savepoint = new SavepointV2(checkpointId, operatorStates.values(), masterStates);
 				final CompletedCheckpointStorageLocation finalizedLocation;
 
 				try (CheckpointMetadataOutputStream out = targetLocation.createMetadataOutputStream()) {
@@ -266,7 +282,7 @@ public class PendingCheckpoint {
 						checkpointTimestamp,
 						System.currentTimeMillis(),
 						operatorStates,
-						masterState,
+						masterStates,
 						props,
 						finalizedLocation);
 
@@ -383,21 +399,22 @@ public class PendingCheckpoint {
 	}
 
 	/**
-	 * Adds a master state (state generated on the checkpoint coordinator) to
+	 * Acknowledges a master state (state generated on the checkpoint coordinator) to
 	 * the pending checkpoint.
 	 *
-	 * @param state The state to add
+	 * @param identifier The identifier of the master state
+	 * @param state The state to acknowledge
 	 */
-	public void addMasterState(MasterState state) {
-		checkNotNull(state);
+	public void acknowledgeMasterState(String identifier, @Nullable MasterState state) {
 
 		synchronized (lock) {
 			if (!discarded) {
-				masterState.add(state);
+				if (notYetAcknowledgedMasterStates.remove(identifier) && state != null) {
+					masterStates.add(state);
+				}
 			}
 		}
 	}
-
 
 	// ------------------------------------------------------------------------
 	//  Cancellation

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/hooks/MasterHooks.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/hooks/MasterHooks.java
@@ -34,8 +34,8 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -114,23 +114,20 @@ public class MasterHooks {
 	 * @throws FlinkException Thrown, if the hooks throw an exception, or the state+
 	 *                        deserialization fails.
 	 */
-	public static List<MasterState> triggerMasterHooks(
-			Collection<MasterTriggerRestoreHook<?>> hooks,
+	public static Map<String, MasterState> triggerMasterHooks(
+			Collection<? extends MasterTriggerRestoreHook<?>> hooks,
 			long checkpointId,
 			long timestamp,
 			Executor executor,
 			Time timeout) throws FlinkException {
 
-		final ArrayList<MasterState> states = new ArrayList<>(hooks.size());
+		final Map<String, MasterState> states = new HashMap<>(hooks.size());
 
 		for (MasterTriggerRestoreHook<?> hook : hooks) {
 			MasterState state = triggerHook(hook, checkpointId, timestamp, executor, timeout);
-			if (state != null) {
-				states.add(state);
-			}
+			states.put(hook.getIdentifier(), state);
 		}
 
-		states.trimToSize();
 		return states;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/hooks/MasterHooks.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/hooks/MasterHooks.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.runtime.checkpoint.hooks;
 
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.checkpoint.MasterState;
 import org.apache.flink.runtime.checkpoint.MasterTriggerRestoreHook;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.LambdaUtil;
@@ -34,13 +34,11 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.TimeoutException;
 
 /**
  * Collection of methods to deal with checkpoint master hooks.
@@ -100,102 +98,65 @@ public class MasterHooks {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * Triggers all given master hooks and returns state objects for each hook that
-	 * produced a state.
-	 *
-	 * @param hooks The hooks to trigger
+	 * Trigger master hook and return a completable future with state.
+	 * @param hook The master hook given
 	 * @param checkpointId The checkpoint ID of the triggering checkpoint
 	 * @param timestamp The (informational) timestamp for the triggering checkpoint
 	 * @param executor An executor that can be used for asynchronous I/O calls
-	 * @param timeout The maximum time that a hook may take to complete
-	 *
-	 * @return A list containing all states produced by the hooks
-	 *
-	 * @throws FlinkException Thrown, if the hooks throw an exception, or the state+
-	 *                        deserialization fails.
+	 * @param <T> The type of data produced by the hook
+	 * @return the completable future with state
 	 */
-	public static Map<String, MasterState> triggerMasterHooks(
-			Collection<? extends MasterTriggerRestoreHook<?>> hooks,
+	public static <T> CompletableFuture<MasterState> triggerHook(
+			MasterTriggerRestoreHook<T> hook,
 			long checkpointId,
 			long timestamp,
-			Executor executor,
-			Time timeout) throws FlinkException {
+			Executor executor) {
 
-		final Map<String, MasterState> states = new HashMap<>(hooks.size());
+		final String id = hook.getIdentifier();
+		final SimpleVersionedSerializer<T> serializer = hook.createCheckpointDataSerializer();
 
-		for (MasterTriggerRestoreHook<?> hook : hooks) {
-			MasterState state = triggerHook(hook, checkpointId, timestamp, executor, timeout);
-			states.put(hook.getIdentifier(), state);
-		}
-
-		return states;
-	}
-
-	private static <T> MasterState triggerHook(
-			MasterTriggerRestoreHook<?> hook,
-			long checkpointId,
-			long timestamp,
-			Executor executor,
-			Time timeout) throws FlinkException {
-
-		@SuppressWarnings("unchecked")
-		final MasterTriggerRestoreHook<T> typedHook = (MasterTriggerRestoreHook<T>) hook;
-
-		final String id = typedHook.getIdentifier();
-		final SimpleVersionedSerializer<T> serializer = typedHook.createCheckpointDataSerializer();
-
-		// call the hook!
-		final CompletableFuture<T> resultFuture;
 		try {
-			resultFuture = typedHook.triggerCheckpoint(checkpointId, timestamp, executor);
+			// call the hook!
+			final CompletableFuture<T> resultFuture =
+				hook.triggerCheckpoint(checkpointId, timestamp, executor);
+
+			if (resultFuture == null) {
+				return CompletableFuture.completedFuture(null);
+			}
+
+			return resultFuture
+				.thenApply(result -> {
+					// if the result of the future is not null, return it as state
+					if (result == null) {
+						return null;
+					}
+					else if (serializer != null) {
+						try {
+							final int version = serializer.getVersion();
+							final byte[] bytes = serializer.serialize(result);
+
+							return new MasterState(id, bytes, version);
+						}
+						catch (Throwable t) {
+							ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
+							throw new CompletionException(new FlinkException(
+								"Failed to serialize state of master hook '" + id + '\'', t));
+						}
+					}
+					else {
+						throw new CompletionException(new FlinkException(
+							"Checkpoint hook '" + id + " is stateful but creates no serializer"));
+					}
+				})
+				.exceptionally((throwable) -> {
+					throw new CompletionException(new FlinkException(
+						"Checkpoint master hook '" + id + "' produced an exception",
+						throwable.getCause()));
+				});
 		}
 		catch (Throwable t) {
-			ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
-			throw new FlinkException("Error while triggering checkpoint master hook '" + id + '\'', t);
-		}
-
-		// is there is a result future, wait for its completion
-		// in the future we want to make this asynchronous with futures (no pun intended)
-		if (resultFuture == null) {
-			return null;
-		}
-		else {
-			final T result;
-			try {
-				result = resultFuture.get(timeout.getSize(), timeout.getUnit());
-			}
-			catch (InterruptedException e) {
-				// cannot continue here - restore interrupt status and leave
-				Thread.currentThread().interrupt();
-				throw new FlinkException("Checkpoint master hook was interrupted");
-			}
-			catch (ExecutionException e) {
-				throw new FlinkException("Checkpoint master hook '" + id + "' produced an exception", e.getCause());
-			}
-			catch (TimeoutException e) {
-				throw new FlinkException("Checkpoint master hook '" + id +
-						"' did not complete in time (" + timeout + ')');
-			}
-
-			// if the result of the future is not null, return it as state
-			if (result == null) {
-				return null;
-			}
-			else if (serializer != null) {
-				try {
-					final int version = serializer.getVersion();
-					final byte[] bytes = serializer.serialize(result);
-
-					return new MasterState(id, bytes, version);
-				}
-				catch (Throwable t) {
-					ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
-					throw new FlinkException("Failed to serialize state of master hook '" + id + '\'', t);
-				}
-			}
-			else {
-				throw new FlinkException("Checkpoint hook '" + id + " is stateful but creates no serializer");
-			}
+			return FutureUtils.completedExceptionally(new FlinkException(
+				"Error while triggering checkpoint master hook '" + id + '\'', t));
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -40,7 +40,6 @@ import org.mockito.stubbing.Answer;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -48,6 +47,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
+import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.StringSerializer;
 import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.mockExecutionVertex;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -475,34 +475,6 @@ public class CheckpointCoordinatorMasterHooksTest {
 		@SuppressWarnings("unchecked")
 		Class<T> typedClass = (Class<T>) clazz;
 		return mock(typedClass);
-	}
-
-	// ------------------------------------------------------------------------
-
-	/**
-	 * A test implementation of {@link SimpleVersionedSerializer} for String type.
-	 */
-	public static final class StringSerializer implements SimpleVersionedSerializer<String> {
-
-		static final int VERSION = 77;
-
-		@Override
-		public int getVersion() {
-			return VERSION;
-		}
-
-		@Override
-		public byte[] serialize(String checkpointData) throws IOException {
-			return checkpointData.getBytes(StandardCharsets.UTF_8);
-		}
-
-		@Override
-		public String deserialize(int version, byte[] serialized) throws IOException {
-			if (version != VERSION) {
-				throw new IOException("version mismatch");
-			}
-			return new String(serialized, StandardCharsets.UTF_8);
-		}
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -361,7 +361,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// acknowledge from one of the tasks
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, checkpointId), TASK_MANAGER_LOCATION_INFO);
 			assertFalse(checkpoint.isDiscarded());
-			assertFalse(checkpoint.isFullyAcknowledged());
+			assertFalse(checkpoint.isTasksFullyAcknowledged());
 
 			// decline checkpoint from the other task
 			coord.receiveDeclineMessage(new DeclineCheckpoint(jid, attemptID1, checkpointId), TASK_MANAGER_LOCATION_INFO);
@@ -429,7 +429,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			assertEquals(0, checkpoint.getNumberOfAcknowledgedTasks());
 			assertEquals(0, checkpoint.getOperatorStates().size());
 			assertFalse(checkpoint.isDiscarded());
-			assertFalse(checkpoint.isFullyAcknowledged());
+			assertFalse(checkpoint.isTasksFullyAcknowledged());
 
 			// check that the vertices received the trigger checkpoint message
 			verify(vertex1.getCurrentExecutionAttempt()).triggerCheckpoint(checkpointId, timestamp, CheckpointOptions.forCheckpointWithDefaultLocation());
@@ -440,12 +440,12 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			assertEquals(1, checkpoint.getNumberOfAcknowledgedTasks());
 			assertEquals(1, checkpoint.getNumberOfNonAcknowledgedTasks());
 			assertFalse(checkpoint.isDiscarded());
-			assertFalse(checkpoint.isFullyAcknowledged());
+			assertFalse(checkpoint.isTasksFullyAcknowledged());
 
 			// acknowledge the same task again (should not matter)
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, checkpointId), "Unknown location");
 			assertFalse(checkpoint.isDiscarded());
-			assertFalse(checkpoint.isFullyAcknowledged());
+			assertFalse(checkpoint.isTasksFullyAcknowledged());
 
 			// decline checkpoint from the other task, this should cancel the checkpoint
 			// and trigger a new one
@@ -527,7 +527,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			assertEquals(0, checkpoint1.getNumberOfAcknowledgedTasks());
 			assertEquals(0, checkpoint1.getOperatorStates().size());
 			assertFalse(checkpoint1.isDiscarded());
-			assertFalse(checkpoint1.isFullyAcknowledged());
+			assertFalse(checkpoint1.isTasksFullyAcknowledged());
 
 			assertNotNull(checkpoint2);
 			assertEquals(checkpoint2Id, checkpoint2.getCheckpointId());
@@ -537,7 +537,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			assertEquals(0, checkpoint2.getNumberOfAcknowledgedTasks());
 			assertEquals(0, checkpoint2.getOperatorStates().size());
 			assertFalse(checkpoint2.isDiscarded());
-			assertFalse(checkpoint2.isFullyAcknowledged());
+			assertFalse(checkpoint2.isTasksFullyAcknowledged());
 
 			// check that the vertices received the trigger checkpoint message
 			{
@@ -572,7 +572,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			assertEquals(0, checkpointNew.getNumberOfAcknowledgedTasks());
 			assertEquals(0, checkpointNew.getOperatorStates().size());
 			assertFalse(checkpointNew.isDiscarded());
-			assertFalse(checkpointNew.isFullyAcknowledged());
+			assertFalse(checkpointNew.isTasksFullyAcknowledged());
 			assertNotEquals(checkpoint1.getCheckpointId(), checkpointNew.getCheckpointId());
 
 			// decline again, nothing should happen
@@ -630,7 +630,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			assertEquals(0, checkpoint.getNumberOfAcknowledgedTasks());
 			assertEquals(0, checkpoint.getOperatorStates().size());
 			assertFalse(checkpoint.isDiscarded());
-			assertFalse(checkpoint.isFullyAcknowledged());
+			assertFalse(checkpoint.isTasksFullyAcknowledged());
 
 			// check that the vertices received the trigger checkpoint message
 			{
@@ -653,13 +653,13 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			assertEquals(1, checkpoint.getNumberOfAcknowledgedTasks());
 			assertEquals(1, checkpoint.getNumberOfNonAcknowledgedTasks());
 			assertFalse(checkpoint.isDiscarded());
-			assertFalse(checkpoint.isFullyAcknowledged());
+			assertFalse(checkpoint.isTasksFullyAcknowledged());
 			verify(taskOperatorSubtaskStates2, never()).registerSharedStates(any(SharedStateRegistry.class));
 
 			// acknowledge the same task again (should not matter)
 			coord.receiveAcknowledgeMessage(acknowledgeCheckpoint1, TASK_MANAGER_LOCATION_INFO);
 			assertFalse(checkpoint.isDiscarded());
-			assertFalse(checkpoint.isFullyAcknowledged());
+			assertFalse(checkpoint.isTasksFullyAcknowledged());
 			verify(subtaskState2, never()).registerSharedStates(any(SharedStateRegistry.class));
 
 			// acknowledge the other task.
@@ -1388,7 +1388,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		assertEquals(0, pending.getNumberOfAcknowledgedTasks());
 		assertEquals(0, pending.getOperatorStates().size());
 		assertFalse(pending.isDiscarded());
-		assertFalse(pending.isFullyAcknowledged());
+		assertFalse(pending.isTasksFullyAcknowledged());
 		assertFalse(pending.canBeSubsumed());
 
 		OperatorID opID1 = OperatorID.fromJobVertexID(vertex1.getJobvertexId());
@@ -1406,13 +1406,13 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		assertEquals(1, pending.getNumberOfAcknowledgedTasks());
 		assertEquals(1, pending.getNumberOfNonAcknowledgedTasks());
 		assertFalse(pending.isDiscarded());
-		assertFalse(pending.isFullyAcknowledged());
+		assertFalse(pending.isTasksFullyAcknowledged());
 		assertFalse(savepointFuture.isDone());
 
 		// acknowledge the same task again (should not matter)
 		coord.receiveAcknowledgeMessage(acknowledgeCheckpoint2, TASK_MANAGER_LOCATION_INFO);
 		assertFalse(pending.isDiscarded());
-		assertFalse(pending.isFullyAcknowledged());
+		assertFalse(pending.isTasksFullyAcknowledged());
 		assertFalse(savepointFuture.isDone());
 
 		// acknowledge the other task.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -361,7 +361,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// acknowledge from one of the tasks
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, checkpointId), TASK_MANAGER_LOCATION_INFO);
 			assertFalse(checkpoint.isDiscarded());
-			assertFalse(checkpoint.isTasksFullyAcknowledged());
+			assertFalse(checkpoint.areTasksFullyAcknowledged());
 
 			// decline checkpoint from the other task
 			coord.receiveDeclineMessage(new DeclineCheckpoint(jid, attemptID1, checkpointId), TASK_MANAGER_LOCATION_INFO);
@@ -429,7 +429,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			assertEquals(0, checkpoint.getNumberOfAcknowledgedTasks());
 			assertEquals(0, checkpoint.getOperatorStates().size());
 			assertFalse(checkpoint.isDiscarded());
-			assertFalse(checkpoint.isTasksFullyAcknowledged());
+			assertFalse(checkpoint.areTasksFullyAcknowledged());
 
 			// check that the vertices received the trigger checkpoint message
 			verify(vertex1.getCurrentExecutionAttempt()).triggerCheckpoint(checkpointId, timestamp, CheckpointOptions.forCheckpointWithDefaultLocation());
@@ -440,12 +440,12 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			assertEquals(1, checkpoint.getNumberOfAcknowledgedTasks());
 			assertEquals(1, checkpoint.getNumberOfNonAcknowledgedTasks());
 			assertFalse(checkpoint.isDiscarded());
-			assertFalse(checkpoint.isTasksFullyAcknowledged());
+			assertFalse(checkpoint.areTasksFullyAcknowledged());
 
 			// acknowledge the same task again (should not matter)
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, checkpointId), "Unknown location");
 			assertFalse(checkpoint.isDiscarded());
-			assertFalse(checkpoint.isTasksFullyAcknowledged());
+			assertFalse(checkpoint.areTasksFullyAcknowledged());
 
 			// decline checkpoint from the other task, this should cancel the checkpoint
 			// and trigger a new one
@@ -527,7 +527,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			assertEquals(0, checkpoint1.getNumberOfAcknowledgedTasks());
 			assertEquals(0, checkpoint1.getOperatorStates().size());
 			assertFalse(checkpoint1.isDiscarded());
-			assertFalse(checkpoint1.isTasksFullyAcknowledged());
+			assertFalse(checkpoint1.areTasksFullyAcknowledged());
 
 			assertNotNull(checkpoint2);
 			assertEquals(checkpoint2Id, checkpoint2.getCheckpointId());
@@ -537,7 +537,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			assertEquals(0, checkpoint2.getNumberOfAcknowledgedTasks());
 			assertEquals(0, checkpoint2.getOperatorStates().size());
 			assertFalse(checkpoint2.isDiscarded());
-			assertFalse(checkpoint2.isTasksFullyAcknowledged());
+			assertFalse(checkpoint2.areTasksFullyAcknowledged());
 
 			// check that the vertices received the trigger checkpoint message
 			{
@@ -572,7 +572,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			assertEquals(0, checkpointNew.getNumberOfAcknowledgedTasks());
 			assertEquals(0, checkpointNew.getOperatorStates().size());
 			assertFalse(checkpointNew.isDiscarded());
-			assertFalse(checkpointNew.isTasksFullyAcknowledged());
+			assertFalse(checkpointNew.areTasksFullyAcknowledged());
 			assertNotEquals(checkpoint1.getCheckpointId(), checkpointNew.getCheckpointId());
 
 			// decline again, nothing should happen
@@ -630,7 +630,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			assertEquals(0, checkpoint.getNumberOfAcknowledgedTasks());
 			assertEquals(0, checkpoint.getOperatorStates().size());
 			assertFalse(checkpoint.isDiscarded());
-			assertFalse(checkpoint.isTasksFullyAcknowledged());
+			assertFalse(checkpoint.areTasksFullyAcknowledged());
 
 			// check that the vertices received the trigger checkpoint message
 			{
@@ -653,13 +653,13 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			assertEquals(1, checkpoint.getNumberOfAcknowledgedTasks());
 			assertEquals(1, checkpoint.getNumberOfNonAcknowledgedTasks());
 			assertFalse(checkpoint.isDiscarded());
-			assertFalse(checkpoint.isTasksFullyAcknowledged());
+			assertFalse(checkpoint.areTasksFullyAcknowledged());
 			verify(taskOperatorSubtaskStates2, never()).registerSharedStates(any(SharedStateRegistry.class));
 
 			// acknowledge the same task again (should not matter)
 			coord.receiveAcknowledgeMessage(acknowledgeCheckpoint1, TASK_MANAGER_LOCATION_INFO);
 			assertFalse(checkpoint.isDiscarded());
-			assertFalse(checkpoint.isTasksFullyAcknowledged());
+			assertFalse(checkpoint.areTasksFullyAcknowledged());
 			verify(subtaskState2, never()).registerSharedStates(any(SharedStateRegistry.class));
 
 			// acknowledge the other task.
@@ -1388,7 +1388,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		assertEquals(0, pending.getNumberOfAcknowledgedTasks());
 		assertEquals(0, pending.getOperatorStates().size());
 		assertFalse(pending.isDiscarded());
-		assertFalse(pending.isTasksFullyAcknowledged());
+		assertFalse(pending.areTasksFullyAcknowledged());
 		assertFalse(pending.canBeSubsumed());
 
 		OperatorID opID1 = OperatorID.fromJobVertexID(vertex1.getJobvertexId());
@@ -1406,13 +1406,13 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		assertEquals(1, pending.getNumberOfAcknowledgedTasks());
 		assertEquals(1, pending.getNumberOfNonAcknowledgedTasks());
 		assertFalse(pending.isDiscarded());
-		assertFalse(pending.isTasksFullyAcknowledged());
+		assertFalse(pending.areTasksFullyAcknowledged());
 		assertFalse(savepointFuture.isDone());
 
 		// acknowledge the same task again (should not matter)
 		coord.receiveAcknowledgeMessage(acknowledgeCheckpoint2, TASK_MANAGER_LOCATION_INFO);
 		assertFalse(pending.isDiscarded());
-		assertFalse(pending.isTasksFullyAcknowledged());
+		assertFalse(pending.areTasksFullyAcknowledged());
 		assertFalse(savepointFuture.isDone());
 
 		// acknowledge the other task.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
@@ -168,7 +168,7 @@ public class PendingCheckpointTest {
 
 		assertFalse(future.isDone());
 		pending.acknowledgeTask(ATTEMPT_ID, null, new CheckpointMetrics());
-		assertTrue(pending.isTasksFullyAcknowledged());
+		assertTrue(pending.areTasksFullyAcknowledged());
 		pending.finalizeCheckpoint();
 		assertTrue(future.isDone());
 
@@ -367,11 +367,11 @@ public class PendingCheckpointTest {
 			Executors.directExecutor()).get();
 
 		pending.acknowledgeMasterState(masterHook.getIdentifier(), masterState);
-		assertTrue(pending.isMasterStatesFullyAcknowledged());
-		assertFalse(pending.isTasksFullyAcknowledged());
+		assertTrue(pending.areMasterStatesFullyAcknowledged());
+		assertFalse(pending.areTasksFullyAcknowledged());
 
 		pending.acknowledgeTask(ATTEMPT_ID, null, new CheckpointMetrics());
-		assertTrue(pending.isTasksFullyAcknowledged());
+		assertTrue(pending.areTasksFullyAcknowledged());
 
 		final List<MasterState> resultMasterStates = pending.getMasterStates();
 		assertEquals(1, resultMasterStates.size());
@@ -406,7 +406,7 @@ public class PendingCheckpointTest {
 			Executors.directExecutor()).get();
 
 		pending.acknowledgeMasterState(masterHook.getIdentifier(), masterStateNormal);
-		assertFalse(pending.isMasterStatesFullyAcknowledged());
+		assertFalse(pending.areMasterStatesFullyAcknowledged());
 
 		final MasterState masterStateNull = MasterHooks.triggerHook(
 			nullableMasterHook,
@@ -414,11 +414,11 @@ public class PendingCheckpointTest {
 			System.currentTimeMillis(),
 			Executors.directExecutor()).get();
 		pending.acknowledgeMasterState(nullableMasterHook.getIdentifier(), masterStateNull);
-		assertTrue(pending.isMasterStatesFullyAcknowledged());
-		assertFalse(pending.isTasksFullyAcknowledged());
+		assertTrue(pending.areMasterStatesFullyAcknowledged());
+		assertFalse(pending.areTasksFullyAcknowledged());
 
 		pending.acknowledgeTask(ATTEMPT_ID, null, new CheckpointMetrics());
-		assertTrue(pending.isTasksFullyAcknowledged());
+		assertTrue(pending.areTasksFullyAcknowledged());
 
 		final List<MasterState> resultMasterStates = pending.getMasterStates();
 		assertEquals(1, resultMasterStates.size());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/hooks/TestMasterHook.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/hooks/TestMasterHook.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.checkpoint.hooks;
 
 import org.apache.flink.core.io.SimpleVersionedSerializer;
-import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorMasterHooksTest;
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils;
 import org.apache.flink.runtime.checkpoint.MasterTriggerRestoreHook;
 
 import javax.annotation.Nullable;
@@ -74,7 +74,7 @@ public class TestMasterHook implements MasterTriggerRestoreHook<String> {
 
 	@Override
 	public SimpleVersionedSerializer<String> createCheckpointDataSerializer() {
-		return new CheckpointCoordinatorMasterHooksTest.StringSerializer();
+		return new CheckpointCoordinatorTestingUtils.StringSerializer();
 	}
 
 	public int getRestoreCount() {


### PR DESCRIPTION
## What is the purpose of the change

* This is a preparation for reworking threading model of `CheckpointCoordinator`
* Changes the `MasterHooks` and `PendingCheckpoint` to support snapshotting master hooks asynchronously 
* Note that it's still synchronously invoked in `CheckpointCoordinator` for now. In the next PR, the `CheckpointCoordinator#triggerCheckpoint` would be separated into asynchronous stages. At that time, the master state could be invoked asynchronously.

## Brief change log

* `PendingCheckpoint` supports acknowledging master state just like task state.
* Indicates that `MasterTriggerRestoreHook#triggerCheckpoint` should be non-blocking
* Changes the util class `MasterHooks` to satisfy asynchronous invocation

## Verifying this change

* Most scenarios of this change are already covered by existing tests
* This change also adds some unit test cases

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
