### PR TITLE
[FLINK-14175] [flink-connector-kinesis] Update KPL version to 0.13.1

### DIFF
--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -35,7 +35,7 @@ under the License.
 	<properties>
 		<aws.sdk.version>1.11.319</aws.sdk.version>
 		<aws.kinesis-kcl.version>1.9.0</aws.kinesis-kcl.version>
-		<aws.kinesis-kpl.version>0.12.9</aws.kinesis-kpl.version>
+		<aws.kinesis-kpl.version>0.13.1</aws.kinesis-kpl.version>
 		<aws.dynamodbstreams-kinesis-adapter.version>1.4.0</aws.dynamodbstreams-kinesis-adapter.version>
 	</properties>
 


### PR DESCRIPTION
This fixes https://github.com/awslabs/amazon-kinesis-producer/issues/224. 

* JIRA - https://issues.apache.org/jira/browse/FLINK-14175
* mvn clean package succeeds after this change
* The version upgrade has already been performed (hence tested) in Flink 1.10.0 as part of FLINK-12847.

## What is the purpose of the change

This pull request upgrades the KPL version in flink-kinesis-connector to fix thread leak mentioned in ttps://github.com/awslabs/amazon-kinesis-producer/issues/224.

## Brief change log

Update the KPL version from 0.12.9 to 0.13.1

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
