### PR TITLE
[FLINK-14330][runtime] Introduce base topology interface

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/topology/Result.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/topology/Result.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.topology;
+
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+
+/**
+ * Represents a data set produced by a {@link Vertex}
+ * Each result is produced by one {@link Vertex}.
+ * Each result can be consumed by multiple {@link Vertex}.
+ */
+public interface Result<VID extends VertexID, RID extends ResultID,
+	V extends Vertex<VID, RID, V, R>, R extends Result<VID, RID, V, R>> {
+
+	RID getId();
+
+	ResultPartitionType getResultType();
+
+	V getProducer();
+
+	Iterable<V> getConsumers();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/topology/ResultID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/topology/ResultID.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.topology;
+
+/**
+ * ID of a {@link Result}.
+ */
+public interface ResultID {
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/topology/Topology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/topology/Topology.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.topology;
+
+/**
+ * Base topology for all logical and execution topologies.
+ * A topology consists of {@link Vertex} and {@link Result}.
+ */
+public interface Topology<VID extends VertexID, RID extends ResultID,
+	V extends Vertex<VID, RID, V, R>, R extends Result<VID, RID, V, R>> {
+
+	/**
+	 * Returns an iterable over all vertices, topologically sorted.
+	 *
+	 * @return topologically sorted iterable over all vertices
+	 */
+	Iterable<V> getVertices();
+
+	/**
+	 * Returns whether the topology contains co-location constraints.
+	 * Co-location constraints are currently used for iterations.
+	 *
+	 * @return whether the topology contains co-location constraints
+	 */
+	boolean containsCoLocationConstraints();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/topology/Vertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/topology/Vertex.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.topology;
+
+/**
+ * Represents a logical or execution task.
+ * Each vertex can consume data from multiple {@link Result}.
+ * Each vertex can produce multiple {@link Result}.
+ */
+public interface Vertex<VID extends VertexID, RID extends ResultID,
+	V extends Vertex<VID, RID, V, R>, R extends Result<VID, RID, V, R>> {
+
+	VID getId();
+
+	Iterable<R> getConsumedResults();
+
+	Iterable<R> getProducedResults();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/topology/VertexID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/topology/VertexID.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.topology;
+
+/**
+ * ID of a {@link Vertex}.
+ */
+public interface VertexID {
+}


### PR DESCRIPTION

## What is the purpose of the change

This PR is to introduce a base topology interface for all logical and execution topologies.
More details see FLINK-14330.

## Brief change log

  - *Added Topology interfaces*


## Verifying this change

This change is a trivial rework without any test coverage.
The usage of it is tried out in this [POC](https://github.com/zhuzhurk/flink/commits/poc_unified_topology_interfaces).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
