### PR TITLE
[FLINK-14355] [docs] Example code in state processor API docs doesn't compile

### DIFF
--- a/docs/dev/libs/state_processor_api.md
+++ b/docs/dev/libs/state_processor_api.md
@@ -238,7 +238,7 @@ This means if an operator contains a stateful process function such as:
 public class StatefulFunctionWithTime extends KeyedProcessFunction<Integer, Integer, Void> {
  
    ValueState<Integer> state;
-   
+
    @Override
    public void open(Configuration parameters) {
       ValueStateDescriptor<Integer> stateDescriptor = new ValueStateDescriptor<>("state", Types.INT);
@@ -283,7 +283,7 @@ class KeyedState {
  
 class ReaderFunction extends KeyedStateReaderFunction<Integer, KeyedState> {
   ValueState<Integer> state;
-  
+
   @Override
   public void open(Configuration parameters) {
      ValueStateDescriptor<Integer> stateDescriptor = new ValueStateDescriptor<>("state", Types.INT);

--- a/docs/dev/libs/state_processor_api.md
+++ b/docs/dev/libs/state_processor_api.md
@@ -238,11 +238,10 @@ This means if an operator contains a stateful process function such as:
 public class StatefulFunctionWithTime extends KeyedProcessFunction<Integer, Integer, Void> {
  
    ValueState<Integer> state;
-   ValueStateDescriptor<Integer> stateDescriptor;
    
    @Override
    public void open(Configuration parameters) {
-	  stateDescriptor = new ValueStateDescriptor<>("state", Types.INT);
+      ValueStateDescriptor<Integer> stateDescriptor = new ValueStateDescriptor<>("state", Types.INT);
       state = getRuntimeContext().getState(stateDescriptor);
    }
  
@@ -257,16 +256,13 @@ public class StatefulFunctionWithTime extends KeyedProcessFunction<Integer, Inte
 {% highlight scala %}
 public class StatefulFunctionWithTime extends KeyedProcessFunction[Integer, Integer, Void] {
  
-  var state: ValueState[Integer];
-  var stateDescriptor: ValueStateDescriptor[Integer];
+   var state: ValueState[Integer];
  
-   @throws[Exception]
    override def open(parameters: Configuration) {
-      stateDescriptor = new ValueStateDescriptor("state", Types.INT);
+      val stateDescriptor = new ValueStateDescriptor("state", Types.INT);
       state = getRuntimeContext().getState(stateDescriptor);
    }
  
-   @throws[Exception]
    override def processElement(value: Integer, ctx: Context, out: Collector[Void]) {
       state.update(value + 1);
    }
@@ -287,11 +283,10 @@ class KeyedState {
  
 class ReaderFunction extends KeyedStateReaderFunction<Integer, KeyedState> {
   ValueState<Integer> state;
-  ValueStateDescriptor<Integer> stateDescriptor;
   
   @Override
   public void open(Configuration parameters) {
-     stateDescriptor = new ValueStateDescriptor<>("state", Types.INT);
+     ValueStateDescriptor<Integer> stateDescriptor = new ValueStateDescriptor<>("state", Types.INT);
      state = getRuntimeContext().getState(stateDescriptor);
   }
  
@@ -317,10 +312,9 @@ case class KeyedState(key: Int, value: Int)
  
 class ReaderFunction extends KeyedStateReaderFunction[Integer, KeyedState] {
   var state: ValueState[Integer];
-  var stateDescriptor: ValueStateDescriptor[Integer]
  
   override def open(parameters: Configuration) {
-     stateDescriptor = new ValueStateDescriptor("state", Types.INT);
+     val stateDescriptor = new ValueStateDescriptor("state", Types.INT);
      state = getRuntimeContext().getState(stateDescriptor);
   }
  

--- a/docs/dev/libs/state_processor_api.md
+++ b/docs/dev/libs/state_processor_api.md
@@ -238,9 +238,11 @@ This means if an operator contains a stateful process function such as:
 public class StatefulFunctionWithTime extends KeyedProcessFunction<Integer, Integer, Void> {
  
    ValueState<Integer> state;
- 
+   ValueStateDescriptor<Integer> stateDescriptor;
+   
    @Override
    public void open(Configuration parameters) {
+	  stateDescriptor = new ValueStateDescriptor<>("state", Types.INT);
       state = getRuntimeContext().getState(stateDescriptor);
    }
  
@@ -256,9 +258,11 @@ public class StatefulFunctionWithTime extends KeyedProcessFunction<Integer, Inte
 public class StatefulFunctionWithTime extends KeyedProcessFunction[Integer, Integer, Void] {
  
   var state: ValueState[Integer];
+  var stateDescriptor: ValueStateDescriptor[Integer];
  
    @throws[Exception]
-   override def open(Configuration parameters) {
+   override def open(parameters: Configuration) {
+      stateDescriptor = new ValueStateDescriptor("state", Types.INT);
       state = getRuntimeContext().getState(stateDescriptor);
    }
  
@@ -283,9 +287,11 @@ class KeyedState {
  
 class ReaderFunction extends KeyedStateReaderFunction<Integer, KeyedState> {
   ValueState<Integer> state;
- 
+  ValueStateDescriptor<Integer> stateDescriptor;
+  
   @Override
   public void open(Configuration parameters) {
+     stateDescriptor = new ValueStateDescriptor<>("state", Types.INT);
      state = getRuntimeContext().getState(stateDescriptor);
   }
  
@@ -310,9 +316,11 @@ DataSet<KeyedState> keyedState = savepoint.readKeyedState("my-uid", new ReaderFu
 case class KeyedState(key: Int, value: Int)
  
 class ReaderFunction extends KeyedStateReaderFunction[Integer, KeyedState] {
-  var state ValueState[Integer];
+  var state: ValueState[Integer];
+  var stateDescriptor: ValueStateDescriptor[Integer]
  
-  override def open(Configuration parameters) {
+  override def open(parameters: Configuration) {
+     stateDescriptor = new ValueStateDescriptor("state", Types.INT);
      state = getRuntimeContext().getState(stateDescriptor);
   }
  

--- a/docs/dev/libs/state_processor_api.md
+++ b/docs/dev/libs/state_processor_api.md
@@ -238,7 +238,7 @@ This means if an operator contains a stateful process function such as:
 public class StatefulFunctionWithTime extends KeyedProcessFunction<Integer, Integer, Void> {
  
    ValueState<Integer> state;
-
+ 
    @Override
    public void open(Configuration parameters) {
       ValueStateDescriptor<Integer> stateDescriptor = new ValueStateDescriptor<>("state", Types.INT);
@@ -283,7 +283,7 @@ class KeyedState {
  
 class ReaderFunction extends KeyedStateReaderFunction<Integer, KeyedState> {
   ValueState<Integer> state;
-
+ 
   @Override
   public void open(Configuration parameters) {
      ValueStateDescriptor<Integer> stateDescriptor = new ValueStateDescriptor<>("state", Types.INT);

--- a/docs/dev/libs/state_processor_api.zh.md
+++ b/docs/dev/libs/state_processor_api.zh.md
@@ -238,9 +238,10 @@ This means if an operator contains a stateful process function such as:
 public class StatefulFunctionWithTime extends KeyedProcessFunction<Integer, Integer, Void> {
  
    ValueState<Integer> state;
- 
+   
    @Override
    public void open(Configuration parameters) {
+      ValueStateDescriptor<Integer> stateDescriptor = new ValueStateDescriptor<>("state", Types.INT);
       state = getRuntimeContext().getState(stateDescriptor);
    }
  
@@ -255,14 +256,13 @@ public class StatefulFunctionWithTime extends KeyedProcessFunction<Integer, Inte
 {% highlight scala %}
 public class StatefulFunctionWithTime extends KeyedProcessFunction[Integer, Integer, Void] {
  
-  var state: ValueState[Integer];
+   var state: ValueState[Integer];
  
-   @throws[Exception]
-   override def open(Configuration parameters) {
+   override def open(parameters: Configuration) {
+      val stateDescriptor = new ValueStateDescriptor("state", Types.INT);
       state = getRuntimeContext().getState(stateDescriptor);
    }
  
-   @throws[Exception]
    override def processElement(value: Integer, ctx: Context, out: Collector[Void]) {
       state.update(value + 1);
    }
@@ -283,9 +283,10 @@ class KeyedState {
  
 class ReaderFunction extends KeyedStateReaderFunction<Integer, KeyedState> {
   ValueState<Integer> state;
- 
+  
   @Override
   public void open(Configuration parameters) {
+     ValueStateDescriptor<Integer> stateDescriptor = new ValueStateDescriptor<>("state", Types.INT);
      state = getRuntimeContext().getState(stateDescriptor);
   }
  
@@ -310,9 +311,10 @@ DataSet<KeyedState> keyedState = savepoint.readKeyedState("my-uid", new ReaderFu
 case class KeyedState(key: Int, value: Int)
  
 class ReaderFunction extends KeyedStateReaderFunction[Integer, KeyedState] {
-  var state ValueState[Integer];
+  var state: ValueState[Integer];
  
-  override def open(Configuration parameters) {
+  override def open(parameters: Configuration) {
+     val stateDescriptor = new ValueStateDescriptor("state", Types.INT);
      state = getRuntimeContext().getState(stateDescriptor);
   }
  

--- a/docs/dev/libs/state_processor_api.zh.md
+++ b/docs/dev/libs/state_processor_api.zh.md
@@ -238,7 +238,7 @@ This means if an operator contains a stateful process function such as:
 public class StatefulFunctionWithTime extends KeyedProcessFunction<Integer, Integer, Void> {
  
    ValueState<Integer> state;
-   
+
    @Override
    public void open(Configuration parameters) {
       ValueStateDescriptor<Integer> stateDescriptor = new ValueStateDescriptor<>("state", Types.INT);

--- a/docs/dev/libs/state_processor_api.zh.md
+++ b/docs/dev/libs/state_processor_api.zh.md
@@ -238,7 +238,7 @@ This means if an operator contains a stateful process function such as:
 public class StatefulFunctionWithTime extends KeyedProcessFunction<Integer, Integer, Void> {
  
    ValueState<Integer> state;
-
+ 
    @Override
    public void open(Configuration parameters) {
       ValueStateDescriptor<Integer> stateDescriptor = new ValueStateDescriptor<>("state", Types.INT);
@@ -283,7 +283,7 @@ class KeyedState {
  
 class ReaderFunction extends KeyedStateReaderFunction<Integer, KeyedState> {
   ValueState<Integer> state;
-
+ 
   @Override
   public void open(Configuration parameters) {
      ValueStateDescriptor<Integer> stateDescriptor = new ValueStateDescriptor<>("state", Types.INT);

--- a/docs/dev/libs/state_processor_api.zh.md
+++ b/docs/dev/libs/state_processor_api.zh.md
@@ -283,7 +283,7 @@ class KeyedState {
  
 class ReaderFunction extends KeyedStateReaderFunction<Integer, KeyedState> {
   ValueState<Integer> state;
-  
+
   @Override
   public void open(Configuration parameters) {
      ValueStateDescriptor<Integer> stateDescriptor = new ValueStateDescriptor<>("state", Types.INT);


### PR DESCRIPTION
Fix compiling errors in examples of state processor api.