### PR TITLE
[FLINK-14464][runtime] Introduce the AbstractUserClassPathJobGraphRetriever

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
@@ -18,11 +18,14 @@
 
 package org.apache.flink.util;
 
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.testutils.CheckedThread;
+import org.apache.flink.util.function.FunctionUtils;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,12 +36,17 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Random;
@@ -259,6 +267,73 @@ public class FileUtilsTest extends TestLogger {
 		assertDirEquals(compressDir.resolve(originalDir), extractDir.resolve(originalDir));
 	}
 
+	@Test
+	public void testListFilesInPathWithoutAnyFileReturnEmptyList() throws IOException {
+		final java.nio.file.Path testDir = tmp.newFolder("_test_0").toPath();
+
+		assertTrue(FileUtils.listFilesInPath(testDir.toFile(), f -> f.getName().endsWith(".jar")).isEmpty());
+	}
+
+	@Test
+	public void testListFilesInPath() throws IOException {
+		final java.nio.file.Path testDir = tmp.newFolder("_test_1").toPath();
+		final Tuple3<Collection<File>, Collection<File>, Collection<URL>> result = prepareTestFiles(testDir);
+
+		assertTrue(CollectionUtils.isEqualCollection(result.f0,
+			FileUtils.listFilesInPath(testDir.toFile(), f ->  f.getName().endsWith(".jar"))));
+	}
+
+	@Test
+	public void testRelativizeToWorkingDir() throws IOException {
+		final java.nio.file.Path testDir = tmp.newFolder("_test_2").toPath();
+		final Tuple3<Collection<File>, Collection<File>, Collection<URL>> result = prepareTestFiles(testDir);
+		final Collection<File> relativeFiles = FileUtils.relativizeToWorkingDir(result.f0);
+		relativeFiles.forEach(file -> assertFalse(file.isAbsolute()));
+		assertTrue(
+			CollectionUtils.isEqualCollection(
+				result.f1,
+				FileUtils.relativizeToWorkingDir(result.f0)
+			)
+		);
+	}
+
+	@Test
+	public void testToRelativeURLs() throws IOException {
+		final java.nio.file.Path testDir = tmp.newFolder("_test_3").toPath();
+		final Tuple3<Collection<File>, Collection<File>, Collection<URL>> result = prepareTestFiles(testDir);
+
+		final Collection<URL> relativeURLs = FileUtils.toRelativeURLs(result.f1);
+		relativeURLs.forEach(url -> assertFalse(new File(url.getPath()).isAbsolute()));
+
+		assertTrue(
+			CollectionUtils.isEqualCollection(
+				result.f2,
+				relativeURLs
+			)
+		);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testToRelativeURLsThrowExceptionBecauseOfAbsolutePath() throws IOException {
+		final File tempFile = tmp.newFile();
+		FileUtils.toRelativeURLs(Arrays.asList(tempFile));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testListDirFailsIfDirectoryDoesNotExist() throws IOException {
+		final String fileName = "_does_not_exists_file";
+		final String doesNotExistsFilePath = tmp.getRoot() + "/" + fileName;
+
+		FileUtils.listFilesInPath(new File(doesNotExistsFilePath), f ->  f.getName().endsWith(".jar"));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testListAFileFailsBecauseDirectoryIsExpected() throws IOException {
+		final String fileName = "a.jar";
+		final File file = tmp.newFile(fileName);
+		FileUtils.listFilesInPath(file, f ->  f.getName().endsWith(".jar"));
+	}
+
 	// ------------------------------------------------------------------------
 	//  Utilities
 	// ------------------------------------------------------------------------
@@ -310,6 +385,60 @@ public class FileUtilsTest extends TestLogger {
 				generateRandomDirs(subdir, numFiles, numDirs, depth - 1);
 			}
 		}
+	}
+
+	/**
+	 * Generate some files in the directory {@code dir}.
+	 * @param dir the directory where the files are generated
+	 * @return Tuple3 holding the generated files' absolute path, relative to the working directory path and relative
+	 * url.
+	 * @throws IOException if I/O error occurs while generating the files
+	 */
+	public static Tuple3<Collection<File>, Collection<File>, Collection<URL>> prepareTestFiles(
+		final java.nio.file.Path dir) throws IOException {
+
+		Tuple3<Collection<File>, Collection<File>, Collection<URL>> result = new Tuple3<>();
+
+		result.f0 = generateSomeFilesInDirectoryReturnJarFiles(dir);
+		result.f1 = toRelativeFiles(result.f0);
+		result.f2 = toRelativeURLs(result.f1);
+
+		return result;
+	}
+
+	private static Collection<File> generateSomeFilesInDirectoryReturnJarFiles(
+			final java.nio.file.Path dir) throws IOException {
+
+		final java.nio.file.Path jobSubDir1 = Files.createDirectory(dir.resolve("_sub_dir1"));
+		final java.nio.file.Path jobSubDir2 = Files.createDirectory(dir.resolve("_sub_dir2"));
+		final java.nio.file.Path jarFile1 = Files.createFile(dir.resolve("file1.jar"));
+		final java.nio.file.Path jarFile2 = Files.createFile(dir.resolve("file2.jar"));
+		final java.nio.file.Path jarFile3 = Files.createFile(jobSubDir1.resolve("file3.jar"));
+		final java.nio.file.Path jarFile4 = Files.createFile(jobSubDir2.resolve("file4.jar"));
+		final Collection<File> jarFiles = new ArrayList<>();
+
+		Files.createFile(dir.resolve("file1.txt"));
+		Files.createFile(jobSubDir2.resolve("file2.txt"));
+
+		jarFiles.add(jarFile1.toFile());
+		jarFiles.add(jarFile2.toFile());
+		jarFiles.add(jarFile3.toFile());
+		jarFiles.add(jarFile4.toFile());
+		return jarFiles;
+	}
+
+	private static Collection<File> toRelativeFiles(Collection<File> files) {
+		final java.nio.file.Path workingDir = Paths.get(System.getProperty("user.dir"));
+		final Collection<File> relativeFiles = new ArrayList<>();
+		files.forEach(file -> relativeFiles.add(workingDir.relativize(file.toPath()).toFile()));
+		return relativeFiles;
+	}
+
+	private static Collection<URL> toRelativeURLs(Collection<File> relativeFiles) throws MalformedURLException {
+		final Collection<URL> relativeURLs = new ArrayList<>();
+		final URL context = new URL(relativeFiles.iterator().next().toURI().getScheme() + ":");
+		relativeFiles.forEach(FunctionUtils.uncheckedConsumer(file -> relativeURLs.add(new URL(context, file.toString()))));
+		return relativeURLs;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetriever.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint.component;
+
+import org.apache.flink.util.FileUtils;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ *  Abstract class for the JobGraphRetriever which supports getting user classpaths.
+ */
+public abstract class AbstractUserClassPathJobGraphRetriever implements JobGraphRetriever {
+
+	/** User classpaths in relative form to the working directory. */
+	private final List<URL> userClassPaths;
+
+	protected AbstractUserClassPathJobGraphRetriever(@Nullable final File jobDir) throws IOException {
+		if (jobDir == null) {
+			userClassPaths = Collections.emptyList();
+		} else {
+			final Collection<File> jarFiles = FileUtils.listFilesInPath(jobDir, file -> file.getName().endsWith(".jar"));
+			final Collection<File> relativeFiles = FileUtils.relativizeToWorkingDir(jarFiles);
+			this.userClassPaths = new ArrayList<>(FileUtils.toRelativeURLs(relativeFiles));
+			if (this.userClassPaths.isEmpty()) {
+				throw new IllegalArgumentException(String.format("The job dir %s does not have any jars.", jobDir));
+			}
+		}
+	}
+
+	public List<URL> getUserClassPaths() {
+		return userClassPaths;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
@@ -18,25 +18,24 @@
 
 package org.apache.flink.runtime.entrypoint.component;
 
-import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.FileUtilsTest;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.FunctionUtils;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import javax.annotation.Nonnull;
-
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.Collection;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -48,29 +47,26 @@ public class AbstractUserClassPathJobGraphRetrieverTest extends TestLogger {
 	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	private static class TestJobGraphRetriever extends AbstractUserClassPathJobGraphRetriever {
-		public TestJobGraphRetriever(@Nonnull final File jobDir) throws IOException {
+		TestJobGraphRetriever(File jobDir) throws IOException {
 			super(jobDir);
 		}
 
 		@Override
 		public JobGraph retrieveJobGraph(Configuration configuration) {
-			return null;
+			throw new UnsupportedOperationException("This method should not be called.");
 		}
 	}
 
 	@Test
 	public void testGetUserClassPath() throws IOException {
-		final Path testJobDir = temporaryFolder.newFolder("_test_job").toPath();
-		final Tuple3<Collection<File>, Collection<File>, Collection<URL>>
-			result = FileUtilsTest.prepareTestFiles(testJobDir);
-		final TestJobGraphRetriever testJobGraphRetriever = new TestJobGraphRetriever(testJobDir.toFile());
-		assertTrue(CollectionUtils.isEqualCollection(result.f2, testJobGraphRetriever.getUserClassPaths()));
-	}
+		final File testJobDir = temporaryFolder.newFolder("_test_job");
+		final Collection<Path> testFiles = FileUtilsTest.prepareTestFiles(testJobDir.toPath());
+		final Path currentWorkingDirectory = FileUtils.getCurrentWorkingDirectory();
+		final TestJobGraphRetriever testJobGraphRetriever = new TestJobGraphRetriever(testJobDir);
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testTheJobGraphRetrieverThrowExceptionBecauseJobDirDoesNotHaveAnyJars() throws IOException {
-		final Path testJobDir = temporaryFolder.newFolder("_test_job_").toPath();
-		new TestJobGraphRetriever(testJobDir.toFile());
+		assertThat(testJobGraphRetriever.getUserClassPaths(), containsInAnyOrder(testFiles.stream()
+			.map(file -> FileUtils.relativizePath(currentWorkingDirectory, file))
+			.map(FunctionUtils.uncheckedFunction(FileUtils::toURL)).toArray()));
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint.component;
+
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.util.FileUtilsTest;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import javax.annotation.Nonnull;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.Collection;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the {@link AbstractUserClassPathJobGraphRetriever}.
+ */
+public class AbstractUserClassPathJobGraphRetrieverTest extends TestLogger {
+
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private static class TestJobGraphRetriever extends AbstractUserClassPathJobGraphRetriever {
+		public TestJobGraphRetriever(@Nonnull final File jobDir) throws IOException {
+			super(jobDir);
+		}
+
+		@Override
+		public JobGraph retrieveJobGraph(Configuration configuration) {
+			return null;
+		}
+	}
+
+	@Test
+	public void testGetUserClassPath() throws IOException {
+		final Path testJobDir = temporaryFolder.newFolder("_test_job").toPath();
+		final Tuple3<Collection<File>, Collection<File>, Collection<URL>>
+			result = FileUtilsTest.prepareTestFiles(testJobDir);
+		final TestJobGraphRetriever testJobGraphRetriever = new TestJobGraphRetriever(testJobDir.toFile());
+		assertTrue(CollectionUtils.isEqualCollection(result.f2, testJobGraphRetriever.getUserClassPaths()));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testTheJobGraphRetrieverThrowExceptionBecauseJobDirDoesNotHaveAnyJars() throws IOException {
+		final Path testJobDir = temporaryFolder.newFolder("_test_job_").toPath();
+		new TestJobGraphRetriever(testJobDir.toFile());
+	}
+
+	@Test
+	public void testGetUserClassPathReturnEmptyListIfJobDirIsNull() throws IOException {
+		final TestJobGraphRetriever testJobGraphRetriever = new TestJobGraphRetriever(null);
+		assertTrue(testJobGraphRetriever.getUserClassPaths().isEmpty());
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Introduce the `AbstractUserClassPathJobGraphRetriever` which could construct the 'user code classpath' from the "job" dir. The `FileJobGraphRetriever` and `ClassPathJobGraphRetriever` could extend this abstract class and set the corresponding 'user code classpath' to the `JobGraph`.


## Brief change log
  - `AbstrctUserClassPathJobGraphRetriever` scan the 'jobdir' recursively and all the jar files in the 'jobdir' are added to the 'user code classpath'


## Verifying this change

  - Add `AbstractUserClassPathJobGraphRetrieverTest` to test the functionality.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
