### PR TITLE
[FLINK-14476] Extend PartitionTracker to support promotions

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/JobMasterPartitionTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/JobMasterPartitionTracker.java
@@ -44,4 +44,9 @@ public interface JobMasterPartitionTracker extends PartitionTracker<ResourceID, 
 	 * Releases all partitions for the given task executor ID, and stop the tracking of partitions that were released.
 	 */
 	void stopTrackingAndReleasePartitionsFor(ResourceID producingTaskExecutorId);
+
+	/**
+	 * Releases all job partitions and promotes all cluster partitions for the given task executor ID, and stops the tracking of partitions that were released/promoted.
+	 */
+	void stopTrackingAndReleaseOrPromotePartitionsFor(ResourceID producingTaskExecutorId);
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/NoOpJobMasterPartitionTracker.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/NoOpJobMasterPartitionTracker.java
@@ -54,6 +54,10 @@ public enum NoOpJobMasterPartitionTracker implements JobMasterPartitionTracker {
 	}
 
 	@Override
+	public void stopTrackingAndReleaseOrPromotePartitionsFor(ResourceID producingTaskExecutorId) {
+	}
+
+	@Override
 	public boolean isTrackingPartitionsFor(ResourceID producingTaskExecutorId) {
 		return false;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/TestingJobMasterPartitionTracker.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/TestingJobMasterPartitionTracker.java
@@ -35,6 +35,7 @@ public class TestingJobMasterPartitionTracker implements JobMasterPartitionTrack
 	private Function<ResultPartitionID, Boolean> isPartitionTrackedFunction = ignored -> false;
 	private Consumer<ResourceID> stopTrackingAllPartitionsConsumer = ignored -> {};
 	private Consumer<ResourceID> stopTrackingAndReleaseAllPartitionsConsumer = ignored -> {};
+	private Consumer<ResourceID> stopTrackingAndReleaseOrPromotePartitionsConsumer = ignored -> {};
 	private BiConsumer<ResourceID, ResultPartitionDeploymentDescriptor> startTrackingPartitionsConsumer = (ignoredA, ignoredB) -> {};
 	private Consumer<Collection<ResultPartitionID>> stopTrackingAndReleasePartitionsConsumer = ignored -> {};
 	private Consumer<Collection<ResultPartitionID>> stopTrackingPartitionsConsumer = ignored -> {};
@@ -57,6 +58,10 @@ public class TestingJobMasterPartitionTracker implements JobMasterPartitionTrack
 
 	public void setStopTrackingAndReleaseAllPartitionsConsumer(Consumer<ResourceID> stopTrackingAndReleaseAllPartitionsConsumer) {
 		this.stopTrackingAndReleaseAllPartitionsConsumer = stopTrackingAndReleaseAllPartitionsConsumer;
+	}
+
+	public void setStopTrackingAndReleaseOrPromotePartitionsConsumer(Consumer<ResourceID> stopTrackingAndReleaseOrPromotePartitionsConsumer) {
+		this.stopTrackingAndReleaseOrPromotePartitionsConsumer = stopTrackingAndReleaseOrPromotePartitionsConsumer;
 	}
 
 	public void setStopTrackingAndReleasePartitionsConsumer(Consumer<Collection<ResultPartitionID>> stopTrackingAndReleasePartitionsConsumer) {
@@ -92,6 +97,11 @@ public class TestingJobMasterPartitionTracker implements JobMasterPartitionTrack
 	@Override
 	public void stopTrackingAndReleasePartitionsFor(ResourceID producingTaskExecutorId) {
 		stopTrackingAndReleaseAllPartitionsConsumer.accept(producingTaskExecutorId);
+	}
+
+	@Override
+	public void stopTrackingAndReleaseOrPromotePartitionsFor(ResourceID producingTaskExecutorId) {
+		stopTrackingAndReleaseOrPromotePartitionsConsumer.accept(producingTaskExecutorId);
 	}
 
 	@Override


### PR DESCRIPTION
Based on #9958.

Extends the PartitionTracker with an additional method which promotes partitions whose partition type is `persistent`. In the future the JM will call this method if the job succeeded.