### PR TITLE
[FLINK-14396][network] Implement rudimentary non-blocking network output

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/AvailabilityProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/AvailabilityProvider.java
@@ -53,4 +53,48 @@ public interface AvailabilityProvider {
 	 * the input is finished.
 	 */
 	CompletableFuture<?> isAvailable();
+
+	/**
+	 * A availability implementation for providing the helpful functions of resetting the
+	 * available/unavailable states.
+	 */
+	final class AvailabilityHelper implements AvailabilityProvider {
+
+		private CompletableFuture<?> isAvailable = new CompletableFuture<>();
+
+		/**
+		 * Judges to reset the current available state as unavailable.
+		 */
+		public void resetUnavailable() {
+			// try to avoid volatile access in isDone()}
+			if (isAvailable == AVAILABLE || isAvailable.isDone()) {
+				isAvailable = new CompletableFuture<>();
+			}
+		}
+
+		/**
+		 * Resets the constant completed {@link #AVAILABLE} as the current state.
+		 */
+		public void resetAvailable() {
+			isAvailable = AVAILABLE;
+		}
+
+		/**
+		 *  Returns the previously not completed future and resets the constant completed
+		 *  {@link #AVAILABLE} as the current state.
+		 */
+		public CompletableFuture<?> getUnavailableToResetAvailable() {
+			CompletableFuture<?> toNotify = isAvailable;
+			isAvailable = AVAILABLE;
+			return toNotify;
+		}
+
+		/**
+		 * @return a future that is completed if the respective provider is available.
+		 */
+		@Override
+		public CompletableFuture<?> isAvailable() {
+			return isAvailable;
+		}
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
@@ -23,6 +23,7 @@ import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.api.serialization.RecordSerializer;
 import org.apache.flink.runtime.io.network.api.serialization.SpanningRecordSerializer;
@@ -38,6 +39,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.runtime.io.network.api.serialization.RecordSerializer.SerializationResult;
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -56,7 +58,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  *
  * @param <T> the type of the record that can be emitted with this record writer
  */
-public abstract class RecordWriter<T extends IOReadableWritable> {
+public abstract class RecordWriter<T extends IOReadableWritable> implements AvailabilityProvider {
 
 	/** Default name for the output flush thread, if no name with a task reference is given. */
 	@VisibleForTesting
@@ -185,6 +187,11 @@ public abstract class RecordWriter<T extends IOReadableWritable> {
 	protected void finishBufferBuilder(BufferBuilder bufferBuilder) {
 		numBytesOut.inc(bufferBuilder.finish());
 		numBuffersOut.inc();
+	}
+
+	@Override
+	public CompletableFuture<?> isAvailable() {
+		return targetPartition.isAvailable();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * A buffer-oriented runtime result writer API for producing results.
@@ -92,4 +93,12 @@ public interface ResultPartitionWriter extends AutoCloseable {
 	 * <p>Closing of partition is still needed afterwards.
 	 */
 	void finish() throws IOException;
+
+	/**
+	 * Check whether the writer is available for output or not.
+	 *
+	 * @return a future that is completed if it is available for output.
+	 */
+
+	CompletableFuture<?> isAvailable();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferProvider.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.io.network.buffer;
 
+import org.apache.flink.runtime.io.AvailabilityProvider;
+
 import java.io.IOException;
 
 /**
@@ -26,7 +28,7 @@ import java.io.IOException;
  * <p>The data producing side (result partition writers) request buffers in a synchronous fashion,
  * whereas the input side requests asynchronously.
  */
-public interface BufferProvider {
+public interface BufferProvider extends AvailabilityProvider {
 
 	/**
 	 * Returns a {@link Buffer} instance from the buffer provider, if one is available.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -320,6 +321,11 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 	 */
 	public boolean isReleased() {
 		return isReleased.get();
+	}
+
+	@Override
+	public CompletableFuture<?> isAvailable() {
+		return bufferPool.isAvailable();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -71,7 +71,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public abstract class InputGate implements PullingAsyncDataInput<BufferOrEvent>, AutoCloseable {
 
-	protected CompletableFuture<?> isAvailable = new CompletableFuture<>();
+	protected final AvailabilityHelper availabilityHelper = new AvailabilityHelper();
 
 	public abstract int getNumberOfInputChannels();
 
@@ -100,14 +100,7 @@ public abstract class InputGate implements PullingAsyncDataInput<BufferOrEvent>,
 	 */
 	@Override
 	public CompletableFuture<?> isAvailable() {
-		return isAvailable;
-	}
-
-	protected void resetIsAvailable() {
-		// try to avoid volatile access in isDone()}
-		if (isAvailable == AVAILABLE || isAvailable.isDone()) {
-			isAvailable = new CompletableFuture<>();
-		}
+		return availabilityHelper.isAvailable();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -516,7 +516,7 @@ public class SingleInputGate extends InputGate {
 				}
 
 				if (inputChannelsWithData.isEmpty()) {
-					resetIsAvailable();
+					availabilityHelper.resetUnavailable();
 				}
 
 				if (result.isPresent()) {
@@ -567,12 +567,11 @@ public class SingleInputGate extends InputGate {
 	}
 
 	private void markAvailable() {
-		CompletableFuture<?> toNotfiy;
+		CompletableFuture<?> toNotify;
 		synchronized (inputChannelsWithData) {
-			toNotfiy = isAvailable;
-			isAvailable = AVAILABLE;
+			toNotify = availabilityHelper.getUnavailableToResetAvailable();
 		}
-		toNotfiy.complete(null);
+		toNotify.complete(null);
 	}
 
 	@Override
@@ -629,8 +628,7 @@ public class SingleInputGate extends InputGate {
 
 			if (availableChannels == 0) {
 				inputChannelsWithData.notifyAll();
-				toNotify = isAvailable;
-				isAvailable = AVAILABLE;
+				toNotify = availabilityHelper.getUnavailableToResetAvailable();
 			}
 		}
 
@@ -650,7 +648,7 @@ public class SingleInputGate extends InputGate {
 					inputChannelsWithData.wait();
 				}
 				else {
-					resetIsAvailable();
+					availabilityHelper.resetUnavailable();
 					return Optional.empty();
 				}
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -118,7 +118,7 @@ public class UnionInputGate extends InputGate {
 			}
 
 			if (!inputGatesWithData.isEmpty()) {
-				isAvailable = AVAILABLE;
+				availabilityHelper.resetAvailable();
 			}
 		}
 
@@ -189,7 +189,7 @@ public class UnionInputGate extends InputGate {
 				}
 
 				if (inputGatesWithData.isEmpty()) {
-					resetIsAvailable();
+					availabilityHelper.resetUnavailable();
 				}
 
 				if (bufferOrEvent.isPresent()) {
@@ -232,12 +232,11 @@ public class UnionInputGate extends InputGate {
 	}
 
 	private void markAvailable() {
-		CompletableFuture<?> toNotfiy;
+		CompletableFuture<?> toNotify;
 		synchronized (inputGatesWithData) {
-			toNotfiy = isAvailable;
-			isAvailable = AVAILABLE;
+			toNotify = availabilityHelper.getUnavailableToResetAvailable();
 		}
-		toNotfiy.complete(null);
+		toNotify.complete(null);
 	}
 
 	@Override
@@ -271,8 +270,7 @@ public class UnionInputGate extends InputGate {
 
 			if (availableInputGates == 0) {
 				inputGatesWithData.notifyAll();
-				toNotify = isAvailable;
-				isAvailable = AVAILABLE;
+				toNotify = availabilityHelper.getUnavailableToResetAvailable();
 			}
 		}
 
@@ -287,7 +285,7 @@ public class UnionInputGate extends InputGate {
 				if (blocking) {
 					inputGatesWithData.wait();
 				} else {
-					resetIsAvailable();
+					availabilityHelper.resetUnavailable();
 					return Optional.empty();
 				}
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/ConsumableNotifyingResultPartitionWriterDecorator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/ConsumableNotifyingResultPartitionWriterDecorator.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -117,6 +118,11 @@ public class ConsumableNotifyingResultPartitionWriterDecorator implements Result
 	@Override
 	public void fail(Throwable throwable) {
 		partitionWriter.fail(throwable);
+	}
+
+	@Override
+	public CompletableFuture<?> isAvailable() {
+		return partitionWriter.isAvailable();
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AbstractCollectingResultPartitionWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AbstractCollectingResultPartitionWriter.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.api.writer;
 
+import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
@@ -29,6 +30,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
+import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -120,6 +122,11 @@ public abstract class AbstractCollectingResultPartitionWriter implements ResultP
 	@Override
 	public void finish() {
 		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CompletableFuture<?> isAvailable() {
+		return AvailabilityProvider.AVAILABLE;
 	}
 
 	protected abstract void deserializeBuffer(Buffer buffer) throws IOException;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.api.writer;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
@@ -33,15 +34,22 @@ import org.apache.flink.runtime.io.network.api.serialization.RecordSerializer.Se
 import org.apache.flink.runtime.io.network.api.serialization.SpillingAdaptiveSpanningRecordDeserializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
 import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.partition.NoOpResultPartitionConsumableNotifier;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionBuilder;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.util.DeserializationUtils;
 import org.apache.flink.runtime.io.network.util.TestPooledBufferProvider;
 import org.apache.flink.runtime.operators.shipping.OutputEmitter;
 import org.apache.flink.runtime.operators.shipping.ShipStrategyType;
+import org.apache.flink.runtime.taskmanager.ConsumableNotifyingResultPartitionWriterDecorator;
+import org.apache.flink.runtime.taskmanager.NoOpTaskActions;
 import org.apache.flink.testutils.serialization.types.SerializationTestType;
 import org.apache.flink.testutils.serialization.types.SerializationTestTypeFactory;
 import org.apache.flink.testutils.serialization.types.Util;
@@ -64,13 +72,17 @@ import java.util.List;
 import java.util.Queue;
 import java.util.Random;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import static org.apache.flink.runtime.io.AvailabilityProvider.AVAILABLE;
 import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.buildSingleBuffer;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -417,6 +429,46 @@ public class RecordWriterTest {
 		}
 	}
 
+	/**
+	 * Tests that the RecordWriter is available iif the respective LocalBufferPool has at-least one available buffer.
+	 */
+	@Test
+	public void testIsAvailableOrNot() throws Exception {
+		// setup
+		final NetworkBufferPool globalPool = new NetworkBufferPool(10, 128, 2);
+		final BufferPool localPool = globalPool.createBufferPool(1, 1);
+		final ResultPartitionWriter resultPartition = new ResultPartitionBuilder()
+			.setBufferPoolFactory(p -> localPool)
+			.build();
+		resultPartition.setup();
+		final ResultPartitionWriter partitionWrapper = new ConsumableNotifyingResultPartitionWriterDecorator(
+			new NoOpTaskActions(),
+			new JobID(),
+			resultPartition,
+			new NoOpResultPartitionConsumableNotifier());
+		final RecordWriter recordWriter = createRecordWriter(partitionWrapper);
+
+		try {
+			// record writer is available because of initial available local pool
+			assertTrue(recordWriter.isAvailable().isDone());
+			assertEquals(recordWriter.AVAILABLE, recordWriter.isAvailable());
+
+			// request one buffer from the local pool to make it unavailable afterwards
+			final BufferBuilder bufferBuilder = resultPartition.getBufferBuilder();
+			assertNotNull(bufferBuilder);
+			assertFalse(recordWriter.isAvailable().isDone());
+
+			// recycle the buffer to make the local pool available again
+			final Buffer buffer = BufferBuilderTestUtils.buildSingleBuffer(bufferBuilder);
+			buffer.recycleBuffer();
+			assertTrue(recordWriter.isAvailable().isDone());
+			assertEquals(recordWriter.AVAILABLE, recordWriter.isAvailable());
+		} finally {
+			localPool.lazyDestroy();
+			globalPool.destroy();
+		}
+	}
+
 	private void verifyBroadcastBufferOrEventIndependence(boolean broadcastEvent) throws Exception {
 		@SuppressWarnings("unchecked")
 		ArrayDeque<BufferConsumer>[] queues = new ArrayDeque[]{new ArrayDeque(), new ArrayDeque()};
@@ -544,6 +596,11 @@ public class RecordWriterTest {
 		}
 
 		@Override
+		public CompletableFuture<?> isAvailable() {
+			return AVAILABLE;
+		}
+
+		@Override
 		public void close() {
 		}
 	}
@@ -617,6 +674,11 @@ public class RecordWriterTest {
 		@Override
 		public void finish() {
 			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public CompletableFuture<?> isAvailable() {
+			return AVAILABLE;
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NoOpBufferPool.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NoOpBufferPool.java
@@ -23,6 +23,7 @@ package org.apache.flink.runtime.io.network.buffer;
 import org.apache.flink.core.memory.MemorySegment;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * No-op implementation of {@link BufferPool}.
@@ -86,5 +87,10 @@ public class NoOpBufferPool implements BufferPool {
 	@Override
 	public void recycle(MemorySegment memorySegment) {
 		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CompletableFuture<?> isAvailable() {
+		return AVAILABLE;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
 import org.apache.flink.runtime.io.network.util.TestBufferFactory;
 import org.apache.flink.runtime.io.network.util.TestPartitionProducer;
 import org.apache.flink.runtime.io.network.util.TestProducerSource;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.util.function.CheckedSupplier;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestPooledBufferProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestPooledBufferProvider.java
@@ -31,6 +31,7 @@ import org.apache.flink.shaded.guava18.com.google.common.collect.Queues;
 import java.io.IOException;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 
@@ -93,6 +94,11 @@ public class TestPooledBufferProvider implements BufferProvider {
 	@Override
 	public boolean isDestroyed() {
 		return false;
+	}
+
+	@Override
+	public CompletableFuture<?> isAvailable() {
+		return AVAILABLE;
 	}
 
 	public int getNumberOfAvailableBuffers() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerMassiveRandomTest.java
@@ -138,7 +138,7 @@ public class CheckpointBarrierAlignerMassiveRandomTest {
 			this.currentBarriers = new int[numberOfChannels];
 			this.bufferPools = bufferPools;
 			this.barrierGens = barrierGens;
-			this.isAvailable = AVAILABLE;
+			availabilityHelper.resetAvailable();
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
@@ -54,7 +54,7 @@ public class MockInputGate extends InputGate {
 		this.closed = new boolean[numberOfChannels];
 		this.finishAfterLastBuffer = finishAfterLastBuffer;
 
-		isAvailable = AVAILABLE;
+		availabilityHelper.resetAvailable();
 	}
 
 	@Override
@@ -75,7 +75,7 @@ public class MockInputGate extends InputGate {
 	public Optional<BufferOrEvent> getNext() {
 		BufferOrEvent next = bufferOrEvents.poll();
 		if (!finishAfterLastBuffer && bufferOrEvents.isEmpty()) {
-			resetIsAvailable();
+			availabilityHelper.resetUnavailable();
 		}
 		if (next == null) {
 			return Optional.empty();


### PR DESCRIPTION
## What is the purpose of the change

Considering the mailbox model and unaligned checkpoints requirements in future, task network output should be non-blocking. In other words, as long as output is available, it should never block for a subsequent/future single record write.
    
In the first version, we only implement the non-blocking output for the most regular case, and do not solve the following cases which still keep the previous behavior.
 
    1. Big record which might span multiple buffers
    2. Flatmap-like operators which might emit multiple records in every process
    3. Broadcast watermark which might request multiple buffers at a time
    
The solution is providing the `RecordWriter#isAvailable` method and respective `LocalBufferPool#isAvailable` for judging the output beforehand. As long as there is at-least one available buffer in `LocalBufferPool`, the `RecordWriter` is available for network output in most cases.  This doesn’t include runtime handling of this non-blocking and availability behavior in `StreamInputProcessor`.
    
Note: It requires the minimum number of buffers in output `LocalBufferPool` adjusting to (numberOfSubpartitions + 1) and also adjusting the monitor of backpressure future.

## Brief change log

  - Refactor to extract `AbstractAvailabilityProvider` class from `InputGate` logics.
  - Provide the #isAvailable method for `RecordWriter`, `ResultPartitionWriter` and `BufferPool`.
  - Refactor the relevant implementations in `LocalBufferPool` for supporting updating the available state.

## Verifying this change

Add new `RecordWriterTest#testIsAvailableOrNot` for verifying the changes.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / `no`)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / `no`)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)