### PR TITLE
[FLINK-14450][runtime] Change SchedulingTopology to extend base topology

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/IterableUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/IterableUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import java.util.Collection;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A collection of utilities that expand the usage of {@link Iterable}.
+ */
+public class IterableUtils {
+
+	/**
+	 * Convert the given {@link Iterable} to a {@link Stream}.
+	 *
+	 * @param iterable to convert to a stream
+	 * @param <E> type of the elements of the iterable
+	 * @return stream converted from the given {@link Iterable}
+	 */
+	public static <E> Stream<E> toStream(Iterable<E> iterable) {
+		checkNotNull(iterable);
+
+		return iterable instanceof Collection ?
+			((Collection) iterable).stream() :
+			StreamSupport.stream(iterable.spliterator(), false);
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/util/IterableUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/IterableUtils.java
@@ -40,7 +40,14 @@ public class IterableUtils {
 		checkNotNull(iterable);
 
 		return iterable instanceof Collection ?
-			((Collection) iterable).stream() :
+			((Collection<E>) iterable).stream() :
 			StreamSupport.stream(iterable.spliterator(), false);
 	}
+
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Private default constructor to avoid instantiation.
+	 */
+	private IterableUtils() {}
 }

--- a/flink-core/src/test/java/org/apache/flink/util/IterableUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/IterableUtilsTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.junit.Test;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.stream.Stream;
+
+/**
+ * Tests for the {@link IterableUtils}.
+ */
+public class IterableUtilsTest extends TestLogger {
+
+	private final Iterable<Integer> testIterable = Arrays.asList(1, 8, 5, 3, 8);
+
+	@Test
+	public void testToStream() {
+		Deque<Integer> deque = new ArrayDeque<>();
+		testIterable.forEach(deque::add);
+
+		Stream<Integer> stream = IterableUtils.toStream(testIterable);
+		stream.forEach(deque.poll()::equals);
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/util/IterableUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/IterableUtilsTest.java
@@ -22,8 +22,10 @@ import org.junit.Test;
 
 import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.Deque;
+import java.util.Queue;
 import java.util.stream.Stream;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for the {@link IterableUtils}.
@@ -34,10 +36,10 @@ public class IterableUtilsTest extends TestLogger {
 
 	@Test
 	public void testToStream() {
-		Deque<Integer> deque = new ArrayDeque<>();
+		Queue<Integer> deque = new ArrayDeque<>();
 		testIterable.forEach(deque::add);
 
 		Stream<Integer> stream = IterableUtils.toStream(testIterable);
-		stream.forEach(deque.poll()::equals);
+		assertTrue(stream.allMatch(value -> deque.poll().equals(value)));
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -259,7 +259,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 
 	private PartitionReleaseStrategy partitionReleaseStrategy;
 
-	private SchedulingTopology schedulingTopology;
+	private SchedulingTopology<?, ?> schedulingTopology;
 
 	@Nullable
 	private InternalTaskFailuresListener internalTaskFailuresListener;
@@ -1644,8 +1644,8 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	}
 
 	ResultPartitionID createResultPartitionId(final IntermediateResultPartitionID resultPartitionId) {
-		final SchedulingResultPartition schedulingResultPartition = schedulingTopology.getResultPartitionOrThrow(resultPartitionId);
-		final SchedulingExecutionVertex producer = schedulingResultPartition.getProducer();
+		final SchedulingResultPartition<?, ?> schedulingResultPartition = schedulingTopology.getResultPartitionOrThrow(resultPartitionId);
+		final SchedulingExecutionVertex<?, ?> producer = schedulingResultPartition.getProducer();
 		final ExecutionVertexID producerId = producer.getId();
 		final JobVertexID jobVertexId = producerId.getJobVertexId();
 		final ExecutionJobVertex jobVertex = getJobVertex(jobVertexId);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/partitionrelease/NotReleasingPartitionReleaseStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/partitionrelease/NotReleasingPartitionReleaseStrategy.java
@@ -48,7 +48,7 @@ public class NotReleasingPartitionReleaseStrategy implements PartitionReleaseStr
 	public static class Factory implements PartitionReleaseStrategy.Factory {
 
 		@Override
-		public PartitionReleaseStrategy createInstance(final SchedulingTopology schedulingStrategy, final FailoverTopology failoverTopology) {
+		public PartitionReleaseStrategy createInstance(final SchedulingTopology<?, ?> schedulingStrategy, final FailoverTopology failoverTopology) {
 			return new NotReleasingPartitionReleaseStrategy();
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/partitionrelease/PartitionReleaseStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/partitionrelease/PartitionReleaseStrategy.java
@@ -53,6 +53,6 @@ public interface PartitionReleaseStrategy {
 	 * Factory for {@link PartitionReleaseStrategy}.
 	 */
 	interface Factory {
-		PartitionReleaseStrategy createInstance(SchedulingTopology schedulingStrategy, FailoverTopology failoverTopology);
+		PartitionReleaseStrategy createInstance(SchedulingTopology<?, ?> schedulingStrategy, FailoverTopology failoverTopology);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/partitionrelease/RegionPartitionReleaseStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/partitionrelease/RegionPartitionReleaseStrategy.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingExecutionVertex;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
+import org.apache.flink.util.IterableUtils;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -47,14 +48,14 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 public class RegionPartitionReleaseStrategy implements PartitionReleaseStrategy {
 
-	private final SchedulingTopology schedulingTopology;
+	private final SchedulingTopology<?, ?> schedulingTopology;
 
 	private final Map<PipelinedRegion, PipelinedRegionConsumedBlockingPartitions> consumedBlockingPartitionsByRegion = new IdentityHashMap<>();
 
 	private final Map<ExecutionVertexID, PipelinedRegionExecutionView> regionExecutionViewByVertex = new HashMap<>();
 
 	public RegionPartitionReleaseStrategy(
-			final SchedulingTopology schedulingTopology,
+			final SchedulingTopology<?, ?> schedulingTopology,
 			final Set<PipelinedRegion> pipelinedRegions) {
 
 		this.schedulingTopology = checkNotNull(schedulingTopology);
@@ -86,23 +87,23 @@ public class RegionPartitionReleaseStrategy implements PartitionReleaseStrategy 
 	}
 
 	private Set<IntermediateResultPartitionID> findResultPartitionsOutsideOfRegion(final PipelinedRegion pipelinedRegion) {
-		final Set<SchedulingResultPartition> allConsumedPartitionsInRegion = pipelinedRegion
+		final Set<SchedulingResultPartition<?, ?>> allConsumedPartitionsInRegion = pipelinedRegion
 			.getExecutionVertexIds()
 			.stream()
 			.map(schedulingTopology::getVertexOrThrow)
-			.flatMap(schedulingExecutionVertex -> schedulingExecutionVertex.getConsumedResultPartitions().stream())
+			.flatMap(vertex -> IterableUtils.toStream(vertex.getConsumedResults()))
 			.collect(Collectors.toSet());
 
 		return filterResultPartitionsOutsideOfRegion(allConsumedPartitionsInRegion, pipelinedRegion);
 	}
 
 	private static Set<IntermediateResultPartitionID> filterResultPartitionsOutsideOfRegion(
-			final Collection<SchedulingResultPartition> resultPartitions,
+			final Collection<SchedulingResultPartition<?, ?>> resultPartitions,
 			final PipelinedRegion pipelinedRegion) {
 
 		final Set<IntermediateResultPartitionID> result = new HashSet<>();
-		for (final SchedulingResultPartition maybeOutsidePartition : resultPartitions) {
-			final SchedulingExecutionVertex producer = maybeOutsidePartition.getProducer();
+		for (final SchedulingResultPartition<?, ?> maybeOutsidePartition : resultPartitions) {
+			final SchedulingExecutionVertex<?, ?> producer = maybeOutsidePartition.getProducer();
 			if (!pipelinedRegion.contains(producer.getId())) {
 				result.add(maybeOutsidePartition.getId());
 			}
@@ -158,10 +159,8 @@ public class RegionPartitionReleaseStrategy implements PartitionReleaseStrategy 
 	}
 
 	private boolean areConsumerRegionsFinished(final IntermediateResultPartitionID resultPartitionId) {
-		final SchedulingResultPartition resultPartition = schedulingTopology.getResultPartitionOrThrow(resultPartitionId);
-		final Collection<SchedulingExecutionVertex> consumers = resultPartition.getConsumers();
-		return consumers
-			.stream()
+		final SchedulingResultPartition<?, ?> resultPartition = schedulingTopology.getResultPartitionOrThrow(resultPartitionId);
+		return IterableUtils.toStream(resultPartition.getConsumers())
 			.map(SchedulingExecutionVertex::getId)
 			.allMatch(this::isRegionOfVertexFinished);
 	}
@@ -178,7 +177,7 @@ public class RegionPartitionReleaseStrategy implements PartitionReleaseStrategy 
 
 		@Override
 		public PartitionReleaseStrategy createInstance(
-				final SchedulingTopology schedulingStrategy,
+				final SchedulingTopology<?, ?> schedulingStrategy,
 				final FailoverTopology failoverTopology) {
 
 			final Set<Set<FailoverVertex>> distinctRegions = PipelinedRegionComputeUtil.computePipelinedRegions(failoverTopology);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/IntermediateResultPartitionID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/IntermediateResultPartitionID.java
@@ -18,11 +18,16 @@
 
 package org.apache.flink.runtime.jobgraph;
 
+import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
+import org.apache.flink.runtime.topology.ResultID;
 import org.apache.flink.util.AbstractID;
 
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 
-public class IntermediateResultPartitionID extends AbstractID {
+/**
+ * Id identifying {@link IntermediateResultPartition}.
+ */
+public class IntermediateResultPartitionID extends AbstractID implements ResultID {
 
 	private static final long serialVersionUID = 1L;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -109,7 +109,7 @@ public abstract class SchedulerBase implements SchedulerNG {
 
 	private final ExecutionGraph executionGraph;
 
-	private final SchedulingTopology schedulingTopology;
+	private final SchedulingTopology<?, ?> schedulingTopology;
 
 	private final FailoverTopology failoverTopology;
 
@@ -301,7 +301,7 @@ public abstract class SchedulerBase implements SchedulerNG {
 		return failoverTopology;
 	}
 
-	protected final SchedulingTopology getSchedulingTopology() {
+	protected final SchedulingTopology<?, ?> getSchedulingTopology() {
 		return schedulingTopology;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingExecutionVertex.java
@@ -37,9 +37,9 @@ class DefaultSchedulingExecutionVertex
 
 	private final ExecutionVertexID executionVertexId;
 
-	private final List<DefaultSchedulingResultPartition> consumedPartitions;
+	private final List<DefaultSchedulingResultPartition> consumedResults;
 
-	private final List<DefaultSchedulingResultPartition> producedPartitions;
+	private final List<DefaultSchedulingResultPartition> producedResults;
 
 	private final Supplier<ExecutionState> stateSupplier;
 
@@ -51,9 +51,9 @@ class DefaultSchedulingExecutionVertex
 			Supplier<ExecutionState> stateSupplier,
 			InputDependencyConstraint constraint) {
 		this.executionVertexId = checkNotNull(executionVertexId);
-		this.consumedPartitions = new ArrayList<>();
+		this.consumedResults = new ArrayList<>();
 		this.stateSupplier = checkNotNull(stateSupplier);
-		this.producedPartitions = checkNotNull(producedPartitions);
+		this.producedResults = checkNotNull(producedPartitions);
 		this.inputDependencyConstraint = checkNotNull(constraint);
 	}
 
@@ -69,12 +69,12 @@ class DefaultSchedulingExecutionVertex
 
 	@Override
 	public Iterable<DefaultSchedulingResultPartition> getConsumedResults() {
-		return consumedPartitions;
+		return consumedResults;
 	}
 
 	@Override
 	public Iterable<DefaultSchedulingResultPartition> getProducedResults() {
-		return producedPartitions;
+		return producedResults;
 	}
 
 	@Override
@@ -82,7 +82,7 @@ class DefaultSchedulingExecutionVertex
 		return inputDependencyConstraint;
 	}
 
-	void addConsumedPartition(DefaultSchedulingResultPartition partition) {
-		consumedPartitions.add(partition);
+	void addConsumedResult(DefaultSchedulingResultPartition result) {
+		consumedResults.add(result);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingExecutionVertex.java
@@ -22,11 +22,8 @@ import org.apache.flink.api.common.InputDependencyConstraint;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingExecutionVertex;
-import org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -35,13 +32,14 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * Default implementation of {@link SchedulingExecutionVertex}.
  */
-class DefaultSchedulingExecutionVertex implements SchedulingExecutionVertex {
+class DefaultSchedulingExecutionVertex
+	implements SchedulingExecutionVertex<DefaultSchedulingExecutionVertex, DefaultSchedulingResultPartition> {
 
 	private final ExecutionVertexID executionVertexId;
 
-	private final List<SchedulingResultPartition> consumedPartitions;
+	private final List<DefaultSchedulingResultPartition> consumedPartitions;
 
-	private final List<? extends SchedulingResultPartition> producedPartitions;
+	private final List<DefaultSchedulingResultPartition> producedPartitions;
 
 	private final Supplier<ExecutionState> stateSupplier;
 
@@ -49,7 +47,7 @@ class DefaultSchedulingExecutionVertex implements SchedulingExecutionVertex {
 
 	DefaultSchedulingExecutionVertex(
 			ExecutionVertexID executionVertexId,
-			List<? extends SchedulingResultPartition> producedPartitions,
+			List<DefaultSchedulingResultPartition> producedPartitions,
 			Supplier<ExecutionState> stateSupplier,
 			InputDependencyConstraint constraint) {
 		this.executionVertexId = checkNotNull(executionVertexId);
@@ -70,13 +68,13 @@ class DefaultSchedulingExecutionVertex implements SchedulingExecutionVertex {
 	}
 
 	@Override
-	public Collection<SchedulingResultPartition> getConsumedResultPartitions() {
-		return Collections.unmodifiableCollection(consumedPartitions);
+	public Iterable<DefaultSchedulingResultPartition> getConsumedResults() {
+		return consumedPartitions;
 	}
 
 	@Override
-	public Collection<SchedulingResultPartition> getProducedResultPartitions() {
-		return Collections.unmodifiableCollection(producedPartitions);
+	public Iterable<DefaultSchedulingResultPartition> getProducedResults() {
+		return producedPartitions;
 	}
 
 	@Override
@@ -84,7 +82,7 @@ class DefaultSchedulingExecutionVertex implements SchedulingExecutionVertex {
 		return inputDependencyConstraint;
 	}
 
-	<X extends SchedulingResultPartition> void addConsumedPartition(X partition) {
+	void addConsumedPartition(DefaultSchedulingResultPartition partition) {
 		consumedPartitions.add(partition);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingResultPartition.java
@@ -21,12 +21,9 @@ package org.apache.flink.runtime.scheduler.adapter;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
-import org.apache.flink.runtime.scheduler.strategy.SchedulingExecutionVertex;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.DONE;
@@ -37,7 +34,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * Default implementation of {@link SchedulingResultPartition}.
  */
-class DefaultSchedulingResultPartition implements SchedulingResultPartition {
+class DefaultSchedulingResultPartition
+	implements SchedulingResultPartition<DefaultSchedulingExecutionVertex, DefaultSchedulingResultPartition> {
 
 	private final IntermediateResultPartitionID resultPartitionId;
 
@@ -45,9 +43,9 @@ class DefaultSchedulingResultPartition implements SchedulingResultPartition {
 
 	private final ResultPartitionType partitionType;
 
-	private SchedulingExecutionVertex producer;
+	private DefaultSchedulingExecutionVertex producer;
 
-	private final List<SchedulingExecutionVertex> consumers;
+	private final List<DefaultSchedulingExecutionVertex> consumers;
 
 	DefaultSchedulingResultPartition(
 			IntermediateResultPartitionID partitionId,
@@ -70,7 +68,7 @@ class DefaultSchedulingResultPartition implements SchedulingResultPartition {
 	}
 
 	@Override
-	public ResultPartitionType getPartitionType() {
+	public ResultPartitionType getResultType() {
 		return partitionType;
 	}
 
@@ -87,20 +85,20 @@ class DefaultSchedulingResultPartition implements SchedulingResultPartition {
 	}
 
 	@Override
-	public SchedulingExecutionVertex getProducer() {
+	public DefaultSchedulingExecutionVertex getProducer() {
 		return producer;
 	}
 
 	@Override
-	public Collection<SchedulingExecutionVertex> getConsumers() {
-		return Collections.unmodifiableCollection(consumers);
+	public Iterable<DefaultSchedulingExecutionVertex> getConsumers() {
+		return consumers;
 	}
 
-	void addConsumer(SchedulingExecutionVertex vertex) {
+	void addConsumer(DefaultSchedulingExecutionVertex vertex) {
 		consumers.add(checkNotNull(vertex));
 	}
 
-	void setProducer(SchedulingExecutionVertex vertex) {
+	void setProducer(DefaultSchedulingExecutionVertex vertex) {
 		producer = checkNotNull(vertex);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/ExecutionGraphToSchedulingTopologyAdapter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/ExecutionGraphToSchedulingTopologyAdapter.java
@@ -140,7 +140,7 @@ public class ExecutionGraphToSchedulingTopologyAdapter
 			for (int index = 0; index < executionVertex.getNumberOfInputs(); index++) {
 				for (ExecutionEdge edge : executionVertex.getInputEdges(index)) {
 					DefaultSchedulingResultPartition partition = resultPartitions.get(edge.getSource().getPartitionId());
-					schedulingVertex.addConsumedPartition(partition);
+					schedulingVertex.addConsumedResult(partition);
 					partition.addConsumer(schedulingVertex);
 				}
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/EagerSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/EagerSchedulingStrategy.java
@@ -41,13 +41,13 @@ public class EagerSchedulingStrategy implements SchedulingStrategy {
 
 	private final SchedulerOperations schedulerOperations;
 
-	private final SchedulingTopology schedulingTopology;
+	private final SchedulingTopology<?, ?> schedulingTopology;
 
 	private final DeploymentOption deploymentOption = new DeploymentOption(false);
 
 	public EagerSchedulingStrategy(
 			SchedulerOperations schedulerOperations,
-			SchedulingTopology schedulingTopology) {
+			SchedulingTopology<?, ?> schedulingTopology) {
 		this.schedulerOperations = checkNotNull(schedulerOperations);
 		this.schedulingTopology = checkNotNull(schedulingTopology);
 	}
@@ -104,7 +104,7 @@ public class EagerSchedulingStrategy implements SchedulingStrategy {
 		@Override
 		public SchedulingStrategy createInstance(
 				SchedulerOperations schedulerOperations,
-				SchedulingTopology schedulingTopology,
+				SchedulingTopology<?, ?> schedulingTopology,
 				JobGraph jobGraph) {
 			return new EagerSchedulingStrategy(schedulerOperations, schedulingTopology);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/ExecutionVertexID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/ExecutionVertexID.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.scheduler.strategy;
 
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.topology.VertexID;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -27,7 +28,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * Id identifying {@link ExecutionVertex}.
  */
-public class ExecutionVertexID {
+public class ExecutionVertexID implements VertexID {
 	private final JobVertexID jobVertexId;
 
 	private final int subtaskIndex;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/InputDependencyConstraintChecker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/InputDependencyConstraintChecker.java
@@ -24,6 +24,8 @@ import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.util.IterableUtils;
 
+import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -47,7 +49,7 @@ public class InputDependencyConstraintChecker {
 
 	public boolean check(final SchedulingExecutionVertex<?, ?> schedulingExecutionVertex) {
 		final InputDependencyConstraint inputConstraint = schedulingExecutionVertex.getInputDependencyConstraint();
-		if (!schedulingExecutionVertex.getConsumedResults().iterator().hasNext() || ALL.equals(inputConstraint)) {
+		if (Iterables.isEmpty(schedulingExecutionVertex.getConsumedResults()) || ALL.equals(inputConstraint)) {
 			return checkAll(schedulingExecutionVertex);
 		} else if (ANY.equals(inputConstraint)) {
 			return checkAny(schedulingExecutionVertex);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/InputDependencyConstraintChecker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/InputDependencyConstraintChecker.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.InputDependencyConstraint;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.util.IterableUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,9 +45,9 @@ public class InputDependencyConstraintChecker {
 	private final SchedulingIntermediateDataSetManager intermediateDataSetManager =
 		new SchedulingIntermediateDataSetManager();
 
-	public boolean check(final SchedulingExecutionVertex schedulingExecutionVertex) {
+	public boolean check(final SchedulingExecutionVertex<?, ?> schedulingExecutionVertex) {
 		final InputDependencyConstraint inputConstraint = schedulingExecutionVertex.getInputDependencyConstraint();
-		if (schedulingExecutionVertex.getConsumedResultPartitions().isEmpty() || ALL.equals(inputConstraint)) {
+		if (!schedulingExecutionVertex.getConsumedResults().iterator().hasNext() || ALL.equals(inputConstraint)) {
 			return checkAll(schedulingExecutionVertex);
 		} else if (ANY.equals(inputConstraint)) {
 			return checkAny(schedulingExecutionVertex);
@@ -55,32 +56,30 @@ public class InputDependencyConstraintChecker {
 		}
 	}
 
-	List<SchedulingResultPartition> markSchedulingResultPartitionFinished(SchedulingResultPartition srp) {
+	List<SchedulingResultPartition<?, ?>> markSchedulingResultPartitionFinished(SchedulingResultPartition<?, ?> srp) {
 		return intermediateDataSetManager.markSchedulingResultPartitionFinished(srp);
 	}
 
-	void resetSchedulingResultPartition(SchedulingResultPartition srp) {
+	void resetSchedulingResultPartition(SchedulingResultPartition<?, ?> srp) {
 		intermediateDataSetManager.resetSchedulingResultPartition(srp);
 	}
 
-	void addSchedulingResultPartition(SchedulingResultPartition srp) {
+	void addSchedulingResultPartition(SchedulingResultPartition<?, ?> srp) {
 		intermediateDataSetManager.addSchedulingResultPartition(srp);
 	}
 
-	private boolean checkAll(final SchedulingExecutionVertex schedulingExecutionVertex) {
-		return schedulingExecutionVertex.getConsumedResultPartitions()
-			.stream()
+	private boolean checkAll(final SchedulingExecutionVertex<?, ?> schedulingExecutionVertex) {
+		return IterableUtils.toStream(schedulingExecutionVertex.getConsumedResults())
 			.allMatch(this::partitionConsumable);
 	}
 
-	private boolean checkAny(final SchedulingExecutionVertex schedulingExecutionVertex) {
-		return schedulingExecutionVertex.getConsumedResultPartitions()
-			.stream()
+	private boolean checkAny(final SchedulingExecutionVertex<?, ?> schedulingExecutionVertex) {
+		return IterableUtils.toStream(schedulingExecutionVertex.getConsumedResults())
 			.anyMatch(this::partitionConsumable);
 	}
 
-	private boolean partitionConsumable(SchedulingResultPartition partition) {
-		if (BLOCKING.equals(partition.getPartitionType())) {
+	private boolean partitionConsumable(SchedulingResultPartition<?, ?> partition) {
+		if (BLOCKING.equals(partition.getResultType())) {
 			return intermediateDataSetManager.allPartitionsFinished(partition);
 		} else {
 			SchedulingResultPartition.ResultPartitionState state = partition.getState();
@@ -92,7 +91,7 @@ public class InputDependencyConstraintChecker {
 
 		private final Map<IntermediateDataSetID, SchedulingIntermediateDataSet> intermediateDataSets = new HashMap<>();
 
-		List<SchedulingResultPartition> markSchedulingResultPartitionFinished(SchedulingResultPartition srp) {
+		List<SchedulingResultPartition<?, ?>> markSchedulingResultPartitionFinished(SchedulingResultPartition<?, ?> srp) {
 			SchedulingIntermediateDataSet intermediateDataSet = getSchedulingIntermediateDataSet(srp.getResultId());
 			if (intermediateDataSet.markPartitionFinished(srp.getId())) {
 				return intermediateDataSet.getSchedulingResultPartitions();
@@ -100,17 +99,17 @@ public class InputDependencyConstraintChecker {
 			return Collections.emptyList();
 		}
 
-		void resetSchedulingResultPartition(SchedulingResultPartition srp) {
+		void resetSchedulingResultPartition(SchedulingResultPartition<?, ?> srp) {
 			SchedulingIntermediateDataSet sid = getSchedulingIntermediateDataSet(srp.getResultId());
 			sid.resetPartition(srp.getId());
 		}
 
-		void addSchedulingResultPartition(SchedulingResultPartition srp) {
+		void addSchedulingResultPartition(SchedulingResultPartition<?, ?> srp) {
 			SchedulingIntermediateDataSet sid = getOrCreateSchedulingIntermediateDataSetIfAbsent(srp.getResultId());
 			sid.addSchedulingResultPartition(srp);
 		}
 
-		boolean allPartitionsFinished(SchedulingResultPartition srp) {
+		boolean allPartitionsFinished(SchedulingResultPartition<?, ?> srp) {
 			SchedulingIntermediateDataSet sid = getSchedulingIntermediateDataSet(srp.getResultId());
 			return sid.allPartitionsFinished();
 		}
@@ -146,7 +145,7 @@ public class InputDependencyConstraintChecker {
 	 */
 	private static class SchedulingIntermediateDataSet {
 
-		private final List<SchedulingResultPartition> partitions;
+		private final List<SchedulingResultPartition<?, ?>> partitions;
 
 		private final Set<IntermediateResultPartitionID> producingPartitionIds;
 
@@ -168,12 +167,12 @@ public class InputDependencyConstraintChecker {
 			return producingPartitionIds.isEmpty();
 		}
 
-		void addSchedulingResultPartition(SchedulingResultPartition partition) {
+		void addSchedulingResultPartition(SchedulingResultPartition<?, ?> partition) {
 			partitions.add(partition);
 			producingPartitionIds.add(partition.getId());
 		}
 
-		List<SchedulingResultPartition> getSchedulingResultPartitions() {
+		List<SchedulingResultPartition<?, ?>> getSchedulingResultPartitions() {
 			return Collections.unmodifiableList(partitions);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingExecutionVertex.java
@@ -21,20 +21,14 @@ package org.apache.flink.runtime.scheduler.strategy;
 import org.apache.flink.api.common.InputDependencyConstraint;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
-
-import java.util.Collection;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.topology.Vertex;
 
 /**
  * Scheduling representation of {@link ExecutionVertex}.
  */
-public interface SchedulingExecutionVertex {
-
-	/**
-	 * Gets id of the execution vertex.
-	 *
-	 * @return id of the execution vertex
-	 */
-	ExecutionVertexID getId();
+public interface SchedulingExecutionVertex<V extends SchedulingExecutionVertex<V, R>, R extends SchedulingResultPartition<V, R>>
+	extends Vertex<ExecutionVertexID, IntermediateResultPartitionID, V, R> {
 
 	/**
 	 * Gets the state of the execution vertex.
@@ -42,20 +36,6 @@ public interface SchedulingExecutionVertex {
 	 * @return state of the execution vertex
 	 */
 	ExecutionState getState();
-
-	/**
-	 * Get all consumed result partitions.
-	 *
-	 * @return collection of input partitions
-	 */
-	Collection<SchedulingResultPartition> getConsumedResultPartitions();
-
-	/**
-	 * Get all produced result partitions.
-	 *
-	 * @return collection of output edges
-	 */
-	Collection<SchedulingResultPartition> getProducedResultPartitions();
 
 	/**
 	 * Get {@link InputDependencyConstraint}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingResultPartition.java
@@ -19,23 +19,15 @@
 package org.apache.flink.runtime.scheduler.strategy;
 
 import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
-
-import java.util.Collection;
+import org.apache.flink.runtime.topology.Result;
 
 /**
  * Representation of {@link IntermediateResultPartition}.
  */
-public interface SchedulingResultPartition {
-
-	/**
-	 * Gets id of the result partition.
-	 *
-	 * @return id of the result partition
-	 */
-	IntermediateResultPartitionID getId();
+public interface SchedulingResultPartition<V extends SchedulingExecutionVertex<V, R>, R extends SchedulingResultPartition<V, R>>
+	extends Result<ExecutionVertexID, IntermediateResultPartitionID, V, R> {
 
 	/**
 	 * Gets id of the intermediate result.
@@ -45,32 +37,11 @@ public interface SchedulingResultPartition {
 	IntermediateDataSetID getResultId();
 
 	/**
-	 * Gets the {@link ResultPartitionType}.
-	 *
-	 * @return result partition type
-	 */
-	ResultPartitionType getPartitionType();
-
-	/**
 	 * Gets the {@link ResultPartitionState}.
 	 *
 	 * @return result partition state
 	 */
 	ResultPartitionState getState();
-
-	/**
-	 * Gets the producer of this result partition.
-	 *
-	 * @return producer vertex of this result partition
-	 */
-	SchedulingExecutionVertex getProducer();
-
-	/**
-	 * Gets the consumers of this result partition.
-	 *
-	 * @return Collection of consumer vertices of this result partition
-	 */
-	Collection<SchedulingExecutionVertex> getConsumers();
 
 	/**
 	 * State of the result partition.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingStrategyFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingStrategyFactory.java
@@ -28,6 +28,6 @@ public interface SchedulingStrategyFactory {
 
 	SchedulingStrategy createInstance(
 			SchedulerOperations schedulerOperations,
-			SchedulingTopology schedulingTopology,
+			SchedulingTopology<?, ?> schedulingTopology,
 			JobGraph jobGraph);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingTopology.java
@@ -19,21 +19,15 @@
 package org.apache.flink.runtime.scheduler.strategy;
 
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.topology.Topology;
 
 import java.util.Optional;
 
 /**
  * Topology of {@link SchedulingExecutionVertex}.
  */
-public interface SchedulingTopology {
-
-	/**
-	 * Returns an iterable over all {@link SchedulingExecutionVertex} in topological
-	 * sorted order.
-	 *
-	 * @return Iterable over all scheduling vertices in topological sorted order
-	 */
-	Iterable<SchedulingExecutionVertex> getVertices();
+public interface SchedulingTopology<V extends SchedulingExecutionVertex<V, R>, R extends SchedulingResultPartition<V, R>>
+	extends Topology<ExecutionVertexID, IntermediateResultPartitionID, V, R> {
 
 	/**
 	 * Looks up the {@link SchedulingExecutionVertex} for the given {@link ExecutionVertexID}.
@@ -41,7 +35,7 @@ public interface SchedulingTopology {
 	 * @param executionVertexId identifying the respective scheduling vertex
 	 * @return Optional containing the respective scheduling vertex or none if the vertex does not exist
 	 */
-	Optional<SchedulingExecutionVertex> getVertex(ExecutionVertexID executionVertexId);
+	Optional<V> getVertex(ExecutionVertexID executionVertexId);
 
 	/**
 	 * Looks up the {@link SchedulingExecutionVertex} for the given {@link ExecutionVertexID}.
@@ -50,7 +44,7 @@ public interface SchedulingTopology {
 	 * @return The respective scheduling vertex
 	 * @throws IllegalArgumentException If the vertex does not exist
 	 */
-	default SchedulingExecutionVertex getVertexOrThrow(ExecutionVertexID executionVertexId) {
+	default V getVertexOrThrow(ExecutionVertexID executionVertexId) {
 		return getVertex(executionVertexId).orElseThrow(
 				() -> new IllegalArgumentException("can not find vertex: " + executionVertexId));
 	}
@@ -61,7 +55,7 @@ public interface SchedulingTopology {
 	 * @param intermediateResultPartitionId identifying the respective scheduling result partition
 	 * @return Optional containing the respective scheduling result partition or none if the partition does not exist
 	 */
-	Optional<SchedulingResultPartition> getResultPartition(IntermediateResultPartitionID intermediateResultPartitionId);
+	Optional<R> getResultPartition(IntermediateResultPartitionID intermediateResultPartitionId);
 
 	/**
 	 * Looks up the {@link SchedulingResultPartition} for the given {@link IntermediateResultPartitionID}.
@@ -70,7 +64,7 @@ public interface SchedulingTopology {
 	 * @return The respective scheduling result partition
 	 * @throws IllegalArgumentException If the partition does not exist
 	 */
-	default SchedulingResultPartition getResultPartitionOrThrow(IntermediateResultPartitionID intermediateResultPartitionId) {
+	default R getResultPartitionOrThrow(IntermediateResultPartitionID intermediateResultPartitionId) {
 		return getResultPartition(intermediateResultPartitionId).orElseThrow(
 				() -> new IllegalArgumentException("can not find partition: " + intermediateResultPartitionId));
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
@@ -293,11 +293,11 @@ public class DefaultSchedulerTest extends TestLogger {
 		final TestSchedulingStrategy.Factory schedulingStrategyFactory = new TestSchedulingStrategy.Factory();
 		final DefaultScheduler scheduler = createScheduler(jobGraph, schedulingStrategyFactory);
 		final TestSchedulingStrategy schedulingStrategy = schedulingStrategyFactory.getLastCreatedSchedulingStrategy();
-		final SchedulingTopology topology = schedulingStrategy.getSchedulingTopology();
+		final SchedulingTopology<?, ?> topology = schedulingStrategy.getSchedulingTopology();
 
 		startScheduling(scheduler);
 
-		final SchedulingExecutionVertex onlySchedulingVertex = Iterables.getOnlyElement(topology.getVertices());
+		final SchedulingExecutionVertex<?, ?> onlySchedulingVertex = Iterables.getOnlyElement(topology.getVertices());
 		schedulingStrategy.schedule(Collections.singleton(onlySchedulingVertex.getId()));
 
 		final ArchivedExecutionVertex onlyExecutionVertex = Iterables.getOnlyElement(scheduler.requestJob().getAllExecutionVertices());
@@ -317,7 +317,7 @@ public class DefaultSchedulerTest extends TestLogger {
 		final TestSchedulingStrategy.Factory schedulingStrategyFactory = new TestSchedulingStrategy.Factory();
 		final DefaultScheduler scheduler = createScheduler(jobGraph, schedulingStrategyFactory);
 		final TestSchedulingStrategy schedulingStrategy = schedulingStrategyFactory.getLastCreatedSchedulingStrategy();
-		final SchedulingTopology topology = schedulingStrategy.getSchedulingTopology();
+		final SchedulingTopology<?, ?> topology = schedulingStrategy.getSchedulingTopology();
 
 		startScheduling(scheduler);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingExecutionVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingExecutionVertexTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition;
+import org.apache.flink.util.IterableUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Before;
@@ -82,16 +83,20 @@ public class DefaultSchedulingExecutionVertexTest extends TestLogger {
 
 	@Test
 	public void testGetProducedResultPartitions() {
-		IntermediateResultPartitionID partitionIds1 = producerVertex
-			.getProducedResultPartitions().stream().findAny().map(SchedulingResultPartition::getId)
+		IntermediateResultPartitionID partitionIds1 = IterableUtils
+			.toStream(producerVertex.getProducedResults())
+			.findAny()
+			.map(SchedulingResultPartition::getId)
 			.orElseThrow(() -> new IllegalArgumentException("can not find result partition"));
 		assertEquals(partitionIds1, intermediateResultPartitionId);
 	}
 
 	@Test
 	public void testGetConsumedResultPartitions() {
-		IntermediateResultPartitionID partitionIds1 = consumerVertex
-			.getConsumedResultPartitions().stream().findAny().map(SchedulingResultPartition::getId)
+		IntermediateResultPartitionID partitionIds1 = IterableUtils
+			.toStream(consumerVertex.getConsumedResults())
+			.findAny()
+			.map(SchedulingResultPartition::getId)
 			.orElseThrow(() -> new IllegalArgumentException("can not find result partition"));
 		assertEquals(partitionIds1, intermediateResultPartitionId);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingExecutionVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingExecutionVertexTest.java
@@ -70,7 +70,7 @@ public class DefaultSchedulingExecutionVertexTest extends TestLogger {
 			Collections.emptyList(),
 			stateSupplier,
 			ANY);
-		consumerVertex.addConsumedPartition(schedulingResultPartition);
+		consumerVertex.addConsumedResult(schedulingResultPartition);
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/EagerSchedulingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/EagerSchedulingStrategyTest.java
@@ -75,7 +75,7 @@ public class EagerSchedulingStrategyTest extends TestLogger {
 		Collection<ExecutionVertexDeploymentOption> scheduledVertices = testingSchedulerOperations.getScheduledVertices().get(0);
 		Collection<ExecutionVertexID> scheduledVertexIDs = getExecutionVertexIdsFromDeployOptions(scheduledVertices);
 		assertThat(scheduledVertexIDs, hasSize(5));
-		for (SchedulingExecutionVertex schedulingExecutionVertex : testingSchedulingTopology.getVertices()) {
+		for (TestingSchedulingExecutionVertex schedulingExecutionVertex : testingSchedulingTopology.getVertices()) {
 			assertThat(scheduledVertexIDs, hasItem(schedulingExecutionVertex.getId()));
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/InputDependencyConstraintCheckerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/InputDependencyConstraintCheckerTest.java
@@ -242,7 +242,7 @@ public class InputDependencyConstraintCheckerTest extends TestLogger {
 		List<TestingSchedulingResultPartition> partitions) {
 
 		InputDependencyConstraintChecker inputChecker = new InputDependencyConstraintChecker();
-		for (SchedulingResultPartition partition : partitions) {
+		for (SchedulingResultPartition<?, ?> partition : partitions) {
 			inputChecker.addSchedulingResultPartition(partition);
 		}
 		return inputChecker;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/LazyFromSourcesSchedulingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/LazyFromSourcesSchedulingStrategyTest.java
@@ -253,7 +253,7 @@ public class LazyFromSourcesSchedulingStrategyTest extends TestLogger {
 		final LazyFromSourcesSchedulingStrategy schedulingStrategy = startScheduling(testingSchedulingTopology);
 
 		final TestingSchedulingExecutionVertex producer1 = producers.get(0);
-		final SchedulingResultPartition partition1 = producer1.getProducedResultPartitions().iterator().next();
+		final TestingSchedulingResultPartition partition1 = producer1.getProducedResults().iterator().next();
 
 		schedulingStrategy.onExecutionStateChange(producer1.getId(), ExecutionState.RUNNING);
 		schedulingStrategy.onPartitionConsumable(producer1.getId(), new ResultPartitionID(partition1.getId(), new ExecutionAttemptID()));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestSchedulingStrategy.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestSchedulingStrategy.java
@@ -39,7 +39,7 @@ public class TestSchedulingStrategy implements SchedulingStrategy {
 
 	private final SchedulerOperations schedulerOperations;
 
-	private final SchedulingTopology schedulingTopology;
+	private final SchedulingTopology<?, ?> schedulingTopology;
 
 	private final DeploymentOption deploymentOption = new DeploymentOption(false);
 
@@ -47,7 +47,7 @@ public class TestSchedulingStrategy implements SchedulingStrategy {
 
 	public TestSchedulingStrategy(
 			final SchedulerOperations schedulerOperations,
-			final SchedulingTopology schedulingTopology) {
+			final SchedulingTopology<?, ?> schedulingTopology) {
 
 		this.schedulerOperations = checkNotNull(schedulerOperations);
 		this.schedulingTopology = checkNotNull(schedulingTopology);
@@ -74,7 +74,7 @@ public class TestSchedulingStrategy implements SchedulingStrategy {
 		allocateSlotsAndDeploy(verticesToSchedule);
 	}
 
-	public SchedulingTopology getSchedulingTopology() {
+	public SchedulingTopology<?, ?> getSchedulingTopology() {
 		return schedulingTopology;
 	}
 
@@ -108,7 +108,7 @@ public class TestSchedulingStrategy implements SchedulingStrategy {
 		@Override
 		public SchedulingStrategy createInstance(
 				final SchedulerOperations schedulerOperations,
-				final SchedulingTopology schedulingTopology,
+				final SchedulingTopology<?, ?> schedulingTopology,
 				final JobGraph jobGraph) {
 
 			lastInstance = new TestSchedulingStrategy(schedulerOperations, schedulingTopology);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingExecutionVertex.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingExecutionVertex.java
@@ -24,20 +24,20 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A simple scheduling execution vertex for testing purposes.
  */
-public class TestingSchedulingExecutionVertex implements SchedulingExecutionVertex {
+public class TestingSchedulingExecutionVertex
+	implements SchedulingExecutionVertex<TestingSchedulingExecutionVertex, TestingSchedulingResultPartition> {
 
 	private final ExecutionVertexID executionVertexId;
 
 	private final Collection<TestingSchedulingResultPartition> consumedPartitions;
 
-	private final Collection<SchedulingResultPartition> producedPartitions;
+	private final Collection<TestingSchedulingResultPartition> producedPartitions;
 
 	private InputDependencyConstraint inputDependencyConstraint;
 
@@ -74,13 +74,13 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
 	}
 
 	@Override
-	public Collection<SchedulingResultPartition> getConsumedResultPartitions() {
-		return Collections.unmodifiableCollection(consumedPartitions);
+	public Iterable<TestingSchedulingResultPartition> getConsumedResults() {
+		return consumedPartitions;
 	}
 
 	@Override
-	public Collection<SchedulingResultPartition> getProducedResultPartitions() {
-		return Collections.unmodifiableCollection(producedPartitions);
+	public Iterable<TestingSchedulingResultPartition> getProducedResults() {
+		return producedPartitions;
 	}
 
 	@Override
@@ -92,7 +92,7 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
 		consumedPartitions.add(partition);
 	}
 
-	void addProducedPartition(SchedulingResultPartition partition) {
+	void addProducedPartition(TestingSchedulingResultPartition partition) {
 		producedPartitions.add(partition);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
@@ -24,23 +24,24 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A simple implementation of {@link SchedulingResultPartition} for testing.
  */
-public class TestingSchedulingResultPartition implements SchedulingResultPartition {
+public class TestingSchedulingResultPartition
+	implements SchedulingResultPartition<TestingSchedulingExecutionVertex, TestingSchedulingResultPartition> {
+
 	private final IntermediateDataSetID intermediateDataSetID;
 
 	private final IntermediateResultPartitionID intermediateResultPartitionID;
 
 	private final ResultPartitionType partitionType;
 
-	private SchedulingExecutionVertex producer;
+	private TestingSchedulingExecutionVertex producer;
 
-	private Collection<SchedulingExecutionVertex> consumers;
+	private Collection<TestingSchedulingExecutionVertex> consumers;
 
 	private ResultPartitionState state;
 
@@ -63,7 +64,7 @@ public class TestingSchedulingResultPartition implements SchedulingResultPartiti
 	}
 
 	@Override
-	public ResultPartitionType getPartitionType() {
+	public ResultPartitionType getResultType() {
 		return partitionType;
 	}
 
@@ -73,16 +74,16 @@ public class TestingSchedulingResultPartition implements SchedulingResultPartiti
 	}
 
 	@Override
-	public SchedulingExecutionVertex getProducer() {
+	public TestingSchedulingExecutionVertex getProducer() {
 		return producer;
 	}
 
 	@Override
-	public Collection<SchedulingExecutionVertex> getConsumers() {
-		return Collections.unmodifiableCollection(consumers);
+	public Iterable<TestingSchedulingExecutionVertex> getConsumers() {
+		return consumers;
 	}
 
-	void addConsumer(SchedulingExecutionVertex consumer) {
+	void addConsumer(TestingSchedulingExecutionVertex consumer) {
 		this.consumers.add(consumer);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.util.Preconditions;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -39,36 +38,42 @@ import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartit
 /**
  * A simple scheduling topology for testing purposes.
  */
-public class TestingSchedulingTopology implements SchedulingTopology {
+public class TestingSchedulingTopology
+	implements SchedulingTopology<TestingSchedulingExecutionVertex, TestingSchedulingResultPartition> {
 
-	private final Map<ExecutionVertexID, SchedulingExecutionVertex> schedulingExecutionVertices = new HashMap<>();
+	private final Map<ExecutionVertexID, TestingSchedulingExecutionVertex> schedulingExecutionVertices = new HashMap<>();
 
-	private final Map<IntermediateResultPartitionID, SchedulingResultPartition> schedulingResultPartitions = new HashMap<>();
+	private final Map<IntermediateResultPartitionID, TestingSchedulingResultPartition> schedulingResultPartitions = new HashMap<>();
 
 	@Override
-	public Iterable<SchedulingExecutionVertex> getVertices() {
+	public Iterable<TestingSchedulingExecutionVertex> getVertices() {
 		return Collections.unmodifiableCollection(schedulingExecutionVertices.values());
 	}
 
 	@Override
-	public Optional<SchedulingExecutionVertex> getVertex(ExecutionVertexID executionVertexId)  {
+	public boolean containsCoLocationConstraints() {
+		return false;
+	}
+
+	@Override
+	public Optional<TestingSchedulingExecutionVertex> getVertex(ExecutionVertexID executionVertexId)  {
 		return Optional.ofNullable(schedulingExecutionVertices.get(executionVertexId));
 	}
 
 	@Override
-	public Optional<SchedulingResultPartition> getResultPartition(
+	public Optional<TestingSchedulingResultPartition> getResultPartition(
 			IntermediateResultPartitionID intermediateResultPartitionId) {
 		return Optional.of(schedulingResultPartitions.get(intermediateResultPartitionId));
 	}
 
-	void addSchedulingExecutionVertex(SchedulingExecutionVertex schedulingExecutionVertex) {
+	void addSchedulingExecutionVertex(TestingSchedulingExecutionVertex schedulingExecutionVertex) {
 		schedulingExecutionVertices.put(schedulingExecutionVertex.getId(), schedulingExecutionVertex);
-		addSchedulingResultPartitions(schedulingExecutionVertex.getConsumedResultPartitions());
-		addSchedulingResultPartitions(schedulingExecutionVertex.getProducedResultPartitions());
+		addSchedulingResultPartitions(schedulingExecutionVertex.getConsumedResults());
+		addSchedulingResultPartitions(schedulingExecutionVertex.getProducedResults());
 	}
 
-	private void addSchedulingResultPartitions(final Collection<SchedulingResultPartition> resultPartitions) {
-		for (SchedulingResultPartition schedulingResultPartition : resultPartitions) {
+	private void addSchedulingResultPartitions(final Iterable<TestingSchedulingResultPartition> resultPartitions) {
+		for (TestingSchedulingResultPartition schedulingResultPartition : resultPartitions) {
 			schedulingResultPartitions.put(schedulingResultPartition.getId(), schedulingResultPartition);
 		}
 	}


### PR DESCRIPTION

## What is the purpose of the change

This PR is to change SchedulingTopology to extend the base topology introduced in FLINK-14330.

More details see FLINK-14330

## Brief change log

  - *Introduced IterableUtils*
  - *Change SchedulingTopology to extend the base topology and unifying the interfaces*
  - *Refactored the implementations of SchedulingTopology*
  - *Refactored the usages of SchedulingTopology*


## Verifying this change

  - *Most changes are trivial rework without any test coverage.*
  - *Added unit tests for ExecutionGraphToSchedulingTopologyAdapter#containsCoLocationConstraints*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
