### PR TITLE
[FLINK-14469][python] Drop Python 2 support for PyFlink

### DIFF
--- a/docs/flinkDev/building.md
+++ b/docs/flinkDev/building.md
@@ -65,6 +65,8 @@ Then go to the root directory of flink source code and run this command to build
 cd flink-python; python3 setup.py sdist bdist_wheel
 {% endhighlight %}
 
+<span class="label label-info">Note</span> Python 3.5+ is required to build PyFlink.
+
 The sdist and wheel package will be found under `./flink-python/dist/`. Either of them could be used for pip installation, such as:
 
 {% highlight bash %}

--- a/docs/flinkDev/building.zh.md
+++ b/docs/flinkDev/building.zh.md
@@ -65,6 +65,8 @@ mvn clean install -DskipTests -Dfast
 cd flink-python; python3 setup.py sdist bdist_wheel
 {% endhighlight %}
 
+<span class="label label-info">注意事项</span> 构建PyFlink需要Python3.5以上的版本.
+
 构建好的源码发布包和wheel包位于`./flink-python/dist/`目录下。它们均可使用pip安装,比如:
 
 {% highlight bash %}

--- a/flink-python/dev/lint-python.sh
+++ b/flink-python/dev/lint-python.sh
@@ -178,7 +178,7 @@ function install_miniconda() {
 
 # Install some kinds of py env.
 function install_py_env() {
-    py_env=("2.7" "3.5" "3.6" "3.7")
+    py_env=("3.5" "3.6" "3.7")
     for ((i=0;i<${#py_env[@]};i++)) do
         if [ -d "$CURRENT_DIR/.conda/envs/${py_env[i]}" ]; then
             rm -rf "$CURRENT_DIR/.conda/envs/${py_env[i]}"
@@ -301,7 +301,7 @@ function install_environment() {
     print_function "STEP" "install miniconda... [SUCCESS]"
 
     # step-3 install python environment whcih includes
-    # 2.7 3.3 3.4 3.5 3.6 3.7
+    # 3.5 3.6 3.7
     print_function "STEP" "installing python environment..."
     if [ $STEP -lt 3 ]; then
         install_py_env

--- a/flink-python/pyflink/__init__.py
+++ b/flink-python/pyflink/__init__.py
@@ -15,3 +15,9 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 #################################################################################
+import sys
+
+if sys.version_info < (3, 5):
+    raise RuntimeError(
+        'Python versions prior to 3.5 are not supported for PyFlink [' +
+        str(sys.version_info) + '].')

--- a/flink-python/pyflink/common/execution_config.py
+++ b/flink-python/pyflink/common/execution_config.py
@@ -15,16 +15,12 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-import sys
 
 from pyflink.common.execution_mode import ExecutionMode
 from pyflink.common.input_dependency_constraint import InputDependencyConstraint
 from pyflink.common.restart_strategy import RestartStrategies
 from pyflink.java_gateway import get_gateway
 from pyflink.util.utils import load_java_class
-
-if sys.version >= '3':
-    unicode = str
 
 __all__ = ['ExecutionConfig']
 
@@ -554,7 +550,7 @@ class ExecutionConfig(object):
         Configuration = gateway.jvm.org.apache.flink.configuration.Configuration
         j_global_job_parameters = Configuration()
         for key in global_job_parameters_dict:
-            if not isinstance(global_job_parameters_dict[key], (str, unicode)):
+            if not isinstance(global_job_parameters_dict[key], str):
                 value = str(global_job_parameters_dict[key])
             else:
                 value = global_job_parameters_dict[key]

--- a/flink-python/pyflink/common/restart_strategy.py
+++ b/flink-python/pyflink/common/restart_strategy.py
@@ -15,7 +15,6 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-import sys
 from abc import ABCMeta
 from datetime import timedelta
 
@@ -25,9 +24,6 @@ from pyflink.java_gateway import get_gateway
 from pyflink.util.utils import to_j_flink_time, from_j_flink_time
 
 __all__ = ['RestartStrategies', 'RestartStrategyConfiguration']
-
-if sys.version >= '3':
-    long = int
 
 
 class RestartStrategyConfiguration(object):
@@ -89,7 +85,7 @@ class RestartStrategies(object):
         def __init__(self, restart_attempts=None, delay_between_attempts_interval=None,
                      j_restart_strategy=None):
             if j_restart_strategy is None:
-                if not isinstance(delay_between_attempts_interval, (timedelta, int, long)):
+                if not isinstance(delay_between_attempts_interval, (timedelta, int)):
                     raise TypeError("The delay_between_attempts_interval 'failure_interval' "
                                     "only supports integer and datetime.timedelta, current input "
                                     "type is %s." % type(delay_between_attempts_interval))
@@ -122,11 +118,11 @@ class RestartStrategies(object):
                      delay_between_attempts_interval=None,
                      j_restart_strategy=None):
             if j_restart_strategy is None:
-                if not isinstance(failure_interval, (timedelta, int, long)):
+                if not isinstance(failure_interval, (timedelta, int)):
                     raise TypeError("The parameter 'failure_interval' "
                                     "only supports integer and datetime.timedelta, current input "
                                     "type is %s." % type(failure_interval))
-                if not isinstance(delay_between_attempts_interval, (timedelta, int, long)):
+                if not isinstance(delay_between_attempts_interval, (timedelta, int)):
                     raise TypeError("The delay_between_attempts_interval 'failure_interval' "
                                     "only supports integer and datetime.timedelta, current input "
                                     "type is %s." % type(delay_between_attempts_interval))

--- a/flink-python/pyflink/datastream/state_backend.py
+++ b/flink-python/pyflink/datastream/state_backend.py
@@ -15,7 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-import sys
+
 from abc import ABCMeta
 
 from py4j.java_gateway import get_java_class
@@ -30,9 +30,6 @@ __all__ = [
     'RocksDBStateBackend',
     'CustomStateBackend',
     'PredefinedOptions']
-
-if sys.version > '3':
-    xrange = range
 
 
 def _from_j_state_backend(j_state_backend):
@@ -532,7 +529,7 @@ class RocksDBStateBackend(StateBackend):
         else:
             gateway = get_gateway()
             j_path_array = gateway.new_array(gateway.jvm.String, len(paths))
-            for i in xrange(0, len(paths)):
+            for i in range(0, len(paths)):
                 j_path_array[i] = paths[i]
             self._j_rocks_db_state_backend.setDbStoragePaths(j_path_array)
 

--- a/flink-python/pyflink/find_flink_home.py
+++ b/flink-python/pyflink/find_flink_home.py
@@ -47,12 +47,8 @@ def _find_flink_home():
                 os.environ['FLINK_HOME'] = build_target
                 return build_target
 
-            if sys.version < "3":
-                import imp
-                module_home = imp.find_module("pyflink")[1]
-            else:
-                from importlib.util import find_spec
-                module_home = os.path.dirname(find_spec("pyflink").origin)
+            from importlib.util import find_spec
+            module_home = os.path.dirname(find_spec("pyflink").origin)
 
             if _is_flink_home(module_home):
                 os.environ['FLINK_HOME'] = module_home

--- a/flink-python/pyflink/fn_execution/coder_impl.py
+++ b/flink-python/pyflink/fn_execution/coder_impl.py
@@ -15,12 +15,8 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-import sys
 
 from apache_beam.coders.coder_impl import StreamCoderImpl
-
-if sys.version > '3':
-    xrange = range
 
 
 class RowCoderImpl(StreamCoderImpl):
@@ -30,7 +26,7 @@ class RowCoderImpl(StreamCoderImpl):
 
     def encode_to_stream(self, value, out_stream, nested):
         self.write_null_mask(value, out_stream)
-        for i in xrange(len(self._field_coders)):
+        for i in range(len(self._field_coders)):
             self._field_coders[i].encode_to_stream(value[i], out_stream, nested)
 
     def decode_from_stream(self, in_stream, nested):
@@ -38,7 +34,7 @@ class RowCoderImpl(StreamCoderImpl):
         null_mask = self.read_null_mask(len(self._field_coders), in_stream)
         assert len(null_mask) == len(self._field_coders)
         return Row(*[None if null_mask[idx] else self._field_coders[idx].decode_from_stream(
-            in_stream, nested) for idx in xrange(0, len(null_mask))])
+            in_stream, nested) for idx in range(0, len(null_mask))])
 
     @staticmethod
     def write_null_mask(value, out_stream):

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -15,7 +15,6 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-import sys
 
 from apache_beam.coders import Coder, VarIntCoder
 from apache_beam.coders.coders import FastCoder
@@ -24,9 +23,6 @@ from pyflink.fn_execution import coder_impl
 from pyflink.fn_execution import flink_fn_execution_pb2
 
 FLINK_SCHEMA_CODER_URN = "flink:coder:schema:v1"
-
-if sys.version > '3':
-    xrange = range
 
 
 __all__ = ['RowCoder']
@@ -57,7 +53,7 @@ class RowCoder(FastCoder):
         return (self.__class__ == other.__class__
                 and len(self._field_coders) == len(other._field_coders)
                 and [self._field_coders[i] == other._field_coders[i] for i in
-                     xrange(len(self._field_coders))])
+                     range(len(self._field_coders))])
 
     def __ne__(self, other):
         return not self == other

--- a/flink-python/pyflink/fn_execution/operations.py
+++ b/flink-python/pyflink/fn_execution/operations.py
@@ -95,20 +95,20 @@ class ConstantInputGetter(InputGetter):
         # the type set contains
         # TINYINT,SMALLINT,INTEGER,BIGINT,FLOAT,DOUBLE,DECIMAL,CHAR,VARCHAR,NULL,BOOLEAN
         # the pickled_data doesn't need to transfer to anther python object
-        if j_type == '\x00' or j_type == 0:
+        if j_type == 0:
             self._constant_value = pickled_data
         # the type is DATE
-        elif j_type == '\x01' or j_type == 1:
+        elif j_type == 1:
             self._constant_value = \
                 datetime.date(year=1970, month=1, day=1) + datetime.timedelta(days=pickled_data)
         # the type is TIME
-        elif j_type == '\x02' or j_type == 2:
+        elif j_type == 2:
             seconds, milliseconds = divmod(pickled_data, 1000)
             minutes, seconds = divmod(seconds, 60)
             hours, minutes = divmod(minutes, 60)
             self._constant_value = datetime.time(hours, minutes, seconds, milliseconds * 1000)
         # the type is TIMESTAMP
-        elif j_type == '\x03' or j_type == 3:
+        elif j_type == 3:
             self._constant_value = \
                 datetime.datetime(year=1970, month=1, day=1, hour=0, minute=0, second=0) \
                 + datetime.timedelta(milliseconds=pickled_data)

--- a/flink-python/pyflink/serializers.py
+++ b/flink-python/pyflink/serializers.py
@@ -16,18 +16,10 @@
 # limitations under the License.
 ################################################################################
 
-import sys
+import pickle
 import struct
 from abc import ABCMeta, abstractmethod
-
-if sys.version < '3':
-    import cPickle as pickle
-    protocol = 2
-    from itertools import imap as map, chain
-else:
-    import pickle
-    protocol = 3
-    xrange = range
+from itertools import chain
 
 
 class SpecialLengths(object):
@@ -144,14 +136,10 @@ class PickleSerializer(VarLengthDataSerializer):
     """
 
     def dumps(self, obj):
-        return pickle.dumps(obj, protocol)
+        return pickle.dumps(obj, 3)
 
-    if sys.version >= '3':
-        def loads(self, obj, encoding="bytes"):
-            return pickle.loads(obj, encoding=encoding)
-    else:
-        def loads(self, obj, encoding=None):
-            return pickle.loads(obj)
+    def loads(self, obj):
+        return pickle.loads(obj, encoding="bytes")
 
 
 class BatchedSerializer(Serializer):
@@ -175,7 +163,7 @@ class BatchedSerializer(Serializer):
             yield list(iterator)
         elif hasattr(iterator, "__len__") and hasattr(iterator, "__getslice__"):
             n = len(iterator)
-            for i in xrange(0, n, self.batch_size):
+            for i in range(0, n, self.batch_size):
                 yield iterator[i: i + self.batch_size]
         else:
             items = []

--- a/flink-python/pyflink/shell.py
+++ b/flink-python/pyflink/shell.py
@@ -28,10 +28,7 @@ from pyflink.table.catalog import *
 from pyflink.table.descriptors import *
 from pyflink.table.window import *
 
-if sys.version > '3':
-    utf8_out = open(sys.stdout.fileno(), mode='w', encoding='utf8', buffering=1)
-else:
-    utf8_out = codecs.getwriter("utf-8")(sys.stdout)
+utf8_out = open(sys.stdout.fileno(), mode='w', encoding='utf8', buffering=1)
 
 print("Using Python version %s (%s, %s)" % (
     platform.python_version(),

--- a/flink-python/pyflink/table/descriptors.py
+++ b/flink-python/pyflink/table/descriptors.py
@@ -15,17 +15,12 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-import sys
 from abc import ABCMeta
 
 from py4j.java_gateway import get_method
 from pyflink.table.types import _to_java_type
 
 from pyflink.java_gateway import get_gateway
-
-if sys.version >= '3':
-    long = int
-    unicode = str
 
 __all__ = [
     'Rowtime',
@@ -215,7 +210,7 @@ class Schema(Descriptor):
         :param field_type: The data type or type string of the field.
         :return: This schema object.
         """
-        if isinstance(field_type, (str, unicode)):
+        if isinstance(field_type, str):
             self._j_schema = self._j_schema.field(field_name, field_type)
         else:
             self._j_schema = self._j_schema.field(field_name, _to_java_type(field_type))
@@ -338,7 +333,7 @@ class OldCsv(FormatDescriptor):
         :param field_type: The data type or type string of the field.
         :return: This :class:`OldCsv` object.
         """
-        if isinstance(field_type, (str, unicode)):
+        if isinstance(field_type, str):
             self._j_csv = self._j_csv.field(field_name, field_type)
         else:
             self._j_csv = self._j_csv.field(field_name, _to_java_type(field_type))
@@ -409,7 +404,7 @@ class Csv(FormatDescriptor):
         :param delimiter: The field delimiter character.
         :return: This :class:`Csv` object.
         """
-        if not isinstance(delimiter, (str, unicode)) or len(delimiter) != 1:
+        if not isinstance(delimiter, str) or len(delimiter) != 1:
             raise TypeError("Only one-character string is supported!")
         self._j_csv = self._j_csv.fieldDelimiter(delimiter)
         return self
@@ -431,7 +426,7 @@ class Csv(FormatDescriptor):
         :param quote_character: The quote character.
         :return: This :class:`Csv` object.
         """
-        if not isinstance(quote_character, (str, unicode)) or len(quote_character) != 1:
+        if not isinstance(quote_character, str) or len(quote_character) != 1:
             raise TypeError("Only one-character string is supported!")
         self._j_csv = self._j_csv.quoteCharacter(quote_character)
         return self
@@ -473,7 +468,7 @@ class Csv(FormatDescriptor):
         :param escape_character: Escaping character (e.g. backslash).
         :return: This :class:`Csv` object.
         """
-        if not isinstance(escape_character, (str, unicode)) or len(escape_character) != 1:
+        if not isinstance(escape_character, str) or len(escape_character) != 1:
             raise TypeError("Only one-character string is supported!")
         self._j_csv = self._j_csv.escapeCharacter(escape_character)
         return self
@@ -627,9 +622,9 @@ class CustomFormatDescriptor(FormatDescriptor):
         :param version: Property version for backwards compatibility.
         """
 
-        if not isinstance(type, (str, unicode)):
+        if not isinstance(type, str):
             raise TypeError("type must be of type str.")
-        if not isinstance(version, (int, long)):
+        if not isinstance(version, int):
             raise TypeError("version must be of type int.")
         gateway = get_gateway()
         super(CustomFormatDescriptor, self).__init__(
@@ -644,9 +639,9 @@ class CustomFormatDescriptor(FormatDescriptor):
         :return: This object.
         """
 
-        if not isinstance(key, (str, unicode)):
+        if not isinstance(key, str):
             raise TypeError("key must be of type str.")
-        if not isinstance(value, (str, unicode)):
+        if not isinstance(value, str):
             raise TypeError("value must be of type str.")
         self._j_format_descriptor = self._j_format_descriptor.property(key, value)
         return self
@@ -716,7 +711,7 @@ class Kafka(ConnectorDescriptor):
         :param version: Kafka version. E.g., "0.8", "0.11", etc.
         :return: This object.
         """
-        if not isinstance(version, (str, unicode)):
+        if not isinstance(version, str):
             version = str(version)
         self._j_kafka = self._j_kafka.version(version)
         return self
@@ -932,7 +927,7 @@ class Elasticsearch(ConnectorDescriptor):
         :param version: Elasticsearch version. E.g., "6".
         :return: This object.
         """
-        if not isinstance(version, (str, unicode)):
+        if not isinstance(version, str):
             version = str(version)
         self._j_elasticsearch = self._j_elasticsearch.version(version)
         return self
@@ -1195,9 +1190,9 @@ class CustomConnectorDescriptor(ConnectorDescriptor):
         :param format_needed: Flag for basic validation of a needed format descriptor.
         """
 
-        if not isinstance(type, (str, unicode)):
+        if not isinstance(type, str):
             raise TypeError("type must be of type str.")
-        if not isinstance(version, (int, long)):
+        if not isinstance(version, int):
             raise TypeError("version must be of type int.")
         if not isinstance(format_needed, bool):
             raise TypeError("format_needed must be of type bool.")
@@ -1214,9 +1209,9 @@ class CustomConnectorDescriptor(ConnectorDescriptor):
         :return: This object.
         """
 
-        if not isinstance(key, (str, unicode)):
+        if not isinstance(key, str):
             raise TypeError("key must be of type str.")
-        if not isinstance(value, (str, unicode)):
+        if not isinstance(value, str):
             raise TypeError("value must be of type str.")
         self._j_connector_descriptor = self._j_connector_descriptor.property(key, value)
         return self

--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -15,7 +15,6 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-import sys
 
 from py4j.java_gateway import get_method
 from pyflink.java_gateway import get_gateway
@@ -23,9 +22,6 @@ from pyflink.table.table_schema import TableSchema
 
 from pyflink.table.window import GroupWindow
 from pyflink.util.utils import to_jarray
-
-if sys.version > '3':
-    xrange = range
 
 __all__ = ['Table', 'GroupedTable', 'GroupWindowedTable', 'OverWindowedTable', 'WindowGroupedTable']
 

--- a/flink-python/pyflink/table/table_config.py
+++ b/flink-python/pyflink/table/table_config.py
@@ -15,7 +15,6 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-import sys
 
 from py4j.compat import long
 
@@ -23,9 +22,6 @@ from pyflink.common import Configuration, SqlDialect
 from pyflink.java_gateway import get_gateway
 
 __all__ = ['TableConfig']
-
-if sys.version > '3':
-    unicode = str
 
 
 class TableConfig(object):
@@ -69,7 +65,7 @@ class TableConfig(object):
                             such as "America/Los_Angeles", or a custom timezone_id such as
                             "GMT-8:00".
         """
-        if timezone_id is not None and isinstance(timezone_id, (str, unicode)):
+        if timezone_id is not None and isinstance(timezone_id, str):
             j_timezone = get_gateway().jvm.java.time.ZoneId.of(timezone_id)
             self._j_table_config.setLocalTimeZone(j_timezone)
         else:

--- a/flink-python/pyflink/table/table_schema.py
+++ b/flink-python/pyflink/table/table_schema.py
@@ -15,14 +15,10 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-import sys
 
 from pyflink.java_gateway import get_gateway
 from pyflink.table.types import _to_java_type, _from_java_type
 from pyflink.util.utils import to_jarray
-
-if sys.version >= '3':
-    unicode = str
 
 __all__ = ['TableSchema']
 
@@ -65,7 +61,7 @@ class TableSchema(object):
         :param field: The index of the field or the name of the field.
         :return: The data type of the specified field.
         """
-        if not isinstance(field, (int, str, unicode)):
+        if not isinstance(field, (int, str)):
             raise TypeError("Expected field index or field name, got %s" % type(field))
         optional_result = self._j_table_schema.getFieldDataType(field)
         if optional_result.isPresent():

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -17,8 +17,6 @@
 ################################################################################
 import os
 
-from py4j.compat import unicode
-
 from pyflink.dataset import ExecutionEnvironment
 from pyflink.datastream import StreamExecutionEnvironment
 from pyflink.table import DataTypes, CsvTableSink, StreamTableEnvironment, EnvironmentSettings
@@ -103,7 +101,7 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
 
         actual = t_env.explain(result)
 
-        assert isinstance(actual, str) or isinstance(actual, unicode)
+        assert isinstance(actual, str)
 
     def test_explain_with_extended(self):
         schema = RowType() \
@@ -116,7 +114,7 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
 
         actual = t_env.explain(result, True)
 
-        assert isinstance(actual, str) or isinstance(actual, unicode)
+        assert isinstance(actual, str)
 
     def test_explain_with_multi_sinks(self):
         t_env = self.t_env
@@ -135,7 +133,7 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
 
         actual = t_env.explain(extended=True)
 
-        assert isinstance(actual, str) or isinstance(actual, unicode)
+        assert isinstance(actual, str)
 
     def test_sql_query(self):
         t_env = self.t_env
@@ -257,7 +255,7 @@ class BatchTableEnvironmentTests(PyFlinkBatchTableTestCase):
 
         actual = t_env.explain(result)
 
-        self.assertIsInstance(actual, (str, unicode))
+        self.assertIsInstance(actual, str)
 
     def test_explain_with_extended(self):
         schema = RowType() \
@@ -270,7 +268,7 @@ class BatchTableEnvironmentTests(PyFlinkBatchTableTestCase):
 
         actual = t_env.explain(result, True)
 
-        assert isinstance(actual, str) or isinstance(actual, unicode)
+        assert isinstance(actual, str)
 
     def test_explain_with_multi_sinks(self):
         t_env = self.t_env

--- a/flink-python/pyflink/table/tests/test_types.py
+++ b/flink-python/pyflink/table/tests/test_types.py
@@ -444,10 +444,6 @@ class TypesTests(unittest.TestCase):
             supported_string_types += ['u']
             # test unicode
             assert_collect_success('u', u'a', 'CHAR')
-        if sys.version_info[0] < 3:
-            supported_string_types += ['c']
-            # test string
-            assert_collect_success('c', 'a', 'CHAR')
 
         # supported float and double
         #
@@ -511,11 +507,7 @@ class TypesTests(unittest.TestCase):
         #
         # Keys in _array_type_mappings is a complete list of all supported types,
         # and types not in _array_type_mappings are considered unsupported.
-        # `array.typecodes` are not supported in python 2.
-        if sys.version_info[0] < 3:
-            all_types = {'c', 'b', 'B', 'u', 'h', 'H', 'i', 'I', 'l', 'L', 'f', 'd'}
-        else:
-            all_types = set(array.typecodes)
+        all_types = set(array.typecodes)
         unsupported_types = all_types - set(supported_types)
         # test unsupported types
         for t in unsupported_types:

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -32,10 +32,6 @@ from py4j.java_gateway import JavaClass, JavaObject, get_java_class
 from pyflink.util.utils import to_jarray
 from pyflink.java_gateway import get_gateway
 
-if sys.version >= '3':
-    long = int
-    basestring = unicode = str
-
 __all__ = ['DataTypes', 'UserDefinedType', 'Row']
 
 
@@ -1024,11 +1020,11 @@ class RowField(object):
         """
         assert isinstance(data_type, DataType), \
             "data_type %s should be an instance of %s" % (data_type, DataType)
-        assert isinstance(name, basestring), "field name %s should be string" % name
+        assert isinstance(name, str), "field name %s should be string" % name
         if not isinstance(name, str):
             name = name.encode('utf-8')
         if description is not None:
-            assert isinstance(description, basestring), \
+            assert isinstance(description, str), \
                 "description %s should be string" % description
             if not isinstance(description, str):
                 description = description.encode('utf-8')
@@ -1313,12 +1309,6 @@ _type_mappings = {
     datetime.time: TimeType(),
 }
 
-if sys.version < "3":
-    _type_mappings.update({
-        unicode: VarCharType(0x7fffffff),
-        long: BigIntType(),
-    })
-
 # Mapping Python array types to Flink SQL types
 # We should be careful here. The size of these types in python depends on C
 # implementation. We need to make sure that this conversion does not lose any
@@ -1393,10 +1383,6 @@ for _typecode in _array_unsigned_int_typecode_ctype_mappings.keys():
 if sys.version_info[0] < 4:
     # it can be 16 bits or 32 bits depending on the platform
     _array_type_mappings['u'] = CharType(ctypes.sizeof(ctypes.c_wchar))
-
-# Type code 'c' are only available at python 2
-if sys.version_info[0] < 3:
-    _array_type_mappings['c'] = CharType(ctypes.sizeof(ctypes.c_char))
 
 
 def _infer_type(obj):
@@ -1696,7 +1682,7 @@ def _to_java_type(data_type):
 
 def _is_instance_of(java_data_type, java_class):
     gateway = get_gateway()
-    if isinstance(java_class, basestring):
+    if isinstance(java_class, str):
         param = java_class
     elif isinstance(java_class, JavaClass):
         param = get_java_class(java_class)
@@ -2010,15 +1996,15 @@ class Row(tuple):
 
 _acceptable_types = {
     BooleanType: (bool,),
-    TinyIntType: (int, long),
-    SmallIntType: (int, long),
-    IntType: (int, long),
-    BigIntType: (int, long),
+    TinyIntType: (int,),
+    SmallIntType: (int,),
+    IntType: (int,),
+    BigIntType: (int,),
     FloatType: (float,),
     DoubleType: (float,),
     DecimalType: (decimal.Decimal,),
-    CharType: (str, unicode),
-    VarCharType: (str, unicode),
+    CharType: (str,),
+    VarCharType: (str,),
     BinaryType: (bytearray,),
     VarBinaryType: (bytearray,),
     DateType: (datetime.date, datetime.datetime),

--- a/flink-python/pyflink/table/udf.py
+++ b/flink-python/pyflink/table/udf.py
@@ -19,19 +19,12 @@ import abc
 import collections
 import functools
 import inspect
-import sys
 
 from pyflink.java_gateway import get_gateway
 from pyflink.table.types import DataType, _to_java_type
 from pyflink.util import utils
 
 __all__ = ['FunctionContext', 'ScalarFunction', 'udf']
-
-
-if sys.version_info >= (3, 4):
-    ABC = abc.ABC
-else:
-    ABC = abc.ABCMeta('ABC', (), {})
 
 
 class FunctionContext(object):
@@ -43,7 +36,7 @@ class FunctionContext(object):
     pass
 
 
-class UserDefinedFunction(ABC):
+class UserDefinedFunction(abc.ABC):
     """
     Base interface for user-defined function.
     """

--- a/flink-python/pyflink/testing/source_sink_utils.py
+++ b/flink-python/pyflink/testing/source_sink_utils.py
@@ -18,7 +18,6 @@
 
 import glob
 import os
-import sys
 import unittest
 from py4j.java_gateway import java_import
 
@@ -27,9 +26,6 @@ from pyflink.java_gateway import get_gateway
 from pyflink.table import TableSink
 from pyflink.table.types import _to_java_type
 from pyflink.util import utils
-
-if sys.version_info[0] >= 3:
-    xrange = range
 
 
 class TestTableSink(TableSink):
@@ -105,7 +101,7 @@ class TestUpsertSink(TestTableSink):
 
         gateway = get_gateway()
         j_keys = gateway.new_array(gateway.jvm.String, len(keys))
-        for i in xrange(0, len(keys)):
+        for i in range(0, len(keys)):
             j_keys[i] = keys[i]
 
         super(TestUpsertSink, self).__init__(
@@ -134,7 +130,7 @@ def upsert_results(keys):
     """
     gateway = get_gateway()
     j_keys = gateway.new_array(gateway.jvm.int, len(keys))
-    for i in xrange(0, len(keys)):
+    for i in range(0, len(keys)):
         j_keys[i] = keys[i]
 
     results = gateway.jvm.RowCollector.getAndClearValues()

--- a/flink-python/pyflink/testing/test_case_utils.py
+++ b/flink-python/pyflink/testing/test_case_utils.py
@@ -34,11 +34,6 @@ from pyflink.find_flink_home import _find_flink_home
 from pyflink.table import BatchTableEnvironment, StreamTableEnvironment, EnvironmentSettings
 from pyflink.java_gateway import get_gateway
 
-if sys.version_info[0] >= 3:
-    xrange = range
-else:
-    unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
-    unittest.TestCase.assertRegex = unittest.TestCase.assertRegexpMatches
 
 if os.getenv("VERBOSE"):
     log_level = logging.DEBUG
@@ -97,7 +92,7 @@ class PyFlinkTestCase(unittest.TestCase):
     @classmethod
     def to_py_list(cls, actual):
         py_list = []
-        for i in xrange(0, actual.length()):
+        for i in range(0, actual.length()):
             py_list.append(actual.apply(i))
         return py_list
 

--- a/flink-python/pyflink/util/utils.py
+++ b/flink-python/pyflink/util/utils.py
@@ -15,13 +15,10 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-import sys
+
 from datetime import timedelta
 
 from pyflink.java_gateway import get_gateway
-
-if sys.version >= '3':
-    unicode = str
 
 
 def to_jarray(j_type, arr):

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -24,8 +24,8 @@ from shutil import copytree, copy, rmtree
 
 from setuptools import setup
 
-if sys.version_info < (2, 7):
-    print("Python versions prior to 2.7 are not supported for PyFlink.",
+if sys.version_info < (3, 5):
+    print("Python versions prior to 3.5 are not supported for PyFlink.",
           file=sys.stderr)
     sys.exit(-1)
 
@@ -206,6 +206,7 @@ run sdist.
         license='https://www.apache.org/licenses/LICENSE-2.0',
         author='Flink Developers',
         author_email='dev@flink.apache.org',
+        python_requires='>=3.5',
         install_requires=['py4j==0.10.8.1', 'python-dateutil==2.8.0', 'apache-beam==2.15.0',
                           'cloudpickle==1.2.2'],
         tests_require=['pytest==4.4.1'],
@@ -215,7 +216,6 @@ run sdist.
         classifiers=[
             'Development Status :: 1 - Planning',
             'License :: OSI Approved :: Apache Software License',
-            'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7']

--- a/flink-python/src/main/java/org/apache/flink/api/common/python/pickle/ArrayConstructor.java
+++ b/flink-python/src/main/java/org/apache/flink/api/common/python/pickle/ArrayConstructor.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.api.common.python.pickle;
 
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
 /**
@@ -29,24 +28,8 @@ public final class ArrayConstructor extends net.razorvine.pickle.objects.ArrayCo
 
 	@Override
 	public Object construct(Object[] args) {
-		if (args.length == 2 && args[1] instanceof String) {
-			char typecode = ((String) args[0]).charAt(0);
-			// This must be ISO 8859-1 / Latin 1, not UTF-8, to interoperate correctly
-			byte[] data = ((String) args[1]).getBytes(StandardCharsets.ISO_8859_1);
-			if (typecode == 'c') {
-				// It seems like the pickle of pypy uses the similar protocol to Python 2.6, which uses
-				// a string for array data instead of list as Python 2.7, and handles an array of
-				// typecode 'c' as 1-byte character.
-				char[] result = new char[data.length];
-				int i = 0;
-				while (i < data.length) {
-					result[i] = (char) data[i];
-					i += 1;
-				}
-				return result;
-			}
-		} else if (args.length == 2 && args[0] == "l") {
-			// On Python 2, an array of typecode 'l' should be handled as long rather than int.
+		if (args.length == 2 && args[0] == "l") {
+			// an array of typecode 'l' should be handled as long rather than int.
 			ArrayList<Object> values = (ArrayList<Object>) args[1];
 			long[] result = new long[values.size()];
 			int i = 0;

--- a/flink-python/tox.ini
+++ b/flink-python/tox.ini
@@ -21,7 +21,7 @@
 # in multiple virtualenvs. This configuration file will run the
 # test suite on all supported python versions.
 # new environments will be excluded by default unless explicitly added to envlist.
-envlist = py27, py35, py36, py37
+envlist = py35, py36, py37
 
 [testenv]
 whitelist_externals=


### PR DESCRIPTION

## What is the purpose of the change

*This pull request drops Python 2 support.*

## Brief change log

  - *Remove the CI for Python 2.7*
  - *Throw an exception if Python below 3.5 is used*
  - *Clean up code specific for Python 2.x*

## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
