### PR TITLE
[FLINK-14471][web]: Hide error when metric api broken

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/app.config.ts
+++ b/flink-runtime-web/web-dashboard/src/app/app.config.ts
@@ -29,6 +29,8 @@ export const COLOR_MAP = {
   RECONCILING: '#eb2f96',
   IN_PROGRESS: '#faad14',
   SCHEDULED: '#722ed1',
-  COMPLETED  : '#1890ff'
+  COMPLETED: '#1890ff'
 };
 export const LONG_MIN_VALUE = -9223372036854776000;
+export const IGNORE_ERROR_HEADER_KEY = 'ErrorResponse';
+export const IGNORE_ERROR_HEADER = { headers: { [IGNORE_ERROR_HEADER_KEY]: 'ignore' } };

--- a/flink-runtime-web/web-dashboard/src/app/services/job.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/job.service.ts
@@ -40,7 +40,7 @@ import {
 } from 'interfaces';
 import { combineLatest, EMPTY, ReplaySubject } from 'rxjs';
 import { catchError, filter, flatMap, map, tap } from 'rxjs/operators';
-import { BASE_URL } from 'config';
+import { BASE_URL, IGNORE_ERROR_HEADER } from 'config';
 
 @Injectable({
   providedIn: 'root'
@@ -205,7 +205,7 @@ export class JobService {
    * @param jobId
    */
   loadCheckpointStats(jobId: string) {
-    return this.httpClient.get<CheckPointInterface>(`${BASE_URL}/jobs/${jobId}/checkpoints`);
+    return this.httpClient.get<CheckPointInterface>(`${BASE_URL}/jobs/${jobId}/checkpoints`, IGNORE_ERROR_HEADER);
   }
 
   /**
@@ -213,7 +213,10 @@ export class JobService {
    * @param jobId
    */
   loadCheckpointConfig(jobId: string) {
-    return this.httpClient.get<CheckPointConfigInterface>(`${BASE_URL}/jobs/${jobId}/checkpoints/config`);
+    return this.httpClient.get<CheckPointConfigInterface>(
+      `${BASE_URL}/jobs/${jobId}/checkpoints/config`,
+      IGNORE_ERROR_HEADER
+    );
   }
 
   /**

--- a/flink-runtime-web/web-dashboard/src/app/services/metrics.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/metrics.service.ts
@@ -19,7 +19,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { map } from 'rxjs/operators';
-import { BASE_URL, LONG_MIN_VALUE } from 'config';
+import { BASE_URL, IGNORE_ERROR_HEADER, LONG_MIN_VALUE } from 'config';
 
 @Injectable({
   providedIn: 'root'
@@ -62,7 +62,8 @@ export class MetricsService {
     const metricName = listOfMetricName.join(',');
     return this.httpClient
       .get<Array<{ id: string; value: string }>>(
-        `${BASE_URL}/jobs/${jobId}/vertices/${vertexId}/metrics?get=${metricName}`
+        `${BASE_URL}/jobs/${jobId}/vertices/${vertexId}/metrics?get=${metricName}`,
+        IGNORE_ERROR_HEADER
       )
       .pipe(
         map(arr => {


### PR DESCRIPTION
## What is the purpose of the change

fix https://issues.apache.org/jira/browse/FLINK-14470 as temp solution

## Brief change log

Hide error message when metric api broken

## Verifying this change

  - *Submit a job with more than 255 parallelisms*
  - *Enter the job overview page*
  - *No error message will display on the top right corner*

<img width="1401" alt="AE658CC7-4C13-4832-9DCA-8C3528F9CCB1" src="https://user-images.githubusercontent.com/1506722/67195984-952cf280-f42c-11e9-9f41-032df54bac0c.png">


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
