### PR TITLE
[FLINK-14381][table] Partition field names should be got from CatalogTable instead of source/sink

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -163,8 +163,7 @@ public class HiveTableSink extends OutputFormatTableSink<Row> implements Partiti
 		return res;
 	}
 
-	@Override
-	public List<String> getPartitionFieldNames() {
+	private List<String> getPartitionFieldNames() {
 		return catalogTable.getPartitionKeys();
 	}
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -142,11 +142,6 @@ public class HiveTableSource extends InputFormatTableSource<Row> implements Part
 	}
 
 	@Override
-	public List<String> getPartitionFieldNames() {
-		return catalogTable.getPartitionKeys();
-	}
-
-	@Override
 	public TableSource applyPartitionPruning(List<Map<String, String>> remainingPartitions) {
 		if (catalogTable.getPartitionKeys() == null || catalogTable.getPartitionKeys().size() == 0) {
 			return this;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sinks/PartitionableTableSink.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sinks/PartitionableTableSink.java
@@ -20,16 +20,13 @@ package org.apache.flink.table.sinks;
 
 import org.apache.flink.annotation.Experimental;
 
-import java.util.List;
 import java.util.Map;
 
 /**
  * An interface for partitionable {@link TableSink}. A partitionable sink can writes
  * query results to partitions.
  *
- * <p>Partition columns are defined via {@link #getPartitionFieldNames()} and the field names
- * should be sorted in a strict order. And all the partition fields should exist in the
- * {@link TableSink#getTableSchema()}.
+ * <p>Partition columns are defined via catalog table.
  *
  * <p>For example, a partitioned table named {@code my_table} with a table schema
  * {@code [a INT, b VARCHAR, c DOUBLE, dt VARCHAR, country VARCHAR]} is partitioned on columns
@@ -61,17 +58,6 @@ import java.util.Map;
  */
 @Experimental
 public interface PartitionableTableSink {
-
-	/**
-	 * Gets the partition field names of the table. The partition field names should be sorted in
-	 * a strict order, i.e. they have the order as specified in the PARTITION statement in DDL.
-	 * This should be an empty set if the table is not partitioned.
-	 *
-	 * <p>All the partition fields should exist in the {@link TableSink#getTableSchema()}.
-	 *
-	 * @return partition field names of the table, empty if the table is not partitioned.
-	 */
-	List<String> getPartitionFieldNames();
 
 	/**
 	 * Sets the static partition into the {@link TableSink}. The static partition may be partial

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/PartitionableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/PartitionableTableSource.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.sources;
 
 import org.apache.flink.annotation.Experimental;
-import org.apache.flink.table.sinks.TableSink;
 
 import java.util.List;
 import java.util.Map;
@@ -33,7 +32,7 @@ import java.util.Map;
  *
  * <p>A partition is represented as a {@code Map<String, String>} which maps from partition
  * field name to partition value. Since the map is NOT ordered, the correct order of partition
- * fields should be obtained via {@link #getPartitionFieldNames()}.
+ * fields should be obtained via partition keys of catalog table.
  */
 @Experimental
 public interface PartitionableTableSource {
@@ -42,17 +41,6 @@ public interface PartitionableTableSource {
 	 * Returns all the partitions of this {@link PartitionableTableSource}.
 	 */
 	List<Map<String, String>> getPartitions();
-
-	/**
-	 * Gets the partition field names of the table. The partition field names should be sorted in
-	 * a strict order, i.e. they have the order as specified in the PARTITION statement in DDL.
-	 * This should be an empty set if the table is not partitioned.
-	 *
-	 * <p>All the partition fields should exist in the {@link TableSink#getTableSchema()}.
-	 *
-	 * @return partition field names of the table, empty if the table is not partitioned.
-	 */
-	List<String> getPartitionFieldNames();
 
 	/**
 	 * Applies the remaining partitions to the table source. The {@code remainingPartitions} is

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/DatabaseCalciteSchema.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/DatabaseCalciteSchema.java
@@ -143,7 +143,8 @@ class DatabaseCalciteSchema extends FlinkSchema {
 			return new TableSourceTable<>(
 					tableSource,
 					isStreamingMode,
-					FlinkStatistic.builder().tableStats(tableStats).build());
+					FlinkStatistic.builder().tableStats(tableStats).build(),
+					null);
 		} else {
 			Optional<TableSinkTable> tableSinkTable = table.getTableSink()
 				.map(tableSink -> new TableSinkTable<>(
@@ -180,7 +181,8 @@ class DatabaseCalciteSchema extends FlinkSchema {
 		return new TableSourceTable<>(
 			tableSource,
 			!((StreamTableSource<?>) tableSource).isBounded(),
-			FlinkStatistic.UNKNOWN()
+			FlinkStatistic.UNKNOWN(),
+			table
 		);
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/QueryOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/QueryOperationConverter.java
@@ -354,7 +354,8 @@ public class QueryOperationConverter extends QueryOperationDefaultVisitor<RelNod
 				names = Collections.singletonList(refId);
 			}
 
-			TableSourceTable<?> tableSourceTable = new TableSourceTable<>(tableSource, !isBatch, statistic);
+			TableSourceTable<?> tableSourceTable = new TableSourceTable<>(
+					tableSource, !isBatch, statistic, null);
 			FlinkRelOptTable table = FlinkRelOptTable.create(
 				relBuilder.getRelOptSchema(),
 				tableSourceTable.getRowType(relBuilder.getTypeFactory()),

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/RelTimeIndicatorConverter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/RelTimeIndicatorConverter.scala
@@ -184,7 +184,8 @@ class RelTimeIndicatorConverter(rexBuilder: RexBuilder) extends RelShuttle {
         sink.getTraitSet,
         newInput,
         sink.sink,
-        sink.sinkName)
+        sink.sinkName,
+        sink.catalogTable)
 
     case _ =>
       throw new TableException(s"Unsupported logical operator: ${other.getClass.getSimpleName}")

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/LogicalSink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/LogicalSink.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.plan.nodes.calcite
 
+import org.apache.flink.table.catalog.CatalogTable
 import org.apache.flink.table.sinks.TableSink
 
 import org.apache.calcite.plan.{Convention, RelOptCluster, RelTraitSet}
@@ -37,11 +38,13 @@ final class LogicalSink(
     traitSet: RelTraitSet,
     input: RelNode,
     sink: TableSink[_],
-    sinkName: String)
+    sinkName: String,
+    val catalogTable: CatalogTable)
   extends Sink(cluster, traitSet, input, sink, sinkName) {
 
   override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
-    new LogicalSink(cluster, traitSet, inputs.head, sink, sinkName)
+    new LogicalSink(
+      cluster, traitSet, inputs.head, sink, sinkName, catalogTable)
   }
 
 }
@@ -50,8 +53,10 @@ object LogicalSink {
 
   def create(input: RelNode,
       sink: TableSink[_],
-      sinkName: String): LogicalSink = {
+      sinkName: String,
+      catalogTable: CatalogTable = null): LogicalSink = {
     val traits = input.getCluster.traitSetOf(Convention.NONE)
-    new LogicalSink(input.getCluster, traits, input, sink, sinkName)
+    new LogicalSink(
+      input.getCluster, traits, input, sink, sinkName, catalogTable)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalSink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalSink.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.plan.nodes.logical
 
+import org.apache.flink.table.catalog.CatalogTable
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.calcite.{LogicalSink, Sink}
 import org.apache.flink.table.sinks.TableSink
@@ -39,12 +40,14 @@ class FlinkLogicalSink(
     traitSet: RelTraitSet,
     input: RelNode,
     sink: TableSink[_],
-    sinkName: String)
+    sinkName: String,
+    val catalogTable: CatalogTable)
   extends Sink(cluster, traitSet, input, sink, sinkName)
   with FlinkLogicalRel {
 
   override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
-    new FlinkLogicalSink(cluster, traitSet, inputs.head, sink, sinkName)
+    new FlinkLogicalSink(
+      cluster, traitSet, inputs.head, sink, sinkName, catalogTable)
   }
 
 }
@@ -62,7 +65,8 @@ private class FlinkLogicalSinkConverter
     FlinkLogicalSink.create(
       newInput,
       sink.sink,
-      sink.sinkName)
+      sink.sinkName,
+      sink.catalogTable)
   }
 }
 
@@ -72,9 +76,11 @@ object FlinkLogicalSink {
   def create(
       input: RelNode,
       sink: TableSink[_],
-      sinkName: String): FlinkLogicalSink = {
+      sinkName: String,
+      catalogTable: CatalogTable = null): FlinkLogicalSink = {
     val cluster = input.getCluster
     val traitSet = cluster.traitSetOf(FlinkConventions.LOGICAL).simplify()
-    new FlinkLogicalSink(cluster, traitSet, input, sink, sinkName)
+    new FlinkLogicalSink(
+      cluster, traitSet, input, sink, sinkName, catalogTable)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.scala
@@ -151,7 +151,10 @@ class PushFilterIntoTableSourceScanRule extends RelOptRule(
       FlinkStatistic.builder().statistic(statistic).tableStats(null).build()
     }
     val newTableSourceTable = new TableSourceTable(
-      newTableSource, tableSourceTable.isStreamingMode, newStatistic)
+      newTableSource,
+      tableSourceTable.isStreamingMode,
+      newStatistic,
+      tableSourceTable.catalogTable)
     relOptTable.copy(newTableSourceTable, tableSourceTable.getRowType(typeFactory))
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoTableSourceScanRule.scala
@@ -18,17 +18,18 @@
 
 package org.apache.flink.table.planner.plan.rules.logical
 
+import org.apache.flink.table.api.TableException
 import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkTypeFactory}
 import org.apache.flink.table.planner.plan.schema.{FlinkRelOptTable, TableSourceTable}
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
 import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, PartitionPruner, RexNodeExtractor}
 import org.apache.flink.table.sources.PartitionableTableSource
+
 import org.apache.calcite.plan.RelOptRule.{none, operand}
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
 import org.apache.calcite.rel.core.Filter
 import org.apache.calcite.rel.logical.LogicalTableScan
 import org.apache.calcite.rex.{RexInputRef, RexNode, RexShuttle}
-import org.apache.flink.table.api.TableException
 
 import scala.collection.JavaConversions._
 
@@ -49,11 +50,9 @@ class PushPartitionIntoTableSourceScanRule extends RelOptRule(
 
     val scan: LogicalTableScan = call.rel(1)
     scan.getTable.unwrap(classOf[TableSourceTable[_]]) match {
-      case table: TableSourceTable[_] =>
-        table.tableSource match {
-          case p: PartitionableTableSource => p.getPartitionFieldNames.nonEmpty
-          case _ => false
-        }
+      case table: TableSourceTable[_] => table.catalogTable != null &&
+          table.catalogTable.isPartitioned &&
+          table.tableSource.isInstanceOf[PartitionableTableSource]
       case _ => false
     }
   }
@@ -62,18 +61,12 @@ class PushPartitionIntoTableSourceScanRule extends RelOptRule(
     val filter: Filter = call.rel(0)
     val scan: LogicalTableScan = call.rel(1)
     val table: FlinkRelOptTable = scan.getTable.asInstanceOf[FlinkRelOptTable]
-    pushPartitionIntoScan(call, filter, scan, table)
-  }
 
-  private def pushPartitionIntoScan(
-      call: RelOptRuleCall,
-      filter: Filter,
-      scan: LogicalTableScan,
-      relOptTable: FlinkRelOptTable): Unit = {
+    val tableSourceTable = table.unwrap(classOf[TableSourceTable[_]])
 
-    val tableSourceTable = relOptTable.unwrap(classOf[TableSourceTable[_]])
+    val partitionFieldNames = tableSourceTable.catalogTable.getPartitionKeys.toSeq.toArray[String]
+
     val tableSource = tableSourceTable.tableSource.asInstanceOf[PartitionableTableSource]
-    val partitionFieldNames = tableSource.getPartitionFieldNames.toList.toArray
     val inputFieldType = filter.getInput.getRowType
 
     val relBuilder = call.builder()
@@ -131,8 +124,11 @@ class PushPartitionIntoTableSourceScanRule extends RelOptRule(
       FlinkStatistic.builder().statistic(statistic).tableStats(null).build()
     }
     val newTableSourceTable = new TableSourceTable(
-      newTableSource, tableSourceTable.isStreamingMode, newStatistic)
-   val newRelOptTable = relOptTable.copy(newTableSourceTable, relOptTable.getRowType)
+      newTableSource,
+      tableSourceTable.isStreamingMode,
+      newStatistic,
+      tableSourceTable.catalogTable)
+    val newRelOptTable = table.copy(newTableSourceTable, table.getRowType)
 
     val newScan = new LogicalTableScan(scan.getCluster, scan.getTraitSet, newRelOptTable)
     // check whether framework still need to do a filter

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRule.scala
@@ -98,7 +98,8 @@ class PushProjectIntoTableSourceScanRule extends RelOptRule(
       newTableSource,
       tableSourceTable.isStreamingMode,
       tableSourceTable.statistic,
-      Option(usedFields))
+      Option(usedFields),
+      tableSourceTable.catalogTable)
     // row type is changed after project push down
     val newRowType = newTableSourceTable.getRowType(scan.getCluster.getTypeFactory)
     val newRelOptTable = relOptTable.copy(newTableSourceTable, newRowType)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecSinkRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecSinkRule.scala
@@ -31,8 +31,6 @@ import org.apache.calcite.rel.convert.ConverterRule
 import org.apache.calcite.rel.{RelCollations, RelNode}
 
 import scala.collection.JavaConversions._
-import org.apache.calcite.rel.RelNode
-import org.apache.calcite.rel.convert.ConverterRule
 
 class BatchExecSinkRule extends ConverterRule(
     classOf[FlinkLogicalSink],
@@ -44,32 +42,27 @@ class BatchExecSinkRule extends ConverterRule(
     val sinkNode = rel.asInstanceOf[FlinkLogicalSink]
     val newTrait = rel.getTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
     var requiredTraitSet = sinkNode.getInput.getTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
-    sinkNode.sink match {
-      case partitionSink: PartitionableTableSink
-        if partitionSink.getPartitionFieldNames != null &&
-          partitionSink.getPartitionFieldNames.nonEmpty =>
-        val partitionFields = partitionSink.getPartitionFieldNames
-        val partitionIndices = partitionFields
-          .map(partitionSink.getTableSchema.getFieldNames.indexOf(_))
-        // validate
-        partitionIndices.foreach { idx =>
-          if (idx < 0) {
-            throw new TableException(s"Partitionable sink ${sinkNode.sinkName} field " +
-              s"${partitionFields.get(idx)} must be in the schema.")
+    if (sinkNode.catalogTable != null && sinkNode.catalogTable.isPartitioned) {
+      sinkNode.sink match {
+        case partitionSink: PartitionableTableSink =>
+          val partKeys = sinkNode.catalogTable.getPartitionKeys
+          val partitionIndices =
+            partKeys.map(partitionSink.getTableSchema.getFieldNames.indexOf(_))
+
+          requiredTraitSet = requiredTraitSet.plus(
+            FlinkRelDistribution.hash(partitionIndices
+                .map(Integer.valueOf), requireStrict = false))
+
+          if (partitionSink.configurePartitionGrouping(true)) {
+            // default to asc.
+            val fieldCollations = partitionIndices.map(FlinkRelOptUtil.ofRelFieldCollation)
+            requiredTraitSet = requiredTraitSet.plus(RelCollations.of(fieldCollations: _*))
           }
-        }
-
-        requiredTraitSet = requiredTraitSet.plus(
-          FlinkRelDistribution.hash(partitionIndices
-            .map(Integer.valueOf), requireStrict = false))
-
-        if (partitionSink.configurePartitionGrouping(true)) {
-          // default to asc.
-          val fieldCollations = partitionIndices.map(FlinkRelOptUtil.ofRelFieldCollation)
-          requiredTraitSet = requiredTraitSet.plus(RelCollations.of(fieldCollations: _*))
-        }
-      case _ =>
+        case _ => throw new TableException("We need PartitionableTableSink to write data to" +
+            s" partitioned table: ${sinkNode.sinkName}")
+      }
     }
+
     val newInput = RelOptRule.convert(sinkNode.getInput, requiredTraitSet)
 
     new BatchExecSink(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecSinkRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecSinkRule.scala
@@ -42,32 +42,27 @@ class StreamExecSinkRule extends ConverterRule(
     val sinkNode = rel.asInstanceOf[FlinkLogicalSink]
     val newTrait = rel.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
     var requiredTraitSet = sinkNode.getInput.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
-    sinkNode.sink match {
-      case partitionSink: PartitionableTableSink
-        if partitionSink.getPartitionFieldNames != null &&
-          partitionSink.getPartitionFieldNames.nonEmpty =>
-        val partitionFields = partitionSink.getPartitionFieldNames
-        val partitionIndices = partitionFields
-          .map(partitionSink.getTableSchema.getFieldNames.indexOf(_))
-        // validate
-        partitionIndices.foreach { idx =>
-          if (idx < 0) {
-            throw new TableException(s"Partitionable sink ${sinkNode.sinkName} field " +
-              s"${partitionFields.get(idx)} must be in the schema.")
+    if (sinkNode.catalogTable != null && sinkNode.catalogTable.isPartitioned) {
+      sinkNode.sink match {
+        case partitionSink: PartitionableTableSink =>
+          val partKeys = sinkNode.catalogTable.getPartitionKeys
+          val partitionIndices = partKeys
+              .map(partitionSink.getTableSchema.getFieldNames.indexOf(_))
+
+          if (partitionSink.configurePartitionGrouping(false)) {
+            throw new TableException("Partition grouping in stream mode is not supported yet!")
           }
-        }
 
-        if (partitionSink.configurePartitionGrouping(false)) {
-          throw new TableException("Partition grouping in stream mode is not supported yet!")
-        }
-
-        if (!partitionSink.isInstanceOf[DataStreamTableSink[_]]) {
-          requiredTraitSet = requiredTraitSet.plus(
-            FlinkRelDistribution.hash(partitionIndices
-              .map(Integer.valueOf), requireStrict = false))
-        }
-      case _ =>
+          if (!partitionSink.isInstanceOf[DataStreamTableSink[_]]) {
+            requiredTraitSet = requiredTraitSet.plus(
+              FlinkRelDistribution.hash(partitionIndices
+                  .map(Integer.valueOf), requireStrict = false))
+          }
+        case _ => throw new TableException("We need PartitionableTableSink to write data to" +
+            s" partitioned table: ${sinkNode.sinkName}")
+      }
     }
+
     val newInput = RelOptRule.convert(sinkNode.getInput, requiredTraitSet)
 
     new StreamExecSink(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/TableSourceTable.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/TableSourceTable.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.plan.schema
 
+import org.apache.flink.table.catalog.CatalogTable
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
 import org.apache.flink.table.planner.sources.TableSourceUtil
@@ -37,11 +38,16 @@ class TableSourceTable[T](
     val tableSource: TableSource[T],
     val isStreamingMode: Boolean,
     val statistic: FlinkStatistic,
-    val selectedFields: Option[Array[Int]])
+    val selectedFields: Option[Array[Int]],
+    val catalogTable: CatalogTable)
   extends FlinkTable {
 
-  def this(tableSource: TableSource[T], isStreamingMode: Boolean, statistic: FlinkStatistic) {
-    this(tableSource, isStreamingMode, statistic, None)
+  def this(
+      tableSource: TableSource[T],
+      isStreamingMode: Boolean,
+      statistic: FlinkStatistic,
+      catalogTable: CatalogTable) {
+    this(tableSource, isStreamingMode, statistic, None, catalogTable)
   }
 
   // TODO implements this
@@ -62,7 +68,7 @@ class TableSourceTable[T](
     * @return Copy of this table, substituting statistic.
     */
   override def copy(statistic: FlinkStatistic): TableSourceTable[T] = {
-    new TableSourceTable(tableSource, isStreamingMode, statistic)
+    new TableSourceTable(tableSource, isStreamingMode, statistic, catalogTable)
   }
 
   /**
@@ -77,6 +83,7 @@ class TableSourceTable[T](
     * @return new TableSourceTable
     */
   def replaceTableSource(tableSource: TableSource[T]): TableSourceTable[T] = {
-    new TableSourceTable[T](tableSource, isStreamingMode, statistic)
+    new TableSourceTable[T](
+      tableSource, isStreamingMode, statistic, catalogTable)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink-table/flink-table-planner-blink/src/test/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -14,3 +14,5 @@
 # limitations under the License.
 
 org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory
+org.apache.flink.table.planner.runtime.batch.sql.TestPartitionableSinkFactory
+org.apache.flink.table.planner.utils.TestPartitionableSourceFactory

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/TableSourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/TableSourceTest.scala
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, LocalTimeTypeInfo, T
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.table.api.{DataTypes, TableSchema, Types, ValidationException}
 import org.apache.flink.table.planner.expressions.utils.Func1
-import org.apache.flink.table.planner.utils.{DateTimeTestUtil, TableTestBase, TestFilterableTableSource, TestNestedProjectableTableSource, TestPartitionableTableSource, TestProjectableTableSource, TestTableSource}
+import org.apache.flink.table.planner.utils.{DateTimeTestUtil, TableTestBase, TestFilterableTableSource, TestNestedProjectableTableSource, TestPartitionableSourceFactory, TestProjectableTableSource, TestTableSource}
 import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter
 import org.apache.flink.table.sources.TableSource
 import org.apache.flink.table.types.DataType
@@ -48,7 +48,7 @@ class TableSourceTest extends TableTestBase {
       Seq.empty[Row])
     )
     util.tableEnv.registerTableSource("FilterableTable", TestFilterableTableSource(true))
-    util.tableEnv.registerTableSource("PartitionableTable", new TestPartitionableTableSource(true))
+    TestPartitionableSourceFactory.registerTableSource(util.tableEnv, "PartitionableTable", true)
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoTableSourceScanRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoTableSourceScanRuleTest.scala
@@ -19,7 +19,7 @@ package org.apache.flink.table.planner.plan.rules.logical
 
 import org.apache.flink.table.planner.expressions.utils.Func1
 import org.apache.flink.table.planner.plan.optimize.program.{FlinkBatchProgram, FlinkHepRuleSetProgramBuilder, HEP_RULES_EXECUTION_TYPE}
-import org.apache.flink.table.planner.utils.{TableConfigUtils, TableTestBase, TestPartitionableTableSource}
+import org.apache.flink.table.planner.utils.{TableConfigUtils, TableTestBase, TestPartitionableSourceFactory}
 
 import org.apache.calcite.plan.hep.HepMatchOrder
 import org.apache.calcite.tools.RuleSets
@@ -44,7 +44,7 @@ class PushPartitionIntoTableSourceScanRuleTest extends TableTestBase {
         .build()
     )
 
-    util.tableEnv.registerTableSource("MyTable", new TestPartitionableTableSource(true))
+    TestPartitionableSourceFactory.registerTableSource(util.tableEnv, "MyTable", true)
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.scala
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, SqlTimeTypeInfo, Typ
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.table.api.{DataTypes, TableSchema, Types, ValidationException}
 import org.apache.flink.table.planner.expressions.utils.Func1
-import org.apache.flink.table.planner.utils.{DateTimeTestUtil, TableTestBase, TestFilterableTableSource, TestNestedProjectableTableSource, TestPartitionableTableSource, TestProjectableTableSource, TestTableSource, TestTableSourceWithTime}
+import org.apache.flink.table.planner.utils.{DateTimeTestUtil, TableTestBase, TestFilterableTableSource, TestNestedProjectableTableSource, TestPartitionableSourceFactory, TestProjectableTableSource, TestTableSource, TestTableSourceWithTime}
 import org.apache.flink.table.sources.TableSource
 import org.apache.flink.table.types.DataType
 import org.apache.flink.types.Row
@@ -40,7 +40,7 @@ class TableSourceTest extends TableTestBase {
   @Before
   def setup(): Unit = {
     util.tableEnv.registerTableSource("FilterableTable", TestFilterableTableSource(false))
-    util.tableEnv.registerTableSource("PartitionableTable", new TestPartitionableTableSource(false))
+    TestPartitionableSourceFactory.registerTableSource(util.tableEnv, "PartitionableTable", false)
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSinkITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSinkITCase.scala
@@ -165,16 +165,6 @@ class PartitionableSinkITCase extends BatchTestBase {
   }
 
   @Test
-  def testDynamicPartitionInFrontOfStaticPartition(): Unit = {
-    expectedEx.expect(classOf[ValidationException])
-    expectedEx.expectMessage("Static partition column b "
-      + "should appear before dynamic partition a")
-    registerTableSink(partitionColumns = Array("a", "b"))
-    tEnv.sqlUpdate("insert into sinkTable partition(b=1) select a, c from sortTable")
-    tEnv.execute("testJob")
-  }
-
-  @Test
   def testStaticPartitionNotInPartitionFields(): Unit = {
     expectedEx.expect(classOf[ValidationException])
     registerTableSink(tableName = "sinkTable2", rowType = type4,

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSinkITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSinkITCase.scala
@@ -23,14 +23,21 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.datastream.{DataStream, DataStreamSink}
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction
 import org.apache.flink.table.api.config.ExecutionConfigOptions
-import org.apache.flink.table.api.{SqlDialect, TableSchema, ValidationException}
+import org.apache.flink.table.api.{SqlDialect, TableException, TableSchema, ValidationException}
+import org.apache.flink.table.catalog.{CatalogTableImpl, ObjectPath}
+import org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE
+import org.apache.flink.table.descriptors.DescriptorProperties
+import org.apache.flink.table.descriptors.Schema.SCHEMA
+import org.apache.flink.table.factories.{TableSinkFactory, TableSourceFactory}
 import org.apache.flink.table.planner.runtime.batch.sql.PartitionableSinkITCase._
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TestData._
 import org.apache.flink.table.sinks.{PartitionableTableSink, StreamTableSink, TableSink}
+import org.apache.flink.table.sources.{StreamTableSource, TableSource}
 import org.apache.flink.table.types.logical.{BigIntType, IntType, VarCharType}
 import org.apache.flink.types.Row
 
@@ -38,9 +45,11 @@ import org.junit.Assert._
 import org.junit.rules.ExpectedException
 import org.junit.{Before, Rule, Test}
 
-import java.util.{ArrayList => JArrayList, LinkedList => JLinkedList, List => JList, Map => JMap}
+import java.util
+import java.util.{function, ArrayList => JArrayList, LinkedList => JLinkedList, List => JList, Map => JMap}
 
 import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.collection.Seq
 
 /**
@@ -115,11 +124,9 @@ class PartitionableSinkITCase extends BatchTestBase {
 
   @Test
   def testInsertWithStaticPartitions(): Unit = {
-    val testSink = registerTableSink()
+    registerTableSink()
     tEnv.sqlUpdate("insert into sinkTable partition(a=1) select b, c from sortTable")
     tEnv.execute("testJob")
-    // this sink should have been set up with static partitions
-    assertEquals(testSink.getStaticPartitions.toMap, Map("a" -> "1"))
     assertEquals(List("1,2,Hi",
       "1,1,Hello world",
       "1,2,Hello",
@@ -138,11 +145,9 @@ class PartitionableSinkITCase extends BatchTestBase {
 
   @Test
   def testInsertWithStaticAndDynamicPartitions(): Unit = {
-    val testSink = registerTableSink(partitionColumns = Array("a", "b"))
+    registerTableSink(partitionColumns = Array("a", "b"))
     tEnv.sqlUpdate("insert into sinkTable partition(a=1) select b, c from sortTable")
     tEnv.execute("testJob")
-    // this sink should have been set up with static partitions
-    assertEquals(testSink.getStaticPartitions.toMap, Map("a" -> "1"))
     assertEquals(List("1,3,I'm fine, thank",
       "1,3,I'm fine, thank you",
       "1,3,I'm fine, thank you, and you?"),
@@ -172,8 +177,6 @@ class PartitionableSinkITCase extends BatchTestBase {
   @Test
   def testStaticPartitionNotInPartitionFields(): Unit = {
     expectedEx.expect(classOf[ValidationException])
-    expectedEx.expectMessage("Static partition column c " +
-      "should be in the partition fields list [a, b].")
     registerTableSink(tableName = "sinkTable2", rowType = type4,
       partitionColumns = Array("a", "b"))
     tEnv.sqlUpdate("insert into sinkTable2 partition(c=1) select a, b from sinkTable2")
@@ -182,9 +185,7 @@ class PartitionableSinkITCase extends BatchTestBase {
 
   @Test
   def testInsertStaticPartitionOnNonPartitionedSink(): Unit = {
-    expectedEx.expect(classOf[ValidationException])
-    expectedEx.expectMessage(
-      "Can't insert static partitions into a non-partitioned table sink.")
+    expectedEx.expect(classOf[TableException])
     registerTableSink(tableName = "sinkTable2", rowType = type4, partitionColumns = Array())
     tEnv.sqlUpdate("insert into sinkTable2 partition(c=1) select a, b from sinkTable2")
     tEnv.execute("testJob")
@@ -194,51 +195,22 @@ class PartitionableSinkITCase extends BatchTestBase {
       tableName: String = "sinkTable",
       rowType: RowTypeInfo = type3,
       grouping: Boolean = true,
-      partitionColumns: Array[String] = Array[String]("a")): TestSink = {
-    val testSink = new TestSink(rowType, grouping, partitionColumns)
-    tEnv.registerTableSink(tableName, testSink)
-    testSink
-  }
-
-  private class TestSink(
-      rowType: RowTypeInfo,
-      supportsGrouping: Boolean,
-      partitionColumns: Array[String])
-    extends StreamTableSink[Row]
-    with PartitionableTableSink {
-    private var staticPartitions: JMap[String, String] = _
-
-    override def getPartitionFieldNames: JList[String] = partitionColumns.toList
-
-    override def setStaticPartition(partitions: JMap[String, String]): Unit =
-      this.staticPartitions = partitions
-
-    override def configure(fieldNames: Array[String],
-      fieldTypes: Array[TypeInformation[_]]): TableSink[Row] = this
-
-    override def configurePartitionGrouping(s: Boolean): Boolean = {
-      supportsGrouping
+      partitionColumns: Array[String] = Array[String]("a")): Unit = {
+    val properties = new DescriptorProperties()
+    properties.putString("supports-grouping", grouping.toString)
+    properties.putString(CONNECTOR_TYPE, "TestPartitionableSink")
+    partitionColumns.zipWithIndex.foreach { case (part, i) =>
+      properties.putString("partition-column." + i, part)
     }
 
-    override def getTableSchema: TableSchema = {
-      new TableSchema(Array("a", "b", "c"), type3.getFieldTypes)
-    }
-
-    override def getOutputType: RowTypeInfo = type3
-
-    override def emitDataStream(dataStream: DataStream[Row]): Unit = {
-      dataStream.addSink(new UnsafeMemorySinkFunction(type3))
-        .setParallelism(dataStream.getParallelism)
-    }
-
-    override def consumeDataStream(dataStream: DataStream[Row]): DataStreamSink[_] = {
-      dataStream.addSink(new UnsafeMemorySinkFunction(type3))
-        .setParallelism(dataStream.getParallelism)
-    }
-
-    def getStaticPartitions: JMap[String, String] = {
-      staticPartitions
-    }
+    val table = new CatalogTableImpl(
+      new TableSchema(Array("a", "b", "c"), rowType.getFieldTypes),
+      util.Arrays.asList[String](partitionColumns: _*),
+      properties.asMap(),
+      ""
+    )
+    tEnv.getCatalog(tEnv.getCurrentCatalog).get()
+        .createTable(new ObjectPath(tEnv.getCurrentDatabase, tableName), table, false)
   }
 }
 
@@ -311,3 +283,93 @@ object PartitionableSinkITCase {
     row(4, 4L, "你好，陌生人，我是中国人，你来自哪里？")
   )
 }
+
+private class TestSink(
+    rowType: RowTypeInfo,
+    supportsGrouping: Boolean,
+    partitionColumns: Array[String])
+    extends StreamTableSink[Row]
+        with PartitionableTableSink {
+  private var staticPartitions: JMap[String, String] = _
+
+  override def getPartitionFieldNames: JList[String] = partitionColumns.toList
+
+  override def setStaticPartition(partitions: JMap[String, String]): Unit =
+    this.staticPartitions = partitions
+
+  override def configure(fieldNames: Array[String],
+      fieldTypes: Array[TypeInformation[_]]): TableSink[Row] = this
+
+  override def configurePartitionGrouping(s: Boolean): Boolean = {
+    supportsGrouping
+  }
+
+  override def getTableSchema: TableSchema = {
+    new TableSchema(Array("a", "b", "c"), type3.getFieldTypes)
+  }
+
+  override def getOutputType: RowTypeInfo = type3
+
+  override def emitDataStream(dataStream: DataStream[Row]): Unit = {
+    dataStream.addSink(new UnsafeMemorySinkFunction(type3))
+        .setParallelism(dataStream.getParallelism)
+  }
+
+  override def consumeDataStream(dataStream: DataStream[Row]): DataStreamSink[_] = {
+    dataStream.addSink(new UnsafeMemorySinkFunction(type3))
+        .setParallelism(dataStream.getParallelism)
+  }
+
+  def getStaticPartitions: JMap[String, String] = {
+    staticPartitions
+  }
+}
+
+class TestPartitionableSinkFactory extends TableSinkFactory[Row] with TableSourceFactory[Row] {
+
+  override def requiredContext(): util.Map[String, String] = {
+    val context = new util.HashMap[String, String]()
+    context.put(CONNECTOR_TYPE, "TestPartitionableSink")
+    context
+  }
+
+  override def supportedProperties(): util.List[String] = {
+    val supported = new util.ArrayList[String]()
+    supported.add("*")
+    supported
+  }
+
+  override def createTableSink(properties: util.Map[String, String]): TableSink[Row] = {
+    val dp = new DescriptorProperties()
+    dp.putProperties(properties)
+
+    val schema = dp.getTableSchema(SCHEMA)
+    val supportsGrouping = dp.getBoolean("supports-grouping")
+    val partitionColumns = dp.getArray("partition-column", new function.Function[String, String] {
+      override def apply(t: String): String = dp.getString(t)
+    })
+    new TestSink(
+      schema.toRowType.asInstanceOf[RowTypeInfo],
+      supportsGrouping,
+      partitionColumns.asScala.toArray[String])
+  }
+
+  /**
+    * Remove it after FLINK-14387.
+    */
+  override def createTableSource(properties: JMap[String, String]): TableSource[Row] = {
+    val dp = new DescriptorProperties()
+    dp.putProperties(properties)
+
+    new StreamTableSource[Row] {
+      override def getTableSchema: TableSchema = {
+        dp.getTableSchema(SCHEMA)
+      }
+
+      override def getDataStream(execEnv: StreamExecutionEnvironment): DataStream[Row] = {
+        throw new RuntimeException
+      }
+    }
+  }
+}
+

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSinkITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSinkITCase.scala
@@ -282,8 +282,6 @@ private class TestSink(
         with PartitionableTableSink {
   private var staticPartitions: JMap[String, String] = _
 
-  override def getPartitionFieldNames: JList[String] = partitionColumns.toList
-
   override def setStaticPartition(partitions: JMap[String, String]): Unit =
     this.staticPartitions = partitions
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSourceITCase.scala
@@ -24,13 +24,13 @@ import org.apache.flink.table.api.{DataTypes, TableSchema, Types}
 import org.apache.flink.table.planner.runtime.utils.BatchAbstractTestBase.TEMPORARY_FOLDER
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.{BatchTestBase, TestData}
-import org.apache.flink.table.planner.utils.{TestDataTypeTableSource, TestFileInputFormatTableSource, TestFilterableTableSource, TestInputFormatTableSource, TestNestedProjectableTableSource, TestPartitionableTableSource, TestProjectableTableSource, TestTableSources}
+import org.apache.flink.table.planner.utils.{TestDataTypeTableSource, TestFileInputFormatTableSource, TestFilterableTableSource, TestInputFormatTableSource, TestNestedProjectableTableSource, TestPartitionableSourceFactory, TestProjectableTableSource, TestTableSources}
 import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter
 import org.apache.flink.types.Row
 
 import org.junit.{Before, Test}
 
-import java.io.{File, FileWriter}
+import java.io.FileWriter
 import java.lang.{Boolean => JBool, Integer => JInt, Long => JLong}
 
 class TableSourceITCase extends BatchTestBase {
@@ -154,7 +154,7 @@ class TableSourceITCase extends BatchTestBase {
 
   @Test
   def testTableSourceWithPartitionable(): Unit = {
-    tEnv.registerTableSource("PartitionableTable", new TestPartitionableTableSource(true))
+    TestPartitionableSourceFactory.registerTableSource(tEnv, "PartitionableTable", true)
     checkResult(
       "SELECT * FROM PartitionableTable WHERE part2 > 1 and id > 2 AND part1 = 'A'",
       Seq(row(3, "John", "A", 2), row(4, "nosharp", "A", 2))

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSourceITCase.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.{DataTypes, TableSchema, Types}
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.{StreamingTestBase, TestData, TestingAppendSink}
-import org.apache.flink.table.planner.utils.{TestDataTypeTableSource, TestFilterableTableSource, TestInputFormatTableSource, TestNestedProjectableTableSource, TestPartitionableTableSource, TestProjectableTableSource, TestStreamTableSource, TestTableSources}
+import org.apache.flink.table.planner.utils.{TestDataTypeTableSource, TestFilterableTableSource, TestInputFormatTableSource, TestNestedProjectableTableSource, TestPartitionableSourceFactory, TestProjectableTableSource, TestStreamTableSource, TestTableSources}
 import org.apache.flink.types.Row
 
 import org.junit.Assert._
@@ -320,7 +320,7 @@ class TableSourceITCase extends StreamingTestBase {
 
   @Test
   def testTableSourceWithPartitionable(): Unit = {
-    tEnv.registerTableSource("PartitionableTable", new TestPartitionableTableSource(true))
+    TestPartitionableSourceFactory.registerTableSource(tEnv, "PartitionableTable", true)
 
     val sqlQuery = "SELECT * FROM PartitionableTable WHERE part2 > 1 and id > 2 AND part1 = 'A'"
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/testTableSources.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/testTableSources.scala
@@ -578,8 +578,6 @@ class TestPartitionableTableSource(
     Map("part1"->"C", "part2"->"1").asJava
   ).asJava
 
-  override def getPartitionFieldNames: JList[String] = List("part1", "part2").asJava
-
   override def applyPartitionPruning(
       remainingPartitions: JList[JMap[String, String]]): TableSource[_] = {
     new TestPartitionableTableSource(isBounded, remainingPartitions)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/BatchTableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/BatchTableEnvImpl.scala
@@ -49,7 +49,6 @@ import org.apache.flink.table.utils.TableConnectorUtils
 import org.apache.flink.types.Row
 
 import _root_.scala.collection.JavaConverters._
-import _root_.scala.collection.JavaConversions._
 
 /**
   * The abstract base class for the implementation of batch TableEnvironments.
@@ -118,13 +117,12 @@ abstract class BatchTableEnvImpl(
         // translate the Table into a DataSet and provide the type that the TableSink expects.
         val result: DataSet[T] = translate(table)(outputType)
         // Give the DataSet to the TableSink to emit it.
-        batchSink.emitDataSet(shuffleByPartitionFieldsIfNeeded(batchSink, result))
+        batchSink.emitDataSet(result)
       case boundedSink: OutputFormatTableSink[T] =>
         val outputType = fromDataTypeToLegacyInfo(sink.getConsumedDataType)
           .asInstanceOf[TypeInformation[T]]
         // translate the Table into a DataSet and provide the type that the TableSink expects.
-        val translated: DataSet[T] = translate(table)(outputType)
-        val result = shuffleByPartitionFieldsIfNeeded(boundedSink, translated)
+        val result: DataSet[T] = translate(table)(outputType)
         // use the OutputFormat to consume the DataSet.
         val dataSink = result.output(boundedSink.getOutputFormat)
         dataSink.name(
@@ -134,26 +132,6 @@ abstract class BatchTableEnvImpl(
       case _ =>
         throw new TableException(
           "BatchTableSink or OutputFormatTableSink required to emit batch Table.")
-    }
-  }
-
-  /**
-    * Key by the partition fields if the sink is a [[PartitionableTableSink]].
-    * @param sink    the table sink
-    * @param dataSet the data set
-    * @tparam R      the data set record type
-    * @return a data set that maybe keyed by.
-    */
-  private def shuffleByPartitionFieldsIfNeeded[R](
-      sink: TableSink[_],
-      dataSet: DataSet[R]): DataSet[R] = {
-    sink match {
-      case partitionableSink: PartitionableTableSink
-        if partitionableSink.getPartitionFieldNames.nonEmpty =>
-        val fieldNames = sink.getTableSchema.getFieldNames
-        val indices = partitionableSink.getPartitionFieldNames.map(fieldNames.indexOf(_))
-        dataSet.partitionByHash(indices:_*)
-      case _ => dataSet
     }
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -488,9 +488,7 @@ abstract class TableEnvImpl(
           tableSink)
         // set static partitions if it is a partitioned table sink
         tableSink match {
-          case partitionableSink: PartitionableTableSink
-            if partitionableSink.getPartitionFieldNames != null
-              && partitionableSink.getPartitionFieldNames.nonEmpty =>
+          case partitionableSink: PartitionableTableSink =>
             partitionableSink.setStaticPartition(insertOptions.staticPartitions)
           case _ =>
         }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/sinks/TableSinkUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/sinks/TableSinkUtils.scala
@@ -24,8 +24,6 @@ import org.apache.flink.table.operations.QueryOperation
 
 import java.util.{Map => JMap}
 
-import scala.collection.JavaConversions._
-
 object TableSinkUtils {
 
   /**
@@ -72,30 +70,10 @@ object TableSinkUtils {
     // check partitions are valid
     if (staticPartitions != null && !staticPartitions.isEmpty) {
       val invalidMsg = "Can't insert static partitions into a non-partitioned table sink. " +
-        "A partitioned sink should implement 'PartitionableTableSink' and return partition " +
-        "field names via 'getPartitionFieldNames()' method."
+        "A partitioned sink should implement 'PartitionableTableSink'."
       sink match {
-        case pts: PartitionableTableSink =>
-          val partitionFields = pts.getPartitionFieldNames
-          if (partitionFields == null || partitionFields.isEmpty) {
-            throw new ValidationException(invalidMsg)
-          }
-          staticPartitions.map(_._1) foreach { p =>
-            if (!partitionFields.contains(p)) {
-              throw new ValidationException(s"Static partition column $p " +
-                s"should be in the partition fields list $partitionFields.")
-            }
-          }
-          staticPartitions.map(_._1).zip(partitionFields).foreach {
-            case (p1, p2) =>
-              if (p1 != p2) {
-                throw new ValidationException(s"Static partition column $p1 " +
-                  s"should appear before dynamic partition $p2.")
-              }
-          }
-        case _ =>
-          throw new ValidationException(invalidMsg)
-
+        case _: PartitionableTableSink =>
+        case _ => throw new ValidationException(invalidMsg)
       }
     }
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/PartitionableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/PartitionableSinkITCase.scala
@@ -28,9 +28,9 @@ import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.scala.ExecutionEnvironment
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.table.api.scala.BatchTableEnvironment
-import org.apache.flink.table.api.{DataTypes, SqlDialect, TableSchema, ValidationException}
+import org.apache.flink.table.api.{DataTypes, SqlDialect, TableSchema}
 import org.apache.flink.table.factories.utils.TestCollectionTableFactory.TestCollectionInputFormat
-import org.apache.flink.table.runtime.batch.sql.PartitionableSinkITCase.{RESULT1, RESULT2, RESULT3, _}
+import org.apache.flink.table.runtime.batch.sql.PartitionableSinkITCase._
 import org.apache.flink.table.sinks.{BatchTableSink, PartitionableTableSink, TableSink}
 import org.apache.flink.table.sources.BatchTableSource
 import org.apache.flink.table.types.logical.{BigIntType, IntType, VarCharType}
@@ -40,7 +40,7 @@ import org.junit.Assert.assertEquals
 import org.junit.rules.ExpectedException
 import org.junit.{Before, Rule, Test}
 
-import java.util.{ArrayList => JArrayList, LinkedList => JLinkedList, List => JList, Map => JMap}
+import java.util.{LinkedList => JLinkedList, List => JList, Map => JMap}
 import org.apache.flink.api.java
 
 import scala.collection.JavaConversions._
@@ -59,7 +59,7 @@ class PartitionableSinkITCase {
 
   @Before
   def before(): Unit = {
-    batchExec.setParallelism(3)
+    batchExec.setParallelism(1)
     tEnv = BatchTableEnvironment.create(batchExec)
     tEnv.getConfig.setSqlDialect(SqlDialect.HIVE)
     registerTableSource("nonSortTable", testData.toList)
@@ -74,52 +74,6 @@ class PartitionableSinkITCase {
       .field("c", DataTypes.STRING())
       .build()
     tEnv.registerTableSource(name, new CollectionTableSource(data, 100, tableSchema))
-  }
-
-  @Test
-  def testInsertWithOutPartitionGrouping(): Unit = {
-    registerTableSink(grouping = false)
-    tEnv.sqlUpdate("insert into sinkTable select a, max(b), c"
-      + " from nonSortTable group by a, c")
-    tEnv.execute("testJob")
-    assertEquals(List("1,5,Hi",
-      "1,5,Hi01",
-      "1,5,Hi02"),
-      RESULT1.sorted)
-    assert(RESULT2.isEmpty)
-    assertEquals(List("2,1,Hello world01",
-      "2,1,Hello world02",
-      "2,1,Hello world03",
-      "2,1,Hello world04",
-      "2,2,Hello world, how are you?",
-      "3,1,Hello world",
-      "3,2,Hello",
-      "3,2,Hello01",
-      "3,2,Hello02",
-      "3,2,Hello03",
-      "3,2,Hello04"),
-      RESULT3.sorted)
-  }
-
-  @Test
-  def testInsertWithPartitionGrouping(): Unit = {
-    registerTableSink()
-    tEnv.sqlUpdate("insert into sinkTable select a, b, c from sortTable")
-    tEnv.execute("testJob")
-    assertEquals(List("1,1,Hello world",
-      "1,1,Hello world, how are you?"),
-      RESULT1.toList)
-    assertEquals(List("4,4,你好，陌生人",
-      "4,4,你好，陌生人，我是",
-      "4,4,你好，陌生人，我是中国人",
-      "4,4,你好，陌生人，我是中国人，你来自哪里？"),
-      RESULT2.toList)
-    assertEquals(List("2,2,Hi",
-      "2,2,Hello",
-      "3,3,I'm fine, thank",
-      "3,3,I'm fine, thank you",
-      "3,3,I'm fine, thank you, and you?"),
-      RESULT3.toList)
   }
 
   @Test
@@ -140,49 +94,12 @@ class PartitionableSinkITCase {
       "1,4,你好，陌生人，我是",
       "1,4,你好，陌生人，我是中国人",
       "1,4,你好，陌生人，我是中国人，你来自哪里？"),
-      RESULT1.toList)
-    assert(RESULT2.isEmpty)
-    assert(RESULT3.isEmpty)
-  }
-
-  @Test
-  def testInsertWithStaticAndDynamicPartitions(): Unit = {
-    val testSink = registerTableSink(partitionColumns = Array("a", "b"))
-    tEnv.sqlUpdate("insert into sinkTable partition(a=1) select b, c from sortTable")
-    tEnv.execute("testJob")
-    // this sink should have been set up with static partitions
-    assertEquals(testSink.getStaticPartitions.toMap, Map("a" -> "1"))
-    assertEquals(List("1,3,I'm fine, thank",
-      "1,3,I'm fine, thank you",
-      "1,3,I'm fine, thank you, and you?"),
-      RESULT1.toList)
-    assertEquals(List("1,2,Hi",
-      "1,2,Hello"),
-      RESULT2.toList)
-    assertEquals(List("1,1,Hello world",
-      "1,1,Hello world, how are you?",
-      "1,4,你好，陌生人",
-      "1,4,你好，陌生人，我是",
-      "1,4,你好，陌生人，我是中国人",
-      "1,4,你好，陌生人，我是中国人，你来自哪里？"),
-      RESULT3.toList)
-  }
-
-  @Test
-  def testDynamicPartitionInFrontOfStaticPartition(): Unit = {
-    expectedEx.expect(classOf[ValidationException])
-    expectedEx.expectMessage("Static partition column b "
-      + "should appear before dynamic partition a")
-    registerTableSink(partitionColumns = Array("a", "b"))
-    tEnv.sqlUpdate("insert into sinkTable partition(b=1) select a, c from sortTable")
-    tEnv.execute("testJob")
+      RESULT.toList)
   }
 
   @Test
   def testStaticPartitionNotInPartitionFields(): Unit = {
-    expectedEx.expect(classOf[ValidationException])
-    expectedEx.expectMessage("Static partition column c " +
-      "should be in the partition fields list [a, b].")
+    expectedEx.expect(classOf[RuntimeException])
     registerTableSink(tableName = "sinkTable2", rowType = type4,
       partitionColumns = Array("a", "b"))
     tEnv.sqlUpdate("insert into sinkTable2 partition(c=1) select a, b from sinkTable2")
@@ -191,9 +108,7 @@ class PartitionableSinkITCase {
 
   @Test
   def testInsertStaticPartitionOnNonPartitionedSink(): Unit = {
-    expectedEx.expect(classOf[ValidationException])
-    expectedEx.expectMessage(
-      "Can't insert static partitions into a non-partitioned table sink.")
+    expectedEx.expect(classOf[RuntimeException])
     registerTableSink(tableName = "sinkTable2", rowType = type4, partitionColumns = Array())
     tEnv.sqlUpdate("insert into sinkTable2 partition(c=1) select a, b from sinkTable2")
     tEnv.execute("testJob")
@@ -202,30 +117,33 @@ class PartitionableSinkITCase {
   private def registerTableSink(
       tableName: String = "sinkTable",
       rowType: RowTypeInfo = type3,
-      grouping: Boolean = true,
       partitionColumns: Array[String] = Array[String]("a")): TestSink = {
-    val testSink = new TestSink(rowType, grouping, partitionColumns)
+    val testSink = new TestSink(rowType, partitionColumns)
     tEnv.registerTableSink(tableName, testSink)
     testSink
   }
 
-  private class TestSink(rowType: RowTypeInfo,
-      supportsGrouping: Boolean,
-      partitionColumns: Array[String])
+  private class TestSink(rowType: RowTypeInfo, partitionColumns: Array[String])
     extends BatchTableSink[Row]
       with PartitionableTableSink {
     private var staticPartitions: JMap[String, String] = _
 
     override def getPartitionFieldNames: JList[String] = partitionColumns.toList
 
-    override def setStaticPartition(partitions: JMap[String, String]): Unit =
+    override def setStaticPartition(partitions: JMap[String, String]): Unit = {
+      partitions.foreach { case (part, v) =>
+        if (!partitionColumns.contains(part)) {
+          throw new RuntimeException
+        }
+      }
       this.staticPartitions = partitions
+    }
 
     override def configure(fieldNames: Array[String],
       fieldTypes: Array[TypeInformation[_]]): TableSink[Row] = this
 
     override def configurePartitionGrouping(s: Boolean): Boolean = {
-      supportsGrouping
+      false
     }
 
     override def getTableSchema: TableSchema = {
@@ -271,33 +189,20 @@ class PartitionableSinkITCase {
 }
 
 object PartitionableSinkITCase {
-  val RESULT1 = new JLinkedList[String]()
-  val RESULT2 = new JLinkedList[String]()
-  val RESULT3 = new JLinkedList[String]()
-  val RESULT_QUEUE: JList[JLinkedList[String]] = new JArrayList[JLinkedList[String]]()
+  val RESULT = new JLinkedList[String]()
 
   def init(): Unit = {
-    RESULT1.clear()
-    RESULT2.clear()
-    RESULT3.clear()
-    RESULT_QUEUE.clear()
-    RESULT_QUEUE.add(RESULT1)
-    RESULT_QUEUE.add(RESULT2)
-    RESULT_QUEUE.add(RESULT3)
+    RESULT.clear()
   }
 
   /** OutputFormat that writes data to a collection. **/
   class CollectionOutputFormat extends RichOutputFormat[String] {
-    private var resultSet: JLinkedList[String] = _
-
     override def configure(parameters: Configuration): Unit = {}
 
-    override def open(taskNumber: Int, numTasks: Int): Unit = {
-      resultSet = RESULT_QUEUE.get(taskNumber)
-    }
+    override def open(taskNumber: Int, numTasks: Int): Unit = {}
 
     override def writeRecord(record: String): Unit = {
-      resultSet.add(record)
+      RESULT.add(record)
     }
 
     override def close(): Unit = {}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/PartitionableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/PartitionableSinkITCase.scala
@@ -128,8 +128,6 @@ class PartitionableSinkITCase {
       with PartitionableTableSink {
     private var staticPartitions: JMap[String, String] = _
 
-    override def getPartitionFieldNames: JList[String] = partitionColumns.toList
-
     override def setStaticPartition(partitions: JMap[String, String]): Unit = {
       partitions.foreach { case (part, v) =>
         if (!partitionColumns.contains(part)) {


### PR DESCRIPTION
## What is the purpose of the change

Now PartitionableTableSource and PartitionableTableSink have "getPartitionFieldNames" method, this should be removed, and planner rules should get it from CatalogManager.

The partition field names are the information of Table, source/sink should only be fed with such information but not get them out of it.

## Brief change log

See commits.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no