### PR TITLE
[FLINK-14235][kafka,tests] Change source in at-least-once test from finite to infinite  

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
@@ -277,7 +277,6 @@ public abstract class KafkaProducerTestBase extends KafkaTestBaseWithFlink {
 			});
 		}
 
-		FailingIdentityMapper.failedBefore = false;
 		try {
 			env.execute("One-to-one at least once test");
 			fail("Job should fail!");

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/FailingIdentityMapper.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/FailingIdentityMapper.java
@@ -42,7 +42,6 @@ public class FailingIdentityMapper<T> extends RichMapFunction<T, T> implements
 	private static final long serialVersionUID = 6334389850158707313L;
 
 	public static volatile boolean failedBefore;
-	public static volatile boolean hasBeenCheckpointedBeforeFailure;
 
 	private final int failCount;
 	private int numElementsTotal;
@@ -74,7 +73,6 @@ public class FailingIdentityMapper<T> extends RichMapFunction<T, T> implements
 			Thread.sleep(10);
 
 			if (failer && numElementsTotal >= failCount) {
-				hasBeenCheckpointedBeforeFailure = hasBeenCheckpointed;
 				failedBefore = true;
 				throw new Exception("Artificial Test Failure");
 			}

--- a/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
@@ -139,23 +139,23 @@ public final class GlobalConfiguration {
 	}
 
 	private static void enrichWithEnvironmentVariable(String environmentVariable, Configuration configuration) {
-		String pluginsDirFromEnv = System.getenv(environmentVariable);
+		String valueFromEnv = System.getenv(environmentVariable);
 
-		if (pluginsDirFromEnv == null) {
+		if (valueFromEnv == null) {
 			return;
 		}
 
-		String pluginsDirFromConfig = configuration.getString(environmentVariable, pluginsDirFromEnv);
+		String valueFromConfig = configuration.getString(environmentVariable, valueFromEnv);
 
-		if (!pluginsDirFromEnv.equals(pluginsDirFromConfig)) {
+		if (!valueFromEnv.equals(valueFromConfig)) {
 			throw new IllegalConfigurationException(
-				"The given configuration file already contains a value (" + pluginsDirFromEnv +
+				"The given configuration file already contains a value (" + valueFromEnv +
 					") for the key (" + environmentVariable +
-					") that would have been overwritten with (" + pluginsDirFromConfig +
+					") that would have been overwritten with (" + valueFromConfig +
 					") by an environment with the same name.");
 		}
 
-		configuration.setString(environmentVariable, pluginsDirFromEnv);
+		configuration.setString(environmentVariable, valueFromEnv);
 	}
 
 	/**


### PR DESCRIPTION
Previously it was possible that the source would end before a first chcekpoint could complete. If that was the case, any exceptions thrown during checkpointing are swallowed, which could explain the apparent data loss from FLINK-14235.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicabl**e / docs / JavaDocs / not documented) 