### PR TITLE
[hotfix][doc]fix typos in richfunction

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RichFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RichFunction.java
@@ -39,7 +39,7 @@ public interface RichFunction extends Function {
 	 * composition.
 	 *
 	 * <pre>{@code
-	 * public class MyMapper extends RichFilterFunction<String> {
+	 * public class MyFilter extends RichFilterFunction<String> {
 	 *
 	 *     private String searchString;
 	 *

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RichFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RichFunction.java
@@ -39,7 +39,7 @@ public interface RichFunction extends Function {
 	 * composition.
 	 *
 	 * <pre>{@code
-	 * public class MyMapper extends FilterFunction<String> {
+	 * public class MyMapper extends RichFilterFunction<String> {
 	 *
 	 *     private String searchString;
 	 *


### PR DESCRIPTION
## What is the purpose of the change
Fix typos in RichFunction annotation. For only RichFilterFunction has open method to extend, so we should change FilterFunction to RichFilterFunction.

## Brief change log
typos in RichFunction

## Verifying this change
This change is a trivial work.

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
