### PR TITLE
[FLINK-14414][table-common] Support string serializable for SymbolType

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/SymbolType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/SymbolType.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.types.logical;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.expressions.TableSymbol;
 import org.apache.flink.util.Preconditions;
 
@@ -32,8 +31,6 @@ import java.util.Objects;
  * and only serves as a helper type within the expression stack.
  *
  * <p>A symbol type only accepts conversions from and to its enum class.
- *
- * <p>This type has no serializable string representation.
  *
  * @param <T> table symbol
  */
@@ -65,7 +62,7 @@ public final class SymbolType<T extends TableSymbol> extends LogicalType {
 
 	@Override
 	public String asSerializableString() {
-		throw new TableException("A symbol type has no serializable string representation.");
+		return withNullability(FORMAT, symbolClass.getName());
 	}
 
 	@Override

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeParserTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeParserTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.types;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.expressions.TimeIntervalUnit;
 import org.apache.flink.table.types.logical.AnyType;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
@@ -41,6 +42,7 @@ import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.NullType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.SymbolType;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
@@ -419,6 +421,10 @@ public class LogicalTypeParserTest {
 						new UnresolvedUserDefinedType("c", "d", "t"))
 				),
 
+			TestSpec
+				.forString("SYMBOL('org.apache.flink.table.expressions.TimeIntervalUnit')")
+				.expectType(new SymbolType<>(TimeIntervalUnit.class)),
+
 			// error message testing
 
 			TestSpec
@@ -443,7 +449,11 @@ public class LogicalTypeParserTest {
 
 			TestSpec
 				.forString("ANY('unknown.class', '')")
-				.expectErrorMessage("Unable to restore the ANY type")
+				.expectErrorMessage("Unable to restore the ANY type"),
+
+			TestSpec
+				.forString("SYMBOL('unknown.class')")
+				.expectErrorMessage("Unable to restore the SYMBOL type")
 		);
 	}
 


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, `SymbolType` has no serializable string representation, but it is helpful to support it. Because symbol literals are used in expressions, e.g. `EXTRACT(DAY FROM DATE '1990-12-01')`. If we want to serialize this experssion, the DAY symbol and type are also need to be serialized.

## Brief change log

- Implement `SymbolType.asSerializableString`, the format is the same with `asSummaryString`, e.g. `SYMBOL('org.apache.flink.table.expressions.TimeIntervalUnit')`
- Adds parser logic for `SymbolType` in `LogicalTypeParser`.

## Verifying this change

This change added tests:
 - Adds test entry for SymbolType

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
