### PR TITLE
[FLINK-14454] [test-stability] Usages of SavepointSerializers.setFailWhenLegacyStateDetected are never reverted

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SavepointMigrationTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SavepointMigrationTestBase.java
@@ -39,6 +39,7 @@ import org.apache.flink.testutils.junit.category.AlsoRunWithSchedulerNG;
 import org.apache.flink.util.OptionalFailure;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -249,5 +250,10 @@ public abstract class SavepointMigrationTestBase extends TestBaseUtils {
 		if (!done) {
 			fail("Did not see the expected accumulator results within time limit.");
 		}
+	}
+
+	@AfterClass
+	public static void after() {
+		SavepointSerializers.setFailWhenLegacyStateDetected(true);
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/AbstractOperatorRestoreTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/AbstractOperatorRestoreTestBase.java
@@ -40,6 +40,7 @@ import org.apache.flink.testutils.junit.category.AlsoRunWithSchedulerNG;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -239,5 +240,10 @@ public abstract class AbstractOperatorRestoreTestBase extends TestLogger {
 		return string
 			.replaceAll("\\(", "\\\\(")
 			.replaceAll("\\)", "\\\\)");
+	}
+
+	@AfterClass
+	public static void after() {
+		SavepointSerializers.setFailWhenLegacyStateDetected(true);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Re-enable FAIL_WHEN_LEGACY_STATE_DETECTED after all state migration tests.

## Brief change log

Adding the revert logic in a @AfterClass method.
