### PR TITLE
[FLINK-14232][runtime] Support global failure handling in NG scheduling

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -1155,9 +1155,8 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	 */
 	public void failGlobal(Throwable t) {
 		if (!isLegacyScheduling()) {
-			// Implementation does not work for new generation scheduler.
-			// Will be fixed with FLINK-14232.
-			ExceptionUtils.rethrow(t);
+			internalTaskFailuresListener.notifyGlobalFailure(t);
+			return;
 		}
 
 		assertRunningInJobMasterMainThread();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -67,7 +67,7 @@ import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguratio
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.query.KvStateLocationRegistry;
-import org.apache.flink.runtime.scheduler.InternalTaskFailuresListener;
+import org.apache.flink.runtime.scheduler.InternalFailuresListener;
 import org.apache.flink.runtime.scheduler.adapter.ExecutionGraphToSchedulingTopologyAdapter;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingExecutionVertex;
@@ -262,7 +262,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	private SchedulingTopology schedulingTopology;
 
 	@Nullable
-	private InternalTaskFailuresListener internalTaskFailuresListener;
+	private InternalFailuresListener internalTaskFailuresListener;
 
 	// ------ Configuration of the Execution -------
 
@@ -884,7 +884,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 		return StringifiedAccumulatorResult.stringifyAccumulatorResults(accumulatorMap);
 	}
 
-	public void enableNgScheduling(final InternalTaskFailuresListener internalTaskFailuresListener) {
+	public void enableNgScheduling(final InternalFailuresListener internalTaskFailuresListener) {
 		checkNotNull(internalTaskFailuresListener);
 		checkState(this.internalTaskFailuresListener == null, "enableNgScheduling can be only called once");
 		this.internalTaskFailuresListener = internalTaskFailuresListener;
@@ -1817,7 +1817,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 
 	void notifySchedulerNgAboutInternalTaskFailure(final ExecutionAttemptID attemptId, final Throwable t) {
 		if (internalTaskFailuresListener != null) {
-			internalTaskFailuresListener.notifyFailed(attemptId, t);
+			internalTaskFailuresListener.notifyTaskFailure(attemptId, t);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/ExecutionFailureHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/ExecutionFailureHandler.java
@@ -24,6 +24,10 @@ import org.apache.flink.runtime.throwable.ThrowableClassifier;
 import org.apache.flink.runtime.throwable.ThrowableType;
 
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -32,6 +36,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * to restart to recover from failures.
  */
 public class ExecutionFailureHandler {
+
+	private final FailoverTopology failoverTopology;
 
 	/** Strategy to judge which tasks should be restarted. */
 	private final FailoverStrategy failoverStrategy;
@@ -42,13 +48,16 @@ public class ExecutionFailureHandler {
 	/**
 	 * Creates the handler to deal with task failures.
 	 *
+	 * @param failoverTopology contains the topology info for failover
 	 * @param failoverStrategy helps to decide tasks to restart on task failures
 	 * @param restartBackoffTimeStrategy helps to decide whether to restart failed tasks and the restarting delay
 	 */
 	public ExecutionFailureHandler(
+		FailoverTopology failoverTopology,
 		FailoverStrategy failoverStrategy,
 		RestartBackoffTimeStrategy restartBackoffTimeStrategy) {
 
+		this.failoverTopology = checkNotNull(failoverTopology);
 		this.failoverStrategy = checkNotNull(failoverStrategy);
 		this.restartBackoffTimeStrategy = checkNotNull(restartBackoffTimeStrategy);
 	}
@@ -62,6 +71,29 @@ public class ExecutionFailureHandler {
 	 * @return result of the failure handling
 	 */
 	public FailureHandlingResult getFailureHandlingResult(ExecutionVertexID failedTask, Throwable cause) {
+		return handleFailure(cause, () -> failoverStrategy.getTasksNeedingRestart(failedTask, cause));
+	}
+
+	/**
+	 * Return result of failure handling on a global failure. Can be a set of task vertices to restart
+	 * and a delay of the restarting. Or that the failure is not recoverable and the reason for it.
+	 *
+	 * @param cause of the task failure
+	 * @return result of the failure handling
+	 */
+	public FailureHandlingResult getGlobalFailureHandlingResult(final Throwable cause) {
+		return handleFailure(
+			cause,
+			() -> StreamSupport
+				.stream(failoverTopology.getFailoverVertices().spliterator(), false)
+				.map(FailoverVertex::getExecutionVertexID)
+				.collect(Collectors.toSet()));
+	}
+
+	private FailureHandlingResult handleFailure(
+			final Throwable cause,
+			final Supplier<Set<ExecutionVertexID>> vertexToRestartSupplier) {
+
 		if (isUnrecoverableError(cause)) {
 			return FailureHandlingResult.unrecoverable(new JobException("The failure is not recoverable", cause));
 		}
@@ -69,11 +101,11 @@ public class ExecutionFailureHandler {
 		restartBackoffTimeStrategy.notifyFailure(cause);
 		if (restartBackoffTimeStrategy.canRestart()) {
 			return FailureHandlingResult.restartable(
-				failoverStrategy.getTasksNeedingRestart(failedTask, cause),
+				vertexToRestartSupplier.get(),
 				restartBackoffTimeStrategy.getBackoffTime());
 		} else {
 			return FailureHandlingResult.unrecoverable(
-				new JobException("Failed task restarting is suppressed by " + restartBackoffTimeStrategy, cause));
+				new JobException("Recovery is suppressed by " + restartBackoffTimeStrategy, cause));
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -176,6 +176,13 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 		maybeRestartTasks(failureHandlingResult);
 	}
 
+	@Override
+	public void handleGlobalFailure(final Throwable error) {
+		log.info("Trying to recover from a global failure.", error);
+		final FailureHandlingResult failureHandlingResult = executionFailureHandler.getGlobalFailureHandlingResult(error);
+		maybeRestartTasks(failureHandlingResult);
+	}
+
 	private void maybeRestartTasks(final FailureHandlingResult failureHandlingResult) {
 		if (failureHandlingResult.canRestart()) {
 			restartTasksWithDelay(failureHandlingResult);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -139,7 +139,10 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 		this.executionVertexOperations = checkNotNull(executionVertexOperations);
 		this.executionVertexVersioner = checkNotNull(executionVertexVersioner);
 
-		this.executionFailureHandler = new ExecutionFailureHandler(failoverStrategyFactory.create(getFailoverTopology()), restartBackoffTimeStrategy);
+		this.executionFailureHandler = new ExecutionFailureHandler(
+			getFailoverTopology(),
+			failoverStrategyFactory.create(getFailoverTopology()),
+			restartBackoffTimeStrategy);
 		this.schedulingStrategy = schedulingStrategyFactory.createInstance(this, getSchedulingTopology(), getJobGraph());
 		this.executionSlotAllocator = checkNotNull(executionSlotAllocatorFactory).createInstance(getInputsLocationsRetriever());
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/InternalFailuresListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/InternalFailuresListener.java
@@ -25,13 +25,14 @@ import org.apache.flink.runtime.jobmaster.JobMasterGateway;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 
 /**
- * This interface enables subscribing to Task failures that are detected from the JobMaster side
+ * This interface enables subscribing to failures that are detected from the JobMaster side
  * (e.g., from within the {@link ExecutionGraph}).
  * In contrast, there are also failures that are detected by the TaskManager, which are communicated
  * via {@link JobMasterGateway#updateTaskExecutionState(TaskExecutionState)}.
  */
-public interface InternalTaskFailuresListener {
+public interface InternalFailuresListener {
 
-	void notifyFailed(ExecutionAttemptID attemptId, Throwable t);
+	void notifyTaskFailure(ExecutionAttemptID attemptId, Throwable t);
 
+	void notifyGlobalFailure(Throwable t);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
@@ -91,4 +91,9 @@ public class LegacyScheduler extends SchedulerBase {
 			executionGraph.failGlobal(t);
 		}
 	}
+
+	@Override
+	public void handleGlobalFailure(Throwable cause) {
+		throw new IllegalStateException("Unexpected handleGlobalFailure(...) call");
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -377,6 +377,10 @@ public abstract class SchedulerBase implements SchedulerNG {
 	}
 
 	@Override
+	public void handleGlobalFailure(final Throwable cause) {
+	}
+
+	@Override
 	public final boolean updateTaskExecutionState(final TaskExecutionState taskExecutionState) {
 		final Optional<ExecutionVertexID> executionVertexId = getExecutionVertexId(taskExecutionState.getID());
 		if (executionVertexId.isPresent()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -310,7 +310,7 @@ public abstract class SchedulerBase implements SchedulerNG {
 	}
 
 	protected final void prepareExecutionGraphForNgScheduling() {
-		executionGraph.enableNgScheduling(new UpdateSchedulerNgOnInternalTaskFailuresListener(this, jobGraph.getJobID()));
+		executionGraph.enableNgScheduling(new UpdateSchedulerNgOnInternalFailuresListener(this, jobGraph.getJobID()));
 		executionGraph.transitionToRunning();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -377,8 +377,7 @@ public abstract class SchedulerBase implements SchedulerNG {
 	}
 
 	@Override
-	public void handleGlobalFailure(final Throwable cause) {
-	}
+	public abstract void handleGlobalFailure(final Throwable cause);
 
 	@Override
 	public final boolean updateTaskExecutionState(final TaskExecutionState taskExecutionState) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
@@ -77,6 +77,8 @@ public interface SchedulerNG {
 
 	CompletableFuture<Void> getTerminationFuture();
 
+	void handleGlobalFailure(Throwable cause);
+
 	boolean updateTaskExecutionState(TaskExecutionState taskExecutionState);
 
 	SerializedInputSplit requestNextInputSplit(JobVertexID vertexID, ExecutionAttemptID executionAttempt) throws IOException;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/UpdateSchedulerNgOnInternalFailuresListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/UpdateSchedulerNgOnInternalFailuresListener.java
@@ -28,14 +28,15 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Calls {@link SchedulerNG#updateTaskExecutionState(TaskExecutionState)} on task failure.
+ * Calls {@link SchedulerNG#handleGlobalFailure(Throwable)} on global failures.
  */
-class UpdateSchedulerNgOnInternalTaskFailuresListener implements InternalTaskFailuresListener {
+class UpdateSchedulerNgOnInternalFailuresListener implements InternalFailuresListener {
 
 	private final SchedulerNG schedulerNg;
 
 	private final JobID jobId;
 
-	public UpdateSchedulerNgOnInternalTaskFailuresListener(
+	public UpdateSchedulerNgOnInternalFailuresListener(
 		final SchedulerNG schedulerNg,
 		final JobID jobId) {
 
@@ -44,11 +45,16 @@ class UpdateSchedulerNgOnInternalTaskFailuresListener implements InternalTaskFai
 	}
 
 	@Override
-	public void notifyFailed(final ExecutionAttemptID attemptId, final Throwable t) {
+	public void notifyTaskFailure(final ExecutionAttemptID attemptId, final Throwable t) {
 		schedulerNg.updateTaskExecutionState(new TaskExecutionState(
 			jobId,
 			attemptId,
 			ExecutionState.FAILED,
 			t));
+	}
+
+	@Override
+	public void notifyGlobalFailure(Throwable t) {
+		schedulerNg.handleGlobalFailure(t);
 	}
 }


### PR DESCRIPTION

## What is the purpose of the change

Global failure handling(full restarts) is widely used in ExecutionGraph components and even other components(CheckpointCoordinator) to recover the job from an inconsistent state.
This PR is to support it for DefaultScheduler to not break such usages.

## Brief change log

- Add getGlobalFailureHandlingResult(Throwable) in ExecutionFailureHandler
- Add an interface handleGlobalFailure(Throwable) in SchedulerNG and implement it in DefaultScheduler
- Add an interface notifyGlobalFailure(Throwable) in InternalTaskFailuresListener and rework the implementations to use SchedulerNG#handleGlobalFailure
- Rework ExecutionGraph#failGlobal to invoke InternalTaskFailuresListener#notifyGlobalFailure for NG scheduling


## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests for ExecutionFailureHandler#getGlobalFailureHandlingResult*
  - *Added unit tests for DefaultScheduler#handleGlobalFailure*
  - *The overall changes can be verified by successfully running ZooKeeperHighAvailabilityITCase. This requires some additional changes though, including tests fix and state restore supporting. It is verified with private patches.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
