### PR TITLE
[FLINK-14130][client] Remove ClusterClient.run() methods

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.api.common.accumulators.AccumulatorHelper;
 import org.apache.flink.api.dag.Pipeline;
+import org.apache.flink.client.ClientUtils;
 import org.apache.flink.client.FlinkPipelineTranslationUtil;
 import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.deployment.ClusterSpecification;
@@ -729,12 +730,7 @@ public class CliFrontend {
 	protected void executeProgram(PackagedProgram program, ClusterClient<?> client, int parallelism) throws ProgramMissingJobException, ProgramInvocationException {
 		logAndSysout("Starting execution of program");
 
-		final JobSubmissionResult result = client.run(program, parallelism);
-
-		if (null == result) {
-			throw new ProgramMissingJobException("No JobSubmissionResult returned, please make sure you called " +
-				"ExecutionEnvironment.execute()");
-		}
+		JobSubmissionResult result = ClientUtils.executeProgram(client, program, parallelism);
 
 		if (result.isJobExecutionResult()) {
 			logAndSysout("Program execution finished");

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -31,9 +31,6 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.OptionalFailure;
 import org.apache.flink.util.Preconditions;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -47,8 +44,6 @@ import java.util.concurrent.CompletableFuture;
  * @param <T> type of the cluster id
  */
 public abstract class ClusterClient<T> implements AutoCloseable {
-
-	protected final Logger log = LoggerFactory.getLogger(getClass());
 
 	/** Configuration of the client. */
 	private final Configuration flinkConfig;

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -117,11 +117,11 @@ public class ContextEnvironment extends ExecutionEnvironment {
 
 	// --------------------------------------------------------------------------------------------
 
-	static void setAsContext(ContextEnvironmentFactory factory) {
+	public static void setAsContext(ContextEnvironmentFactory factory) {
 		initializeContextEnvironment(factory);
 	}
 
-	static void unsetContext() {
+	public static void unsetContext() {
 		resetContextEnvironment();
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -100,6 +100,9 @@ import org.apache.flink.util.function.CheckedSupplier;
 import org.apache.flink.shaded.netty4.io.netty.channel.ConnectTimeoutException;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -130,6 +133,8 @@ import java.util.stream.Collectors;
  * A {@link ClusterClient} implementation that communicates via HTTP REST requests.
  */
 public class RestClusterClient<T> extends ClusterClient<T> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(RestClusterClient.class);
 
 	private final RestClusterClientConfiguration restClusterClientConfiguration;
 
@@ -203,25 +208,25 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 		try {
 			webMonitorRetrievalService.stop();
 		} catch (Exception e) {
-			log.error("An error occurred during stopping the WebMonitorRetrievalService", e);
+			LOG.error("An error occurred during stopping the WebMonitorRetrievalService", e);
 		}
 
 		try {
 			clientHAServices.close();
 		} catch (Exception e) {
-			log.error("An error occurred during stopping the ClientHighAvailabilityServices", e);
+			LOG.error("An error occurred during stopping the ClientHighAvailabilityServices", e);
 		}
 
 		try {
 			super.close();
 		} catch (Exception e) {
-			log.error("Error while closing the Cluster Client", e);
+			LOG.error("Error while closing the Cluster Client", e);
 		}
 	}
 
 	@Override
 	public JobSubmissionResult submitJob(JobGraph jobGraph, ClassLoader classLoader) throws ProgramInvocationException {
-		log.info("Submitting job {} (detached: {}).", jobGraph.getJobID(), isDetached());
+		LOG.info("Submitting job {} (detached: {}).", jobGraph.getJobID(), isDetached());
 
 		final CompletableFuture<JobSubmissionResult> jobSubmissionFuture = submitJob(jobGraph);
 
@@ -229,7 +234,7 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 			try {
 				final JobSubmissionResult jobSubmissionResult = jobSubmissionFuture.get();
 
-				log.warn("Job was executed in detached mode, the results will be available on completion.");
+				LOG.warn("Job was executed in detached mode, the results will be available on completion.");
 
 				this.lastJobExecutionResult = new DetachedJobExecutionResult(jobSubmissionResult.getJobID());
 				return lastJobExecutionResult;
@@ -252,9 +257,7 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 			try {
 				this.lastJobExecutionResult = jobResult.toJobExecutionResult(classLoader);
 				return lastJobExecutionResult;
-			} catch (JobExecutionException e) {
-				throw new ProgramInvocationException("Job failed.", jobGraph.getJobID(), e);
-			} catch (IOException | ClassNotFoundException e) {
+			} catch (JobExecutionException | IOException | ClassNotFoundException e) {
 				throw new ProgramInvocationException("Job failed.", jobGraph.getJobID(), e);
 			}
 		}
@@ -364,7 +367,7 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 			try {
 				Files.delete(jobGraphFile);
 			} catch (IOException e) {
-				log.warn("Could not delete temporary file {}.", jobGraphFile, e);
+				LOG.warn("Could not delete temporary file {}.", jobGraphFile, e);
 			}
 		});
 
@@ -559,7 +562,7 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
 		} catch (ExecutionException e) {
-			log.error("Error while shutting down cluster", e);
+			LOG.error("Error while shutting down cluster", e);
 		}
 	}
 
@@ -613,7 +616,7 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 		} catch (InterruptedException | ExecutionException e) {
 			ExceptionUtils.checkInterrupted(e);
 
-			log.warn("Could not retrieve the web interface URL for the cluster.", e);
+			LOG.warn("Could not retrieve the web interface URL for the cluster.", e);
 			return "Unknown address.";
 		}
 	}

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -102,7 +102,7 @@ public class ClientTest extends TestLogger {
 
 		try {
 			PackagedProgram prg = new PackagedProgram(TestExecuteTwice.class);
-			clusterClient.run(prg, 1);
+			ClientUtils.executeProgram(clusterClient, prg, 1);
 			fail(FAIL_MESSAGE);
 		} catch (ProgramInvocationException e) {
 			assertEquals(
@@ -112,7 +112,7 @@ public class ClientTest extends TestLogger {
 
 		try {
 			PackagedProgram prg = new PackagedProgram(TestEager.class);
-			clusterClient.run(prg, 1);
+			ClientUtils.executeProgram(clusterClient, prg, 1);
 			fail(FAIL_MESSAGE);
 		} catch (ProgramInvocationException e) {
 			assertEquals(
@@ -122,7 +122,7 @@ public class ClientTest extends TestLogger {
 
 		try {
 			PackagedProgram prg = new PackagedProgram(TestGetRuntime.class);
-			clusterClient.run(prg, 1);
+			ClientUtils.executeProgram(clusterClient, prg, 1);
 			fail(FAIL_MESSAGE);
 		} catch (ProgramInvocationException e) {
 			assertEquals(
@@ -132,7 +132,7 @@ public class ClientTest extends TestLogger {
 
 		try {
 			PackagedProgram prg = new PackagedProgram(TestGetAccumulator.class);
-			clusterClient.run(prg, 1);
+			ClientUtils.executeProgram(clusterClient, prg, 1);
 			fail(FAIL_MESSAGE);
 		} catch (ProgramInvocationException e) {
 			assertEquals(
@@ -142,7 +142,7 @@ public class ClientTest extends TestLogger {
 
 		try {
 			PackagedProgram prg = new PackagedProgram(TestGetAllAccumulator.class);
-			clusterClient.run(prg, 1);
+			ClientUtils.executeProgram(clusterClient, prg, 1);
 			fail(FAIL_MESSAGE);
 		} catch (ProgramInvocationException e) {
 			assertEquals(
@@ -190,7 +190,7 @@ public class ClientTest extends TestLogger {
 		try {
 			final ClusterClient<?> client = new MiniClusterClient(new Configuration(), MINI_CLUSTER_RESOURCE.getMiniCluster());
 			client.setDetached(true);
-			client.run(packagedProgramMock, 1);
+			ClientUtils.executeProgram(client, packagedProgramMock, 1);
 			fail("Creating the local execution environment should not be possible");
 		}
 		catch (InvalidProgramException e) {


### PR DESCRIPTION
## What is the purpose of the change

Remove legacy `run` method in `ClusterClient`. This is part of effort towards a `ClusterClient` interface.

The following works contain make operations async and then we can remove `lastJobExecutionResult` and `detachedJobSubmission`, let them env configuration and taken care of by FLIP-73. Also shift down `flinkConfig`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
