### PR TITLE
[FLINK-14429][YARN]Fix wrong app final status when running batch job on yarn with non detached mode

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -34,6 +34,7 @@ import org.apache.flink.optimizer.plan.StreamingPlan;
 import org.apache.flink.optimizer.plandump.PlanJSONDumpGenerator;
 import org.apache.flink.optimizer.plantranslate.JobGraphGenerator;
 import org.apache.flink.runtime.client.JobStatusMessage;
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
@@ -388,7 +389,7 @@ public abstract class ClusterClient<T> implements AutoCloseable {
 	 */
 	public abstract CompletableFuture<JobResult> requestJobResult(@Nonnull JobID jobId);
 
-	public void shutDownCluster() {
+	public void shutDownCluster(ApplicationStatus status, String diagnostics) {
 		throw new UnsupportedOperationException("The " + getClass().getSimpleName() + " does not support shutDownCluster.");
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -64,9 +64,11 @@ import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.rest.messages.MessageParameters;
 import org.apache.flink.runtime.rest.messages.RequestBody;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.runtime.rest.messages.ShutdownMessageParameters;
 import org.apache.flink.runtime.rest.messages.TerminationModeQueryParameter;
 import org.apache.flink.runtime.rest.messages.TriggerId;
 import org.apache.flink.runtime.rest.messages.cluster.ShutdownHeaders;
+import org.apache.flink.runtime.rest.messages.cluster.ShutdownRequestBody;
 import org.apache.flink.runtime.rest.messages.job.JobDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
 import org.apache.flink.runtime.rest.messages.job.JobExecutionResultHeaders;
@@ -555,8 +557,12 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 
 	@Override
 	public void shutDownCluster(ApplicationStatus status, String diagnostics) {
+		ShutdownHeaders shutdownHeaders = ShutdownHeaders.getInstance();
+		ShutdownMessageParameters shutdownParameters = shutdownHeaders.getUnresolvedMessageParameters();
+		shutdownParameters.status.resolve(Collections.singletonList(status));
+		ShutdownRequestBody requestBody = new ShutdownRequestBody(diagnostics);
 		try {
-			sendRequest(ShutdownHeaders.getInstance()).get();
+			sendRequest(shutdownHeaders, shutdownParameters, requestBody).get();
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
 		} catch (ExecutionException e) {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.client.JobSubmissionException;
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.runtime.highavailability.ClientHighAvailabilityServices;
@@ -553,7 +554,7 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 	}
 
 	@Override
-	public void shutDownCluster() {
+	public void shutDownCluster(ApplicationStatus status, String diagnostics) {
 		try {
 			sendRequest(ShutdownHeaders.getInstance()).get();
 		} catch (InterruptedException e) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -225,7 +225,6 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 		log.info("Stopping dispatcher {}.", getAddress());
 
 		final CompletableFuture<Void> allJobManagerRunnersTerminationFuture = terminateJobManagerRunnersAndGetTerminationFuture();
-
 		return FutureUtils.runAfterwards(
 			allJobManagerRunnersTerminationFuture,
 			() -> {
@@ -617,9 +616,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 	@Override
 	public CompletableFuture<Acknowledge> shutDownCluster(ApplicationStatus status, String diagnostics) {
 		CompletableFuture<Void> terminationFuture = closeAsync();
-		terminationFuture.whenComplete((aVoid, throwable) -> {
-			shutDownFuture.complete(Tuple2.of(status, diagnostics));
-		});
+		terminationFuture.thenRun(() -> shutDownFuture.complete(Tuple2.of(status, diagnostics)));
 		return CompletableFuture.completedFuture(Acknowledge.get());
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DispatcherRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DispatcherRunner.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.dispatcher.runner;
 
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.dispatcher.Dispatcher;
 import org.apache.flink.util.AutoCloseableAsync;
@@ -43,5 +44,5 @@ public interface DispatcherRunner extends AutoCloseableAsync {
 	 *
 	 * @return future with the final application status
 	 */
-	CompletableFuture<ApplicationStatus> getShutDownFuture();
+	CompletableFuture<Tuple2<ApplicationStatus, String>> getShutDownFuture();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DispatcherRunnerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DispatcherRunnerImpl.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.dispatcher.runner;
 
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.dispatcher.Dispatcher;
 import org.apache.flink.runtime.dispatcher.DispatcherFactory;
@@ -55,7 +56,7 @@ class DispatcherRunnerImpl implements DispatcherRunner {
 	}
 
 	@Override
-	public CompletableFuture<ApplicationStatus> getShutDownFuture() {
+	public CompletableFuture<Tuple2<ApplicationStatus, String>> getShutDownFuture() {
 		return dispatcher.getShutDownFuture();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.entrypoint;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
@@ -224,7 +225,9 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 				this);
 
 			clusterComponent.getShutDownFuture().whenComplete(
-				(ApplicationStatus applicationStatus, Throwable throwable) -> {
+				(Tuple2<ApplicationStatus, String> applicationStatusWithDiagnostics, Throwable throwable) -> {
+					ApplicationStatus status = applicationStatusWithDiagnostics.f0;
+					String diagnostics = applicationStatusWithDiagnostics.f1;
 					if (throwable != null) {
 						shutDownAsync(
 							ApplicationStatus.UNKNOWN,
@@ -234,8 +237,8 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 						// This is the general shutdown path. If a separate more specific shutdown was
 						// already triggered, this will do nothing
 						shutDownAsync(
-							applicationStatus,
-							null,
+							status,
+							diagnostics,
 							true);
 					}
 				});

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponent.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.entrypoint.component;
 
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.dispatcher.Dispatcher;
@@ -60,7 +61,7 @@ public class DispatcherResourceManagerComponent implements AutoCloseableAsync {
 
 	private final CompletableFuture<Void> terminationFuture;
 
-	private final CompletableFuture<ApplicationStatus> shutDownFuture;
+	private final CompletableFuture<Tuple2<ApplicationStatus, String>> shutDownFuture;
 
 	private final AtomicBoolean isRunning = new AtomicBoolean(true);
 
@@ -85,7 +86,7 @@ public class DispatcherResourceManagerComponent implements AutoCloseableAsync {
 		FutureUtils.forward(dispatcherRunner.getShutDownFuture(), shutDownFuture);
 	}
 
-	public final CompletableFuture<ApplicationStatus> getShutDownFuture() {
+	public final CompletableFuture<Tuple2<ApplicationStatus, String>> getShutDownFuture() {
 		return shutDownFuture;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/JobDispatcherResourceManagerComponent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/JobDispatcherResourceManagerComponent.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint.component;
+
+import org.apache.flink.runtime.dispatcher.MiniDispatcher;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.runtime.metrics.groups.JobManagerMetricGroup;
+import org.apache.flink.runtime.resourcemanager.ResourceManager;
+import org.apache.flink.runtime.webmonitor.WebMonitorEndpoint;
+
+/**
+ * {@link DispatcherResourceManagerComponent} for a job cluster. The dispatcher component starts
+ * a {@link MiniDispatcher}.
+ */
+class JobDispatcherResourceManagerComponent extends DispatcherResourceManagerComponent<MiniDispatcher> {
+
+	JobDispatcherResourceManagerComponent(
+			MiniDispatcher dispatcher,
+			ResourceManager<?> resourceManager,
+			LeaderRetrievalService dispatcherLeaderRetrievalService,
+			LeaderRetrievalService resourceManagerRetrievalService,
+			WebMonitorEndpoint<?> webMonitorEndpoint,
+			JobManagerMetricGroup jobManagerMetricGroup) {
+		super(dispatcher, resourceManager, dispatcherLeaderRetrievalService, resourceManagerRetrievalService, webMonitorEndpoint, jobManagerMetricGroup);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/ShutdownHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/ShutdownHandler.java
@@ -19,18 +19,24 @@
 package org.apache.flink.runtime.rest.handler.cluster;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.ApplicationStatusParameter;
+import org.apache.flink.runtime.rest.messages.DiagnosticsParameter;
 import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.ShutdownMessageParameters;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.ExceptionUtils;
 
 import javax.annotation.Nonnull;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -38,20 +44,33 @@ import java.util.concurrent.CompletableFuture;
  * REST handler which allows to shut down the cluster.
  */
 public class ShutdownHandler extends
-		AbstractRestHandler<RestfulGateway, EmptyRequestBody, EmptyResponseBody, EmptyMessageParameters> {
+		AbstractRestHandler<RestfulGateway, EmptyRequestBody, EmptyResponseBody, ShutdownMessageParameters> {
 
 	public ShutdownHandler(
 			final GatewayRetriever<? extends RestfulGateway> leaderRetriever,
 			final Time timeout,
 			final Map<String, String> responseHeaders,
-			final MessageHeaders<EmptyRequestBody, EmptyResponseBody, EmptyMessageParameters> messageHeaders) {
+			final MessageHeaders<EmptyRequestBody, EmptyResponseBody, ShutdownMessageParameters> messageHeaders) {
 		super(leaderRetriever, timeout, responseHeaders, messageHeaders);
 	}
 
 	@Override
 	protected CompletableFuture<EmptyResponseBody> handleRequest(
-			@Nonnull final HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request,
+			@Nonnull final HandlerRequest<EmptyRequestBody, ShutdownMessageParameters> request,
 			@Nonnull final RestfulGateway gateway) throws RestHandlerException {
-		return gateway.shutDownCluster().thenApply(ignored -> EmptyResponseBody.getInstance());
+		ApplicationStatus status = null;
+		String diagnosticMessage = null;
+		List<ApplicationStatus> statuses = request.getQueryParameter(ApplicationStatusParameter.class);
+		List<String> diagnosticMessages = request.getQueryParameter(DiagnosticsParameter.class);
+
+		if (!statuses.isEmpty()) {
+			status = statuses.get(0);
+		} else {
+			throw new IllegalArgumentException(ApplicationStatusParameter.APP_STATUS + " is required.");
+		}
+		if (!diagnosticMessages.isEmpty()) {
+			diagnosticMessage = diagnosticMessages.get(0);
+		}
+		return gateway.shutDownCluster(status, diagnosticMessage).thenApply(ignored -> EmptyResponseBody.getInstance());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ApplicationStatusParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ApplicationStatusParameter.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
+
+/**
+ * Message parameter with appStatus {@link ApplicationStatus}.
+ */
+public class ApplicationStatusParameter extends MessageQueryParameter<ApplicationStatus> {
+	public static final String APP_STATUS = "appStatus";
+
+	ApplicationStatusParameter() {
+		super(APP_STATUS, MessageParameterRequisiteness.MANDATORY);
+	}
+
+	@Override
+	public ApplicationStatus convertStringToValue(String value) throws ConversionException {
+		return ApplicationStatus.valueOf(value);
+	}
+
+	@Override
+	public String convertValueToString(ApplicationStatus value) {
+		return value.toString();
+	}
+
+	@Override
+	public String getDescription() {
+		return "The status of the application";
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ShutdownMessageParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ShutdownMessageParameters.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Message parameters for shutdown handlers.
+ */
+public class ShutdownMessageParameters extends MessageParameters {
+	public final ApplicationStatusParameter status = new ApplicationStatusParameter();
+	@Override
+	public Collection<MessagePathParameter<?>> getPathParameters() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public Collection<MessageQueryParameter<?>> getQueryParameters() {
+		return Collections.singletonList(status);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/cluster/ShutdownHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/cluster/ShutdownHeaders.java
@@ -19,18 +19,16 @@
 package org.apache.flink.runtime.rest.messages.cluster;
 
 import org.apache.flink.runtime.rest.HttpMethodWrapper;
-import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
-import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
-
 import org.apache.flink.runtime.rest.messages.ShutdownMessageParameters;
+
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 /**
  * Message headers for {@link org.apache.flink.runtime.rest.handler.cluster.ShutdownHandler}.
  */
-public class ShutdownHeaders implements MessageHeaders<EmptyRequestBody, EmptyResponseBody, ShutdownMessageParameters> {
+public class ShutdownHeaders implements MessageHeaders<ShutdownRequestBody, EmptyResponseBody, ShutdownMessageParameters> {
 
 	private static final ShutdownHeaders INSTANCE = new ShutdownHeaders();
 
@@ -45,8 +43,8 @@ public class ShutdownHeaders implements MessageHeaders<EmptyRequestBody, EmptyRe
 	}
 
 	@Override
-	public Class<EmptyRequestBody> getRequestClass() {
-		return EmptyRequestBody.class;
+	public Class<ShutdownRequestBody> getRequestClass() {
+		return ShutdownRequestBody.class;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/cluster/ShutdownHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/cluster/ShutdownHeaders.java
@@ -24,12 +24,13 @@ import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
 
+import org.apache.flink.runtime.rest.messages.ShutdownMessageParameters;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 /**
  * Message headers for {@link org.apache.flink.runtime.rest.handler.cluster.ShutdownHandler}.
  */
-public class ShutdownHeaders implements MessageHeaders<EmptyRequestBody, EmptyResponseBody, EmptyMessageParameters> {
+public class ShutdownHeaders implements MessageHeaders<EmptyRequestBody, EmptyResponseBody, ShutdownMessageParameters> {
 
 	private static final ShutdownHeaders INSTANCE = new ShutdownHeaders();
 
@@ -49,8 +50,8 @@ public class ShutdownHeaders implements MessageHeaders<EmptyRequestBody, EmptyRe
 	}
 
 	@Override
-	public EmptyMessageParameters getUnresolvedMessageParameters() {
-		return EmptyMessageParameters.getInstance();
+	public ShutdownMessageParameters getUnresolvedMessageParameters() {
+		return new ShutdownMessageParameters();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/cluster/ShutdownRequestBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/cluster/ShutdownRequestBody.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.cluster;
+
+import org.apache.flink.runtime.rest.messages.RequestBody;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+/**
+ * Request for shutting down a cluster.
+ *
+ * <p>This request only contains the diagnostics messages of the application</p>.
+ */
+public final class ShutdownRequestBody implements RequestBody {
+
+	public static final String DIAGNOSTICS_MESSAGE = "diagnostics";
+
+	@JsonProperty(DIAGNOSTICS_MESSAGE)
+	@Nullable
+	public final String diagnostics;
+
+	@JsonCreator
+	public ShutdownRequestBody(
+			@Nullable @JsonProperty(DIAGNOSTICS_MESSAGE) String diagnostics) {
+		this.diagnostics = diagnostics;
+	}
+
+	@Nullable
+	@JsonIgnore
+	public String getDiagnostics() {
+		return diagnostics;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
@@ -126,11 +126,11 @@ class AkkaRpcActor<T extends RpcEndpoint & RpcGateway> extends AbstractActor {
 	public void postStop() throws Exception {
 		super.postStop();
 
-		if (rpcEndpointTerminationResult.isSuccess()) {
-			terminationFuture.complete(null);
-		} else {
-			terminationFuture.completeExceptionally(rpcEndpointTerminationResult.getFailureCause());
-		}
+//		if (rpcEndpointTerminationResult.isSuccess()) {
+//			terminationFuture.complete(null);
+//		} else {
+//			terminationFuture.completeExceptionally(rpcEndpointTerminationResult.getFailureCause());
+//		}
 
 		state = state.finishTermination();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
@@ -126,11 +126,11 @@ class AkkaRpcActor<T extends RpcEndpoint & RpcGateway> extends AbstractActor {
 	public void postStop() throws Exception {
 		super.postStop();
 
-//		if (rpcEndpointTerminationResult.isSuccess()) {
-//			terminationFuture.complete(null);
-//		} else {
-//			terminationFuture.completeExceptionally(rpcEndpointTerminationResult.getFailureCause());
-//		}
+		if (rpcEndpointTerminationResult.isSuccess()) {
+			terminationFuture.complete(null);
+		} else {
+			terminationFuture.completeExceptionally(rpcEndpointTerminationResult.getFailureCause());
+		}
 
 		state = state.finishTermination();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
@@ -183,7 +184,7 @@ public interface RestfulGateway extends RpcGateway {
 		throw new UnsupportedOperationException();
 	}
 
-	default CompletableFuture<Acknowledge> shutDownCluster() {
+	default CompletableFuture<Acknowledge> shutDownCluster(ApplicationStatus status, String diagnostics) {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.checkpoint.Checkpoints;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.savepoint.SavepointV2;
 import org.apache.flink.runtime.client.JobSubmissionException;
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
@@ -774,7 +775,7 @@ public class DispatcherTest extends TestLogger {
 		dispatcherLeaderElectionService.isLeader(UUID.randomUUID()).get();
 		final DispatcherGateway dispatcherGateway = dispatcher.getSelfGateway(DispatcherGateway.class);
 
-		dispatcherGateway.shutDownCluster().get();
+		dispatcherGateway.shutDownCluster(ApplicationStatus.SUCCEEDED, null).get();
 
 		dispatcher.getShutDownFuture().get();
 	}

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -26,10 +26,11 @@ import org.apache.flink.client.deployment.ClusterDescriptor
 import org.apache.flink.client.program.ClusterClient
 import org.apache.flink.configuration.{Configuration, GlobalConfiguration, JobManagerOptions}
 import org.apache.flink.runtime.minicluster.{MiniCluster, MiniClusterConfiguration}
-
 import scala.collection.mutable.ArrayBuffer
 import scala.tools.nsc.Settings
 import scala.tools.nsc.interpreter._
+
+import org.apache.flink.runtime.clusterframework.ApplicationStatus
 
 object FlinkShell {
 
@@ -224,7 +225,7 @@ object FlinkShell {
       cluster match {
         case Some(Left(miniCluster)) => miniCluster.close()
         case Some(Right(yarnCluster)) =>
-          yarnCluster.shutDownCluster()
+          yarnCluster.shutDownCluster(ApplicationStatus.SUCCEEDED, null)
           yarnCluster.close()
         case _ =>
       }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -684,7 +684,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 			LOG.info("Could not properly close the Yarn application status monitor.", e);
 		}
 
-		clusterClient.shutDownCluster();
+		clusterClient.shutDownCluster(ApplicationStatus.SUCCEEDED, null);
 
 		try {
 			clusterClient.close();


### PR DESCRIPTION


## What is the purpose of the change

Currently, The app final status is not correct when an application failed when running batch job on yarn with non-detached mode,  It reported SUCCEEDED but FAILED is what we expected.(e.g. failures caused by taskManager oom, client exits and etc.)

This PR is trying to make the final status correct.


## Brief change log

  - Update Shutdown rpc messages to to bring appStatus and diagnostics messages.
  - Calling code paths.
  - Shutdown future related


## Verifying this change

This change is verified with an terasort app, we tested it on yarn with non-detached mode.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
