### PR TITLE
[FLINK-14123][DOCS]Update release notes for flink-1.9

### DIFF
--- a/docs/release-notes/flink-1.9.md
+++ b/docs/release-notes/flink-1.9.md
@@ -75,6 +75,16 @@ have skipped Java 9 support.
 Related issues:
 - [FLINK-8033: JDK 9 support](https://issues.apache.org/jira/browse/FLINK-8033)
 
+### Memory management
+
+In Fink 1.9.0 and prior version, the managed memory fraction of taskmanager is controlled by `taskmanager.memory.fraction`,
+and with 0.7 as the default value. However, sometimes this will cause OOMs due to the fact that the default value of JVM
+parameter `NewRatio` is 2, which means the old generation occupied only 2/3 (0.66) of the heap memory. So if you run into
+this case, please manually change this value to a lower value.
+
+Related issues:
+- [FLINK-14123: Lower the default value of taskmanager.memory.fraction](https://issues.apache.org/jira/browse/FLINK-14123)
+
 ## Deprecations and breaking changes
 
 ### Scala expression DSL for Table API moved to `flink-table-api-scala`

--- a/docs/release-notes/flink-1.9.zh.md
+++ b/docs/release-notes/flink-1.9.zh.md
@@ -75,6 +75,16 @@ have skipped Java 9 support.
 Related issues:
 - [FLINK-8033: JDK 9 support](https://issues.apache.org/jira/browse/FLINK-8033)
 
+### Memory management
+
+In Fink 1.9.0 and prior version, the managed memory fraction of taskmanager is controlled by `taskmanager.memory.fraction`,
+and with 0.7 as the default value. However, sometimes this will cause OOMs due to the fact that the default value of JVM
+parameter `NewRatio` is 2, which means the old generation occupied only 2/3 (0.66) of the heap memory. So if you run into
+this case, please manually change this value to a lower value.
+
+Related issues:
+- [FLINK-14123: Lower the default value of taskmanager.memory.fraction](https://issues.apache.org/jira/browse/FLINK-14123)
+
 ## Deprecations and breaking changes
 
 ### Scala expression DSL for Table API moved to `flink-table-api-scala`


### PR DESCRIPTION

## What is the purpose of the change

Update the release notes docs for flink-1.9 on the memory management. We suggest users to manually lower the `taskmanager.memory.fraction` conf value to avoid OOMs in some case.


## Brief change log

  - Update release notes for flink-1.9 on the memory management.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
