### PR TITLE
[FLINK-14477][coordination] Implement promotion logic on TaskExecutor 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionInfo.java
@@ -19,6 +19,8 @@ package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 
+import java.util.Objects;
+
 /**
  * Encapsulates meta-information the TaskExecutor requires to be kept for each partition.
  */
@@ -32,5 +34,24 @@ public final class TaskExecutorPartitionInfo {
 
 	public IntermediateDataSetID getIntermediateDataSetId() {
 		return intermediateDataSetId;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		TaskExecutorPartitionInfo that = (TaskExecutorPartitionInfo) o;
+		// only use the dataset ID here, so we can use this as an efficient place for meta data
+		return Objects.equals(intermediateDataSetId, that.intermediateDataSetId);
+	}
+
+	@Override
+	public int hashCode() {
+		// only use the dataset ID here, so we can use this as an efficient place for meta data
+		return Objects.hash(intermediateDataSetId);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTracker.java
@@ -44,4 +44,14 @@ public interface TaskExecutorPartitionTracker extends PartitionTracker<JobID, Ta
 	 * Releases all partitions for the given job and stop the tracking of partitions that were released.
 	 */
 	void stopTrackingAndReleaseJobPartitionsFor(JobID producingJobId);
+
+	/**
+	 * Promotes the given partitions.
+	 */
+	void promoteJobPartitions(Collection<ResultPartitionID> partitionsToPromote);
+
+	/**
+	 * Releases and stops tracking all partitions.
+	 */
+	void stopTrackingAndReleaseAllClusterPartitions();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTracker.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.io.network.partition;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 
+import java.util.Collection;
+
 /**
  * Utility for tracking partitions.
  */
@@ -32,4 +34,14 @@ public interface TaskExecutorPartitionTracker extends PartitionTracker<JobID, Ta
 	 * @param intermediateDataSetId the corresponding dataset ID
 	 */
 	void startTrackingPartition(JobID producingJobId, ResultPartitionID resultPartitionId, IntermediateDataSetID intermediateDataSetId);
+
+	/**
+	 * Releases the given partitions and stop the tracking of partitions that were released.
+	 */
+	void stopTrackingAndReleaseJobPartitions(Collection<ResultPartitionID> resultPartitionIds);
+
+	/**
+	 * Releases all partitions for the given job and stop the tracking of partitions that were released.
+	 */
+	void stopTrackingAndReleaseJobPartitionsFor(JobID producingJobId);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTrackerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTrackerImpl.java
@@ -19,12 +19,22 @@ package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
+
+import java.util.Collection;
 
 /**
  * Utility for tracking partitions and issuing release calls to task executors and shuffle masters.
  */
 public class TaskExecutorPartitionTrackerImpl extends AbstractPartitionTracker<JobID, TaskExecutorPartitionInfo> implements TaskExecutorPartitionTracker {
+
+	private final ShuffleEnvironment<?, ?> shuffleEnvironment;
+
+	public TaskExecutorPartitionTrackerImpl(ShuffleEnvironment<?, ?> shuffleEnvironment) {
+		this.shuffleEnvironment = shuffleEnvironment;
+	}
 
 	@Override
 	public void startTrackingPartition(JobID producingJobId, ResultPartitionID resultPartitionId, IntermediateDataSetID intermediateDataSetId) {
@@ -33,5 +43,19 @@ public class TaskExecutorPartitionTrackerImpl extends AbstractPartitionTracker<J
 		Preconditions.checkNotNull(intermediateDataSetId);
 
 		startTrackingPartition(producingJobId, resultPartitionId, new TaskExecutorPartitionInfo(intermediateDataSetId));
+	}
+
+	@Override
+	public void stopTrackingAndReleaseJobPartitions(Collection<ResultPartitionID> partitionsToRelease) {
+		stopTrackingPartitions(partitionsToRelease);
+		shuffleEnvironment.releasePartitionsLocally(partitionsToRelease);
+	}
+
+	@Override
+	public void stopTrackingAndReleaseJobPartitionsFor(JobID producingJobId) {
+		Collection<ResultPartitionID> partitionsForJob = CollectionUtil.project(
+			stopTrackingPartitionsFor(producingJobId),
+			PartitionTrackerEntry::getResultPartitionId);
+		shuffleEnvironment.releasePartitionsLocally(partitionsForJob);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -728,6 +728,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	public void releaseOrPromotePartitions(JobID jobId, Set<ResultPartitionID> partitionToRelease, Set<ResultPartitionID> partitionsToPromote) {
 		try {
 			partitionTracker.stopTrackingAndReleaseJobPartitions(partitionToRelease);
+			partitionTracker.promoteJobPartitions(partitionsToPromote);
 
 			closeJobManagerConnectionIfNoAllocatedResources(jobId);
 		} catch (Throwable t) {
@@ -1070,6 +1071,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 			resourceManagerGateway.disconnectTaskManager(getResourceID(), cause);
 
 			establishedResourceManagerConnection = null;
+
+			partitionTracker.stopTrackingAndReleaseAllClusterPartitions();
 		}
 
 		if (resourceManagerConnection != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -52,7 +52,6 @@ import org.apache.flink.runtime.heartbeat.HeartbeatTarget;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.InstanceID;
-import org.apache.flink.runtime.io.network.partition.PartitionTrackerEntry;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.TaskExecutorPartitionTracker;
@@ -109,7 +108,6 @@ import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerActions;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.types.SerializableOptional;
-import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 
@@ -729,8 +727,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	@Override
 	public void releaseOrPromotePartitions(JobID jobId, Set<ResultPartitionID> partitionToRelease, Set<ResultPartitionID> partitionsToPromote) {
 		try {
-			partitionTracker.stopTrackingPartitions(partitionToRelease);
-			shuffleEnvironment.releasePartitionsLocally(partitionToRelease);
+			partitionTracker.stopTrackingAndReleaseJobPartitions(partitionToRelease);
+
 			closeJobManagerConnectionIfNoAllocatedResources(jobId);
 		} catch (Throwable t) {
 			// TODO: Do we still need this catch branch?
@@ -1371,10 +1369,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		if (taskTerminationFutures != null) {
 			FutureUtils.waitForAll(taskTerminationFutures)
 				.thenRunAsync(() -> {
-					Collection<ResultPartitionID> partitionsForJob = CollectionUtil.project(
-						partitionTracker.stopTrackingPartitionsFor(jobId),
-						PartitionTrackerEntry::getResultPartitionId);
-					shuffleEnvironment.releasePartitionsLocally(partitionsForJob);
+					partitionTracker.stopTrackingAndReleaseJobPartitionsFor(jobId);
 				}, getMainThreadExecutor());
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -387,7 +387,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 			metricQueryServiceAddress,
 			blobCacheService,
 			fatalErrorHandler,
-			new TaskExecutorPartitionTrackerImpl());
+			new TaskExecutorPartitionTrackerImpl(taskManagerServices.getShuffleEnvironment()));
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -151,7 +151,7 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 			.setTaskSlotTable(createTaskSlotTable())
 			.build();
 
-		final TaskExecutorPartitionTracker partitionTracker = new TaskExecutorPartitionTrackerImpl();
+		final TaskExecutorPartitionTracker partitionTracker = new TaskExecutorPartitionTrackerImpl(shuffleEnvironment);
 		final ResultPartitionDeploymentDescriptor resultPartitionDeploymentDescriptor = PartitionTestUtils.createPartitionDeploymentDescriptor(ResultPartitionType.BLOCKING);
 		final ResultPartitionID resultPartitionId = resultPartitionDeploymentDescriptor.getShuffleDescriptor().getResultPartitionID();
 
@@ -307,7 +307,7 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 			})
 			.build();
 
-		final TaskExecutorPartitionTracker partitionTracker = new TaskExecutorPartitionTrackerImpl();
+		final TaskExecutorPartitionTracker partitionTracker = new TaskExecutorPartitionTrackerImpl(shuffleEnvironment);
 
 		final TestingTaskExecutor taskExecutor = createTestingTaskExecutor(taskManagerServices, partitionTracker);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -1919,7 +1919,7 @@ public class TaskExecutorTest extends TestLogger {
 			null,
 			dummyBlobCacheService,
 			testingFatalErrorHandler,
-			new TaskExecutorPartitionTrackerImpl());
+			new TaskExecutorPartitionTrackerImpl(taskManagerServices.getShuffleEnvironment()));
 	}
 
 	private TestingTaskExecutor createTestingTaskExecutor(TaskManagerServices taskManagerServices) {
@@ -1937,7 +1937,7 @@ public class TaskExecutorTest extends TestLogger {
 			null,
 			dummyBlobCacheService,
 			testingFatalErrorHandler,
-			new TaskExecutorPartitionTrackerImpl());
+			new TaskExecutorPartitionTrackerImpl(taskManagerServices.getShuffleEnvironment()));
 	}
 
 	private static final class StartStopNotifyingLeaderRetrievalService implements LeaderRetrievalService {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -207,7 +207,7 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
 			null,
 			blobCacheService,
 			testingFatalErrorHandler,
-			new TaskExecutorPartitionTrackerImpl()
+			new TaskExecutorPartitionTrackerImpl(taskManagerServices.getShuffleEnvironment())
 		);
 	}
 


### PR DESCRIPTION
Based on #10050.

With this PR the TaskExecutor properly handles partitions that should be promoted. The corresponding partitions are removed from the `PartitionTable`, decoupling them from the job life-cycle, and added to a separate data-structure for book-keeping. This new data structure groups result partitions by IntermediateResultPartitionID, to simplify release calls issued by ResourceManagers (there is no use-case where only part of the intermediate result is to be released, hence there is no value in sending all ResultPartitionIDs from the RM to the TE).

Additionally, if the ResourceManager disconnects all partitions will be released.