### PR TITLE
[hotfix] Fix the typo in the comment of CompositeTypeSerializerSnapshot

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshot.java
@@ -58,7 +58,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * This means that the outer snapshot's version can be maintained only taking into account changes in how the
  * outer snapshot is written. Any changes in the base format does not require upticks in the outer snapshot's version.
  *
- * <h2>Serialization Format</hr>
+ * <h2>Serialization Format</h2>
  *
  * <p>The current version of the serialization format of a {@link CompositeTypeSerializerSnapshot} is as follows:
  *


### PR DESCRIPTION
## What is the purpose of the change

This PR fix the typo in the comment of `CompositeTypeSerializerSnapshot`.

## Brief change log

d4e13f6d20b241609bce5a1d81c84211afb7096c fixes the typo.

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented?  **not applicable**
