### PR TITLE
[FLINK-14022][table-planner][table-planner-blink] Add validation check for places where Python ScalarFunction cannot be used

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPhysicalJoin.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPhysicalJoin.scala
@@ -18,8 +18,10 @@
 
 package org.apache.flink.table.planner.plan.nodes.common
 
+import org.apache.flink.table.api.TableException
 import org.apache.flink.table.planner.plan.nodes.physical.FlinkPhysicalRel
 import org.apache.flink.table.planner.plan.utils.{JoinTypeUtil, JoinUtil}
+import org.apache.flink.table.planner.plan.utils.PythonUtil.containsPythonCall
 import org.apache.flink.table.planner.plan.utils.RelExplainUtil.preferExpressionFormat
 import org.apache.flink.table.runtime.operators.join.FlinkJoinType
 
@@ -48,6 +50,12 @@ abstract class CommonPhysicalJoin(
     joinType: JoinRelType)
   extends Join(cluster, traitSet, leftRel, rightRel, condition, Set.empty[CorrelationId], joinType)
   with FlinkPhysicalRel {
+
+  if (containsPythonCall(condition)) {
+    throw new TableException("Only inner join condition with equality predicates supports the " +
+      "Python UDF taking the inputs from the left table and the right table at the same time, " +
+      "e.g., ON T1.id = T2.id && pythonUdf(T1.a, T2.b)")
+  }
 
   def getJoinInfo: JoinInfo = joinInfo
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecMatch.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecMatch.scala
@@ -39,6 +39,7 @@ import org.apache.flink.table.planner.delegation.StreamPlanner
 import org.apache.flink.table.planner.plan.logical.MatchRecognize
 import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, StreamExecNode}
 import org.apache.flink.table.planner.plan.rules.physical.stream.StreamExecRetractionRules
+import org.apache.flink.table.planner.plan.utils.PythonUtil.containsPythonCall
 import org.apache.flink.table.planner.plan.utils.RelExplainUtil._
 import org.apache.flink.table.planner.plan.utils.{KeySelectorUtil, RexDefaultVisitor, SortUtil}
 import org.apache.flink.table.runtime.operators.`match`.{BaseRowEventComparator, RowtimeProcessFunction}
@@ -74,6 +75,11 @@ class StreamExecMatch(
   extends SingleRel(cluster, traitSet, inputNode)
   with StreamPhysicalRel
   with StreamExecNode[BaseRow] {
+
+  if (logicalMatch.measures.values().exists(containsPythonCall) ||
+    logicalMatch.patternDefinitions.values().exists(containsPythonCall)) {
+    throw new TableException("Python Function can not be used in MATCH_RECOGNIZE for now.")
+  }
 
   override def needsUpdatesAsRetraction(input: RelNode): Boolean = true
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -356,6 +356,8 @@ object FlinkBatchRuleSets {
   val LOGICAL_REWRITE: RuleSet = RuleSets.ofList(
     // transpose calc past snapshot
     CalcSnapshotTransposeRule.INSTANCE,
+    // Rule that splits python ScalarFunctions from join conditions
+    SplitPythonConditionFromJoinRule.INSTANCE,
     // merge calc after calc transpose
     FlinkCalcMergeRule.INSTANCE,
     // Rule that splits python ScalarFunctions from java/scala ScalarFunctions

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -336,6 +336,8 @@ object FlinkStreamRuleSets {
     SplitAggregateRule.INSTANCE,
     // transpose calc past snapshot
     CalcSnapshotTransposeRule.INSTANCE,
+    // Rule that splits python ScalarFunctions from join conditions
+    SplitPythonConditionFromJoinRule.INSTANCE,
     // merge calc after calc transpose
     FlinkCalcMergeRule.INSTANCE,
     // Rule that splits python ScalarFunctions from java/scala ScalarFunctions.

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/SplitPythonConditionFromJoinRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/SplitPythonConditionFromJoinRule.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical
+
+import org.apache.calcite.plan.RelOptRule.{none, operand}
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelOptUtil}
+import org.apache.calcite.rel.core.JoinRelType
+import org.apache.calcite.rex.{RexProgram, RexProgramBuilder, RexUtil}
+import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalCalc, FlinkLogicalJoin}
+import org.apache.flink.table.planner.plan.utils.PythonUtil.containsPythonCall
+
+import scala.collection.JavaConversions._
+
+/**
+  * Rule will splits the [[FlinkLogicalJoin]] which contains Python Functions in join condition
+  * into a [[FlinkLogicalJoin]] and a [[FlinkLogicalCalc]] with python Functions. Currently, only
+  * inner join is supported.
+  *
+  * After this rule is applied, there will be no Python Functions in the condition of the
+  * [[FlinkLogicalJoin]].
+  */
+class SplitPythonConditionFromJoinRule extends RelOptRule(
+  operand(classOf[FlinkLogicalJoin], none),
+  "SplitPythonConditionFromJoinRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val join: FlinkLogicalJoin = call.rel(0).asInstanceOf[FlinkLogicalJoin]
+    val joinType: JoinRelType = join.getJoinType
+    // matches if it is inner join and it contains Python functions in condition
+    joinType == JoinRelType.INNER && Option(join.getCondition).exists(containsPythonCall)
+  }
+
+  override def onMatch(call: RelOptRuleCall): Unit = {
+    val join: FlinkLogicalJoin = call.rel(0).asInstanceOf[FlinkLogicalJoin]
+    val rexBuilder = join.getCluster.getRexBuilder
+
+    val joinFilters = RelOptUtil.conjunctions(join.getCondition)
+    val pythonFilters = joinFilters.filter(containsPythonCall)
+    val remainingFilters = joinFilters.filter(!containsPythonCall(_))
+
+    val newJoinCondition = RexUtil.composeConjunction(rexBuilder, remainingFilters)
+    val bottomJoin = new FlinkLogicalJoin(
+      join.getCluster,
+      join.getTraitSet,
+      join.getLeft,
+      join.getRight,
+      newJoinCondition,
+      join.getJoinType)
+
+    val rexProgram = new RexProgramBuilder(bottomJoin.getRowType, rexBuilder).getProgram
+    val topCalcCondition = RexUtil.composeConjunction(rexBuilder, pythonFilters)
+
+    val topCalc = new FlinkLogicalCalc(
+      join.getCluster,
+      join.getTraitSet,
+      bottomJoin,
+      RexProgram.create(
+        bottomJoin.getRowType,
+        rexProgram.getExprList,
+        topCalcCondition,
+        bottomJoin.getRowType,
+        rexBuilder))
+
+    call.transformTo(topCalc)
+  }
+}
+
+object SplitPythonConditionFromJoinRule {
+  val INSTANCE = new SplitPythonConditionFromJoinRule
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/SplitPythonConditionFromJoinRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/SplitPythonConditionFromJoinRuleTest.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testPythonFunctionInJoinCondition">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b, d FROM leftTable JOIN rightTable ON a=d and pyFunc(a, d)=b ]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], d=[$3])
++- LogicalJoin(condition=[AND(=($0, $3), =(pyFunc($0, $3), $1))], joinType=[inner])
+   :- LogicalTableScan(table=[[default_catalog, default_database, leftTable, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, rightTable, source: [TestTableSource(d, e, f)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, b, d], where=[=(f0, b)])
++- FlinkLogicalCalc(select=[a, b, d, pyFunc(a, d) AS f0])
+   +- FlinkLogicalJoin(condition=[=($0, $2)], joinType=[inner])
+      :- FlinkLogicalCalc(select=[a, b])
+      :  +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, leftTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+      +- FlinkLogicalCalc(select=[d])
+         +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, rightTable, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testPythonFunctionInAboveFilter">
+    <Resource name="sql">
+      <![CDATA[
+SELECT a, d + 1 FROM(
+  SELECT a, d FROM(
+    SELECT a, d
+    FROM leftTable JOIN rightTable ON
+    a = d and pyFunc(a, a) = a + d)
+  WHERE pyFunc(a, d) = a * d)
+      ]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], EXPR$1=[+($1, 1)])
++- LogicalFilter(condition=[=(pyFunc($0, $1), *($0, $1))])
+   +- LogicalProject(a=[$0], d=[$3])
+      +- LogicalJoin(condition=[AND(=($0, $3), =(pyFunc($0, $0), +($0, $3)))], joinType=[inner])
+         :- LogicalTableScan(table=[[default_catalog, default_database, leftTable, source: [TestTableSource(a, b, c)]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, rightTable, source: [TestTableSource(d, e, f)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, +(d, 1) AS EXPR$1], where=[AND(=(f0, +(a, d)), =(f1, *(a, d)))])
++- FlinkLogicalCalc(select=[a, d, pyFunc(a, a) AS f0, pyFunc(a, d) AS f1])
+   +- FlinkLogicalJoin(condition=[=($0, $1)], joinType=[inner])
+      :- FlinkLogicalCalc(select=[a])
+      :  +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, leftTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+      +- FlinkLogicalCalc(select=[d])
+         +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, rightTable, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
+]]>
+
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/SplitPythonConditionFromJoinRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/SplitPythonConditionFromJoinRuleTest.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical
+
+import org.apache.calcite.plan.hep.HepMatchOrder
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.planner.plan.nodes.FlinkConventions
+import org.apache.flink.table.planner.plan.optimize.program._
+import org.apache.flink.table.planner.plan.rules.FlinkBatchRuleSets
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.PythonScalarFunction
+import org.apache.flink.table.planner.utils.TableTestBase
+import org.junit.{Before, Test}
+
+/**
+  * Test for [[SplitPythonConditionFromJoinRule]].
+  */
+class SplitPythonConditionFromJoinRuleTest extends TableTestBase {
+
+  private val util = batchTestUtil()
+
+  @Before
+  def setup(): Unit = {
+    val programs = new FlinkChainedProgram[BatchOptimizeContext]()
+    programs.addLast(
+      "logical",
+      FlinkVolcanoProgramBuilder.newBuilder
+        .add(FlinkBatchRuleSets.LOGICAL_OPT_RULES)
+        .setRequiredOutputTraits(Array(FlinkConventions.LOGICAL))
+        .build())
+    programs.addLast(
+      "logical_rewrite",
+      FlinkHepRuleSetProgramBuilder.newBuilder
+        .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
+        .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+        .add(FlinkBatchRuleSets.LOGICAL_REWRITE)
+        .build())
+    util.replaceBatchProgram(programs)
+
+    util.addTableSource[(Int, Int, Int)]("leftTable", 'a, 'b, 'c)
+    util.addTableSource[(Int, Int, Int)]("rightTable", 'd, 'e, 'f)
+    util.addFunction("pyFunc", new PythonScalarFunction("pyFunc"))
+  }
+
+  @Test
+  def testPythonFunctionInJoinCondition(): Unit = {
+    val sqlQuery = "SELECT a, b, d FROM leftTable JOIN rightTable ON a=d and pyFunc(a, d)=b "
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testPythonFunctionInAboveFilter(): Unit = {
+    val sqlQuery =
+      """
+        |SELECT a, d + 1 FROM(
+        |  SELECT a, d FROM(
+        |    SELECT a, d
+        |    FROM leftTable JOIN rightTable ON
+        |    a = d and pyFunc(a, a) = a + d)
+        |  WHERE pyFunc(a, d) = a * d)
+      """.stripMargin
+    util.verifyPlan(sqlQuery)
+  }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/Optimizer.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/Optimizer.scala
@@ -182,7 +182,7 @@ abstract class Optimizer(
   protected def optimizeLogicalRewritePlan(relNode: RelNode): RelNode = {
     val logicalRewriteRuleSet = getLogicalRewriteRuleSet
     if (logicalRewriteRuleSet.iterator().hasNext) {
-      runHepPlannerSimultaneously(
+      runHepPlannerSequentially(
         HepMatchOrder.TOP_DOWN,
         logicalRewriteRuleSet,
         relNode,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonJoin.scala
@@ -21,10 +21,20 @@ import org.apache.calcite.rel.RelWriter
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.JoinRelType
 import org.apache.calcite.rex.RexNode
+import org.apache.flink.table.api.TableException
+import org.apache.flink.table.plan.util.PythonUtil.containsPythonCall
 
 import scala.collection.JavaConverters._
 
 trait CommonJoin {
+
+  protected def validatePythonFunctionInJoinCondition(joinCondition: RexNode): Unit = {
+    if (containsPythonCall(joinCondition)) {
+      throw new TableException("Only inner join condition with equality predicates supports the " +
+        "Python UDF taking the inputs from the left table and the right table at the same time, " +
+        "e.g., ON T1.id = T2.id && pythonUdf(T1.a, T2.b)")
+    }
+  }
 
   private[flink] def joinSelectionToString(inputType: RelDataType): String = {
     inputType.getFieldNames.asScala.toList.mkString(", ")

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamJoin.scala
@@ -51,6 +51,8 @@ class DataStreamJoin(
   with CommonJoin
   with DataStreamRel {
 
+  validatePythonFunctionInJoinCondition(joinCondition)
+
   override def deriveRowType(): RelDataType = schema.relDataType
 
   override def needsUpdatesAsRetraction: Boolean = true

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamMatch.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamMatch.scala
@@ -42,6 +42,7 @@ import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.windowing.time.Time
 
 import scala.collection.JavaConverters._
+import scala.collection.JavaConversions._
 import org.apache.flink.table.api._
 import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.codegen.MatchCodeGenerator
@@ -49,6 +50,7 @@ import org.apache.flink.table.plan.logical.MatchRecognize
 import org.apache.flink.table.plan.nodes.CommonMatchRecognize
 import org.apache.flink.table.plan.rules.datastream.DataStreamRetractionRules
 import org.apache.flink.table.plan.schema.RowSchema
+import org.apache.flink.table.plan.util.PythonUtil.containsPythonCall
 import org.apache.flink.table.plan.util.RexDefaultVisitor
 import org.apache.flink.table.planner.StreamPlanner
 import org.apache.flink.table.runtime.`match`._
@@ -74,6 +76,11 @@ class DataStreamMatch(
   extends SingleRel(cluster, traitSet, inputNode)
   with CommonMatchRecognize
   with DataStreamRel {
+
+  if (logicalMatch.measures.values().exists(containsPythonCall) ||
+    logicalMatch.patternDefinitions.values().exists(containsPythonCall)) {
+    throw new TableException("Python Function can not be used in MATCH_RECOGNIZE for now.")
+  }
 
   override def needsUpdatesAsRetraction = true
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamWindowJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamWindowJoin.scala
@@ -67,6 +67,8 @@ class DataStreamWindowJoin(
     with DataStreamRel
     with Logging {
 
+  validatePythonFunctionInJoinCondition(joinCondition)
+
   override def deriveRowType(): RelDataType = schema.relDataType
 
   override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -147,6 +147,9 @@ object FlinkRuleSets {
     * RuleSet to do rewrite on FlinkLogicalRel
     */
   val LOGICAL_REWRITE_RULES: RuleSet = RuleSets.ofList(
+    // Rule that splits python ScalarFunctions from join conditions
+    SplitPythonConditionFromJoinRule.INSTANCE,
+    CalcMergeRule.INSTANCE,
     PythonCalcSplitRule.SPLIT_CONDITION,
     PythonCalcSplitRule.SPLIT_PROJECT,
     PythonCalcSplitRule.PUSH_CONDITION,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/SplitPythonConditionFromJoinRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/SplitPythonConditionFromJoinRule.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.logical
+
+import org.apache.calcite.plan.RelOptRule.{none, operand}
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelOptUtil}
+import org.apache.calcite.rel.core.JoinRelType
+import org.apache.calcite.rex.{RexProgram, RexProgramBuilder, RexUtil}
+import org.apache.flink.table.plan.nodes.logical.{FlinkLogicalCalc, FlinkLogicalJoin}
+import org.apache.flink.table.plan.util.PythonUtil.containsPythonCall
+
+import scala.collection.JavaConversions._
+
+/**
+  * Rule will splits the [[FlinkLogicalJoin]] which contains Python Functions in join condition
+  * into a [[FlinkLogicalJoin]] and a [[FlinkLogicalCalc]] with python Functions. Currently, only
+  * inner join is supported.
+  *
+  * After this rule is applied, there will be no Python Functions in the condition of the
+  * [[FlinkLogicalJoin]].
+  */
+class SplitPythonConditionFromJoinRule extends RelOptRule(
+  operand(classOf[FlinkLogicalJoin], none),
+  "SplitPythonConditionFromJoinRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val join: FlinkLogicalJoin = call.rel(0).asInstanceOf[FlinkLogicalJoin]
+    val joinType: JoinRelType = join.getJoinType
+    // matches if it is inner join and it contains Python functions in condition
+    joinType == JoinRelType.INNER && Option(join.getCondition).exists(containsPythonCall)
+  }
+
+  override def onMatch(call: RelOptRuleCall): Unit = {
+    val join: FlinkLogicalJoin = call.rel(0).asInstanceOf[FlinkLogicalJoin]
+    val rexBuilder = join.getCluster.getRexBuilder
+
+    val joinFilters = RelOptUtil.conjunctions(join.getCondition)
+    val pythonFilters = joinFilters.filter(containsPythonCall)
+    val remainingFilters = joinFilters.filter(!containsPythonCall(_))
+
+    val newJoinCondition = RexUtil.composeConjunction(rexBuilder, remainingFilters)
+    val bottomJoin = new FlinkLogicalJoin(
+      join.getCluster,
+      join.getTraitSet,
+      join.getLeft,
+      join.getRight,
+      newJoinCondition,
+      join.getJoinType)
+
+    val rexProgram = new RexProgramBuilder(bottomJoin.getRowType, rexBuilder).getProgram
+    val topCalcCondition = RexUtil.composeConjunction(rexBuilder, pythonFilters)
+
+    val topCalc = new FlinkLogicalCalc(
+      join.getCluster,
+      join.getTraitSet,
+      bottomJoin,
+      RexProgram.create(
+        bottomJoin.getRowType,
+        rexProgram.getExprList,
+        topCalcCondition,
+        bottomJoin.getRowType,
+        rexBuilder))
+
+    call.transformTo(topCalc)
+  }
+}
+
+object SplitPythonConditionFromJoinRule {
+  val INSTANCE = new SplitPythonConditionFromJoinRule
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/utils/JavaUserDefinedScalarFunctions.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/utils/JavaUserDefinedScalarFunctions.java
@@ -18,7 +18,11 @@
 
 package org.apache.flink.table.runtime.utils;
 
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.functions.python.PythonEnv;
+import org.apache.flink.table.functions.python.PythonFunction;
 
 import java.util.Arrays;
 
@@ -80,4 +84,73 @@ public class JavaUserDefinedScalarFunctions {
 		}
 	}
 
+	/**
+	 * Test for Python Scalar Function.
+	 */
+	public static class PythonScalarFunction extends ScalarFunction implements PythonFunction {
+		private final String name;
+
+		public PythonScalarFunction(String name) {
+			this.name = name;
+		}
+
+		public int eval(int i, int j) {
+			return i + j;
+		}
+
+		@Override
+		public TypeInformation<?> getResultType(Class<?>[] signature) {
+			return BasicTypeInfo.INT_TYPE_INFO;
+		}
+
+		@Override
+		public String toString() {
+			return name;
+		}
+
+		@Override
+		public byte[] getSerializedPythonFunction() {
+			return new byte[0];
+		}
+
+		@Override
+		public PythonEnv getPythonEnv() {
+			return null;
+		}
+	}
+
+	/**
+	 * Test for Python Scalar Function.
+	 */
+	public static class BooleanPythonScalarFunction extends ScalarFunction implements PythonFunction {
+		private final String name;
+
+		public BooleanPythonScalarFunction(String name) {
+			this.name = name;
+		}
+
+		public boolean eval(int i, int j) {
+			return i + j > 1;
+		}
+
+		@Override
+		public TypeInformation<?> getResultType(Class<?>[] signature) {
+			return BasicTypeInfo.BOOLEAN_TYPE_INFO;
+		}
+
+		@Override
+		public String toString() {
+			return name;
+		}
+
+		@Override
+		public byte[] getSerializedPythonFunction() {
+			return new byte[0];
+		}
+
+		@Override
+		public PythonEnv getPythonEnv() {
+			return null;
+		}
+	}
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/validation/JoinValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/validation/JoinValidationTest.scala
@@ -21,7 +21,9 @@ package org.apache.flink.table.api.stream.sql.validation
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.api.scala._
+import org.apache.flink.table.runtime.utils.JavaUserDefinedScalarFunctions.PythonScalarFunction
 import org.apache.flink.table.utils.{StreamTableTestUtil, TableTestBase}
+import org.hamcrest.Matchers
 import org.junit.Test
 
 class JoinValidationTest extends TableTestBase {
@@ -195,6 +197,26 @@ class JoinValidationTest extends TableTestBase {
         |FROM MyTable t1 JOIN MyTable2 t2 ON
         |  t1.a = t2.a
         |""".stripMargin
+
+    streamUtil.verifySql(sql, "n/a")
+  }
+
+  /**
+    * Currently only the inner join condition can support the Python UDF taking the inputs from
+    * the left table and the right table at the same time.
+    */
+  @Test
+  def testOuterJoinWithPythonFunctionInCondition(): Unit = {
+    expectedException.expectCause(Matchers.isA(classOf[TableException]))
+    streamUtil.addFunction("pyFunc", new PythonScalarFunction("pyFunc"))
+    streamUtil.addTable[(Int, Int, Long)]("leftTable", 'a, 'b, 'c)
+    streamUtil.addTable[(Int, Int, Long)]("rightTable", 'd, 'e, 'f)
+    val sql =
+      """
+        |SELECT *
+        |FROM leftTable LEFT OUTER JOIN rightTable ON
+        | a = d AND pyFunc(a, d) = a + d
+      """.stripMargin
 
     streamUtil.verifySql(sql, "n/a")
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/validation/MatchRecognizeValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/validation/MatchRecognizeValidationTest.scala
@@ -19,9 +19,11 @@
 package org.apache.flink.table.api.stream.sql.validation
 
 import org.apache.flink.api.scala._
-import org.apache.flink.table.api.ValidationException
+import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.api.scala._
+import org.apache.flink.table.runtime.utils.JavaUserDefinedScalarFunctions.PythonScalarFunction
 import org.apache.flink.table.utils.{StreamTableTestUtil, TableTestBase}
+import org.hamcrest.Matchers
 import org.junit.Test
 
 class MatchRecognizeValidationTest extends TableTestBase {
@@ -40,6 +42,27 @@ class MatchRecognizeValidationTest extends TableTestBase {
   @Test(expected = classOf[ValidationException])
   def testMatchProctimeInSelect() = {
     val sql = "SELECT MATCH_PROCTIME() FROM MyTable"
+    streamUtil.verifySql(sql, "n/a")
+  }
+
+  /** Python Function can not be used in MATCH_RECOGNIZE for now **/
+  @Test
+  def testMatchPythonFunction() = {
+    expectedException.expectCause(Matchers.isA(classOf[TableException]))
+    streamUtil.addFunction("pyFunc", new PythonScalarFunction("pyFunc"))
+    val sql =
+      """SELECT T.aa as ta
+        |FROM MyTable
+        |MATCH_RECOGNIZE (
+        |  ORDER BY proctime
+        |  MEASURES
+        |    A.a as aa,
+        |    pyFunc(1,2) as bb
+        |  PATTERN (A B)
+        |  DEFINE
+        |    A AS a = 1,
+        |    B AS b = 'b'
+        |) AS T""".stripMargin
     streamUtil.verifySql(sql, "n/a")
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/PythonCalcSplitRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/PythonCalcSplitRuleTest.scala
@@ -18,11 +18,9 @@
 
 package org.apache.flink.table.plan
 
-import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.functions.python.{PythonEnv, PythonFunction}
-import org.apache.flink.table.functions.ScalarFunction
+import org.apache.flink.table.runtime.utils.JavaUserDefinedScalarFunctions.{BooleanPythonScalarFunction, PythonScalarFunction}
 import org.apache.flink.table.utils.TableTestUtil._
 import org.apache.flink.table.utils.TableTestBase
 import org.junit.Test
@@ -268,30 +266,4 @@ class PythonCalcSplitRuleTest extends TableTestBase {
 
     util.verifyTable(resultTable, expected)
   }
-}
-
-class PythonScalarFunction(name: String) extends ScalarFunction with PythonFunction {
-  def eval(i: Int, j: Int): Int = i + j
-
-  override def getResultType(signature: Array[Class[_]]): TypeInformation[_] =
-    BasicTypeInfo.INT_TYPE_INFO
-
-  override def toString: String = name
-
-  override def getSerializedPythonFunction: Array[Byte] = null
-
-  override def getPythonEnv: PythonEnv = null
-}
-
-class BooleanPythonScalarFunction(name: String) extends ScalarFunction with PythonFunction {
-  def eval(i: Int, j: Int): Boolean = i + j > 1
-
-  override def getResultType(signature: Array[Class[_]]): TypeInformation[_] =
-    BasicTypeInfo.BOOLEAN_TYPE_INFO
-
-  override def toString: String = name
-
-  override def getSerializedPythonFunction: Array[Byte] = null
-
-  override def getPythonEnv: PythonEnv = null
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/SplitPythonConditionFromJoinRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/SplitPythonConditionFromJoinRuleTest.scala
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.runtime.utils.JavaUserDefinedScalarFunctions.PythonScalarFunction
+import org.apache.flink.table.utils.TableTestBase
+import org.apache.flink.table.utils.TableTestUtil._
+import org.junit.Test
+
+class SplitPythonConditionFromJoinRuleTest extends TableTestBase {
+
+  @Test
+  def testPythonFunctionInJoinCondition(): Unit = {
+    val util = streamTestUtil()
+    val left = util.addTable[(Int, Int, Int)]("leftTable", 'a, 'b, 'c)
+    val right = util.addTable[(Int, Int, Int)]("rightTable", 'd, 'e, 'f)
+    util.tableEnv.registerFunction("pyFunc", new PythonScalarFunction("pyFunc"))
+
+    val result = left
+      .join(right, "a === d && pyFunc(a, d) === b")
+      .select("a, b, d")
+
+    val expected = unaryNode(
+      "DataStreamCalc",
+      unaryNode(
+        "DataStreamPythonCalc",
+        binaryNode(
+          "DataStreamJoin",
+          unaryNode(
+            "DataStreamCalc",
+            streamTableNode(left),
+            term("select", "a", "b")
+          ),
+          unaryNode(
+            "DataStreamCalc",
+            streamTableNode(right),
+            term("select", "d")
+          ),
+          term("where", "=(a, d)"),
+          term("join", "a, b, d"),
+          term("joinType", "InnerJoin")
+        ),
+        term("select", "a", "b", "d", "pyFunc(a, d) AS f0")
+      ),
+      term("select", "a", "b", "d"),
+      term("where", "=(f0, b)")
+    )
+    util.verifyTable(result, expected)
+  }
+
+  @Test
+  def testPythonFunctionInAboveFilter(): Unit = {
+    val util = streamTestUtil()
+    val left = util.addTable[(Int, Int, Int)]("leftTable", 'a, 'b, 'c)
+    val right = util.addTable[(Int, Int, Int)]("rightTable", 'd, 'e, 'f)
+    util.tableEnv.registerFunction("pyFunc", new PythonScalarFunction("pyFunc"))
+
+    val result = left
+      .join(right, "a === d && pyFunc(a, d) = a + b")
+      .select("a, b, d")
+      .filter("pyFunc(a, b) = b * d")
+      .select("a + 1, b, d")
+
+    val expected = unaryNode(
+      "DataStreamCalc",
+      unaryNode(
+        "DataStreamPythonCalc",
+        binaryNode(
+          "DataStreamJoin",
+          unaryNode(
+            "DataStreamCalc",
+            streamTableNode(left),
+            term("select", "a", "b")),
+          unaryNode(
+            "DataStreamCalc",
+            streamTableNode(right),
+            term("select", "d")
+          ),
+          term("where", "=(a, d)"),
+          term("join", "a, b, d"),
+          term("joinType", "InnerJoin")
+        ),
+        term("select", "a", "b", "d", "pyFunc(a, d) AS f0", "pyFunc(a, b) AS f1")
+      ),
+      term("select", "+(a, 1) AS _c0, b, d"),
+      term("where", "AND(=(f0, +(a, b)), =(f1, *(b, d)))")
+    )
+
+    util.verifyTable(result, expected)
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

*Currently, there are places where Python ScalarFunction could not be used, for example:*
  - *Python UDF could not be used in MatchRecognize*
  - *Python UDFs could not be used in Join condition which take the columns from both the left table and the right table as inputs* 

We should add validation check for places where it’s not supported.


## Brief change log

This change added tests and can be verified as follows:
 * add join and matchRecognize tests*
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
