### PR TITLE
[FLINK-14004][runtime,test] Add test coverage for stateful SourceReaderOperator implementation

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -521,7 +521,7 @@ public class OneInputStreamTaskTest extends TestLogger {
 		TestingStreamOperator.numberRestoreCalls = 0;
 
 		testHarness.invoke();
-		testHarness.waitForTaskRunning(deadline.timeLeft().toMillis());
+		testHarness.waitForTaskRunning();
 
 		final OneInputStreamTask<String, String> streamTask = testHarness.getTask();
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceReaderStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceReaderStreamTaskTest.java
@@ -18,71 +18,188 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.execution.CancelTaskException;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.SourceReaderOperator;
 import org.apache.flink.streaming.runtime.io.InputStatus;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.util.TestHarnessUtil;
+import org.apache.flink.util.ExceptionUtils;
 
 import org.junit.Test;
 
+import java.util.Iterator;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.streaming.util.TestHarnessUtil.assertOutputEquals;
+import static org.apache.flink.util.Preconditions.checkState;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for verifying that the {@link SourceReaderOperator} as a task input can be integrated
  * well with {@link org.apache.flink.streaming.runtime.io.StreamOneInputProcessor}.
  */
 public class SourceReaderStreamTaskTest {
+	private static final int TIMEOUT = 30_000;
 
+	/**
+	 * Tests that the stream operator can snapshot and restore the operator state of chained
+	 * operators.
+	 */
 	@Test
-	public void testSourceOutputCorrectness() throws Exception {
+	public void testSnapshotAndRestore() throws Exception {
 		final int numRecords = 10;
+
+		TaskStateSnapshot taskStateSnapshot = executeAndWaitForCheckpoint(
+			numRecords,
+			1,
+			IntStream.range(0, numRecords),
+			Optional.empty());
+
+		executeAndWaitForCheckpoint(
+			numRecords,
+			2,
+			IntStream.range(numRecords, 2 * numRecords),
+			Optional.of(taskStateSnapshot));
+	}
+
+	private TaskStateSnapshot executeAndWaitForCheckpoint(
+			int numRecords,
+			long checkpointId,
+			IntStream expectedOutputStream,
+			Optional<TaskStateSnapshot> initialSnapshot) throws Exception {
+
+		final LinkedBlockingQueue<Object> expectedOutput = new LinkedBlockingQueue<>();
+		expectedOutputStream.forEach(record -> expectedOutput.add(new StreamRecord<>(record)));
+		CheckpointOptions checkpointOptions = CheckpointOptions.forCheckpointWithDefaultLocation();
+		expectedOutput.add(new CheckpointBarrier(checkpointId, checkpointId, checkpointOptions));
+
+		final StreamTaskTestHarness<Integer> testHarness = createTestHarness(numRecords);
+		if (initialSnapshot.isPresent()) {
+			testHarness.setTaskStateSnapshot(checkpointId, initialSnapshot.get());
+		}
+
+		TestTaskStateManager taskStateManager = testHarness.taskStateManager;
+		OneShotLatch waitForAcknowledgeLatch = new OneShotLatch();
+
+		taskStateManager.setWaitForReportLatch(waitForAcknowledgeLatch);
+
+		testHarness.invoke();
+		testHarness.waitForTaskRunning();
+
+		StreamTask<Integer, ?> streamTask = testHarness.getTask();
+		CheckpointMetaData checkpointMetaData = new CheckpointMetaData(checkpointId, checkpointId);
+
+		// wait with triggering the checkpoint until we emit all of the data
+		while (testHarness.getTask().inputProcessor.isAvailable().isDone()) {
+			Thread.sleep(1);
+		}
+
+		streamTask.triggerCheckpointAsync(checkpointMetaData, checkpointOptions, false).get();
+
+		waitForAcknowledgeLatch.await();
+
+		assertEquals(checkpointId, taskStateManager.getReportedCheckpointId());
+
+		testHarness.getTask().cancel();
+		try {
+			testHarness.waitForTaskCompletion(TIMEOUT);
+		}
+		catch (Exception ex) {
+			if (!ExceptionUtils.findThrowable(ex, CancelTaskException.class).isPresent()) {
+				throw ex;
+			}
+		}
+
+		assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
+		return taskStateManager.getLastJobManagerTaskStateSnapshot();
+	}
+
+	private static StreamTaskTestHarness<Integer> createTestHarness(int numRecords) {
 		final StreamTaskTestHarness<Integer> testHarness = new StreamTaskTestHarness<>(
 			SourceReaderStreamTask::new,
 			BasicTypeInfo.INT_TYPE_INFO);
 		final StreamConfig streamConfig = testHarness.getStreamConfig();
 
 		testHarness.setupOutputForSingletonOperatorChain();
-		streamConfig.setStreamOperator(new TestingFiniteSourceReaderOperator(numRecords));
-		streamConfig.setOperatorID(new OperatorID());
+		streamConfig.setStreamOperator(new TestingIntegerSourceReaderOperator(numRecords));
+		streamConfig.setOperatorID(new OperatorID(42, 44));
 
-		testHarness.invoke();
-		testHarness.waitForTaskCompletion();
-
-		final LinkedBlockingQueue<Object> expectedOutput = new LinkedBlockingQueue<>();
-		for (int i = 1; i <= numRecords; i++) {
-			expectedOutput.add(new StreamRecord<>(i));
-		}
-
-		TestHarnessUtil.assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
+		return testHarness;
 	}
 
 	/**
 	 * A simple {@link SourceReaderOperator} implementation for emitting limited int type records.
 	 */
-	private static class TestingFiniteSourceReaderOperator extends SourceReaderOperator<Integer> {
+	private static class TestingIntegerSourceReaderOperator extends SourceReaderOperator<Integer> {
 		private static final long serialVersionUID = 1L;
 
 		private final int numRecords;
+
+		private int lastRecord;
 		private int counter;
 
-		TestingFiniteSourceReaderOperator(int numRecords) {
+		private ListState<Integer> counterState;
+
+		TestingIntegerSourceReaderOperator(int numRecords) {
 			this.numRecords = numRecords;
 		}
 
 		@Override
 		public InputStatus emitNext(DataOutput<Integer> output) throws Exception {
-			output.emitRecord(new StreamRecord<>(++counter));
+			output.emitRecord(new StreamRecord<>(counter++));
 
-			return counter < numRecords ? InputStatus.MORE_AVAILABLE : InputStatus.END_OF_INPUT;
+			return hasEmittedEverything() ? InputStatus.NOTHING_AVAILABLE : InputStatus.MORE_AVAILABLE;
+		}
+
+		private boolean hasEmittedEverything() {
+			return counter >= lastRecord;
+		}
+
+		@Override
+		public void initializeState(StateInitializationContext context) throws Exception {
+			super.initializeState(context);
+
+			counterState = context.getOperatorStateStore().getListState(
+				new ListStateDescriptor<>("counter", IntSerializer.INSTANCE));
+
+			Iterator<Integer> counters = counterState.get().iterator();
+			if (counters.hasNext()) {
+				counter = counters.next();
+			}
+			lastRecord = counter + numRecords;
+			checkState(!counters.hasNext());
+		}
+
+		@Override
+		public void snapshotState(StateSnapshotContext context) throws Exception {
+			super.snapshotState(context);
+
+			counterState.clear();
+			counterState.add(counter);
 		}
 
 		@Override
 		public CompletableFuture<?> isAvailable() {
-			throw new UnsupportedOperationException();
+			if (hasEmittedEverything()) {
+				return new CompletableFuture<>();
+			}
+			return AVAILABLE;
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -282,17 +282,6 @@ public class StreamTaskTestHarness<OUT> {
 	 * @throws Exception
 	 */
 	public void waitForTaskRunning() throws Exception {
-		waitForTaskRunning(Long.MAX_VALUE);
-	}
-
-	/**
-	 * Waits fro the task to be running. If this does not happen within the timeout, then a
-	 * TimeoutException is thrown.
-	 *
-	 * @param timeout Timeout for the task to be running.
-	 * @throws Exception
-	 */
-	public void waitForTaskRunning(long timeout) throws Exception {
 		Preconditions.checkState(taskThread != null, "Task thread was not started.");
 		StreamTask<?, ?> streamTask = taskThread.task;
 		while (!streamTask.isRunning()) {


### PR DESCRIPTION
This PR simply adds a test to make sure that stateful `SourceReaderOperator` implementation is supported by the runtime.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
