### PR TITLE
[FLINK-14363][runtime] Prevent vertex from being affected by outdated deployment

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -423,7 +423,6 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 	}
 
 	private void stopDeployment(final DeploymentHandle deploymentHandle) {
-		cancelExecutionVertex(deploymentHandle.getExecutionVertexId());
 		// Canceling the vertex normally releases the slot. However, we might not have assigned
 		// the slot to the vertex yet.
 		deploymentHandle

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -373,7 +373,6 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 			if (executionVertexVersioner.isModified(requiredVertexVersion)) {
 				log.debug("Refusing to assign slot to execution vertex {} because this deployment was " +
 					"superseded by another deployment", executionVertexId);
-				stopDeployment(deploymentHandle);
 				return null;
 			}
 
@@ -409,7 +408,6 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 			if (executionVertexVersioner.isModified(requiredVertexVersion)) {
 				log.debug("Refusing to deploy execution vertex {} because this deployment was " +
 					"superseded by another deployment", executionVertexId);
-				stopDeployment(deploymentHandle);
 				return null;
 			}
 
@@ -420,14 +418,6 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 			}
 			return null;
 		};
-	}
-
-	private void stopDeployment(final DeploymentHandle deploymentHandle) {
-		// Canceling the vertex normally releases the slot. However, we might not have assigned
-		// the slot to the vertex yet.
-		deploymentHandle
-			.getLogicalSlot()
-			.ifPresent(logicalSlot -> logicalSlot.releaseSlot(null));
 	}
 
 	private void deployTaskSafe(final ExecutionVertexID executionVertexId) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DeploymentHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DeploymentHandle.java
@@ -20,12 +20,8 @@
 package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
-import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.util.Preconditions;
-
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * This class is a tuple holding the information necessary to deploy an {@link ExecutionVertex}.
@@ -69,15 +65,5 @@ class DeploymentHandle {
 
 	public SlotExecutionVertexAssignment getSlotExecutionVertexAssignment() {
 		return slotExecutionVertexAssignment;
-	}
-
-	public Optional<LogicalSlot> getLogicalSlot() {
-		final CompletableFuture<LogicalSlot> logicalSlotFuture = slotExecutionVertexAssignment.getLogicalSlotFuture();
-		Preconditions.checkState(logicalSlotFuture.isDone(), "method can only be called after slot future is done");
-
-		if (logicalSlotFuture.isCompletedExceptionally() || logicalSlotFuture.isCancelled()) {
-			return Optional.empty();
-		}
-		return Optional.ofNullable(logicalSlotFuture.getNow(null));
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingLogicalSlot.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingLogicalSlot.java
@@ -56,6 +56,8 @@ public class TestingLogicalSlot implements LogicalSlot {
 	@Nullable
 	private final SlotSharingGroupId slotSharingGroupId;
 
+	private boolean released;
+
 	TestingLogicalSlot(
 			TaskManagerLocation taskManagerLocation,
 			TaskManagerGateway taskManagerGateway,
@@ -111,10 +113,14 @@ public class TestingLogicalSlot implements LogicalSlot {
 
 	@Override
 	public CompletableFuture<?> releaseSlot(@Nullable Throwable cause) {
-		slotOwner.returnLogicalSlot(this);
+		if (!released) {
+			released = true;
 
-		if (automaticallyCompleteReleaseFuture) {
-			releaseFuture.complete(null);
+			slotOwner.returnLogicalSlot(this);
+
+			if (automaticallyCompleteReleaseFuture) {
+				releaseFuture.complete(null);
+			}
 		}
 
 		return releaseFuture;


### PR DESCRIPTION

## What is the purpose of the change

DefaultScheduler currently will cancel latest execution of a vertex when the vertex version is outdated. This may lead to undesirable failover of a healthy vertex.

This PR is to remove the vertex cancel process in DefaultScheduler#stopDeployment. This should be valid because the cancellation is not not needed here, since the version of a scheduled vertex is only outdated after the vertex is canceled by others.


## Brief change log

  - *Removed the vertex cancellation in DefaultScheduler#stopDeployment*
  - *hotfix changes see each commit*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit test vertexIsNotAffectedByOutdatedDeployment in DefaultSchedulerTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
