### PR TITLE
[FLINK-14389][runtime] Restore task state before restarting tasks in DefaultScheduler

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.OperatorInstanceID;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -55,7 +54,7 @@ public class StateAssignmentOperation {
 
 	private static final Logger LOG = LoggerFactory.getLogger(StateAssignmentOperation.class);
 
-	private final Map<JobVertexID, ExecutionJobVertex> tasks;
+	private final Set<ExecutionJobVertex> tasks;
 	private final Map<OperatorID, OperatorState> operatorStates;
 
 	private final long restoreCheckpointId;
@@ -63,7 +62,7 @@ public class StateAssignmentOperation {
 
 	public StateAssignmentOperation(
 		long restoreCheckpointId,
-		Map<JobVertexID, ExecutionJobVertex> tasks,
+		Set<ExecutionJobVertex> tasks,
 		Map<OperatorID, OperatorState> operatorStates,
 		boolean allowNonRestoredState) {
 
@@ -78,8 +77,7 @@ public class StateAssignmentOperation {
 
 		checkStateMappingCompleteness(allowNonRestoredState, operatorStates, tasks);
 
-		for (Map.Entry<JobVertexID, ExecutionJobVertex> task : this.tasks.entrySet()) {
-			final ExecutionJobVertex executionJobVertex = task.getValue();
+		for (ExecutionJobVertex executionJobVertex : this.tasks) {
 
 			// find the states of all operators belonging to this task
 			List<OperatorID> operatorIDs = executionJobVertex.getOperatorIDs();
@@ -106,7 +104,7 @@ public class StateAssignmentOperation {
 				continue;
 			}
 
-			assignAttemptState(task.getValue(), operatorStates);
+			assignAttemptState(executionJobVertex, operatorStates);
 		}
 
 	}
@@ -550,10 +548,10 @@ public class StateAssignmentOperation {
 	private static void checkStateMappingCompleteness(
 			boolean allowNonRestoredState,
 			Map<OperatorID, OperatorState> operatorStates,
-			Map<JobVertexID, ExecutionJobVertex> tasks) {
+			Set<ExecutionJobVertex> tasks) {
 
 		Set<OperatorID> allOperatorIDs = new HashSet<>();
-		for (ExecutionJobVertex executionJobVertex : tasks.values()) {
+		for (ExecutionJobVertex executionJobVertex : tasks) {
 			allOperatorIDs.addAll(executionJobVertex.getOperatorIDs());
 		}
 		for (Map.Entry<OperatorID, OperatorState> operatorGroupStateEntry : operatorStates.entrySet()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -616,14 +616,8 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 		}
 	}
 
-	public void resetForNewExecutionIfInTerminalState() {
-		if (isExecutionInTerminalState()) {
-			resetForNewExecutionInternal(System.currentTimeMillis(), getExecutionGraph().getGlobalModVersion());
-		}
-	}
-
-	private boolean isExecutionInTerminalState() {
-		return currentExecution.getState().isTerminal();
+	public void resetForNewExecution() {
+		resetForNewExecutionInternal(System.currentTimeMillis(), getExecutionGraph().getGlobalModVersion());
 	}
 
 	private Execution resetForNewExecutionInternal(final long timestamp, final long originatingGlobalModVersion) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -822,7 +822,7 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 	 * Get whether an input of the vertex is consumable.
 	 * An input is consumable when when any partition in it is consumable.
 	 *
-	 * Note that a BLOCKING result partition is only consumable when all partitions in the result are FINISHED.
+	 * <p>Note that a BLOCKING result partition is only consumable when all partitions in the result are FINISHED.
 	 *
 	 * @return whether the input is consumable
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -210,7 +210,14 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 		return () -> {
 			final Set<ExecutionVertexID> verticesToRestart = executionVertexVersioner.getUnmodifiedExecutionVertices(executionVertexVersions);
 
-			resetForNewExecutionIfInTerminalState(verticesToRestart);
+			resetForNewExecutions(verticesToRestart);
+
+			try {
+				restoreState(verticesToRestart);
+			} catch (Throwable t) {
+				handleGlobalFailure(t);
+				return;
+			}
 
 			schedulingStrategy.restartTasks(verticesToRestart);
 		};

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -88,6 +88,7 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -202,7 +203,7 @@ public abstract class SchedulerBase implements SchedulerNG {
 		if (checkpointCoordinator != null) {
 			// check whether we find a valid checkpoint
 			if (!checkpointCoordinator.restoreLatestCheckpointedState(
-				newExecutionGraph.getAllVertices(),
+				new HashSet<>(newExecutionGraph.getAllVertices().values()),
 				false,
 				false)) {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -24,10 +24,8 @@ import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.JobStatus;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
@@ -144,7 +142,7 @@ public class CheckpointCoordinatorMasterHooksTest {
 
 		// initialize the hooks
 		cc.restoreLatestCheckpointedState(
-			Collections.<JobVertexID, ExecutionJobVertex>emptyMap(),
+			Collections.emptySet(),
 			false,
 			false);
 		verify(hook1, times(1)).reset();
@@ -284,7 +282,7 @@ public class CheckpointCoordinatorMasterHooksTest {
 
 		cc.getCheckpointStore().addCheckpoint(checkpoint);
 		cc.restoreLatestCheckpointedState(
-				Collections.<JobVertexID, ExecutionJobVertex>emptyMap(),
+				Collections.emptySet(),
 				true,
 				false);
 
@@ -339,7 +337,7 @@ public class CheckpointCoordinatorMasterHooksTest {
 		// since we have unmatched state, this should fail
 		try {
 			cc.restoreLatestCheckpointedState(
-					Collections.<JobVertexID, ExecutionJobVertex>emptyMap(),
+					Collections.emptySet(),
 					true,
 					false);
 			fail("exception expected");
@@ -348,7 +346,7 @@ public class CheckpointCoordinatorMasterHooksTest {
 
 		// permitting unmatched state should succeed
 		cc.restoreLatestCheckpointedState(
-				Collections.<JobVertexID, ExecutionJobVertex>emptyMap(),
+				Collections.emptySet(),
 				true,
 				true);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -481,7 +481,10 @@ public class CheckpointCoordinatorMasterHooksTest {
 
 	// ------------------------------------------------------------------------
 
-	private static final class StringSerializer implements SimpleVersionedSerializer<String> {
+	/**
+	 * A test implementation of {@link SimpleVersionedSerializer} for String type.
+	 */
+	public static final class StringSerializer implements SimpleVersionedSerializer<String> {
 
 		static final int VERSION = 77;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
@@ -60,9 +60,11 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.compareKeyedState;
@@ -212,10 +214,10 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 		store.shutdown(JobStatus.SUSPENDED);
 
 		// restore the store
-		Map<JobVertexID, ExecutionJobVertex> tasks = new HashMap<>();
+		Set<ExecutionJobVertex> tasks = new HashSet<>();
 
-		tasks.put(jobVertexID1, jobVertex1);
-		tasks.put(jobVertexID2, jobVertex2);
+		tasks.add(jobVertex1);
+		tasks.add(jobVertex2);
 
 		coord.restoreLatestCheckpointedState(tasks, true, false);
 
@@ -273,9 +275,9 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 			ExecutionJobVertex stateless = mockExecutionJobVertex(statelessId,
 				new ExecutionVertex[] { stateless1 });
 
-			Map<JobVertexID, ExecutionJobVertex> map = new HashMap<JobVertexID, ExecutionJobVertex>();
-			map.put(statefulId, stateful);
-			map.put(statelessId, stateless);
+			Set<ExecutionJobVertex> tasks = new HashSet<>();
+			tasks.add(stateful);
+			tasks.add(stateless);
 
 			CompletedCheckpointStore store = new RecoverableCompletedCheckpointStore(2);
 
@@ -357,7 +359,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 			assertNotNull(savepointFuture.get());
 
 			//restore and jump the latest savepoint
-			coord.restoreLatestCheckpointedState(map, true, false);
+			coord.restoreLatestCheckpointedState(tasks, true, false);
 
 			//compare and see if it used the checkpoint's subtaskStates
 			BaseMatcher<JobManagerTaskRestore> matcher = new BaseMatcher<JobManagerTaskRestore>() {
@@ -516,7 +518,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 
 		assertEquals(1, completedCheckpoints.size());
 
-		Map<JobVertexID, ExecutionJobVertex> tasks = new HashMap<>();
+		Set<ExecutionJobVertex> tasks = new HashSet<>();
 
 		List<KeyGroupRange> newKeyGroupPartitions2 =
 			StateAssignmentOperation.createKeyGroupPartitions(maxParallelism2, newParallelism2);
@@ -532,8 +534,8 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 			newParallelism2,
 			maxParallelism2);
 
-		tasks.put(jobVertexID1, newJobVertex1);
-		tasks.put(jobVertexID2, newJobVertex2);
+		tasks.add(newJobVertex1);
+		tasks.add(newJobVertex2);
 		coord.restoreLatestCheckpointedState(tasks, true, false);
 
 		// verify the restored state
@@ -679,7 +681,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 
 		assertEquals(1, completedCheckpoints.size());
 
-		Map<JobVertexID, ExecutionJobVertex> tasks = new HashMap<>();
+		Set<ExecutionJobVertex> tasks = new HashSet<>();
 
 		int newMaxParallelism1 = 20;
 		int newMaxParallelism2 = 42;
@@ -694,8 +696,8 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 			parallelism2,
 			newMaxParallelism2);
 
-		tasks.put(jobVertexID1, newJobVertex1);
-		tasks.put(jobVertexID2, newJobVertex2);
+		tasks.add(newJobVertex1);
+		tasks.add(newJobVertex2);
 
 		coord.restoreLatestCheckpointedState(tasks, true, false);
 
@@ -846,10 +848,10 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 			newParallelism2,
 			maxParallelism2);
 
-		Map<JobVertexID, ExecutionJobVertex> tasks = new HashMap<>();
+		Set<ExecutionJobVertex> tasks = new HashSet<>();
 
-		tasks.put(id5.f0, newJobVertex1);
-		tasks.put(id3.f0, newJobVertex2);
+		tasks.add(newJobVertex1);
+		tasks.add(newJobVertex2);
 
 		JobID jobID = new JobID();
 		StandaloneCompletedCheckpointStore standaloneCompletedCheckpointStore =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -68,10 +68,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -2252,7 +2254,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		CheckpointStatsTracker tracker = mock(CheckpointStatsTracker.class);
 		coord.setCheckpointStatsTracker(tracker);
 
-		assertTrue(coord.restoreLatestCheckpointedState(Collections.<JobVertexID, ExecutionJobVertex>emptyMap(), false, true));
+		assertTrue(coord.restoreLatestCheckpointedState(Collections.emptySet(), false, true));
 
 		verify(tracker, times(1))
 			.reportRestoredCheckpoint(any(RestoredCheckpointStats.class));
@@ -2380,8 +2382,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		store.shutdown(JobStatus.SUSPENDED);
 
 		// restore the store
-		Map<JobVertexID, ExecutionJobVertex> tasks = new HashMap<>();
-		tasks.put(jobVertexID1, jobVertex1);
+		Set<ExecutionJobVertex> tasks = new HashSet<>();
+		tasks.add(jobVertex1);
 		coord.restoreLatestCheckpointedState(tasks, true, false);
 
 		// validate that all shared states are registered again after the recovery.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
@@ -46,9 +46,11 @@ import org.mockito.hamcrest.MockitoHamcrest;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -108,9 +110,9 @@ public class CheckpointStateRestoreTest {
 			ExecutionJobVertex stateless = mockExecutionJobVertex(statelessId,
 					new ExecutionVertex[] { stateless1, stateless2 });
 
-			Map<JobVertexID, ExecutionJobVertex> map = new HashMap<JobVertexID, ExecutionJobVertex>();
-			map.put(statefulId, stateful);
-			map.put(statelessId, stateless);
+			Set<ExecutionJobVertex> tasks = new HashSet<>();
+			tasks.add(stateful);
+			tasks.add(stateless);
 
 			CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
 				200000L,
@@ -163,7 +165,7 @@ public class CheckpointStateRestoreTest {
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 
 			// let the coordinator inject the state
-			coord.restoreLatestCheckpointedState(map, true, false);
+			coord.restoreLatestCheckpointedState(tasks, true, false);
 
 			// verify that each stateful vertex got the state
 
@@ -222,7 +224,7 @@ public class CheckpointStateRestoreTest {
 				failureManager);
 
 			try {
-				coord.restoreLatestCheckpointedState(new HashMap<JobVertexID, ExecutionJobVertex>(), true, false);
+				coord.restoreLatestCheckpointedState(Collections.emptySet(), true, false);
 				fail("this should throw an exception");
 			}
 			catch (IllegalStateException e) {
@@ -259,9 +261,9 @@ public class CheckpointStateRestoreTest {
 		ExecutionJobVertex jobVertex1 = mockExecutionJobVertex(jobVertexId1, new ExecutionVertex[] { vertex11, vertex12, vertex13 });
 		ExecutionJobVertex jobVertex2 = mockExecutionJobVertex(jobVertexId2, new ExecutionVertex[] { vertex21, vertex22 });
 
-		Map<JobVertexID, ExecutionJobVertex> tasks = new HashMap<>();
-		tasks.put(jobVertexId1, jobVertex1);
-		tasks.put(jobVertexId2, jobVertex2);
+		Set<ExecutionJobVertex> tasks = new HashSet<>();
+		tasks.add(jobVertex1);
+		tasks.add(jobVertex2);
 
 		CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
 			Integer.MAX_VALUE,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/hooks/TestMasterHook.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/hooks/TestMasterHook.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.hooks;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorMasterHooksTest;
+import org.apache.flink.runtime.checkpoint.MasterTriggerRestoreHook;
+
+import javax.annotation.Nullable;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link MasterTriggerRestoreHook} implementation for testing.
+ */
+public class TestMasterHook implements MasterTriggerRestoreHook<String> {
+
+	private static final String DEFAULT_STATE = "default";
+
+	private final String id;
+
+	private int restoreCount = 0;
+
+	private boolean failOnRestore = false;
+
+	private TestMasterHook(String id) {
+		this.id = checkNotNull(id);
+	}
+
+	public static TestMasterHook fromId(String id) {
+		return new TestMasterHook(id);
+	}
+
+	@Override
+	public String getIdentifier() {
+		return id;
+	}
+
+	@Override
+	public CompletableFuture<String> triggerCheckpoint(
+			final long checkpointId,
+			final long timestamp,
+			final Executor executor) {
+
+		return CompletableFuture.completedFuture(DEFAULT_STATE);
+	}
+
+	@Override
+	public void restoreCheckpoint(final long checkpointId, @Nullable final String checkpointData) throws Exception {
+		restoreCount++;
+		if (failOnRestore) {
+			throw new Exception("Failing mast hook state restore on purpose.");
+		}
+	}
+
+	@Override
+	public SimpleVersionedSerializer<String> createCheckpointDataSerializer() {
+		return new CheckpointCoordinatorMasterHooksTest.StringSerializer();
+	}
+
+	public int getRestoreCount() {
+		return restoreCount;
+	}
+
+	public void enableFailOnRestore() {
+		this.failOnRestore = true;
+	}
+
+	public void disableFailOnRestore() {
+		this.failOnRestore = false;
+	}
+}


### PR DESCRIPTION

## What is the purpose of the change

This PR is to enabled DefaultScheduler to restore task state before restarting tasks.

## Brief change log

  - *Added SchedulerBase#restartState for task state restore*
  - *Changed DefaultScheduler to invoke SchedulerBase#restartState before restarting tasks*

## Verifying this change

This change added tests and can be verified as follows:
  - *Added unit tests*
  - *KeyedStateCheckpointingITCase is able to pass with this fix when using ng scheduler*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
