### PR TITLE
[FLINK-14456][client] Remove or shift down field from ClusterClient

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.jar.JarFile;
 
 /**
@@ -106,6 +107,8 @@ public enum ClientUtils {
 
 			final List<URL> libraries = program.getAllLibraries();
 
+			final AtomicReference<JobExecutionResult> jobExecutionResult = new AtomicReference<>();
+
 			ContextEnvironmentFactory factory = new ContextEnvironmentFactory(
 				client,
 				libraries,
@@ -113,13 +116,14 @@ public enum ClientUtils {
 				program.getUserCodeClassLoader(),
 				parallelism,
 				client.isDetached(),
-				program.getSavepointSettings());
+				program.getSavepointSettings(),
+				jobExecutionResult);
 			ContextEnvironment.setAsContext(factory);
 
 			try {
 				program.invokeInteractiveModeForExecution();
 
-				JobExecutionResult result = client.getLastJobExecutionResult();
+				JobExecutionResult result = jobExecutionResult.get();
 				if (result == null) {
 					throw new ProgramMissingJobException("The program didn't contain a Flink job.");
 				}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.OptionalFailure;
-import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -44,26 +43,8 @@ import java.util.concurrent.CompletableFuture;
  */
 public abstract class ClusterClient<T> implements AutoCloseable {
 
-	/** Configuration of the client. */
-	private final Configuration flinkConfig;
-
 	/** Switch for blocking/detached job submission of the client. */
 	private boolean detachedJobSubmission = false;
-
-	// ------------------------------------------------------------------------
-	//                            Construction
-	// ------------------------------------------------------------------------
-
-	/**
-	 * Creates a instance that submits the programs to the JobManager defined in the
-	 * configuration. This method will try to resolve the JobManager hostname and throw an exception
-	 * if that is not possible.
-	 *
-	 * @param flinkConfig The config used to obtain the job-manager's address, and used to configure the optimizer.
-	 */
-	public ClusterClient(Configuration flinkConfig) {
-		this.flinkConfig = Preconditions.checkNotNull(flinkConfig);
-	}
 
 	/**
 	 * User overridable hook to close the client, possibly closes internal services.
@@ -192,9 +173,7 @@ public abstract class ClusterClient<T> implements AutoCloseable {
 	 * Return the Flink configuration object.
 	 * @return The Flink configuration object
 	 */
-	public Configuration getFlinkConfiguration() {
-		return flinkConfig.clone();
-	}
+	public abstract Configuration getFlinkConfiguration();
 
 	/**
 	 * Calls the subclasses' submitJob method. It may decide to simply call one of the run methods or it may perform

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.client.program;
 
-import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.configuration.Configuration;
@@ -47,8 +46,6 @@ public abstract class ClusterClient<T> implements AutoCloseable {
 
 	/** Configuration of the client. */
 	private final Configuration flinkConfig;
-
-	protected JobExecutionResult lastJobExecutionResult;
 
 	/** Switch for blocking/detached job submission of the client. */
 	private boolean detachedJobSubmission = false;
@@ -225,14 +222,5 @@ public abstract class ClusterClient<T> implements AutoCloseable {
 
 	public void shutDownCluster() {
 		throw new UnsupportedOperationException("The " + getClass().getSimpleName() + " does not support shutDownCluster.");
-	}
-
-	/**
-	 * For interactive invocations, the job results are only available after the ContextEnvironment has
-	 * been run inside the user JAR. We pass the Client to every instance of the ContextEnvironment
-	 * which lets us access the execution result here.
-	 */
-	public JobExecutionResult getLastJobExecutionResult() {
-		return lastJobExecutionResult;
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -49,10 +49,16 @@ import java.util.concurrent.ExecutionException;
 public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClusterId> {
 
 	private final MiniCluster miniCluster;
+	private final Configuration configuration;
 
 	public MiniClusterClient(@Nonnull Configuration configuration, @Nonnull MiniCluster miniCluster) {
-		super(configuration);
+		this.configuration = configuration;
 		this.miniCluster = miniCluster;
+	}
+
+	@Override
+	public Configuration getFlinkConfiguration() {
+		return new Configuration(configuration);
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -62,9 +62,7 @@ public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClust
 		if (isDetached()) {
 			try {
 				final JobSubmissionResult jobSubmissionResult = jobSubmissionResultFuture.get();
-
-				lastJobExecutionResult = new DetachedJobExecutionResult(jobSubmissionResult.getJobID());
-				return lastJobExecutionResult;
+				return new DetachedJobExecutionResult(jobSubmissionResult.getJobID());
 			} catch (InterruptedException | ExecutionException e) {
 				ExceptionUtils.checkInterrupted(e);
 
@@ -84,8 +82,7 @@ public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClust
 			}
 
 			try {
-				lastJobExecutionResult = jobResult.toJobExecutionResult(classLoader);
-				return lastJobExecutionResult;
+				return jobResult.toJobExecutionResult(classLoader);
 			} catch (JobExecutionException | IOException | ClassNotFoundException e) {
 				throw new ProgramInvocationException("Job failed", jobGraph.getJobID(), e);
 			}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -236,8 +236,7 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 
 				LOG.warn("Job was executed in detached mode, the results will be available on completion.");
 
-				this.lastJobExecutionResult = new DetachedJobExecutionResult(jobSubmissionResult.getJobID());
-				return lastJobExecutionResult;
+				return new DetachedJobExecutionResult(jobSubmissionResult.getJobID());
 			} catch (Exception e) {
 				throw new ProgramInvocationException("Could not submit job",
 					jobGraph.getJobID(), ExceptionUtils.stripExecutionException(e));
@@ -255,8 +254,7 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 			}
 
 			try {
-				this.lastJobExecutionResult = jobResult.toJobExecutionResult(classLoader);
-				return lastJobExecutionResult;
+				return jobResult.toJobExecutionResult(classLoader);
 			} catch (JobExecutionException | IOException | ClassNotFoundException e) {
 				throw new ProgramInvocationException("Job failed.", jobGraph.getJobID(), e);
 			}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamContextEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamContextEnvironment.java
@@ -57,9 +57,12 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
 		// running from the CLI will override the savepoint restore settings
 		jobGraph.setSavepointRestoreSettings(ctx.getSavepointRestoreSettings());
 
-		return ctx
-				.getClient()
-				.submitJob(jobGraph, ctx.getUserCodeClassLoader())
-				.getJobExecutionResult();
+		JobExecutionResult jobExecutionResult =  ctx.getClient()
+			.submitJob(jobGraph, ctx.getUserCodeClassLoader())
+			.getJobExecutionResult();
+
+		ctx.setJobExecutionResult(jobExecutionResult);
+
+		return jobExecutionResult;
 	}
 }

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/CliFrontendRunWithYarnTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/CliFrontendRunWithYarnTest.java
@@ -99,7 +99,7 @@ public class CliFrontendRunWithYarnTest extends CliFrontendTestBase {
 				String longPrefix) throws Exception {
 			super(configuration, configurationDirectory, shortPrefix, longPrefix);
 
-			this.clusterClient = new FakeClusterClient(configuration);
+			this.clusterClient = new FakeClusterClient();
 			this.configurationDirectory = configurationDirectory;
 		}
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/util/FakeClusterClient.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/util/FakeClusterClient.java
@@ -44,8 +44,9 @@ import java.util.concurrent.CompletableFuture;
  */
 public class FakeClusterClient extends ClusterClient<ApplicationId> {
 
-	public FakeClusterClient(Configuration flinkConfig) throws Exception {
-		super(flinkConfig);
+	@Override
+	public Configuration getFlinkConfiguration() {
+		throw new UnsupportedOperationException("Not needed in test.");
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

Towards a `ClusterClient` interface.

## Brief change log

1. Exclude lastJobExecutionResult from ClusterClient. Client only returns the result in submit, the tweaking logic in ContextEnvironment is hacky resolved by hold a container of execution result in ContextEnvironment.

2. Shift down ClusterClient#configuration. A follow up could be figure out what configuration is exactly used. I suspect we don't have to hold this configuration object.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
