### PR TITLE
[FLINK-14415][table-common] ValueLiteralExpression#equals should take array value into account

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
@@ -187,7 +187,7 @@ public final class ValueLiteralExpression implements ResolvedExpression {
 			return false;
 		}
 		ValueLiteralExpression that = (ValueLiteralExpression) o;
-		return Objects.equals(value, that.value) && dataType.equals(that.dataType);
+		return Objects.deepEquals(value, that.value) && dataType.equals(that.dataType);
 	}
 
 	@Override

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.Period;
@@ -70,6 +71,27 @@ public class ExpressionTest {
 	@Test
 	public void testExpressionEquality() {
 		assertEquals(TREE_WITH_VALUE, TREE_WITH_SAME_VALUE);
+	}
+
+	@Test
+	public void testArrayValueLiteralEquality() {
+		assertEquals(
+			new ValueLiteralExpression(new Integer[][]{null, null, {1, 2, 3}}),
+			new ValueLiteralExpression(new Integer[][]{null, null, {1, 2, 3}}));
+
+		assertEquals(
+			new ValueLiteralExpression(
+				new String[][]{null, null, {"1", "2", "3", "Dog's"}},
+				DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.STRING()))),
+			new ValueLiteralExpression(
+				new String[][]{null, null, {"1", "2", "3", "Dog's"}},
+				DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.STRING())))
+		);
+
+		assertEquals(
+			new ValueLiteralExpression("abc".getBytes(StandardCharsets.UTF_8)),
+			new ValueLiteralExpression("abc".getBytes(StandardCharsets.UTF_8))
+		);
 	}
 
 	@Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

`ValueLiteralExpression#equals` uses `Objects.equals` to check the equality between two value object. Howeveer, the value object might be an array object, using `Object.equals` will lead to wrong result.

## Brief change log

- Use `Objects.deepEquals` instead of `Object.equals`

## Verifying this change


This change added tests:
 - Adds array literal expression test in `ExpressionTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
