### PR TITLE
[FLINK-14388][python][table-planner][table-planner-blink] Support common data types in Python user-defined functions

### DIFF
--- a/flink-python/pyflink/fn_execution/coder_impl.py
+++ b/flink-python/pyflink/fn_execution/coder_impl.py
@@ -16,6 +16,10 @@
 # limitations under the License.
 ################################################################################
 
+import datetime
+import decimal
+import struct
+
 from apache_beam.coders.coder_impl import StreamCoderImpl
 
 
@@ -74,3 +78,251 @@ class RowCoderImpl(StreamCoderImpl):
 
     def __repr__(self):
         return 'RowCoderImpl[%s]' % ', '.join(str(c) for c in self._field_coders)
+
+
+class ArrayCoderImpl(StreamCoderImpl):
+
+    def __init__(self, elem_coder):
+        self._elem_coder = elem_coder
+
+    def encode_to_stream(self, value, out_stream, nested):
+        out_stream.write_var_int64(len(value))
+        for elem in value:
+            self._elem_coder.encode_to_stream(elem, out_stream, nested)
+
+    def decode_from_stream(self, in_stream, nested):
+        size = in_stream.read_var_int64()
+        assert size >= 0
+        elements = [self._elem_coder.decode_from_stream(in_stream, nested) for _ in range(size)]
+        return elements
+
+    def __repr__(self):
+        return 'ArrayCoderImpl[%s]' % str(self._elem_coder)
+
+
+class MapCoderImpl(StreamCoderImpl):
+
+    def __init__(self, key_coder, value_coder):
+        self._key_coder = key_coder
+        self._value_coder = value_coder
+
+    def encode_to_stream(self, map_value, out_stream, nested):
+        out_stream.write_bigendian_int32(len(map_value))
+        for key in map_value:
+            self._key_coder.encode_to_stream(key, out_stream, nested)
+            self._value_coder.encode_to_stream(map_value[key], out_stream, nested)
+
+    def decode_from_stream(self, in_stream, nested):
+        size = in_stream.read_bigendian_int32()
+        assert size >= 0
+        map_value = {}
+        for _ in range(size):
+            key = self._key_coder.decode_from_stream(in_stream, nested)
+            value = self._value_coder.decode_from_stream(in_stream, nested)
+            map_value[key] = value
+        return map_value
+
+    def __repr__(self):
+        return 'MapCoderImpl[%s]' % ' : '.join([str(self._key_coder), str(self._value_coder)])
+
+
+class MultiSetCoderImpl(StreamCoderImpl):
+
+    def __init__(self, element_coder):
+        self._element_coder = element_coder
+
+    def encode_to_stream(self, value, out_stream, nested):
+        dict_value = self.multiset_to_dict(value)
+        out_stream.write_bigendian_int32(len(dict_value))
+        for key in dict_value:
+            self._element_coder.encode_to_stream(key, out_stream, nested)
+            out_stream.write_var_int64(dict_value[key])
+
+    def decode_from_stream(self, in_stream, nested):
+        size = in_stream.read_bigendian_int32()
+        assert size >= 0
+        multiset_value = []
+        for _ in range(size):
+            element = self._element_coder.decode_from_stream(in_stream, nested)
+            count = in_stream.read_var_int64()
+            for i in range(count):
+                multiset_value.append(element)
+        return multiset_value
+
+    def multiset_to_dict(self, multiset):
+        dict_value = {}
+        for ele in multiset:
+            if ele in dict_value:
+                dict_value[ele] += 1
+            else:
+                dict_value[ele] = 1
+        return dict_value
+
+    def __repr__(self):
+        return 'MultiSetCoderImpl[%s]' % str(self._element_coder)
+
+
+class ByteCoderImpl(StreamCoderImpl):
+
+    def encode_to_stream(self, value, out_stream, nested):
+        out_stream.write_byte(value)
+
+    def decode_from_stream(self, in_stream, nested):
+        return int(in_stream.read_byte())
+
+    def __repr__(self):
+        return 'ByteCoderImpl'
+
+
+class BooleanCoderImpl(StreamCoderImpl):
+
+    def encode_to_stream(self, value, out_stream, nested):
+        out_stream.write_byte(value)
+
+    def decode_from_stream(self, in_stream, nested):
+        return not not in_stream.read_byte()
+
+    def __repr__(self):
+        return 'BooleanCoderImpl'
+
+
+class ShortCoderImpl(StreamCoderImpl):
+
+    def encode_to_stream(self, value, out_stream, nested):
+        out_stream.write(struct.pack('>h', value))
+
+    def decode_from_stream(self, in_stream, nested):
+        return struct.unpack('>h', in_stream.read(2))[0]
+
+    def __repr__(self):
+        return 'ShortCoderImpl'
+
+
+class FloatCoderImpl(StreamCoderImpl):
+
+    def encode_to_stream(self, value, out_stream, nested):
+        out_stream.write(struct.pack('>f', value))
+
+    def decode_from_stream(self, in_stream, nested):
+        return struct.unpack('>f', in_stream.read(4))[0]
+
+    def __repr__(self):
+        return 'FloatCoderImpl'
+
+
+class DoubleCoderImpl(StreamCoderImpl):
+
+    def encode_to_stream(self, value, out_stream, nested):
+        out_stream.write_bigendian_double(value)
+
+    def decode_from_stream(self, in_stream, nested):
+        return in_stream.read_bigendian_double()
+
+    def __repr__(self):
+        return 'DoubleCoderImpl'
+
+
+class DecimalCoderImpl(StreamCoderImpl):
+
+    def __init__(self, str_coder):
+        self._str_coder = str_coder
+
+    def encode_to_stream(self, value, out_stream, nested):
+        self._str_coder.encode_to_stream(str(value), out_stream, True)
+
+    def decode_from_stream(self, in_stream, nested):
+        return decimal.Decimal(self._str_coder.decode_from_stream(in_stream, True))
+
+    def __repr__(self):
+        return 'DecimalCoderImpl'
+
+
+class DateCoderImpl(StreamCoderImpl):
+
+    EPOCH_ORDINAL = datetime.datetime(1970, 1, 1).toordinal()
+
+    def encode_to_stream(self, value, out_stream, nested):
+        out_stream.write_var_int64(self.date_to_internal(value))
+
+    def decode_from_stream(self, in_stream, nested):
+        value = in_stream.read_var_int64()
+        return self.internal_to_date(value)
+
+    def date_to_internal(self, d):
+        return d.toordinal() - self.EPOCH_ORDINAL
+
+    def internal_to_date(self, v):
+        return datetime.date.fromordinal(v + self.EPOCH_ORDINAL)
+
+    def __repr__(self):
+        return "DateCoderImpl"
+
+
+class TimeCoderImpl(StreamCoderImpl):
+
+    def encode_to_stream(self, value, out_stream, nested):
+        out_stream.write_var_int64(self.time_to_internal(value))
+
+    def decode_from_stream(self, in_stream, nested):
+        value = in_stream.read_var_int64()
+        return self.internal_to_time(value)
+
+    def time_to_internal(self, t):
+        milliseconds = (t.hour * 3600000
+                        + t.minute * 60000
+                        + t.second * 1000
+                        + t.microsecond // 1000)
+        return milliseconds
+
+    def internal_to_time(self, v):
+        seconds, milliseconds = divmod(v, 1000)
+        minutes, seconds = divmod(seconds, 60)
+        hours, minutes = divmod(minutes, 60)
+        return datetime.time(hours, minutes, seconds, milliseconds * 1000)
+
+    def __repr__(self):
+        return "TimeCoderImpl"
+
+
+class DateTimeCoderImpl(StreamCoderImpl):
+
+    def encode_to_stream(self, value, out_stream, nested):
+        out_stream.write_var_int64(self.timestamp_to_internal(value))
+
+    def decode_from_stream(self, in_stream, nested):
+        value = in_stream.read_var_int64()
+        return self.internal_to_timestamp(value)
+
+    def timestamp_to_internal(self, timestamp):
+        from datetime import timezone
+        return int(timestamp.replace(tzinfo=timezone.utc).timestamp() * 1000)
+
+    def internal_to_timestamp(self, v):
+        return datetime.datetime.utcfromtimestamp(v // 1000).replace(microsecond=v % 1000 * 1000)
+
+    def __repr__(self):
+        return "DateTimeCoderImpl"
+
+
+class BinaryCoderImpl(StreamCoderImpl):
+
+    def encode_to_stream(self, value, out_stream, nested):
+        out_stream.write(value, True)
+
+    def decode_from_stream(self, in_stream, nested):
+        return in_stream.read_all(True)
+
+    def __repr__(self):
+        return "BinaryCoderImpl"
+
+
+class StringCoderImpl(StreamCoderImpl):
+
+    def encode_to_stream(self, value, out_stream, nested):
+        out_stream.write(value.encode("utf-8"), True)
+
+    def decode_from_stream(self, in_stream, nested):
+        return in_stream.read_all(True).decode("utf-8")
+
+    def __repr__(self):
+        return "StringCoderImpl"

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -16,6 +16,8 @@
 # limitations under the License.
 ################################################################################
 
+import datetime
+from decimal import Decimal
 from apache_beam.coders import Coder, VarIntCoder
 from apache_beam.coders.coders import FastCoder
 
@@ -62,9 +64,305 @@ class RowCoder(FastCoder):
         return hash(self._field_coders)
 
 
+class ArrayCoder(FastCoder):
+    """
+    Coder for Array.
+    """
+
+    def __init__(self, elem_coder):
+        self._elem_coder = elem_coder
+
+    def _create_impl(self):
+        return coder_impl.ArrayCoderImpl(self._elem_coder.get_impl())
+
+    def is_deterministic(self):
+        return self._elem_coder.is_deterministic()
+
+    def to_type_hint(self):
+        return []
+
+    def __repr__(self):
+        return 'ArrayCoder[%s]' % str(self._elem_coder)
+
+
+class MapCoder(FastCoder):
+    """
+    Coder for Map.
+    """
+
+    def __init__(self, key_coder, value_coder):
+        self._key_coder = key_coder
+        self._value_coder = value_coder
+
+    def _create_impl(self):
+        return coder_impl.MapCoderImpl(self._key_coder.get_impl(), self._value_coder.get_impl())
+
+    def is_deterministic(self):
+        return self._key_coder.is_deterministic() and self._value_coder.is_deterministic()
+
+    def to_type_hint(self):
+        return {}
+
+    def __repr__(self):
+        return 'MapCoder[%s]' % ','.join([str(self._key_coder), str(self._value_coder)])
+
+
+class MultiSetCoder(FastCoder):
+    """
+    Coder for Multiset
+    """
+
+    def __init__(self, element_coder):
+        self._element_coder = element_coder
+
+    def _create_impl(self):
+        return coder_impl.MultiSetCoderImpl(self._element_coder.get_impl())
+
+    def is_deterministic(self):
+        return self._element_coder.is_deterministic()
+
+    def to_type_hint(self):
+        return []
+
+    def __repr__(self):
+        return 'MultiSetCoder[%s]' % str(self._element_coder)
+
+
+class BooleanCoder(FastCoder):
+    """
+    Coder for Boolean
+    """
+
+    def _create_impl(self):
+        return coder_impl.BooleanCoderImpl()
+
+    def is_deterministic(self):
+        return True
+
+    def to_type_hint(self):
+        return bool
+
+    def __repr__(self):
+        return 'BooleanCoder'
+
+
+class ByteCoder(FastCoder):
+    """
+    Coder for Byte.
+    """
+
+    def _create_impl(self):
+        return coder_impl.ByteCoderImpl()
+
+    def is_deterministic(self):
+        return True
+
+    def to_type_hint(self):
+        return int
+
+    def __repr__(self):
+        return 'ByteCoder'
+
+
+class ShortCoder(FastCoder):
+    """
+    Coder for Short.
+    """
+
+    def _create_impl(self):
+        return coder_impl.ShortCoderImpl()
+
+    def is_deterministic(self):
+        return True
+
+    def to_type_hint(self):
+        return int
+
+    def __repr__(self):
+        return 'ShortCoder'
+
+
+class FloatCoder(FastCoder):
+    """
+    Coder for Float.
+    """
+
+    def _create_impl(self):
+        return coder_impl.FloatCoderImpl()
+
+    def is_deterministic(self):
+        return True
+
+    def to_type_hint(self):
+        return float
+
+    def __repr__(self):
+        return 'FloatCoder'
+
+
+class DoubleCoder(FastCoder):
+    """
+    Coder for Double.
+    """
+
+    def _create_impl(self):
+        return coder_impl.DoubleCoderImpl()
+
+    def is_deterministic(self):
+        return True
+
+    def to_type_hint(self):
+        return float
+
+    def __repr__(self):
+        return 'DoubleCoder'
+
+
+class DecimalCoder(FastCoder):
+    """
+    Coder for Decimal.
+    """
+
+    def __init__(self, str_coder):
+        self._str_coder = str_coder
+
+    def _create_impl(self):
+        return coder_impl.DecimalCoderImpl(self._str_coder.get_impl())
+
+    def is_deterministic(self):
+        return True
+
+    def to_type_hint(self):
+        return Decimal
+
+    def __repr__(self):
+        return "DecimalCoder"
+
+
+class DateCoder(FastCoder):
+    """
+    Coder for Date
+    """
+
+    def _create_impl(self):
+        return coder_impl.DateCoderImpl()
+
+    def is_deterministic(self):
+        return True
+
+    def to_type_hint(self):
+        return datetime.date
+
+    def __repr__(self):
+        return "DateCoder"
+
+
+class TimeCoder(FastCoder):
+    """
+    Coder for Time
+    """
+
+    def _create_impl(self):
+        return coder_impl.TimeCoderImpl()
+
+    def is_deterministic(self):
+        return True
+
+    def to_type_hint(self):
+        return datetime.time
+
+    def __repr__(self):
+        return "TimeCoder"
+
+
+class DateTimeCoder(FastCoder):
+    """
+    Coder for DateTime
+    """
+
+    def _create_impl(self):
+        return coder_impl.DateTimeCoderImpl()
+
+    def is_deterministic(self):
+        return True
+
+    def to_type_hint(self):
+        return datetime.datetime
+
+    def __repr__(self):
+        return "DateTimeCoder"
+
+
+class BinaryCoder(FastCoder):
+    """
+    Coder for Binary String
+    """
+
+    def _create_impl(self):
+        return coder_impl.BinaryCoderImpl()
+
+    def is_deterministic(self):
+        return True
+
+    def to_type_hint(self):
+        return bytearray
+
+    def __repr__(self):
+        return "BinaryCoder"
+
+
+class StringCoder(FastCoder):
+    """
+    Coder for Character String
+    """
+    def _create_impl(self):
+        return coder_impl.StringCoderImpl()
+
+    def is_deterministic(self):
+        return True
+
+    def to_type_hint(self):
+        return str
+
+    def __repr__(self):
+        return "StringCoder"
+
+
 @Coder.register_urn(FLINK_SCHEMA_CODER_URN, flink_fn_execution_pb2.Schema)
 def _pickle_from_runner_api_parameter(schema_proto, unused_components, unused_context):
     return RowCoder([from_proto(f.type) for f in schema_proto.fields])
+
+
+type_name = flink_fn_execution_pb2.Schema.TypeName
+BYTE_CODER = ByteCoder()
+SHORT_CODER = ShortCoder()
+BIGINT_CODER = VarIntCoder()
+BOOLEAN_CODER = BooleanCoder()
+BINARY_CODER = BinaryCoder()
+CHARACTER_CODER = StringCoder()
+FLOAT_CODER = FloatCoder()
+DOUBLE_CODER = DoubleCoder()
+DECIMAL_CODER = DecimalCoder(CHARACTER_CODER)
+DATE_CODER = DateCoder()
+TIME_CODER = TimeCoder()
+DATETIME_CODER = DateTimeCoder()
+_type_name_mappings = {
+    type_name.BOOLEAN: BOOLEAN_CODER,
+    type_name.TINYINT: BYTE_CODER,
+    type_name.SMALLINT: SHORT_CODER,
+    type_name.INT: BIGINT_CODER,
+    type_name.BIGINT: BIGINT_CODER,
+    type_name.BINARY: BINARY_CODER,
+    type_name.VARBINARY: BINARY_CODER,
+    type_name.CHAR: CHARACTER_CODER,
+    type_name.VARCHAR: CHARACTER_CODER,
+    type_name.FLOAT: FLOAT_CODER,
+    type_name.DOUBLE: DOUBLE_CODER,
+    type_name.DECIMAL: DECIMAL_CODER,
+    type_name.DATE: DATE_CODER,
+    type_name.TIME: TIME_CODER,
+    type_name.DATETIME: DATETIME_CODER
+}
 
 
 def from_proto(field_type):
@@ -74,9 +372,18 @@ def from_proto(field_type):
     :param field_type: the protocol representation of the field type
     :return: :class:`Coder`
     """
-    if field_type.type_name == flink_fn_execution_pb2.Schema.TypeName.BIGINT:
-        return VarIntCoder()
-    elif field_type.type_name == flink_fn_execution_pb2.Schema.TypeName.ROW:
+    field_type_name = field_type.type_name
+    coder = _type_name_mappings.get(field_type_name)
+    if coder is not None:
+        return coder
+    if field_type_name == type_name.ROW:
         return RowCoder([from_proto(f.type) for f in field_type.row_schema.fields])
+    elif field_type_name == type_name.ARRAY:
+        return ArrayCoder(from_proto(field_type.collection_element_type))
+    elif field_type_name == type_name.MAP:
+        return MapCoder(from_proto(field_type.map_type.key_type),
+                        from_proto(field_type.map_type.value_type))
+    elif field_type_name == type_name.MULTISET:
+        return MultiSetCoder(from_proto(field_type.collection_element_type))
     else:
         raise ValueError("field_type %s is not supported." % field_type)

--- a/flink-python/pyflink/table/tests/test_udf.py
+++ b/flink-python/pyflink/table/tests/test_udf.py
@@ -118,9 +118,6 @@ class UserDefinedFunctionTests(object):
                                      bigint_param, decimal_param, float_param, double_param,
                                      boolean_param, str_param,
                                      date_param, time_param, timestamp_param):
-            # decide whether two floats are equal
-            def float_equal(a, b, rel_tol=1e-09, abs_tol=0.0):
-                return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
 
             from decimal import Decimal
             import datetime
@@ -326,6 +323,253 @@ class UserDefinedFunctionTests(object):
         self.t_env.execute("test")
         actual = source_sink_utils.results()
         self.assert_equals(actual, ["1,2", "1,2", "1,2"])
+
+    def test_all_data_types(self):
+        def boolean_func(bool_param):
+            assert isinstance(bool_param, bool), 'bool_param of wrong type %s !' \
+                                                 % type(bool_param)
+            return bool_param
+
+        def tinyint_func(tinyint_param):
+            assert isinstance(tinyint_param, int), 'tinyint_param of wrong type %s !' \
+                                                   % type(tinyint_param)
+            return tinyint_param
+
+        def smallint_func(smallint_param):
+            assert isinstance(smallint_param, int), 'smallint_param of wrong type %s !' \
+                                                    % type(smallint_param)
+            return smallint_param
+
+        def int_func(int_param):
+            assert isinstance(int_param, int), 'int_param of wrong type %s !' \
+                                               % type(int_param)
+            return int_param
+
+        def bigint_func(bigint_param):
+            assert isinstance(bigint_param, int), 'bigint_param of wrong type %s !' \
+                                                  % type(bigint_param)
+            return bigint_param
+
+        def bytes_func(bytes_param):
+            assert bytes_param == b'flink', \
+                'bytes_param is wrong value %s !' % bytes_param
+            return bytes_param
+
+        def str_func(str_param):
+            assert str_param == 'pyflink', \
+                'str_param is wrong value %s !' % str_param
+            return str_param
+
+        def float_func(float_param):
+            assert isinstance(float_param, float) and float_equal(float_param, 1.23, 1e-6), \
+                'float_param is wrong value %s !' % float_param
+            return float_param
+
+        def double_func(double_param):
+            assert isinstance(double_param, float) and float_equal(double_param, 1.98932, 1e-7), \
+                'double_param is wrong value %s !' % double_param
+            return double_param
+
+        def decimal_func(decimal_param):
+            from decimal import Decimal
+            assert decimal_param == Decimal('1.050000000000000000'), \
+                'decimal_param is wrong value %s !' % decimal_param
+            return decimal_param
+
+        def date_func(date_param):
+            from datetime import date
+            assert date_param == date(year=2014, month=9, day=13), \
+                'date_param is wrong value %s !' % date_param
+            return date_param
+
+        def time_func(time_param):
+            from datetime import time
+            assert time_param == time(hour=12, minute=0, second=0), \
+                'time_param is wrong value %s !' % time_param
+            return time_param
+
+        def timestamp_func(timestamp_param):
+            from datetime import datetime
+            assert timestamp_param == datetime(1999, 9, 10, 5, 20, 10), \
+                'timestamp_param is wrong value %s !' % timestamp_param
+            return timestamp_param
+
+        def array_func(array_param):
+            assert array_param == [1, 2, 3], \
+                'array_param is wrong value %s !' % array_param
+            return array_param
+
+        def map_func(map_param):
+            assert map_param == {1: 'flink', 2: 'pyflink'}, \
+                'map_param is wrong value %s !' % map_param
+            return map_param
+
+        def multiset_func(multiset_param):
+            assert multiset_param == [1, 1, 2], \
+                'multiset_param is wrong value %s !' % multiset_param
+            return multiset_param
+
+        def create_multiset_func(p):
+            assert isinstance(p, int)
+            return [1, 1, 2]
+
+        self.t_env.register_function("boolean_func",
+                                     udf(boolean_func,
+                                         [DataTypes.BOOLEAN()],
+                                         DataTypes.BOOLEAN()))
+        self.t_env.register_function("tinyint_func",
+                                     udf(tinyint_func,
+                                         [DataTypes.TINYINT()],
+                                         DataTypes.TINYINT()))
+        self.t_env.register_function("smallint_func",
+                                     udf(smallint_func,
+                                         [DataTypes.SMALLINT()],
+                                         DataTypes.SMALLINT()))
+        self.t_env.register_function("int_func",
+                                     udf(int_func,
+                                         [DataTypes.INT()],
+                                         DataTypes.INT()))
+        self.t_env.register_function("bigint_func",
+                                     udf(bigint_func,
+                                         [DataTypes.BIGINT()],
+                                         DataTypes.BIGINT()))
+
+        self.t_env.register_function("bytes_func",
+                                     udf(bytes_func,
+                                         [DataTypes.BYTES()],
+                                         DataTypes.BYTES()))
+
+        self.t_env.register_function("str_func",
+                                     udf(str_func,
+                                         [DataTypes.STRING()],
+                                         DataTypes.STRING()))
+
+        self.t_env.register_function("float_func",
+                                     udf(float_func,
+                                         [DataTypes.FLOAT()],
+                                         DataTypes.FLOAT()))
+
+        self.t_env.register_function("double_func",
+                                     udf(double_func,
+                                         [DataTypes.DOUBLE()],
+                                         DataTypes.DOUBLE()))
+
+        self.t_env.register_function("decimal_func",
+                                     udf(decimal_func,
+                                         [DataTypes.DECIMAL(20, 10)],
+                                         DataTypes.DECIMAL(20, 10)))
+
+        self.t_env.register_function("date_func",
+                                     udf(date_func,
+                                         [DataTypes.DATE()],
+                                         DataTypes.DATE()))
+
+        self.t_env.register_function("time_func",
+                                     udf(time_func,
+                                         [DataTypes.TIME()],
+                                         DataTypes.TIME()))
+
+        self.t_env.register_function("timestamp_func",
+                                     udf(timestamp_func,
+                                         [DataTypes.TIMESTAMP()],
+                                         DataTypes.TIMESTAMP()))
+
+        self.t_env.register_function("array_func",
+                                     udf(array_func,
+                                         [DataTypes.ARRAY(DataTypes.BIGINT())],
+                                         DataTypes.ARRAY(DataTypes.BIGINT())))
+
+        self.t_env.register_function("map_func",
+                                     udf(map_func,
+                                         [DataTypes.MAP(DataTypes.BIGINT(), DataTypes.STRING())],
+                                         DataTypes.MAP(DataTypes.BIGINT(), DataTypes.STRING())))
+
+        self.t_env.register_function("create_multiset_func",
+                                     udf(create_multiset_func,
+                                         [DataTypes.BIGINT()],
+                                         DataTypes.MULTISET(DataTypes.BIGINT())))
+
+        self.t_env.register_function("multiset_func",
+                                     udf(multiset_func,
+                                         [DataTypes.MULTISET(DataTypes.BIGINT())],
+                                         DataTypes.MULTISET(DataTypes.BIGINT())))
+
+        table_sink = source_sink_utils.TestAppendSink(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h',
+                                                       'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p'],
+                                                      [DataTypes.BOOLEAN(),
+                                                       DataTypes.TINYINT(),
+                                                       DataTypes.SMALLINT(),
+                                                       DataTypes.INT(),
+                                                       DataTypes.BIGINT(),
+                                                       DataTypes.BYTES(),
+                                                       DataTypes.STRING(),
+                                                       DataTypes.FLOAT(),
+                                                       DataTypes.DOUBLE(),
+                                                       DataTypes.DECIMAL(20, 10),
+                                                       DataTypes.DATE(),
+                                                       DataTypes.TIME(),
+                                                       DataTypes.TIMESTAMP(),
+                                                       DataTypes.ARRAY(DataTypes.BIGINT()),
+                                                       DataTypes.MAP(DataTypes.BIGINT(),
+                                                                     DataTypes.STRING()),
+                                                       DataTypes.MULTISET(DataTypes.BIGINT())])
+        self.t_env.register_table_sink("Results", table_sink)
+
+        from decimal import Decimal
+        import datetime
+        t = self.t_env.from_elements(
+            [(True, 1, 1, 1, 1, bytearray(b'flink'), 'pyflink', 1.23,
+              1.98932, Decimal('1.050000000000000000'), datetime.date(2014, 9, 13),
+              datetime.time(hour=12, minute=0, second=0),
+              datetime.datetime(1999, 9, 10, 5, 20, 10),
+              [1, 2, 3], {1: 'flink', 2: 'pyflink'}, 1)],
+            DataTypes.ROW(
+                [DataTypes.FIELD("a", DataTypes.BOOLEAN()),
+                 DataTypes.FIELD("b", DataTypes.TINYINT()),
+                 DataTypes.FIELD("c", DataTypes.SMALLINT()),
+                 DataTypes.FIELD("d", DataTypes.INT()),
+                 DataTypes.FIELD("e", DataTypes.BIGINT()),
+                 DataTypes.FIELD("f", DataTypes.BYTES()),
+                 DataTypes.FIELD('g', DataTypes.STRING()),
+                 DataTypes.FIELD('h', DataTypes.FLOAT()),
+                 DataTypes.FIELD('i', DataTypes.DOUBLE()),
+                 DataTypes.FIELD('j', DataTypes.DECIMAL(20, 10)),
+                 DataTypes.FIELD('k', DataTypes.DATE()),
+                 DataTypes.FIELD('l', DataTypes.TIME()),
+                 DataTypes.FIELD('m', DataTypes.TIMESTAMP()),
+                 DataTypes.FIELD('n', DataTypes.ARRAY(DataTypes.BIGINT())),
+                 DataTypes.FIELD('o', DataTypes.MAP(DataTypes.BIGINT(),
+                                                    DataTypes.STRING())),
+                 DataTypes.FIELD('p', DataTypes.BIGINT())]))
+
+        t.select("boolean_func(a),"
+                 "tinyint_func(b),"
+                 "smallint_func(c),"
+                 "int_func(d),"
+                 "bigint_func(e),"
+                 "bytes_func(f),"
+                 "str_func(g),"
+                 "float_func(h),"
+                 "double_func(i),"
+                 "decimal_func(j),"
+                 "date_func(k),"
+                 "time_func(l),"
+                 "timestamp_func(m),"
+                 "array_func(n),"
+                 "map_func(o),"
+                 "multiset_func(create_multiset_func(p))") \
+            .insert_into("Results")
+        self.t_env.execute("test")
+        actual = source_sink_utils.results()
+        self.assert_equals(actual,
+                           ["true,1,1,1,1,[102, 108, 105, 110, 107],pyflink,1.23,1.98932,"
+                            "1.050000000000000000,2014-09-13,12:00:00,1999-09-10 05:20:10.0,"
+                            "[1, 2, 3],{1=flink, 2=pyflink},{1=2, 2=1}"])
+
+
+# decide whether two floats are equal
+def float_equal(a, b, rel_tol=1e-09, abs_tol=0.0):
+    return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
 
 
 class PyFlinkStreamUserDefinedFunctionTests(UserDefinedFunctionTests,

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonScalarFunctionOperator.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.planner.codegen.ProjectionCodeGenerator;
 import org.apache.flink.table.runtime.generated.GeneratedProjection;
 import org.apache.flink.table.runtime.generated.Projection;
 import org.apache.flink.table.runtime.runners.python.BaseRowPythonScalarFunctionRunner;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Collector;
 
@@ -71,8 +72,8 @@ public class BaseRowPythonScalarFunctionOperator
 
 	public BaseRowPythonScalarFunctionOperator(
 		PythonFunctionInfo[] scalarFunctions,
-		RowType inputType,
-		RowType outputType,
+		DataType inputType,
+		DataType outputType,
 		int[] udfInputOffsets,
 		int[] forwardedFields) {
 		super(scalarFunctions, inputType, outputType, udfInputOffsets, forwardedFields);
@@ -128,8 +129,8 @@ public class BaseRowPythonScalarFunctionOperator
 		final GeneratedProjection generatedProjection = ProjectionCodeGenerator.generateProjection(
 			CodeGeneratorContext.apply(new TableConfig()),
 			"UdfInputProjection",
-			inputType,
-			udfInputType,
+			(RowType) inputType.getLogicalType(),
+			(RowType) udfInputType.getLogicalType(),
 			udfInputOffsets);
 		// noinspection unchecked
 		return generatedProjection.newInstance(Thread.currentThread().getContextClassLoader());
@@ -138,12 +139,12 @@ public class BaseRowPythonScalarFunctionOperator
 	private Projection<BaseRow, BinaryRow> createForwardedFieldProjection() {
 		final RowType forwardedFieldType = new RowType(
 			Arrays.stream(forwardedFields)
-				.mapToObj(i -> inputType.getFields().get(i))
+				.mapToObj(i -> ((RowType) inputType.getLogicalType()).getFields().get(i))
 				.collect(Collectors.toList()));
 		final GeneratedProjection generatedProjection = ProjectionCodeGenerator.generateProjection(
 			CodeGeneratorContext.apply(new TableConfig()),
 			"ForwardedFieldProjection",
-			inputType,
+			(RowType) inputType.getLogicalType(),
 			forwardedFieldType,
 			forwardedFields);
 		// noinspection unchecked

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperator.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.runtime.runners.python.PythonScalarFunctionRunner;
 import org.apache.flink.table.runtime.types.CRow;
 import org.apache.flink.table.runtime.types.CRowTypeInfo;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.types.Row;
@@ -58,8 +59,8 @@ public class PythonScalarFunctionOperator extends AbstractPythonScalarFunctionOp
 
 	public PythonScalarFunctionOperator(
 		PythonFunctionInfo[] scalarFunctions,
-		RowType inputType,
-		RowType outputType,
+		DataType inputType,
+		DataType outputType,
 		int[] udfInputOffsets,
 		int[] forwardedFields) {
 		super(scalarFunctions, inputType, outputType, udfInputOffsets, forwardedFields);
@@ -72,7 +73,7 @@ public class PythonScalarFunctionOperator extends AbstractPythonScalarFunctionOp
 
 		CRowTypeInfo forwardedInputTypeInfo = new CRowTypeInfo(new RowTypeInfo(
 			Arrays.stream(forwardedFields)
-				.mapToObj(i -> inputType.getFields().get(i))
+				.mapToObj(i -> ((RowType) inputType.getLogicalType()).getFields().get(i))
 				.map(RowType.RowField::getType)
 				.map(TypeConversions::fromLogicalToDataType)
 				.map(TypeConversions::fromDataTypeToLegacyInfo)

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/AbstractPythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/AbstractPythonScalarFunctionRunner.java
@@ -27,7 +27,8 @@ import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.python.PythonEnv;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.runtime.typeutils.BeamTypeUtils;
-import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.util.Preconditions;
 
 import com.google.protobuf.ByteString;
@@ -71,16 +72,16 @@ public abstract class AbstractPythonScalarFunctionRunner<IN, OUT> extends Abstra
 	private static final String WINDOW_STRATEGY = "windowing_strategy";
 
 	private final PythonFunctionInfo[] scalarFunctions;
-	private final RowType inputType;
-	private final RowType outputType;
+	private final DataType inputType;
+	private final DataType outputType;
 
 	public AbstractPythonScalarFunctionRunner(
 		String taskName,
 		FnDataReceiver<OUT> resultReceiver,
 		PythonFunctionInfo[] scalarFunctions,
 		PythonEnv pythonEnv,
-		RowType inputType,
-		RowType outputType,
+		DataType inputType,
+		DataType outputType,
 		String[] tempDirs) {
 		super(taskName, resultReceiver, pythonEnv, StateRequestHandler.unsupported(), tempDirs);
 		this.scalarFunctions = Preconditions.checkNotNull(scalarFunctions);
@@ -89,16 +90,16 @@ public abstract class AbstractPythonScalarFunctionRunner<IN, OUT> extends Abstra
 	}
 
 	/**
-	 * Gets the logical type of the input elements of the Python user-defined functions.
+	 * Gets the DataType of the input elements of the Python user-defined functions.
 	 */
-	public RowType getInputType() {
+	public DataType getInputType() {
 		return inputType;
 	}
 
 	/**
-	 * Gets the logical type of the execution results of the Python user-defined functions.
+	 * Gets the DataType of the execution results of the Python user-defined functions.
 	 */
-	public RowType getOutputType() {
+	public DataType getOutputType() {
 		return outputType;
 	}
 
@@ -197,17 +198,17 @@ public abstract class AbstractPythonScalarFunctionRunner<IN, OUT> extends Abstra
 	 * Gets the proto representation of the input coder.
 	 */
 	private RunnerApi.Coder getInputCoderProto() {
-		return getRowCoderProto(inputType);
+		return getRowCoderProto(inputType.getLogicalType());
 	}
 
 	/**
 	 * Gets the proto representation of the output coder.
 	 */
 	private RunnerApi.Coder getOutputCoderProto() {
-		return getRowCoderProto(outputType);
+		return getRowCoderProto(outputType.getLogicalType());
 	}
 
-	private RunnerApi.Coder getRowCoderProto(RowType rowType) {
+	private RunnerApi.Coder getRowCoderProto(LogicalType rowType) {
 		return RunnerApi.Coder.newBuilder()
 			.setSpec(
 				RunnerApi.FunctionSpec.newBuilder()

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/BaseRowPythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/BaseRowPythonScalarFunctionRunner.java
@@ -25,7 +25,7 @@ import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.python.PythonEnv;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.runtime.typeutils.BeamTypeUtils;
-import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.DataType;
 
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
@@ -42,8 +42,8 @@ public class BaseRowPythonScalarFunctionRunner extends AbstractPythonScalarFunct
 		FnDataReceiver<BaseRow> resultReceiver,
 		PythonFunctionInfo[] scalarFunctions,
 		PythonEnv pythonEnv,
-		RowType inputType,
-		RowType outputType,
+		DataType inputType,
+		DataType outputType,
 		String[] tempDirs) {
 		super(taskName, resultReceiver, scalarFunctions, pythonEnv, inputType, outputType, tempDirs);
 	}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/PythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/PythonScalarFunctionRunner.java
@@ -24,7 +24,7 @@ import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.python.PythonEnv;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.runtime.typeutils.BeamTypeUtils;
-import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.types.Row;
 
 import org.apache.beam.sdk.coders.Coder;
@@ -42,8 +42,8 @@ public class PythonScalarFunctionRunner extends AbstractPythonScalarFunctionRunn
 		FnDataReceiver<Row> resultReceiver,
 		PythonFunctionInfo[] scalarFunctions,
 		PythonEnv pythonEnv,
-		RowType inputType,
-		RowType outputType,
+		DataType inputType,
+		DataType outputType,
 		String[] tempDirs) {
 		super(taskName, resultReceiver, scalarFunctions, pythonEnv, inputType, outputType, tempDirs);
 	}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/AbstractCoderFinder.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/AbstractCoderFinder.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders;
+
+import org.apache.beam.sdk.coders.Coder;
+
+import java.util.Map;
+
+/**
+ * The Abstract implementation of coder Finder find coder.
+ */
+public abstract class AbstractCoderFinder implements CoderFinder {
+
+	@Override
+	public <T> Coder<T> findMatchedCoder(Class<T> conversionClass) {
+		Coder<T> coder = (Coder<T>) getCoders().get(conversionClass);
+		if (coder == null) {
+			throw new IllegalArgumentException(
+				String.format("Unknown conversion class %s for %s coder.", conversionClass, getDataTypeName()));
+		}
+		return coder;
+	}
+
+	@Override
+	public <IN, OUT> Class<OUT> toInternalType(Class<IN> externalType) {
+		Class<OUT> internalTypeClass = (Class<OUT>) externalToInterval().get(externalType);
+		if (internalTypeClass == null) {
+			throw new IllegalArgumentException(
+				String.format("Unknown externalType class %s for %s.", externalType, getDataTypeName()));
+		}
+		return internalTypeClass;
+	}
+
+	abstract Map<Class<?>, Coder<?>> getCoders();
+
+	abstract Map<Class<?>, Class<?>> externalToInterval();
+
+	abstract String getDataTypeName();
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/ArrayCoder.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/ArrayCoder.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders;
+
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.util.VarInt;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Array;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A {@link Coder} for K[].
+ *
+ * @param <K> type of element.
+ */
+public class ArrayCoder<K> extends Coder<K[]> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final Coder<K> elementCoder;
+
+	private final Class<?> type;
+
+	public static <K> ArrayCoder<K> of(Coder<K> elementCoder, Class<?> type) {
+		return new ArrayCoder<>(elementCoder, type);
+	}
+
+	private ArrayCoder(Coder<K> elementCoder, Class<?> type) {
+		this.elementCoder = elementCoder;
+		this.type = type;
+	}
+
+	@Override
+	public void encode(K[] value, OutputStream outStream) throws IOException {
+		if (value == null) {
+			throw new CoderException("cannot encode a null Array");
+		}
+		VarInt.encode(value.length, outStream);
+		for (K ele : value) {
+			elementCoder.encode(ele, outStream);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public K[] decode(InputStream inStream) throws IOException {
+		int len = VarInt.decodeInt(inStream);
+		K[] arr = (K[]) Array.newInstance(type, len);
+		for (int i = 0; i < len; i++) {
+			arr[i] = elementCoder.decode(inStream);
+		}
+		return arr;
+	}
+
+	@Override
+	public List<? extends Coder<?>> getCoderArguments() {
+		return Collections.singletonList(elementCoder);
+	}
+
+	@Override
+	public void verifyDeterministic() {
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/BigDecimalCoder.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/BigDecimalCoder.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders;
+
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A {@link Coder} for {@link BigDecimal}.
+ */
+public class BigDecimalCoder extends Coder<BigDecimal> {
+
+	public static BigDecimalCoder of() {
+		return INSTANCE;
+	}
+
+	private static final BigDecimalCoder INSTANCE = new BigDecimalCoder();
+
+	private static final StringUtf8Coder STRING_CODER = StringUtf8Coder.of();
+
+	private BigDecimalCoder() {
+	}
+
+	@Override
+	public void encode(BigDecimal value, OutputStream outStream) throws IOException {
+		if (value == null) {
+			throw new CoderException("Cannot encode a null BigDecimal for BigDecimalCoder");
+		}
+		STRING_CODER.encode(value.toString(), outStream, Context.NESTED);
+	}
+
+	@Override
+	public BigDecimal decode(InputStream inStream) throws IOException {
+		return new BigDecimal(STRING_CODER.decode(inStream, Context.NESTED));
+	}
+
+	@Override
+	public List<? extends Coder<?>> getCoderArguments() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public void verifyDeterministic() {
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/BinaryArrayCoder.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/BinaryArrayCoder.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.dataformat.BinaryArray;
+import org.apache.flink.table.dataformat.BinaryArrayWriter;
+import org.apache.flink.table.dataformat.BinaryWriter;
+import org.apache.flink.table.dataformat.TypeGetterSetters;
+import org.apache.flink.table.runtime.types.InternalSerializers;
+import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.util.VarInt;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+/**
+ * A {@link Coder} for {@link BinaryArray}.
+ */
+public class BinaryArrayCoder extends Coder<BinaryArray> {
+	private static final long serialVersionUID = 1L;
+
+	private final LogicalType elementType;
+
+	private final int elementSize;
+
+	private final Coder<Object> elementCoder;
+
+	private final TypeSerializer eleSer;
+
+	public static BinaryArrayCoder of(DataType elementType, Coder<?> elementCoder) {
+		return new BinaryArrayCoder(elementType, elementCoder);
+	}
+
+	@SuppressWarnings("unchecked")
+	private BinaryArrayCoder(DataType elementType, Coder<?> elementCoder) {
+		this.elementType = LogicalTypeDataTypeConverter.fromDataTypeToLogicalType(elementType);
+		this.elementSize = BinaryArray.calculateFixLengthPartSize(this.elementType);
+		this.eleSer = InternalSerializers.create(this.elementType, new ExecutionConfig());
+		this.elementCoder = (Coder<Object>) elementCoder;
+	}
+
+	@Override
+	public void encode(BinaryArray array, OutputStream outStream) throws IOException {
+		if (array == null) {
+			throw new CoderException("Cannot encode a null BinaryArray for BinaryArrayCoder");
+		}
+		int size = array.numElements();
+		VarInt.encode(size, outStream);
+		for (int i = 0; i < size; i++) {
+			if (array.isNullAt(i)) {
+				throw new CoderException(String.format("Cannot encode a null at position %s in BinaryArray", i));
+			}
+			elementCoder.encode(TypeGetterSetters.get(array, i, elementType), outStream);
+		}
+	}
+
+	@Override
+	public BinaryArray decode(InputStream inStream) throws IOException {
+		int size = VarInt.decodeInt(inStream);
+		BinaryArray array = new BinaryArray();
+		BinaryArrayWriter arrayWriter = new BinaryArrayWriter(array, size, elementSize);
+		for (int i = 0; i < size; i++) {
+			BinaryWriter.write(arrayWriter, i, elementCoder.decode(inStream), elementType, eleSer);
+		}
+		arrayWriter.complete();
+		return array;
+	}
+
+	@Override
+	public List<? extends Coder<?>> getCoderArguments() {
+		return null;
+	}
+
+	@Override
+	public void verifyDeterministic() {
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/BinaryMapCoder.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/BinaryMapCoder.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.dataformat.BinaryArray;
+import org.apache.flink.table.dataformat.BinaryArrayWriter;
+import org.apache.flink.table.dataformat.BinaryMap;
+import org.apache.flink.table.dataformat.BinaryWriter;
+import org.apache.flink.table.dataformat.TypeGetterSetters;
+import org.apache.flink.table.runtime.types.InternalSerializers;
+import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+/**
+ * A {@link Coder} for {@link BinaryMap}.
+ */
+public class BinaryMapCoder extends Coder<BinaryMap> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final LogicalType keyType;
+
+	private final LogicalType valueType;
+
+	private final int keyElementSize;
+
+	private final int valueElementSize;
+
+	private final TypeSerializer keySer;
+
+	private final TypeSerializer valueSer;
+
+	private final Coder<Object> keyCoder;
+
+	private final Coder<Object> valueCoder;
+
+	public static BinaryMapCoder of(DataType keyDataType, DataType valueDataType, Coder<?> keyCoder, Coder<?> valueCoder) {
+		return new BinaryMapCoder(keyDataType, valueDataType, keyCoder, valueCoder);
+	}
+
+	@SuppressWarnings("unchecked")
+	private BinaryMapCoder(DataType keyDataType, DataType valueDataType, Coder<?> keyCoder, Coder<?> valueCoder) {
+		this.keyType = LogicalTypeDataTypeConverter.fromDataTypeToLogicalType(keyDataType);
+		this.valueType = LogicalTypeDataTypeConverter.fromDataTypeToLogicalType(valueDataType);
+		this.keyElementSize = BinaryArray.calculateFixLengthPartSize(keyType);
+		this.valueElementSize = BinaryArray.calculateFixLengthPartSize(valueType);
+		this.keySer = InternalSerializers.create(this.keyType, new ExecutionConfig());
+		this.valueSer = InternalSerializers.create(this.valueType, new ExecutionConfig());
+		this.keyCoder = (Coder<Object>) keyCoder;
+		this.valueCoder = (Coder<Object>) valueCoder;
+	}
+
+	@Override
+	public void encode(BinaryMap map, OutputStream outStream) throws IOException {
+		if (map == null) {
+			throw new CoderException("Cannot encode a null BinaryMap for BinaryMapCoder");
+		}
+		DataOutputStream dataOutStream = new DataOutputStream(outStream);
+		int size = map.numElements();
+		dataOutStream.writeInt(size);
+		BinaryArray keyArray = map.keyArray();
+		BinaryArray valueArray = map.valueArray();
+		for (int i = 0; i < size; i++) {
+			if (keyArray.isNullAt(i)) {
+				throw new CoderException(String.format("Cannot encode a null key at position %s in BinaryMap", i));
+			}
+			if (valueArray.isNullAt(i)) {
+				throw new CoderException(String.format("Cannot encode a null value at position %s in BinaryMap", i));
+			}
+			keyCoder.encode(TypeGetterSetters.get(keyArray, i, keyType), outStream);
+			valueCoder.encode(TypeGetterSetters.get(valueArray, i, valueType), outStream);
+		}
+	}
+
+	@Override
+	public BinaryMap decode(InputStream inStream) throws IOException {
+		DataInputStream dataInStream = new DataInputStream(inStream);
+		int size = dataInStream.readInt();
+		BinaryArray keyArray = new BinaryArray();
+		BinaryArray valueArray = new BinaryArray();
+		BinaryArrayWriter keyWriter = new BinaryArrayWriter(keyArray, size, keyElementSize);
+		BinaryArrayWriter valueWriter = new BinaryArrayWriter(valueArray, size, valueElementSize);
+		for (int i = 0; i < size; i++) {
+			BinaryWriter.write(keyWriter, i, keyCoder.decode(inStream), keyType, keySer);
+			BinaryWriter.write(valueWriter, i, valueCoder.decode(inStream), valueType, valueSer);
+		}
+		keyWriter.complete();
+		valueWriter.complete();
+		return BinaryMap.valueOf(keyArray, valueArray);
+	}
+
+	@Override
+	public List<? extends Coder<?>> getCoderArguments() {
+		return null;
+	}
+
+	@Override
+	public void verifyDeterministic() {
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/CharTypeCoders.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/CharTypeCoders.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders;
+
+import org.apache.flink.table.dataformat.BinaryString;
+
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * CharTypeCoders include all kinds of coders for CharType/VarCharType.
+ */
+public class CharTypeCoders extends AbstractCoderFinder {
+
+	private static final StringUtf8Coder STRING_UTF_8_CODER = StringUtf8Coder.of();
+
+	private static final BinaryStringCoder BINARY_STRING_CODER = BinaryStringCoder.of();
+
+	public static CharTypeCoders of() {
+		return INSTANCE;
+	}
+
+	private static final CharTypeCoders INSTANCE = new CharTypeCoders();
+
+	private Map<Class<?>, Coder<?>> coders = new HashMap<>();
+
+	private Map<Class<?>, Class<?>> externalToInternal = new HashMap<>();
+
+	private CharTypeCoders() {
+		coders.put(String.class, STRING_UTF_8_CODER);
+		coders.put(BinaryString.class, BINARY_STRING_CODER);
+		externalToInternal.put(String.class, BinaryString.class);
+	}
+
+	@Override
+	Map<Class<?>, Coder<?>> getCoders() {
+		return coders;
+	}
+
+	@Override
+	Map<Class<?>, Class<?>> externalToInterval() {
+		return externalToInternal;
+	}
+
+	@Override
+	String getDataTypeName() {
+		return "CharType/VarCharType";
+	}
+
+	/**
+	 * A {@link Coder} for {@link BinaryString}.
+	 */
+	public static class BinaryStringCoder extends Coder<BinaryString> {
+		private static final long serialVersionUID = 1L;
+
+		public static BinaryStringCoder of() {
+			return INSTANCE;
+		}
+
+		private static final BinaryStringCoder INSTANCE = new BinaryStringCoder();
+
+		private BinaryStringCoder() {
+		}
+
+		@Override
+		public void encode(BinaryString value, OutputStream outStream) throws IOException {
+			if (value == null) {
+				throw new CoderException("Cannot encode a null BinaryString for BinaryStringCoder");
+			}
+			STRING_UTF_8_CODER.encode(value.toString(), outStream);
+		}
+
+		@Override
+		public BinaryString decode(InputStream inStream) throws IOException {
+			return BinaryString.fromString(STRING_UTF_8_CODER.decode(inStream));
+		}
+
+		@Override
+		public List<? extends Coder<?>> getCoderArguments() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public void verifyDeterministic() {
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/CoderFinder.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/CoderFinder.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders;
+
+import org.apache.beam.sdk.coders.Coder;
+
+/**
+ * The coder Finder find coder for corresponding conversionClass.
+ */
+public interface CoderFinder {
+	<T> Coder<T> findMatchedCoder(Class<T> conversionClass);
+
+	<IN, OUT> Class<OUT> toInternalType(Class<IN> externalType);
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/DateTypeCoders.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/DateTypeCoders.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders;
+
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.util.VarInt;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+
+/**
+ * DataTypeCoders include all kinds of coders for DateType.
+ */
+public class DateTypeCoders extends AbstractCoderFinder {
+
+	private static final VarIntCoder INT_DATE_CODER = VarIntCoder.of();
+
+	private static final DateCoder DATE_CODER = DateCoder.of();
+
+	public static DateTypeCoders of() {
+		return INSTANCE;
+	}
+
+	private static final DateTypeCoders INSTANCE = new DateTypeCoders();
+
+	private Map<Class<?>, Coder<?>> coders = new HashMap<>();
+
+	private Map<Class<?>, Class<?>> externalToInternal = new HashMap<>();
+
+	private DateTypeCoders() {
+		coders.put(Date.class, DATE_CODER);
+		coders.put(Integer.class, INT_DATE_CODER);
+		coders.put(int.class, INT_DATE_CODER);
+		externalToInternal.put(LocalDate.class, Integer.class);
+	}
+
+	@Override
+	Map<Class<?>, Coder<?>> getCoders() {
+		return coders;
+	}
+
+	@Override
+	Map<Class<?>, Class<?>> externalToInterval() {
+		return externalToInternal;
+	}
+
+	@Override
+	String getDataTypeName() {
+		return "DateType";
+	}
+
+	/**
+	 * A {@link Coder} for {@link Date}.
+	 */
+	public static class DateCoder extends Coder<Date> {
+
+		private static final long serialVersionUID = 1L;
+
+		/**
+		 * The local time zone.
+		 */
+		private static final TimeZone LOCAL_TZ = TimeZone.getDefault();
+
+		private static final long MILLIS_PER_DAY = 86400000L; // = 24 * 60 * 60 * 1000
+
+		private static final DateCoder INSTANCE = new DateCoder();
+
+		public static DateCoder of() {
+			return INSTANCE;
+		}
+
+		private DateCoder() {
+		}
+
+		@Override
+		public void encode(Date value, OutputStream outStream) throws IOException {
+			if (value == null) {
+				throw new CoderException("Cannot encode a null java.sql.Date for DateCoder");
+			}
+			VarInt.encode(dateToInternal(value), outStream);
+		}
+
+		@Override
+		public Date decode(InputStream inStream) throws IOException {
+			return internalToDate(VarInt.decodeInt(inStream));
+		}
+
+		@Override
+		public List<? extends Coder<?>> getCoderArguments() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public void verifyDeterministic() {
+		}
+
+		private int dateToInternal(Date date) {
+			long ts = date.getTime() + LOCAL_TZ.getOffset(date.getTime());
+			return (int) (ts / MILLIS_PER_DAY);
+		}
+
+		private Date internalToDate(int v) {
+			final long t = v * MILLIS_PER_DAY;
+			return new Date(t - LOCAL_TZ.getOffset(t));
+		}
+
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/DecimalCoder.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/DecimalCoder.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders;
+
+import org.apache.flink.table.dataformat.Decimal;
+
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A {@link Coder} for {@link Decimal}.
+ */
+public class DecimalCoder extends Coder<Decimal> {
+
+	private static final long serialVersionUID = 1L;
+
+	public static DecimalCoder of(int precision, int scale) {
+		return new DecimalCoder(precision, scale);
+	}
+
+	private static final BigDecimalCoder BIG_DECIMAL_CODER = BigDecimalCoder.of();
+
+	private final int precision;
+
+	private final int scale;
+
+	private DecimalCoder(int precision, int scale) {
+		this.precision = precision;
+		this.scale = scale;
+	}
+
+	@Override
+	public void encode(Decimal value, OutputStream outStream) throws IOException {
+		if (value == null) {
+			throw new CoderException("Cannot encode a null Decimal for DecimalCoder");
+		}
+		BIG_DECIMAL_CODER.encode(value.toBigDecimal(), outStream);
+	}
+
+	@Override
+	public Decimal decode(InputStream inStream) throws IOException {
+		return Decimal.fromBigDecimal(BIG_DECIMAL_CODER.decode(inStream), precision, scale);
+	}
+
+	@Override
+	public List<? extends Coder<?>> getCoderArguments() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public void verifyDeterministic() {
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/LegacyTypeInformationTypeCoders.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/LegacyTypeInformationTypeCoders.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders;
+
+import org.apache.beam.sdk.coders.Coder;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * LegacyTypeInformationTypeCoders only include BigDecimalCoder currently.
+ */
+public class LegacyTypeInformationTypeCoders extends AbstractCoderFinder {
+
+	public static LegacyTypeInformationTypeCoders of() {
+		return INSTANCE;
+	}
+
+	private static final LegacyTypeInformationTypeCoders INSTANCE = new LegacyTypeInformationTypeCoders();
+
+	private Map<Class<?>, Coder<?>> coders = new HashMap<>();
+
+	private LegacyTypeInformationTypeCoders() {
+		coders.put(BigDecimal.class, BigDecimalCoder.of());
+	}
+
+	@Override
+	Map<Class<?>, Coder<?>> getCoders() {
+		return coders;
+	}
+
+	@Override
+	Map<Class<?>, Class<?>> externalToInterval() {
+		return null;
+	}
+
+	@Override
+	String getDataTypeName() {
+		return "LegacyTypeInformationType";
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/TimeTypeCoders.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/TimeTypeCoders.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders;
+
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.util.VarInt;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.sql.Time;
+import java.time.LocalTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * TimeTypeCoders includes all kinds of coders for TimeType.
+ */
+public class TimeTypeCoders extends AbstractCoderFinder {
+
+	private static final TimeCoder TIME_CODER = TimeCoder.of();
+
+	private static final VarIntCoder INT_CODER = VarIntCoder.of();
+
+	public static TimeTypeCoders of() {
+		return INSTANCE;
+	}
+
+	private static final TimeTypeCoders INSTANCE = new TimeTypeCoders();
+
+	private Map<Class<?>, Coder<?>> coders = new HashMap<>();
+
+	private Map<Class<?>, Class<?>> externalToInternal = new HashMap<>();
+
+	private TimeTypeCoders() {
+		coders.put(Time.class, TIME_CODER);
+		coders.put(int.class, INT_CODER);
+		coders.put(Integer.class, INT_CODER);
+		externalToInternal.put(LocalTime.class, Integer.class);
+	}
+
+	@Override
+	Map<Class<?>, Coder<?>> getCoders() {
+		return coders;
+	}
+
+	@Override
+	Map<Class<?>, Class<?>> externalToInterval() {
+		return externalToInternal;
+	}
+
+	@Override
+	String getDataTypeName() {
+		return "TimeType";
+	}
+
+	/**
+	 * A {@link Coder} for {@link Time}.
+	 */
+	public static class TimeCoder extends Coder<Time> {
+
+		private static final long serialVersionUID = 1L;
+
+		/**
+		 * The number of milliseconds in a second.
+		 */
+		private static final int MILLIS_PER_SECOND = 1000;
+
+		/**
+		 * The number of milliseconds in a minute.
+		 */
+		private static final int MILLIS_PER_MINUTE = 60000;
+
+		/**
+		 * The number of milliseconds in an hour.
+		 */
+		private static final int MILLIS_PER_HOUR = 3600000; // = 60 * 60 * 1000
+
+		public static TimeCoder of() {
+			return INSTANCE;
+		}
+
+		private static final TimeCoder INSTANCE = new TimeCoder();
+
+		private TimeCoder() {
+		}
+
+		@Override
+		public void encode(Time value, OutputStream outStream) throws IOException {
+			if (value == null) {
+				throw new CoderException("Cannot encode a null java.sql.Time for TimeCoder");
+			}
+			VarInt.encode(timeToInternal(value), outStream);
+		}
+
+		@Override
+		public Time decode(InputStream inStream) throws IOException {
+			return internalToTime(VarInt.decodeInt(inStream));
+		}
+
+		@Override
+		public List<? extends Coder<?>> getCoderArguments() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public void verifyDeterministic() {
+		}
+
+		private int timeToInternal(Time time) {
+			return time.getHours() * MILLIS_PER_HOUR
+				+ time.getMinutes() * MILLIS_PER_MINUTE
+				+ time.getSeconds() * MILLIS_PER_SECOND;
+		}
+
+		private Time internalToTime(int time) {
+			int h = time / MILLIS_PER_HOUR;
+			int time2 = time % MILLIS_PER_HOUR;
+			int m = time2 / MILLIS_PER_MINUTE;
+			int time3 = time2 % MILLIS_PER_MINUTE;
+			int s = time3 / MILLIS_PER_SECOND;
+			return new Time(h, m, s);
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/TimestampTypeCoders.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/TimestampTypeCoders.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders;
+
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.coders.VarLongCoder;
+import org.apache.beam.sdk.util.VarInt;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+
+/**
+ * TimestampTypeCoders includes all kinds of coders for TimestampType.
+ */
+public class TimestampTypeCoders extends AbstractCoderFinder {
+
+	public static final TimestampCoder TIMESTAMP_CODER = TimestampCoder.of();
+
+	private static final VarLongCoder LONG_CODER = VarLongCoder.of();
+
+	public static TimestampTypeCoders of() {
+		return INSTANCE;
+	}
+
+	private static final TimestampTypeCoders INSTANCE = new TimestampTypeCoders();
+
+	private Map<Class<?>, Coder<?>> coders = new HashMap<>();
+
+	private Map<Class<?>, Class<?>> externalToInternal = new HashMap<>();
+
+	private TimestampTypeCoders() {
+		coders.put(Long.class, LONG_CODER);
+		coders.put(long.class, LONG_CODER);
+		coders.put(Timestamp.class, TIMESTAMP_CODER);
+		externalToInternal.put(LocalDateTime.class, Long.class);
+	}
+
+	@Override
+	Map<Class<?>, Coder<?>> getCoders() {
+		return coders;
+	}
+
+	@Override
+	Map<Class<?>, Class<?>> externalToInterval() {
+		return externalToInternal;
+	}
+
+	@Override
+	String getDataTypeName() {
+		return "TimestampType";
+	}
+
+	/**
+	 * A {@link Coder} for {@link Timestamp}.
+	 */
+	public static class TimestampCoder extends Coder<Timestamp> {
+
+		private static final long serialVersionUID = 1L;
+
+		private static final TimeZone LOCAL_TZ = TimeZone.getDefault();
+
+		public static TimestampCoder of() {
+			return INSTANCE;
+		}
+
+		private static final TimestampCoder INSTANCE = new TimestampCoder();
+
+		private TimestampCoder() {
+		}
+
+		@Override
+		public void encode(Timestamp value, OutputStream outStream) throws IOException {
+			if (value == null) {
+				throw new CoderException("Cannot encode a null java.sql.Timestamp for TimestampTypeCoders");
+			}
+			VarInt.encode(timestampToInternal(value), outStream);
+		}
+
+		@Override
+		public Timestamp decode(InputStream inStream) throws IOException {
+			return internalToTimestamp(VarInt.decodeLong(inStream));
+		}
+
+		@Override
+		public List<? extends Coder<?>> getCoderArguments() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public void verifyDeterministic() {
+		}
+
+		private long timestampToInternal(Timestamp ts) {
+			long time = ts.getTime();
+			return time + LOCAL_TZ.getOffset(time);
+		}
+
+		public Timestamp internalToTimestamp(long v) {
+			return new Timestamp(v - LOCAL_TZ.getOffset(v));
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/factory/AtomicDataTypeCoderFactory.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/factory/AtomicDataTypeCoderFactory.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders.factory;
+
+import org.apache.flink.table.runtime.typeutils.coders.CharTypeCoders;
+import org.apache.flink.table.runtime.typeutils.coders.CoderFinder;
+import org.apache.flink.table.runtime.typeutils.coders.DateTypeCoders;
+import org.apache.flink.table.runtime.typeutils.coders.DecimalCoder;
+import org.apache.flink.table.runtime.typeutils.coders.LegacyTypeInformationTypeCoders;
+import org.apache.flink.table.runtime.typeutils.coders.TimeTypeCoders;
+import org.apache.flink.table.runtime.typeutils.coders.TimestampTypeCoders;
+import org.apache.flink.table.types.AtomicDataType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LegacyTypeInformationType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.NullType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import org.apache.beam.sdk.coders.BigEndianShortCoder;
+import org.apache.beam.sdk.coders.BooleanCoder;
+import org.apache.beam.sdk.coders.ByteArrayCoder;
+import org.apache.beam.sdk.coders.ByteCoder;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.DoubleCoder;
+import org.apache.beam.sdk.coders.FloatCoder;
+import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.coders.VarLongCoder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The coder factory for {@link AtomicDataType}.
+ */
+public class AtomicDataTypeCoderFactory implements DataTypeCoderFactory<AtomicDataType> {
+
+	private static final BooleanCoder BOOLEAN_CODER = BooleanCoder.of();
+
+	private static final ByteCoder BYTE_CODER = ByteCoder.of();
+
+	private static final DoubleCoder DOUBLE_CODER = DoubleCoder.of();
+
+	private static final FloatCoder FLOAT_CODER = FloatCoder.of();
+
+	private static final VarIntCoder INT_CODER = VarIntCoder.of();
+
+	private static final VarLongCoder LONG_CODER = VarLongCoder.of();
+
+	private static final BigEndianShortCoder SHORT_CODER = BigEndianShortCoder.of();
+
+	private static final ByteArrayCoder BYTE_ARRAY_CODER = ByteArrayCoder.of();
+
+	private Map<Class<? extends LogicalType>, Coder<?>> primitiveLogicalTypeCoderMap = new HashMap<>();
+
+	private Map<Class<? extends LogicalType>, CoderFinder> complicatedLogicalTypeCoderMap = new HashMap<>();
+
+	public static AtomicDataTypeCoderFactory of(boolean isBlinkPlanner) {
+		if (isBlinkPlanner) {
+			return BLINK_INSTANCE;
+		} else {
+			return FLINK_INSTANCE;
+		}
+	}
+
+	private static final AtomicDataTypeCoderFactory FLINK_INSTANCE = new AtomicDataTypeCoderFactory(false);
+
+	private static final AtomicDataTypeCoderFactory BLINK_INSTANCE = new AtomicDataTypeCoderFactory(true);
+
+	private final boolean isBlinkPlanner;
+
+	private AtomicDataTypeCoderFactory(boolean isBlinkPlanner) {
+		this.isBlinkPlanner = isBlinkPlanner;
+		// Coder for primitive coder.
+		primitiveLogicalTypeCoderMap.put(BooleanType.class, BOOLEAN_CODER);
+		primitiveLogicalTypeCoderMap.put(TinyIntType.class, BYTE_CODER);
+		primitiveLogicalTypeCoderMap.put(SmallIntType.class, SHORT_CODER);
+		primitiveLogicalTypeCoderMap.put(IntType.class, INT_CODER);
+		primitiveLogicalTypeCoderMap.put(BigIntType.class, LONG_CODER);
+		primitiveLogicalTypeCoderMap.put(FloatType.class, FLOAT_CODER);
+		primitiveLogicalTypeCoderMap.put(DoubleType.class, DOUBLE_CODER);
+		primitiveLogicalTypeCoderMap.put(NullType.class, null);
+		primitiveLogicalTypeCoderMap.put(BinaryType.class, BYTE_ARRAY_CODER);
+		primitiveLogicalTypeCoderMap.put(VarBinaryType.class, BYTE_ARRAY_CODER);
+
+		// coder for complicated coder which may choose coder according conversion class.
+		complicatedLogicalTypeCoderMap.put(CharType.class, CharTypeCoders.of());
+		complicatedLogicalTypeCoderMap.put(VarCharType.class, CharTypeCoders.of());
+		complicatedLogicalTypeCoderMap.put(DateType.class, DateTypeCoders.of());
+		complicatedLogicalTypeCoderMap.put(TimeType.class, TimeTypeCoders.of());
+		complicatedLogicalTypeCoderMap.put(TimestampType.class, TimestampTypeCoders.of());
+		complicatedLogicalTypeCoderMap.put(LegacyTypeInformationType.class, LegacyTypeInformationTypeCoders.of());
+	}
+
+	@Override
+	public Coder findCoder(AtomicDataType dataType) {
+		LogicalType logicalType = dataType.getLogicalType();
+		Class<?> conversionClass = dataType.getConversionClass();
+		Coder foundCoder = primitiveLogicalTypeCoderMap.get(logicalType.getClass());
+		if (foundCoder != null) {
+			return foundCoder;
+		}
+		if (logicalType instanceof DecimalType) {
+			DecimalType decimalType = (DecimalType) logicalType;
+			return DecimalCoder.of(decimalType.getPrecision(), decimalType.getScale());
+		} else {
+			CoderFinder finder = complicatedLogicalTypeCoderMap.getOrDefault(logicalType.getClass(), NotFoundCoder.of());
+			return finder.findMatchedCoder(isBlinkPlanner ?
+				finder.toInternalType(conversionClass) : conversionClass);
+		}
+	}
+
+	private static class NotFoundCoder implements CoderFinder {
+
+		public static NotFoundCoder of() {
+			return INSTANCE;
+		}
+
+		private static final NotFoundCoder INSTANCE = new NotFoundCoder();
+
+		@Override
+		public <T> Coder<T> findMatchedCoder(Class<T> conversionClass) {
+			throw new IllegalArgumentException("No matched AtomicDataType Coder for " + conversionClass);
+		}
+
+		@Override
+		public <IN, OUT> Class<OUT> toInternalType(Class<IN> externalType) {
+			return null;
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/factory/CollectionDataTypeCoderFactory.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/factory/CollectionDataTypeCoderFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders.factory;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.runtime.typeutils.coders.ArrayCoder;
+import org.apache.flink.table.runtime.typeutils.coders.BinaryArrayCoder;
+import org.apache.flink.table.runtime.typeutils.coders.BinaryMapCoder;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.DataTypeVisitor;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MultisetType;
+
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.MapCoder;
+import org.apache.beam.sdk.coders.VarIntCoder;
+
+/**
+ * The coder factory for {@link CollectionDataType}.
+ */
+public class CollectionDataTypeCoderFactory implements DataTypeCoderFactory<CollectionDataType> {
+	public static CollectionDataTypeCoderFactory of(DataTypeVisitor<Coder> dataTypeVisitor, boolean isBlinkPlanner) {
+		return new CollectionDataTypeCoderFactory(dataTypeVisitor, isBlinkPlanner);
+	}
+
+	private final DataTypeVisitor<Coder> dataTypeVisitor;
+
+	private final boolean isBlinkPlanner;
+
+	private CollectionDataTypeCoderFactory(DataTypeVisitor<Coder> dataTypeVisitor, boolean isBlinkPlanner) {
+		this.dataTypeVisitor = dataTypeVisitor;
+		this.isBlinkPlanner = isBlinkPlanner;
+	}
+
+	@Override
+	public Coder findCoder(CollectionDataType dataType) {
+		DataType elementType = dataType.getElementDataType();
+		LogicalType logicalType = dataType.getLogicalType();
+		Coder<?> elementCoder = elementType.accept(dataTypeVisitor);
+		if (logicalType instanceof ArrayType) {
+			if (isBlinkPlanner) {
+				return BinaryArrayCoder.of(elementType, elementCoder);
+			}
+			return ArrayCoder.of(elementCoder, elementType.getConversionClass());
+		} else if (logicalType instanceof MultisetType) {
+			if (isBlinkPlanner) {
+				return BinaryMapCoder.of(elementType, DataTypes.INT(), elementCoder, VarIntCoder.of());
+			}
+			return MapCoder.of(elementCoder, VarIntCoder.of());
+		}
+		throw new IllegalArgumentException("No matched CollectionDataType Coder for " + logicalType);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/factory/DataTypeCoderFactory.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/factory/DataTypeCoderFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders.factory;
+
+import org.apache.flink.table.types.DataType;
+
+import org.apache.beam.sdk.coders.Coder;
+
+/**
+ * The coder factory of {@link DataType}. The factory find coder for corresponding DataType.
+ */
+public interface DataTypeCoderFactory<T extends DataType> {
+	Coder findCoder(T dataType);
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/factory/FieldsDataTypeCoderFactory.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/factory/FieldsDataTypeCoderFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders.factory;
+
+import org.apache.flink.table.runtime.typeutils.coders.BaseRowCoder;
+import org.apache.flink.table.runtime.typeutils.coders.RowCoder;
+import org.apache.flink.table.types.DataTypeVisitor;
+import org.apache.flink.table.types.FieldsDataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.beam.sdk.coders.Coder;
+
+/**
+ * The coder factory for {@link FieldsDataType}.
+ */
+public class FieldsDataTypeCoderFactory implements DataTypeCoderFactory<FieldsDataType> {
+	public static FieldsDataTypeCoderFactory of(DataTypeVisitor<Coder> dataTypeVisitor, boolean isBlinkPlanner) {
+		return new FieldsDataTypeCoderFactory(dataTypeVisitor, isBlinkPlanner);
+	}
+
+	private final DataTypeVisitor<Coder> dataTypeVisitor;
+
+	private final boolean isBlinkPlanner;
+
+	private FieldsDataTypeCoderFactory(DataTypeVisitor<Coder> dataTypeVisitor, boolean isBlinkPlanner) {
+		this.dataTypeVisitor = dataTypeVisitor;
+		this.isBlinkPlanner = isBlinkPlanner;
+	}
+
+	@Override
+	public Coder findCoder(FieldsDataType dataType) {
+		LogicalType logicalType = dataType.getLogicalType();
+		LogicalType[] fieldTypes = dataType.getLogicalType().getChildren().toArray(new LogicalType[0]);
+		if (logicalType instanceof RowType) {
+			final Coder[] fieldCoders = ((RowType) logicalType).getFieldNames()
+				.stream()
+				.map(f -> dataType.getFieldDataTypes().get(f).accept(dataTypeVisitor))
+				.toArray(Coder[]::new);
+			if (isBlinkPlanner) {
+				return new BaseRowCoder(fieldCoders, fieldTypes);
+			}
+			return new RowCoder(fieldCoders);
+		}
+		throw new IllegalArgumentException("No matched FieldsDataType Coder for " + logicalType);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/factory/KeyValueDataTypeCoderFactory.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/coders/factory/KeyValueDataTypeCoderFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders.factory;
+
+import org.apache.flink.table.runtime.typeutils.coders.BinaryMapCoder;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.DataTypeVisitor;
+import org.apache.flink.table.types.KeyValueDataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.MapCoder;
+
+/**
+ * The coder factory for {@link KeyValueDataType}.
+ */
+public class KeyValueDataTypeCoderFactory implements DataTypeCoderFactory<KeyValueDataType> {
+	public static KeyValueDataTypeCoderFactory of(DataTypeVisitor<Coder> dataTypeVisitor, boolean isBlinkPlanner) {
+		return new KeyValueDataTypeCoderFactory(dataTypeVisitor, isBlinkPlanner);
+	}
+
+	private final DataTypeVisitor<Coder> dataTypeVisitor;
+
+	private final boolean isBlinkPlanner;
+
+	private KeyValueDataTypeCoderFactory(DataTypeVisitor<Coder> dataTypeVisitor, boolean isBlinkPlanner) {
+		this.dataTypeVisitor = dataTypeVisitor;
+		this.isBlinkPlanner = isBlinkPlanner;
+	}
+
+	@Override
+	public Coder findCoder(KeyValueDataType dataType) {
+		LogicalType logicalType = dataType.getLogicalType();
+		DataType keyDataType = dataType.getKeyDataType();
+		DataType valueDataType = dataType.getValueDataType();
+		Coder<?> keyCoder = keyDataType.accept(dataTypeVisitor);
+		Coder<?> valueCoder = valueDataType.accept(dataTypeVisitor);
+		if (logicalType instanceof MapType) {
+			if (isBlinkPlanner) {
+				return BinaryMapCoder.of(keyDataType, valueDataType, keyCoder, valueCoder);
+			}
+			return MapCoder.of(keyCoder, valueCoder);
+		}
+		throw new IllegalArgumentException("No matched KeyValueDataType Coder for " + logicalType);
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/table/functions/python/AbstractPythonScalarFunctionRunnerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/functions/python/AbstractPythonScalarFunctionRunnerTest.java
@@ -18,12 +18,9 @@
 
 package org.apache.flink.table.functions.python;
 
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.runtime.runners.python.AbstractPythonScalarFunctionRunner;
-import org.apache.flink.table.types.logical.BigIntType;
-import org.apache.flink.table.types.logical.RowType;
-
-import java.util.Arrays;
-import java.util.Collections;
+import org.apache.flink.table.types.DataType;
 
 /**
  * Base class for PythonScalarFunctionRunner and BaseRowPythonScalarFunctionRunner test.
@@ -40,8 +37,10 @@ public abstract class AbstractPythonScalarFunctionRunnerTest<IN, OUT>  {
 				new Integer[]{0})
 		};
 
-		RowType rowType = new RowType(Collections.singletonList(new RowType.RowField("f1", new BigIntType())));
-		return createPythonScalarFunctionRunner(pythonFunctionInfos, rowType, rowType);
+		DataType dataType = DataTypes.ROW(
+			DataTypes.FIELD("f1", DataTypes.BIGINT())
+		);
+		return createPythonScalarFunctionRunner(pythonFunctionInfos, dataType, dataType);
 	}
 
 	AbstractPythonScalarFunctionRunner<IN, OUT> createMultipleUDFRunner() {
@@ -54,13 +53,16 @@ public abstract class AbstractPythonScalarFunctionRunnerTest<IN, OUT>  {
 				new Integer[]{0, 2})
 		};
 
-		RowType inputType = new RowType(Arrays.asList(
-			new RowType.RowField("f1", new BigIntType()),
-			new RowType.RowField("f2", new BigIntType()),
-			new RowType.RowField("f3", new BigIntType())));
-		RowType outputType = new RowType(Arrays.asList(
-			new RowType.RowField("f1", new BigIntType()),
-			new RowType.RowField("f2", new BigIntType())));
+		DataType inputType = DataTypes.ROW(
+			DataTypes.FIELD("f1", DataTypes.BIGINT()),
+			DataTypes.FIELD("f2", DataTypes.BIGINT()),
+			DataTypes.FIELD("f3", DataTypes.BIGINT())
+		);
+
+		DataType outputType = DataTypes.ROW(
+			DataTypes.FIELD("f1", DataTypes.BIGINT()),
+			DataTypes.FIELD("f2", DataTypes.BIGINT())
+		);
 		return createPythonScalarFunctionRunner(pythonFunctionInfos, inputType, outputType);
 	}
 
@@ -89,21 +91,24 @@ public abstract class AbstractPythonScalarFunctionRunnerTest<IN, OUT>  {
 				})
 		};
 
-		RowType inputType = new RowType(Arrays.asList(
-			new RowType.RowField("f1", new BigIntType()),
-			new RowType.RowField("f2", new BigIntType()),
-			new RowType.RowField("f3", new BigIntType()),
-			new RowType.RowField("f4", new BigIntType()),
-			new RowType.RowField("f5", new BigIntType())));
-		RowType outputType = new RowType(Arrays.asList(
-			new RowType.RowField("f1", new BigIntType()),
-			new RowType.RowField("f2", new BigIntType()),
-			new RowType.RowField("f3", new BigIntType())));
+		DataType inputType = DataTypes.ROW(
+			DataTypes.FIELD("f1", DataTypes.BIGINT()),
+			DataTypes.FIELD("f2", DataTypes.BIGINT()),
+			DataTypes.FIELD("f3", DataTypes.BIGINT()),
+			DataTypes.FIELD("f4", DataTypes.BIGINT()),
+			DataTypes.FIELD("f5", DataTypes.BIGINT())
+		);
+
+		DataType outputType = DataTypes.ROW(
+			DataTypes.FIELD("f1", DataTypes.BIGINT()),
+			DataTypes.FIELD("f2", DataTypes.BIGINT()),
+			DataTypes.FIELD("f3", DataTypes.BIGINT())
+		);
 		return createPythonScalarFunctionRunner(pythonFunctionInfos, inputType, outputType);
 	}
 
 	public abstract AbstractPythonScalarFunctionRunner<IN, OUT> createPythonScalarFunctionRunner(
-		PythonFunctionInfo[] pythonFunctionInfos, RowType inputType, RowType outputType);
+		PythonFunctionInfo[] pythonFunctionInfos, DataType inputType, DataType outputType);
 
 	/**
 	 * Dummy PythonFunction.

--- a/flink-python/src/test/java/org/apache/flink/table/functions/python/BaseRowPythonScalarFunctionRunnerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/functions/python/BaseRowPythonScalarFunctionRunnerTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.runtime.runners.python.AbstractPythonScalarFunctionRunner;
 import org.apache.flink.table.runtime.runners.python.BaseRowPythonScalarFunctionRunner;
 import org.apache.flink.table.runtime.typeutils.coders.BaseRowCoder;
-import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.DataType;
 
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.VarLongCoder;
@@ -110,8 +110,8 @@ public class BaseRowPythonScalarFunctionRunnerTest extends AbstractPythonScalarF
 	@Override
 	public AbstractPythonScalarFunctionRunner<BaseRow, BaseRow> createPythonScalarFunctionRunner(
 		final PythonFunctionInfo[] pythonFunctionInfos,
-		RowType inputType,
-		RowType outputType) {
+		DataType inputType,
+		DataType outputType) {
 		final FnDataReceiver<BaseRow> dummyReceiver = input -> {
 			// ignore the execution results
 		};

--- a/flink-python/src/test/java/org/apache/flink/table/functions/python/BeamTypeUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/functions/python/BeamTypeUtilsTest.java
@@ -19,9 +19,11 @@
 package org.apache.flink.table.functions.python;
 
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.runtime.typeutils.BeamTypeUtils;
 import org.apache.flink.table.runtime.typeutils.coders.BaseRowCoder;
 import org.apache.flink.table.runtime.typeutils.coders.RowCoder;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.RowType;
 
@@ -42,10 +44,10 @@ public class BeamTypeUtilsTest {
 
 	@Test
 	public void testLogicalTypeToCoder() {
-		List<RowType.RowField> rowFields = new ArrayList<>();
-		rowFields.add(new RowType.RowField("f1", new BigIntType()));
-		RowType rowType = new RowType(rowFields);
-		Coder coder = BeamTypeUtils.toCoder(rowType);
+		DataType dataType = DataTypes.ROW(
+			DataTypes.FIELD("f1", DataTypes.BIGINT())
+		);
+		Coder coder = BeamTypeUtils.toCoder(dataType);
 		assertTrue(coder instanceof RowCoder);
 
 		Coder<?>[] fieldCoders = ((RowCoder) coder).getFieldCoders();
@@ -55,10 +57,10 @@ public class BeamTypeUtilsTest {
 
 	@Test
 	public void testLogicalTypeToBlinkCoder() {
-		List<RowType.RowField> rowFields = new ArrayList<>();
-		rowFields.add(new RowType.RowField("f1", new BigIntType()));
-		RowType rowType = new RowType(rowFields);
-		Coder coder = BeamTypeUtils.toBlinkCoder(rowType);
+		DataType dataType = DataTypes.ROW(
+			DataTypes.FIELD("f1", DataTypes.BIGINT())
+		);
+		Coder coder = BeamTypeUtils.toBlinkCoder(dataType);
 		assertTrue(coder instanceof BaseRowCoder);
 
 		Coder<?>[] fieldCoders = ((BaseRowCoder) coder).getFieldCoders();

--- a/flink-python/src/test/java/org/apache/flink/table/functions/python/PythonScalarFunctionRunnerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/functions/python/PythonScalarFunctionRunnerTest.java
@@ -19,11 +19,11 @@
 package org.apache.flink.table.functions.python;
 
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.runtime.runners.python.AbstractPythonScalarFunctionRunner;
 import org.apache.flink.table.runtime.runners.python.PythonScalarFunctionRunner;
 import org.apache.flink.table.runtime.typeutils.coders.RowCoder;
-import org.apache.flink.table.types.logical.BigIntType;
-import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.types.Row;
 
 import org.apache.beam.runners.fnexecution.control.JobBundleFactory;
@@ -238,8 +238,8 @@ public class PythonScalarFunctionRunnerTest extends AbstractPythonScalarFunction
 	@Override
 	public AbstractPythonScalarFunctionRunner<Row, Row> createPythonScalarFunctionRunner(
 		final PythonFunctionInfo[] pythonFunctionInfos,
-		RowType inputType,
-		RowType outputType) {
+		DataType inputType,
+		DataType outputType) {
 		final FnDataReceiver<Row> dummyReceiver = input -> {
 			// ignore the execution results
 		};
@@ -264,7 +264,9 @@ public class PythonScalarFunctionRunnerTest extends AbstractPythonScalarFunction
 				new Integer[]{0})
 		};
 
-		RowType rowType = new RowType(Collections.singletonList(new RowType.RowField("f1", new BigIntType())));
+		DataType dataType = DataTypes.ROW(
+			DataTypes.FIELD("f1", DataTypes.BIGINT())
+		);
 
 		final PythonEnv pythonEnv = new PythonEnv(PythonEnv.ExecType.PROCESS);
 
@@ -273,8 +275,8 @@ public class PythonScalarFunctionRunnerTest extends AbstractPythonScalarFunction
 			receiver,
 			pythonFunctionInfos,
 			pythonEnv,
-			rowType,
-			rowType,
+			dataType,
+			dataType,
 			jobBundleFactory,
 			new String[] {System.getProperty("java.io.tmpdir")});
 	}
@@ -288,7 +290,8 @@ public class PythonScalarFunctionRunnerTest extends AbstractPythonScalarFunction
 			FnDataReceiver<Row> resultReceiver,
 			PythonFunctionInfo[] scalarFunctions,
 			PythonEnv pythonEnv,
-			RowType inputType, RowType outputType,
+			DataType inputType,
+			DataType outputType,
 			JobBundleFactory jobBundleFactory,
 			String[] tempDirs) {
 			super(taskName, resultReceiver, scalarFunctions, pythonEnv, inputType, outputType, tempDirs);

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonScalarFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonScalarFunctionOperatorTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.util.BaseRowUtil;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.runtime.util.BaseRowHarnessAssertor;
-import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.DataType;
 
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
@@ -38,7 +38,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.binaryrow;
  * Tests for {@link BaseRowPythonScalarFunctionOperator}.
  */
 public class BaseRowPythonScalarFunctionOperatorTest
-		extends PythonScalarFunctionOperatorTestBase<BaseRow, BaseRow, BaseRow, BaseRow> {
+	extends PythonScalarFunctionOperatorTestBase<BaseRow, BaseRow, BaseRow, BaseRow> {
 
 	private final BaseRowHarnessAssertor assertor = new BaseRowHarnessAssertor(new TypeInformation[]{
 		Types.STRING,
@@ -49,8 +49,8 @@ public class BaseRowPythonScalarFunctionOperatorTest
 	@Override
 	public AbstractPythonScalarFunctionOperator<BaseRow, BaseRow, BaseRow, BaseRow> getTestOperator(
 		PythonFunctionInfo[] scalarFunctions,
-		RowType inputType,
-		RowType outputType,
+		DataType inputType,
+		DataType outputType,
 		int[] udfInputOffsets,
 		int[] forwardedFields) {
 		return new PassThroughPythonScalarFunctionOperator(
@@ -80,8 +80,8 @@ public class BaseRowPythonScalarFunctionOperatorTest
 
 		PassThroughPythonScalarFunctionOperator(
 			PythonFunctionInfo[] scalarFunctions,
-			RowType inputType,
-			RowType outputType,
+			DataType inputType,
+			DataType outputType,
 			int[] udfInputOffsets,
 			int[] forwardedFields) {
 			super(scalarFunctions, inputType, outputType, udfInputOffsets, forwardedFields);

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperatorTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.streaming.util.TestHarnessUtil;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.runtime.types.CRow;
-import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.types.Row;
 
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
@@ -38,8 +38,8 @@ public class PythonScalarFunctionOperatorTest extends PythonScalarFunctionOperat
 	@Override
 	public AbstractPythonScalarFunctionOperator<CRow, CRow, Row, Row> getTestOperator(
 		PythonFunctionInfo[] scalarFunctions,
-		RowType inputType,
-		RowType outputType,
+		DataType inputType,
+		DataType outputType,
 		int[] udfInputOffsets,
 		int[] forwardedFields) {
 		return new PassThroughPythonScalarFunctionOperator(
@@ -60,8 +60,8 @@ public class PythonScalarFunctionOperatorTest extends PythonScalarFunctionOperat
 
 		PassThroughPythonScalarFunctionOperator(
 			PythonFunctionInfo[] scalarFunctions,
-			RowType inputType,
-			RowType outputType,
+			DataType inputType,
+			DataType outputType,
 			int[] udfInputOffsets,
 			int[] forwardedFields) {
 			super(scalarFunctions, inputType, outputType, udfInputOffsets, forwardedFields);

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperatorTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperatorTestBase.java
@@ -23,15 +23,13 @@ import org.apache.flink.python.PythonOptions;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.functions.python.AbstractPythonScalarFunctionRunnerTest;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
-import org.apache.flink.table.types.logical.BigIntType;
-import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.DataType;
 
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -191,10 +189,11 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN, UDFOU
 	}
 
 	private OneInputStreamOperatorTestHarness<IN, OUT> getTestHarness() throws Exception {
-		RowType dataType = new RowType(Arrays.asList(
-			new RowType.RowField("f1", new VarCharType()),
-			new RowType.RowField("f2", new VarCharType()),
-			new RowType.RowField("f3", new BigIntType())));
+		DataType dataType = DataTypes.ROW(
+			DataTypes.FIELD("f1", DataTypes.STRING()),
+			DataTypes.FIELD("f2", DataTypes.STRING()),
+			DataTypes.FIELD("f3", DataTypes.BIGINT())
+		);
 		AbstractPythonScalarFunctionOperator<IN, OUT, UDFIN, UDFOUT> operator = getTestOperator(
 			new PythonFunctionInfo[] {
 				new PythonFunctionInfo(
@@ -212,8 +211,8 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN, UDFOU
 
 	public abstract AbstractPythonScalarFunctionOperator<IN, OUT, UDFIN, UDFOUT> getTestOperator(
 		PythonFunctionInfo[] scalarFunctions,
-		RowType inputType,
-		RowType outputType,
+		DataType inputType,
+		DataType outputType,
 		int[] udfInputOffsets,
 		int[] forwardedFields);
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/coders/ArrayCoderTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/coders/ArrayCoderTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders;
+
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.coders.VarLongCoder;
+
+/**
+ * Tests for {@link ArrayCoder}.
+ */
+public class ArrayCoderTest {
+
+	/**
+	 * Test for one dimensional array for {@link ArrayCoder}.
+	 */
+	public static class OneDimensionalArrayCoderTest extends CoderTestBase<Long[]> {
+		@Override
+		protected Coder<Long[]> createCoder() {
+			return ArrayCoder.of(VarLongCoder.of(), Long.class);
+		}
+
+		@Override
+		protected Long[][] getTestData() {
+			return new Long[][]{{1L, 2L, 3L}, {2L, 3L, 4L}};
+		}
+	}
+
+	/**
+	 * Test for two dimensional array for {@link ArrayCoder}.
+	 */
+	public static class TwoDimensionalArrayCoderTest extends CoderTestBase<Integer[][]> {
+		@Override
+		protected Coder<Integer[][]> createCoder() {
+			return ArrayCoder.of(ArrayCoder.of(VarIntCoder.of(), Integer.class), Integer[].class);
+		}
+
+		@Override
+		protected Integer[][][] getTestData() {
+			return new Integer[][][]{{{1, 2, 3}, {2, 3, 4}}, {{3, 4, 5}, {4, 5, 6}}};
+		}
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/coders/BigDecimalCoderTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/coders/BigDecimalCoderTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders;
+
+import org.apache.beam.sdk.coders.Coder;
+
+import java.math.BigDecimal;
+
+/**
+ * Tests for {@link BigDecimalCoder}.
+ */
+public class BigDecimalCoderTest extends CoderTestBase<BigDecimal> {
+	@Override
+	protected Coder<BigDecimal> createCoder() {
+		return BigDecimalCoder.of();
+	}
+
+	@Override
+	protected BigDecimal[] getTestData() {
+		return new BigDecimal[]{
+			BigDecimal.valueOf(1000L),
+			BigDecimal.valueOf(200.0),
+			BigDecimal.valueOf(100L)
+		};
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/coders/BinaryArrayCoderTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/coders/BinaryArrayCoderTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.dataformat.BinaryArray;
+
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.VarLongCoder;
+
+/**
+ * Tests for {@link BinaryArrayCoder}.
+ */
+public class BinaryArrayCoderTest extends CoderTestBase<BinaryArray> {
+	@Override
+	protected Coder<BinaryArray> createCoder() {
+		return BinaryArrayCoder.of(DataTypes.BIGINT(), VarLongCoder.of());
+	}
+
+	@Override
+	protected BinaryArray[] getTestData() {
+		return new BinaryArray[]{BinaryArray.fromPrimitiveArray(new long[]{100L})};
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/coders/BinaryMapCoderTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/coders/BinaryMapCoderTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.dataformat.BinaryArray;
+import org.apache.flink.table.dataformat.BinaryMap;
+
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.FloatCoder;
+import org.apache.beam.sdk.coders.VarLongCoder;
+
+/**
+ * Tests for {@link BinaryMapCoder}.
+ */
+public class BinaryMapCoderTest extends CoderTestBase<BinaryMap> {
+	@Override
+	protected Coder<BinaryMap> createCoder() {
+		return BinaryMapCoder.of(DataTypes.BIGINT(), DataTypes.FLOAT(), VarLongCoder.of(), FloatCoder.of());
+	}
+
+	@Override
+	protected BinaryMap[] getTestData() {
+		BinaryArray keyBinary = BinaryArray.fromPrimitiveArray(new long[]{10L});
+		BinaryArray valueBinary = BinaryArray.fromPrimitiveArray(new float[]{10.2F});
+		return new BinaryMap[]{BinaryMap.valueOf(keyBinary, valueBinary)};
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/coders/CharTypeCodersTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/coders/CharTypeCodersTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders;
+
+import org.apache.flink.table.dataformat.BinaryString;
+
+import org.apache.beam.sdk.coders.Coder;
+
+/**
+ * Tests for {@link CharTypeCoders}.
+ */
+public class CharTypeCodersTest {
+	private static CharTypeCoders charTypeCoders = CharTypeCoders.of();
+
+	/**
+	 * Test for {@link CharTypeCoders.BinaryStringCoder}.
+	 */
+	public static class BinaryStringCoderTest extends CoderTestBase<BinaryString> {
+
+		@Override
+		protected Coder<BinaryString> createCoder() {
+			return charTypeCoders.findMatchedCoder(BinaryString.class);
+		}
+
+		@Override
+		protected BinaryString[] getTestData() {
+			return new BinaryString[]{BinaryString.fromString("flink"), BinaryString.fromBytes("pyflink".getBytes())};
+		}
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/coders/DateTypeCodersTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/coders/DateTypeCodersTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders;
+
+import org.apache.beam.sdk.coders.Coder;
+
+import java.sql.Date;
+import java.time.LocalDate;
+
+/**
+ * Tests for {@link DateTypeCoders}.
+ */
+public class DateTypeCodersTest {
+	private static DateTypeCoders dateTypeCoders = DateTypeCoders.of();
+
+	/**
+	 * Test for {@link DateTypeCoders.DateCoder}.
+	 */
+	public static class SqlDateCoderTest extends CoderTestBase<Date> {
+
+		@Override
+		protected Coder<Date> createCoder() {
+			return dateTypeCoders.findMatchedCoder(Date.class);
+		}
+
+		@Override
+		protected Date[] getTestData() {
+			return new Date[]{Date.valueOf(LocalDate.now())};
+		}
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/coders/DecimalCoderTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/coders/DecimalCoderTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders;
+
+import org.apache.flink.table.dataformat.Decimal;
+
+import org.apache.beam.sdk.coders.Coder;
+
+import java.math.BigDecimal;
+
+/**
+ * Tests for {@link DecimalCoder}.
+ */
+public class DecimalCoderTest extends CoderTestBase<Decimal> {
+	@Override
+	protected Coder<Decimal> createCoder() {
+		return DecimalCoder.of(20, 10);
+	}
+
+	@Override
+	protected Decimal[] getTestData() {
+		return new Decimal[]{
+			Decimal.fromBigDecimal(BigDecimal.valueOf(1000L), 20, 10),
+			Decimal.fromBigDecimal(BigDecimal.valueOf(200.0), 20, 10),
+			Decimal.fromBigDecimal(BigDecimal.valueOf(100L), 20, 10)
+		};
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/coders/TimeTypeCodersTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/coders/TimeTypeCodersTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders;
+
+import org.apache.beam.sdk.coders.Coder;
+
+import java.sql.Time;
+import java.time.LocalTime;
+
+/**
+ * Tests for {@link TimeTypeCoders}.
+ */
+public class TimeTypeCodersTest {
+
+	private static TimeTypeCoders timeTypeCoders = TimeTypeCoders.of();
+
+	/**
+	 * Test for {@link TimeTypeCoders.TimeCoder}.
+	 */
+	public static class SqlTimeCoderTest extends CoderTestBase<Time> {
+
+		@Override
+		protected Coder<Time> createCoder() {
+			return timeTypeCoders.findMatchedCoder(Time.class);
+		}
+
+		@Override
+		protected Time[] getTestData() {
+			return new Time[]{Time.valueOf(LocalTime.now())};
+		}
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/coders/TimestampTypeCodersTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/coders/TimestampTypeCodersTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.coders;
+
+import org.apache.beam.sdk.coders.Coder;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+/**
+ * Tests for {@link TimestampTypeCoders}.
+ */
+public class TimestampTypeCodersTest {
+	private static TimestampTypeCoders timestampTypeCoders = TimestampTypeCoders.of();
+
+	/**
+	 * Test for {@link TimestampTypeCoders.TimestampCoder}.
+	 */
+	public static class SqlTimestampCoderTest extends CoderTestBase<Timestamp> {
+
+		@Override
+		protected Coder<Timestamp> createCoder() {
+			return timestampTypeCoders.findMatchedCoder(Timestamp.class);
+		}
+
+		@Override
+		protected Timestamp[] getTestData() {
+			return new Timestamp[]{Timestamp.valueOf(LocalDateTime.now())};
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCalc.scala
@@ -34,7 +34,9 @@ import org.apache.flink.table.planner.codegen.{CalcCodeGenerator, CodeGeneratorC
 import org.apache.flink.table.planner.functions.utils.ScalarSqlFunction
 import org.apache.flink.table.planner.plan.nodes.common.CommonPythonCalc.PYTHON_SCALAR_FUNCTION_OPERATOR_NAME
 import org.apache.flink.table.runtime.typeutils.BaseRowTypeInfo
+import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.logical.RowType
+import org.apache.flink.table.types.utils.TypeConversions
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable
@@ -103,14 +105,14 @@ trait CommonPythonCalc {
     val clazz = Class.forName(PYTHON_SCALAR_FUNCTION_OPERATOR_NAME)
     val ctor = clazz.getConstructor(
       classOf[Array[PythonFunctionInfo]],
-      classOf[RowType],
-      classOf[RowType],
+      classOf[DataType],
+      classOf[DataType],
       classOf[Array[Int]],
       classOf[Array[Int]])
     ctor.newInstance(
       pythonFunctionInfos,
-      inputRowTypeInfo.toRowType,
-      outputRowTypeInfo.toRowType,
+      TypeConversions.fromLogicalToDataType(inputRowTypeInfo.toRowType),
+      TypeConversions.fromLogicalToDataType(outputRowTypeInfo.toRowType),
       udfInputOffsets,
       forwardedFields)
       .asInstanceOf[OneInputStreamOperator[BaseRow, BaseRow]]


### PR DESCRIPTION
## What is the purpose of the change

*Currently, only BigInt type is supported and we should support the other types as well. This PR includes almost DataTypes except TIMESTAMP_WITH_ZONE and INTERVAL*


## Brief change log

*(for example:)*
  - *Add mange coders in flink-python module*
  - *Change logical type to datatype in python operator and runner*

## Verifying this change

This change added tests and can be verified as follows:
 
- *Add tests in coders directory of flink-python module*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
