### PR TITLE
[hotfix][typo] fix typo in YarnClusterDescriptor

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -951,7 +951,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
 		if (UserGroupInformation.isSecurityEnabled()) {
 			// set HDFS delegation tokens when security is enabled
-			LOG.info("Adding delegation token to the AM container..");
+			LOG.info("Adding delegation token to the AM container.");
 			Utils.setTokensFor(amContainer, paths, yarnConfiguration);
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

fix typo in YarnClusterDescriptor

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
