### PR TITLE
[FLINK-14466][runtime] Let YarnJobClusterEntrypoint use user code class loader

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -2035,6 +2035,9 @@ public final class ConfigConstants {
 	/** The environment variable name which contains the Flink installation root directory. */
 	public static final String ENV_FLINK_HOME_DIR = "FLINK_HOME";
 
+	/** The default job directory name in the per-job mode. */
+	public static final String DEFAULT_JOB_DIRECTORY_NAME = "job";
+
 	// ---------------------------- Encoding ------------------------------
 
 	public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;

--- a/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
@@ -18,11 +18,14 @@
 
 package org.apache.flink.util;
 
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.testutils.CheckedThread;
+import org.apache.flink.util.function.FunctionUtils;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,12 +36,17 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Random;
@@ -259,6 +267,67 @@ public class FileUtilsTest extends TestLogger {
 		assertDirEquals(compressDir.resolve(originalDir), extractDir.resolve(originalDir));
 	}
 
+	@Test
+	public void testListFilesInPathWithoutAnyFileReturnEmptyList() throws IOException {
+		final java.nio.file.Path testDir = tmp.newFolder("_test_0").toPath();
+
+		assertTrue(Collections.<File>emptyList() ==
+			FileUtils.listFilesInPath(testDir.toFile(), f -> f.getName().endsWith(".jar")));
+	}
+
+	@Test
+	public void testListFilesInPath() throws IOException {
+		final java.nio.file.Path testDir = tmp.newFolder("_test_1").toPath();
+		final Tuple3<Collection<File>, Collection<File>, Collection<URL>> result = prepareTestFiles(testDir);
+
+		assertTrue(CollectionUtils.isEqualCollection(result.f0,
+			FileUtils.listFilesInPath(testDir.toFile(), f ->  f.getName().endsWith(".jar"))));
+	}
+
+	@Test
+	public void testRelativizeToWorkingDir() throws IOException {
+		final java.nio.file.Path testDir = tmp.newFolder("_test_2").toPath();
+		final Tuple3<Collection<File>, Collection<File>, Collection<URL>> result = prepareTestFiles(testDir);
+		final Collection<File> relativeFiles = FileUtils.relativizeToWorkingDir(result.f0);
+		relativeFiles.forEach(file -> assertFalse(file.isAbsolute()));
+		assertTrue(
+			CollectionUtils.isEqualCollection(
+				result.f1,
+				FileUtils.relativizeToWorkingDir(result.f0)
+			)
+		);
+	}
+
+	@Test
+	public void testToRelativeURLs() throws IOException {
+		final java.nio.file.Path testDir = tmp.newFolder("_test_3").toPath();
+		final Tuple3<Collection<File>, Collection<File>, Collection<URL>> result = prepareTestFiles(testDir);
+
+		final Collection<URL> relativeURLs = FileUtils.toRelativeURLs(result.f1);
+		relativeURLs.forEach(url -> assertFalse(new File(url.getPath()).isAbsolute()));
+
+		assertTrue(
+			CollectionUtils.isEqualCollection(
+				result.f2,
+				relativeURLs
+			)
+		);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testListDirFailsIfDirectoryDoesNotExist() throws IOException {
+		final String fileName = "_does_not_exists_file";
+		final String doesNotExistsFilePath = tmp.getRoot() + "/" + fileName;
+
+		FileUtils.listFilesInPath(new File(doesNotExistsFilePath), f ->  f.getName().endsWith(".jar"));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testListAFileFailsBecauseDirectoryIsExpected() throws IOException {
+		final String fileName = "a.jar";
+		File file = tmp.newFile(fileName);
+		FileUtils.listFilesInPath(file, f ->  f.getName().endsWith(".jar"));
+	}
 	// ------------------------------------------------------------------------
 	//  Utilities
 	// ------------------------------------------------------------------------
@@ -310,6 +379,60 @@ public class FileUtilsTest extends TestLogger {
 				generateRandomDirs(subdir, numFiles, numDirs, depth - 1);
 			}
 		}
+	}
+
+	/**
+	 * Generate some files in the directory {@code dir}.
+	 * @param dir the directory where the files are generated
+	 * @return Tuple3 holding the generated files' absolute path, relative to the working directory path and relative
+	 * url.
+	 * @throws IOException if I/O error occurs while generating the files
+	 */
+	public static Tuple3<Collection<File>, Collection<File>, Collection<URL>> prepareTestFiles(
+		final java.nio.file.Path dir) throws IOException {
+
+		Tuple3<Collection<File>, Collection<File>, Collection<URL>> result = new Tuple3<>();
+
+		result.f0 = generateSomeFilesInDirectoryReturnJarFiles(dir);
+		result.f1 = toRelativeFiles(result.f0);
+		result.f2 = toRelativeURLs(result.f1);
+
+		return result;
+	}
+
+	private static Collection<File> generateSomeFilesInDirectoryReturnJarFiles(
+			final java.nio.file.Path dir) throws IOException {
+
+		final java.nio.file.Path jobSubDir1 = Files.createDirectory(dir.resolve("_sub_dir1"));
+		final java.nio.file.Path jobSubDir2 = Files.createDirectory(dir.resolve("_sub_dir2"));
+		final java.nio.file.Path jarFile1 = Files.createFile(dir.resolve("file1.jar"));
+		final java.nio.file.Path jarFile2 = Files.createFile(dir.resolve("file2.jar"));
+		final java.nio.file.Path jarFile3 = Files.createFile(jobSubDir1.resolve("file3.jar"));
+		final java.nio.file.Path jarFile4 = Files.createFile(jobSubDir2.resolve("file4.jar"));
+		final Collection<File> jarFiles = new ArrayList<>();
+
+		Files.createFile(dir.resolve("file1.txt"));
+		Files.createFile(jobSubDir2.resolve("file2.txt"));
+
+		jarFiles.add(jarFile1.toFile());
+		jarFiles.add(jarFile2.toFile());
+		jarFiles.add(jarFile3.toFile());
+		jarFiles.add(jarFile4.toFile());
+		return jarFiles;
+	}
+
+	private static Collection<File> toRelativeFiles(Collection<File> files) {
+		final java.nio.file.Path workingDir = Paths.get(System.getProperty("user.dir"));
+		final Collection<File> relativeFiles = new ArrayList<>();
+		files.forEach(file -> relativeFiles.add(workingDir.relativize(file.toPath()).toFile()));
+		return relativeFiles;
+	}
+
+	private static Collection<URL> toRelativeURLs(Collection<File> relativeFiles) throws MalformedURLException {
+		final Collection<URL> relativeURLs = new ArrayList<>();
+		final URL context = new URL(relativeFiles.iterator().next().toURI().getScheme() + ":");
+		relativeFiles.forEach(FunctionUtils.uncheckedConsumer(file -> relativeURLs.add(new URL(context, file.toString()))));
+		return relativeURLs;
 	}
 
 	/**

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
@@ -42,6 +42,7 @@ import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.PosixParser;
 
+import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -108,7 +109,7 @@ public class MesosJobClusterEntrypoint extends JobClusterEntrypoint {
 	}
 
 	@Override
-	protected DefaultDispatcherResourceManagerComponentFactory createDispatcherResourceManagerComponentFactory(Configuration configuration) {
+	protected DefaultDispatcherResourceManagerComponentFactory createDispatcherResourceManagerComponentFactory(Configuration configuration) throws IOException {
 		return DefaultDispatcherResourceManagerComponentFactory.createJobComponentFactory(
 			new MesosResourceManagerFactory(
 				mesosServices,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -476,7 +476,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 	// Abstract methods
 	// --------------------------------------------------
 
-	protected abstract DispatcherResourceManagerComponentFactory createDispatcherResourceManagerComponentFactory(Configuration configuration);
+	protected abstract DispatcherResourceManagerComponentFactory createDispatcherResourceManagerComponentFactory(Configuration configuration) throws IOException;
 
 	protected abstract ArchivedExecutionGraphStore createSerializableExecutionGraphStore(
 		Configuration configuration,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetriever.java
@@ -51,7 +51,7 @@ public abstract class AbstractUserClassPathJobGraphRetriever implements JobGraph
 		}
 	}
 
-	protected List<URL> getUserClassPaths() {
+	public List<URL> getUserClassPaths() {
 		return userClassPaths;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetriever.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint.component;
+
+import org.apache.flink.core.fs.Path;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ *  Abstract class for the JobGraphRetriever, which wants to get classpath user's code depends on.
+ */
+
+public abstract class AbstractUserClassPathJobGraphRetriever implements JobGraphRetriever {
+
+	protected static final Logger LOG = LoggerFactory.getLogger(AbstractUserClassPathJobGraphRetriever.class);
+
+	public static final String DEFAULT_JOB_DIR = "job";
+
+	/** The directory contains all the jars, which user code depends on. */
+	@Nullable
+	private final String jobDir;
+
+	private List<URL> userClassPaths;
+
+	public AbstractUserClassPathJobGraphRetriever(String jobDir) {
+		this.jobDir = jobDir;
+	}
+
+	public List<URL> getUserClassPaths() throws IOException {
+		if (userClassPaths == null) {
+			userClassPaths = scanJarsInJobClassDir(jobDir);
+		}
+		return userClassPaths;
+	}
+
+	private List<URL> scanJarsInJobClassDir(String dir) throws IOException {
+
+		if (dir == null) {
+			return Collections.emptyList();
+		}
+
+		final File dirFile = new File(new Path(dir).toString());
+		final List<URL> jarURLs = new LinkedList<>();
+
+		if (!dirFile.exists()) {
+			LOG.warn("the job dir " + dirFile + " dose not exists.");
+			return Collections.emptyList();
+		}
+		if (!dirFile.isDirectory()) {
+			LOG.warn("the job dir " + dirFile + " is not a directory.");
+			return Collections.emptyList();
+		}
+
+		Files.walkFileTree(dirFile.toPath(),
+			EnumSet.of(FileVisitOption.FOLLOW_LINKS),
+			Integer.MAX_VALUE,
+			new SimpleFileVisitor<java.nio.file.Path>(){
+
+			@Override
+			public FileVisitResult visitFile(java.nio.file.Path file, BasicFileAttributes attrs)
+				throws IOException {
+				FileVisitResult fileVisitResult = super.visitFile(file, attrs);
+				if (file.getFileName().toString().endsWith(".jar")) {
+					LOG.info("add " + file.toString() + " to user classpath");
+					if (file.isAbsolute()) {
+						jarURLs.add(file.toUri().toURL());
+					} else {
+						jarURLs.add(
+							new URL(new URL(file.getFileName().toUri().getScheme() + ":"), file.toString())
+						);
+					}
+				}
+				return fileVisitResult;
+			}
+		});
+
+		if (jarURLs.isEmpty()) {
+			return Collections.emptyList();
+		} else {
+				return jarURLs;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetriever.java
@@ -93,19 +93,19 @@ public abstract class AbstractUserClassPathJobGraphRetriever implements JobGraph
 			Integer.MAX_VALUE,
 			new SimpleFileVisitor<java.nio.file.Path>() {
 
-			@Override
-			public FileVisitResult visitFile(java.nio.file.Path file, BasicFileAttributes attrs)
-					throws IOException {
-				FileVisitResult fileVisitResult = super.visitFile(file, attrs);
-				if (file.getFileName().toString().endsWith(".jar")) {
-					LOG.info("add " + file.toString() + " to user classpath");
+				@Override
+				public FileVisitResult visitFile(java.nio.file.Path file, BasicFileAttributes attrs)
+						throws IOException {
+					FileVisitResult fileVisitResult = super.visitFile(file, attrs);
+					if (file.getFileName().toString().endsWith(".jar")) {
+						LOG.info("add " + file.toString() + " to user classpath");
 						jarURLs.add(
 							new URL(new URL(file.getFileName().toUri().getScheme() + ":"), file.toString())
 						);
+					}
+					return fileVisitResult;
 				}
-				return fileVisitResult;
-			}
-		});
+			});
 
 		if (jarURLs.isEmpty()) {
 			return Collections.emptyList();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetriever.java
@@ -54,7 +54,7 @@ public abstract class AbstractUserClassPathJobGraphRetriever implements JobGraph
 		this.jobDir = jobDir;
 	}
 
-	public List<URL> getUserClassPaths() throws IOException {
+	protected List<URL> getUserClassPaths() throws IOException {
 		if (userClassPaths == null) {
 			userClassPaths = getRelativeJarsURLFromDir(jobDir);
 		}
@@ -73,7 +73,6 @@ public abstract class AbstractUserClassPathJobGraphRetriever implements JobGraph
 			return Collections.emptyList();
 		}
 
-		final List<URL> jarURLs = new LinkedList<>();
 		if (!Files.exists(Paths.get(dir))) {
 			throw new IllegalArgumentException("the job dir " + dir + " dose not exists.");
 		}
@@ -82,6 +81,8 @@ public abstract class AbstractUserClassPathJobGraphRetriever implements JobGraph
 		}
 
 		Path dirPath;
+		final List<URL> jarURLs = new LinkedList<>();
+
 		if (Paths.get(dir).isAbsolute()) {
 			dirPath = Paths.get(System.getProperty("user.dir")).relativize(Paths.get(dir));
 		} else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/FileJobGraphRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/FileJobGraphRetriever.java
@@ -25,18 +25,22 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.util.FlinkException;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * {@link JobGraphRetriever} implementation which retrieves the {@link JobGraph} from
  * a file on disk.
  */
-public class FileJobGraphRetriever implements JobGraphRetriever {
+public class FileJobGraphRetriever extends AbstractUserClassPathJobGraphRetriever {
 
 	public static final ConfigOption<String> JOB_GRAPH_FILE_PATH = ConfigOptions
 		.key("internal.jobgraph-path")
@@ -45,7 +49,8 @@ public class FileJobGraphRetriever implements JobGraphRetriever {
 	@Nonnull
 	private final String jobGraphFile;
 
-	public FileJobGraphRetriever(@Nonnull String jobGraphFile) {
+	public FileJobGraphRetriever(@Nonnull String jobGraphFile, @Nullable File jobDir) throws IOException {
+		super(jobDir);
 		this.jobGraphFile = jobGraphFile;
 	}
 
@@ -55,8 +60,19 @@ public class FileJobGraphRetriever implements JobGraphRetriever {
 
 		try (FileInputStream input = new FileInputStream(fp);
 			ObjectInputStream obInput = new ObjectInputStream(input)) {
+			final JobGraph jobGraph = (JobGraph) obInput.readObject();
 
-			return (JobGraph) obInput.readObject();
+			if (!getUserClassPaths().isEmpty()) {
+				if (jobGraph.getClasspaths() != null && !jobGraph.getClasspaths().isEmpty()) {
+					final List<URL> list = new ArrayList<>();
+					list.addAll(jobGraph.getClasspaths());
+					list.addAll(getUserClassPaths());
+					jobGraph.setClasspaths(list);
+				} else {
+					jobGraph.setClasspaths(getUserClassPaths());
+				}
+			}
+			return jobGraph;
 		} catch (FileNotFoundException e) {
 			throw new FlinkException("Could not find the JobGraph file.", e);
 		} catch (ClassNotFoundException | IOException e) {
@@ -64,7 +80,11 @@ public class FileJobGraphRetriever implements JobGraphRetriever {
 		}
 	}
 
-	public static FileJobGraphRetriever createFrom(Configuration configuration) {
-		return new FileJobGraphRetriever(configuration.getString(JOB_GRAPH_FILE_PATH));
+	public static FileJobGraphRetriever createFrom(Configuration configuration) throws IOException {
+		return new FileJobGraphRetriever(configuration.getString(JOB_GRAPH_FILE_PATH), null);
+	}
+
+	public static FileJobGraphRetriever createFrom(Configuration configuration, File jobDir) throws IOException {
+		return new FileJobGraphRetriever(configuration.getString(JOB_GRAPH_FILE_PATH), jobDir);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
@@ -141,5 +141,4 @@ public class AbstractUserClassPathJobGraphRetrieverTest extends TestLogger {
 			Files.deleteIfExists(jobRelativeDir);
 		}
 	}
-
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
@@ -48,9 +48,6 @@ public class AbstractUserClassPathJobGraphRetrieverTest extends TestLogger {
 	@Rule
 	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-	/**
-	 * Test class.
-	 */
 	private static class TestJobGraphRetriever extends AbstractUserClassPathJobGraphRetriever {
 		public TestJobGraphRetriever(String jobDir) {
 			super(jobDir);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
@@ -51,8 +51,7 @@ public class AbstractUserClassPathJobGraphRetrieverTest extends TestLogger {
 	/**
 	 * Test class.
 	 */
-	public static class TestJobGraphRetriever extends AbstractUserClassPathJobGraphRetriever {
-
+	private static class TestJobGraphRetriever extends AbstractUserClassPathJobGraphRetriever {
 		public TestJobGraphRetriever(String jobDir) {
 			super(jobDir);
 		}
@@ -63,17 +62,17 @@ public class AbstractUserClassPathJobGraphRetrieverTest extends TestLogger {
 		}
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testGetUserClassPathFromAFile() throws IOException {
 		final String fileName = "a.jar";
 		File file = temporaryFolder.newFile(fileName);
 
 		TestJobGraphRetriever testJobGraphRetriever = new TestJobGraphRetriever(file.getAbsolutePath());
 
-		assertEquals(Collections.emptyList(), testJobGraphRetriever.getUserClassPaths());
+		testJobGraphRetriever.getUserClassPaths();
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testGetUserClassPathFormADoesNotExistsFile() throws IOException {
 		final String fileName = "_does_not_exists_file";
 		final String doesNotExistsFilePath = temporaryFolder.getRoot() + "/" + fileName;
@@ -81,12 +80,10 @@ public class AbstractUserClassPathJobGraphRetrieverTest extends TestLogger {
 		TestJobGraphRetriever testJobGraphRetriever = new TestJobGraphRetriever(doesNotExistsFilePath);
 
 		assertEquals(Collections.emptyList(), testJobGraphRetriever.getUserClassPaths());
-
 	}
 
 	@Test
 	public void testGetUserClassPath() throws IOException {
-
 		final Path jobDir = temporaryFolder.newFolder("_job_dir").toPath();
 		final Path jobSubDir1 = Files.createDirectory(jobDir.resolve("_sub_dir1"));
 		final Path jobSubDir2 = Files.createDirectory(jobDir.resolve("_sub_dir2"));
@@ -98,10 +95,13 @@ public class AbstractUserClassPathJobGraphRetrieverTest extends TestLogger {
 		Files.createFile(jobDir.resolve("file1.txt"));
 		Files.createFile(jobSubDir2.resolve("file2.txt"));
 
-		List<URL> expectedUrls = Arrays.asList(jarFile1.toUri().toURL(),
-			jarFile2.toUri().toURL(),
-			jarFile3.toUri().toURL(),
-			jarFile4.toUri().toURL());
+		Path userDir = Paths.get(System.getProperty("user.dir"));
+		URL spec = new URL(jobDir.toUri().getScheme() + ":");
+		List<URL> expectedUrls = Arrays.asList(
+			new URL(spec, userDir.relativize(jarFile1).toString()),
+			new URL(spec, userDir.relativize(jarFile2).toString()),
+			new URL(spec, userDir.relativize(jarFile3).toString()),
+			new URL(spec, userDir.relativize(jarFile4).toString()));
 
 		TestJobGraphRetriever testJobGraphRetriever =
 			new TestJobGraphRetriever(jobDir.toString());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/AbstractUserClassPathJobGraphRetrieverTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint.component;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the {@link AbstractUserClassPathJobGraphRetriever}.
+ */
+public class AbstractUserClassPathJobGraphRetrieverTest extends TestLogger {
+
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	/**
+	 * Test class.
+	 */
+	public static class TestJobGraphRetriever extends AbstractUserClassPathJobGraphRetriever {
+
+		public TestJobGraphRetriever(String jobDir) {
+			super(jobDir);
+		}
+
+		@Override
+		public JobGraph retrieveJobGraph(Configuration configuration) {
+			return null;
+		}
+	}
+
+	@Test
+	public void testGetUserClassPathFromAFile() throws IOException {
+		final String fileName = "a.jar";
+		File file = temporaryFolder.newFile(fileName);
+
+		TestJobGraphRetriever testJobGraphRetriever = new TestJobGraphRetriever(file.getAbsolutePath());
+
+		assertEquals(Collections.emptyList(), testJobGraphRetriever.getUserClassPaths());
+	}
+
+	@Test
+	public void testGetUserClassPathFormADoesNotExistsFile() throws IOException {
+		final String fileName = "_does_not_exists_file";
+		final String doesNotExistsFilePath = temporaryFolder.getRoot() + "/" + fileName;
+
+		TestJobGraphRetriever testJobGraphRetriever = new TestJobGraphRetriever(doesNotExistsFilePath);
+
+		assertEquals(Collections.emptyList(), testJobGraphRetriever.getUserClassPaths());
+
+	}
+
+	@Test
+	public void testGetUserClassPath() throws IOException {
+
+		final Path jobDir = temporaryFolder.newFolder("_job_dir").toPath();
+		final Path jobSubDir1 = Files.createDirectory(jobDir.resolve("_sub_dir1"));
+		final Path jobSubDir2 = Files.createDirectory(jobDir.resolve("_sub_dir2"));
+		final Path jarFile1 = Files.createFile(jobDir.resolve("file1.jar"));
+		final Path jarFile2 = Files.createFile(jobDir.resolve("file2.jar"));
+		final Path jarFile3 = Files.createFile(jobSubDir1.resolve("file3.jar"));
+		final Path jarFile4 = Files.createFile(jobSubDir2.resolve("file4.jar"));
+
+		Files.createFile(jobDir.resolve("file1.txt"));
+		Files.createFile(jobSubDir2.resolve("file2.txt"));
+
+		List<URL> expectedUrls = Arrays.asList(jarFile1.toUri().toURL(),
+			jarFile2.toUri().toURL(),
+			jarFile3.toUri().toURL(),
+			jarFile4.toUri().toURL());
+
+		TestJobGraphRetriever testJobGraphRetriever =
+			new TestJobGraphRetriever(jobDir.toString());
+
+		assertTrue(CollectionUtils.isEqualCollection(expectedUrls, testJobGraphRetriever.getUserClassPaths()));
+	}
+
+	@Test
+	public void testGetUserClassPathWithRelativeJobDir() throws IOException {
+		Path jobRelativeDir = Paths.get("_job_dir");
+		Path jobRelativeSubDir = Paths.get("_job_dir", "_sub_dir");
+		Path jarFile1 = Paths.get(jobRelativeDir.toString(), "file1.jar");
+		Path jarFile2 = Paths.get(jobRelativeSubDir.toString(), "file2.jar");
+
+		URL context = new URL(jobRelativeDir.toUri().getScheme() + ":");
+		List<URL> expectedURLs = Arrays.asList(
+			new URL(context, jarFile1.toString()), new URL(context, jarFile2.toString()));
+
+		try {
+			if (!Files.exists(jobRelativeDir)) {
+				Files.createDirectory(jobRelativeDir);
+			}
+			if (!Files.exists(jobRelativeSubDir)) {
+				Files.createDirectory(jobRelativeSubDir);
+			}
+			if (!Files.exists(jarFile1)) {
+				Files.createFile(jarFile1);
+			}
+			if (!Files.exists(jarFile2)) {
+				Files.createFile(jarFile2);
+			}
+
+			TestJobGraphRetriever testJobGraphRetriever =
+				new TestJobGraphRetriever(jobRelativeDir.toString());
+			assertTrue(CollectionUtils.isEqualCollection(expectedURLs, testJobGraphRetriever.getUserClassPaths()));
+		} finally {
+			Files.deleteIfExists(jarFile1);
+			Files.deleteIfExists(jarFile2);
+			Files.deleteIfExists(jobRelativeSubDir);
+			Files.deleteIfExists(jobRelativeDir);
+		}
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/FileJobGraphRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/FileJobGraphRetrieverTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint.component;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.util.FileUtils;
+import org.apache.flink.util.FlinkException;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+import static java.nio.file.StandardOpenOption.CREATE;
+import static org.apache.flink.runtime.entrypoint.component.FileJobGraphRetriever.JOB_GRAPH_FILE_PATH;
+import static org.junit.Assert.assertTrue;
+
+
+
+/**
+ * Tests for the {@link FileJobGraphRetriever}.
+ */
+public class FileJobGraphRetrieverTest {
+
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@ClassRule
+	public static final TemporaryFolder GOBGRAPH_FOLDER = new TemporaryFolder();
+
+	private static Path jarFileInJobGraph;
+	private static Configuration configuration;
+
+	@BeforeClass
+	public static void init() throws IOException {
+		final Path jobGraphPath = GOBGRAPH_FOLDER.newFile(JOB_GRAPH_FILE_PATH.defaultValue()).toPath();
+		jarFileInJobGraph = GOBGRAPH_FOLDER.newFile("jar_file_in_job_graph.jar").toPath();
+
+		final JobVertex source = new JobVertex("source");
+		final JobVertex target = new JobVertex("target");
+		final JobGraph jobGraph = new JobGraph(new JobID(), "test", source, target);
+
+		jobGraph.setClasspaths(Arrays.asList(jarFileInJobGraph.toUri().toURL()));
+
+		try (ObjectOutputStream objectOutputStream =
+				new ObjectOutputStream(Files.newOutputStream(jobGraphPath, CREATE))) {
+			objectOutputStream.writeObject(jobGraph);
+		}
+
+		configuration = new Configuration();
+		configuration.setString(JOB_GRAPH_FILE_PATH.key(), jobGraphPath.toString());
+	}
+
+	@Test
+	public void testRetrieveJobGraphWithJarInJobDir() throws IOException, FlinkException {
+		final File jobDir = temporaryFolder.newFolder("job");
+		final File jarFileInJobDir = Files.createFile(jobDir.toPath().resolve("jar_file_in_job_dir.jar")).toFile();
+
+		final Collection<File> relativeFiles = FileUtils.relativizeToWorkingDir(Arrays.asList(jarFileInJobDir));
+		final Collection<URL> relativeURLs = FileUtils.toRelativeURLs(relativeFiles);
+		final List<URL> expectedURLs = new LinkedList<>();
+		expectedURLs.add(jarFileInJobGraph.toUri().toURL());
+		expectedURLs.addAll(relativeURLs);
+
+		final FileJobGraphRetriever fileJobGraphRetriever = FileJobGraphRetriever.createFrom(configuration, jobDir);
+		final JobGraph jobGraphFromFile = fileJobGraphRetriever.retrieveJobGraph(configuration);
+
+		assertTrue(CollectionUtils.isEqualCollection(expectedURLs, jobGraphFromFile.getClasspaths()));
+	}
+
+	@Test
+	public void testRetrieveJobGraphWithOutJobDir() throws IOException, FlinkException {
+		final FileJobGraphRetriever fileJobGraphRetriever = FileJobGraphRetriever.createFrom(configuration);
+		final List<URL> expectedUrls = Arrays.asList(jarFileInJobGraph.toUri().toURL());
+		final JobGraph jobGraph = fileJobGraphRetriever.retrieveJobGraph(configuration);
+
+		assertTrue(CollectionUtils.isEqualCollection(expectedUrls, jobGraph.getClasspaths()));
+	}
+
+}

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -35,11 +35,14 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.client.api.YarnClient;
-import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
@@ -48,6 +51,8 @@ import static org.apache.flink.yarn.configuration.YarnConfigOptions.CLASSPATH_IN
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Test cases for the deployment of Yarn Flink clusters.
@@ -58,6 +63,9 @@ public class YARNITCase extends YarnTestBase {
 
 	private final int sleepIntervalInMS = 100;
 
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
 	@BeforeClass
 	public static void setup() {
 		YARN_CONFIGURATION.set(YarnTestBase.TEST_CLUSTER_NAME_KEY, "flink-yarn-tests-per-job");
@@ -66,15 +74,29 @@ public class YARNITCase extends YarnTestBase {
 
 	@Test
 	public void testPerJobModeWithEnableSystemClassPathIncludeUserJar() throws Exception {
-		runTest(() -> deployPerjob(YarnConfigOptions.UserJarInclusion.FIRST));
+		runTest(() -> deployPerjob(YarnConfigOptions.UserJarInclusion.FIRST, false));
 	}
 
 	@Test
 	public void testPerJobModeWithDisableSystemClassPathIncludeUserJar() throws Exception {
-		runTest(() -> deployPerjob(YarnConfigOptions.UserJarInclusion.DISABLED));
+		runTest(() -> deployPerjob(YarnConfigOptions.UserJarInclusion.DISABLED, false));
 	}
 
-	private void deployPerjob(YarnConfigOptions.UserJarInclusion userJarInclusion) throws Exception {
+	@Test
+	public void testPerJobModeWithDisableSystemClassPathIncludeUserJarAndWithIllegalShipDirectoryName() {
+		try {
+			runTest(() -> deployPerjob(YarnConfigOptions.UserJarInclusion.DISABLED, true));
+			fail();
+		} catch (Exception e) {
+			StringWriter errors = new StringWriter();
+			e.printStackTrace(new PrintWriter(errors));
+			assertTrue(errors.toString().contains("This is an illegal ship directory :"));
+		}
+	}
+
+	private void deployPerjob(
+		YarnConfigOptions.UserJarInclusion userJarInclusion,
+		boolean shipIllegalShipDirectory) throws Exception {
 		Configuration configuration = new Configuration();
 		configuration.setString(AkkaOptions.ASK_TIMEOUT, "30 s");
 		configuration.setString(CLASSPATH_INCLUDE_USER_JAR, userJarInclusion.toString());
@@ -91,6 +113,10 @@ public class YARNITCase extends YarnTestBase {
 			yarnClusterDescriptor.setLocalJarPath(new Path(flinkUberjar.getAbsolutePath()));
 			yarnClusterDescriptor.addShipFiles(Arrays.asList(flinkLibFolder.listFiles()));
 			yarnClusterDescriptor.addShipFiles(Arrays.asList(flinkShadedHadoopDir.listFiles()));
+			if (shipIllegalShipDirectory) {
+				yarnClusterDescriptor.addShipFiles(Arrays.asList(
+					temporaryFolder.newFolder(ConfigConstants.DEFAULT_JOB_DIRECTORY_NAME)));
+			}
 
 			final ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
 				.setMasterMemoryMB(768)
@@ -139,12 +165,12 @@ public class YARNITCase extends YarnTestBase {
 
 		while (state != YarnApplicationState.FINISHED) {
 			if (state == YarnApplicationState.FAILED || state == YarnApplicationState.KILLED) {
-				Assert.fail("Application became FAILED or KILLED while expecting FINISHED");
+				fail("Application became FAILED or KILLED while expecting FINISHED");
 			}
 
 			if (deadline.isOverdue()) {
 				yarnClusterDescriptor.killCluster(applicationId);
-				Assert.fail("Application didn't finish before timeout");
+				fail("Application didn't finish before timeout");
 			}
 
 			sleep(sleepIntervalInMS);

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.yarn.configuration.YarnConfigOptions;
 import org.apache.flink.yarn.util.YarnTestUtils;
 
 import org.apache.hadoop.fs.Path;
@@ -43,6 +44,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 
+import static org.apache.flink.yarn.configuration.YarnConfigOptions.CLASSPATH_INCLUDE_USER_JAR;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
@@ -63,61 +65,69 @@ public class YARNITCase extends YarnTestBase {
 	}
 
 	@Test
-	public void testPerJobMode() throws Exception {
-		runTest(() -> {
-			Configuration configuration = new Configuration();
-			configuration.setString(AkkaOptions.ASK_TIMEOUT, "30 s");
-			final YarnClient yarnClient = getYarnClient();
+	public void testPerJobModeWithEnableSystemClassPathIncludeUserJar() throws Exception {
+		runTest(() -> deployPerjob(YarnConfigOptions.UserJarInclusion.FIRST));
+	}
 
-			try (final YarnClusterDescriptor yarnClusterDescriptor = new YarnClusterDescriptor(
-				configuration,
-				getYarnConfiguration(),
-				System.getenv(ConfigConstants.ENV_FLINK_CONF_DIR),
-				yarnClient,
-				true)) {
+	@Test
+	public void testPerJobModeWithDisableSystemClassPathIncludeUserJar() throws Exception {
+		runTest(() -> deployPerjob(YarnConfigOptions.UserJarInclusion.DISABLED));
+	}
 
-				yarnClusterDescriptor.setLocalJarPath(new Path(flinkUberjar.getAbsolutePath()));
-				yarnClusterDescriptor.addShipFiles(Arrays.asList(flinkLibFolder.listFiles()));
-				yarnClusterDescriptor.addShipFiles(Arrays.asList(flinkShadedHadoopDir.listFiles()));
+	private void deployPerjob(YarnConfigOptions.UserJarInclusion userJarInclusion) throws Exception {
+		Configuration configuration = new Configuration();
+		configuration.setString(AkkaOptions.ASK_TIMEOUT, "30 s");
+		configuration.setString(CLASSPATH_INCLUDE_USER_JAR, userJarInclusion.toString());
 
-				final ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
-					.setMasterMemoryMB(768)
-					.setTaskManagerMemoryMB(1024)
-					.setSlotsPerTaskManager(1)
-					.setNumberTaskManagers(1)
-					.createClusterSpecification();
+		final YarnClient yarnClient = getYarnClient();
 
-				StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-				env.setParallelism(2);
+		try (final YarnClusterDescriptor yarnClusterDescriptor = new YarnClusterDescriptor(
+			configuration,
+			getYarnConfiguration(),
+			System.getenv(ConfigConstants.ENV_FLINK_CONF_DIR),
+			yarnClient,
+			true)) {
 
-				env.addSource(new NoDataSource())
-					.shuffle()
-					.addSink(new DiscardingSink<>());
+			yarnClusterDescriptor.setLocalJarPath(new Path(flinkUberjar.getAbsolutePath()));
+			yarnClusterDescriptor.addShipFiles(Arrays.asList(flinkLibFolder.listFiles()));
+			yarnClusterDescriptor.addShipFiles(Arrays.asList(flinkShadedHadoopDir.listFiles()));
 
-				final JobGraph jobGraph = env.getStreamGraph().getJobGraph();
+			final ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
+				.setMasterMemoryMB(768)
+				.setTaskManagerMemoryMB(1024)
+				.setSlotsPerTaskManager(1)
+				.setNumberTaskManagers(1)
+				.createClusterSpecification();
 
-				File testingJar = YarnTestBase.findFile("..", new YarnTestUtils.TestJarFinder("flink-yarn-tests"));
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setParallelism(2);
 
-				jobGraph.addJar(new org.apache.flink.core.fs.Path(testingJar.toURI()));
+			env.addSource(new NoDataSource())
+				.shuffle()
+				.addSink(new DiscardingSink<>());
 
-				try (ClusterClient<ApplicationId> clusterClient = yarnClusterDescriptor.deployJobCluster(
-					clusterSpecification,
-					jobGraph,
-					false)) {
+			final JobGraph jobGraph = env.getStreamGraph().getJobGraph();
 
-					ApplicationId applicationId = clusterClient.getClusterId();
+			File testingJar = YarnTestBase.findFile("..", new YarnTestUtils.TestJarFinder("flink-yarn-tests"));
 
-					final CompletableFuture<JobResult> jobResultCompletableFuture = clusterClient.requestJobResult(jobGraph.getJobID());
+			jobGraph.addJar(new org.apache.flink.core.fs.Path(testingJar.toURI()));
+			try (ClusterClient<ApplicationId> clusterClient = yarnClusterDescriptor.deployJobCluster(
+				clusterSpecification,
+				jobGraph,
+				false)) {
 
-					final JobResult jobResult = jobResultCompletableFuture.get();
+				ApplicationId applicationId = clusterClient.getClusterId();
 
-					assertThat(jobResult, is(notNullValue()));
-					assertThat(jobResult.getSerializedThrowable().isPresent(), is(false));
+				final CompletableFuture<JobResult> jobResultCompletableFuture = clusterClient.requestJobResult(jobGraph.getJobID());
 
-					waitApplicationFinishedElseKillIt(applicationId, yarnAppTerminateTimeout, yarnClusterDescriptor);
-				}
+				final JobResult jobResult = jobResultCompletableFuture.get();
+
+				assertThat(jobResult, is(notNullValue()));
+				assertThat(jobResult.getSerializedThrowable().isPresent(), is(false));
+
+				waitApplicationFinishedElseKillIt(applicationId, yarnAppTerminateTimeout, yarnClusterDescriptor);
 			}
-		});
+		}
 	}
 
 	private void waitApplicationFinishedElseKillIt(

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -210,7 +210,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 	 * Adds the given files to the list of files to ship.
 	 *
 	 * <p>Note that any file matching "<tt>flink-dist*.jar</tt>" will be excluded from the upload by
-	 * {@link #uploadAndRegisterFiles(Collection, FileSystem, Path, ApplicationId, List, Map, StringBuilder)}
+	 * {@link #uploadAndRegisterFiles(Collection, FileSystem, Path, ApplicationId, List, Map, String, StringBuilder)}
 	 * since we upload the Flink uber jar ourselves and do not need to deploy it multiple times.
 	 *
 	 * @param shipFiles files to ship
@@ -775,22 +775,25 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
 		// upload and register ship files
 		List<String> systemClassPaths = uploadAndRegisterFiles(
-				systemShipFiles,
-				fs,
-				homeDir,
-				appId,
-				paths,
-				localResources,
-				envShipFileList);
+			systemShipFiles,
+			fs,
+			homeDir,
+			appId,
+			paths,
+			localResources,
+			Path.CUR_DIR,
+			envShipFileList);
 
 		final List<String> userClassPaths = uploadAndRegisterFiles(
-				userJarFiles,
-				fs,
-				homeDir,
-				appId,
-				paths,
-				localResources,
-				envShipFileList);
+			userJarFiles,
+			fs,
+			homeDir,
+			appId,
+			paths,
+			localResources,
+			userJarInclusion == YarnConfigOptions.UserJarInclusion.DISABLED ?
+				ConfigConstants.DEFAULT_JOB_DIRECTORY_NAME : Path.CUR_DIR,
+			envShipFileList);
 
 		if (userJarInclusion == YarnConfigOptions.UserJarInclusion.ORDER) {
 			systemClassPaths.addAll(userClassPaths);
@@ -1158,6 +1161,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 	 * 		paths of the remote resources (uploaded resources will be added)
 	 * @param localResources
 	 * 		map of resources (uploaded resources will be added)
+	 * @param localResourcesDirectory
+	 *		the directory the localResources are uploaded to
 	 * @param envShipFileList
 	 * 		list of shipped files in a format understood by {@link Utils#createTaskExecutorContext}
 	 *
@@ -1170,6 +1175,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			ApplicationId appId,
 			List<Path> remotePaths,
 			Map<String, LocalResource> localResources,
+			String localResourcesDirectory,
 			StringBuilder envShipFileList) throws IOException {
 		final List<Path> localPaths = new ArrayList<>();
 		final List<Path> relativePaths = new ArrayList<>();
@@ -1182,13 +1188,13 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 					@Override
 					public FileVisitResult visitFile(java.nio.file.Path file, BasicFileAttributes attrs) {
 						localPaths.add(new Path(file.toUri()));
-						relativePaths.add(new Path(parentPath.relativize(file).toString()));
+						relativePaths.add(new Path(localResourcesDirectory, parentPath.relativize(file).toString()));
 						return FileVisitResult.CONTINUE;
 					}
 				});
 			} else {
 				localPaths.add(new Path(shipFile.toURI()));
-				relativePaths.add(new Path(shipFile.getName()));
+				relativePaths.add(new Path(localResourcesDirectory, shipFile.getName()));
 			}
 		}
 
@@ -1653,17 +1659,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 	}
 
 	private static YarnConfigOptions.UserJarInclusion getUserJarInclusionMode(org.apache.flink.configuration.Configuration config) {
-		throwIfUserTriesToDisableUserJarInclusionInSystemClassPath(config);
-
 		return config.getEnum(YarnConfigOptions.UserJarInclusion.class, YarnConfigOptions.CLASSPATH_INCLUDE_USER_JAR);
-	}
-
-	private static void throwIfUserTriesToDisableUserJarInclusionInSystemClassPath(final Configuration config) {
-		final String userJarInclusion = config.getString(YarnConfigOptions.CLASSPATH_INCLUDE_USER_JAR);
-		if ("DISABLED".equalsIgnoreCase(userJarInclusion)) {
-			throw new IllegalArgumentException(String.format("Config option %s cannot be set to DISABLED anymore (see FLINK-11781)",
-				YarnConfigOptions.CLASSPATH_INCLUDE_USER_JAR.key()));
-		}
 	}
 
 	/**

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -60,14 +60,15 @@ public class YarnConfigOptions {
 	/**
 	 * Defines whether user-jars are included in the system class path for per-job-clusters as well as their positioning
 	 * in the path. They can be positioned at the beginning ("FIRST"), at the end ("LAST"), or be positioned based on
-	 * their name ("ORDER").
+	 * their name ("ORDER"). "DISABLED" means the user-jars are excluded from the system class path.
 	 */
 	public static final ConfigOption<String> CLASSPATH_INCLUDE_USER_JAR =
 		key("yarn.per-job-cluster.include-user-jar")
 			.defaultValue("ORDER")
 			.withDescription("Defines whether user-jars are included in the system class path for per-job-clusters as" +
 				" well as their positioning in the path. They can be positioned at the beginning (\"FIRST\"), at the" +
-				" end (\"LAST\"), or be positioned based on their name (\"ORDER\").");
+				" end (\"LAST\"), or be positioned based on their name (\"ORDER\"). \"DISABLED\" means the user-jars" +
+				" are excluded from the system class path.");
 
 	/**
 	 * The vcores exposed by YARN.
@@ -211,6 +212,7 @@ public class YarnConfigOptions {
 
 	/** @see YarnConfigOptions#CLASSPATH_INCLUDE_USER_JAR */
 	public enum UserJarInclusion {
+		DISABLED,
 		FIRST,
 		LAST,
 		ORDER

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypoint.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypoint.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.yarn.entrypoint;
 
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
 import org.apache.flink.runtime.entrypoint.JobClusterEntrypoint;
@@ -32,6 +33,7 @@ import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
@@ -61,10 +63,15 @@ public class YarnJobClusterEntrypoint extends JobClusterEntrypoint {
 	}
 
 	@Override
-	protected DefaultDispatcherResourceManagerComponentFactory createDispatcherResourceManagerComponentFactory(Configuration configuration) {
+	protected DefaultDispatcherResourceManagerComponentFactory createDispatcherResourceManagerComponentFactory(Configuration configuration) throws IOException {
+		final YarnConfigOptions.UserJarInclusion userJarInclusion = configuration
+			.getEnum(YarnConfigOptions.UserJarInclusion.class, YarnConfigOptions.CLASSPATH_INCLUDE_USER_JAR);
+		final File jobDir =
+			userJarInclusion == YarnConfigOptions.UserJarInclusion.DISABLED ?
+				new File(ConfigConstants.DEFAULT_JOB_DIRECTORY_NAME) : null;
 		return DefaultDispatcherResourceManagerComponentFactory.createJobComponentFactory(
 			YarnResourceManagerFactory.getInstance(),
-			FileJobGraphRetriever.createFrom(configuration));
+			FileJobGraphRetriever.createFrom(configuration, jobDir));
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -54,9 +54,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static junit.framework.TestCase.assertTrue;
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 /**
@@ -90,22 +88,6 @@ public class YarnClusterDescriptorTest extends TestLogger {
 	@AfterClass
 	public static void tearDownClass() {
 		yarnClient.stop();
-	}
-
-	/**
-	 * @see <a href="https://issues.apache.org/jira/browse/FLINK-11781">FLINK-11781</a>
-	 */
-	@Test
-	public void testThrowsExceptionIfUserTriesToDisableUserJarInclusionInSystemClassPath() {
-		final Configuration configuration = new Configuration();
-		configuration.setString(YarnConfigOptions.CLASSPATH_INCLUDE_USER_JAR, "DISABLED");
-
-		try {
-			createYarnClusterDescriptor(configuration);
-			fail("Expected exception not thrown");
-		} catch (final IllegalArgumentException e) {
-			assertThat(e.getMessage(), containsString("cannot be set to DISABLED anymore"));
-		}
 	}
 
 	@Test

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTest.java
@@ -44,6 +44,8 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -59,6 +61,8 @@ import static org.junit.Assert.assertFalse;
  * Tests for verifying file staging during submission to YARN works.
  */
 public class YarnFileStageTest extends TestLogger {
+
+	private static final String LOCAL_RESOURCE_DIRECTORY = "stage_test";
 
 	@ClassRule
 	public static final TemporaryFolder CLASS_TEMP_DIR = new TemporaryFolder();
@@ -114,7 +118,7 @@ public class YarnFileStageTest extends TestLogger {
 		final FileSystem targetFileSystem = hdfsRootPath.getFileSystem(hadoopConfig);
 		final Path targetDir = targetFileSystem.getWorkingDirectory();
 
-		testCopyFromLocalRecursive(targetFileSystem, targetDir, tempFolder, true);
+		testCopyFromLocalRecursive(targetFileSystem, targetDir, LOCAL_RESOURCE_DIRECTORY, tempFolder, true);
 	}
 
 	/**
@@ -126,7 +130,18 @@ public class YarnFileStageTest extends TestLogger {
 		final FileSystem targetFileSystem = hdfsRootPath.getFileSystem(hadoopConfig);
 		final Path targetDir = targetFileSystem.getWorkingDirectory();
 
-		testCopyFromLocalRecursive(targetFileSystem, targetDir, tempFolder, false);
+		testCopyFromLocalRecursive(targetFileSystem, targetDir, LOCAL_RESOURCE_DIRECTORY, tempFolder, false);
+	}
+
+	/**
+	 * Verifies that a single file is properly copied.
+	 */
+	@Test
+	public void testCopyAFileFromLocal() throws IOException, URISyntaxException, InterruptedException {
+		final FileSystem targetFileSystem = hdfsRootPath.getFileSystem(hadoopConfig);
+		final Path targetDir = targetFileSystem.getWorkingDirectory();
+
+		testCopyAFileFromLocal(targetFileSystem, targetDir, LOCAL_RESOURCE_DIRECTORY, tempFolder);
 	}
 
 	/**
@@ -136,6 +151,8 @@ public class YarnFileStageTest extends TestLogger {
 	 * 		file system of the target path
 	 * @param targetDir
 	 * 		target path (URI like <tt>hdfs://...</tt>)
+	 * @param localResourceDirectory
+	 * 		the directory that localResource are uploaded to
 	 * @param tempFolder
 	 * 		JUnit temporary folder rule to create the source directory with
 	 * @param addSchemeToLocalPath
@@ -144,6 +161,7 @@ public class YarnFileStageTest extends TestLogger {
 	static void testCopyFromLocalRecursive(
 			FileSystem targetFileSystem,
 			Path targetDir,
+			String localResourceDirectory,
 			TemporaryFolder tempFolder,
 			boolean addSchemeToLocalPath) throws Exception {
 
@@ -166,14 +184,8 @@ public class YarnFileStageTest extends TestLogger {
 		srcFiles.put("nested/3", "Hello nested/3");
 		srcFiles.put("nested/4/5", "Hello nested/4/5");
 		srcFiles.put("test.jar", "JAR Content");
-		for (Map.Entry<String, String> src : srcFiles.entrySet()) {
-			File file = new File(srcDir, src.getKey());
-			//noinspection ResultOfMethodCallIgnored
-			file.getParentFile().mkdirs();
-			try (DataOutputStream out = new DataOutputStream(new FileOutputStream(file))) {
-				out.writeUTF(src.getValue());
-			}
-		}
+
+		generateFilesInDirectory(srcDir, srcFiles);
 
 		// copy the created directory recursively:
 		try {
@@ -186,55 +198,137 @@ public class YarnFileStageTest extends TestLogger {
 				ApplicationId.newInstance(0, 0),
 				remotePaths,
 				localResources,
+				localResourceDirectory,
 				new StringBuilder());
 
+			final Path basePath = new Path(localResourceDirectory, srcDir.getName());
+			final Path nestedPath = new Path(basePath, "nested");
 			assertThat(
 				classpath,
 				Matchers.containsInAnyOrder(
-					srcDir.getName(),
-					srcDir.getName() + "/nested",
-					srcDir.getName() + "/nested/4",
-					srcDir.getName() + "/test.jar"));
+					basePath.toString(),
+					nestedPath.toString(),
+					new Path(nestedPath, "4").toString(),
+					new Path(basePath, "test.jar").toString()));
 
 			assertEquals(srcFiles.size(), localResources.size());
 
 			Path workDir = ConverterUtils
-				.getPathFromYarnURL(localResources.get(srcPath.getName() + "/1").getResource())
-				.getParent();
+				.getPathFromYarnURL(
+					localResources.get(new Path(localResourceDirectory, new Path(srcPath.getName(), "1")).toString())
+						.getResource()).getParent();
 
-			RemoteIterator<LocatedFileStatus> targetFilesIterator =
-				targetFileSystem.listFiles(workDir, true);
-			HashMap<String /* (relative) path */, /* contents */ String> targetFiles =
-				new HashMap<>(4);
+			verifyDirectoryRecursive(targetFileSystem, workDir, srcFiles);
 
-			final int workDirPrefixLength =
-				workDir.toString().length() + 1; // one more for the concluding "/"
-			while (targetFilesIterator.hasNext()) {
-				LocatedFileStatus targetFile = targetFilesIterator.next();
-
-				int retries = 5;
-				do {
-					try (FSDataInputStream in = targetFileSystem.open(targetFile.getPath())) {
-						String absolutePathString = targetFile.getPath().toString();
-						String relativePath = absolutePathString.substring(workDirPrefixLength);
-						targetFiles.put(relativePath, in.readUTF());
-
-						assertEquals("extraneous data in file " + relativePath, -1, in.read());
-						break;
-					} catch (FileNotFoundException e) {
-						// For S3, read-after-write may be eventually consistent, i.e. when trying
-						// to access the object before writing it; see
-						// https://docs.aws.amazon.com/AmazonS3/latest/dev/Introduction.html#ConsistencyModel
-						// -> try again a bit later
-						Thread.sleep(50);
-					}
-				} while ((retries--) > 0);
-			}
-
-			assertThat(targetFiles, equalTo(srcFiles));
 		} finally {
 			// clean up
 			targetFileSystem.delete(targetDir, true);
 		}
+	}
+
+	/**
+	 * Verifies a single file is properly uploaded.
+	 * @param targetFileSystem file system of the target path
+	 * @param targetDir target path (URI like <tt>hdfs://...</tt>)
+	 * @param localResourceDirectory the directory that localResource are uploaded to
+	 * @param temporaryFolder JUnit temporary folder rule to create the source directory with
+	 * @throws IOException if error occurs when accessing the file system
+	 * @throws URISyntaxException if the format of url has errors when converting a given url to hadoop path
+	 */
+	private static void testCopyAFileFromLocal(
+		FileSystem targetFileSystem,
+		Path targetDir,
+		String localResourceDirectory,
+		TemporaryFolder temporaryFolder) throws IOException, InterruptedException, URISyntaxException {
+
+		final File srcDir = temporaryFolder.newFolder();
+
+		final String localFile = "local.jar";
+		final String localFileContent = "Local Jar Content";
+
+		HashMap<String /* (relative) path */, /* contents */ String> srcFiles = new HashMap<>(4);
+		srcFiles.put(localFile, localFileContent);
+
+		generateFilesInDirectory(srcDir, srcFiles);
+		try {
+			List<Path> remotePaths = new ArrayList<>();
+			HashMap<String, LocalResource> localResources = new HashMap<>();
+			final List<String> classpath = YarnClusterDescriptor.uploadAndRegisterFiles(
+				Collections.singletonList(new File(srcDir, localFile)),
+				targetFileSystem,
+				targetDir,
+				ApplicationId.newInstance(0, 0),
+				remotePaths,
+				localResources,
+				localResourceDirectory,
+				new StringBuilder());
+
+			assertThat(classpath, Matchers.containsInAnyOrder(new Path(localResourceDirectory, localFile).toString()));
+
+			Path workDir = ConverterUtils.getPathFromYarnURL(
+				localResources.get(new Path(localResourceDirectory, localFile).toString()).getResource()).getParent();
+			verifyDirectoryRecursive(targetFileSystem, workDir, srcFiles);
+		} finally {
+			targetFileSystem.delete(targetDir, true);
+		}
+	}
+
+	private static void generateFilesInDirectory(
+		File directory,
+		HashMap<String /* (relative) path */, /* contents */ String> srcFiles) throws IOException {
+
+		for (Map.Entry<String, String> src : srcFiles.entrySet()) {
+			File file = new File(directory, src.getKey());
+			//noinspection ResultOfMethodCallIgnored
+			file.getParentFile().mkdirs();
+			try (DataOutputStream out = new DataOutputStream(new FileOutputStream(file))) {
+				out.writeUTF(src.getValue());
+			}
+		}
+	}
+
+
+	/**
+	 * Verifies the content and name of file in the directory {@code worDir} are same with {@code expectedFiles}.
+	 * @param targetFileSystem the filesystem type of {@code workDir}
+	 * @param workDir the directory verified
+	 * @param expectedFiles the expected name and content of the files
+	 * @throws IOException if error occurs when visiting the {@code workDir}
+	 * @throws InterruptedException if the sleep is interrupted.
+	 */
+	private static void verifyDirectoryRecursive(
+		FileSystem targetFileSystem,
+		Path workDir,
+		Map<String, String> expectedFiles)
+		throws IOException, InterruptedException {
+
+		HashMap<String /* (relative) path */, /* contents */ String> targetFiles =
+			new HashMap<>(4);
+		RemoteIterator<LocatedFileStatus> targetFilesIterator =
+			targetFileSystem.listFiles(workDir, true);
+		final int workDirPrefixLength =
+			workDir.toString().length() + 1; // one more for the concluding "/"
+		while (targetFilesIterator.hasNext()) {
+			final LocatedFileStatus targetFile = targetFilesIterator.next();
+
+			int retries = 5;
+			do {
+				try (FSDataInputStream in = targetFileSystem.open(targetFile.getPath())) {
+					String absolutePathString = targetFile.getPath().toString();
+					String relativePath = absolutePathString.substring(workDirPrefixLength);
+					targetFiles.put(relativePath, in.readUTF());
+
+					assertEquals("extraneous data in file " + relativePath, -1, in.read());
+					break;
+				} catch (FileNotFoundException e) {
+					// For S3, read-after-write may be eventually consistent, i.e. when trying
+					// to access the object before writing it; see
+					// https://docs.aws.amazon.com/AmazonS3/latest/dev/Introduction.html#ConsistencyModel
+					// -> try again a bit later
+					Thread.sleep(50);
+				}
+			} while ((retries--) > 0);
+		}
+		assertThat(targetFiles, equalTo(expectedFiles));
 	}
 }

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTestS3ITCase.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTestS3ITCase.java
@@ -157,7 +157,7 @@ public class YarnFileStageTestS3ITCase extends TestLogger {
 			final Path directory = new Path(basePath, pathSuffix);
 
 			YarnFileStageTest.testCopyFromLocalRecursive(fs.getHadoopFileSystem(),
-				new org.apache.hadoop.fs.Path(directory.toUri()), tempFolder, true);
+				new org.apache.hadoop.fs.Path(directory.toUri()), Path.CUR_DIR, tempFolder, false);
 		} finally {
 			// clean up
 			fs.delete(basePath, true);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
This pull request will let `YarnJobClusterEntrypoint` use the user code class loader if setting the yarn.per-job-cluster.include-user-jar to "DISABLE".

## Brief change log
  - `YarnClusterDescriptor` does not put the user jars to the system classpath and put the user jar to the "job/" dir if setting `yarn.per-job-cluster.include-user-jar` to "DISABLE".
  - `FileJobGraphRetriever` adds the user classpath to the `JobGraph` if it is not empty.

## Verifying this change

This change added tests and can be verified as follows:
  - Added integration test for verifying that `YarnJobClusterEntrypoint` could use user code class loader 
  - Added integration test for verifying that the user will get notified error if there is a ship dir, whose name is "job" when setting yarn.per-job-cluster.include-user-jar to "DISABLE".

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
