### PR TITLE
[FLINK-14395] Refactor ES 6 connector to split table-specific code into flink-sql-connector-elasticsearch6

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch6/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch6/pom.xml
@@ -84,16 +84,6 @@ under the License.
 			<version>2.9.1</version>
 		</dependency>
 
-		<!-- Table ecosystem -->
-		<!-- Projects depending on this project won't depend on flink-table-*. -->
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-table-api-java-bridge_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-			<scope>provided</scope>
-			<optional>true</optional>
-		</dependency>
-
 		<!-- test dependencies -->
 
 		<dependency>
@@ -152,15 +142,6 @@ under the License.
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
 			<version>2.9.1</version>
-			<scope>test</scope>
-		</dependency>
-
-		<!-- Elasticsearch table descriptor testing -->
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink-connectors/flink-sql-connector-elasticsearch6/pom.xml
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/pom.xml
@@ -38,8 +38,62 @@ under the License.
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-elasticsearch-base_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<exclusions>
+				<!-- Elasticsearch Java Client has been moved to a different module in 5.x -->
+				<exclusion>
+					<groupId>org.elasticsearch</groupId>
+					<artifactId>elasticsearch</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-elasticsearch6_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
+		</dependency>
+
+		<!-- Table ecosystem -->
+		<!-- Projects depending on this project won't depend on flink-table-*. -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-api-java-bridge_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-elasticsearch-base_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.elasticsearch</groupId>
+					<artifactId>elasticsearch</artifactId>
+				</exclusion>
+			</exclusions>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Elasticsearch table sink factory testing -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-json</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Elasticsearch table descriptor testing -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/flink-connectors/flink-sql-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/sql/connectors/elasticsearch6/Elasticsearch6UpsertTableSink.java
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/sql/connectors/elasticsearch6/Elasticsearch6UpsertTableSink.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.connectors.elasticsearch6;
+package org.apache.flink.streaming.sql.connectors.elasticsearch6;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
@@ -27,6 +27,8 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.connectors.elasticsearch.ActionRequestFailureHandler;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkBase;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchUpsertTableSinkBase;
+import org.apache.flink.streaming.connectors.elasticsearch6.ElasticsearchSink;
+import org.apache.flink.streaming.connectors.elasticsearch6.RestClientFactory;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.types.Row;
 

--- a/flink-connectors/flink-sql-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/sql/connectors/elasticsearch6/Elasticsearch6UpsertTableSinkFactory.java
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/sql/connectors/elasticsearch6/Elasticsearch6UpsertTableSinkFactory.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.connectors.elasticsearch6;
+package org.apache.flink.streaming.sql.connectors.elasticsearch6;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.serialization.SerializationSchema;

--- a/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.flink.streaming.connectors.elasticsearch6.Elasticsearch6UpsertTableSinkFactory
+org.apache.flink.streaming.sql.connectors.elasticsearch6.Elasticsearch6UpsertTableSinkFactory

--- a/flink-connectors/flink-sql-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/sql/connectors/elasticsearch6/Elasticsearch6UpsertTableSinkFactoryTest.java
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/sql/connectors/elasticsearch6/Elasticsearch6UpsertTableSinkFactoryTest.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.connectors.elasticsearch6;
+package org.apache.flink.streaming.sql.connectors.elasticsearch6;
 
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.serialization.SerializationSchema;
@@ -37,7 +37,7 @@ import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchUpsertTa
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchUpsertTableSinkBase.Host;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchUpsertTableSinkBase.SinkOption;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchUpsertTableSinkFactoryTestBase;
-import org.apache.flink.streaming.connectors.elasticsearch6.Elasticsearch6UpsertTableSink.DefaultRestClientFactory;
+import org.apache.flink.streaming.connectors.elasticsearch6.ElasticsearchSink;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.types.Row;
 
@@ -65,11 +65,11 @@ public class Elasticsearch6UpsertTableSinkFactoryTest extends ElasticsearchUpser
 		final TestElasticsearch6UpsertTableSink testSink = new TestElasticsearch6UpsertTableSink(
 			false,
 			schema,
-			Collections.singletonList(new Host(HOSTNAME, PORT, SCHEMA)),
-			INDEX,
-			DOC_TYPE,
-			KEY_DELIMITER,
-			KEY_NULL_LITERAL,
+			Collections.singletonList(new Host(ElasticsearchUpsertTableSinkFactoryTestBase.HOSTNAME, ElasticsearchUpsertTableSinkFactoryTestBase.PORT, ElasticsearchUpsertTableSinkFactoryTestBase.SCHEMA)),
+			ElasticsearchUpsertTableSinkFactoryTestBase.INDEX,
+			ElasticsearchUpsertTableSinkFactoryTestBase.DOC_TYPE,
+			ElasticsearchUpsertTableSinkFactoryTestBase.KEY_DELIMITER,
+			ElasticsearchUpsertTableSinkFactoryTestBase.KEY_NULL_LITERAL,
 			new JsonRowSerializationSchema(schema.toRowType()),
 			XContentType.JSON,
 			new DummyFailureHandler(),
@@ -82,12 +82,12 @@ public class Elasticsearch6UpsertTableSinkFactoryTest extends ElasticsearchUpser
 		testSink.emitDataStream(dataStreamMock);
 
 		final ElasticsearchSink.Builder<Tuple2<Boolean, Row>> expectedBuilder = new ElasticsearchSink.Builder<>(
-			Collections.singletonList(new HttpHost(HOSTNAME, PORT, SCHEMA)),
+			Collections.singletonList(new HttpHost(ElasticsearchUpsertTableSinkFactoryTestBase.HOSTNAME, ElasticsearchUpsertTableSinkFactoryTestBase.PORT, ElasticsearchUpsertTableSinkFactoryTestBase.SCHEMA)),
 			new ElasticsearchUpsertSinkFunction(
-				INDEX,
-				DOC_TYPE,
-				KEY_DELIMITER,
-				KEY_NULL_LITERAL,
+				ElasticsearchUpsertTableSinkFactoryTestBase.INDEX,
+				ElasticsearchUpsertTableSinkFactoryTestBase.DOC_TYPE,
+				ElasticsearchUpsertTableSinkFactoryTestBase.KEY_DELIMITER,
+				ElasticsearchUpsertTableSinkFactoryTestBase.KEY_NULL_LITERAL,
 				new JsonRowSerializationSchema(schema.toRowType()),
 				XContentType.JSON,
 				Elasticsearch6UpsertTableSink.UPDATE_REQUEST_FACTORY,
@@ -100,7 +100,7 @@ public class Elasticsearch6UpsertTableSinkFactoryTest extends ElasticsearchUpser
 		expectedBuilder.setBulkFlushInterval(100);
 		expectedBuilder.setBulkFlushMaxActions(1000);
 		expectedBuilder.setBulkFlushMaxSizeMb(1);
-		expectedBuilder.setRestClientFactory(new DefaultRestClientFactory(100, "/myapp"));
+		expectedBuilder.setRestClientFactory(new Elasticsearch6UpsertTableSink.DefaultRestClientFactory(100, "/myapp"));
 
 		assertEquals(expectedBuilder, testSink.builder);
 	}

--- a/flink-connectors/flink-sql-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/sql/connectors/elasticsearch6/Elasticsearch6UpsertTableSinkFactoryTest.java
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/sql/connectors/elasticsearch6/Elasticsearch6UpsertTableSinkFactoryTest.java
@@ -65,11 +65,11 @@ public class Elasticsearch6UpsertTableSinkFactoryTest extends ElasticsearchUpser
 		final TestElasticsearch6UpsertTableSink testSink = new TestElasticsearch6UpsertTableSink(
 			false,
 			schema,
-			Collections.singletonList(new Host(ElasticsearchUpsertTableSinkFactoryTestBase.HOSTNAME, ElasticsearchUpsertTableSinkFactoryTestBase.PORT, ElasticsearchUpsertTableSinkFactoryTestBase.SCHEMA)),
-			ElasticsearchUpsertTableSinkFactoryTestBase.INDEX,
-			ElasticsearchUpsertTableSinkFactoryTestBase.DOC_TYPE,
-			ElasticsearchUpsertTableSinkFactoryTestBase.KEY_DELIMITER,
-			ElasticsearchUpsertTableSinkFactoryTestBase.KEY_NULL_LITERAL,
+			Collections.singletonList(new Host(HOSTNAME, PORT, SCHEMA)),
+			INDEX,
+			DOC_TYPE,
+			KEY_DELIMITER,
+			KEY_NULL_LITERAL,
 			new JsonRowSerializationSchema(schema.toRowType()),
 			XContentType.JSON,
 			new DummyFailureHandler(),
@@ -82,12 +82,12 @@ public class Elasticsearch6UpsertTableSinkFactoryTest extends ElasticsearchUpser
 		testSink.emitDataStream(dataStreamMock);
 
 		final ElasticsearchSink.Builder<Tuple2<Boolean, Row>> expectedBuilder = new ElasticsearchSink.Builder<>(
-			Collections.singletonList(new HttpHost(ElasticsearchUpsertTableSinkFactoryTestBase.HOSTNAME, ElasticsearchUpsertTableSinkFactoryTestBase.PORT, ElasticsearchUpsertTableSinkFactoryTestBase.SCHEMA)),
+			Collections.singletonList(new HttpHost(HOSTNAME, PORT, SCHEMA)),
 			new ElasticsearchUpsertSinkFunction(
-				ElasticsearchUpsertTableSinkFactoryTestBase.INDEX,
-				ElasticsearchUpsertTableSinkFactoryTestBase.DOC_TYPE,
-				ElasticsearchUpsertTableSinkFactoryTestBase.KEY_DELIMITER,
-				ElasticsearchUpsertTableSinkFactoryTestBase.KEY_NULL_LITERAL,
+				INDEX,
+				DOC_TYPE,
+				KEY_DELIMITER,
+				KEY_NULL_LITERAL,
 				new JsonRowSerializationSchema(schema.toRowType()),
 				XContentType.JSON,
 				Elasticsearch6UpsertTableSink.UPDATE_REQUEST_FACTORY,

--- a/flink-connectors/flink-sql-connector-elasticsearch6/src/test/resources/log4j-test.properties
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/src/test/resources/log4j-test.properties
@@ -1,0 +1,24 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=INFO, testlogger
+
+log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
+log4j.appender.testlogger.target=System.err
+log4j.appender.testlogger.layout=org.apache.log4j.PatternLayout
+log4j.appender.testlogger.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n


### PR DESCRIPTION
## What is the purpose of the change

*This pull request try to refactor ES 6 connector to split table-specific code into flink-sql-connector-elasticsearch6*

## Brief change log

  - *Moved table-specific code from elasticsearch 6.x general connector to sql connector*
  - *changed pom file and some resource files*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
