### PR TITLE
[FLINK-14045][runtime] Use SlotProviderStrategy in DefaultExecutionSlotAllocator

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SlotProviderStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SlotProviderStrategy.java
@@ -35,7 +35,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * Strategy to switch between different {@link SlotProvider} allocation strategies.
  */
-abstract class SlotProviderStrategy {
+public abstract class SlotProviderStrategy {
 
 	protected final SlotProvider slotProvider;
 
@@ -58,7 +58,7 @@ abstract class SlotProviderStrategy {
 	 * @param slotProfile profile of the requested slot
 	 * @return The future of the allocation
 	 */
-	abstract CompletableFuture<LogicalSlot> allocateSlot(
+	public abstract CompletableFuture<LogicalSlot> allocateSlot(
 		SlotRequestId slotRequestId,
 		ScheduledUnit scheduledUnit,
 		SlotProfile slotProfile);
@@ -70,14 +70,14 @@ abstract class SlotProviderStrategy {
 	 * @param slotSharingGroupId identifying the slot request to cancel
 	 * @param cause of the cancellation
 	 */
-	void cancelSlotRequest(
+	public void cancelSlotRequest(
 		SlotRequestId slotRequestId,
 		@Nullable SlotSharingGroupId slotSharingGroupId,
 		Throwable cause) {
 		slotProvider.cancelSlotRequest(slotRequestId, slotSharingGroupId, cause);
 	}
 
-	static SlotProviderStrategy from(
+	public static SlotProviderStrategy from(
 		ScheduleMode scheduleMode,
 		SlotProvider slotProvider,
 		Time allocationTimeout,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocator.java
@@ -36,7 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -108,7 +107,7 @@ public class DefaultExecutionSlotAllocator implements ExecutionSlotAllocator {
 									new SlotProfile(
 										schedulingRequirements.getResourceProfile(),
 										preferredLocations,
-										Arrays.asList(schedulingRequirements.getPreviousAllocationId()),
+										Collections.singletonList(schedulingRequirements.getPreviousAllocationId()),
 										allPreviousAllocationIds)));
 
 			SlotExecutionVertexAssignment slotExecutionVertexAssignment =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocatorFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocatorFactory.java
@@ -19,8 +19,7 @@
 
 package org.apache.flink.runtime.scheduler;
 
-import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
+import org.apache.flink.runtime.executiongraph.SlotProviderStrategy;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -29,20 +28,14 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class DefaultExecutionSlotAllocatorFactory implements ExecutionSlotAllocatorFactory {
 
-	private final SlotProvider slotProvider;
+	private final SlotProviderStrategy slotProvider;
 
-	private final Time allocationTimeout;
-
-	public DefaultExecutionSlotAllocatorFactory(
-		final SlotProvider slotProvider,
-		final Time allocationTimeout) {
-
+	public DefaultExecutionSlotAllocatorFactory(final SlotProviderStrategy slotProvider) {
 		this.slotProvider = checkNotNull(slotProvider);
-		this.allocationTimeout = checkNotNull(allocationTimeout);
 	}
 
 	@Override
 	public ExecutionSlotAllocator createInstance(final InputsLocationsRetriever inputsLocationsRetriever) {
-		return new DefaultExecutionSlotAllocator(slotProvider, inputsLocationsRetriever, allocationTimeout);
+		return new DefaultExecutionSlotAllocator(slotProvider, inputsLocationsRetriever);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
+import org.apache.flink.runtime.executiongraph.SlotProviderStrategy;
 import org.apache.flink.runtime.executiongraph.failover.flip1.RestartBackoffTimeStrategy;
 import org.apache.flink.runtime.executiongraph.failover.flip1.RestartBackoffTimeStrategyFactoryLoader;
 import org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionStrategy;
@@ -77,6 +78,12 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
 				jobGraph.isCheckpointingEnabled())
 			.create();
 
+		final SlotProviderStrategy slotProviderStrategy = SlotProviderStrategy.from(
+			jobGraph.getScheduleMode(),
+			slotProvider,
+			slotRequestTimeout,
+			true);
+
 		return new DefaultScheduler(
 			log,
 			jobGraph,
@@ -99,7 +106,7 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
 			restartBackoffTimeStrategy,
 			new DefaultExecutionVertexOperations(),
 			new ExecutionVertexVersioner(),
-			new DefaultExecutionSlotAllocatorFactory(slotProvider, slotRequestTimeout));
+			new DefaultExecutionSlotAllocatorFactory(slotProviderStrategy));
 	}
 
 	private SchedulingStrategyFactory createSchedulingStrategyFactory(final ScheduleMode scheduleMode) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocatorTest.java
@@ -23,8 +23,10 @@ import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
+import org.apache.flink.runtime.executiongraph.SlotProviderStrategy;
 import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationConstraint;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
@@ -259,7 +261,13 @@ public class DefaultExecutionSlotAllocatorTest extends TestLogger {
 	}
 
 	private DefaultExecutionSlotAllocator createExecutionSlotAllocator(InputsLocationsRetriever inputsLocationsRetriever) {
-		return new DefaultExecutionSlotAllocator(slotProvider, inputsLocationsRetriever, Time.seconds(10));
+		return new DefaultExecutionSlotAllocator(
+			SlotProviderStrategy.from(
+				ScheduleMode.EAGER,
+				slotProvider,
+				Time.seconds(10),
+				true),
+			inputsLocationsRetriever);
 	}
 
 	private List<ExecutionVertexSchedulingRequirements> createSchedulingRequirements(ExecutionVertexID... executionVertexIds) {


### PR DESCRIPTION
## What is the purpose of the change

*Use SlotProviderStrategy in DefaultExecutionSlotAllocator.*


## Brief change log

  - *Use SlotProviderStrategy in DefaultExecutionSlotAllocator.*

## Verifying this change

This change is already covered by existing tests, such as *DefaultExecutionSlotAllocatorTest, DefaultSchedulerTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
