### PR TITLE
[FLINK-14441][Table-Common] Fix ValueLiteralExpression#getValueAs when valueClass is Period.class

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
@@ -104,7 +104,7 @@ public final class ValueLiteralExpression implements ResolvedExpression {
 			convertedValue = Duration.ofMillis(longVal);
 		}
 
-		else if (valueClass == Period.class && clazz == Integer.class) {
+		else if (valueClass == Period.class && clazz == Long.class) {
 			final Period period = (Period) value;
 			convertedValue = period.toTotalMonths();
 		}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
@@ -106,7 +106,7 @@ public final class ValueLiteralExpression implements ResolvedExpression {
 
 		else if (valueClass == Period.class && clazz == Integer.class) {
 			final Period period = (Period) value;
-			convertedValue = (int)period.toTotalMonths();
+			convertedValue = (int) period.toTotalMonths();
 		}
 
 		else if (valueClass == Integer.class && clazz == Period.class) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
@@ -104,9 +104,9 @@ public final class ValueLiteralExpression implements ResolvedExpression {
 			convertedValue = Duration.ofMillis(longVal);
 		}
 
-		else if (valueClass == Period.class && clazz == Long.class) {
+		else if (valueClass == Period.class && clazz == Integer.class) {
 			final Period period = (Period) value;
-			convertedValue = period.toTotalMonths();
+			convertedValue = (int)period.toTotalMonths();
 		}
 
 		else if (valueClass == Integer.class && clazz == Period.class) {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java
@@ -164,10 +164,10 @@ public class ExpressionTest {
 	@Test
 	public void testPeriodlValueLiteralExtraction() {
 		final Period period = Period.ofMonths(10);
-		Long expectedValue = 10L;
+		Integer expectedValue = 10;
 		assertEquals(
 			expectedValue,
-			new ValueLiteralExpression(period).getValueAs(Long.class)
+			new ValueLiteralExpression(period).getValueAs(Integer.class)
 				.orElseThrow(AssertionError::new));
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java
@@ -162,7 +162,7 @@ public class ExpressionTest {
 	}
 
 	@Test
-	public void testPeriodlValueLiteralExtraction() {
+	public void testPeriodValueLiteralExtraction() {
 		final Period period = Period.ofMonths(10);
 		Integer expectedValue = 10;
 		assertEquals(

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java
@@ -30,6 +30,7 @@ import org.junit.rules.ExpectedException;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.time.Period;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -157,6 +158,16 @@ public class ExpressionTest {
 		assertEquals(
 			intervalUnit,
 			new ValueLiteralExpression(intervalUnit).getValueAs(TimeIntervalUnit.class)
+				.orElseThrow(AssertionError::new));
+	}
+
+	@Test
+	public void testPeriodlValueLiteralExtraction() {
+		final Period period = Period.ofMonths(10);
+		Long expectedValue = 10L;
+		assertEquals(
+			expectedValue,
+			new ValueLiteralExpression(period).getValueAs(Long.class)
 				.orElseThrow(AssertionError::new));
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

In ValueLiteralExpression#getValueAs, when valueClass is Period.class, the expect class is inconsistent with the result class. This PR will fix it.

## Brief change log
change clazz from Integer to Long when valueClass is Period.class

## Verifying this change
This change added tests and can be verified as follows:
(1)ExpressionTest#testPeriodlValueLiteralExtraction

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
