### PR TITLE
[FLINK-12122] Add support for spreading slots out across all TaskExecutors

### DIFF
--- a/docs/_includes/generated/cluster_configuration.html
+++ b/docs/_includes/generated/cluster_configuration.html
@@ -8,6 +8,11 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>cluster.evenly-spread-out-slots</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Enable the slot spread out allocation strategy. This strategy tries to spread out the slots evenly across all available <span markdown="span">`TaskExecutors`</span>.</td>
+        </tr>
+        <tr>
             <td><h5>cluster.registration.error-delay</h5></td>
             <td style="word-wrap: break-word;">10000</td>
             <td>The pause made after an registration attempt caused an exception (other than timeout) in milliseconds.</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -19,6 +19,9 @@
 package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.description.Description;
+
+import static org.apache.flink.configuration.description.TextElement.code;
 
 /**
  * Options which control the cluster behaviour.
@@ -50,4 +53,13 @@ public class ClusterOptions {
 		.key("cluster.services.shutdown-timeout")
 		.defaultValue(30000L)
 		.withDescription("The shutdown timeout for cluster services like executors in milliseconds.");
+
+	public static final ConfigOption<Boolean> EVENLY_SPREAD_OUT_SLOTS_STRATEGY = ConfigOptions
+		.key("cluster.evenly-spread-out-slots")
+		.defaultValue(false)
+		.withDescription(
+			Description.builder()
+				.text("Enable the slot spread out allocation strategy. This strategy tries to spread out " +
+					"the slots evenly across all available %s.", code("TaskExecutors"))
+				.build());
 }

--- a/flink-core/src/main/java/org/apache/flink/util/OptionalConsumer.java
+++ b/flink-core/src/main/java/org/apache/flink/util/OptionalConsumer.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.util;
 
+import org.apache.flink.util.function.ThrowingRunnable;
+
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -45,7 +47,7 @@ public class OptionalConsumer<T> {
 		return this;
 	}
 
-	public OptionalConsumer<T> ifNotPresent(Runnable r) {
+	public <E extends Exception> OptionalConsumer<T> ifNotPresent(ThrowingRunnable<E> r) throws E {
 		if (!optional.isPresent()) {
 			r.run();
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultLocationPreferenceSlotSelectionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultLocationPreferenceSlotSelectionStrategy.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobmanager.scheduler.Locality;
+
+import javax.annotation.Nonnull;
+
+import java.util.Collection;
+import java.util.Optional;
+
+class DefaultLocationPreferenceSlotSelectionStrategy extends LocationPreferenceSlotSelectionStrategy {
+
+	@Nonnull
+	@Override
+	protected Optional<SlotInfoAndLocality> selectWithoutLocationPreference(@Nonnull Collection<SlotInfoAndResources> availableSlots, @Nonnull ResourceProfile resourceProfile) {
+		for (SlotInfoAndResources candidate : availableSlots) {
+			if (candidate.getRemainingResources().isMatching(resourceProfile)) {
+				return Optional.of(SlotInfoAndLocality.of(candidate.getSlotInfo(), Locality.UNCONSTRAINED));
+			}
+		}
+		return Optional.empty();
+	}
+
+	@Override
+	protected double calculateCandidateScore(int localWeigh, int hostLocalWeigh, double taskExecutorUtilization) {
+		return localWeigh * 10 + hostLocalWeigh;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultSchedulerFactory.java
@@ -44,9 +44,9 @@ public class DefaultSchedulerFactory implements SchedulerFactory {
 	@Nonnull
 	private static SlotSelectionStrategy selectSlotSelectionStrategy(@Nonnull Configuration configuration) {
 		if (configuration.getBoolean(CheckpointingOptions.LOCAL_RECOVERY)) {
-			return PreviousAllocationSlotSelectionStrategy.INSTANCE;
+			return PreviousAllocationSlotSelectionStrategy.create();
 		} else {
-			return LocationPreferenceSlotSelectionStrategy.INSTANCE;
+			return LocationPreferenceSlotSelectionStrategy.createDefault();
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultSchedulerFactory.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.jobmaster.slotpool;
 
 import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 
 import javax.annotation.Nonnull;
@@ -43,10 +44,20 @@ public class DefaultSchedulerFactory implements SchedulerFactory {
 
 	@Nonnull
 	private static SlotSelectionStrategy selectSlotSelectionStrategy(@Nonnull Configuration configuration) {
-		if (configuration.getBoolean(CheckpointingOptions.LOCAL_RECOVERY)) {
-			return PreviousAllocationSlotSelectionStrategy.create();
+		final boolean evenlySpreadOutSlots = configuration.getBoolean(ClusterOptions.EVENLY_SPREAD_OUT_SLOTS_STRATEGY);
+
+		final SlotSelectionStrategy locationPreferenceSlotSelectionStrategy;
+
+		if (evenlySpreadOutSlots) {
+			locationPreferenceSlotSelectionStrategy = LocationPreferenceSlotSelectionStrategy.createEvenlySpreadOut();
 		} else {
-			return LocationPreferenceSlotSelectionStrategy.createDefault();
+			locationPreferenceSlotSelectionStrategy = LocationPreferenceSlotSelectionStrategy.createDefault();
+		}
+
+		if (configuration.getBoolean(CheckpointingOptions.LOCAL_RECOVERY)) {
+			return PreviousAllocationSlotSelectionStrategy.create(locationPreferenceSlotSelectionStrategy);
+		} else {
+			return locationPreferenceSlotSelectionStrategy;
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/EvenlySpreadOutLocationPreferenceSlotSelectionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/EvenlySpreadOutLocationPreferenceSlotSelectionStrategy.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobmanager.scheduler.Locality;
+
+import javax.annotation.Nonnull;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Optional;
+
+class EvenlySpreadOutLocationPreferenceSlotSelectionStrategy extends LocationPreferenceSlotSelectionStrategy {
+	@Nonnull
+	@Override
+	protected Optional<SlotInfoAndLocality> selectWithoutLocationPreference(@Nonnull Collection<SlotInfoAndResources> availableSlots, @Nonnull ResourceProfile resourceProfile) {
+		return availableSlots.stream()
+			.filter(slotInfoAndResources -> slotInfoAndResources.getRemainingResources().isMatching(resourceProfile))
+			.min(Comparator.comparing(SlotInfoAndResources::getTaskExecutorUtilization))
+			.map(slotInfoAndResources -> SlotInfoAndLocality.of(slotInfoAndResources.getSlotInfo(), Locality.UNCONSTRAINED));
+	}
+
+	@Override
+	protected double calculateCandidateScore(int localWeigh, int hostLocalWeigh, double taskExecutorUtilization) {
+		// taskExecutorUtilization in [0, 1] --> only affects choice if localWeigh and hostLocalWeigh
+		// between two candidates are equal
+		return localWeigh * 20 + hostLocalWeigh * 2 - taskExecutorUtilization;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/LocationPreferenceSlotSelectionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/LocationPreferenceSlotSelectionStrategy.java
@@ -30,20 +30,13 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.BiFunction;
 
 /**
  * This class implements a {@link SlotSelectionStrategy} that is based on location preference hints.
  */
-public enum LocationPreferenceSlotSelectionStrategy implements SlotSelectionStrategy {
+public abstract class LocationPreferenceSlotSelectionStrategy implements SlotSelectionStrategy {
 
-	INSTANCE;
-
-	/**
-	 * Calculates the candidate's locality score.
-	 */
-	private static final BiFunction<Integer, Integer, Integer> LOCALITY_EVALUATION_FUNCTION =
-		(localWeigh, hostLocalWeigh) -> localWeigh * 10 + hostLocalWeigh;
+	LocationPreferenceSlotSelectionStrategy() {}
 
 	@Override
 	public Optional<SlotInfoAndLocality> selectBestSlotForProfile(
@@ -65,19 +58,6 @@ public enum LocationPreferenceSlotSelectionStrategy implements SlotSelectionStra
 	}
 
 	@Nonnull
-	private Optional<SlotInfoAndLocality> selectWithoutLocationPreference(
-		@Nonnull Collection<SlotInfoAndResources> availableSlots,
-		@Nonnull ResourceProfile resourceProfile) {
-
-		for (SlotInfoAndResources candidate : availableSlots) {
-			if (candidate.getRemainingResources().isMatching(resourceProfile)) {
-				return Optional.of(SlotInfoAndLocality.of(candidate.getSlotInfo(), Locality.UNCONSTRAINED));
-			}
-		}
-		return Optional.empty();
-	}
-
-	@Nonnull
 	private Optional<SlotInfoAndLocality> selectWitLocationPreference(
 		@Nonnull Collection<SlotInfoAndResources> availableSlots,
 		@Nonnull Collection<TaskManagerLocation> locationPreferences,
@@ -94,21 +74,21 @@ public enum LocationPreferenceSlotSelectionStrategy implements SlotSelectionStra
 
 		SlotInfoAndResources bestCandidate = null;
 		Locality bestCandidateLocality = Locality.UNKNOWN;
-		int bestCandidateScore = Integer.MIN_VALUE;
+		double bestCandidateScore = Double.MIN_VALUE;
 
 		for (SlotInfoAndResources candidate : availableSlots) {
 
 			if (candidate.getRemainingResources().isMatching(resourceProfile)) {
 
 				// this gets candidate is local-weigh
-				Integer localWeigh = preferredResourceIDs.getOrDefault(
+				int localWeigh = preferredResourceIDs.getOrDefault(
 					candidate.getSlotInfo().getTaskManagerLocation().getResourceID(), 0);
 
 				// this gets candidate is host-local-weigh
-				Integer hostLocalWeigh = preferredFQHostNames.getOrDefault(
+				int hostLocalWeigh = preferredFQHostNames.getOrDefault(
 					candidate.getSlotInfo().getTaskManagerLocation().getFQDNHostname(), 0);
 
-				int candidateScore = LOCALITY_EVALUATION_FUNCTION.apply(localWeigh, hostLocalWeigh);
+				double candidateScore = calculateCandidateScore(localWeigh, hostLocalWeigh, candidate.getTaskExecutorUtilization());
 				if (candidateScore > bestCandidateScore) {
 					bestCandidateScore = candidateScore;
 					bestCandidate = candidate;
@@ -123,5 +103,24 @@ public enum LocationPreferenceSlotSelectionStrategy implements SlotSelectionStra
 		return bestCandidate != null ?
 			Optional.of(SlotInfoAndLocality.of(bestCandidate.getSlotInfo(), bestCandidateLocality)) :
 			Optional.empty();
+	}
+
+	@Nonnull
+	protected abstract Optional<SlotInfoAndLocality> selectWithoutLocationPreference(
+		@Nonnull Collection<SlotInfoAndResources> availableSlots,
+		@Nonnull ResourceProfile resourceProfile);
+
+	protected abstract double calculateCandidateScore(int localWeigh, int hostLocalWeigh, double taskExecutorUtilization);
+
+	// -------------------------------------------------------------------------------------------
+	// Factory methods
+	// -------------------------------------------------------------------------------------------
+
+	public static LocationPreferenceSlotSelectionStrategy createDefault() {
+		return new DefaultLocationPreferenceSlotSelectionStrategy();
+	}
+
+	public static LocationPreferenceSlotSelectionStrategy createEvenlySpreadOut() {
+		return new EvenlySpreadOutLocationPreferenceSlotSelectionStrategy();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PreviousAllocationSlotSelectionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PreviousAllocationSlotSelectionStrategy.java
@@ -85,6 +85,10 @@ public class PreviousAllocationSlotSelectionStrategy implements SlotSelectionStr
 	}
 
 	public static PreviousAllocationSlotSelectionStrategy create() {
-		return new PreviousAllocationSlotSelectionStrategy(LocationPreferenceSlotSelectionStrategy.createDefault());
+		return create(LocationPreferenceSlotSelectionStrategy.createDefault());
+	}
+
+	public static PreviousAllocationSlotSelectionStrategy create(SlotSelectionStrategy fallbackSlotSelectionStrategy) {
+		return new PreviousAllocationSlotSelectionStrategy(fallbackSlotSelectionStrategy);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PreviousAllocationSlotSelectionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PreviousAllocationSlotSelectionStrategy.java
@@ -34,9 +34,13 @@ import java.util.Set;
  * This class implements a {@link SlotSelectionStrategy} that is based on previous allocations and
  * falls back to using location preference hints if there is no previous allocation.
  */
-public enum PreviousAllocationSlotSelectionStrategy implements SlotSelectionStrategy {
+public class PreviousAllocationSlotSelectionStrategy implements SlotSelectionStrategy {
 
-	INSTANCE;
+	private final SlotSelectionStrategy fallbackSlotSelectionStrategy;
+
+	private PreviousAllocationSlotSelectionStrategy(SlotSelectionStrategy fallbackSlotSelectionStrategy) {
+		this.fallbackSlotSelectionStrategy = fallbackSlotSelectionStrategy;
+	}
 
 	@Override
 	public Optional<SlotInfoAndLocality> selectBestSlotForProfile(
@@ -58,7 +62,7 @@ public enum PreviousAllocationSlotSelectionStrategy implements SlotSelectionStra
 		// Second, select based on location preference, excluding blacklisted allocations
 		Set<AllocationID> blackListedAllocations = slotProfile.getPreviousExecutionGraphAllocations();
 		Collection<SlotInfoAndResources> availableAndAllowedSlots = computeWithoutBlacklistedSlots(availableSlots, blackListedAllocations);
-		return LocationPreferenceSlotSelectionStrategy.INSTANCE.selectBestSlotForProfile(availableAndAllowedSlots, slotProfile);
+		return fallbackSlotSelectionStrategy.selectBestSlotForProfile(availableAndAllowedSlots, slotProfile);
 	}
 
 	@Nonnull
@@ -78,5 +82,9 @@ public enum PreviousAllocationSlotSelectionStrategy implements SlotSelectionStra
 		}
 
 		return availableAndAllowedSlots;
+	}
+
+	public static PreviousAllocationSlotSelectionStrategy create() {
+		return new PreviousAllocationSlotSelectionStrategy(LocationPreferenceSlotSelectionStrategy.createDefault());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulerImpl.java
@@ -283,7 +283,7 @@ public class SchedulerImpl implements Scheduler {
 		Collection<SlotSelectionStrategy.SlotInfoAndResources> slotInfoList =
 				slotPool.getAvailableSlotsInformation()
 						.stream()
-						.map(SlotSelectionStrategy.SlotInfoAndResources::new)
+						.map(SlotSelectionStrategy.SlotInfoAndResources::fromSingleSlot)
 						.collect(Collectors.toList());
 
 		Optional<SlotSelectionStrategy.SlotInfoAndLocality> selectedAvailableSlot =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotInfoWithUtilization.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotInfoWithUtilization.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+
+/**
+ * Container for {@link SlotInfo} and the task executors utilization (freeSlots / totalOfferedSlots).
+ */
+public final class SlotInfoWithUtilization implements SlotInfo {
+	private final SlotInfo slotInfoDelegate;
+	private final double taskExecutorUtilization;
+
+	private SlotInfoWithUtilization(SlotInfo slotInfo, double taskExecutorUtilization) {
+		this.slotInfoDelegate = slotInfo;
+		this.taskExecutorUtilization = taskExecutorUtilization;
+	}
+
+	double getTaskExecutorUtilization() {
+		return taskExecutorUtilization;
+	}
+
+	@Override
+	public AllocationID getAllocationId() {
+		return slotInfoDelegate.getAllocationId();
+	}
+
+	@Override
+	public TaskManagerLocation getTaskManagerLocation() {
+		return slotInfoDelegate.getTaskManagerLocation();
+	}
+
+	@Override
+	public int getPhysicalSlotNumber() {
+		return slotInfoDelegate.getPhysicalSlotNumber();
+	}
+
+	@Override
+	public ResourceProfile getResourceProfile() {
+		return slotInfoDelegate.getResourceProfile();
+	}
+
+	public static SlotInfoWithUtilization from(SlotInfo slotInfo, double taskExecutorUtilization) {
+		return new SlotInfoWithUtilization(slotInfo, taskExecutorUtilization);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -26,7 +26,6 @@ import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.AllocatedSlotReport;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
-import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
@@ -128,13 +127,13 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * Returns a list of {@link SlotInfo} objects about all slots that are currently available in the slot
+	 * Returns a list of {@link SlotInfoWithUtilization} objects about all slots that are currently available in the slot
 	 * pool.
 	 *
-	 * @return a list of {@link SlotInfo} objects about all slots that are currently available in the slot pool.
+	 * @return a list of {@link SlotInfoWithUtilization} objects about all slots that are currently available in the slot pool.
 	 */
 	@Nonnull
-	Collection<SlotInfo> getAvailableSlotsInformation();
+	Collection<SlotInfoWithUtilization> getAvailableSlotsInformation();
 
 	/**
 	 * Allocates the available slot with the given allocation id under the given request id. This method returns

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSelectionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSelectionStrategy.java
@@ -56,9 +56,12 @@ public interface SlotSelectionStrategy {
 		@Nonnull
 		private final ResourceProfile remainingResources;
 
-		public SlotInfoAndResources(@Nonnull SlotInfo slotInfo, @Nonnull ResourceProfile remainingResources) {
+		private final double taskExecutorUtilization;
+
+		public SlotInfoAndResources(@Nonnull SlotInfo slotInfo, @Nonnull ResourceProfile remainingResources, double taskExecutorUtilization) {
 			this.slotInfo = slotInfo;
 			this.remainingResources = remainingResources;
+			this.taskExecutorUtilization = taskExecutorUtilization;
 		}
 
 		@Nonnull
@@ -71,8 +74,15 @@ public interface SlotSelectionStrategy {
 			return remainingResources;
 		}
 
-		public static SlotInfoAndResources fromSingleSlot(@Nonnull SlotInfo slotInfo) {
-			return new SlotInfoAndResources(slotInfo, slotInfo.getResourceProfile());
+		public double getTaskExecutorUtilization() {
+			return taskExecutorUtilization;
+		}
+
+		public static SlotInfoAndResources fromSingleSlot(@Nonnull SlotInfoWithUtilization slotInfoWithUtilization) {
+			return new SlotInfoAndResources(
+				slotInfoWithUtilization,
+				slotInfoWithUtilization.getResourceProfile(),
+				slotInfoWithUtilization.getTaskExecutorUtilization());
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSelectionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSelectionStrategy.java
@@ -56,10 +56,6 @@ public interface SlotSelectionStrategy {
 		@Nonnull
 		private final ResourceProfile remainingResources;
 
-		public SlotInfoAndResources(@Nonnull SlotInfo slotInfo) {
-			this(slotInfo, slotInfo.getResourceProfile());
-		}
-
 		public SlotInfoAndResources(@Nonnull SlotInfo slotInfo, @Nonnull ResourceProfile remainingResources) {
 			this.slotInfo = slotInfo;
 			this.remainingResources = remainingResources;
@@ -73,6 +69,10 @@ public interface SlotSelectionStrategy {
 		@Nonnull
 		public ResourceProfile getRemainingResources() {
 			return remainingResources;
+		}
+
+		public static SlotInfoAndResources fromSingleSlot(@Nonnull SlotInfo slotInfo) {
+			return new SlotInfoAndResources(slotInfo, slotInfo.getResourceProfile());
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
@@ -53,6 +53,7 @@ import java.util.concurrent.CompletionException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Manager which is responsible for slot sharing. Slot sharing allows to run different
@@ -185,18 +186,55 @@ public class SlotSharingManager {
 		return resolvedRootSlots
 			.values()
 			.stream()
-				.flatMap((Map<AllocationID, MultiTaskSlot> map) -> map.values().stream())
-				.filter(validMultiTaskSlotAndDoesNotContain(groupId))
-				.map((MultiTaskSlot multiTaskSlot) -> {
-					SlotInfo slotInfo = multiTaskSlot.getSlotContextFuture().join();
+				.flatMap((Map<AllocationID, MultiTaskSlot> map) -> createValidMultiTaskSlotInfos(map, groupId))
+				.map((MultiTaskSlotInfo multiTaskSlotInfo) -> {
+					SlotInfo slotInfo = multiTaskSlotInfo.getSlotInfo();
 					return new SlotSelectionStrategy.SlotInfoAndResources(
-							slotInfo,
-							slotInfo.getResourceProfile().subtract(multiTaskSlot.getReservedResources()));
+						slotInfo,
+						slotInfo.getResourceProfile().subtract(multiTaskSlotInfo.getReservedResources()),
+						multiTaskSlotInfo.getTaskExecutorUtilization());
 				}).collect(Collectors.toList());
 	}
 
+	private Stream<MultiTaskSlotInfo> createValidMultiTaskSlotInfos(Map<AllocationID, MultiTaskSlot> taskExecutorSlots, AbstractID groupId) {
+		final double taskExecutorUtilization = calculateTaskExecutorUtilization(taskExecutorSlots, groupId);
+
+		return taskExecutorSlots.values().stream()
+			.filter(validMultiTaskSlotAndDoesNotContain(groupId))
+			.map(multiTaskSlot ->
+				new MultiTaskSlotInfo(
+					multiTaskSlot.getSlotContextFuture().join(),
+					multiTaskSlot.getReservedResources(),
+					taskExecutorUtilization));
+	}
+
+	private double calculateTaskExecutorUtilization(Map<AllocationID, MultiTaskSlot> map, AbstractID groupId) {
+		int numberValidSlots = 0;
+		int numberFreeSlots = 0;
+
+		for (MultiTaskSlot multiTaskSlot : map.values()) {
+			if (isNotReleasing(multiTaskSlot)) {
+				numberValidSlots++;
+
+				if (doesNotContain(groupId, multiTaskSlot)) {
+					numberFreeSlots++;
+				}
+			}
+		}
+
+		return (double) (numberValidSlots - numberFreeSlots) / numberValidSlots;
+	}
+
+	private boolean isNotReleasing(MultiTaskSlot multiTaskSlot) {
+		return !multiTaskSlot.isReleasing();
+	}
+
+	private boolean doesNotContain(@Nullable AbstractID groupId, MultiTaskSlot multiTaskSlot) {
+		return !multiTaskSlot.contains(groupId);
+	}
+
 	private Predicate<MultiTaskSlot> validMultiTaskSlotAndDoesNotContain(@Nullable AbstractID groupId) {
-		return (MultiTaskSlot multiTaskSlot) -> !multiTaskSlot.contains(groupId) && !multiTaskSlot.isReleasing();
+		return (MultiTaskSlot multiTaskSlot) -> doesNotContain(groupId, multiTaskSlot) && isNotReleasing(multiTaskSlot);
 	}
 
 	@Nullable
@@ -814,6 +852,30 @@ public class SlotSharingManager {
 			while (baseIterator.hasNext() && !currentIterator.hasNext()) {
 				currentIterator = baseIterator.next().values().iterator();
 			}
+		}
+	}
+
+	private static class MultiTaskSlotInfo {
+		private final SlotInfo slotInfo;
+		private final ResourceProfile reservedResources;
+		private final double taskExecutorUtilization;
+
+		private MultiTaskSlotInfo(SlotInfo slotInfo, ResourceProfile reservedResources, double taskExecutorUtilization) {
+			this.slotInfo = slotInfo;
+			this.reservedResources = reservedResources;
+			this.taskExecutorUtilization = taskExecutorUtilization;
+		}
+
+		private ResourceProfile getReservedResources() {
+			return reservedResources;
+		}
+
+		private double getTaskExecutorUtilization() {
+			return taskExecutorUtilization;
+		}
+
+		private SlotInfo getSlotInfo() {
+			return slotInfo;
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
@@ -21,9 +21,11 @@ package org.apache.flink.runtime.resourcemanager;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.resourcemanager.slotmanager.AnyMatchingSlotMatchingStrategy;
+import org.apache.flink.runtime.resourcemanager.slotmanager.LeastUtilizationSlotMatchingStrategy;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerConfiguration;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerImpl;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotMatchingStrategy;
 import org.apache.flink.util.Preconditions;
 
 /**
@@ -54,15 +56,7 @@ public class ResourceManagerRuntimeServices {
 			HighAvailabilityServices highAvailabilityServices,
 			ScheduledExecutor scheduledExecutor) throws Exception {
 
-		final SlotManagerConfiguration slotManagerConfiguration = configuration.getSlotManagerConfiguration();
-
-		final SlotManager slotManager = new SlotManagerImpl(
-			AnyMatchingSlotMatchingStrategy.INSTANCE,
-			scheduledExecutor,
-			slotManagerConfiguration.getTaskManagerRequestTimeout(),
-			slotManagerConfiguration.getSlotRequestTimeout(),
-			slotManagerConfiguration.getTaskManagerTimeout(),
-			slotManagerConfiguration.isWaitResultConsumedBeforeRelease());
+		final SlotManager slotManager = createSlotManager(configuration, scheduledExecutor);
 
 		final JobLeaderIdService jobLeaderIdService = new JobLeaderIdService(
 			highAvailabilityServices,
@@ -70,5 +64,25 @@ public class ResourceManagerRuntimeServices {
 			configuration.getJobTimeout());
 
 		return new ResourceManagerRuntimeServices(slotManager, jobLeaderIdService);
+	}
+
+	private static SlotManager createSlotManager(ResourceManagerRuntimeServicesConfiguration configuration, ScheduledExecutor scheduledExecutor) {
+		final SlotManagerConfiguration slotManagerConfiguration = configuration.getSlotManagerConfiguration();
+
+		final SlotMatchingStrategy slotMatchingStrategy;
+
+		if (slotManagerConfiguration.evenlySpreadOutSlots()) {
+			slotMatchingStrategy = LeastUtilizationSlotMatchingStrategy.INSTANCE;
+		} else {
+			slotMatchingStrategy = AnyMatchingSlotMatchingStrategy.INSTANCE;
+		}
+
+		return new SlotManagerImpl(
+			slotMatchingStrategy,
+			scheduledExecutor,
+			slotManagerConfiguration.getTaskManagerRequestTimeout(),
+			slotManagerConfiguration.getSlotRequestTimeout(),
+			slotManagerConfiguration.getTaskManagerTimeout(),
+			slotManagerConfiguration.isWaitResultConsumedBeforeRelease());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.resourcemanager.slotmanager.AnyMatchingSlotMatchingStrategy;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerConfiguration;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerImpl;
@@ -56,6 +57,7 @@ public class ResourceManagerRuntimeServices {
 		final SlotManagerConfiguration slotManagerConfiguration = configuration.getSlotManagerConfiguration();
 
 		final SlotManager slotManager = new SlotManagerImpl(
+			AnyMatchingSlotMatchingStrategy.INSTANCE,
 			scheduledExecutor,
 			slotManagerConfiguration.getTaskManagerRequestTimeout(),
 			slotManagerConfiguration.getSlotRequestTimeout(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/AnyMatchingSlotMatchingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/AnyMatchingSlotMatchingStrategy.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.instance.InstanceID;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * {@link SlotMatchingStrategy} which picks the first matching slot.
+ */
+public enum AnyMatchingSlotMatchingStrategy implements SlotMatchingStrategy {
+	INSTANCE;
+
+	@Override
+	public <T extends TaskManagerSlotInformation> Optional<T> findMatchingSlot(
+			ResourceProfile requestedProfile,
+			Collection<T> freeSlots,
+			Function<InstanceID, Integer> numberRegisteredSlotsLookup) {
+
+		return freeSlots.stream().filter(slot -> slot.isMatchingRequirement(requestedProfile)).findAny();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/LeastUtilizationSlotMatchingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/LeastUtilizationSlotMatchingStrategy.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * {@link SlotMatchingStrategy} which picks a matching slot from a TaskExecutor
+ * with the least utilization.
+ */
+public enum LeastUtilizationSlotMatchingStrategy implements SlotMatchingStrategy {
+	INSTANCE;
+
+	@Override
+	public <T extends TaskManagerSlotInformation> Optional<T> findMatchingSlot(
+			ResourceProfile requestedProfile,
+			Collection<T> freeSlots,
+			Function<InstanceID, Integer> numberRegisteredSlotsLookup) {
+		final Map<InstanceID, Integer> numSlotsPerTaskExecutor = freeSlots.stream()
+			.collect(Collectors.groupingBy(
+				TaskManagerSlotInformation::getInstanceId,
+				Collectors.reducing(0, i -> 1, Integer::sum)));
+
+		return freeSlots.stream()
+			.filter(taskManagerSlot -> taskManagerSlot.isMatchingRequirement(requestedProfile))
+			.min(Comparator.comparingDouble(taskManagerSlot -> calculateUtilization(taskManagerSlot.getInstanceId(), numberRegisteredSlotsLookup, numSlotsPerTaskExecutor)));
+	}
+
+	private static double calculateUtilization(InstanceID instanceId, Function<? super InstanceID, Integer> numberRegisteredSlotsLookup, Map<InstanceID, Integer> numSlotsPerTaskExecutor) {
+		final int numberRegisteredSlots = numberRegisteredSlotsLookup.apply(instanceId);
+
+		Preconditions.checkArgument(numberRegisteredSlots > 0, "The TaskExecutor %s has no slots registered.", instanceId);
+
+		final int numberFreeSlots = numSlotsPerTaskExecutor.getOrDefault(instanceId, 0);
+
+		Preconditions.checkArgument(numberRegisteredSlots >= numberFreeSlots, "The TaskExecutor %s has fewer registered slots than free slots.", instanceId);
+
+		return (double) (numberRegisteredSlots - numberFreeSlots) / numberRegisteredSlots;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.AkkaOptions;
+import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.ResourceManagerOptions;
@@ -41,17 +42,20 @@ public class SlotManagerConfiguration {
 	private final Time slotRequestTimeout;
 	private final Time taskManagerTimeout;
 	private final boolean waitResultConsumedBeforeRelease;
+	private final boolean evenlySpreadOutSlots;
 
 	public SlotManagerConfiguration(
 			Time taskManagerRequestTimeout,
 			Time slotRequestTimeout,
 			Time taskManagerTimeout,
-			boolean waitResultConsumedBeforeRelease) {
+			boolean waitResultConsumedBeforeRelease,
+			boolean evenlySpreadOutSlots) {
 
 		this.taskManagerRequestTimeout = Preconditions.checkNotNull(taskManagerRequestTimeout);
 		this.slotRequestTimeout = Preconditions.checkNotNull(slotRequestTimeout);
 		this.taskManagerTimeout = Preconditions.checkNotNull(taskManagerTimeout);
 		this.waitResultConsumedBeforeRelease = waitResultConsumedBeforeRelease;
+		this.evenlySpreadOutSlots = evenlySpreadOutSlots;
 	}
 
 	public Time getTaskManagerRequestTimeout() {
@@ -70,6 +74,10 @@ public class SlotManagerConfiguration {
 		return waitResultConsumedBeforeRelease;
 	}
 
+	public boolean evenlySpreadOutSlots() {
+		return evenlySpreadOutSlots;
+	}
+
 	public static SlotManagerConfiguration fromConfiguration(Configuration configuration) throws ConfigurationException {
 		final Time rpcTimeout;
 		try {
@@ -86,7 +94,14 @@ public class SlotManagerConfiguration {
 		boolean waitResultConsumedBeforeRelease =
 			configuration.getBoolean(ResourceManagerOptions.TASK_MANAGER_RELEASE_WHEN_RESULT_CONSUMED);
 
-		return new SlotManagerConfiguration(rpcTimeout, slotRequestTimeout, taskManagerTimeout, waitResultConsumedBeforeRelease);
+		boolean evenlySpreadOutSlots = configuration.getBoolean(ClusterOptions.EVENLY_SPREAD_OUT_SLOTS_STRATEGY);
+
+		return new SlotManagerConfiguration(
+			rpcTimeout,
+			slotRequestTimeout,
+			taskManagerTimeout,
+			waitResultConsumedBeforeRelease,
+			evenlySpreadOutSlots);
 	}
 
 	private static Time getSlotRequestTimeout(final Configuration configuration) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
-import org.apache.flink.runtime.clusterframework.types.TaskManagerSlot;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.messages.Acknowledge;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -510,7 +510,7 @@ public class SlotManagerImpl implements SlotManager {
 	 * @return A matching slot request which can be deployed in a slot with the given resource
 	 * profile. Null if there is no such slot request pending.
 	 */
-	protected PendingSlotRequest findMatchingRequest(ResourceProfile slotResourceProfile) {
+	private PendingSlotRequest findMatchingRequest(ResourceProfile slotResourceProfile) {
 
 		for (PendingSlotRequest pendingSlotRequest : pendingSlotRequests.values()) {
 			if (!pendingSlotRequest.isAssigned() && slotResourceProfile.isMatching(pendingSlotRequest.getResourceProfile())) {
@@ -533,7 +533,7 @@ public class SlotManagerImpl implements SlotManager {
 	 * @return A matching slot which fulfills the given resource profile. Null if there is no such
 	 * slot available.
 	 */
-	protected TaskManagerSlot findMatchingSlot(ResourceProfile requestResourceProfile) {
+	private TaskManagerSlot findMatchingSlot(ResourceProfile requestResourceProfile) {
 		Iterator<Map.Entry<SlotID, TaskManagerSlot>> iterator = freeSlots.entrySet().iterator();
 
 		while (iterator.hasNext()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotMatchingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotMatchingStrategy.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.instance.InstanceID;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Strategy how to find a matching slot.
+ */
+public interface SlotMatchingStrategy {
+
+	/**
+	 * Finds a matching slot for the requested {@link ResourceProfile} given the
+	 * collection of free slots and the total number of slots per TaskExecutor.
+	 *
+	 * @param requestedProfile to find a matching slot for
+	 * @param freeSlots collection of free slots
+	 * @param numberRegisteredSlotsLookup lookup for the number of registered slots
+	 * @return Returns a matching slots or {@link Optional#empty()} if there is none
+	 */
+	<T extends TaskManagerSlotInformation> Optional<T> findMatchingSlot(
+		ResourceProfile requestedProfile,
+		Collection<T> freeSlots,
+		Function<InstanceID, Integer> numberRegisteredSlotsLookup);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerSlot.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,12 +16,14 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.clusterframework.types;
+package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
-import org.apache.flink.runtime.resourcemanager.slotmanager.PendingSlotRequest;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerSlot.java
@@ -36,7 +36,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * A TaskManagerSlot represents a slot located in a TaskManager. It has a unique identification and
  * resource profile associated.
  */
-public class TaskManagerSlot {
+public class TaskManagerSlot implements TaskManagerSlotInformation {
 
 	/** The unique identification of this slot. */
 	private final SlotID slotId;
@@ -76,10 +76,12 @@ public class TaskManagerSlot {
 		return state;
 	}
 
+	@Override
 	public SlotID getSlotId() {
 		return slotId;
 	}
 
+	@Override
 	public ResourceProfile getResourceProfile() {
 		return resourceProfile;
 	}
@@ -101,6 +103,7 @@ public class TaskManagerSlot {
 		return assignedSlotRequest;
 	}
 
+	@Override
 	public InstanceID getInstanceId() {
 		return taskManagerConnection.getInstanceID();
 	}
@@ -153,6 +156,7 @@ public class TaskManagerSlot {
 	 * @param required The required resource profile
 	 * @return true if requirement can be matched
 	 */
+	@Override
 	public boolean isMatchingRequirement(ResourceProfile required) {
 		return resourceProfile.isMatching(required);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerSlotId.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerSlotId.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
-import org.apache.flink.runtime.clusterframework.types.TaskManagerSlot;
 import org.apache.flink.util.AbstractID;
 
 /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerSlotInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerSlotInformation.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.instance.InstanceID;
+
+/**
+ * Basic information about a {@link TaskManagerSlot}.
+ */
+public interface TaskManagerSlotInformation {
+
+	SlotID getSlotId();
+
+	InstanceID getInstanceId();
+
+	/**
+	 * Returns true if the required {@link ResourceProfile} can be fulfilled
+	 * by this slot.
+	 *
+	 * @param required resources
+	 * @return true if the this slot can fulfill the resource requirements
+	 */
+	boolean isMatchingRequirement(ResourceProfile required);
+
+	/**
+	 * Get resource profile of this slot.
+	 *
+	 * @return resource profile of this slot
+	 */
+	ResourceProfile getResourceProfile();
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/LocationPreferenceSlotSelectionStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/LocationPreferenceSlotSelectionStrategyTest.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 public class LocationPreferenceSlotSelectionStrategyTest extends SlotSelectionStrategyTestBase {
 
 	public LocationPreferenceSlotSelectionStrategyTest() {
-		super(LocationPreferenceSlotSelectionStrategy.INSTANCE);
+		super(LocationPreferenceSlotSelectionStrategy.createDefault());
 	}
 
 	protected LocationPreferenceSlotSelectionStrategyTest(SlotSelectionStrategy slotSelectionStrategy) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/LocationPreferenceSlotSelectionStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/LocationPreferenceSlotSelectionStrategyTest.java
@@ -88,17 +88,17 @@ public class LocationPreferenceSlotSelectionStrategyTest extends SlotSelectionSt
 		SlotProfile slotProfile = new SlotProfile(resourceProfile, Collections.singletonList(tml2), Collections.emptySet());
 		Optional<SlotSelectionStrategy.SlotInfoAndLocality> match = runMatching(slotProfile);
 
-		Assert.assertEquals(ssc2, match.get().getSlotInfo());
+		Assert.assertEquals(slotInfo2, match.get().getSlotInfo());
 
 		slotProfile = new SlotProfile(resourceProfile, Arrays.asList(tmlX, tml4), Collections.emptySet());
 		match = runMatching(slotProfile);
 
-		Assert.assertEquals(ssc4, match.get().getSlotInfo());
+		Assert.assertEquals(slotInfo4, match.get().getSlotInfo());
 
 		slotProfile = new SlotProfile(resourceProfile, Arrays.asList(tml3, tml1, tml3, tmlX), Collections.emptySet());
 		match = runMatching(slotProfile);
 
-		Assert.assertEquals(ssc3, match.get().getSlotInfo());
+		Assert.assertEquals(slotInfo3, match.get().getSlotInfo());
 	}
 
 	@Test
@@ -112,6 +112,6 @@ public class LocationPreferenceSlotSelectionStrategyTest extends SlotSelectionSt
 		Optional<SlotSelectionStrategy.SlotInfoAndLocality> match = runMatching(slotProfile);
 
 		// available previous allocation should override blacklisting
-		Assert.assertEquals(ssc3, match.get().getSlotInfo());
+		Assert.assertEquals(slotInfo3, match.get().getSlotInfo());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/PreviousAllocationSlotSelectionStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/PreviousAllocationSlotSelectionStrategyTest.java
@@ -41,12 +41,12 @@ public class PreviousAllocationSlotSelectionStrategyTest extends LocationPrefere
 		SlotProfile slotProfile = new SlotProfile(resourceProfile, Collections.singletonList(tml2), Collections.singleton(aid3));
 		Optional<SlotSelectionStrategy.SlotInfoAndLocality> match = runMatching(slotProfile);
 
-		Assert.assertEquals(ssc3, match.get().getSlotInfo());
+		Assert.assertEquals(slotInfo3, match.get().getSlotInfo());
 
 		slotProfile = new SlotProfile(resourceProfile, Arrays.asList(tmlX, tml1), new HashSet<>(Arrays.asList(aidX, aid2)));
 		match = runMatching(slotProfile);
 
-		Assert.assertEquals(ssc2, match.get().getSlotInfo());
+		Assert.assertEquals(slotInfo2, match.get().getSlotInfo());
 	}
 
 	@Test
@@ -55,7 +55,7 @@ public class PreviousAllocationSlotSelectionStrategyTest extends LocationPrefere
 		SlotProfile slotProfile = new SlotProfile(resourceProfile, Collections.singletonList(tml4), Collections.singleton(aidX));
 		Optional<SlotSelectionStrategy.SlotInfoAndLocality> match = runMatching(slotProfile);
 
-		Assert.assertEquals(ssc4, match.get().getSlotInfo());
+		Assert.assertEquals(slotInfo4, match.get().getSlotInfo());
 	}
 
 	@Test
@@ -82,6 +82,6 @@ public class PreviousAllocationSlotSelectionStrategyTest extends LocationPrefere
 		Optional<SlotSelectionStrategy.SlotInfoAndLocality> match = runMatching(slotProfile);
 
 		// we expect that the candidate that is not blacklisted is returned
-		Assert.assertEquals(ssc2, match.get().getSlotInfo());
+		Assert.assertEquals(slotInfo2, match.get().getSlotInfo());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/PreviousAllocationSlotSelectionStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/PreviousAllocationSlotSelectionStrategyTest.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 public class PreviousAllocationSlotSelectionStrategyTest extends LocationPreferenceSlotSelectionStrategyTest {
 
 	public PreviousAllocationSlotSelectionStrategyTest() {
-		super(PreviousAllocationSlotSelectionStrategy.INSTANCE);
+		super(PreviousAllocationSlotSelectionStrategy.create());
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotSelectionStrategyTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotSelectionStrategyTestBase.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.clusterframework.types;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.instance.SimpleSlotContext;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotInfoWithUtilization;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotSelectionStrategy;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.TestLogger;
@@ -50,10 +51,18 @@ public abstract class SlotSelectionStrategyTestBase extends TestLogger {
 
 	protected final TaskManagerGateway taskManagerGateway = new SimpleAckingTaskManagerGateway();
 
-	protected final SimpleSlotContext ssc1 = new SimpleSlotContext(aid1, tml1, 1, taskManagerGateway, resourceProfile);
-	protected final SimpleSlotContext ssc2 = new SimpleSlotContext(aid2, tml2, 2, taskManagerGateway, biggerResourceProfile);
-	protected final SimpleSlotContext ssc3 = new SimpleSlotContext(aid3, tml3, 3, taskManagerGateway, resourceProfile);
-	protected final SimpleSlotContext ssc4 = new SimpleSlotContext(aid4, tml4, 4, taskManagerGateway, resourceProfile);
+	protected final SlotInfoWithUtilization slotInfo1 = SlotInfoWithUtilization.from(
+		new SimpleSlotContext(aid1, tml1, 1, taskManagerGateway, resourceProfile),
+		0);
+	protected final SlotInfoWithUtilization slotInfo2 = SlotInfoWithUtilization.from(
+		new SimpleSlotContext(aid2, tml2, 2, taskManagerGateway, biggerResourceProfile),
+		0);
+	protected final SlotInfoWithUtilization slotInfo3 = SlotInfoWithUtilization.from(
+		new SimpleSlotContext(aid3, tml3, 3, taskManagerGateway, resourceProfile),
+		0);
+	protected final SlotInfoWithUtilization slotInfo4 = SlotInfoWithUtilization.from(
+		new SimpleSlotContext(aid4, tml4, 4, taskManagerGateway, resourceProfile),
+		0);
 
 	protected final Set<SlotSelectionStrategy.SlotInfoAndResources> candidates = Collections.unmodifiableSet(createCandidates());
 
@@ -65,10 +74,10 @@ public abstract class SlotSelectionStrategyTestBase extends TestLogger {
 
 	private Set<SlotSelectionStrategy.SlotInfoAndResources> createCandidates() {
 		Set<SlotSelectionStrategy.SlotInfoAndResources> candidates = new HashSet<>(4);
-		candidates.add(SlotSelectionStrategy.SlotInfoAndResources.fromSingleSlot(ssc1));
-		candidates.add(SlotSelectionStrategy.SlotInfoAndResources.fromSingleSlot(ssc2));
-		candidates.add(SlotSelectionStrategy.SlotInfoAndResources.fromSingleSlot(ssc3));
-		candidates.add(SlotSelectionStrategy.SlotInfoAndResources.fromSingleSlot(ssc4));
+		candidates.add(SlotSelectionStrategy.SlotInfoAndResources.fromSingleSlot(slotInfo1));
+		candidates.add(SlotSelectionStrategy.SlotInfoAndResources.fromSingleSlot(slotInfo2));
+		candidates.add(SlotSelectionStrategy.SlotInfoAndResources.fromSingleSlot(slotInfo3));
+		candidates.add(SlotSelectionStrategy.SlotInfoAndResources.fromSingleSlot(slotInfo4));
 		return candidates;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotSelectionStrategyTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotSelectionStrategyTestBase.java
@@ -65,10 +65,10 @@ public abstract class SlotSelectionStrategyTestBase extends TestLogger {
 
 	private Set<SlotSelectionStrategy.SlotInfoAndResources> createCandidates() {
 		Set<SlotSelectionStrategy.SlotInfoAndResources> candidates = new HashSet<>(4);
-		candidates.add(new SlotSelectionStrategy.SlotInfoAndResources(ssc1));
-		candidates.add(new SlotSelectionStrategy.SlotInfoAndResources(ssc2));
-		candidates.add(new SlotSelectionStrategy.SlotInfoAndResources(ssc3));
-		candidates.add(new SlotSelectionStrategy.SlotInfoAndResources(ssc4));
+		candidates.add(SlotSelectionStrategy.SlotInfoAndResources.fromSingleSlot(ssc1));
+		candidates.add(SlotSelectionStrategy.SlotInfoAndResources.fromSingleSlot(ssc2));
+		candidates.add(SlotSelectionStrategy.SlotInfoAndResources.fromSingleSlot(ssc3));
+		candidates.add(SlotSelectionStrategy.SlotInfoAndResources.fromSingleSlot(ssc4));
 		return candidates;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphNotEnoughResourceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphNotEnoughResourceTest.java
@@ -150,7 +150,7 @@ public class ExecutionGraphNotEnoughResourceTest extends TestLogger {
 		final ResourceManagerGateway resourceManagerGateway = new TestingResourceManagerGateway();
 		slotPool.start(JobMasterId.generate(), jobManagerAddress, mainThreadExecutor);
 		slotPool.connectToResourceManager(resourceManagerGateway);
-		Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.INSTANCE, slotPool);
+		Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.createDefault(), slotPool);
 		scheduler.start(mainThreadExecutor);
 
 		CompletableFuture.runAsync(() -> slotPool.registerTaskManager(taskManagerLocation.getResourceID()), mainThreadExecutor).join();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -761,7 +761,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
 		final TaskManagerGateway taskManagerGateway = new SimpleAckingTaskManagerGateway();
 		setupSlotPool(slotPool);
-		Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.INSTANCE, slotPool);
+		Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.createDefault(), slotPool);
 		scheduler.start(mainThreadExecutor);
 		slotPool.registerTaskManager(taskManagerLocation.getResourceID());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestBase.java
@@ -72,7 +72,7 @@ public abstract class SchedulerTestBase extends TestLogger {
 	public void setup() throws Exception {
 		final JobID jobId = new JobID();
 		slotPool = new TestingSlotPoolImpl(jobId);
-		scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.INSTANCE, slotPool);
+		scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.createDefault(), slotPool);
 
 		testingSlotProvider = new TestingSlotPoolSlotProvider();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -88,6 +88,7 @@ import org.apache.flink.runtime.jobmaster.factories.UnregisteredJobManagerJobMet
 import org.apache.flink.runtime.jobmaster.slotpool.DefaultSchedulerFactory;
 import org.apache.flink.runtime.jobmaster.slotpool.DefaultSlotPoolFactory;
 import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlot;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotInfoWithUtilization;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolFactory;
 import org.apache.flink.runtime.jobmaster.utils.JobMasterBuilder;
@@ -570,8 +571,11 @@ public class JobMasterTest extends TestLogger {
 
 		@Nonnull
 		@Override
-		public Collection<SlotInfo> getAvailableSlotsInformation() {
-			final Collection<SlotInfo> allSlotInfos = registeredSlots.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
+		public Collection<SlotInfoWithUtilization> getAvailableSlotsInformation() {
+			final Collection<SlotInfoWithUtilization> allSlotInfos = registeredSlots.values().stream()
+				.flatMap(Collection::stream)
+				.map(slot -> SlotInfoWithUtilization.from(slot, 0))
+				.collect(Collectors.toList());
 
 			return Collections.unmodifiableCollection(allSlotInfos);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolCoLocationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolCoLocationTest.java
@@ -64,7 +64,7 @@ public class SlotPoolCoLocationTest extends TestLogger {
 
 	@Rule
 	public final SlotPoolResource slotPoolResource =
-		new SlotPoolResource(PreviousAllocationSlotSelectionStrategy.INSTANCE);
+		new SlotPoolResource(PreviousAllocationSlotSelectionStrategy.create());
 
 	/**
 	 * Tests the scheduling of two tasks with a parallelism of 2 and a co-location constraint.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImplTest.java
@@ -51,6 +51,8 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableMap;
+
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
@@ -73,9 +75,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.apache.flink.runtime.jobmaster.slotpool.AvailableSlotsTest.DEFAULT_TESTING_PROFILE;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -704,6 +708,52 @@ public class SlotPoolImplTest extends TestLogger {
 			assertThat(jobId, is(slotReport.getJobId()));
 			assertThat(slotReport.getAllocatedSlotInfos(), containsInAnyOrder(isEachEqual(allocatedSlotInfos)));
 		}
+	}
+
+	@Test
+	public void testCalculationOfTaskExecutorUtilization() throws Exception {
+		try (final SlotPoolImpl slotPool = createSlotPoolImpl()) {
+			setupSlotPool(slotPool, resourceManagerGateway, mainThreadExecutor);
+
+			final TaskManagerLocation firstTaskManagerLocation = new LocalTaskManagerLocation();
+			final TaskManagerLocation secondTaskManagerLocation = new LocalTaskManagerLocation();
+
+			final List<AllocationID> firstTaskManagersSlots = registerAndOfferSlots(firstTaskManagerLocation, slotPool, 4);
+			final List<AllocationID> secondTaskManagersSlots = registerAndOfferSlots(secondTaskManagerLocation, slotPool, 4);
+
+			slotPool.allocateAvailableSlot(new SlotRequestId(), firstTaskManagersSlots.get(0));
+			slotPool.allocateAvailableSlot(new SlotRequestId(), firstTaskManagersSlots.get(1));
+			slotPool.allocateAvailableSlot(new SlotRequestId(), secondTaskManagersSlots.get(3));
+
+			final Collection<SlotInfoWithUtilization> availableSlotsInformation = slotPool.getAvailableSlotsInformation();
+
+			final Map<TaskManagerLocation, Double> utilizationPerTaskExecutor = ImmutableMap.of(
+				firstTaskManagerLocation, 2.0 / 4,
+				secondTaskManagerLocation, 1.0 / 4);
+
+			for (SlotInfoWithUtilization slotInfoWithUtilization : availableSlotsInformation) {
+				final double expectedTaskExecutorUtilization = utilizationPerTaskExecutor.get(slotInfoWithUtilization.getTaskManagerLocation());
+				assertThat(slotInfoWithUtilization.getTaskExecutorUtilization(), is(closeTo(expectedTaskExecutorUtilization, 0.1)));
+			}
+		}
+	}
+
+	private List<AllocationID> registerAndOfferSlots(TaskManagerLocation taskManagerLocation, SlotPoolImpl slotPool, int numberOfSlotsToRegister) {
+		slotPool.registerTaskManager(taskManagerLocation.getResourceID());
+		final List<AllocationID> allocationIds = IntStream.range(0, numberOfSlotsToRegister)
+			.mapToObj(ignored -> new AllocationID())
+			.collect(Collectors.toList());
+
+		Collection<SlotOffer> slotOffers = IntStream.range(0, numberOfSlotsToRegister)
+			.mapToObj(index -> new SlotOffer(allocationIds.get(index), index, ResourceProfile.ANY))
+			.collect(Collectors.toList());
+
+		slotPool.offerSlots(
+			taskManagerLocation,
+			new SimpleAckingTaskManagerGateway(),
+			slotOffers);
+
+		return allocationIds;
 	}
 
 	private static Collection<Matcher<? super AllocatedSlotInfo>> isEachEqual(Collection<AllocatedSlotInfo> allocatedSlotInfos) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImplTest.java
@@ -814,7 +814,7 @@ public class SlotPoolImplTest extends TestLogger {
 	private static Scheduler setupScheduler(
 		SlotPool slotPool,
 		ComponentMainThreadExecutor mainThreadExecutable) {
-		Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.INSTANCE, slotPool);
+		Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.createDefault(), slotPool);
 		scheduler.start(mainThreadExecutable);
 		return scheduler;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolInteractionsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolInteractionsTest.java
@@ -91,7 +91,7 @@ public class SlotPoolInteractionsTest extends TestLogger {
 		)) {
 
 			pool.start(JobMasterId.generate(), "foobar", testMainThreadExecutor.getMainThreadExecutor());
-			Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.INSTANCE, pool);
+			Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.createDefault(), pool);
 			scheduler.start(testMainThreadExecutor.getMainThreadExecutor());
 
 			CompletableFuture<LogicalSlot> future = testMainThreadExecutor.execute(() -> scheduler.allocateSlot(
@@ -118,7 +118,7 @@ public class SlotPoolInteractionsTest extends TestLogger {
 			final CompletableFuture<SlotRequestId> timeoutFuture = new CompletableFuture<>();
 			pool.setTimeoutPendingSlotRequestConsumer(timeoutFuture::complete);
 			pool.start(JobMasterId.generate(), "foobar", testMainThreadExecutor.getMainThreadExecutor());
-			Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.INSTANCE, pool);
+			Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.createDefault(), pool);
 			scheduler.start(testMainThreadExecutor.getMainThreadExecutor());
 
 			SlotRequestId requestId = new SlotRequestId();
@@ -169,7 +169,7 @@ public class SlotPoolInteractionsTest extends TestLogger {
 			ResourceManagerGateway resourceManagerGateway = new TestingResourceManagerGateway();
 			pool.connectToResourceManager(resourceManagerGateway);
 
-			Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.INSTANCE, pool);
+			Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.createDefault(), pool);
 			scheduler.start(testMainThreadExecutor.getMainThreadExecutor());
 
 			SlotRequestId requestId = new SlotRequestId();
@@ -204,7 +204,7 @@ public class SlotPoolInteractionsTest extends TestLogger {
 
 			pool.start(JobMasterId.generate(), "foobar", testMainThreadExecutor.getMainThreadExecutor());
 
-			Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.INSTANCE, pool);
+			Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.createDefault(), pool);
 			scheduler.start(testMainThreadExecutor.getMainThreadExecutor());
 
 			final CompletableFuture<AllocationID> allocationIdFuture = new CompletableFuture<>();
@@ -271,7 +271,7 @@ public class SlotPoolInteractionsTest extends TestLogger {
 			ResourceManagerGateway resourceManagerGateway = new TestingResourceManagerGateway();
 			pool.connectToResourceManager(resourceManagerGateway);
 
-			Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.INSTANCE, pool);
+			Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.createDefault(), pool);
 			scheduler.start(testMainThreadExecutor.getMainThreadExecutor());
 
 			// test the pending request is clear when timed out

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolSlotSharingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolSlotSharingTest.java
@@ -56,7 +56,7 @@ public class SlotPoolSlotSharingTest extends TestLogger {
 
 	@Rule
 	public final SlotPoolResource slotPoolResource =
-		new SlotPoolResource(PreviousAllocationSlotSelectionStrategy.INSTANCE);
+		new SlotPoolResource(PreviousAllocationSlotSelectionStrategy.create());
 
 	@Test
 	public void testSingleQueuedSharedSlotScheduling() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolSlotSpreadOutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolSlotSpreadOutTest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotProfile;
+import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Tests for the {@link SchedulerImpl} and {@link SlotPoolImpl} which verify
+ * the spread out of slots.
+ */
+public class SlotPoolSlotSpreadOutTest extends TestLogger {
+
+	public static final Time TIMEOUT = Time.seconds(10L);
+
+	@Rule
+	public final SlotPoolResource slotPoolResource = new SlotPoolResource(LocationPreferenceSlotSelectionStrategy.createEvenlySpreadOut());
+
+	@Test
+	public void allocateSingleSlot_withNoRequirements_selectsSlotSoThatWorkloadIsSpreadOut() {
+		registerTaskExecutors(2, 4);
+
+		final ScheduledUnit firstSlotRequest = createSimpleSlotRequest();
+		final ScheduledUnit secondSlotRequest = createSimpleSlotRequest();
+
+		final CompletableFuture<LogicalSlot> firstSlotFuture = allocateSlot(firstSlotRequest);
+		final CompletableFuture<LogicalSlot> secondSlotFuture = allocateSlot(secondSlotRequest);
+
+		final TaskManagerLocation firstTaskManagerLocation = getTaskManagerLocation(firstSlotFuture);
+		final TaskManagerLocation secondTaskManagerLocation = getTaskManagerLocation(secondSlotFuture);
+
+		assertThat(firstTaskManagerLocation, is(not(equalTo(secondTaskManagerLocation))));
+	}
+
+	@Test
+	public void allocateSingleSlot_withInputPreference_inputPreferenceHasPrecedenceOverSpreadOut() {
+		registerTaskExecutors(2, 2);
+
+		final ScheduledUnit sourceSlotRequest = createSimpleSlotRequest();
+		final ScheduledUnit sinkSlotRequest = createSimpleSlotRequest();
+
+		final CompletableFuture<LogicalSlot> sourceSlotFuture = allocateSlot(sourceSlotRequest);
+		final TaskManagerLocation sourceTaskManagerLocation = getTaskManagerLocation(sourceSlotFuture);
+
+		Collection<TaskManagerLocation> preferredLocations = Collections.singleton(sourceTaskManagerLocation);
+		final CompletableFuture<LogicalSlot> sinkSlotFuture = allocateSlotWithInputPreference(sinkSlotRequest, preferredLocations);
+		final TaskManagerLocation sinkTaskManagerLocation = getTaskManagerLocation(sinkSlotFuture);
+
+		// input preference should have precedence over task spread out
+		assertThat(sinkTaskManagerLocation, is(equalTo(sourceTaskManagerLocation)));
+	}
+
+	@Test
+	public void allocateSharedSlot_withNoRequirements_selectsSlotsSoThatWorkloadIsSpreadOut() {
+		final int numberSlotsPerTaskExecutor = 2;
+		final int numberTaskExecutors = 2;
+		final int numberSlots = numberTaskExecutors * numberSlotsPerTaskExecutor;
+
+		registerTaskExecutors(numberTaskExecutors, numberSlotsPerTaskExecutor);
+
+		final JobVertexID sourceJobVertexId = new JobVertexID();
+		final JobVertexID sinkJobVertexId = new JobVertexID();
+		final SlotSharingGroupId slotSharingGroupId = new SlotSharingGroupId();
+
+		final List<ScheduledUnit> sourceScheduledUnits = IntStream.range(0, numberSlots)
+			.mapToObj(ignored -> createSharedSlotRequest(sourceJobVertexId, slotSharingGroupId))
+			.collect(Collectors.toList());
+
+		final List<ScheduledUnit> sinkScheduledUnits = IntStream.range(0, numberTaskExecutors)
+			.mapToObj(ignored -> createSharedSlotRequest(sinkJobVertexId, slotSharingGroupId))
+			.collect(Collectors.toList());
+
+		sourceScheduledUnits.forEach(this::allocateSlot);
+		final Set<TaskManagerLocation> sinkLocations = sinkScheduledUnits.stream()
+			.map(this::allocateSlot)
+			.map(this::getTaskManagerLocation)
+			.collect(Collectors.toSet());
+
+		// verify that the sinks have been evenly spread across the available TaskExecutors
+		assertThat(sinkLocations, hasSize(numberTaskExecutors));
+	}
+
+	private ScheduledUnit createSharedSlotRequest(JobVertexID jobVertexId, SlotSharingGroupId slotSharingGroupId) {
+		return new ScheduledUnit(jobVertexId, slotSharingGroupId, null);
+	}
+
+	private ScheduledUnit createSimpleSlotRequest() {
+		return new ScheduledUnit(new JobVertexID(), null, null);
+	}
+
+	private CompletableFuture<LogicalSlot> allocateSlot(ScheduledUnit scheduledUnit) {
+		return internalAllocateSlot(scheduledUnit, SlotProfile.noRequirements());
+	}
+
+	private CompletableFuture<LogicalSlot> internalAllocateSlot(ScheduledUnit scheduledUnit, SlotProfile slotProfile) {
+		SlotProvider slotProvider = slotPoolResource.getSlotProvider();
+		return slotProvider.allocateSlot(
+			new SlotRequestId(),
+			scheduledUnit,
+			slotProfile,
+			TIMEOUT);
+	}
+
+	private CompletableFuture<LogicalSlot> allocateSlotWithInputPreference(ScheduledUnit scheduledUnit, Collection<TaskManagerLocation> preferredLocations) {
+		return internalAllocateSlot(scheduledUnit, SlotProfile.preferredLocality(ResourceProfile.UNKNOWN, preferredLocations));
+	}
+
+	private TaskManagerLocation getTaskManagerLocation(CompletableFuture<? extends LogicalSlot> slotFuture) {
+		return slotFuture.join().getTaskManagerLocation();
+	}
+
+	private void registerTaskExecutors(int numberTaskExecutors, int numberSlotsPerTaskExecutor) {
+		for (int i = 0; i < numberTaskExecutors; i++) {
+			registerTaskExecutor(numberSlotsPerTaskExecutor);
+		}
+	}
+
+	private void registerTaskExecutor(int numberSlotsPerTaskExecutor) {
+		final SlotPool slotPool = slotPoolResource.getSlotPool();
+		final LocalTaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+
+		slotPool.registerTaskManager(taskManagerLocation.getResourceID());
+
+		final Collection<SlotOffer> slotOffers = IntStream
+			.range(0, numberSlotsPerTaskExecutor)
+			.mapToObj(index -> new SlotOffer(new AllocationID(), index, ResourceProfile.ANY))
+			.collect(Collectors.toList());
+
+		slotPool.offerSlots(taskManagerLocation, new SimpleAckingTaskManagerGateway(), slotOffers);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManagerTest.java
@@ -174,7 +174,7 @@ public class SlotSharingManagerTest extends TestLogger {
 	}
 
 	/**
-	 * Tests that we can release nested slots from the leaves onwards
+	 * Tests that we can release nested slots from the leaves onwards.
 	 */
 	@Test
 	public void testNestedSlotRelease() throws Exception {
@@ -351,7 +351,7 @@ public class SlotSharingManagerTest extends TestLogger {
 	}
 
 	/**
-	 * Tests that slot context future failures will release the root slot
+	 * Tests that slot context future failures will release the root slot.
 	 */
 	@Test
 	public void testSlotContextFutureFailure() {
@@ -387,7 +387,7 @@ public class SlotSharingManagerTest extends TestLogger {
 
 	/**
 	 * Tests that the root slot are moved from unresolved to resolved once the
-	 * slot context future is successfully completed
+	 * slot context future is successfully completed.
 	 */
 	@Test
 	public void testRootSlotTransition() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManagerTest.java
@@ -442,8 +442,9 @@ public class SlotSharingManagerTest extends TestLogger {
 		SlotSharingManager.MultiTaskSlot resolvedMultiTaskSlot =
 			slotSharingManager.getResolvedRootSlot(slotInfoAndRemainingResource.getSlotInfo());
 
-		SlotSelectionStrategy.SlotInfoAndLocality slotInfoAndLocality =
-			LocationPreferenceSlotSelectionStrategy.INSTANCE.selectBestSlotForProfile(slotInfos, SlotProfile.noRequirements()).get();
+		final LocationPreferenceSlotSelectionStrategy locationPreferenceSlotSelectionStrategy = LocationPreferenceSlotSelectionStrategy.createDefault();
+		SlotSelectionStrategy.SlotInfoAndLocality slotInfoAndLocality = locationPreferenceSlotSelectionStrategy
+			.selectBestSlotForProfile(slotInfos, SlotProfile.noRequirements()).get();
 
 		assertNotNull(resolvedMultiTaskSlot);
 		assertEquals(Locality.UNCONSTRAINED, slotInfoAndLocality.getLocality());
@@ -482,8 +483,9 @@ public class SlotSharingManagerTest extends TestLogger {
 		SlotProfile slotProfile = SlotProfile.preferredLocality(ResourceProfile.UNKNOWN, Collections.singleton(taskManagerLocation));
 
 		Collection<SlotSelectionStrategy.SlotInfoAndResources> slotInfos = slotSharingManager.listResolvedRootSlotInfo(groupId);
+		final LocationPreferenceSlotSelectionStrategy locationPreferenceSlotSelectionStrategy = LocationPreferenceSlotSelectionStrategy.createDefault();
 		SlotSelectionStrategy.SlotInfoAndLocality slotInfoAndLocality =
-			LocationPreferenceSlotSelectionStrategy.INSTANCE.selectBestSlotForProfile(slotInfos, slotProfile).get();
+			locationPreferenceSlotSelectionStrategy.selectBestSlotForProfile(slotInfos, slotProfile).get();
 		SlotSharingManager.MultiTaskSlot resolvedRootSlot = slotSharingManager.getResolvedRootSlot(slotInfoAndLocality.getSlotInfo());
 
 		assertNotNull(resolvedRootSlot);
@@ -498,7 +500,7 @@ public class SlotSharingManagerTest extends TestLogger {
 			slotInfoAndLocality.getLocality());
 
 		slotInfos = slotSharingManager.listResolvedRootSlotInfo(groupId);
-		slotInfoAndLocality = LocationPreferenceSlotSelectionStrategy.INSTANCE.selectBestSlotForProfile(slotInfos, slotProfile).get();
+		slotInfoAndLocality = locationPreferenceSlotSelectionStrategy.selectBestSlotForProfile(slotInfos, slotProfile).get();
 		resolvedRootSlot = slotSharingManager.getResolvedRootSlot(slotInfoAndLocality.getSlotInfo());
 		assertNotNull(resolvedRootSlot);
 		assertNotSame(Locality.LOCAL, (slotInfoAndLocality.getLocality()));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
@@ -68,7 +68,8 @@ public class ResourceManagerHATest extends TestLogger {
 				TestingUtils.infiniteTime(),
 				TestingUtils.infiniteTime(),
 				TestingUtils.infiniteTime(),
-				true));
+				true,
+				false));
 		ResourceManagerRuntimeServices resourceManagerRuntimeServices = ResourceManagerRuntimeServices.fromConfiguration(
 			resourceManagerRuntimeServicesConfiguration,
 			highAvailabilityServices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/AnyMatchingSlotMatchingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/AnyMatchingSlotMatchingStrategyTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the {@link AnyMatchingSlotMatchingStrategy}.
+ */
+public class AnyMatchingSlotMatchingStrategyTest extends TestLogger {
+
+	private final InstanceID instanceId = new InstanceID();
+
+	private TestingTaskManagerSlotInformation largeTaskManagerSlotInformation = null;
+	private Collection<TestingTaskManagerSlotInformation> freeSlots = null;
+
+	@Before
+	public void setup() {
+		final ResourceProfile largeResourceProfile = new ResourceProfile(10.2 , 42);
+		final ResourceProfile smallResourceProfile = new ResourceProfile(1 , 1);
+
+		largeTaskManagerSlotInformation = TestingTaskManagerSlotInformation.newBuilder()
+			.setInstanceId(instanceId)
+			.setResourceProfile(largeResourceProfile)
+			.build();
+
+		freeSlots = Arrays.asList(
+			TestingTaskManagerSlotInformation.newBuilder()
+				.setInstanceId(instanceId)
+				.setResourceProfile(smallResourceProfile)
+				.build(),
+			largeTaskManagerSlotInformation);
+	}
+
+	@Test
+	public void findMatchingSlot_withFulfillableRequest_returnsFulfillingSlot() {
+		final Optional<TestingTaskManagerSlotInformation> optionalMatchingSlot = AnyMatchingSlotMatchingStrategy.INSTANCE.findMatchingSlot(
+			largeTaskManagerSlotInformation.getResourceProfile(),
+			freeSlots,
+			countSlotsPerInstance(freeSlots));
+
+		assertTrue(optionalMatchingSlot.isPresent());
+		assertThat(optionalMatchingSlot.get().getSlotId(), is(largeTaskManagerSlotInformation.getSlotId()));
+	}
+
+	@Test
+	public void findMatchingSlot_withUnfulfillableRequest_returnsEmptyResult() {
+		final Optional<TestingTaskManagerSlotInformation> optionalMatchingSlot = AnyMatchingSlotMatchingStrategy.INSTANCE.findMatchingSlot(
+			new ResourceProfile(Double.MAX_VALUE, Integer.MAX_VALUE),
+			freeSlots,
+			countSlotsPerInstance(freeSlots));
+
+		assertFalse(optionalMatchingSlot.isPresent());
+	}
+
+	private Function<InstanceID, Integer> countSlotsPerInstance(Collection<? extends TestingTaskManagerSlotInformation> freeSlots) {
+		return currentInstanceId -> (int) freeSlots.stream().filter(slot -> slot.getInstanceId().equals(currentInstanceId)).count();
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/LeastUtilizationSlotMatchingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/LeastUtilizationSlotMatchingStrategyTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableMap;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the {@link LeastUtilizationSlotMatchingStrategy}.
+ */
+public class LeastUtilizationSlotMatchingStrategyTest extends TestLogger {
+
+	@Test
+	public void findMatchingSlot_multipleMatchingSlots_returnsSlotWithLeastUtilization() {
+		final ResourceProfile requestedResourceProfile = new ResourceProfile(2.0, 2);
+
+		final TestingTaskManagerSlotInformation leastUtilizedSlot = TestingTaskManagerSlotInformation.newBuilder()
+			.setResourceProfile(requestedResourceProfile)
+			.build();
+		final TestingTaskManagerSlotInformation tooSmallSlot = TestingTaskManagerSlotInformation.newBuilder()
+			.setResourceProfile(new ResourceProfile(1.0, 10))
+			.build();
+		final TestingTaskManagerSlotInformation alternativeSlot = TestingTaskManagerSlotInformation.newBuilder()
+			.setResourceProfile(requestedResourceProfile)
+			.build();
+
+		final Collection<TestingTaskManagerSlotInformation> freeSlots = Arrays.asList(
+			tooSmallSlot,
+			leastUtilizedSlot,
+			alternativeSlot);
+
+		Map<InstanceID, Integer> registeredSlotPerTaskExecutor = ImmutableMap.of(
+			leastUtilizedSlot.getInstanceId(), 1,
+			tooSmallSlot.getInstanceId(), 1,
+			alternativeSlot.getInstanceId(), 2);
+
+		final Optional<TestingTaskManagerSlotInformation> matchingSlot = LeastUtilizationSlotMatchingStrategy.INSTANCE.findMatchingSlot(
+			requestedResourceProfile,
+			freeSlots,
+			createRegisteredSlotsLookupFunction(registeredSlotPerTaskExecutor));
+
+		assertTrue(matchingSlot.isPresent());
+		assertThat(matchingSlot.get().getSlotId(), is(leastUtilizedSlot.getSlotId()));
+	}
+
+	private Function<InstanceID, Integer> createRegisteredSlotsLookupFunction(Map<InstanceID, Integer> registeredSlotPerTaskExecutor) {
+		return instanceID -> registeredSlotPerTaskExecutor.getOrDefault(instanceID, 0);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerBuilder.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.testingUtils.TestingUtils;
 
 /** Builder for {@link SlotManagerImpl}. */
 public class SlotManagerBuilder {
+	private SlotMatchingStrategy slotMatchingStrategy;
 	private ScheduledExecutor scheduledExecutor;
 	private Time taskManagerRequestTimeout;
 	private Time slotRequestTimeout;
@@ -31,6 +32,7 @@ public class SlotManagerBuilder {
 	private boolean waitResultConsumedBeforeRelease;
 
 	private SlotManagerBuilder() {
+		this.slotMatchingStrategy = AnyMatchingSlotMatchingStrategy.INSTANCE;
 		this.scheduledExecutor = TestingUtils.defaultScheduledExecutor();
 		this.taskManagerRequestTimeout = TestingUtils.infiniteTime();
 		this.slotRequestTimeout = TestingUtils.infiniteTime();
@@ -67,8 +69,14 @@ public class SlotManagerBuilder {
 		return this;
 	}
 
+	public SlotManagerBuilder setSlotMatchingStrategy(SlotMatchingStrategy slotMatchingStrategy) {
+		this.slotMatchingStrategy = slotMatchingStrategy;
+		return this;
+	}
+
 	public SlotManagerImpl build() {
 		return new SlotManagerImpl(
+			slotMatchingStrategy,
 			scheduledExecutor,
 			taskManagerRequestTimeout,
 			slotRequestTimeout,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
@@ -1389,6 +1389,10 @@ public class SlotManagerImplTest extends TestLogger {
 
 	private TaskExecutorConnection createTaskExecutorConnection() {
 		final TestingTaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway();
+		return createTaskExecutorConnection(taskExecutorGateway);
+	}
+
+	private TaskExecutorConnection createTaskExecutorConnection(TaskExecutorGateway taskExecutorGateway) {
 		return new TaskExecutorConnection(ResourceID.generate(), taskExecutorGateway);
 	}
 
@@ -1497,5 +1501,56 @@ public class SlotManagerImplTest extends TestLogger {
 			1,
 			ResourceProfile.UNKNOWN,
 			(slotId, resourceProfile) -> new SlotStatus(slotId, resourceProfile, jobId, new AllocationID()));
+	}
+
+	/**
+	 * The spread out slot allocation strategy should spread out the allocated
+	 * slots across all available TaskExecutors. See FLINK-12122.
+	 */
+	@Test
+	public void testSpreadOutSlotAllocationStrategy() throws Exception {
+		try (SlotManagerImpl slotManager = SlotManagerBuilder.newBuilder()
+			.setSlotMatchingStrategy(LeastUtilizationSlotMatchingStrategy.INSTANCE)
+			.build()) {
+			slotManager.start(
+				ResourceManagerId.generate(),
+				Executors.directExecutor(),
+				new TestingResourceActionsBuilder().build());
+
+			final List<CompletableFuture<JobID>> requestSlotFutures = new ArrayList<>();
+
+			final int numberTaskExecutors = 5;
+
+			// register n TaskExecutors with 2 slots each
+			for (int i = 0; i < numberTaskExecutors; i++) {
+				final CompletableFuture<JobID> requestSlotFuture = new CompletableFuture<>();
+				requestSlotFutures.add(requestSlotFuture);
+				registerTaskExecutorWithTwoSlots(slotManager, requestSlotFuture);
+			}
+
+			final JobID jobId = new JobID();
+
+			// request n slots
+			for (int i = 0; i < numberTaskExecutors; i++) {
+				assertTrue(slotManager.registerSlotRequest(createSlotRequest(jobId)));
+			}
+
+			// check that every TaskExecutor has received a slot request
+			final Set<JobID> jobIds = new HashSet<>(FutureUtils.combineAll(requestSlotFutures).get(10L, TimeUnit.SECONDS));
+			assertThat(jobIds, hasSize(1));
+			assertThat(jobIds, containsInAnyOrder(jobId));
+		}
+	}
+
+	private void registerTaskExecutorWithTwoSlots(SlotManagerImpl slotManager, CompletableFuture<JobID> firstRequestSlotFuture) {
+		final TestingTaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
+			.setRequestSlotFunction(slotIDJobIDAllocationIDStringResourceManagerIdTuple5 -> {
+				firstRequestSlotFuture.complete(slotIDJobIDAllocationIDStringResourceManagerIdTuple5.f1);
+				return CompletableFuture.completedFuture(Acknowledge.get());
+			})
+			.createTestingTaskExecutorGateway();
+		final TaskExecutorConnection firstTaskExecutorConnection = createTaskExecutorConnection(taskExecutorGateway);
+		final SlotReport firstSlotReport = createSlotReport(firstTaskExecutorConnection.getResourceID(), 2);
+		slotManager.registerTaskManager(firstTaskExecutorConnection, firstSlotReport);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
-import org.apache.flink.runtime.clusterframework.types.TaskManagerSlot;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingTaskManagerSlotInformation.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingTaskManagerSlotInformation.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.instance.InstanceID;
+
+/**
+ * Testing implementation of {@link TaskManagerSlotInformation}.
+ */
+public final class TestingTaskManagerSlotInformation implements TaskManagerSlotInformation {
+
+	private final SlotID slotId;
+	private final InstanceID instanceId;
+	private final ResourceProfile resourceProfile;
+
+	private TestingTaskManagerSlotInformation(SlotID slotId, InstanceID instanceId, ResourceProfile resourceProfile) {
+		this.slotId = slotId;
+		this.instanceId = instanceId;
+		this.resourceProfile = resourceProfile;
+	}
+
+	@Override
+	public SlotID getSlotId() {
+		return slotId;
+	}
+
+	@Override
+	public InstanceID getInstanceId() {
+		return instanceId;
+	}
+
+	@Override
+	public boolean isMatchingRequirement(ResourceProfile required) {
+		return resourceProfile.isMatching(required);
+	}
+
+	@Override
+	public ResourceProfile getResourceProfile() {
+		return resourceProfile;
+	}
+
+	public static Builder newBuilder() {
+		return new Builder();
+	}
+
+	static class Builder {
+		private SlotID slotId = new SlotID(ResourceID.generate(), 0);
+		private InstanceID instanceId = new InstanceID();
+		private ResourceProfile resourceProfile = ResourceProfile.ANY;
+
+		public Builder setInstanceId(InstanceID instanceId) {
+			this.instanceId = instanceId;
+			return this;
+		}
+
+		public Builder setResourceProfile(ResourceProfile resourceProfile) {
+			this.resourceProfile = resourceProfile;
+			return this;
+		}
+
+		public Builder setSlotId(SlotID slotId) {
+			this.slotId = slotId;
+			return this;
+		}
+
+		public TestingTaskManagerSlotInformation build() {
+			return new TestingTaskManagerSlotInformation(slotId, instanceId, resourceProfile);
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/LegacySchedulerBatchSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/LegacySchedulerBatchSchedulingTest.java
@@ -170,7 +170,7 @@ public class LegacySchedulerBatchSchedulingTest extends TestLogger {
 
 	@Nonnull
 	private SchedulerImpl createScheduler(SlotPool slotPool, ComponentMainThreadExecutor mainThreadExecutor) {
-		final SchedulerImpl scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.INSTANCE, slotPool);
+		final SchedulerImpl scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.createDefault(), slotPool);
 		scheduler.start(mainThreadExecutor);
 
 		return scheduler;


### PR DESCRIPTION
## What is the purpose of the change

This PR adds support for spreading slots out across all currently registered `TaskExecutors`.

This feature can be enabled by setting `cluster.evenly-spread-out-slots: true` in Flink's configuration file.

If the feature is enabled, then Flink's `ResourceManager` tries to fulfill slot requests with slots whose `TaskExecutor's` utilization is minimal if there are multiple slots matching the resource requirements.

The `TaskExecutor's` utilization is calculated by `usedSlots / totalSlots`.

On the `JobMaster` side, the `SlotPool` tries to do the same wrt to the available slots being allocated for this job. This means that the `SlotPool` always picks the slot with the least utilization if there are multiple slots fulfilling the resource requirements.

Here the `TaskExecutor's` utilization is calculates by `usedSlotsByJob / totalSlotsOfferedToJob`.

## Brief change log

* 5f74a8f: Introduce SlotMatchingStrategy for SlotManager

The SlotMatchingStrategy encapsulates how the SlotManager finds a matching slot
for a slot request. At the moment, the only implementation AnyMatchingSlotMatchingStrategy
picks any matching slot.

* 752462a: Add LeastUtilizationSlotMatchingStrategy for spreading slot allocations out

The LeastUtilizationSlotMatchingStrategy picks the matching slots which belongs to a
TaskExecutor with the least utilization value. That way the SlotManager will spread out
slot allocations across all available/registered TaskExecutors.

* 5511ada: [FLINK-12122] Introduce ClusterOptions#EVENLY_SPREAD_OUT_SLOTS_STRATEGY

Add config option to enable to evenly spread out slots across all available
TaskExecutors.

* bbb0723: Calculate TaskExecutorUtilization when listing available slots

When listing available slots stored in the SlotPool and the SlotSharingManager, the system
will now also calculate the utilization of the owning TaskExecutor wrt the job.

* 268e688: Add EvenlySpreadOutLocationPreferenceSlotSelectionStrategy

The EvenlySpreadOutLocationPreferenceSlotSelectionStrategy is a special implementation of
the LocationPreferenceSlotSelectionStrategy which tries to evenly spread out the workload
across all TaskExecutors by choosing the slot with the least utilization if there is a tie
wrt the locality.

* 86b81f9: Choose SlotSelectionStrategy based on ClusterOptions#EVENLY_SPREAD_OUT_SLOTS_STRATEGY

If ClusterOptions#EVENLY_SPREAD_OUT_SLOTS_STRATEGY is enabled, then Flink will use the evenly spread
out location preference strategy to spread out the workload as much as possible.

## Verifying this change

- Added tests: `SlotPoolSlotSpreadOutTest`, `AnyMatchingSlotMatchingStrategyTest`, `LeastUtilizationSlotMatchingStrategyTest`, `SlotPoolImplTest#testCalculationOfTaskExecutorUtilization`, `SlotSharingManagerTest#testTaskExecutorUtilizationCalculation`, `SlotManagerImplTest#testSpreadOutSlotAllocationStrategy`

- Tried out manually

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
