### PR TITLE
[FLINK-14413][build] Specify encoding for ApacheNoticeResourceTransformer

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -581,6 +581,7 @@ under the License.
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
 									<projectName>Apache Flink</projectName>
+									<encoding>UTF-8</encoding>
 								</transformer>
 							</transformers>
 						</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1589,6 +1589,7 @@ under the License.
 								<!-- The ApacheNoticeResourceTransformer collects and aggregates NOTICE files -->
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
 									<projectName>Apache Flink</projectName>
+									<encoding>UTF-8</encoding>
 								</transformer>
 							</transformers>
 						</configuration>


### PR DESCRIPTION
Pins the encoding for the `ApacheNoticeResourceTransformer`. Without this the transformer reads/writes all files using a platform-dependent encoding, which makes some parts of the build non-deterministic.