### PR TITLE
[FLINK-14501][FLINK-14502] Decouple ClusterDescriptor/ClusterSpecification from CommandLine

### DIFF
--- a/docs/_includes/generated/deployment_configuration.html
+++ b/docs/_includes/generated/deployment_configuration.html
@@ -12,5 +12,10 @@
             <td style="word-wrap: break-word;">false</td>
             <td>Specifies if the pipeline is submitted in attached or detached mode.</td>
         </tr>
+        <tr>
+            <td><h5>execution.target</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>The deployment target for the execution, e.g. "local" for local execution.</td>
+        </tr>
     </tbody>
 </table>

--- a/docs/_includes/generated/deployment_configuration.html
+++ b/docs/_includes/generated/deployment_configuration.html
@@ -1,0 +1,16 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>execution.attached</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Specifies if the pipeline is submitted in attached or detached mode.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -8,6 +8,11 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>$internal.yarn.dynamic-properties</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>**DO NOT USE** Specify YARN dynamic properties.</td>
+        </tr>
+        <tr>
             <td><h5>yarn.application-attempt-failures-validity-interval</h5></td>
             <td style="word-wrap: break-word;">10000</td>
             <td>Time window in milliseconds which defines the number of application attempt failures when restarting the AM. Failures which fall outside of this window are not being considered. Set this value to -1 in order to count globally. See <a href="https://hortonworks.com/blog/apache-hadoop-yarn-hdp-2-2-fault-tolerance-features-long-running-services/">here</a> for more information.</td>
@@ -23,9 +28,34 @@
             <td>With this configuration option, users can specify a port, a range of ports or a list of ports for the Application Master (and JobManager) RPC port. By default we recommend using the default value (0) to let the operating system choose an appropriate port. In particular when multiple AMs are running on the same physical host, fixed port assignments prevent the AM from starting. For example when running Flink on YARN on an environment with a restrictive firewall, this option allows specifying a range of allowed ports.</td>
         </tr>
         <tr>
+            <td><h5>yarn.application.id</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>The YARN application id of the running yarn cluster. This is the YARN cluster where the pipeline is going to be executed.</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.application.name</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>A custom name for your YARN application.</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.application.node-label</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Specify YARN node label for the YARN application.</td>
+        </tr>
+        <tr>
             <td><h5>yarn.application.priority</h5></td>
             <td style="word-wrap: break-word;">-1</td>
             <td>A non-negative integer indicating the priority for submitting a Flink YARN application. It will only take effect if YARN priority scheduling setting is enabled. Larger integer corresponds with higher priority. If priority is negative or set to '-1'(default), Flink will unset yarn priority setting and use cluster default priority. Please refer to YARN's official documentation for specific settings required to enable priority scheduling for the targeted YARN version.</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.application.queue</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>The YARN queue on which to put the current pipeline.</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.application.type</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>A custom type for your YARN application..</td>
         </tr>
         <tr>
             <td><h5>yarn.appmaster.rpc.address</h5></td>
@@ -48,6 +78,11 @@
             <td>The number of virtual cores (vcores) per YARN container. By default, the number of vcores is set to the number of slots per TaskManager, if set, or to 1, otherwise. In order for this parameter to be used your cluster must have CPU scheduling enabled. You can do this by setting the <span markdown="span">`org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler`</span>.</td>
         </tr>
         <tr>
+            <td><h5>yarn.flink-dist-jar</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>The location of the Flink dist jar.</td>
+        </tr>
+        <tr>
             <td><h5>yarn.heartbeat.container-request-interval</h5></td>
             <td style="word-wrap: break-word;">500</td>
             <td>Time between heartbeats with the ResourceManager in milliseconds if Flink requests containers:<ul><li>The lower this value is, the faster Flink will get notified about container allocations since requests and allocations are transmitted via heartbeats.</li><li>The lower this value is, the more excessive containers might get allocated which will eventually be released but put pressure on Yarn.</li></ul>If you observe too many container allocations on the ResourceManager, then it is recommended to increase this value. See <a href="https://issues.apache.org/jira/browse/YARN-1902">this link</a> for more information.</td>
@@ -56,6 +91,11 @@
             <td><h5>yarn.heartbeat.interval</h5></td>
             <td style="word-wrap: break-word;">5</td>
             <td>Time between heartbeats with the ResourceManager in seconds.</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.log-config-file</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>The location of the log config file, e.g. the path to your log4j.properties for log4j.</td>
         </tr>
         <tr>
             <td><h5>yarn.maximum-failed-containers</h5></td>
@@ -71,6 +111,11 @@
             <td><h5>yarn.properties-file.location</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>When a Flink job is submitted to YARN, the JobManager’s host and the number of available processing slots is written into a properties file, so that the Flink client is able to pick those details up. This configuration parameter allows changing the default location of that file (for example for environments sharing a Flink installation between users).</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.ship-directories</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>A semicolon-separated list of directories to be shipped to the YARN cluster.</td>
         </tr>
         <tr>
             <td><h5>yarn.tags</h5></td>

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -64,6 +64,10 @@ These parameters configure the default HDFS used by Flink. Setups that do not sp
 
 {% include generated/core_configuration.html %}
 
+### Execution
+
+{% include generated/deployment_configuration.html %}
+
 ### JobManager
 
 {% include generated/job_manager_configuration.html %}

--- a/docs/ops/config.zh.md
+++ b/docs/ops/config.zh.md
@@ -64,6 +64,10 @@ These parameters configure the default HDFS used by Flink. Setups that do not sp
 
 {% include generated/core_configuration.html %}
 
+### Execution
+
+{% include generated/deployment_configuration.html %}
+
 ### JobManager
 
 {% include generated/job_manager_configuration.html %}

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
@@ -39,7 +39,7 @@ import static org.apache.flink.client.cli.CliFrontend.setJobManagerAddressInConf
  * a ZooKeeper namespace.
  *
  */
-public abstract class AbstractCustomCommandLine<T> implements CustomCommandLine<T> {
+public abstract class AbstractCustomCommandLine implements CustomCommandLine {
 
 	protected final Option zookeeperNamespaceOption = new Option("z", "zookeeperNamespace", true,
 		"Namespace to create the Zookeeper sub-paths for high availability mode");

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
@@ -19,6 +19,7 @@
 package org.apache.flink.client.cli;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.util.FlinkException;
@@ -72,6 +73,7 @@ public abstract class AbstractCustomCommandLine<T> implements CustomCommandLine<
 	@Override
 	public Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) throws FlinkException {
 		final Configuration resultingConfiguration = new Configuration(configuration);
+		resultingConfiguration.setString(DeploymentOptions.TARGET, getId());
 
 		if (commandLine.hasOption(addressOption.getOpt())) {
 			String addressWithPort = commandLine.getOptionValue(addressOption.getOpt());

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
@@ -69,13 +69,8 @@ public abstract class AbstractCustomCommandLine<T> implements CustomCommandLine<
 		baseOptions.addOption(zookeeperNamespaceOption);
 	}
 
-	/**
-	 * Override configuration settings by specified command line options.
-	 *
-	 * @param commandLine containing the overriding values
-	 * @return Effective configuration with the overridden configuration settings
-	 */
-	protected Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) throws FlinkException {
+	@Override
+	public Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) throws FlinkException {
 		final Configuration resultingConfiguration = new Configuration(configuration);
 
 		if (commandLine.hasOption(addressOption.getOpt())) {

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -175,7 +175,7 @@ public class CliFrontend {
 	 *
 	 * @param args Command line arguments for the run action.
 	 */
-	protected void run(String[] args) throws Exception {
+	public void run(String[] args) throws Exception {
 		LOG.info("Running 'run' command.");
 
 		final Options commandOptions = CliFrontendParser.getRunCommandOptions();
@@ -217,20 +217,20 @@ public class CliFrontend {
 		}
 	}
 
-	private <T> void runProgram(
+	private <ClusterID> void runProgram(
 			Configuration executorConfig,
 			RunOptions runOptions,
 			PackagedProgram program) throws ProgramInvocationException, FlinkException {
 
-		final ClusterClientFactory<T> clusterClientFactory = clusterClientServiceLoader.getClusterClientFactory(executorConfig);
+		final ClusterClientFactory<ClusterID> clusterClientFactory = clusterClientServiceLoader.getClusterClientFactory(executorConfig);
 		checkNotNull(clusterClientFactory);
 
-		final ClusterDescriptor<T> clusterDescriptor = clusterClientFactory.createClusterDescriptor(executorConfig);
+		final ClusterDescriptor<ClusterID> clusterDescriptor = clusterClientFactory.createClusterDescriptor(executorConfig);
 
 		try {
-			final T clusterId = clusterClientFactory.getClusterId(executorConfig);
+			final ClusterID clusterId = clusterClientFactory.getClusterId(executorConfig);
 
-			final ClusterClient<T> client;
+			final ClusterClient<ClusterID> client;
 
 			// directly deploy the job if the cluster is started in job mode and detached
 			if (clusterId == null && runOptions.getDetachedMode()) {
@@ -421,8 +421,8 @@ public class CliFrontend {
 
 	}
 
-	private <T> void listJobs(
-			ClusterClient<T> clusterClient,
+	private <ClusterID> void listJobs(
+			ClusterClient<ClusterID> clusterClient,
 			boolean showRunning,
 			boolean showScheduled,
 			boolean showAll) throws FlinkException {
@@ -965,10 +965,10 @@ public class CliFrontend {
 	 * Internal interface to encapsulate cluster actions which are executed via
 	 * the {@link ClusterClient}.
 	 *
-	 * @param <T> type of the cluster id
+	 * @param <ClusterID> type of the cluster id
 	 */
 	@FunctionalInterface
-	private interface ClusterAction<T> {
+	private interface ClusterAction<ClusterID> {
 
 		/**
 		 * Run the cluster action with the given {@link ClusterClient}.
@@ -976,7 +976,7 @@ public class CliFrontend {
 		 * @param clusterClient to run the cluster action against
 		 * @throws FlinkException if something goes wrong
 		 */
-		void runAction(ClusterClient<T> clusterClient) throws FlinkException;
+		void runAction(ClusterClient<ClusterID> clusterClient) throws FlinkException;
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -67,7 +67,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.net.InetSocketAddress;
 import java.net.URL;
@@ -85,7 +84,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * Implementation of a simple command line frontend for executing programs.
@@ -225,7 +223,7 @@ public class CliFrontend {
 			PackagedProgram program) throws ProgramInvocationException, FlinkException {
 
 		final ClusterClientFactory<T> clusterClientFactory = clusterClientServiceLoader.getClusterClientFactory(executorConfig);
-		checkState(clusterClientFactory != null);
+		checkNotNull(clusterClientFactory);
 
 		final ClusterDescriptor<T> clusterDescriptor = clusterClientFactory.createClusterDescriptor(executorConfig);
 
@@ -1184,7 +1182,7 @@ public class CliFrontend {
 	 * @param className The fully-qualified class name to load.
 	 * @param params The constructor parameters
 	 */
-	private static CustomCommandLine loadCustomCommandLine(String className, Object... params) throws IllegalAccessException, InvocationTargetException, InstantiationException, ClassNotFoundException, NoSuchMethodException {
+	private static CustomCommandLine loadCustomCommandLine(String className, Object... params) throws Exception {
 
 		Class<? extends CustomCommandLine> customCliClass =
 			Class.forName(className).asSubclass(CustomCommandLine.class);

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -306,7 +306,7 @@ public class CliFrontendParser {
 	/**
 	 * Prints the help for the client.
 	 */
-	public static void printHelp(Collection<CustomCommandLine<?>> customCommandLines) {
+	public static void printHelp(Collection<CustomCommandLine> customCommandLines) {
 		System.out.println("./flink <ACTION> [OPTIONS] [ARGUMENTS]");
 		System.out.println();
 		System.out.println("The following actions are available:");
@@ -321,7 +321,7 @@ public class CliFrontendParser {
 		System.out.println();
 	}
 
-	public static void printHelpForRun(Collection<CustomCommandLine<?>> customCommandLines) {
+	public static void printHelpForRun(Collection<CustomCommandLine> customCommandLines) {
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.setLeftPadding(5);
 		formatter.setWidth(80);
@@ -349,7 +349,7 @@ public class CliFrontendParser {
 		System.out.println();
 	}
 
-	public static void printHelpForList(Collection<CustomCommandLine<?>> customCommandLines) {
+	public static void printHelpForList(Collection<CustomCommandLine> customCommandLines) {
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.setLeftPadding(5);
 		formatter.setWidth(80);
@@ -364,7 +364,7 @@ public class CliFrontendParser {
 		System.out.println();
 	}
 
-	public static void printHelpForStop(Collection<CustomCommandLine<?>> customCommandLines) {
+	public static void printHelpForStop(Collection<CustomCommandLine> customCommandLines) {
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.setLeftPadding(5);
 		formatter.setWidth(80);
@@ -379,7 +379,7 @@ public class CliFrontendParser {
 		System.out.println();
 	}
 
-	public static void printHelpForCancel(Collection<CustomCommandLine<?>> customCommandLines) {
+	public static void printHelpForCancel(Collection<CustomCommandLine> customCommandLines) {
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.setLeftPadding(5);
 		formatter.setWidth(80);
@@ -394,7 +394,7 @@ public class CliFrontendParser {
 		System.out.println();
 	}
 
-	public static void printHelpForSavepoint(Collection<CustomCommandLine<?>> customCommandLines) {
+	public static void printHelpForSavepoint(Collection<CustomCommandLine> customCommandLines) {
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.setLeftPadding(5);
 		formatter.setWidth(80);
@@ -415,7 +415,7 @@ public class CliFrontendParser {
 	 * @param runOptions True if the run options should be printed, False to print only general options
 	 */
 	private static void printCustomCliOptions(
-			Collection<CustomCommandLine<?>> customCommandLines,
+			Collection<CustomCommandLine> customCommandLines,
 			HelpFormatter formatter,
 			boolean runOptions) {
 		// prints options from all available command-line classes

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CustomCommandLine.java
@@ -20,6 +20,7 @@ package org.apache.flink.client.cli;
 
 import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.deployment.ClusterSpecification;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.FlinkException;
 
 import org.apache.commons.cli.CommandLine;
@@ -59,37 +60,40 @@ public interface CustomCommandLine<T> {
 	void addGeneralOptions(Options baseOptions);
 
 	/**
-	 * Create a {@link ClusterDescriptor} from the given configuration, configuration directory
-	 * and the command line.
+	 * Override configuration settings by specified command line options.
 	 *
-	 * @param commandLine containing command line options relevant for the ClusterDescriptor
-	 * @return ClusterDescriptor
-	 * @throws FlinkException if the ClusterDescriptor could not be created
+	 * @param commandLine containing the overriding values
+	 * @return the effective configuration with the overridden configuration settings
 	 */
-	ClusterDescriptor<T> createClusterDescriptor(CommandLine commandLine) throws FlinkException;
+	Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) throws FlinkException;
 
 	/**
-	 * Returns the cluster id if a cluster id was specified on the command line, otherwise it
-	 * returns null.
+	 * Create a {@link ClusterDescriptor} from the given configuration.
 	 *
-	 * <p>A cluster id identifies a running cluster, e.g. the Yarn application id for a Flink
-	 * cluster running on Yarn.
+	 * @param configuration containing the configuration options relevant for the {@link ClusterDescriptor}
+	 * @return the corresponding {@link ClusterDescriptor}.
+	 */
+	ClusterDescriptor<T> createClusterDescriptor(Configuration configuration);
+
+	/**
+	 * Returns the cluster id if a cluster id is specified in the provided configuration, otherwise it returns {@code null}.
 	 *
-	 * @param commandLine containing command line options relevant for the cluster id retrieval
+	 * <p>A cluster id identifies a running cluster, e.g. the Yarn application id for a Flink cluster running on Yarn.
+	 *
+	 * @param configuration containing the configuration options relevant for the cluster id retrieval
 	 * @return Cluster id identifying the cluster to deploy jobs to or null
 	 */
 	@Nullable
-	T getClusterId(CommandLine commandLine);
+	T getClusterId(Configuration configuration);
 
 	/**
 	 * Returns the {@link ClusterSpecification} specified by the configuration and the command
 	 * line options. This specification can be used to deploy a new Flink cluster.
 	 *
-	 * @param commandLine containing command line options relevant for the ClusterSpecification
-	 * @return ClusterSpecification for a new Flink cluster
-	 * @throws FlinkException if the ClusterSpecification could not be created
+	 * @param configuration containing the configuration options relevant for the {@link ClusterSpecification}
+	 * @return the corresponding {@link ClusterSpecification} for a new Flink cluster
 	 */
-	ClusterSpecification getClusterSpecification(CommandLine commandLine) throws FlinkException;
+	ClusterSpecification getClusterSpecification(Configuration configuration);
 
 	default CommandLine parseCommandLineOptions(String[] args, boolean stopAtNonOptions) throws CliArgsException {
 		final Options options = new Options();

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CustomCommandLine.java
@@ -18,20 +18,16 @@
 
 package org.apache.flink.client.cli;
 
-import org.apache.flink.client.deployment.ClusterDescriptor;
-import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.FlinkException;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 
-import javax.annotation.Nullable;
-
 /**
  * Custom command-line interface to load hooks for the command-line interface.
  */
-public interface CustomCommandLine<T> {
+public interface CustomCommandLine {
 
 	/**
 	 * Signals whether the custom command-line wants to execute or not.
@@ -66,34 +62,6 @@ public interface CustomCommandLine<T> {
 	 * @return the effective configuration with the overridden configuration settings
 	 */
 	Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) throws FlinkException;
-
-	/**
-	 * Create a {@link ClusterDescriptor} from the given configuration.
-	 *
-	 * @param configuration containing the configuration options relevant for the {@link ClusterDescriptor}
-	 * @return the corresponding {@link ClusterDescriptor}.
-	 */
-	ClusterDescriptor<T> createClusterDescriptor(Configuration configuration);
-
-	/**
-	 * Returns the cluster id if a cluster id is specified in the provided configuration, otherwise it returns {@code null}.
-	 *
-	 * <p>A cluster id identifies a running cluster, e.g. the Yarn application id for a Flink cluster running on Yarn.
-	 *
-	 * @param configuration containing the configuration options relevant for the cluster id retrieval
-	 * @return Cluster id identifying the cluster to deploy jobs to or null
-	 */
-	@Nullable
-	T getClusterId(Configuration configuration);
-
-	/**
-	 * Returns the {@link ClusterSpecification} specified by the configuration and the command
-	 * line options. This specification can be used to deploy a new Flink cluster.
-	 *
-	 * @param configuration containing the configuration options relevant for the {@link ClusterSpecification}
-	 * @return the corresponding {@link ClusterSpecification} for a new Flink cluster
-	 */
-	ClusterSpecification getClusterSpecification(Configuration configuration);
 
 	default CommandLine parseCommandLineOptions(String[] args, boolean stopAtNonOptions) throws CliArgsException {
 		final Options options = new Options();

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
@@ -22,7 +22,6 @@ import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.deployment.StandaloneClusterDescriptor;
 import org.apache.flink.client.deployment.StandaloneClusterId;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.util.FlinkException;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
@@ -55,21 +54,18 @@ public class DefaultCLI extends AbstractCustomCommandLine<StandaloneClusterId> {
 	}
 
 	@Override
-	public StandaloneClusterDescriptor createClusterDescriptor(
-			CommandLine commandLine) throws FlinkException {
-		final Configuration effectiveConfiguration = applyCommandLineOptionsToConfiguration(commandLine);
-
-		return new StandaloneClusterDescriptor(effectiveConfiguration);
+	public StandaloneClusterDescriptor createClusterDescriptor(Configuration configuration) {
+		return new StandaloneClusterDescriptor(configuration);
 	}
 
 	@Override
 	@Nullable
-	public StandaloneClusterId getClusterId(CommandLine commandLine) {
+	public StandaloneClusterId getClusterId(Configuration configuration) {
 		return StandaloneClusterId.getInstance();
 	}
 
 	@Override
-	public ClusterSpecification getClusterSpecification(CommandLine commandLine) {
+	public ClusterSpecification getClusterSpecification(Configuration configuration) {
 		return new ClusterSpecification.ClusterSpecificationBuilder().createClusterSpecification();
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment;
+
+import org.apache.flink.configuration.Configuration;
+
+import javax.annotation.Nullable;
+
+/**
+ * A factory containing all the necessary information for creating clients to Flink clusters.
+ */
+public interface ClusterClientFactory<ClusterID> {
+
+	/**
+	 * Returns {@code true} if the current {@link ClusterClientFactory} is compatible with the provided configuration,
+	 * {@code false} otherwise.
+	 */
+	boolean isCompatibleWith(Configuration configuration);
+
+	/**
+	 * Create a {@link ClusterDescriptor} from the given configuration.
+	 *
+	 * @param configuration containing the configuration options relevant for the {@link ClusterDescriptor}
+	 * @return the corresponding {@link ClusterDescriptor}.
+	 */
+	ClusterDescriptor<ClusterID> createClusterDescriptor(Configuration configuration);
+
+	/**
+	 * Returns the cluster id if a cluster id is specified in the provided configuration, otherwise it returns {@code null}.
+	 *
+	 * <p>A cluster id identifies a running cluster, e.g. the Yarn application id for a Flink cluster running on Yarn.
+	 *
+	 * @param configuration containing the configuration options relevant for the cluster id retrieval
+	 * @return Cluster id identifying the cluster to deploy jobs to or null
+	 */
+	@Nullable
+	ClusterID getClusterId(Configuration configuration);
+
+	/**
+	 * Returns the {@link ClusterSpecification} specified by the configuration and the command
+	 * line options. This specification can be used to deploy a new Flink cluster.
+	 *
+	 * @param configuration containing the configuration options relevant for the {@link ClusterSpecification}
+	 * @return the corresponding {@link ClusterSpecification} for a new Flink cluster
+	 */
+	ClusterSpecification getClusterSpecification(Configuration configuration);
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientServiceLoader.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientServiceLoader.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment;
+
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * An interface used to discover the appropriate {@link ClusterClientFactory cluster client factory} based on the
+ * provided {@link Configuration}.
+ */
+public interface ClusterClientServiceLoader {
+
+	/**
+	 * Discovers the appropriate {@link ClusterClientFactory} based on the provided configuration.
+	 *
+	 * @param configuration the configuration based on which the appropriate factory is going to be used.
+	 * @return the appropriate {@link ClusterClientFactory}.
+	 */
+	<ClusterID> ClusterClientFactory<ClusterID> getClusterClientFactory(final Configuration configuration);
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/DefaultClusterClientServiceLoader.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/DefaultClusterClientServiceLoader.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment;
+
+import org.apache.flink.configuration.Configuration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A service provider for {@link ClusterClientFactory cluster client factories}.
+ */
+public class DefaultClusterClientServiceLoader implements ClusterClientServiceLoader {
+
+	private static final Logger LOG = LoggerFactory.getLogger(DefaultClusterClientServiceLoader.class);
+
+	private static final ServiceLoader<ClusterClientFactory> defaultLoader = ServiceLoader.load(ClusterClientFactory.class);
+
+	@Override
+	public <ClusterID> ClusterClientFactory<ClusterID> getClusterClientFactory(final Configuration configuration) {
+		checkNotNull(configuration);
+
+		final List<ClusterClientFactory> compatibleFactories = new ArrayList<>();
+		final Iterator<ClusterClientFactory> factories = defaultLoader.iterator();
+		while (factories.hasNext()) {
+			try {
+				final ClusterClientFactory factory = factories.next();
+				if (factory != null && factory.isCompatibleWith(configuration)) {
+					compatibleFactories.add(factory);
+				}
+			} catch (Throwable e) {
+				if (e.getCause() instanceof NoClassDefFoundError) {
+					LOG.info("Could not load factory due to missing dependencies.");
+				} else {
+					throw e;
+				}
+			}
+		}
+
+		if (compatibleFactories.size() > 1) {
+			final List<String> configStr =
+					configuration.toMap().entrySet().stream()
+							.map(e -> e.getKey() + "=" + e.getValue())
+							.collect(Collectors.toList());
+
+			throw new IllegalStateException("Multiple compatible client factories found for:\n" + String.join("\n", configStr) + ".");
+		}
+
+		return compatibleFactories.isEmpty() ? null : (ClusterClientFactory<ClusterID>) compatibleFactories.get(0);
+	}
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClientFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClientFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+
+import javax.annotation.Nullable;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link ClusterClientFactory} for a standalone cluster, i.e. Flink on bare-metal.
+ */
+public class StandaloneClientFactory implements ClusterClientFactory<StandaloneClusterId> {
+
+	public static final String ID = "default";
+
+	@Override
+	public boolean isCompatibleWith(Configuration configuration) {
+		checkNotNull(configuration);
+		return ID.equals(configuration.getString(DeploymentOptions.TARGET));
+	}
+
+	@Override
+	public StandaloneClusterDescriptor createClusterDescriptor(Configuration configuration) {
+		checkNotNull(configuration);
+		return new StandaloneClusterDescriptor(configuration);
+	}
+
+	@Override
+	@Nullable
+	public StandaloneClusterId getClusterId(Configuration configuration) {
+		checkNotNull(configuration);
+		return StandaloneClusterId.getInstance();
+	}
+
+	@Override
+	public ClusterSpecification getClusterSpecification(Configuration configuration) {
+		checkNotNull(configuration);
+		return new ClusterSpecification.ClusterSpecificationBuilder().createClusterSpecification();
+	}
+}

--- a/flink-clients/src/main/resources/META-INF/services/org.apache.flink.client.deployment.ClusterClientFactory
+++ b/flink-clients/src/main/resources/META-INF/services/org.apache.flink.client.deployment.ClusterClientFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.client.deployment.StandaloneClientFactory

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -146,33 +146,25 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 
 	// --------------------------------------------------------------------------------------------
 
-	public static void verifyCliFrontend(
-		AbstractCustomCommandLine cli,
-		String[] parameters,
-		int expectedParallelism,
-		boolean isDetached) throws Exception {
+	private static void verifyCliFrontend(
+			AbstractCustomCommandLine cli,
+			String[] parameters,
+			int expectedParallelism,
+			boolean isDetached) throws Exception {
 		RunTestingCliFrontend testFrontend =
 			new RunTestingCliFrontend(new DefaultClusterClientServiceLoader(), cli, expectedParallelism, isDetached);
 		testFrontend.run(parameters); // verifies the expected values (see below)
 	}
 
-	public static void verifyCliFrontend(
-		ClusterClientServiceLoader clusterClientServiceLoader,
-		AbstractCustomCommandLine cli,
-		String[] parameters,
-		int expectedParallelism,
-		boolean isDetached) throws Exception {
-		RunTestingCliFrontend testFrontend =
-			new RunTestingCliFrontend(clusterClientServiceLoader, cli, expectedParallelism, isDetached);
-		testFrontend.run(parameters); // verifies the expected values (see below)
-	}
-
-	private static final class RunTestingCliFrontend extends CliFrontend {
+	/**
+	 * A mock {@link CliFrontend}.
+	 */
+	public static final class RunTestingCliFrontend extends CliFrontend {
 
 		private final int expectedParallelism;
 		private final boolean isDetached;
 
-		private RunTestingCliFrontend(
+		public RunTestingCliFrontend(
 				ClusterClientServiceLoader clusterClientServiceLoader,
 				AbstractCustomCommandLine cli,
 				int expectedParallelism,

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.client.cli;
 
+import org.apache.flink.client.deployment.ClusterClientServiceLoader;
+import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.configuration.Configuration;
@@ -145,12 +147,23 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 	// --------------------------------------------------------------------------------------------
 
 	public static void verifyCliFrontend(
-		AbstractCustomCommandLine<?> cli,
+		AbstractCustomCommandLine cli,
 		String[] parameters,
 		int expectedParallelism,
 		boolean isDetached) throws Exception {
 		RunTestingCliFrontend testFrontend =
-			new RunTestingCliFrontend(cli, expectedParallelism, isDetached);
+			new RunTestingCliFrontend(new DefaultClusterClientServiceLoader(), cli, expectedParallelism, isDetached);
+		testFrontend.run(parameters); // verifies the expected values (see below)
+	}
+
+	public static void verifyCliFrontend(
+		ClusterClientServiceLoader clusterClientServiceLoader,
+		AbstractCustomCommandLine cli,
+		String[] parameters,
+		int expectedParallelism,
+		boolean isDetached) throws Exception {
+		RunTestingCliFrontend testFrontend =
+			new RunTestingCliFrontend(clusterClientServiceLoader, cli, expectedParallelism, isDetached);
 		testFrontend.run(parameters); // verifies the expected values (see below)
 	}
 
@@ -160,11 +173,13 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 		private final boolean isDetached;
 
 		private RunTestingCliFrontend(
-				AbstractCustomCommandLine<?> cli,
+				ClusterClientServiceLoader clusterClientServiceLoader,
+				AbstractCustomCommandLine cli,
 				int expectedParallelism,
 				boolean isDetached) {
 			super(
 				cli.getConfiguration(),
+				clusterClientServiceLoader,
 				Collections.singletonList(cli));
 			this.expectedParallelism = expectedParallelism;
 			this.isDetached = isDetached;

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestBase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestBase.java
@@ -28,12 +28,10 @@ import org.apache.flink.util.TestLogger;
 public abstract class CliFrontendTestBase extends TestLogger {
 
 	protected Configuration getConfiguration() {
-		final Configuration configuration = GlobalConfiguration
-			.loadConfiguration(CliFrontendTestUtils.getConfigDir());
-		return configuration;
+		return GlobalConfiguration.loadConfiguration(CliFrontendTestUtils.getConfigDir());
 	}
 
-	static AbstractCustomCommandLine<?> getCli(Configuration configuration) {
+	static AbstractCustomCommandLine getCli(Configuration configuration) {
 		return new DefaultCLI(configuration);
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
@@ -64,11 +64,10 @@ public class DefaultCLITest extends CliFrontendTestBase {
 		final String[] args = {};
 
 		CommandLine commandLine = defaultCLI.parseCommandLineOptions(args, false);
+		final Configuration executorConfig = defaultCLI.applyCommandLineOptionsToConfiguration(commandLine);
 
-		final ClusterDescriptor<StandaloneClusterId> clusterDescriptor =
-			defaultCLI.createClusterDescriptor(commandLine);
-
-		final ClusterClient<?> clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(commandLine));
+		final ClusterDescriptor<StandaloneClusterId> clusterDescriptor = defaultCLI.createClusterDescriptor(executorConfig);
+		final ClusterClient<?> clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(executorConfig));
 
 		final URL webInterfaceUrl = new URL(clusterClient.getWebInterfaceURL());
 
@@ -97,11 +96,10 @@ public class DefaultCLITest extends CliFrontendTestBase {
 		final String[] args = {"-m", manualHostname + ':' + manualPort};
 
 		CommandLine commandLine = defaultCLI.parseCommandLineOptions(args, false);
+		final Configuration executorConfig = defaultCLI.applyCommandLineOptionsToConfiguration(commandLine);
 
-		final ClusterDescriptor<StandaloneClusterId> clusterDescriptor =
-			defaultCLI.createClusterDescriptor(commandLine);
-
-		final ClusterClient<?> clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(commandLine));
+		final ClusterDescriptor<StandaloneClusterId> clusterDescriptor = defaultCLI.createClusterDescriptor(executorConfig);
+		final ClusterClient<?> clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(executorConfig));
 
 		final URL webInterfaceUrl = new URL(clusterClient.getWebInterfaceURL());
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
@@ -18,12 +18,16 @@
 
 package org.apache.flink.client.cli;
 
+import org.apache.flink.client.deployment.ClusterClientFactory;
+import org.apache.flink.client.deployment.ClusterClientServiceLoader;
 import org.apache.flink.client.deployment.ClusterDescriptor;
+import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
 import org.apache.flink.client.deployment.StandaloneClusterId;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.util.FlinkException;
 
 import org.apache.commons.cli.CommandLine;
 import org.hamcrest.Matchers;
@@ -33,6 +37,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.net.URL;
 
+import static org.apache.flink.util.Preconditions.checkState;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -57,17 +62,12 @@ public class DefaultCLITest extends CliFrontendTestBase {
 		configuration.setString(RestOptions.ADDRESS, localhost);
 		configuration.setInteger(RestOptions.PORT, port);
 
-		@SuppressWarnings("unchecked")
-		final AbstractCustomCommandLine<StandaloneClusterId> defaultCLI =
-			(AbstractCustomCommandLine<StandaloneClusterId>) getCli(configuration);
+		final AbstractCustomCommandLine defaultCLI = getCli(configuration);
 
 		final String[] args = {};
 
-		CommandLine commandLine = defaultCLI.parseCommandLineOptions(args, false);
-		final Configuration executorConfig = defaultCLI.applyCommandLineOptionsToConfiguration(commandLine);
-
-		final ClusterDescriptor<StandaloneClusterId> clusterDescriptor = defaultCLI.createClusterDescriptor(executorConfig);
-		final ClusterClient<?> clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(executorConfig));
+		final CommandLine commandLine = defaultCLI.parseCommandLineOptions(args, false);
+		final ClusterClient<?> clusterClient = getClusterClient(defaultCLI, commandLine);
 
 		final URL webInterfaceUrl = new URL(clusterClient.getWebInterfaceURL());
 
@@ -87,19 +87,14 @@ public class DefaultCLITest extends CliFrontendTestBase {
 		configuration.setString(JobManagerOptions.ADDRESS, localhost);
 		configuration.setInteger(JobManagerOptions.PORT, port);
 
-		@SuppressWarnings("unchecked")
-		final AbstractCustomCommandLine<StandaloneClusterId> defaultCLI =
-			(AbstractCustomCommandLine<StandaloneClusterId>) getCli(configuration);
+		final AbstractCustomCommandLine defaultCLI = getCli(configuration);
 
 		final String manualHostname = "123.123.123.123";
 		final int manualPort = 4321;
 		final String[] args = {"-m", manualHostname + ':' + manualPort};
 
-		CommandLine commandLine = defaultCLI.parseCommandLineOptions(args, false);
-		final Configuration executorConfig = defaultCLI.applyCommandLineOptionsToConfiguration(commandLine);
-
-		final ClusterDescriptor<StandaloneClusterId> clusterDescriptor = defaultCLI.createClusterDescriptor(executorConfig);
-		final ClusterClient<?> clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(executorConfig));
+		final CommandLine commandLine = defaultCLI.parseCommandLineOptions(args, false);
+		final ClusterClient<?> clusterClient = getClusterClient(defaultCLI, commandLine);
 
 		final URL webInterfaceUrl = new URL(clusterClient.getWebInterfaceURL());
 
@@ -107,4 +102,13 @@ public class DefaultCLITest extends CliFrontendTestBase {
 		assertThat(webInterfaceUrl.getPort(), Matchers.equalTo(manualPort));
 	}
 
+	private ClusterClient<?> getClusterClient(AbstractCustomCommandLine defaultCLI, CommandLine commandLine) throws FlinkException {
+		final ClusterClientServiceLoader serviceLoader = new DefaultClusterClientServiceLoader();
+		final Configuration executorConfig = defaultCLI.applyCommandLineOptionsToConfiguration(commandLine);
+		final ClusterClientFactory<StandaloneClusterId> clusterFactory = serviceLoader.getClusterClientFactory(executorConfig);
+		checkState(clusterFactory != null);
+
+		final ClusterDescriptor<StandaloneClusterId> clusterDescriptor = clusterFactory.createClusterDescriptor(executorConfig);
+		return clusterDescriptor.retrieve(clusterFactory.getClusterId(executorConfig));
+	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyClusterClientFactory.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyClusterClientFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.cli.util;
+
+import org.apache.flink.client.deployment.ClusterClientFactory;
+import org.apache.flink.client.deployment.ClusterDescriptor;
+import org.apache.flink.client.deployment.ClusterSpecification;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+
+import javax.annotation.Nullable;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link ClusterClientFactory} used for testing.
+ * @param <ClusterID> The type of the id of the cluster.
+ */
+public class DummyClusterClientFactory<ClusterID> implements ClusterClientFactory {
+
+	public static final String ID = "dummy-client-factory";
+
+	private final ClusterClient<ClusterID> clusterClient;
+
+	public DummyClusterClientFactory(ClusterClient<ClusterID> clusterClient) {
+		this.clusterClient = checkNotNull(clusterClient);
+	}
+
+	@Override
+	public boolean isCompatibleWith(Configuration configuration) {
+		return ID.equals(configuration.getString(DeploymentOptions.TARGET));
+	}
+
+	@Override
+	public ClusterDescriptor<ClusterID> createClusterDescriptor(Configuration configuration) {
+		return new DummyClusterDescriptor<>(checkNotNull(clusterClient));
+	}
+
+	@Override
+	@Nullable
+	public String getClusterId(Configuration configuration) {
+		return "dummy";
+	}
+
+	@Override
+	public ClusterSpecification getClusterSpecification(Configuration configuration) {
+		return new ClusterSpecification.ClusterSpecificationBuilder().createClusterSpecification();
+	}
+}

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyClusterClientServiceLoader.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyClusterClientServiceLoader.java
@@ -16,36 +16,29 @@
  * limitations under the License.
  */
 
-package org.apache.flink.client.cli;
+package org.apache.flink.client.cli.util;
 
-import org.apache.flink.client.deployment.StandaloneClientFactory;
+import org.apache.flink.client.deployment.ClusterClientFactory;
+import org.apache.flink.client.deployment.ClusterClientServiceLoader;
+import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
 
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Options;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * The default CLI which is used for interaction with standalone clusters.
+ * A test {@link ClusterClientServiceLoader} that returns always a {@link DummyClusterClientFactory}.
  */
-public class DefaultCLI extends AbstractCustomCommandLine {
+public class DummyClusterClientServiceLoader<ClusterID> implements ClusterClientServiceLoader {
 
-	public DefaultCLI(Configuration configuration) {
-		super(configuration);
+	private final ClusterClient<ClusterID> clusterClient;
+
+	public DummyClusterClientServiceLoader(final ClusterClient<ClusterID> clusterClient) {
+		this.clusterClient = checkNotNull(clusterClient);
 	}
 
 	@Override
-	public boolean isActive(CommandLine commandLine) {
-		// always active because we can try to read a JobManager address from the config
-		return true;
-	}
-
-	@Override
-	public String getId() {
-		return StandaloneClientFactory.ID;
-	}
-
-	@Override
-	public void addGeneralOptions(Options baseOptions) {
-		super.addGeneralOptions(baseOptions);
+	public <C> ClusterClientFactory<C> getClusterClientFactory(final Configuration configuration) {
+		checkNotNull(configuration);
+		return new DummyClusterClientFactory<>(clusterClient);
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyClusterDescriptor.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyClusterDescriptor.java
@@ -22,7 +22,6 @@ import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 
 /**
@@ -60,7 +59,7 @@ public class DummyClusterDescriptor<T> implements ClusterDescriptor<T> {
 	}
 
 	@Override
-	public void killCluster(T clusterId) throws FlinkException {
+	public void killCluster(T clusterId) {
 		throw new UnsupportedOperationException("Cannot terminate a dummy cluster.");
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyCustomCommandLine.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyCustomCommandLine.java
@@ -19,26 +19,16 @@
 package org.apache.flink.client.cli.util;
 
 import org.apache.flink.client.cli.CustomCommandLine;
-import org.apache.flink.client.deployment.ClusterDescriptor;
-import org.apache.flink.client.deployment.ClusterSpecification;
-import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.util.Preconditions;
+import org.apache.flink.configuration.DeploymentOptions;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 
-import javax.annotation.Nullable;
-
 /**
  * Dummy implementation of the {@link CustomCommandLine} for testing purposes.
  */
-public class DummyCustomCommandLine<T> implements CustomCommandLine {
-	private final ClusterClient<T> clusterClient;
-
-	public DummyCustomCommandLine(ClusterClient<T> clusterClient) {
-		this.clusterClient = Preconditions.checkNotNull(clusterClient);
-	}
+public class DummyCustomCommandLine implements CustomCommandLine {
 
 	@Override
 	public boolean isActive(CommandLine commandLine) {
@@ -47,7 +37,7 @@ public class DummyCustomCommandLine<T> implements CustomCommandLine {
 
 	@Override
 	public String getId() {
-		return DummyCustomCommandLine.class.getSimpleName();
+		return DummyClusterClientFactory.ID;
 	}
 
 	@Override
@@ -62,22 +52,8 @@ public class DummyCustomCommandLine<T> implements CustomCommandLine {
 
 	@Override
 	public Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) {
-		return new Configuration();
-	}
-
-	@Override
-	public ClusterDescriptor<T> createClusterDescriptor(Configuration configuration) {
-		return new DummyClusterDescriptor<>(clusterClient);
-	}
-
-	@Override
-	@Nullable
-	public String getClusterId(Configuration configuration) {
-		return "dummy";
-	}
-
-	@Override
-	public ClusterSpecification getClusterSpecification(Configuration configuration) {
-		return new ClusterSpecification.ClusterSpecificationBuilder().createClusterSpecification();
+		final Configuration configuration = new Configuration();
+		configuration.setString(DeploymentOptions.TARGET, DummyClusterClientFactory.ID);
+		return configuration;
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyCustomCommandLine.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyCustomCommandLine.java
@@ -22,6 +22,7 @@ import org.apache.flink.client.cli.CustomCommandLine;
 import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.commons.cli.CommandLine;
@@ -60,18 +61,23 @@ public class DummyCustomCommandLine<T> implements CustomCommandLine {
 	}
 
 	@Override
-	public ClusterDescriptor<T> createClusterDescriptor(CommandLine commandLine) {
+	public Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) {
+		return new Configuration();
+	}
+
+	@Override
+	public ClusterDescriptor<T> createClusterDescriptor(Configuration configuration) {
 		return new DummyClusterDescriptor<>(clusterClient);
 	}
 
 	@Override
 	@Nullable
-	public String getClusterId(CommandLine commandLine) {
+	public String getClusterId(Configuration configuration) {
 		return "dummy";
 	}
 
 	@Override
-	public ClusterSpecification getClusterSpecification(CommandLine commandLine) {
+	public ClusterSpecification getClusterSpecification(Configuration configuration) {
 		return new ClusterSpecification.ClusterSpecificationBuilder().createClusterSpecification();
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/util/MockedCliFrontend.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/util/MockedCliFrontend.java
@@ -31,9 +31,10 @@ import java.util.Collections;
  */
 public class MockedCliFrontend extends CliFrontend {
 
-	public MockedCliFrontend(ClusterClient clusterClient) throws Exception {
+	public MockedCliFrontend(ClusterClient clusterClient) {
 		super(
 			new Configuration(),
-			Collections.singletonList(new DummyCustomCommandLine(clusterClient)));
+			new DummyClusterClientServiceLoader<>(clusterClient),
+			Collections.singletonList(new DummyCustomCommandLine()));
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/ClusterClientServiceLoaderTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/ClusterClientServiceLoaderTest.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the {@link DefaultClusterClientServiceLoader}.
+ */
+public class ClusterClientServiceLoaderTest {
+
+	private static final String VALID_TARGET = "existing";
+	private static final String AMBIGUOUS_TARGET = "duplicate";
+	private static final String NON_EXISTING_TARGET = "non-existing";
+
+	private static final int VALID_ID = 42;
+
+	private ClusterClientServiceLoader serviceLoaderUnderTest;
+
+	@Before
+	public void init() {
+		serviceLoaderUnderTest = new DefaultClusterClientServiceLoader();
+	}
+
+	@Test
+	public void testStandaloneClusterClientFactoryDiscovery() {
+		final Configuration config = new Configuration();
+		config.setString(DeploymentOptions.TARGET, StandaloneClientFactory.ID);
+
+		ClusterClientFactory<StandaloneClusterId> factory = serviceLoaderUnderTest.getClusterClientFactory(config);
+		assertTrue(factory instanceof StandaloneClientFactory);
+	}
+
+	@Test
+	public void testFactoryDiscovery() {
+		final Configuration config = new Configuration();
+		config.setString(DeploymentOptions.TARGET, VALID_TARGET);
+
+		final ClusterClientFactory<Integer> factory = serviceLoaderUnderTest.getClusterClientFactory(config);
+		assertNotNull(factory);
+
+		final Integer id = factory.getClusterId(config);
+		assertThat(id, allOf(is(notNullValue()), equalTo(VALID_ID)));
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testMoreThanOneCompatibleFactoriesException() {
+		final Configuration config = new Configuration();
+		config.setString(DeploymentOptions.TARGET, AMBIGUOUS_TARGET);
+
+		serviceLoaderUnderTest.getClusterClientFactory(config);
+		fail();
+	}
+
+	@Test
+	public void testNoFactoriesFound() {
+		final Configuration config = new Configuration();
+		config.setString(DeploymentOptions.TARGET, NON_EXISTING_TARGET);
+
+		final ClusterClientFactory<Integer> factory = serviceLoaderUnderTest.getClusterClientFactory(config);
+		assertNull(factory);
+	}
+
+	/**
+	 * Test {@link ClusterClientFactory} that is successfully discovered.
+	 */
+	public static class ValidClusterClientFactory extends DummyClusterClientFactory {
+
+		public static final String ID = VALID_TARGET;
+
+		@Override
+		public boolean isCompatibleWith(Configuration configuration) {
+			return configuration.getString(DeploymentOptions.TARGET).equals(VALID_TARGET);
+		}
+
+		@Nullable
+		@Override
+		public Integer getClusterId(Configuration configuration) {
+			return VALID_ID;
+		}
+	}
+
+	/**
+	 * Test {@link ClusterClientFactory} that has a duplicate.
+	 */
+	public static class FirstCollidingClusterClientFactory extends DummyClusterClientFactory {
+
+		public static final String ID = AMBIGUOUS_TARGET;
+
+		@Override
+		public boolean isCompatibleWith(Configuration configuration) {
+			return configuration.getString(DeploymentOptions.TARGET).equals(AMBIGUOUS_TARGET);
+		}
+	}
+
+	/**
+	 * Test {@link ClusterClientFactory} that has a duplicate.
+	 */
+	public static class SecondCollidingClusterClientFactory extends DummyClusterClientFactory {
+
+		public static final String ID = AMBIGUOUS_TARGET;
+
+		@Override
+		public boolean isCompatibleWith(Configuration configuration) {
+			return configuration.getString(DeploymentOptions.TARGET).equals(AMBIGUOUS_TARGET);
+		}
+	}
+
+	/**
+	 * A base test {@link ClusterClientFactory} that supports no operation and is meant to be extended.
+	 */
+	public static class DummyClusterClientFactory implements ClusterClientFactory<Integer> {
+
+		@Override
+		public boolean isCompatibleWith(Configuration configuration) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public ClusterDescriptor<Integer> createClusterDescriptor(Configuration configuration) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Nullable
+		@Override
+		public Integer getClusterId(Configuration configuration) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public ClusterSpecification getClusterSpecification(Configuration configuration) {
+			throw new UnsupportedOperationException();
+		}
+	}
+}

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/ClusterClientServiceLoaderTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/ClusterClientServiceLoaderTest.java
@@ -96,7 +96,7 @@ public class ClusterClientServiceLoaderTest {
 	/**
 	 * Test {@link ClusterClientFactory} that is successfully discovered.
 	 */
-	public static class ValidClusterClientFactory extends DummyClusterClientFactory {
+	public static class ValidClusterClientFactory extends BaseTestingClusterClientFactory {
 
 		public static final String ID = VALID_TARGET;
 
@@ -115,7 +115,7 @@ public class ClusterClientServiceLoaderTest {
 	/**
 	 * Test {@link ClusterClientFactory} that has a duplicate.
 	 */
-	public static class FirstCollidingClusterClientFactory extends DummyClusterClientFactory {
+	public static class FirstCollidingClusterClientFactory extends BaseTestingClusterClientFactory {
 
 		public static final String ID = AMBIGUOUS_TARGET;
 
@@ -128,7 +128,7 @@ public class ClusterClientServiceLoaderTest {
 	/**
 	 * Test {@link ClusterClientFactory} that has a duplicate.
 	 */
-	public static class SecondCollidingClusterClientFactory extends DummyClusterClientFactory {
+	public static class SecondCollidingClusterClientFactory extends BaseTestingClusterClientFactory {
 
 		public static final String ID = AMBIGUOUS_TARGET;
 
@@ -141,7 +141,7 @@ public class ClusterClientServiceLoaderTest {
 	/**
 	 * A base test {@link ClusterClientFactory} that supports no operation and is meant to be extended.
 	 */
-	public static class DummyClusterClientFactory implements ClusterClientFactory<Integer> {
+	public static class BaseTestingClusterClientFactory implements ClusterClientFactory<Integer> {
 
 		@Override
 		public boolean isCompatibleWith(Configuration configuration) {

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -554,10 +554,10 @@ public class RestClusterClientTest extends TestLogger {
 		final String[] args = {"-m", manualHostname + ':' + manualPort};
 
 		CommandLine commandLine = defaultCLI.parseCommandLineOptions(args, false);
+		final Configuration executorConfig = defaultCLI.applyCommandLineOptionsToConfiguration(commandLine);
 
-		final StandaloneClusterDescriptor clusterDescriptor = defaultCLI.createClusterDescriptor(commandLine);
-
-		final RestClusterClient<?> clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(commandLine));
+		final StandaloneClusterDescriptor clusterDescriptor = defaultCLI.createClusterDescriptor(executorConfig);
+		final RestClusterClient<?> clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(executorConfig));
 
 		URL webMonitorBaseUrl = clusterClient.getWebMonitorBaseUrl().get();
 		assertThat(webMonitorBaseUrl.getHost(), equalTo(manualHostname));

--- a/flink-clients/src/test/resources/META-INF/services/org.apache.flink.client.deployment.ClusterClientFactory
+++ b/flink-clients/src/test/resources/META-INF/services/org.apache.flink.client.deployment.ClusterClientFactory
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.client.deployment.ClusterClientServiceLoaderTest$ValidClusterClientFactory
+org.apache.flink.client.deployment.ClusterClientServiceLoaderTest$FirstCollidingClusterClientFactory
+org.apache.flink.client.deployment.ClusterClientServiceLoaderTest$SecondCollidingClusterClientFactory

--- a/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import static org.apache.flink.configuration.ConfigOptions.key;
+
+/**
+ * The {@link ConfigOption configuration options} relevant for all Executors.
+ */
+@PublicEvolving
+public class DeploymentOptions {
+
+	public static final ConfigOption<Boolean> ATTACHED =
+			key("execution.attached")
+					.defaultValue(false)
+					.withDescription("Specifies if the pipeline is submitted in attached or detached mode.");
+}

--- a/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
@@ -28,6 +28,11 @@ import static org.apache.flink.configuration.ConfigOptions.key;
 @PublicEvolving
 public class DeploymentOptions {
 
+	public static final ConfigOption<String> TARGET =
+			key("execution.target")
+					.noDefaultValue()
+					.withDescription("The deployment target for the execution, e.g. \"local\" for local execution.");
+
 	public static final ConfigOption<Boolean> ATTACHED =
 			key("execution.attached")
 					.defaultValue(false)

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -22,7 +22,7 @@ import java.io._
 import java.net.URL
 
 import org.apache.flink.client.cli.{CliFrontend, CliFrontendParser}
-import org.apache.flink.client.deployment.ClusterDescriptor
+import org.apache.flink.client.deployment.{ClusterDescriptor, DefaultClusterClientServiceLoader}
 import org.apache.flink.client.program.ClusterClient
 import org.apache.flink.configuration.{Configuration, GlobalConfiguration, JobManagerOptions}
 import org.apache.flink.runtime.minicluster.{MiniCluster, MiniClusterConfiguration}
@@ -258,11 +258,12 @@ object FlinkShell {
     val commandLine = CliFrontendParser.parse(commandLineOptions, args.toArray, true)
 
     val customCLI = frontend.getActiveCustomCommandLine(commandLine)
-    val executorConfig = customCLI.applyCommandLineOptionsToConfiguration(commandLine);
+    val executorConfig = customCLI.applyCommandLineOptionsToConfiguration(commandLine)
 
-    val clusterDescriptor = customCLI.createClusterDescriptor(executorConfig)
-
-    val clusterSpecification = customCLI.getClusterSpecification(executorConfig)
+    val serviceLoader = new DefaultClusterClientServiceLoader
+    val clientFactory = serviceLoader.getClusterClientFactory(executorConfig)
+    val clusterDescriptor = clientFactory.createClusterDescriptor(executorConfig)
+    val clusterSpecification = clientFactory.getClusterSpecification(executorConfig)
 
     val cluster = clusterDescriptor.deploySessionCluster(clusterSpecification)
 
@@ -291,11 +292,12 @@ object FlinkShell {
     val customCLI = frontend.getActiveCustomCommandLine(commandLine)
     val executorConfig = customCLI.applyCommandLineOptionsToConfiguration(commandLine);
 
-    val clusterDescriptor = customCLI
+    val serviceLoader = new DefaultClusterClientServiceLoader
+    val clientFactory = serviceLoader.getClusterClientFactory(executorConfig)
+    val clusterDescriptor = clientFactory
       .createClusterDescriptor(executorConfig)
       .asInstanceOf[ClusterDescriptor[Any]]
-
-    val clusterId = customCLI.getClusterId(executorConfig)
+    val clusterId = clientFactory.getClusterId(executorConfig)
 
     val cluster = clusterDescriptor.retrieve(clusterId)
 

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -258,10 +258,11 @@ object FlinkShell {
     val commandLine = CliFrontendParser.parse(commandLineOptions, args.toArray, true)
 
     val customCLI = frontend.getActiveCustomCommandLine(commandLine)
+    val executorConfig = customCLI.applyCommandLineOptionsToConfiguration(commandLine);
 
-    val clusterDescriptor = customCLI.createClusterDescriptor(commandLine)
+    val clusterDescriptor = customCLI.createClusterDescriptor(executorConfig)
 
-    val clusterSpecification = customCLI.getClusterSpecification(commandLine)
+    val clusterSpecification = customCLI.getClusterSpecification(executorConfig)
 
     val cluster = clusterDescriptor.deploySessionCluster(clusterSpecification)
 
@@ -288,12 +289,13 @@ object FlinkShell {
       configuration,
       CliFrontend.loadCustomCommandLines(configuration, configurationDirectory))
     val customCLI = frontend.getActiveCustomCommandLine(commandLine)
+    val executorConfig = customCLI.applyCommandLineOptionsToConfiguration(commandLine);
 
     val clusterDescriptor = customCLI
-      .createClusterDescriptor(commandLine)
+      .createClusterDescriptor(executorConfig)
       .asInstanceOf[ClusterDescriptor[Any]]
 
-    val clusterId = customCLI.getClusterId(commandLine)
+    val clusterId = customCLI.getClusterId(executorConfig)
 
     val cluster = clusterDescriptor.retrieve(clusterId)
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -103,9 +103,9 @@ import static org.apache.flink.util.Preconditions.checkState;
  * multiple queries as long as the session context does not change. This must be thread-safe as
  * it might be reused across different query submissions.
  *
- * @param <T> cluster id
+ * @param <ClusterID> cluster id
  */
-public class ExecutionContext<T> {
+public class ExecutionContext<ClusterID> {
 
 	private final SessionContext sessionContext;
 	private final Environment mergedEnv;
@@ -117,9 +117,9 @@ public class ExecutionContext<T> {
 	private final Map<String, UserDefinedFunction> functions;
 	private final Configuration flinkConfig;
 	private final Configuration executorConfig;
-	private final ClusterClientFactory<T> clusterClientFactory;
+	private final ClusterClientFactory<ClusterID> clusterClientFactory;
 	private final RunOptions runOptions;
-	private final T clusterId;
+	private final ClusterID clusterId;
 	private final ClusterSpecification clusterSpec;
 
 	public ExecutionContext(Environment defaultEnvironment, SessionContext sessionContext, List<URL> dependencies,
@@ -194,11 +194,11 @@ public class ExecutionContext<T> {
 		return clusterSpec;
 	}
 
-	public T getClusterId() {
+	public ClusterID getClusterId() {
 		return clusterId;
 	}
 
-	public ClusterDescriptor<T> createClusterDescriptor() {
+	public ClusterDescriptor<ClusterID> createClusterDescriptor() {
 		return clusterClientFactory.createClusterDescriptor(executorConfig);
 	}
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -110,14 +110,14 @@ public class ExecutionContext<T> {
 	private final Map<String, TableSink<?>> tableSinks;
 	private final Map<String, UserDefinedFunction> functions;
 	private final Configuration flinkConfig;
-	private final CommandLine commandLine;
+	private final Configuration executorConfig;
 	private final CustomCommandLine<T> activeCommandLine;
 	private final RunOptions runOptions;
 	private final T clusterId;
 	private final ClusterSpecification clusterSpec;
 
 	public ExecutionContext(Environment defaultEnvironment, SessionContext sessionContext, List<URL> dependencies,
-			Configuration flinkConfig, Options commandLineOptions, List<CustomCommandLine<?>> availableCommandLines) {
+			Configuration flinkConfig, Options commandLineOptions, List<CustomCommandLine<?>> availableCommandLines) throws FlinkException {
 		this.sessionContext = sessionContext.copy(); // create internal copy because session context is mutable
 		this.mergedEnv = Environment.merge(defaultEnvironment, sessionContext.getEnvironment());
 		this.dependencies = dependencies;
@@ -154,11 +154,12 @@ public class ExecutionContext<T> {
 		});
 
 		// convert deployment options into command line options that describe a cluster
-		commandLine = createCommandLine(mergedEnv.getDeployment(), commandLineOptions);
+		final CommandLine commandLine = createCommandLine(mergedEnv.getDeployment(), commandLineOptions);
 		activeCommandLine = findActiveCommandLine(availableCommandLines, commandLine);
+		executorConfig = activeCommandLine.applyCommandLineOptionsToConfiguration(commandLine);
 		runOptions = createRunOptions(commandLine);
-		clusterId = activeCommandLine.getClusterId(commandLine);
-		clusterSpec = createClusterSpecification(activeCommandLine, commandLine);
+		clusterId = activeCommandLine.getClusterId(executorConfig);
+		clusterSpec = activeCommandLine.getClusterSpecification(executorConfig);
 	}
 
 	public SessionContext getSessionContext() {
@@ -181,8 +182,8 @@ public class ExecutionContext<T> {
 		return clusterId;
 	}
 
-	public ClusterDescriptor<T> createClusterDescriptor() throws Exception {
-		return activeCommandLine.createClusterDescriptor(commandLine);
+	public ClusterDescriptor<T> createClusterDescriptor() {
+		return activeCommandLine.createClusterDescriptor(executorConfig);
 	}
 
 	public EnvironmentInstance createEnvironmentInstance() {
@@ -240,14 +241,6 @@ public class ExecutionContext<T> {
 			return new RunOptions(commandLine);
 		} catch (CliArgsException e) {
 			throw new SqlExecutionException("Invalid deployment run options.", e);
-		}
-	}
-
-	private static ClusterSpecification createClusterSpecification(CustomCommandLine<?> activeCommandLine, CommandLine commandLine) {
-		try {
-			return activeCommandLine.getClusterSpecification(commandLine);
-		} catch (FlinkException e) {
-			throw new SqlExecutionException("Could not create cluster specification for the given deployment.", e);
 		}
 	}
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -24,7 +24,9 @@ import org.apache.flink.client.ClientUtils;
 import org.apache.flink.client.cli.CliFrontend;
 import org.apache.flink.client.cli.CliFrontendParser;
 import org.apache.flink.client.cli.CustomCommandLine;
+import org.apache.flink.client.deployment.ClusterClientServiceLoader;
 import org.apache.flink.client.deployment.ClusterDescriptor;
+import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
@@ -73,6 +75,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * Executor that performs the Flink communication locally. The calls are blocking depending on the
  * response time to the Flink cluster. Flink jobs are not blocking.
@@ -85,10 +89,11 @@ public class LocalExecutor implements Executor {
 
 	// deployment
 
+	private final ClusterClientServiceLoader clusterClientServiceLoader;
 	private final Environment defaultEnvironment;
 	private final List<URL> dependencies;
 	private final Configuration flinkConfig;
-	private final List<CustomCommandLine<?>> commandLines;
+	private final List<CustomCommandLine> commandLines;
 	private final Options commandLineOptions;
 
 	// result maintenance
@@ -160,12 +165,14 @@ public class LocalExecutor implements Executor {
 
 		// prepare result store
 		resultStore = new ResultStore(flinkConfig);
+
+		clusterClientServiceLoader = new DefaultClusterClientServiceLoader();
 	}
 
 	/**
 	 * Constructor for testing purposes.
 	 */
-	public LocalExecutor(Environment defaultEnvironment, List<URL> dependencies, Configuration flinkConfig, CustomCommandLine<?> commandLine) {
+	public LocalExecutor(Environment defaultEnvironment, List<URL> dependencies, Configuration flinkConfig, CustomCommandLine commandLine, ClusterClientServiceLoader clusterClientServiceLoader) {
 		this.defaultEnvironment = defaultEnvironment;
 		this.dependencies = dependencies;
 		this.flinkConfig = flinkConfig;
@@ -173,7 +180,8 @@ public class LocalExecutor implements Executor {
 		this.commandLineOptions = collectCommandLineOptions(commandLines);
 
 		// prepare result store
-		resultStore = new ResultStore(flinkConfig);
+		this.resultStore = new ResultStore(flinkConfig);
+		this.clusterClientServiceLoader = checkNotNull(clusterClientServiceLoader);
 	}
 
 	@Override
@@ -565,7 +573,7 @@ public class LocalExecutor implements Executor {
 		if (executionContext == null || !executionContext.getSessionContext().equals(session)) {
 			try {
 				executionContext = new ExecutionContext<>(defaultEnvironment, session, dependencies,
-					flinkConfig, commandLineOptions, commandLines);
+					flinkConfig, clusterClientServiceLoader, commandLineOptions, commandLines);
 			} catch (Throwable t) {
 				// catch everything such that a configuration does not crash the executor
 				throw new SqlExecutionException("Could not create execution context.", t);
@@ -617,9 +625,9 @@ public class LocalExecutor implements Executor {
 		return dependencies;
 	}
 
-	private static Options collectCommandLineOptions(List<CustomCommandLine<?>> commandLines) {
+	private static Options collectCommandLineOptions(List<CustomCommandLine> commandLines) {
 		final Options customOptions = new Options();
-		for (CustomCommandLine<?> customCommandLine : commandLines) {
+		for (CustomCommandLine customCommandLine : commandLines) {
 			customCommandLine.addRunOptions(customOptions);
 		}
 		return CliFrontendParser.mergeOptions(

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.client.gateway.local;
 
 import org.apache.flink.client.cli.DefaultCLI;
+import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
@@ -91,7 +92,8 @@ public class DependencyTest {
 			env,
 			Collections.singletonList(dependency),
 			new Configuration(),
-			new DefaultCLI(new Configuration()));
+			new DefaultCLI(new Configuration()),
+			new DefaultClusterClientServiceLoader());
 
 		final SessionContext session = new SessionContext("test-session", new Environment());
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.client.cli.util.DummyClusterClientServiceLoader;
 import org.apache.flink.client.cli.util.DummyCustomCommandLine;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.ConfigConstants;
@@ -609,7 +610,8 @@ public class LocalExecutorITCase extends TestLogger {
 			EnvironmentFileUtil.parseModified(DEFAULTS_ENVIRONMENT_FILE, replaceVars),
 			Collections.emptyList(),
 			clusterClient.getFlinkConfiguration(),
-			new DummyCustomCommandLine<T>(clusterClient));
+			new DummyCustomCommandLine(),
+			new DummyClusterClientServiceLoader(clusterClient));
 	}
 
 	private <T> LocalExecutor createModifiedExecutor(ClusterClient<T> clusterClient, Map<String, String> replaceVars) throws Exception {
@@ -617,7 +619,8 @@ public class LocalExecutorITCase extends TestLogger {
 			EnvironmentFileUtil.parseModified(DEFAULTS_ENVIRONMENT_FILE, replaceVars),
 			Collections.emptyList(),
 			clusterClient.getFlinkConfiguration(),
-			new DummyCustomCommandLine<T>(clusterClient));
+			new DummyCustomCommandLine(),
+			new DummyClusterClientServiceLoader(clusterClient));
 	}
 
 	private <T> LocalExecutor createModifiedExecutor(
@@ -626,7 +629,8 @@ public class LocalExecutorITCase extends TestLogger {
 			EnvironmentFileUtil.parseModified(yamlFile, replaceVars),
 			Collections.emptyList(),
 			clusterClient.getFlinkConfiguration(),
-			new DummyCustomCommandLine<T>(clusterClient));
+			new DummyCustomCommandLine(),
+			new DummyClusterClientServiceLoader(clusterClient));
 	}
 
 	private List<String> retrieveTableResult(

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/CliFrontendRunWithYarnTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/CliFrontendRunWithYarnTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.yarn;
 
+import org.apache.flink.client.cli.AbstractCustomCommandLine;
+import org.apache.flink.client.cli.CliFrontendRunTest;
 import org.apache.flink.client.cli.CliFrontendTestBase;
 import org.apache.flink.client.cli.CliFrontendTestUtils;
 import org.apache.flink.client.deployment.ClusterClientFactory;
@@ -37,7 +39,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.apache.flink.client.cli.CliFrontendRunTest.verifyCliFrontend;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.yarn.util.YarnTestUtils.getTestJarPath;
 
@@ -92,6 +93,17 @@ public class CliFrontendRunWithYarnTest extends CliFrontendTestBase {
 			String[] parameters = {"-m", "yarn-cluster", "-p", "2", "-yd", testJarPath};
 			verifyCliFrontend(testServiceLoader, yarnCLI, parameters, 2, true);
 		}
+	}
+
+	private static void verifyCliFrontend(
+			ClusterClientServiceLoader clusterClientServiceLoader,
+			AbstractCustomCommandLine cli,
+			String[] parameters,
+			int expectedParallelism,
+			boolean isDetached) throws Exception {
+		CliFrontendRunTest.RunTestingCliFrontend testFrontend =
+				new CliFrontendRunTest.RunTestingCliFrontend(clusterClientServiceLoader, cli, expectedParallelism, isDetached);
+		testFrontend.run(parameters); // verifies the expected values (see below)
 	}
 
 	private static class TestingYarnClusterClientServiceLoader implements ClusterClientServiceLoader {

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/CliFrontendRunWithYarnTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/CliFrontendRunWithYarnTest.java
@@ -23,12 +23,10 @@ import org.apache.flink.client.cli.CliFrontendTestUtils;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
-import org.apache.flink.util.FlinkException;
 import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
 import org.apache.flink.yarn.util.FakeClusterClient;
 import org.apache.flink.yarn.util.NonDeployingYarnClusterDescriptor;
 
-import org.apache.commons.cli.CommandLine;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.junit.AfterClass;
@@ -90,7 +88,6 @@ public class CliFrontendRunWithYarnTest extends CliFrontendTestBase {
 
 	private static class TestingFlinkYarnSessionCli extends FlinkYarnSessionCli {
 		private final ClusterClient<ApplicationId> clusterClient;
-		private final String configurationDirectory;
 
 		private TestingFlinkYarnSessionCli(
 				Configuration configuration,
@@ -99,18 +96,15 @@ public class CliFrontendRunWithYarnTest extends CliFrontendTestBase {
 				String longPrefix) throws Exception {
 			super(configuration, configurationDirectory, shortPrefix, longPrefix);
 
-			this.clusterClient = new FakeClusterClient();
-			this.configurationDirectory = configurationDirectory;
+			this.clusterClient = new FakeClusterClient(configuration);
 		}
 
 		@Override
-		public YarnClusterDescriptor createClusterDescriptor(CommandLine commandLine)
-			throws FlinkException {
-			YarnClusterDescriptor parent = super.createClusterDescriptor(commandLine);
+		public YarnClusterDescriptor createClusterDescriptor(Configuration configuration) {
+			YarnClusterDescriptor parent = super.createClusterDescriptor(configuration);
 			return new NonDeployingYarnClusterDescriptor(
 					parent.getFlinkConfiguration(),
 					(YarnConfiguration) parent.getYarnClient().getConfig(),
-					configurationDirectory,
 					parent.getYarnClient(),
 					clusterClient);
 		}

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.AkkaOptions;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.JobResult;
@@ -72,7 +71,6 @@ public class YARNITCase extends YarnTestBase {
 			try (final YarnClusterDescriptor yarnClusterDescriptor = new YarnClusterDescriptor(
 				configuration,
 				getYarnConfiguration(),
-				System.getenv(ConfigConstants.ENV_FLINK_CONF_DIR),
 				yarnClient,
 				true)) {
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
@@ -19,7 +19,6 @@
 package org.apache.flink.yarn;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.client.cli.CliFrontend;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.PackagedProgram;
@@ -98,7 +97,6 @@ public class YarnConfigurationITCase extends YarnTestBase {
 			final YarnClusterDescriptor clusterDescriptor = new YarnClusterDescriptor(
 				configuration,
 				yarnConfiguration,
-				CliFrontend.getConfigurationDirectoryFromEnv(),
 				yarnClient,
 				true);
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -307,7 +307,6 @@ public abstract class YarnTestBase extends TestLogger {
 		final YarnClusterDescriptor yarnClusterDescriptor = new YarnClusterDescriptor(
 			flinkConfiguration,
 			YARN_CONFIGURATION,
-			CliFrontend.getConfigurationDirectoryFromEnv(),
 			yarnClient,
 			true);
 		yarnClusterDescriptor.setLocalJarPath(new Path(flinkUberjar.toURI()));

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/util/NonDeployingYarnClusterDescriptor.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/util/NonDeployingYarnClusterDescriptor.java
@@ -40,10 +40,9 @@ public class NonDeployingYarnClusterDescriptor extends YarnClusterDescriptor {
 	public NonDeployingYarnClusterDescriptor(
 			Configuration flinkConfiguration,
 			YarnConfiguration yarnConfiguration,
-			String configurationDirectory,
 			YarnClient yarnClient,
 			ClusterClient<ApplicationId> clusterClient) {
-		super(flinkConfiguration, yarnConfiguration, configurationDirectory, yarnClient, true);
+		super(flinkConfiguration, yarnConfiguration, yarnClient, true);
 
 		this.clusterClient = Preconditions.checkNotNull(clusterClient);
 	}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClientFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClientFactory.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.flink.client.deployment.ClusterClientFactory;
+import org.apache.flink.client.deployment.ClusterSpecification;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.yarn.cli.YarnConfigUtils;
+import org.apache.flink.yarn.configuration.YarnConfigOptions;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.client.api.YarnClient;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.util.ConverterUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link ClusterClientFactory} for a YARN cluster.
+ */
+public class YarnClusterClientFactory implements ClusterClientFactory<ApplicationId> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(YarnClusterClientFactory.class);
+
+	public static final String ID = "yarn-cluster";
+
+	@Override
+	public boolean isCompatibleWith(Configuration configuration) {
+		checkNotNull(configuration);
+		return ID.equals(configuration.getString(DeploymentOptions.TARGET));
+	}
+
+	@Override
+	public YarnClusterDescriptor createClusterDescriptor(Configuration configuration) {
+		checkNotNull(configuration);
+
+		final YarnClusterDescriptor yarnClusterDescriptor = getClusterDescriptor(configuration);
+		yarnClusterDescriptor.setDetachedMode(!configuration.getBoolean(DeploymentOptions.ATTACHED));
+
+		getLocalFlinkDistPath(configuration, yarnClusterDescriptor)
+				.ifPresent(yarnClusterDescriptor::setLocalJarPath);
+
+		decodeDirsToShipToCluster(configuration)
+				.ifPresent(yarnClusterDescriptor::addShipFiles);
+
+		handleConfigOption(configuration, YarnConfigOptions.APPLICATION_QUEUE, yarnClusterDescriptor::setQueue);
+		handleConfigOption(configuration, YarnConfigOptions.DYNAMIC_PROPERTIES, yarnClusterDescriptor::setDynamicPropertiesEncoded);
+		handleConfigOption(configuration, YarnConfigOptions.APPLICATION_NAME, yarnClusterDescriptor::setName);
+		handleConfigOption(configuration, YarnConfigOptions.APPLICATION_TYPE, yarnClusterDescriptor::setApplicationType);
+		handleConfigOption(configuration, YarnConfigOptions.NODE_LABEL, yarnClusterDescriptor::setNodeLabel);
+		handleConfigOption(configuration, HighAvailabilityOptions.HA_CLUSTER_ID, yarnClusterDescriptor::setZookeeperNamespace);
+		return yarnClusterDescriptor;
+	}
+
+	@Nullable
+	@Override
+	public ApplicationId getClusterId(Configuration configuration) {
+		checkNotNull(configuration);
+		final String clusterId = configuration.getString(YarnConfigOptions.APPLICATION_ID);
+		return clusterId != null ? ConverterUtils.toApplicationId(clusterId) : null;
+	}
+
+	@Override
+	public ClusterSpecification getClusterSpecification(Configuration configuration) {
+		checkNotNull(configuration);
+
+		// JobManager Memory
+		final int jobManagerMemoryMB = ConfigurationUtils.getJobManagerHeapMemory(configuration).getMebiBytes();
+
+		// Task Managers memory
+		final int taskManagerMemoryMB = ConfigurationUtils.getTaskManagerHeapMemory(configuration).getMebiBytes();
+
+		int slotsPerTaskManager = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
+
+		return new ClusterSpecification.ClusterSpecificationBuilder()
+				.setMasterMemoryMB(jobManagerMemoryMB)
+				.setTaskManagerMemoryMB(taskManagerMemoryMB)
+				.setSlotsPerTaskManager(slotsPerTaskManager)
+				.createClusterSpecification();
+	}
+
+	private Optional<List<File>> decodeDirsToShipToCluster(final Configuration configuration) {
+		checkNotNull(configuration);
+
+		final List<File> files = YarnConfigUtils.decodeListFromConfig(configuration, YarnConfigOptions.SHIP_DIRECTORIES, File::new);
+		return files.isEmpty() ? Optional.empty() : Optional.of(files);
+	}
+
+	private Optional<Path> getLocalFlinkDistPath(final Configuration configuration, final YarnClusterDescriptor yarnClusterDescriptor) {
+		final String localJarPath = configuration.getString(YarnConfigOptions.FLINK_DIST_JAR);
+		if (localJarPath != null) {
+			return Optional.of(new Path(localJarPath));
+		}
+
+		LOG.info("No path for the flink jar passed. Using the location of " + yarnClusterDescriptor.getClass() + " to locate the jar");
+
+		// check whether it's actually a jar file --> when testing we execute this class without a flink-dist jar
+		final String decodedPath = getDecodedJarPath(yarnClusterDescriptor);
+		return decodedPath.endsWith(".jar")
+				? Optional.of(new Path(new File(decodedPath).toURI()))
+				: Optional.empty();
+	}
+
+	private String getDecodedJarPath(final YarnClusterDescriptor yarnClusterDescriptor) {
+		final String encodedJarPath = yarnClusterDescriptor
+				.getClass().getProtectionDomain().getCodeSource().getLocation().getPath();
+		try {
+			return URLDecoder.decode(encodedJarPath, Charset.defaultCharset().name());
+		} catch (UnsupportedEncodingException e) {
+			throw new RuntimeException("Couldn't decode the encoded Flink dist jar path: " + encodedJarPath +
+					" You can supply a path manually via the command line.");
+		}
+	}
+
+	private void handleConfigOption(final Configuration configuration, final ConfigOption<String> option, final Consumer<String> consumer) {
+		checkNotNull(configuration);
+		checkNotNull(option);
+		checkNotNull(consumer);
+
+		final String value = configuration.getString(option);
+		if (value != null) {
+			consumer.accept(value);
+		}
+	}
+
+	private YarnClusterDescriptor getClusterDescriptor(Configuration configuration) {
+		final YarnClient yarnClient = YarnClient.createYarnClient();
+		final YarnConfiguration yarnConfiguration = new YarnConfiguration();
+
+		yarnClient.init(yarnConfiguration);
+		yarnClient.start();
+
+		return new YarnClusterDescriptor(
+				configuration,
+				yarnConfiguration,
+				yarnClient,
+				false);
+	}
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClientFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClientFactory.java
@@ -20,32 +20,18 @@ package org.apache.flink.yarn;
 
 import org.apache.flink.client.deployment.ClusterClientFactory;
 import org.apache.flink.client.deployment.ClusterSpecification;
-import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.DeploymentOptions;
-import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.yarn.cli.YarnConfigUtils;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.util.ConverterUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-
-import java.io.File;
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.nio.charset.Charset;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Consumer;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -53,8 +39,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * A {@link ClusterClientFactory} for a YARN cluster.
  */
 public class YarnClusterClientFactory implements ClusterClientFactory<ApplicationId> {
-
-	private static final Logger LOG = LoggerFactory.getLogger(YarnClusterClientFactory.class);
 
 	public static final String ID = "yarn-cluster";
 
@@ -67,23 +51,7 @@ public class YarnClusterClientFactory implements ClusterClientFactory<Applicatio
 	@Override
 	public YarnClusterDescriptor createClusterDescriptor(Configuration configuration) {
 		checkNotNull(configuration);
-
-		final YarnClusterDescriptor yarnClusterDescriptor = getClusterDescriptor(configuration);
-		yarnClusterDescriptor.setDetachedMode(!configuration.getBoolean(DeploymentOptions.ATTACHED));
-
-		getLocalFlinkDistPath(configuration, yarnClusterDescriptor)
-				.ifPresent(yarnClusterDescriptor::setLocalJarPath);
-
-		decodeDirsToShipToCluster(configuration)
-				.ifPresent(yarnClusterDescriptor::addShipFiles);
-
-		handleConfigOption(configuration, YarnConfigOptions.APPLICATION_QUEUE, yarnClusterDescriptor::setQueue);
-		handleConfigOption(configuration, YarnConfigOptions.DYNAMIC_PROPERTIES, yarnClusterDescriptor::setDynamicPropertiesEncoded);
-		handleConfigOption(configuration, YarnConfigOptions.APPLICATION_NAME, yarnClusterDescriptor::setName);
-		handleConfigOption(configuration, YarnConfigOptions.APPLICATION_TYPE, yarnClusterDescriptor::setApplicationType);
-		handleConfigOption(configuration, YarnConfigOptions.NODE_LABEL, yarnClusterDescriptor::setNodeLabel);
-		handleConfigOption(configuration, HighAvailabilityOptions.HA_CLUSTER_ID, yarnClusterDescriptor::setZookeeperNamespace);
-		return yarnClusterDescriptor;
+		return getClusterDescriptor(configuration);
 	}
 
 	@Nullable
@@ -111,50 +79,6 @@ public class YarnClusterClientFactory implements ClusterClientFactory<Applicatio
 				.setTaskManagerMemoryMB(taskManagerMemoryMB)
 				.setSlotsPerTaskManager(slotsPerTaskManager)
 				.createClusterSpecification();
-	}
-
-	private Optional<List<File>> decodeDirsToShipToCluster(final Configuration configuration) {
-		checkNotNull(configuration);
-
-		final List<File> files = YarnConfigUtils.decodeListFromConfig(configuration, YarnConfigOptions.SHIP_DIRECTORIES, File::new);
-		return files.isEmpty() ? Optional.empty() : Optional.of(files);
-	}
-
-	private Optional<Path> getLocalFlinkDistPath(final Configuration configuration, final YarnClusterDescriptor yarnClusterDescriptor) {
-		final String localJarPath = configuration.getString(YarnConfigOptions.FLINK_DIST_JAR);
-		if (localJarPath != null) {
-			return Optional.of(new Path(localJarPath));
-		}
-
-		LOG.info("No path for the flink jar passed. Using the location of " + yarnClusterDescriptor.getClass() + " to locate the jar");
-
-		// check whether it's actually a jar file --> when testing we execute this class without a flink-dist jar
-		final String decodedPath = getDecodedJarPath(yarnClusterDescriptor);
-		return decodedPath.endsWith(".jar")
-				? Optional.of(new Path(new File(decodedPath).toURI()))
-				: Optional.empty();
-	}
-
-	private String getDecodedJarPath(final YarnClusterDescriptor yarnClusterDescriptor) {
-		final String encodedJarPath = yarnClusterDescriptor
-				.getClass().getProtectionDomain().getCodeSource().getLocation().getPath();
-		try {
-			return URLDecoder.decode(encodedJarPath, Charset.defaultCharset().name());
-		} catch (UnsupportedEncodingException e) {
-			throw new RuntimeException("Couldn't decode the encoded Flink dist jar path: " + encodedJarPath +
-					" You can supply a path manually via the command line.");
-		}
-	}
-
-	private void handleConfigOption(final Configuration configuration, final ConfigOption<String> option, final Consumer<String> consumer) {
-		checkNotNull(configuration);
-		checkNotNull(option);
-		checkNotNull(consumer);
-
-		final String value = configuration.getString(option);
-		if (value != null) {
-			consumer.accept(value);
-		}
 	}
 
 	private YarnClusterDescriptor getClusterDescriptor(Configuration configuration) {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -695,15 +695,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		}
 	}
 
-	private boolean containsFileWithEnding(final Set<File> files, final String suffix) {
-		for (File file: files) {
-			if (file.getPath().endsWith(suffix)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
 	private ApplicationReport startAppMaster(
 			Configuration configuration,
 			String applicationName,

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -175,7 +175,9 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		this.customName = flinkConfiguration.getString(YarnConfigOptions.APPLICATION_NAME);
 		this.applicationType = flinkConfiguration.getString(YarnConfigOptions.APPLICATION_TYPE);
 		this.nodeLabel = flinkConfiguration.getString(YarnConfigOptions.NODE_LABEL);
-		this.zookeeperNamespace = flinkConfiguration.getString(HighAvailabilityOptions.HA_CLUSTER_ID);
+
+		// ignore the default value at this point
+		this.zookeeperNamespace = flinkConfiguration.getString(HighAvailabilityOptions.HA_CLUSTER_ID, null);
 	}
 
 	private Optional<List<File>> decodeDirsToShipToCluster(final Configuration configuration) {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -29,6 +29,7 @@ import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.JobManagerOptions;
@@ -44,8 +45,8 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.runtime.taskexecutor.TaskManagerServices;
 import org.apache.flink.util.FlinkException;
-import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.ShutdownHookUtil;
+import org.apache.flink.yarn.cli.YarnConfigUtils;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
 import org.apache.flink.yarn.entrypoint.YarnJobClusterEntrypoint;
 import org.apache.flink.yarn.entrypoint.YarnSessionClusterEntrypoint;
@@ -86,8 +87,11 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.URLDecoder;
+import java.nio.charset.Charset;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.SimpleFileVisitor;
@@ -101,12 +105,14 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_LIB_DIR;
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_PLUGINS_DIR;
 import static org.apache.flink.runtime.entrypoint.component.FileJobGraphRetriever.JOB_GRAPH_FILE_PATH;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.yarn.cli.FlinkYarnSessionCli.CONFIG_FILE_LOG4J_NAME;
 import static org.apache.flink.yarn.cli.FlinkYarnSessionCli.CONFIG_FILE_LOGBACK_NAME;
 import static org.apache.flink.yarn.cli.FlinkYarnSessionCli.getDynamicProperties;
@@ -127,31 +133,25 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 	/** Lazily initialized list of files to ship. */
 	private final List<File> shipFiles = new LinkedList<>();
 
-	private String yarnQueue;
+	private final String yarnQueue;
 
 	private Path flinkJarPath;
 
-	private String dynamicPropertiesEncoded;
+	private final String dynamicPropertiesEncoded;
 
 	private final Configuration flinkConfiguration;
 
-	private boolean detached;
+	private final boolean detached;
 
-	private String customName;
+	private final String customName;
+
+	private final String nodeLabel;
+
+	private final String applicationType;
 
 	private String zookeeperNamespace;
 
-	private String nodeLabel;
-
-	private String applicationType;
-
 	private YarnConfigOptions.UserJarInclusion userJarInclusion;
-
-	public YarnClusterDescriptor(Configuration flinkConfiguration) {
-		this(flinkConfiguration, new YarnConfiguration(), YarnClient.createYarnClient(), false);
-		yarnClient.init(yarnConfiguration);
-		yarnClient.start();
-	}
 
 	public YarnClusterDescriptor(
 			Configuration flinkConfiguration,
@@ -159,12 +159,55 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			YarnClient yarnClient,
 			boolean sharedYarnClient) {
 
-		this.yarnConfiguration = Preconditions.checkNotNull(yarnConfiguration);
-		this.yarnClient = Preconditions.checkNotNull(yarnClient);
+		this.yarnConfiguration = checkNotNull(yarnConfiguration);
+		this.yarnClient = checkNotNull(yarnClient);
 		this.sharedYarnClient = sharedYarnClient;
 
-		this.flinkConfiguration = Preconditions.checkNotNull(flinkConfiguration);
+		this.flinkConfiguration = checkNotNull(flinkConfiguration);
 		this.userJarInclusion = getUserJarInclusionMode(flinkConfiguration);
+
+		getLocalFlinkDistPath(flinkConfiguration).ifPresent(this::setLocalJarPath);
+		decodeDirsToShipToCluster(flinkConfiguration).ifPresent(this::addShipFiles);
+
+		this.detached = !flinkConfiguration.getBoolean(DeploymentOptions.ATTACHED);
+		this.yarnQueue = flinkConfiguration.getString(YarnConfigOptions.APPLICATION_QUEUE);
+		this.dynamicPropertiesEncoded = flinkConfiguration.getString(YarnConfigOptions.DYNAMIC_PROPERTIES);
+		this.customName = flinkConfiguration.getString(YarnConfigOptions.APPLICATION_NAME);
+		this.applicationType = flinkConfiguration.getString(YarnConfigOptions.APPLICATION_TYPE);
+		this.nodeLabel = flinkConfiguration.getString(YarnConfigOptions.NODE_LABEL);
+		this.zookeeperNamespace = flinkConfiguration.getString(HighAvailabilityOptions.HA_CLUSTER_ID);
+	}
+
+	private Optional<List<File>> decodeDirsToShipToCluster(final Configuration configuration) {
+		checkNotNull(configuration);
+
+		final List<File> files = YarnConfigUtils.decodeListFromConfig(configuration, YarnConfigOptions.SHIP_DIRECTORIES, File::new);
+		return files.isEmpty() ? Optional.empty() : Optional.of(files);
+	}
+
+	private Optional<Path> getLocalFlinkDistPath(final Configuration configuration) {
+		final String localJarPath = configuration.getString(YarnConfigOptions.FLINK_DIST_JAR);
+		if (localJarPath != null) {
+			return Optional.of(new Path(localJarPath));
+		}
+
+		LOG.info("No path for the flink jar passed. Using the location of " + getClass() + " to locate the jar");
+
+		// check whether it's actually a jar file --> when testing we execute this class without a flink-dist jar
+		final String decodedPath = getDecodedJarPath();
+		return decodedPath.endsWith(".jar")
+				? Optional.of(new Path(new File(decodedPath).toURI()))
+				: Optional.empty();
+	}
+
+	private String getDecodedJarPath() {
+		final String encodedJarPath = getClass().getProtectionDomain().getCodeSource().getLocation().getPath();
+		try {
+			return URLDecoder.decode(encodedJarPath, Charset.defaultCharset().name());
+		} catch (UnsupportedEncodingException e) {
+			throw new RuntimeException("Couldn't decode the encoded Flink dist jar path: " + encodedJarPath +
+					" You can supply a path manually via the command line.");
+		}
 	}
 
 	@VisibleForTesting
@@ -196,10 +239,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		return flinkConfiguration;
 	}
 
-	public void setQueue(String queue) {
-		this.yarnQueue = queue;
-	}
-
 	public void setLocalJarPath(Path localJarPath) {
 		if (!localJarPath.toString().endsWith("jar")) {
 			throw new IllegalArgumentException("The passed jar path ('" + localJarPath + "') does not end with the 'jar' extension");
@@ -218,10 +257,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 	 */
 	public void addShipFiles(List<File> shipFiles) {
 		this.shipFiles.addAll(shipFiles);
-	}
-
-	public void setDynamicPropertiesEncoded(String dynamicPropertiesEncoded) {
-		this.dynamicPropertiesEncoded = dynamicPropertiesEncoded;
 	}
 
 	public String getDynamicPropertiesEncoded() {
@@ -295,14 +330,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 	 * @deprecated The cluster descriptor should not know about this option.
 	 */
 	@Deprecated
-	public void setDetachedMode(boolean detachedMode) {
-		this.detached = detachedMode;
-	}
-
-	/**
-	 * @deprecated The cluster descriptor should not know about this option.
-	 */
-	@Deprecated
 	public boolean isDetachedMode() {
 		return detached;
 	}
@@ -311,16 +338,12 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		return zookeeperNamespace;
 	}
 
-	public void setZookeeperNamespace(String zookeeperNamespace) {
+	private void setZookeeperNamespace(String zookeeperNamespace) {
 		this.zookeeperNamespace = zookeeperNamespace;
 	}
 
 	public String getNodeLabel() {
 		return nodeLabel;
-	}
-
-	public void setNodeLabel(String nodeLabel) {
-		this.nodeLabel = nodeLabel;
 	}
 
 	// -------------------------------------------------------------
@@ -945,7 +968,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
 		if (UserGroupInformation.isSecurityEnabled()) {
 			// set HDFS delegation tokens when security is enabled
-			LOG.info("Adding delegation token to the AM container..");
+			LOG.info("Adding delegation token to the AM container.");
 			Utils.setTokensFor(amContainer, paths, yarnConfiguration);
 		}
 
@@ -1308,14 +1331,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		}
 	}
 
-	public void setName(String name) {
-		this.customName = Preconditions.checkNotNull(name, "The customized name must not be null");
-	}
-
-	public void setApplicationType(String type) {
-		this.applicationType = Preconditions.checkNotNull(type, "The customized application type must not be null");
-	}
-
 	private void activateHighAvailabilitySupport(ApplicationSubmissionContext appContext) throws
 			InvocationTargetException, IllegalAccessException {
 
@@ -1521,9 +1536,9 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		private final Path yarnFilesDir;
 
 		DeploymentFailureHook(YarnClient yarnClient, YarnClientApplication yarnApplication, Path yarnFilesDir) {
-			this.yarnClient = Preconditions.checkNotNull(yarnClient);
-			this.yarnApplication = Preconditions.checkNotNull(yarnApplication);
-			this.yarnFilesDir = Preconditions.checkNotNull(yarnFilesDir);
+			this.yarnClient = checkNotNull(yarnClient);
+			this.yarnApplication = checkNotNull(yarnApplication);
+			this.yarnFilesDir = checkNotNull(yarnFilesDir);
 		}
 
 		@Override

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -46,7 +46,6 @@ import org.apache.flink.runtime.taskexecutor.TaskManagerServices;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.ShutdownHookUtil;
-import org.apache.flink.yarn.cli.YarnConfigUtils;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
 import org.apache.flink.yarn.entrypoint.YarnJobClusterEntrypoint;
 import org.apache.flink.yarn.entrypoint.YarnSessionClusterEntrypoint;
@@ -717,10 +716,9 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			systemShipFiles.add(file.getAbsoluteFile());
 		}
 
-		final List<File> logConfigFiles = YarnConfigUtils
-				.decodeListFromConfig(configuration, YarnConfigOptions.APPLICATION_LOG_CONFIG_FILES, File::new);
-		if (logConfigFiles != null) {
-			systemShipFiles.addAll(logConfigFiles);
+		final String logConfigFilePath = configuration.getString(YarnConfigOptions.APPLICATION_LOG_CONFIG_FILE);
+		if (logConfigFilePath != null) {
+			systemShipFiles.add(new File(logConfigFilePath));
 		}
 
 		addEnvironmentFoldersToShipFiles(systemShipFiles);
@@ -940,8 +938,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
 		final ContainerLaunchContext amContainer = setupApplicationMasterContainer(
 				yarnClusterEntrypoint,
-				containsFileWithEnding(systemShipFiles, CONFIG_FILE_LOGBACK_NAME),
-				containsFileWithEnding(systemShipFiles, CONFIG_FILE_LOG4J_NAME),
+				logConfigFilePath != null && logConfigFilePath.endsWith(CONFIG_FILE_LOGBACK_NAME),
+				logConfigFilePath != null && logConfigFilePath.endsWith(CONFIG_FILE_LOG4J_NAME),
 				hasKrb5,
 				clusterSpecification.getMasterMemoryMB());
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -26,6 +26,7 @@ import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
@@ -37,7 +38,6 @@ import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.FlinkException;
-import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.ShutdownHookUtil;
 import org.apache.flink.yarn.YarnClusterDescriptor;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
@@ -52,7 +52,6 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.client.api.YarnClient;
-import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.slf4j.Logger;
@@ -72,12 +71,13 @@ import java.io.UnsupportedEncodingException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -87,6 +87,7 @@ import static org.apache.flink.client.cli.CliFrontendParser.DETACHED_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.SHUTDOWN_IF_ATTACHED_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.YARN_DETACHED_OPTION;
 import static org.apache.flink.configuration.HighAvailabilityOptions.HA_CLUSTER_ID;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Class handling the command line interface to the YARN session.
@@ -158,8 +159,6 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 
 	private final String yarnPropertiesFileLocation;
 
-	private final YarnConfiguration yarnConfiguration;
-
 	public FlinkYarnSessionCli(
 			Configuration configuration,
 			String configurationDirectory,
@@ -175,7 +174,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 			String longPrefix,
 			boolean acceptInteractiveInput) throws FlinkException {
 		super(configuration);
-		this.configurationDirectory = Preconditions.checkNotNull(configurationDirectory);
+		this.configurationDirectory = checkNotNull(configurationDirectory);
 		this.acceptInteractiveInput = acceptInteractiveInput;
 
 		// Create the command line options
@@ -256,126 +255,118 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 		} else {
 			yarnApplicationIdFromYarnProperties = null;
 		}
-
-		this.yarnConfiguration = new YarnConfiguration();
 	}
 
-	private YarnClusterDescriptor createDescriptor(
-			Configuration configuration,
-			YarnConfiguration yarnConfiguration,
-			String configurationDirectory,
-			CommandLine cmd) {
+	private YarnClusterDescriptor createDescriptor(Configuration configuration) {
+		YarnClusterDescriptor yarnClusterDescriptor = new YarnClusterDescriptor(configuration);
 
-		YarnClusterDescriptor yarnClusterDescriptor = getClusterDescriptor(
-			configuration,
-			yarnConfiguration,
-			configurationDirectory);
-
-		// Jar Path
-		final Path localJarPath;
-		if (cmd.hasOption(flinkJar.getOpt())) {
-			String userPath = cmd.getOptionValue(flinkJar.getOpt());
-			if (!userPath.startsWith("file://")) {
-				userPath = "file://" + userPath;
-			}
-			localJarPath = new Path(userPath);
-		} else {
-			LOG.info("No path for the flink jar passed. Using the location of "
-				+ yarnClusterDescriptor.getClass() + " to locate the jar");
-			String encodedJarPath =
-				yarnClusterDescriptor.getClass().getProtectionDomain().getCodeSource().getLocation().getPath();
-
-			final String decodedPath;
-			try {
-				// we have to decode the url encoded parts of the path
-				decodedPath = URLDecoder.decode(encodedJarPath, Charset.defaultCharset().name());
-			} catch (UnsupportedEncodingException e) {
-				throw new RuntimeException("Couldn't decode the encoded Flink dist jar path: " + encodedJarPath +
-					" Please supply a path manually via the -" + flinkJar.getOpt() + " option.");
-			}
-
-			// check whether it's actually a jar file --> when testing we execute this class without a flink-dist jar
-			if (decodedPath.endsWith(".jar")) {
-				localJarPath = new Path(new File(decodedPath).toURI());
-			} else {
-				localJarPath = null;
-			}
-		}
-
+		final Path localJarPath = getLocalFlinkDistPath(configuration, yarnClusterDescriptor);
 		if (localJarPath != null) {
 			yarnClusterDescriptor.setLocalJarPath(localJarPath);
 		}
 
-		List<File> shipFiles = new ArrayList<>();
-		// path to directories to ship
-		if (cmd.hasOption(shipPath.getOpt())) {
-			String[] shipPaths = cmd.getOptionValues(this.shipPath.getOpt());
-			for (String shipPath : shipPaths) {
-				File shipDir = new File(shipPath);
-				if (shipDir.isDirectory()) {
-					shipFiles.add(shipDir);
-				} else {
-					LOG.warn("Ship directory {} is not a directory. Ignoring it.", shipDir.getAbsolutePath());
-				}
-			}
-		}
-
+		final List<File> shipFiles = decodeDirsToShipToCluster(configuration);
 		yarnClusterDescriptor.addShipFiles(shipFiles);
 
-		// queue
-		if (cmd.hasOption(queue.getOpt())) {
-			yarnClusterDescriptor.setQueue(cmd.getOptionValue(queue.getOpt()));
+		final String queueName = configuration.getString(YarnConfigOptions.APPLICATION_QUEUE);
+		if (queueName != null) {
+			yarnClusterDescriptor.setQueue(queueName);
 		}
 
-		final Properties properties = cmd.getOptionProperties(dynamicproperties.getOpt());
-
-		for (String key : properties.stringPropertyNames()) {
-			LOG.info("Dynamic Property set: {}={}", key, GlobalConfiguration.isSensitive(key) ? GlobalConfiguration.HIDDEN_CONTENT : properties.getProperty(key));
-		}
-
-		String[] dynamicProperties = properties.stringPropertyNames().stream()
-			.flatMap(
-				(String key) -> {
-					final String value = properties.getProperty(key);
-
-					if (value != null) {
-						return Stream.of(key + dynamicproperties.getValueSeparator() + value);
-					} else {
-						return Stream.empty();
-					}
-				})
-			.toArray(String[]::new);
-
-		String dynamicPropertiesEncoded = StringUtils.join(dynamicProperties, YARN_DYNAMIC_PROPERTIES_SEPARATOR);
-
+		final String dynamicPropertiesEncoded = configuration.getString(YarnConfigOptions.DYNAMIC_PROPERTIES);
 		yarnClusterDescriptor.setDynamicPropertiesEncoded(dynamicPropertiesEncoded);
 
-		if (cmd.hasOption(YARN_DETACHED_OPTION.getOpt()) || cmd.hasOption(DETACHED_OPTION.getOpt())) {
-			yarnClusterDescriptor.setDetachedMode(true);
+		final boolean detached = !configuration.getBoolean(DeploymentOptions.ATTACHED);
+		yarnClusterDescriptor.setDetachedMode(detached);
+
+		final String appName = configuration.getString(YarnConfigOptions.APPLICATION_NAME);
+		if (appName != null) {
+			yarnClusterDescriptor.setName(appName);
 		}
 
-		if (cmd.hasOption(name.getOpt())) {
-			yarnClusterDescriptor.setName(cmd.getOptionValue(name.getOpt()));
+		final String appType = configuration.getString(YarnConfigOptions.APPLICATION_TYPE);
+		if (appType != null) {
+			yarnClusterDescriptor.setApplicationType(appType);
 		}
 
-		if (cmd.hasOption(applicationType.getOpt())) {
-			yarnClusterDescriptor.setApplicationType(cmd.getOptionValue(applicationType.getOpt()));
+		final String zkNamespace = configuration.getString(HA_CLUSTER_ID);
+		if (zkNamespace != null) {
+			yarnClusterDescriptor.setZookeeperNamespace(zkNamespace);
 		}
 
-		if (cmd.hasOption(zookeeperNamespace.getOpt())) {
-			String zookeeperNamespaceValue = cmd.getOptionValue(this.zookeeperNamespace.getOpt());
-			yarnClusterDescriptor.setZookeeperNamespace(zookeeperNamespaceValue);
-		}
-
-		if (cmd.hasOption(nodeLabel.getOpt())) {
-			String nodeLabelValue = cmd.getOptionValue(this.nodeLabel.getOpt());
-			yarnClusterDescriptor.setNodeLabel(nodeLabelValue);
+		final String nodeLabel = configuration.getString(YarnConfigOptions.NODE_LABEL);
+		if (nodeLabel != null) {
+			yarnClusterDescriptor.setNodeLabel(nodeLabel);
 		}
 
 		return yarnClusterDescriptor;
 	}
 
-	private ClusterSpecification createClusterSpecification(Configuration configuration, CommandLine cmd) {
+	private Path getLocalFlinkDistPath(final Configuration configuration, final YarnClusterDescriptor yarnClusterDescriptor) {
+		final String localJarPath = configuration.getString(YarnConfigOptions.FLINK_DIST_JAR);
+		if (localJarPath != null) {
+			return new Path(localJarPath);
+		}
+
+		LOG.info("No path for the flink jar passed. Using the location of " + yarnClusterDescriptor.getClass() + " to locate the jar");
+
+		// check whether it's actually a jar file --> when testing we execute this class without a flink-dist jar
+		final String decodedPath = getDecodedJarPath(yarnClusterDescriptor);
+		return decodedPath.endsWith(".jar")
+				? new Path(new File(decodedPath).toURI())
+				: null;
+	}
+
+	private String getDecodedJarPath(final YarnClusterDescriptor yarnClusterDescriptor) {
+		final String encodedJarPath = yarnClusterDescriptor
+				.getClass().getProtectionDomain().getCodeSource().getLocation().getPath();
+		try {
+			return URLDecoder.decode(encodedJarPath, Charset.defaultCharset().name());
+		} catch (UnsupportedEncodingException e) {
+			throw new RuntimeException("Couldn't decode the encoded Flink dist jar path: " + encodedJarPath +
+					" Please supply a path manually via the -" + flinkJar.getOpt() + " option.");
+		}
+	}
+
+	private Path getLocalFlinkDistPathFromCmd(final CommandLine cmd) {
+		final String flinkJarOptionName = flinkJar.getOpt();
+		if (!cmd.hasOption(flinkJarOptionName)) {
+			return null;
+		}
+
+		String userPath = cmd.getOptionValue(flinkJarOptionName);
+		if (!userPath.startsWith("file://")) {
+			userPath = "file://" + userPath;
+		}
+		return new Path(userPath);
+	}
+
+	private List<File> decodeDirsToShipToCluster(final Configuration configuration) {
+		checkNotNull(configuration);
+		return YarnConfigUtils.decodeListFromConfig(configuration, YarnConfigOptions.SHIP_DIRECTORIES, File::new);
+	}
+
+	private void encodeDirsToShipToCluster(final Configuration configuration, final CommandLine cmd) {
+		checkNotNull(cmd);
+		checkNotNull(configuration);
+
+		if (cmd.hasOption(shipPath.getOpt())) {
+			YarnConfigUtils.encodeListToConfig(
+					configuration,
+					YarnConfigOptions.SHIP_DIRECTORIES,
+					cmd.getOptionValues(this.shipPath.getOpt()),
+					(String path) -> {
+						final File shipDir = new File(path);
+						if (shipDir.isDirectory()) {
+							return path;
+						}
+						LOG.warn("Ship directory {} is not a directory. Ignoring it.", shipDir.getAbsolutePath());
+						return null;
+					});
+		}
+	}
+
+	private ClusterSpecification createClusterSpecification(Configuration configuration) {
 		// JobManager Memory
 		final int jobManagerMemoryMB = ConfigurationUtils.getJobManagerHeapMemory(configuration).getMebiBytes();
 
@@ -433,47 +424,30 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 	}
 
 	@Override
-	public YarnClusterDescriptor createClusterDescriptor(CommandLine commandLine) throws FlinkException {
-		final Configuration effectiveConfiguration = applyCommandLineOptionsToConfiguration(commandLine);
-
-		return createDescriptor(
-			effectiveConfiguration,
-			yarnConfiguration,
-			configurationDirectory,
-			commandLine);
+	public YarnClusterDescriptor createClusterDescriptor(Configuration configuration) {
+		return createDescriptor(configuration);
 	}
 
 	@Override
 	@Nullable
-	public ApplicationId getClusterId(CommandLine commandLine) {
-		if (commandLine.hasOption(applicationId.getOpt())) {
-			return ConverterUtils.toApplicationId(commandLine.getOptionValue(applicationId.getOpt()));
-		} else if (isYarnPropertiesFileMode(commandLine)) {
-			return yarnApplicationIdFromYarnProperties;
-		} else {
-			return null;
-		}
+	public ApplicationId getClusterId(Configuration configuration) {
+		final String clusterId = configuration.getString(YarnConfigOptions.APPLICATION_ID);
+		return clusterId != null ? ConverterUtils.toApplicationId(clusterId) : null;
 	}
 
 	@Override
-	public ClusterSpecification getClusterSpecification(CommandLine commandLine) throws FlinkException {
-		final Configuration effectiveConfiguration = applyCommandLineOptionsToConfiguration(commandLine);
-
-		return createClusterSpecification(effectiveConfiguration, commandLine);
+	public ClusterSpecification getClusterSpecification(Configuration configuration) {
+		return createClusterSpecification(configuration);
 	}
 
 	@Override
-	protected Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) throws FlinkException {
+	public Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) throws FlinkException {
 		// we ignore the addressOption because it can only contain "yarn-cluster"
 		final Configuration effectiveConfiguration = new Configuration(configuration);
 
-		if (commandLine.hasOption(zookeeperNamespaceOption.getOpt())) {
-			String zkNamespace = commandLine.getOptionValue(zookeeperNamespaceOption.getOpt());
-			effectiveConfiguration.setString(HA_CLUSTER_ID, zkNamespace);
-		}
+		applyDescriptorOptionToConfig(commandLine, effectiveConfiguration);
 
-		final ApplicationId applicationId = getClusterId(commandLine);
-
+		final ApplicationId applicationId = getApplicationId(commandLine);
 		if (applicationId != null) {
 			final String zooKeeperNamespace;
 			if (commandLine.hasOption(zookeeperNamespace.getOpt())){
@@ -483,6 +457,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 			}
 
 			effectiveConfiguration.setString(HA_CLUSTER_ID, zooKeeperNamespace);
+			effectiveConfiguration.setString(YarnConfigOptions.APPLICATION_ID, ConverterUtils.toString(applicationId));
 		}
 
 		if (commandLine.hasOption(jmMemory.getOpt())) {
@@ -510,6 +485,89 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 		} else {
 			return effectiveConfiguration;
 		}
+	}
+
+	private ApplicationId getApplicationId(CommandLine commandLine) {
+		if (commandLine.hasOption(applicationId.getOpt())) {
+			return ConverterUtils.toApplicationId(commandLine.getOptionValue(applicationId.getOpt()));
+		} else if (isYarnPropertiesFileMode(commandLine)) {
+			return yarnApplicationIdFromYarnProperties;
+		}
+		return null;
+	}
+
+	private void applyDescriptorOptionToConfig(final CommandLine commandLine, final Configuration configuration) {
+		checkNotNull(commandLine);
+		checkNotNull(configuration);
+
+		final Path localJarPath = getLocalFlinkDistPathFromCmd(commandLine);
+		if (localJarPath != null) {
+			configuration.setString(YarnConfigOptions.FLINK_DIST_JAR, localJarPath.toString());
+		}
+
+		encodeDirsToShipToCluster(configuration, commandLine);
+
+		if (commandLine.hasOption(queue.getOpt())) {
+			final String queueName = commandLine.getOptionValue(queue.getOpt());
+			configuration.setString(YarnConfigOptions.APPLICATION_QUEUE, queueName);
+		}
+
+		final String dynamicPropertiesEncoded = encodeDynamicProperties(commandLine);
+		configuration.setString(YarnConfigOptions.DYNAMIC_PROPERTIES, dynamicPropertiesEncoded);
+
+		final boolean detached = commandLine.hasOption(YARN_DETACHED_OPTION.getOpt()) || commandLine.hasOption(DETACHED_OPTION.getOpt());
+		configuration.setBoolean(DeploymentOptions.ATTACHED, !detached);
+
+		if (commandLine.hasOption(name.getOpt())) {
+			final String appName = commandLine.getOptionValue(name.getOpt());
+			configuration.setString(YarnConfigOptions.APPLICATION_NAME, appName);
+		}
+
+		if (commandLine.hasOption(applicationType.getOpt())) {
+			final String appType = commandLine.getOptionValue(applicationType.getOpt());
+			configuration.setString(YarnConfigOptions.APPLICATION_TYPE, appType);
+		}
+
+		if (commandLine.hasOption(zookeeperNamespace.getOpt())) {
+			String zookeeperNamespaceValue = commandLine.getOptionValue(zookeeperNamespace.getOpt());
+			configuration.setString(HA_CLUSTER_ID, zookeeperNamespaceValue);
+		} else if (commandLine.hasOption(zookeeperNamespaceOption.getOpt())) {
+			String zookeeperNamespaceValue = commandLine.getOptionValue(zookeeperNamespaceOption.getOpt());
+			configuration.setString(HA_CLUSTER_ID, zookeeperNamespaceValue);
+		}
+
+		if (commandLine.hasOption(nodeLabel.getOpt())) {
+			final String nodeLabelValue = commandLine.getOptionValue(this.nodeLabel.getOpt());
+			configuration.setString(YarnConfigOptions.NODE_LABEL, nodeLabelValue);
+		}
+
+		discoverAndEncodeLogConfigFiles(configuration);
+	}
+
+	private void discoverAndEncodeLogConfigFiles(final Configuration configuration) {
+		final Set<File> logFiles = discoverLogConfigFiles();
+		YarnConfigUtils.encodeListToConfig(configuration, YarnConfigOptions.APPLICATION_LOG_CONFIG_FILES, logFiles, File::getPath);
+	}
+
+	private Set<File> discoverLogConfigFiles() {
+		final Set<File> logConfigFiles = new HashSet<>();
+
+		File logbackFile = new File(configurationDirectory + File.separator + CONFIG_FILE_LOGBACK_NAME);
+		final boolean hasLogback = logbackFile.exists();
+		if (hasLogback) {
+			logConfigFiles.add(logbackFile);
+		}
+
+		File log4jFile = new File(configurationDirectory + File.separator + CONFIG_FILE_LOG4J_NAME);
+		final boolean hasLog4j = log4jFile.exists();
+		if (hasLog4j) {
+			logConfigFiles.add(log4jFile);
+			if (hasLogback) {
+				LOG.warn("The configuration directory ('" + configurationDirectory + "') contains both LOG4J and " +
+						"Logback configuration files. Please delete or rename one of them.");
+			}
+		}
+		return logConfigFiles;
 	}
 
 	private boolean isYarnPropertiesFileMode(CommandLine commandLine) {
@@ -573,7 +631,8 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 			return 0;
 		}
 
-		final YarnClusterDescriptor yarnClusterDescriptor = createClusterDescriptor(cmd);
+		final Configuration configuration = applyCommandLineOptionsToConfiguration(cmd);
+		final YarnClusterDescriptor yarnClusterDescriptor = createClusterDescriptor(configuration);
 
 		try {
 			// Query cluster for metrics
@@ -590,7 +649,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 
 					clusterClient = yarnClusterDescriptor.retrieve(yarnApplicationId);
 				} else {
-					final ClusterSpecification clusterSpecification = getClusterSpecification(cmd);
+					final ClusterSpecification clusterSpecification = getClusterSpecification(configuration);
 
 					clusterClient = yarnClusterDescriptor.deploySessionCluster(clusterSpecification);
 
@@ -770,6 +829,26 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 	private void logAndSysout(String message) {
 		LOG.info(message);
 		System.out.println(message);
+	}
+
+	private String encodeDynamicProperties(final CommandLine cmd) {
+		final Properties properties = cmd.getOptionProperties(dynamicproperties.getOpt());
+		final String[] dynamicProperties = properties.stringPropertyNames().stream()
+				.flatMap(
+						(String key) -> {
+							final String value = properties.getProperty(key);
+
+							LOG.info("Dynamic Property set: {}={}", key, GlobalConfiguration.isSensitive(key) ? GlobalConfiguration.HIDDEN_CONTENT : value);
+
+							if (value != null) {
+								return Stream.of(key + dynamicproperties.getValueSeparator() + value);
+							} else {
+								return Stream.empty();
+							}
+						})
+				.toArray(String[]::new);
+
+		return StringUtils.join(dynamicProperties, YARN_DYNAMIC_PROPERTIES_SEPARATOR);
 	}
 
 	public static Map<String, String> getDynamicProperties(String dynamicPropertiesEncoded) {
@@ -957,21 +1036,5 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 		String currentUser = System.getProperty("user.name");
 
 		return new File(propertiesFileLocation, YARN_PROPERTIES_FILE + currentUser);
-	}
-
-	private YarnClusterDescriptor getClusterDescriptor(
-			Configuration configuration,
-			YarnConfiguration yarnConfiguration,
-			String configurationDirectory) {
-		final YarnClient yarnClient = YarnClient.createYarnClient();
-		yarnClient.init(yarnConfiguration);
-		yarnClient.start();
-
-		return new YarnClusterDescriptor(
-			configuration,
-			yarnConfiguration,
-			configurationDirectory,
-			yarnClient,
-			false);
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -443,6 +443,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 	public Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) throws FlinkException {
 		// we ignore the addressOption because it can only contain "yarn-cluster"
 		final Configuration effectiveConfiguration = new Configuration(configuration);
+		effectiveConfiguration.setString(DeploymentOptions.TARGET, getId());
 
 		applyDescriptorOptionToConfig(commandLine, effectiveConfiguration);
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/YarnConfigUtils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/YarnConfigUtils.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn.cli;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Utilities for parsing {@link org.apache.flink.configuration.ConfigOption configuration options}.
+ */
+public class YarnConfigUtils {
+	// TODO: 16.10.19 test this and test LOG FILES discovery.
+	private static final String COLLECTION_DELIMITER = ";";
+
+	public static <T> void encodeListToConfig(
+			final Configuration configuration,
+			final ConfigOption<String> key,
+			final Collection<T> value,
+			final Function<T, String> mapper) {
+		encodeListToConfig(configuration, key, value.stream(), mapper);
+	}
+
+	public static <T> void encodeListToConfig(
+			final Configuration configuration,
+			final ConfigOption<String> key,
+			final T[] value,
+			final Function<T, String> mapper) {
+		encodeListToConfig(configuration, key, Arrays.stream(value), mapper);
+	}
+
+	private static <T> void encodeListToConfig(
+			final Configuration configuration,
+			final ConfigOption<String> key,
+			final Stream<T> values,
+			final Function<T, String> mapper) {
+
+		checkNotNull(values);
+		checkNotNull(key);
+		checkNotNull(configuration);
+
+		final String encodedString = values.map(mapper).filter(Objects::nonNull).collect(Collectors.joining(COLLECTION_DELIMITER));
+		if (encodedString != null && !encodedString.isEmpty()) {
+			configuration.setString(key, encodedString);
+		}
+	}
+
+	public static <R> List<R> decodeListFromConfig(
+			final Configuration configuration,
+			final ConfigOption<String> key,
+			final Function<String, R> mapper) {
+
+		checkNotNull(configuration);
+		checkNotNull(key);
+
+		final String encodedString = configuration.getString(key);
+		return encodedString != null
+				? Arrays.stream(encodedString.split(COLLECTION_DELIMITER)).map(mapper).collect(Collectors.toList())
+				: Collections.emptyList();
+	}
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -204,6 +204,54 @@ public class YarnConfigOptions {
 		.defaultValue("")
 		.withDescription("A comma-separated list of tags to apply to the Flink YARN application.");
 
+	// ----------------------- YARN CLI OPTIONS ------------------------------------
+
+	public static final ConfigOption<String> APPLICATION_LOG_CONFIG_FILES =
+			key("yarn.log-config-file")
+				.noDefaultValue()
+				.withDescription("The location of the log config file, e.g. the path to your log4j.properties for log4j.");
+
+	public static final ConfigOption<String> DYNAMIC_PROPERTIES =
+			key("$internal.yarn.dynamic-properties")
+				.noDefaultValue()
+				.withDescription("**DO NOT USE** Specify YARN dynamic properties.");
+
+	public static final ConfigOption<String> SHIP_DIRECTORIES =
+			key("yarn.ship-directories")
+				.noDefaultValue()
+				.withDescription("A semicolon-separated list of directories to be shipped to the YARN cluster.");
+
+	public static final ConfigOption<String> FLINK_DIST_JAR =
+			key("yarn.flink-dist-jar")
+				.noDefaultValue()
+				.withDescription("The location of the Flink dist jar.");
+
+	public static final ConfigOption<String> APPLICATION_ID =
+			key("yarn.application.id")
+				.noDefaultValue()
+				.withDescription("The YARN application id of the running yarn cluster." +
+						" This is the YARN cluster where the pipeline is going to be executed.");
+
+	public static final ConfigOption<String> APPLICATION_QUEUE =
+			key("yarn.application.queue")
+				.noDefaultValue()
+				.withDescription("The YARN queue on which to put the current pipeline.");
+
+	public static final ConfigOption<String> APPLICATION_NAME =
+			key("yarn.application.name")
+				.noDefaultValue()
+				.withDescription("A custom name for your YARN application.");
+
+	public static final ConfigOption<String> APPLICATION_TYPE =
+			key("yarn.application.type")
+				.noDefaultValue()
+				.withDescription("A custom type for your YARN application..");
+
+	public static final ConfigOption<String> NODE_LABEL =
+			key("yarn.application.node-label")
+				.noDefaultValue()
+				.withDescription("Specify YARN node label for the YARN application.");
+
 	// ------------------------------------------------------------------------
 
 	/** This class is not meant to be instantiated. */

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -206,7 +206,7 @@ public class YarnConfigOptions {
 
 	// ----------------------- YARN CLI OPTIONS ------------------------------------
 
-	public static final ConfigOption<String> APPLICATION_LOG_CONFIG_FILES =
+	public static final ConfigOption<String> APPLICATION_LOG_CONFIG_FILE =
 			key("yarn.log-config-file")
 				.noDefaultValue()
 				.withDescription("The location of the log config file, e.g. the path to your log4j.properties for log4j.");

--- a/flink-yarn/src/main/resources/META-INF/services/org.apache.flink.client.deployment.ClusterClientFactory
+++ b/flink-yarn/src/main/resources/META-INF/services/org.apache.flink.client.deployment.ClusterClientFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.yarn.YarnClusterClientFactory

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/AbstractYarnClusterTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/AbstractYarnClusterTest.java
@@ -67,7 +67,6 @@ public class AbstractYarnClusterTest extends TestLogger {
 		final YarnClusterDescriptor clusterDescriptor = new YarnClusterDescriptor(
 			new Configuration(),
 			yarnConfiguration,
-			temporaryFolder.newFolder().getAbsolutePath(),
 			yarnClient,
 			false);
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -85,7 +85,8 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 		CommandLine cmd = parser.parse(options, new String[]{"run", "-j", "fake.jar",
 				"-D", "akka.ask.timeout=5 min", "-D", "env.java.opts=-DappName=foobar", "-D", "security.ssl.internal.key-password=changeit"});
 
-		YarnClusterDescriptor flinkYarnDescriptor = cli.createClusterDescriptor(cmd);
+		Configuration executorConfig = cli.applyCommandLineOptionsToConfiguration(cmd);
+		YarnClusterDescriptor flinkYarnDescriptor = cli.createClusterDescriptor(executorConfig);
 
 		Assert.assertNotNull(flinkYarnDescriptor);
 
@@ -109,10 +110,10 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 			"yarn");
 
 		final CommandLine commandLine = yarnCLI.parseCommandLineOptions(params, true);
+		final Configuration executorConfig = yarnCLI.applyCommandLineOptionsToConfiguration(commandLine);
 
-		YarnClusterDescriptor descriptor = yarnCLI.createClusterDescriptor(commandLine);
-
-		final ClusterSpecification clusterSpecification = yarnCLI.getClusterSpecification(commandLine);
+		final YarnClusterDescriptor descriptor = yarnCLI.createClusterDescriptor(executorConfig);
+		final ClusterSpecification clusterSpecification = yarnCLI.getClusterSpecification(executorConfig);
 
 		// each task manager has 3 slots but the parallelism is 7. Thus the slots should be increased.
 		assertEquals(3, clusterSpecification.getSlotsPerTaskManager());
@@ -131,8 +132,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 			"yarn");
 
 		final CommandLine commandLine = yarnCLI.parseCommandLineOptions(params, true);
+		final Configuration executorConfig = yarnCLI.applyCommandLineOptionsToConfiguration(commandLine);
 
-		YarnClusterDescriptor descriptor = yarnCLI.createClusterDescriptor(commandLine);
+		YarnClusterDescriptor descriptor = yarnCLI.createClusterDescriptor(executorConfig);
 
 		// each task manager has 3 slots but the parallelism is 7. Thus the slots should be increased.
 		assertTrue(descriptor.isDetachedMode());
@@ -151,8 +153,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 			"yarn");
 
 		CommandLine commandLine = yarnCLI.parseCommandLineOptions(params, true);
+		Configuration executorConfig = yarnCLI.applyCommandLineOptionsToConfiguration(commandLine);
 
-		YarnClusterDescriptor descriptor = yarnCLI.createClusterDescriptor(commandLine);
+		YarnClusterDescriptor descriptor = yarnCLI.createClusterDescriptor(executorConfig);
 
 		assertEquals(zkNamespaceCliInput, descriptor.getZookeeperNamespace());
 	}
@@ -170,8 +173,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 			"yarn");
 
 		CommandLine commandLine = yarnCLI.parseCommandLineOptions(params, true);
+		Configuration executorConfig = yarnCLI.applyCommandLineOptionsToConfiguration(commandLine);
 
-		YarnClusterDescriptor descriptor = yarnCLI.createClusterDescriptor(commandLine);
+		YarnClusterDescriptor descriptor = yarnCLI.createClusterDescriptor(executorConfig);
 
 		assertEquals(nodeLabelCliInput, descriptor.getNodeLabel());
 	}
@@ -194,8 +198,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 			"yarn");
 
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(new String[] {}, true);
+		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
 
-		final ApplicationId clusterId = flinkYarnSessionCli.getClusterId(commandLine);
+		final ApplicationId clusterId = flinkYarnSessionCli.getClusterId(executorConfig);
 
 		assertEquals(TEST_YARN_APPLICATION_ID, clusterId);
 	}
@@ -229,8 +234,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 			"yarn");
 
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(new String[] {"-yid", TEST_YARN_APPLICATION_ID.toString()}, true);
+		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
 
-		final ApplicationId clusterId = flinkYarnSessionCli.getClusterId(commandLine);
+		final ApplicationId clusterId = flinkYarnSessionCli.getClusterId(executorConfig);
 
 		assertEquals(TEST_YARN_APPLICATION_ID, clusterId);
 	}
@@ -245,8 +251,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 			"yarn");
 
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(new String[] {"-yid", TEST_YARN_APPLICATION_ID.toString()}, true);
+		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
 
-		final YarnClusterDescriptor clusterDescriptor = flinkYarnSessionCli.createClusterDescriptor(commandLine);
+		final YarnClusterDescriptor clusterDescriptor = flinkYarnSessionCli.createClusterDescriptor(executorConfig);
 
 		final Configuration clusterDescriptorConfiguration = clusterDescriptor.getFlinkConfiguration();
 
@@ -266,8 +273,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 		final String overrideZkNamespace = "my_cluster";
 
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(new String[] {"-yid", TEST_YARN_APPLICATION_ID.toString(), "-yz", overrideZkNamespace}, true);
+		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
 
-		final YarnClusterDescriptor clusterDescriptor = flinkYarnSessionCli.createClusterDescriptor(commandLine);
+		final YarnClusterDescriptor clusterDescriptor = flinkYarnSessionCli.createClusterDescriptor(executorConfig);
 
 		final Configuration clusterDescriptorConfiguration = clusterDescriptor.getFlinkConfiguration();
 
@@ -288,7 +296,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 			"y",
 			"yarn");
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(new String[] {"-yid", TEST_YARN_APPLICATION_ID_2.toString() }, true);
-		final ApplicationId clusterId = flinkYarnSessionCli.getClusterId(commandLine);
+		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
+
+		final ApplicationId clusterId = flinkYarnSessionCli.getClusterId(executorConfig);
 		assertEquals(TEST_YARN_APPLICATION_ID_2, clusterId);
 	}
 
@@ -315,8 +325,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 			"yarn");
 
 		CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(args, false);
+		Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
 
-		final ClusterSpecification clusterSpecification = flinkYarnSessionCli.getClusterSpecification(commandLine);
+		final ClusterSpecification clusterSpecification = flinkYarnSessionCli.getClusterSpecification(executorConfig);
 
 		assertThat(clusterSpecification.getMasterMemoryMB(), is(jobManagerMemory));
 		assertThat(clusterSpecification.getTaskManagerMemoryMB(), is(taskManagerMemory));
@@ -345,8 +356,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 			"yarn");
 
 		CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(args, false);
+		Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
 
-		final ClusterSpecification clusterSpecification = flinkYarnSessionCli.getClusterSpecification(commandLine);
+		final ClusterSpecification clusterSpecification = flinkYarnSessionCli.getClusterSpecification(executorConfig);
 
 		assertThat(clusterSpecification.getMasterMemoryMB(), is(jobManagerMemory));
 		assertThat(clusterSpecification.getTaskManagerMemoryMB(), is(taskManagerMemory));
@@ -366,8 +378,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 			"yarn");
 
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(args, false);
+		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
 
-		final ClusterSpecification clusterSpecification = flinkYarnSessionCli.getClusterSpecification(commandLine);
+		final ClusterSpecification clusterSpecification = flinkYarnSessionCli.getClusterSpecification(executorConfig);
 
 		assertThat(clusterSpecification.getMasterMemoryMB(), is(1024));
 		assertThat(clusterSpecification.getTaskManagerMemoryMB(), is(2048));
@@ -385,7 +398,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 			"y",
 			"yarn");
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(args, false);
-		final ClusterSpecification clusterSpecification = flinkYarnSessionCli.getClusterSpecification(commandLine);
+		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
+
+		final ClusterSpecification clusterSpecification = flinkYarnSessionCli.getClusterSpecification(executorConfig);
 
 		assertThat(clusterSpecification.getMasterMemoryMB(), is(1024));
 		assertThat(clusterSpecification.getTaskManagerMemoryMB(), is(2048));
@@ -403,7 +418,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 			"y",
 			"yarn");
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(args, false);
-		final ClusterSpecification clusterSpecification = flinkYarnSessionCli.getClusterSpecification(commandLine);
+		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
+
+		final ClusterSpecification clusterSpecification = flinkYarnSessionCli.getClusterSpecification(executorConfig);
 
 		assertThat(clusterSpecification.getMasterMemoryMB(), is(1024));
 		assertThat(clusterSpecification.getTaskManagerMemoryMB(), is(2048));
@@ -425,8 +442,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 			"yarn");
 
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(new String[0], false);
+		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
 
-		final ClusterSpecification clusterSpecification = flinkYarnSessionCli.getClusterSpecification(commandLine);
+		final ClusterSpecification clusterSpecification = flinkYarnSessionCli.getClusterSpecification(executorConfig);
 
 		assertThat(clusterSpecification.getMasterMemoryMB(), is(2048));
 		assertThat(clusterSpecification.getTaskManagerMemoryMB(), is(4096));
@@ -444,8 +462,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 			"yarn");
 
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(new String[0], false);
+		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
 
-		final ClusterSpecification clusterSpecification = flinkYarnSessionCli.getClusterSpecification(commandLine);
+		final ClusterSpecification clusterSpecification = flinkYarnSessionCli.getClusterSpecification(executorConfig);
 
 		assertThat(clusterSpecification.getMasterMemoryMB(), is(1024));
 		assertThat(clusterSpecification.getTaskManagerMemoryMB(), is(1024));
@@ -461,8 +480,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 			"yarn");
 
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(args, false);
+		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
 
-		YarnClusterDescriptor flinkYarnDescriptor = flinkYarnSessionCli.createClusterDescriptor(commandLine);
+		YarnClusterDescriptor flinkYarnDescriptor = flinkYarnSessionCli.createClusterDescriptor(executorConfig);
 
 		assertEquals(2, flinkYarnDescriptor.getShipFiles().size());
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterClientFactoryTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterClientFactoryTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.flink.client.deployment.ClusterClientFactory;
+import org.apache.flink.client.deployment.ClusterClientServiceLoader;
+import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for the {@link YarnClusterClientFactory} discovery.
+ */
+public class YarnClusterClientFactoryTest {
+
+	@Test
+	public void testYarnClusterClientFactoryDiscovery() {
+		final Configuration configuration = new Configuration();
+		configuration.setString(DeploymentOptions.TARGET, YarnClusterClientFactory.ID);
+
+		final ClusterClientServiceLoader serviceLoader = new DefaultClusterClientServiceLoader();
+		final ClusterClientFactory<ApplicationId> factory = serviceLoader.getClusterClientFactory(configuration);
+
+		assertTrue(factory instanceof YarnClusterClientFactory);
+	}
+}

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -525,7 +525,6 @@ public class YarnClusterDescriptorTest extends TestLogger {
 		yarnClusterDescriptor = new YarnClusterDescriptor(
 			new Configuration(),
 			yarnConfiguration,
-			temporaryFolder.getRoot().getAbsolutePath(),
 			closableYarnClient,
 			false);
 
@@ -542,7 +541,6 @@ public class YarnClusterDescriptorTest extends TestLogger {
 		return new YarnClusterDescriptor(
 			configuration,
 			yarnConfiguration,
-			temporaryFolder.getRoot().getAbsolutePath(),
 			yarnClient,
 			true);
 	}


### PR DESCRIPTION
## What is the purpose of the change

This change decouples the cluster/cluster client creation from the command line, by putting a configuration object in-between.

Previously, the `CustomCommandLine` was responsible for the cluster client creation based on the methods:

```
ClusterDescriptor<T> createClusterDescriptor(CommandLine commandLine) throws FlinkException;

T getClusterId(CommandLine commandLine);

ClusterSpecification getClusterSpecification(CommandLine commandLine) throws FlinkException;
```

This was an unnecessary coupling and also bad from a separation of concerns standpoint. Ideally, the `CLI` should be responsible for parsing the command line options only.

This PR aims at doing exactly that. 

*Previously the command line options were directly passed to the descriptor and the specification from the `CustomCommandLine`. 

*Now the `CustomCommandLine` only has a method:
```
Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) throws FlinkException;
``` 
which maps the command-line options to a configuration object and this object is then used to:
1. instantiate the correct `ClusterClientFactory` (Yarn or Standalone currently) based on the `execution.target` config option.
2. create the adequate `ClusterDescriptor`.

## Brief change log

The previous `CustomCommandLine` is now only responsible for translating the CLI-options to a configuration.

A new `ClusterClientFactory` abstraction is introduced with the following methods that take care of cluster creation/ retrieval: 

```
/**
 * Returns {@code true} if the current {@link ClusterClientFactory} is compatible with the provided configuration, {@code false} otherwise.
 */
	boolean isCompatibleWith(Configuration configuration);

	ClusterDescriptor<ClusterID> createClusterDescriptor(Configuration configuration);

	@Nullable
	ClusterID getClusterId(Configuration configuration);

	ClusterSpecification getClusterSpecification(Configuration configuration);
```

## Verifying this change

This change is mainly covered by existing test. Some additional tests are added for the service discovery part.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / **JavaDocs** / not documented)

**This PR is part of FLIP-73 and the new configuration options it introduces are under voting process with FLIP-81. This PR is here for pre-reviewing but it will only be merged after FLIP-81 is merged.**