### PR TITLE
[FLINK-9955] Add Kubernetes ClusterDescriptor to support deploying session cluster.

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes;
+
+import org.apache.flink.client.deployment.ClusterDeploymentException;
+import org.apache.flink.client.deployment.ClusterDescriptor;
+import org.apache.flink.client.deployment.ClusterRetrieveException;
+import org.apache.flink.client.deployment.ClusterSpecification;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.client.program.rest.RestClusterClient;
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptionsInternal;
+import org.apache.flink.kubernetes.entrypoint.KubernetesSessionClusterEntrypoint;
+import org.apache.flink.kubernetes.kubeclient.Endpoint;
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesService;
+import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.kubernetes.utils.KubernetesUtils;
+import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Kubernetes specific {@link ClusterDescriptor} implementation.
+ */
+public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(KubernetesClusterDescriptor.class);
+
+	private static final String CLUSTER_DESCRIPTION = "Kubernetes cluster";
+
+	private final Configuration flinkConfig;
+
+	private final FlinkKubeClient client;
+
+	private final String clusterId;
+
+	public KubernetesClusterDescriptor(Configuration flinkConfig, FlinkKubeClient client) {
+		this.flinkConfig = flinkConfig;
+		this.client = client;
+		this.clusterId = flinkConfig.getString(KubernetesConfigOptions.CLUSTER_ID);
+		Preconditions.checkNotNull(clusterId, "ClusterId must be specified!");
+	}
+
+	@Override
+	public String getClusterDescription() {
+		return CLUSTER_DESCRIPTION;
+	}
+
+	private ClusterClient<String> createClusterClient(String clusterId) throws Exception {
+
+		Configuration configuration = new Configuration(flinkConfig);
+
+		final Endpoint restEndpoint = this.client.getRestEndpoint(clusterId);
+
+		if (restEndpoint != null) {
+			configuration.setString(RestOptions.ADDRESS, restEndpoint.getAddress());
+			configuration.setInteger(RestOptions.PORT, restEndpoint.getPort());
+		} else {
+			throw new ClusterRetrieveException("Could not get the rest endpoint of " + clusterId);
+		}
+
+		return new RestClusterClient<>(configuration, clusterId);
+	}
+
+	@Override
+	public ClusterClient<String> retrieve(String clusterId) throws ClusterRetrieveException {
+		try {
+			final ClusterClient<String> retrievedClient = createClusterClient(clusterId);
+			LOG.info("Retrieve flink cluster {} successfully, JobManager Web Interface : {}", clusterId,
+				retrievedClient.getWebInterfaceURL());
+			return retrievedClient;
+		} catch (Exception e) {
+			this.client.handleException(e);
+			throw new ClusterRetrieveException("Could not create the RestClusterClient.", e);
+		}
+	}
+
+	@Override
+	public ClusterClient<String> deploySessionCluster(ClusterSpecification clusterSpecification)
+		throws ClusterDeploymentException {
+
+		final ClusterClient<String> clusterClient = deployClusterInternal(
+			KubernetesSessionClusterEntrypoint.class.getName(), clusterSpecification, false);
+
+		LOG.info("Create flink session cluster {} successfully, JobManager Web Interface: {}",
+			clusterId, clusterClient.getWebInterfaceURL());
+		return clusterClient;
+	}
+
+	@Override
+	public ClusterClient<String> deployJobCluster(ClusterSpecification clusterSpecification,
+			JobGraph jobGraph, boolean detached) throws ClusterDeploymentException {
+		throw new ClusterDeploymentException("Per job could not be supported now.");
+	}
+
+	private ClusterClient<String> deployClusterInternal(
+			String entryPoint,
+			ClusterSpecification clusterSpecification,
+			boolean detached) throws ClusterDeploymentException {
+
+		final ClusterEntrypoint.ExecutionMode executionMode = detached ?
+			ClusterEntrypoint.ExecutionMode.DETACHED
+			: ClusterEntrypoint.ExecutionMode.NORMAL;
+		flinkConfig.setString(ClusterEntrypoint.EXECUTION_MODE, executionMode.toString());
+
+		flinkConfig.setString(KubernetesConfigOptionsInternal.ENTRY_POINT_CLASS, entryPoint);
+
+		// Rpc, blob, rest, taskManagerRpc ports need to be exposed, so update them to fixed values.
+		if (KubernetesUtils.parsePort(flinkConfig, BlobServerOptions.PORT) == 0) {
+			flinkConfig.setString(BlobServerOptions.PORT, String.valueOf(Constants.BLOB_SERVER_PORT));
+		}
+		if (KubernetesUtils.parsePort(flinkConfig, TaskManagerOptions.RPC_PORT) == 0) {
+			flinkConfig.setString(TaskManagerOptions.RPC_PORT, String.valueOf(Constants.TASK_MANAGER_RPC_PORT));
+		}
+
+		// Set jobmanager address to namespaced service name
+		final String nameSpace = flinkConfig.getString(KubernetesConfigOptions.NAMESPACE);
+		flinkConfig.setString(JobManagerOptions.ADDRESS, clusterId + "." + nameSpace);
+
+		try {
+			final KubernetesService internalSvc = this.client.createInternalService(clusterId).get();
+			// Update the service id in Flink config, it will be used for gc.
+			final String serviceId = internalSvc.getInternalResource().getMetadata().getUid();
+			if (serviceId != null) {
+				flinkConfig.setString(KubernetesConfigOptionsInternal.SERVICE_ID, serviceId);
+			} else {
+				throw new ClusterDeploymentException("Get service id failed.");
+			}
+
+			// Create the rest service when exposed type is not ClusterIp.
+			final String restSvcExposedType = flinkConfig.getString(KubernetesConfigOptions.REST_SERVICE_EXPOSED_TYPE);
+			if (!restSvcExposedType.equals(KubernetesConfigOptions.ServiceExposedType.ClusterIP.toString())) {
+				this.client.createRestService(clusterId).get();
+			}
+
+			this.client.createConfigMap();
+			this.client.createFlinkMasterDeployment(clusterSpecification);
+
+			return this.createClusterClient(clusterId);
+		} catch (Exception e) {
+			this.client.handleException(e);
+			throw new ClusterDeploymentException("Could not create Kubernetes cluster " + clusterId, e);
+		}
+	}
+
+	@Override
+	public void killCluster(String clusterId) throws FlinkException {
+		try {
+			this.client.stopAndCleanupCluster(clusterId);
+		} catch (Exception e) {
+			this.client.handleException(e);
+			throw new FlinkException("Could not kill Kubernetes cluster " + clusterId);
+		}
+	}
+
+	@Override
+	public void close() {
+		try {
+			this.client.close();
+		} catch (Exception e) {
+			this.client.handleException(e);
+			LOG.error("failed to close client, exception {}", e.toString());
+		}
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
 import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
 import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.util.FlinkRuntimeException;
 
 import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.KeyToPath;
@@ -81,6 +82,26 @@ public class KubernetesUtils {
 			return content.toString();
 		}
 		throw new FileNotFoundException("File " + filePath + " not exists.");
+	}
+
+	/**
+	 * Parse a valid port for the config option. A fixed port is expected, and do not support a range of ports.
+	 *
+	 * @param flinkConfig flink config
+	 * @param port port config option
+	 * @return valid port
+	 */
+	public static Integer parsePort(Configuration flinkConfig, ConfigOption<String> port) {
+		if (flinkConfig.get(port) == null) {
+			throw new FlinkRuntimeException(port.key() + " should not be null.");
+		}
+		try {
+			return Integer.parseInt(flinkConfig.get(port));
+		} catch (NumberFormatException ex) {
+			throw new FlinkRuntimeException(
+				port.key() + " should be specified to a fixed port. Do not support a range of ports.",
+				ex);
+		}
 	}
 
 	/**

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes;
+
+import org.apache.flink.client.deployment.ClusterSpecification;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptionsInternal;
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
+import org.apache.flink.kubernetes.utils.Constants;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ServiceList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for the {@link KubernetesClusterDescriptor}.
+ */
+public class KubernetesClusterDescriptorTest extends KubernetesTestBase {
+
+	@Test
+	public void testDeploySessionCluster() throws Exception {
+
+		final FlinkKubeClient flinkKubeClient = getFabric8FlinkKubeClient();
+		final KubernetesClusterDescriptor descriptor = new KubernetesClusterDescriptor(FLINK_CONFIG, flinkKubeClient);
+
+		final ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
+			.setMasterMemoryMB(1234)
+			.setTaskManagerMemoryMB(1222)
+			.setNumberTaskManagers(1)
+			.setSlotsPerTaskManager(1)
+			.createClusterSpecification();
+
+		final ClusterClient<String> clusterClient = descriptor.deploySessionCluster(clusterSpecification);
+
+		assertEquals(CLUSTER_ID, clusterClient.getClusterId());
+		assertEquals(String.format("http://%s:8081", MOCK_SERVICE_IP), clusterClient.getWebInterfaceURL());
+
+		// Check updated flink config options
+		assertEquals(String.valueOf(Constants.BLOB_SERVER_PORT), FLINK_CONFIG.getString(BlobServerOptions.PORT));
+		assertEquals(String.valueOf(Constants.TASK_MANAGER_RPC_PORT), FLINK_CONFIG.getString(TaskManagerOptions.RPC_PORT));
+		assertEquals(CLUSTER_ID + "." + NAMESPACE, FLINK_CONFIG.getString(JobManagerOptions.ADDRESS));
+		assertEquals(MOCK_SERVICE_ID, FLINK_CONFIG.getString(KubernetesConfigOptionsInternal.SERVICE_ID));
+
+		final KubernetesClient kubeClient = server.getClient();
+		final ServiceList serviceList = kubeClient.services().list();
+		assertEquals(2, serviceList.getItems().size());
+		assertEquals(CLUSTER_ID, serviceList.getItems().get(0).getMetadata().getName());
+
+		final Container jmContainer = kubeClient.apps().deployments().list().getItems().get(0).getSpec()
+			.getTemplate().getSpec().getContainers().get(0);
+		assertEquals(clusterSpecification.getMasterMemoryMB() + Constants.RESOURCE_UNIT_MB,
+			jmContainer.getResources().getRequests().get(Constants.RESOURCE_NAME_MEMORY).getAmount());
+		assertEquals(clusterSpecification.getMasterMemoryMB() + Constants.RESOURCE_UNIT_MB,
+			jmContainer.getResources().getLimits().get(Constants.RESOURCE_NAME_MEMORY).getAmount());
+	}
+
+	@Test
+	public void testKillCluster() throws Exception {
+
+		final FlinkKubeClient flinkKubeClient = getFabric8FlinkKubeClient();
+		final KubernetesClusterDescriptor descriptor = new KubernetesClusterDescriptor(FLINK_CONFIG, flinkKubeClient);
+
+		final ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
+			.setMasterMemoryMB(1)
+			.setTaskManagerMemoryMB(1)
+			.setNumberTaskManagers(1)
+			.setSlotsPerTaskManager(1)
+			.createClusterSpecification();
+
+		descriptor.deploySessionCluster(clusterSpecification);
+
+		final KubernetesClient kubeClient = server.getClient();
+		assertEquals(2, kubeClient.services().list().getItems().size());
+
+		descriptor.killCluster(CLUSTER_ID);
+		// Mock kubernetes server do not delete the rest service by gc, so the rest service still exist.
+		assertEquals(1, kubeClient.services().list().getItems().size());
+		assertEquals(MOCK_SERVICE_ID, kubeClient.services().list().getItems().get(0)
+			.getMetadata().getOwnerReferences().get(0).getUid());
+	}
+
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesTestBase.java
@@ -18,8 +18,10 @@
 
 package org.apache.flink.kubernetes;
 
+import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptionsInternal;
 import org.apache.flink.kubernetes.kubeclient.Fabric8FlinkKubeClient;
@@ -83,6 +85,8 @@ public class KubernetesTestBase extends TestLogger {
 		FLINK_CONFIG.setString(KubernetesConfigOptions.CONTAINER_IMAGE, CONTAINER_IMAGE);
 		FLINK_CONFIG.setString(KubernetesConfigOptionsInternal.SERVICE_ID, MOCK_SERVICE_ID);
 		FLINK_CONFIG.setString(KubernetesConfigOptionsInternal.ENTRY_POINT_CLASS, "main-class");
+		FLINK_CONFIG.setString(BlobServerOptions.PORT, String.valueOf(Constants.BLOB_SERVER_PORT));
+		FLINK_CONFIG.setString(TaskManagerOptions.RPC_PORT, String.valueOf(Constants.TASK_MANAGER_RPC_PORT));
 
 		flinkConfDir = temporaryFolder.newFolder().getAbsoluteFile();
 		BootstrapTools.writeConfiguration(new Configuration(), new File(flinkConfDir, "flink-conf.yaml"));


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR is part of FLINK-9953. `KubernetesClusterDescriptor` is added to support deploy session cluster.

This PR is based on #9957 #9965 #9986.


## Brief change log

* Add Kubernetes ClusterDescriptor to support deploying session cluster


## Verifying this change

This change added related unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
