### PR TITLE
[FLINK-14465][runtime] Let `StandaloneJobClusterEntrypoint` use user code class loader

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -184,8 +184,6 @@ public class PackagedProgram {
 			}
 
 			checkJarFile(jarFileUrl);
-		} else if (!isPython) {
-			throw new IllegalArgumentException("The jar file must not be null.");
 		}
 
 		this.jarFile = jarFileUrl;

--- a/flink-clients/src/test/java/org/apache/flink/client/program/PackagedProgramTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/PackagedProgramTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.client.program;
 
+import org.apache.flink.client.cli.CliFrontendTestUtils;
 import org.apache.flink.configuration.ConfigConstants;
 
 import org.junit.Assert;
@@ -28,9 +29,12 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.nio.file.Files;
+import java.util.Collections;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+
+import static org.junit.Assert.fail;
 
 /**
  * Tests for the {@link PackagedProgram}.
@@ -57,8 +61,16 @@ public class PackagedProgramTest {
 		Assert.assertArrayEquals(nestedJarContent, Files.readAllBytes(files.iterator().next().toPath()));
 	}
 
-	private static final class NullOutputStream extends java.io.OutputStream {
-		@Override
-		public void write(int b) {}
+	@Test
+	public void testNotThrowExceptionWhenJarFileIsNull() {
+		try {
+			new PackagedProgram(
+				null,
+				Collections.singletonList(new File(CliFrontendTestUtils.getTestJarPath()).toURI().toURL()),
+				"org.apache.flink.client.testjar.WordCount", new String[0]);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail("can not throw exception");
+		}
 	}
 }

--- a/flink-container/docker/Dockerfile
+++ b/flink-container/docker/Dockerfile
@@ -28,6 +28,7 @@ ENV FLINK_LIB_DIR $FLINK_HOME/lib
 ENV FLINK_PLUGINS_DIR $FLINK_HOME/plugins
 ENV FLINK_OPT_DIR $FLINK_HOME/opt
 ENV FLINK_JOB_ARTIFACTS_DIR $FLINK_INSTALL_PATH/artifacts
+ENV FLINK_JOB_DIR $FLINK_HOME/job
 ENV PATH $PATH:$FLINK_HOME/bin
 
 # flink-dist can point to a directory or a tarball on the local system
@@ -51,7 +52,7 @@ ADD $job_artifacts/* $FLINK_JOB_ARTIFACTS_DIR/
 
 RUN set -x && \
   ln -s $FLINK_INSTALL_PATH/flink-[0-9]* $FLINK_HOME && \
-  for jar in $FLINK_JOB_ARTIFACTS_DIR/*.jar; do [ -f "$jar" ] || continue; ln -s $jar $FLINK_LIB_DIR; done && \
+  ln -s $FLINK_JOB_ARTIFACTS_DIR $FLINK_JOB_DIR && \
   if [ -n "$python_version" ]; then ln -s $FLINK_OPT_DIR/flink-python*.jar $FLINK_LIB_DIR; fi && \
   if [ -f ${FLINK_INSTALL_PATH}/flink-shaded-hadoop* ]; then ln -s ${FLINK_INSTALL_PATH}/flink-shaded-hadoop* $FLINK_LIB_DIR; fi && \
   addgroup -S flink && adduser -D -S -H -G flink -h $FLINK_HOME flink && \

--- a/flink-container/pom.xml
+++ b/flink-container/pom.xml
@@ -95,6 +95,66 @@ under the License.
 							</descriptors>
 						</configuration>
 					</execution>
+					<execution>
+						<id>create-test-dependency-user-jar</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<archive>
+								<manifest>
+									<mainClass>org.apache.flink.container.entrypoint.testjar.UserJar</mainClass>
+								</manifest>
+							</archive>
+							<finalName>maven</finalName>
+							<attach>false</attach>
+							<descriptors>
+								<descriptor>src/test/assembly/test-assembly-user-jar.xml</descriptor>
+							</descriptors>
+						</configuration>
+					</execution>
+					<execution>
+						<id>create-test-dependency-user-jar-depend</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<finalName>maven</finalName>
+							<attach>false</attach>
+							<descriptors>
+								<descriptor>src/test/assembly/test-assembly-user-jar-depend-jar.xml</descriptor>
+							</descriptors>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<!--Remove the external jar test code from the test-classes directory since it mustn't be in the
+			classpath when running the tests to actually test whether the user code class loader
+			is properly used.-->
+			<plugin>
+				<artifactId>maven-clean-plugin</artifactId>
+				<version>2.5</version><!--$NO-MVN-MAN-VER$-->
+				<executions>
+					<execution>
+						<id>remove-externaltestclasses</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>clean</goal>
+						</goals>
+						<configuration>
+							<excludeDefaultDirectories>true</excludeDefaultDirectories>
+							<filesets>
+								<fileset>
+									<directory>${project.build.testOutputDirectory}</directory>
+									<includes>
+										<include>**/testjar/*.class</include>
+									</includes>
+								</fileset>
+							</filesets>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 		</plugins>

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetriever.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetriever.java
@@ -26,6 +26,7 @@ import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.container.entrypoint.JarManifestParser.JarFileWithEntryClass;
+import org.apache.flink.runtime.entrypoint.component.AbstractUserClassPathJobGraphRetriever;
 import org.apache.flink.runtime.entrypoint.component.JobGraphRetriever;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
@@ -40,6 +41,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -50,7 +52,7 @@ import static java.util.Objects.requireNonNull;
  * {@link JobGraphRetriever} which creates the {@link JobGraph} from a class
  * on the class path.
  */
-class ClassPathJobGraphRetriever implements JobGraphRetriever {
+class ClassPathJobGraphRetriever extends AbstractUserClassPathJobGraphRetriever {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ClassPathJobGraphRetriever.class);
 
@@ -73,8 +75,9 @@ class ClassPathJobGraphRetriever implements JobGraphRetriever {
 			@Nonnull JobID jobId,
 			@Nonnull SavepointRestoreSettings savepointRestoreSettings,
 			@Nonnull String[] programArguments,
-			@Nullable String jobClassName) {
-		this(jobId, savepointRestoreSettings, programArguments, jobClassName, JarsOnClassPath.INSTANCE);
+			@Nullable String jobClassName,
+			@Nullable File jobDir) throws IOException {
+		this(jobId, savepointRestoreSettings, programArguments, jobClassName, JarsOnClassPath.INSTANCE, jobDir);
 	}
 
 	@VisibleForTesting
@@ -83,7 +86,9 @@ class ClassPathJobGraphRetriever implements JobGraphRetriever {
 			@Nonnull SavepointRestoreSettings savepointRestoreSettings,
 			@Nonnull String[] programArguments,
 			@Nullable String jobClassName,
-			@Nonnull Supplier<Iterable<File>> jarsOnClassPath) {
+			@Nonnull Supplier<Iterable<File>> jarsOnClassPath,
+			@Nullable File jobDir) throws IOException {
+		super(jobDir);
 		this.jobId = requireNonNull(jobId, "jobId");
 		this.savepointRestoreSettings = requireNonNull(savepointRestoreSettings, "savepointRestoreSettings");
 		this.programArguments = requireNonNull(programArguments, "programArguments");
@@ -111,11 +116,10 @@ class ClassPathJobGraphRetriever implements JobGraphRetriever {
 	}
 
 	private PackagedProgram createPackagedProgram() throws FlinkException {
-		final String entryClass = getJobClassNameOrScanClassPath();
 		try {
-			final Class<?> mainClass = getClass().getClassLoader().loadClass(entryClass);
-			return new PackagedProgram(mainClass, programArguments);
-		} catch (ClassNotFoundException | ProgramInvocationException e) {
+			final String entryClass = getJobClassNameOrScanClassPath();
+			return new PackagedProgram(null, getUserClassPaths(), entryClass, programArguments);
+		} catch (ProgramInvocationException e) {
 			throw new FlinkException("Could not load the provided entrypoint class.", e);
 		}
 	}
@@ -133,9 +137,18 @@ class ClassPathJobGraphRetriever implements JobGraphRetriever {
 	}
 
 	private String scanClassPathForJobJar() throws IOException {
-		LOG.info("Scanning class path for job JAR");
-		JarFileWithEntryClass jobJar = JarManifestParser.findOnlyEntryClass(jarsOnClassPath.get());
-
+		final JarFileWithEntryClass jobJar;
+		if (getUserClassPaths().isEmpty()) {
+			LOG.info("Scanning system class path for job JAR");
+			jobJar = JarManifestParser.findOnlyEntryClass(jarsOnClassPath.get());
+		} else {
+			LOG.info("Scanning user class path for job JAR");
+			final List<File> userJars = getUserClassPaths()
+				.stream()
+				.map(url -> new File(url.getFile()))
+				.collect(Collectors.toList());
+			jobJar = JarManifestParser.findOnlyEntryClass(userJars);
+		}
 		LOG.info("Using {} as job jar", jobJar);
 		return jobJar.getEntryClass();
 	}

--- a/flink-container/src/test/assembly/test-assembly-user-jar-depend-jar.xml
+++ b/flink-container/src/test/assembly/test-assembly-user-jar-depend-jar.xml
@@ -1,0 +1,35 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<assembly>
+	<id>test-user-jar-depend</id>
+	<formats>
+		<format>jar</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.testOutputDirectory}</directory>
+			<outputDirectory>/</outputDirectory>
+			<includes>
+				<include>org/apache/flink/container/entrypoint/testjar/UserJarDepend.class</include>
+			</includes>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/flink-container/src/test/assembly/test-assembly-user-jar.xml
+++ b/flink-container/src/test/assembly/test-assembly-user-jar.xml
@@ -1,0 +1,35 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<assembly>
+	<id>test-user-jar</id>
+	<formats>
+		<format>jar</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.testOutputDirectory}</directory>
+			<outputDirectory>/</outputDirectory>
+			<includes>
+				<include>org/apache/flink/container/entrypoint/testjar/UserJar.class</include>
+			</includes>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetrieverTest.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetrieverTest.java
@@ -24,16 +24,27 @@ import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.container.entrypoint.ClassPathJobGraphRetriever.JarsOnClassPath;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 
 import static org.hamcrest.Matchers.contains;
@@ -44,6 +55,7 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for the {@link ClassPathJobGraphRetriever}.
@@ -55,8 +67,75 @@ public class ClassPathJobGraphRetrieverTest extends TestLogger {
 
 	private static final String[] PROGRAM_ARGUMENTS = {"--arg", "suffix"};
 
+	private static URL testJobForUserClassLoaderJarURL = null;
+	private static URL testJobDependedJarURL = null;
+
+	private Path userDirHasEntryClass;
+	private Path userJarHasEntryClass;
+	private Path userEntryClassDependJarAtUserDirHasEntryClass;
+	private Path textAtUserDirHasEntryClass;
+
+	private Path userDirHasNotEntryClass;
+	private Path userJarHasNotEntryClass;
+	private Path userEntryClassDependJarAtUserDirHasNotEntryClass;
+	private Path textAtUserDirHasNotEntryClass;
+
+	/*
+	 * The directory structure used to test
+	 *
+	 * userDirHasEntryClass/
+	 * 					  |_userJarHasEntryClass
+	 * 					  |_userEntryClassDependJarAtUserDirHasEntryClass
+	 * 					  |_textAtUserDirHasEntryClass
+	 *
+	 * userDirHasNotEntryClass/
+	 * 						 |_userJarHasNotEntryClass
+	 * 						 |_userEntryClassDependJarAtUserDirHasNotEntryClass
+	 * 						 |_textAtUserDirHasNotEntryClass
+	 */
+
+	private static final String testEntryClassName = "TestJobContainerForClassLoader";
+
+	@Before
+	public void init() throws IOException {
+
+		if (testJobForUserClassLoaderJarURL == null && testJobDependedJarURL == null) {
+			testJobForUserClassLoaderJarURL =
+				Paths.get("target", "maven-test-user-jar.jar").toFile().toURI().toURL();
+			testJobDependedJarURL =
+				Paths.get("target", "maven-test-user-jar-depend.jar").toFile().toURI().toURL();
+		}
+
+		userDirHasEntryClass = temporaryFolder.newFolder("_test_user_dir_has_entry_class").toPath();
+		userJarHasEntryClass = userDirHasEntryClass.resolve("user-jar-has-entry-class.jar");
+		userEntryClassDependJarAtUserDirHasEntryClass =
+			userDirHasEntryClass.resolve("user-entry-class-depended-jar-at-user-dir-has-entry-class.jar");
+		textAtUserDirHasEntryClass =
+			userDirHasEntryClass.resolve("text-at-user-dir-has-entry-class.txt");
+
+		userDirHasNotEntryClass = temporaryFolder.newFolder("_test_user_dir_has_not_entry_class").toPath();
+		userJarHasNotEntryClass =
+			userDirHasNotEntryClass.resolve("user-jar-has-not-entry-class.jar");
+		userEntryClassDependJarAtUserDirHasNotEntryClass =
+			userDirHasNotEntryClass.resolve("user-entry-class-depend-jar-at-dir-has-not-entry-class.jar");
+		textAtUserDirHasNotEntryClass =
+			userDirHasNotEntryClass.resolve("text-at-user-dir-has-not-entry-class.txt");
+		buildENV();
+	}
+
+	private void buildENV() throws IOException {
+		Files.copy(testJobForUserClassLoaderJarURL.openStream(), userJarHasEntryClass);
+		Files.copy(testJobDependedJarURL.openStream(), userEntryClassDependJarAtUserDirHasEntryClass);
+		Files.createFile(textAtUserDirHasEntryClass);
+
+		Files.createFile(userJarHasNotEntryClass);
+		Files.copy(testJobDependedJarURL.openStream(), userEntryClassDependJarAtUserDirHasNotEntryClass);
+		Files.createFile(textAtUserDirHasNotEntryClass);
+
+	}
+
 	@Test
-	public void testJobGraphRetrieval() throws FlinkException {
+	public void testJobGraphRetrieval() throws FlinkException, IOException {
 		final int parallelism = 42;
 		final Configuration configuration = new Configuration();
 		configuration.setInteger(CoreOptions.DEFAULT_PARALLELISM, parallelism);
@@ -66,7 +145,8 @@ public class ClassPathJobGraphRetrieverTest extends TestLogger {
 			jobId,
 			SavepointRestoreSettings.none(),
 			PROGRAM_ARGUMENTS,
-			TestJob.class.getCanonicalName());
+			TestJob.class.getCanonicalName(),
+			null);
 
 		final JobGraph jobGraph = classPathJobGraphRetriever.retrieveJobGraph(configuration);
 
@@ -76,7 +156,7 @@ public class ClassPathJobGraphRetrieverTest extends TestLogger {
 	}
 
 	@Test
-	public void testJobGraphRetrievalFromJar() throws FlinkException, FileNotFoundException {
+	public void testJobGraphRetrievalFromJar() throws FlinkException, IOException {
 		final File testJar = TestJob.getTestJobJar();
 		final ClassPathJobGraphRetriever classPathJobGraphRetriever = new ClassPathJobGraphRetriever(
 			new JobID(),
@@ -84,7 +164,8 @@ public class ClassPathJobGraphRetrieverTest extends TestLogger {
 			PROGRAM_ARGUMENTS,
 			// No class name specified, but the test JAR "is" on the class path
 			null,
-			() -> Collections.singleton(testJar));
+			() -> Collections.singleton(testJar),
+			null);
 
 		final JobGraph jobGraph = classPathJobGraphRetriever.retrieveJobGraph(new Configuration());
 
@@ -92,7 +173,7 @@ public class ClassPathJobGraphRetrieverTest extends TestLogger {
 	}
 
 	@Test
-	public void testJobGraphRetrievalJobClassNameHasPrecedenceOverClassPath() throws FlinkException, FileNotFoundException {
+	public void testJobGraphRetrievalJobClassNameHasPrecedenceOverClassPath() throws FlinkException, IOException {
 		final File testJar = new File("non-existing");
 
 		final ClassPathJobGraphRetriever classPathJobGraphRetriever = new ClassPathJobGraphRetriever(
@@ -102,7 +183,8 @@ public class ClassPathJobGraphRetrieverTest extends TestLogger {
 			// Both a class name is specified and a JAR "is" on the class path
 			// The class name should have precedence.
 			TestJob.class.getCanonicalName(),
-			() -> Collections.singleton(testJar));
+			() -> Collections.singleton(testJar),
+			null);
 
 		final JobGraph jobGraph = classPathJobGraphRetriever.retrieveJobGraph(new Configuration());
 
@@ -110,7 +192,7 @@ public class ClassPathJobGraphRetrieverTest extends TestLogger {
 	}
 
 	@Test
-	public void testSavepointRestoreSettings() throws FlinkException {
+	public void testSavepointRestoreSettings() throws FlinkException, IOException {
 		final Configuration configuration = new Configuration();
 		final SavepointRestoreSettings savepointRestoreSettings = SavepointRestoreSettings.forPath("foobar", true);
 		final JobID jobId = new JobID();
@@ -119,7 +201,8 @@ public class ClassPathJobGraphRetrieverTest extends TestLogger {
 			jobId,
 			savepointRestoreSettings,
 			PROGRAM_ARGUMENTS,
-			TestJob.class.getCanonicalName());
+			TestJob.class.getCanonicalName(),
+			null);
 
 		final JobGraph jobGraph = classPathJobGraphRetriever.retrieveJobGraph(configuration);
 
@@ -158,6 +241,85 @@ public class ClassPathJobGraphRetrieverTest extends TestLogger {
 		Iterable<File> jarFiles = setClassPathAndGetJarsOnClassPath(classPath);
 
 		assertThat(jarFiles, contains(file1, file2));
+	}
+
+	@Test
+	public void testJobGraphRetrievalFailFromUserClassPath() throws IOException {
+		final ClassPathJobGraphRetriever classPathJobGraphRetriever = new ClassPathJobGraphRetriever(
+			new JobID(),
+			SavepointRestoreSettings.none(),
+			PROGRAM_ARGUMENTS,
+			null,
+			// only find the entry class from job dir
+			() -> Arrays.asList(new File(testJobForUserClassLoaderJarURL.getPath()), new File(testJobDependedJarURL.getPath())),
+			userDirHasNotEntryClass.toFile());
+		try {
+			classPathJobGraphRetriever.retrieveJobGraph(new Configuration());
+		} catch (FlinkException e) {
+			StringWriter errors = new StringWriter();
+			e.printStackTrace(new PrintWriter(errors));
+			assertTrue(errors.toString().contains("Failed to find job JAR on class path"));
+			return;
+		}
+
+		Assert.fail("This case should throw exception !");
+	}
+
+	@Test
+	public void testJobGraphRetrievalFromUserClassPath() throws IOException, FlinkException {
+		final Collection<File> relativeFiles = FileUtils.relativizeToWorkingDir(
+			Arrays.asList(userJarHasEntryClass.toFile(), userEntryClassDependJarAtUserDirHasEntryClass.toFile()));
+
+		final Collection<URL> expectedURLs = FileUtils.toRelativeURLs(relativeFiles);
+
+		final ClassPathJobGraphRetriever classPathJobGraphRetriever = new ClassPathJobGraphRetriever(
+			new JobID(),
+			SavepointRestoreSettings.none(),
+			PROGRAM_ARGUMENTS,
+			null,
+			Collections::emptyList,
+			userDirHasEntryClass.toFile());
+		final JobGraph jobGraph = classPathJobGraphRetriever.retrieveJobGraph(new Configuration());
+		assertTrue(CollectionUtils.isEqualCollection(expectedURLs, jobGraph.getClasspaths()));
+	}
+
+	@Test
+	public void testJobGraphRetrievalFromUserClassPathWithClassNameSpecify() throws IOException {
+		final Collection<File> relativeFiles = FileUtils.relativizeToWorkingDir(
+			Arrays.asList(userJarHasEntryClass.toFile(), userEntryClassDependJarAtUserDirHasEntryClass.toFile()));
+
+		final Collection<URL> expectedURLs = FileUtils.toRelativeURLs(relativeFiles);
+
+		final ClassPathJobGraphRetriever classPathJobGraphRetriever = new ClassPathJobGraphRetriever(
+			new JobID(),
+			SavepointRestoreSettings.none(),
+			PROGRAM_ARGUMENTS,
+			testEntryClassName,
+			Collections::emptyList,
+			userDirHasEntryClass.toFile());
+		assertTrue(CollectionUtils.isEqualCollection(expectedURLs, classPathJobGraphRetriever.getUserClassPaths()));
+	}
+
+	@Test
+	public void testJobGraphRetrievalFailWithClassNameSpecify() throws IOException {
+		final ClassPathJobGraphRetriever classPathJobGraphRetriever = new ClassPathJobGraphRetriever(
+			new JobID(),
+			SavepointRestoreSettings.none(),
+			PROGRAM_ARGUMENTS,
+			testEntryClassName,
+			Collections::emptyList,
+			userDirHasNotEntryClass.toFile()
+		);
+		try {
+			classPathJobGraphRetriever.retrieveJobGraph(new Configuration());
+		} catch (FlinkException e) {
+			StringWriter errors = new StringWriter();
+			e.printStackTrace(new PrintWriter(errors));
+			assertTrue(errors.toString().contains("java.lang.ClassNotFoundException: " + testEntryClassName));
+			return;
+		}
+
+		Assert.fail("This case should throw class not found exception!!");
 	}
 
 	private static String javaClassPath(String... entries) {

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/testjar/UserJar.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/testjar/UserJar.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.container.entrypoint.testjar;
+
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+
+/**
+ * This class can used to test situation that the jar is not in the system classpath.
+ */
+public class UserJar {
+	public static void main(String[] args) throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		final DataStreamSource<Integer> source = env.fromElements(new UserJarDepend().getValue(), 1, 2, 3, 4);
+		final SingleOutputStreamOperator<Integer> mapper = source.map(element -> 2 * element);
+		mapper.addSink(new DiscardingSink<>());
+
+		ParameterTool parameterTool = ParameterTool.fromArgs(args);
+		env.execute(UserJar.class.getCanonicalName() + "-" + parameterTool.getRequired("arg"));
+	}
+}

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/testjar/UserJarDepend.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/testjar/UserJarDepend.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.container.entrypoint.testjar;
+
+/**
+ * This class is depended by {@link UserJar}.
+ */
+class UserJarDepend {
+
+	private int value = 0;
+
+	int getValue() {
+		return value;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -2035,6 +2035,9 @@ public final class ConfigConstants {
 	/** The environment variable name which contains the Flink installation root directory. */
 	public static final String ENV_FLINK_HOME_DIR = "FLINK_HOME";
 
+	/** The default job directory name in the per-job mode. */
+	public static final String DEFAULT_JOB_DIRECTORY_NAME = "job";
+
 	// ---------------------------- Encoding ------------------------------
 
 	public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;

--- a/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
@@ -18,11 +18,14 @@
 
 package org.apache.flink.util;
 
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.testutils.CheckedThread;
+import org.apache.flink.util.function.FunctionUtils;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,12 +36,17 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Random;
@@ -259,6 +267,67 @@ public class FileUtilsTest extends TestLogger {
 		assertDirEquals(compressDir.resolve(originalDir), extractDir.resolve(originalDir));
 	}
 
+	@Test
+	public void testListFilesInPathWithoutAnyFileReturnEmptyList() throws IOException {
+		final java.nio.file.Path testDir = tmp.newFolder("_test_0").toPath();
+
+		assertTrue(Collections.<File>emptyList() ==
+			FileUtils.listFilesInPath(testDir.toFile(), f -> f.getName().endsWith(".jar")));
+	}
+
+	@Test
+	public void testListFilesInPath() throws IOException {
+		final java.nio.file.Path testDir = tmp.newFolder("_test_1").toPath();
+		final Tuple3<Collection<File>, Collection<File>, Collection<URL>> result = prepareTestFiles(testDir);
+
+		assertTrue(CollectionUtils.isEqualCollection(result.f0,
+			FileUtils.listFilesInPath(testDir.toFile(), f ->  f.getName().endsWith(".jar"))));
+	}
+
+	@Test
+	public void testRelativizeToWorkingDir() throws IOException {
+		final java.nio.file.Path testDir = tmp.newFolder("_test_2").toPath();
+		final Tuple3<Collection<File>, Collection<File>, Collection<URL>> result = prepareTestFiles(testDir);
+		final Collection<File> relativeFiles = FileUtils.relativizeToWorkingDir(result.f0);
+		relativeFiles.forEach(file -> assertFalse(file.isAbsolute()));
+		assertTrue(
+			CollectionUtils.isEqualCollection(
+				result.f1,
+				FileUtils.relativizeToWorkingDir(result.f0)
+			)
+		);
+	}
+
+	@Test
+	public void testToRelativeURLs() throws IOException {
+		final java.nio.file.Path testDir = tmp.newFolder("_test_3").toPath();
+		final Tuple3<Collection<File>, Collection<File>, Collection<URL>> result = prepareTestFiles(testDir);
+
+		final Collection<URL> relativeURLs = FileUtils.toRelativeURLs(result.f1);
+		relativeURLs.forEach(url -> assertFalse(new File(url.getPath()).isAbsolute()));
+
+		assertTrue(
+			CollectionUtils.isEqualCollection(
+				result.f2,
+				relativeURLs
+			)
+		);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testListDirFailsIfDirectoryDoesNotExist() throws IOException {
+		final String fileName = "_does_not_exists_file";
+		final String doesNotExistsFilePath = tmp.getRoot() + "/" + fileName;
+
+		FileUtils.listFilesInPath(new File(doesNotExistsFilePath), f ->  f.getName().endsWith(".jar"));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testListAFileFailsBecauseDirectoryIsExpected() throws IOException {
+		final String fileName = "a.jar";
+		File file = tmp.newFile(fileName);
+		FileUtils.listFilesInPath(file, f ->  f.getName().endsWith(".jar"));
+	}
 	// ------------------------------------------------------------------------
 	//  Utilities
 	// ------------------------------------------------------------------------
@@ -310,6 +379,60 @@ public class FileUtilsTest extends TestLogger {
 				generateRandomDirs(subdir, numFiles, numDirs, depth - 1);
 			}
 		}
+	}
+
+	/**
+	 * Generate some files in the directory {@code dir}.
+	 * @param dir the directory where the files are generated
+	 * @return Tuple3 holding the generated files' absolute path, relative to the working directory path and relative
+	 * url.
+	 * @throws IOException if I/O error occurs while generating the files
+	 */
+	public static Tuple3<Collection<File>, Collection<File>, Collection<URL>> prepareTestFiles(
+		final java.nio.file.Path dir) throws IOException {
+
+		Tuple3<Collection<File>, Collection<File>, Collection<URL>> result = new Tuple3<>();
+
+		result.f0 = generateSomeFilesInDirectoryReturnJarFiles(dir);
+		result.f1 = toRelativeFiles(result.f0);
+		result.f2 = toRelativeURLs(result.f1);
+
+		return result;
+	}
+
+	private static Collection<File> generateSomeFilesInDirectoryReturnJarFiles(
+			final java.nio.file.Path dir) throws IOException {
+
+		final java.nio.file.Path jobSubDir1 = Files.createDirectory(dir.resolve("_sub_dir1"));
+		final java.nio.file.Path jobSubDir2 = Files.createDirectory(dir.resolve("_sub_dir2"));
+		final java.nio.file.Path jarFile1 = Files.createFile(dir.resolve("file1.jar"));
+		final java.nio.file.Path jarFile2 = Files.createFile(dir.resolve("file2.jar"));
+		final java.nio.file.Path jarFile3 = Files.createFile(jobSubDir1.resolve("file3.jar"));
+		final java.nio.file.Path jarFile4 = Files.createFile(jobSubDir2.resolve("file4.jar"));
+		final Collection<File> jarFiles = new ArrayList<>();
+
+		Files.createFile(dir.resolve("file1.txt"));
+		Files.createFile(jobSubDir2.resolve("file2.txt"));
+
+		jarFiles.add(jarFile1.toFile());
+		jarFiles.add(jarFile2.toFile());
+		jarFiles.add(jarFile3.toFile());
+		jarFiles.add(jarFile4.toFile());
+		return jarFiles;
+	}
+
+	private static Collection<File> toRelativeFiles(Collection<File> files) {
+		final java.nio.file.Path workingDir = Paths.get(System.getProperty("user.dir"));
+		final Collection<File> relativeFiles = new ArrayList<>();
+		files.forEach(file -> relativeFiles.add(workingDir.relativize(file.toPath()).toFile()));
+		return relativeFiles;
+	}
+
+	private static Collection<URL> toRelativeURLs(Collection<File> relativeFiles) throws MalformedURLException {
+		final Collection<URL> relativeURLs = new ArrayList<>();
+		final URL context = new URL(relativeFiles.iterator().next().toURI().getScheme() + ":");
+		relativeFiles.forEach(FunctionUtils.uncheckedConsumer(file -> relativeURLs.add(new URL(context, file.toString()))));
+		return relativeURLs;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -476,7 +476,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 	// Abstract methods
 	// --------------------------------------------------
 
-	protected abstract DispatcherResourceManagerComponentFactory createDispatcherResourceManagerComponentFactory(Configuration configuration);
+	protected abstract DispatcherResourceManagerComponentFactory createDispatcherResourceManagerComponentFactory(Configuration configuration) throws IOException;
 
 	protected abstract ArchivedExecutionGraphStore createSerializableExecutionGraphStore(
 		Configuration configuration,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetriever.java
@@ -51,7 +51,7 @@ public abstract class AbstractUserClassPathJobGraphRetriever implements JobGraph
 		}
 	}
 
-	protected List<URL> getUserClassPaths() {
+	public List<URL> getUserClassPaths() {
 		return userClassPaths;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetriever.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint.component;
+
+import org.apache.flink.core.fs.Path;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ *  Abstract class for the JobGraphRetriever, which wants to get classpath user's code depends on.
+ */
+
+public abstract class AbstractUserClassPathJobGraphRetriever implements JobGraphRetriever {
+
+	protected static final Logger LOG = LoggerFactory.getLogger(AbstractUserClassPathJobGraphRetriever.class);
+
+	public static final String DEFAULT_JOB_DIR = "job";
+
+	/** The directory contains all the jars, which user code depends on. */
+	@Nullable
+	private final String jobDir;
+
+	private List<URL> userClassPaths;
+
+	public AbstractUserClassPathJobGraphRetriever(String jobDir) {
+		this.jobDir = jobDir;
+	}
+
+	public List<URL> getUserClassPaths() throws IOException {
+		if (userClassPaths == null) {
+			userClassPaths = scanJarsInJobClassDir(jobDir);
+		}
+		return userClassPaths;
+	}
+
+	private List<URL> scanJarsInJobClassDir(String dir) throws IOException {
+
+		if (dir == null) {
+			return Collections.emptyList();
+		}
+
+		final File dirFile = new File(new Path(dir).toString());
+		final List<URL> jarURLs = new LinkedList<>();
+
+		if (!dirFile.exists()) {
+			LOG.warn("the job dir " + dirFile + " dose not exists.");
+			return Collections.emptyList();
+		}
+		if (!dirFile.isDirectory()) {
+			LOG.warn("the job dir " + dirFile + " is not a directory.");
+			return Collections.emptyList();
+		}
+
+		Files.walkFileTree(dirFile.toPath(),
+			EnumSet.of(FileVisitOption.FOLLOW_LINKS),
+			Integer.MAX_VALUE,
+			new SimpleFileVisitor<java.nio.file.Path>(){
+
+			@Override
+			public FileVisitResult visitFile(java.nio.file.Path file, BasicFileAttributes attrs)
+				throws IOException {
+				FileVisitResult fileVisitResult = super.visitFile(file, attrs);
+				if (file.getFileName().toString().endsWith(".jar")) {
+					LOG.info("add " + file.toString() + " to user classpath");
+					if (file.isAbsolute()) {
+						jarURLs.add(file.toUri().toURL());
+					} else {
+						jarURLs.add(
+							new URL(new URL(file.getFileName().toUri().getScheme() + ":"), file.toString())
+						);
+					}
+				}
+				return fileVisitResult;
+			}
+		});
+
+		if (jarURLs.isEmpty()) {
+			return Collections.emptyList();
+		} else {
+				return jarURLs;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetriever.java
@@ -93,19 +93,19 @@ public abstract class AbstractUserClassPathJobGraphRetriever implements JobGraph
 			Integer.MAX_VALUE,
 			new SimpleFileVisitor<java.nio.file.Path>() {
 
-			@Override
-			public FileVisitResult visitFile(java.nio.file.Path file, BasicFileAttributes attrs)
-					throws IOException {
-				FileVisitResult fileVisitResult = super.visitFile(file, attrs);
-				if (file.getFileName().toString().endsWith(".jar")) {
-					LOG.info("add " + file.toString() + " to user classpath");
+				@Override
+				public FileVisitResult visitFile(java.nio.file.Path file, BasicFileAttributes attrs)
+						throws IOException {
+					FileVisitResult fileVisitResult = super.visitFile(file, attrs);
+					if (file.getFileName().toString().endsWith(".jar")) {
+						LOG.info("add " + file.toString() + " to user classpath");
 						jarURLs.add(
 							new URL(new URL(file.getFileName().toUri().getScheme() + ":"), file.toString())
 						);
+					}
+					return fileVisitResult;
 				}
-				return fileVisitResult;
-			}
-		});
+			});
 
 		if (jarURLs.isEmpty()) {
 			return Collections.emptyList();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetriever.java
@@ -54,7 +54,7 @@ public abstract class AbstractUserClassPathJobGraphRetriever implements JobGraph
 		this.jobDir = jobDir;
 	}
 
-	public List<URL> getUserClassPaths() throws IOException {
+	protected List<URL> getUserClassPaths() throws IOException {
 		if (userClassPaths == null) {
 			userClassPaths = getRelativeJarsURLFromDir(jobDir);
 		}
@@ -73,7 +73,6 @@ public abstract class AbstractUserClassPathJobGraphRetriever implements JobGraph
 			return Collections.emptyList();
 		}
 
-		final List<URL> jarURLs = new LinkedList<>();
 		if (!Files.exists(Paths.get(dir))) {
 			throw new IllegalArgumentException("the job dir " + dir + " dose not exists.");
 		}
@@ -82,6 +81,8 @@ public abstract class AbstractUserClassPathJobGraphRetriever implements JobGraph
 		}
 
 		Path dirPath;
+		final List<URL> jarURLs = new LinkedList<>();
+
 		if (Paths.get(dir).isAbsolute()) {
 			dirPath = Paths.get(System.getProperty("user.dir")).relativize(Paths.get(dir));
 		} else {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
@@ -141,5 +141,4 @@ public class AbstractUserClassPathJobGraphRetrieverTest extends TestLogger {
 			Files.deleteIfExists(jobRelativeDir);
 		}
 	}
-
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
@@ -48,9 +48,6 @@ public class AbstractUserClassPathJobGraphRetrieverTest extends TestLogger {
 	@Rule
 	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-	/**
-	 * Test class.
-	 */
 	private static class TestJobGraphRetriever extends AbstractUserClassPathJobGraphRetriever {
 		public TestJobGraphRetriever(String jobDir) {
 			super(jobDir);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
@@ -51,8 +51,7 @@ public class AbstractUserClassPathJobGraphRetrieverTest extends TestLogger {
 	/**
 	 * Test class.
 	 */
-	public static class TestJobGraphRetriever extends AbstractUserClassPathJobGraphRetriever {
-
+	private static class TestJobGraphRetriever extends AbstractUserClassPathJobGraphRetriever {
 		public TestJobGraphRetriever(String jobDir) {
 			super(jobDir);
 		}
@@ -63,17 +62,17 @@ public class AbstractUserClassPathJobGraphRetrieverTest extends TestLogger {
 		}
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testGetUserClassPathFromAFile() throws IOException {
 		final String fileName = "a.jar";
 		File file = temporaryFolder.newFile(fileName);
 
 		TestJobGraphRetriever testJobGraphRetriever = new TestJobGraphRetriever(file.getAbsolutePath());
 
-		assertEquals(Collections.emptyList(), testJobGraphRetriever.getUserClassPaths());
+		testJobGraphRetriever.getUserClassPaths();
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testGetUserClassPathFormADoesNotExistsFile() throws IOException {
 		final String fileName = "_does_not_exists_file";
 		final String doesNotExistsFilePath = temporaryFolder.getRoot() + "/" + fileName;
@@ -81,12 +80,10 @@ public class AbstractUserClassPathJobGraphRetrieverTest extends TestLogger {
 		TestJobGraphRetriever testJobGraphRetriever = new TestJobGraphRetriever(doesNotExistsFilePath);
 
 		assertEquals(Collections.emptyList(), testJobGraphRetriever.getUserClassPaths());
-
 	}
 
 	@Test
 	public void testGetUserClassPath() throws IOException {
-
 		final Path jobDir = temporaryFolder.newFolder("_job_dir").toPath();
 		final Path jobSubDir1 = Files.createDirectory(jobDir.resolve("_sub_dir1"));
 		final Path jobSubDir2 = Files.createDirectory(jobDir.resolve("_sub_dir2"));
@@ -98,10 +95,13 @@ public class AbstractUserClassPathJobGraphRetrieverTest extends TestLogger {
 		Files.createFile(jobDir.resolve("file1.txt"));
 		Files.createFile(jobSubDir2.resolve("file2.txt"));
 
-		List<URL> expectedUrls = Arrays.asList(jarFile1.toUri().toURL(),
-			jarFile2.toUri().toURL(),
-			jarFile3.toUri().toURL(),
-			jarFile4.toUri().toURL());
+		Path userDir = Paths.get(System.getProperty("user.dir"));
+		URL spec = new URL(jobDir.toUri().getScheme() + ":");
+		List<URL> expectedUrls = Arrays.asList(
+			new URL(spec, userDir.relativize(jarFile1).toString()),
+			new URL(spec, userDir.relativize(jarFile2).toString()),
+			new URL(spec, userDir.relativize(jarFile3).toString()),
+			new URL(spec, userDir.relativize(jarFile4).toString()));
 
 		TestJobGraphRetriever testJobGraphRetriever =
 			new TestJobGraphRetriever(jobDir.toString());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint.component;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the {@link AbstractUserClassPathJobGraphRetriever}.
+ */
+public class AbstractUserClassPathJobGraphRetrieverTest extends TestLogger {
+
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	/**
+	 * Test class.
+	 */
+	public static class TestJobGraphRetriever extends AbstractUserClassPathJobGraphRetriever {
+
+		public TestJobGraphRetriever(String jobDir) {
+			super(jobDir);
+		}
+
+		@Override
+		public JobGraph retrieveJobGraph(Configuration configuration) {
+			return null;
+		}
+	}
+
+	@Test
+	public void testGetUserClassPathFromAFile() throws IOException {
+		final String fileName = "a.jar";
+		File file = temporaryFolder.newFile(fileName);
+
+		TestJobGraphRetriever testJobGraphRetriever = new TestJobGraphRetriever(file.getAbsolutePath());
+
+		assertEquals(Collections.emptyList(), testJobGraphRetriever.getUserClassPaths());
+	}
+
+	@Test
+	public void testGetUserClassPathFormADoesNotExistsFile() throws IOException {
+		final String fileName = "_does_not_exists_file";
+		final String doesNotExistsFilePath = temporaryFolder.getRoot() + "/" + fileName;
+
+		TestJobGraphRetriever testJobGraphRetriever = new TestJobGraphRetriever(doesNotExistsFilePath);
+
+		assertEquals(Collections.emptyList(), testJobGraphRetriever.getUserClassPaths());
+
+	}
+
+	@Test
+	public void testGetUserClassPath() throws IOException {
+
+		final Path jobDir = temporaryFolder.newFolder("_job_dir").toPath();
+		final Path jobSubDir1 = Files.createDirectory(jobDir.resolve("_sub_dir1"));
+		final Path jobSubDir2 = Files.createDirectory(jobDir.resolve("_sub_dir2"));
+		final Path jarFile1 = Files.createFile(jobDir.resolve("file1.jar"));
+		final Path jarFile2 = Files.createFile(jobDir.resolve("file2.jar"));
+		final Path jarFile3 = Files.createFile(jobSubDir1.resolve("file3.jar"));
+		final Path jarFile4 = Files.createFile(jobSubDir2.resolve("file4.jar"));
+
+		Files.createFile(jobDir.resolve("file1.txt"));
+		Files.createFile(jobSubDir2.resolve("file2.txt"));
+
+		List<URL> expectedUrls = Arrays.asList(jarFile1.toUri().toURL(),
+			jarFile2.toUri().toURL(),
+			jarFile3.toUri().toURL(),
+			jarFile4.toUri().toURL());
+
+		TestJobGraphRetriever testJobGraphRetriever =
+			new TestJobGraphRetriever(jobDir.toString());
+
+		assertTrue(CollectionUtils.isEqualCollection(expectedUrls, testJobGraphRetriever.getUserClassPaths()));
+	}
+
+	@Test
+	public void testGetUserClassPathWithRelativeJobDir() throws IOException {
+		Path jobRelativeDir = Paths.get("_job_dir");
+		Path jobRelativeSubDir = Paths.get("_job_dir", "_sub_dir");
+		Path jarFile1 = Paths.get(jobRelativeDir.toString(), "file1.jar");
+		Path jarFile2 = Paths.get(jobRelativeSubDir.toString(), "file2.jar");
+
+		URL context = new URL(jobRelativeDir.toUri().getScheme() + ":");
+		List<URL> expectedURLs = Arrays.asList(
+			new URL(context, jarFile1.toString()), new URL(context, jarFile2.toString()));
+
+		try {
+			if (!Files.exists(jobRelativeDir)) {
+				Files.createDirectory(jobRelativeDir);
+			}
+			if (!Files.exists(jobRelativeSubDir)) {
+				Files.createDirectory(jobRelativeSubDir);
+			}
+			if (!Files.exists(jarFile1)) {
+				Files.createFile(jarFile1);
+			}
+			if (!Files.exists(jarFile2)) {
+				Files.createFile(jarFile2);
+			}
+
+			TestJobGraphRetriever testJobGraphRetriever =
+				new TestJobGraphRetriever(jobRelativeDir.toString());
+			assertTrue(CollectionUtils.isEqualCollection(expectedURLs, testJobGraphRetriever.getUserClassPaths()));
+		} finally {
+			Files.deleteIfExists(jarFile1);
+			Files.deleteIfExists(jarFile2);
+			Files.deleteIfExists(jobRelativeSubDir);
+			Files.deleteIfExists(jobRelativeDir);
+		}
+	}
+
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
This pull requests make the `StandaloneJobClusterEntrypoint` use the user code class loader.

## Brief change log
  - link the `FLINK_JOB_ARTIFACTS_DIR` to the `FLINK_HOME/job` dir
  - `ClassPathJobGraphRetriever` constructs a user code classpath from `FLINK_HOME/job`
  - `ClassPathJobGraphRetriever` sets the user code classpath to `PacakgeProgram`
  - `ClassPathJobGraphRetriever` uses the `packageProgram` to build a jobgraph with the user clode classpath


## Verifying this change

  - Extended the test that validates`ClassPathJobGraphRetriever` can retrieve a `JobGraph` with correct user classpath
 - Extended the test that validates `PackagedProgram` can create a `JobGraph` even if the `jarFile` param of the constructor is null
  - execute the `test_docker_embedded_job.sh` manually to verify the StandaloneJobCluster runs well.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
