### PR TITLE
[FLINK-14398][SQL/Legacy Planner]Further split input unboxing code into separate methods

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -1060,6 +1060,7 @@ abstract class CodeGenerator(
     }
     reusableMemberStatements.add(s"private $resultTypeTerm ${expr.resultTerm};")
 
+    // when expr has no code, no need to split it into a method, but still need to assign
     if (expr.code.isEmpty) {
       if (nullCheck && !expr.nullTerm.equals(NEVER_NULL) && !expr.nullTerm.equals(ALWAYS_NULL)) {
         reusablePerRecordStatements.add(s"this.${expr.nullTerm} = ${expr.nullTerm};")
@@ -1073,9 +1074,7 @@ abstract class CodeGenerator(
         if (nullCheck && !expr.nullTerm.equals(NEVER_NULL) && !expr.nullTerm.equals(ALWAYS_NULL)) {
           s"""
              |private final void $methodName() throws Exception {
-             |  // read from input
              |  ${expr.code}
-             |  // save to member variable
              |  this.${expr.nullTerm} = ${expr.nullTerm};
              |  this.${expr.resultTerm} = ${expr.resultTerm};
              |}
@@ -1083,9 +1082,7 @@ abstract class CodeGenerator(
         } else {
           s"""
              |private final void $methodName() throws Exception {
-             |  // read from input
              |  ${expr.code}
-             |  // save to member variable
              |  this.${expr.resultTerm} = ${expr.resultTerm};
              |}
            """.stripMargin

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -1052,24 +1052,46 @@ abstract class CodeGenerator(
   // ----------------------------------------------------------------------------------------------
   // generator helping methods
   // ----------------------------------------------------------------------------------------------
-
-  protected def makeReusableInSplits(exprs: Iterable[GeneratedExpression]): Unit = {
-    // add results of expressions to member area such that all split functions can access it
-    exprs.foreach { expr =>
-
-      // declaration
-      val resultTypeTerm = primitiveTypeTermForTypeInfo(expr.resultType)
-      if (nullCheck && !expr.nullTerm.equals(NEVER_NULL) && !expr.nullTerm.equals(ALWAYS_NULL)) {
-        reusableMemberStatements.add(s"private boolean ${expr.nullTerm};")
-      }
-      reusableMemberStatements.add(s"private $resultTypeTerm ${expr.resultTerm};")
-
-      // assignment
-      if (nullCheck && !expr.nullTerm.equals(NEVER_NULL) && !expr.nullTerm.equals(ALWAYS_NULL)) {
-        reusablePerRecordStatements.add(s"this.${expr.nullTerm} = ${expr.nullTerm};")
-      }
-      reusablePerRecordStatements.add(s"this.${expr.resultTerm} = ${expr.resultTerm};")
+  protected def makeReusableInSplits(expr: GeneratedExpression): GeneratedExpression = {
+    // prepare declaration in class
+    val resultTypeTerm = primitiveTypeTermForTypeInfo(expr.resultType)
+    if (nullCheck && !expr.nullTerm.equals(NEVER_NULL) && !expr.nullTerm.equals(ALWAYS_NULL)) {
+      reusableMemberStatements.add(s"private boolean ${expr.nullTerm};")
     }
+    reusableMemberStatements.add(s"private $resultTypeTerm ${expr.resultTerm};")
+
+    // create a method for the unboxing block
+    val methodName = newName(s"inputUnboxingSplit")
+    val method =
+      if (nullCheck && !expr.nullTerm.equals(NEVER_NULL) && !expr.nullTerm.equals(ALWAYS_NULL)) {
+        s"""
+           |private final void $methodName() {
+           |  // read from input
+           |  ${expr.code}
+           |  // save to member variable
+           |  this.${expr.nullTerm} = ${expr.nullTerm};
+           |  this.${expr.resultTerm} = ${expr.resultTerm};
+           |}
+           """.stripMargin
+      } else {
+        s"""
+           |private final void $methodName() {
+           |  // read from input
+           |  ${expr.code}
+           |  // save to member variable
+           |  this.${expr.resultTerm} = ${expr.resultTerm};
+           |}
+           """.stripMargin
+      }
+    // add this method to reusable section for later generation
+    reusableMemberStatements.add(method)
+
+    // create method call
+    GeneratedExpression(
+      expr.resultTerm,
+      expr.nullTerm,
+      s"$methodName();",
+      expr.resultType)
   }
 
   private def generateCodeSplits(splits: Seq[String]): String = {
@@ -1081,7 +1103,9 @@ abstract class CodeGenerator(
       hasCodeSplits = true
 
       // add input unboxing to member area such that all split functions can access it
-      makeReusableInSplits(reusableInputUnboxingExprs.values)
+      reusableInputUnboxingExprs.keys.foreach(
+        key =>
+          reusableInputUnboxingExprs(key) = makeReusableInSplits(reusableInputUnboxingExprs(key)))
 
       // add split methods to the member area and return the code necessary to call those methods
       val methodCalls = splits.map { split =>

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/CollectorCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/CollectorCodeGenerator.scala
@@ -78,8 +78,8 @@ class CollectorCodeGenerator(
            s"private $input2TypeClass $input2Term;")
 
     val inputAssignment =
-      List(s"$input1Term = ($input1TypeClass) getInput()",
-           s"$input2Term = ($input2TypeClass) record")
+      List(s"$input1Term = ($input1TypeClass) getInput();",
+           s"$input2Term = ($input2TypeClass) record;")
 
     reusableMemberStatements ++= filterGenerator.reusableMemberStatements
     reusableInitStatements ++= filterGenerator.reusableInitStatements

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/CollectorCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/CollectorCodeGenerator.scala
@@ -73,19 +73,13 @@ class CollectorCodeGenerator(
     val input1TypeClass = boxedTypeTermForTypeInfo(input1)
     val input2TypeClass = boxedTypeTermForTypeInfo(collectedType)
 
-    // declaration in case of code splits
-    val recordMember = if (hasCodeSplits) {
-      s"private $input2TypeClass $input2Term;"
-    } else {
-      ""
-    }
+    val inputDecleration =
+      List(s"private $input1TypeClass $input1Term;",
+           s"private $input2TypeClass $input2Term;")
 
-    // assignment in case of code splits
-    val recordAssignment = if (hasCodeSplits) {
-      s"$input2Term" // use member
-    } else {
-      s"$input2TypeClass $input2Term" // local variable
-    }
+    val inputAssignment =
+      List(s"$input1Term = ($input1TypeClass) getInput()",
+           s"$input2Term = ($input2TypeClass) record")
 
     reusableMemberStatements ++= filterGenerator.reusableMemberStatements
     reusableInitStatements ++= filterGenerator.reusableInitStatements
@@ -94,7 +88,7 @@ class CollectorCodeGenerator(
     val funcCode = j"""
       |public class $className extends ${classOf[TableFunctionCollector[_]].getCanonicalName} {
       |
-      |  $recordMember
+      |  ${inputDecleration.mkString("\n")}
       |  ${reuseMemberCode()}
       |
       |  public $className() throws Exception {
@@ -109,8 +103,7 @@ class CollectorCodeGenerator(
       |  @Override
       |  public void collect(Object record) throws Exception {
       |    super.collect(record);
-      |    $input1TypeClass $input1Term = ($input1TypeClass) getInput();
-      |    $recordAssignment = ($input2TypeClass) record;
+      |    ${inputAssignment.mkString("\n")}
       |    ${reuseInputUnboxingCode()}
       |    ${reusePerRecordCode()}
       |    $bodyCode

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/FunctionCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/FunctionCodeGenerator.scala
@@ -101,18 +101,22 @@ class FunctionCodeGenerator(
     if (clazz == classOf[FlatMapFunction[_, _]]) {
       val baseClass = classOf[RichFlatMapFunction[_, _]]
       val inputTypeTerm = boxedTypeTermForTypeInfo(input1)
+      // declaration: make variable accessible for separated method
+      reusableMemberStatements.add(s"private $inputTypeTerm $input1Term;")
       (baseClass,
         s"void flatMap(Object _in1, $collectorTypeTerm $collectorTerm)",
-        List(s"$inputTypeTerm $input1Term = ($inputTypeTerm) _in1;"))
+        List(s"$input1Term = ($inputTypeTerm) _in1;"))
     }
 
     // MapFunction
     else if (clazz == classOf[MapFunction[_, _]]) {
       val baseClass = classOf[RichMapFunction[_, _]]
       val inputTypeTerm = boxedTypeTermForTypeInfo(input1)
+      // declaration: make variable accessible for separated method
+      reusableMemberStatements.add(s"private $inputTypeTerm $input1Term;")
       (baseClass,
         "Object map(Object _in1)",
-        List(s"$inputTypeTerm $input1Term = ($inputTypeTerm) _in1;"))
+        List(s"$input1Term = ($inputTypeTerm) _in1;"))
     }
 
     // FlatJoinFunction
@@ -121,10 +125,13 @@ class FunctionCodeGenerator(
       val inputTypeTerm1 = boxedTypeTermForTypeInfo(input1)
       val inputTypeTerm2 = boxedTypeTermForTypeInfo(input2.getOrElse(
         throw new CodeGenException("Input 2 for FlatJoinFunction should not be null")))
+      // declaration: make variables accessible for separated methods
+      reusableMemberStatements.add(s"private $inputTypeTerm1 $input1Term;")
+      reusableMemberStatements.add(s"private $inputTypeTerm2 $input2Term;")
       (baseClass,
         s"void join(Object _in1, Object _in2, $collectorTypeTerm $collectorTerm)",
-        List(s"$inputTypeTerm1 $input1Term = ($inputTypeTerm1) _in1;",
-             s"$inputTypeTerm2 $input2Term = ($inputTypeTerm2) _in2;"))
+        List(s"$input1Term = ($inputTypeTerm1) _in1;",
+             s"$input2Term = ($inputTypeTerm2) _in2;"))
     }
 
     // JoinFunction
@@ -133,10 +140,13 @@ class FunctionCodeGenerator(
       val inputTypeTerm1 = boxedTypeTermForTypeInfo(input1)
       val inputTypeTerm2 = boxedTypeTermForTypeInfo(input2.getOrElse(
         throw new CodeGenException("Input 2 for JoinFunction should not be null")))
+      // declaration: make variables accessible for separated methods
+      reusableMemberStatements.add(s"private $inputTypeTerm1 $input1Term;")
+      reusableMemberStatements.add(s"private $inputTypeTerm2 $input2Term;")
       (baseClass,
         s"Object join(Object _in1, Object _in2)",
-        List(s"$inputTypeTerm1 $input1Term = ($inputTypeTerm1) _in1;",
-          s"$inputTypeTerm2 $input2Term = ($inputTypeTerm2) _in2;"))
+        List(s"$input1Term = ($inputTypeTerm1) _in1;",
+             s"$input2Term = ($inputTypeTerm2) _in2;"))
     }
 
     // ProcessFunction
@@ -155,10 +165,12 @@ class FunctionCodeGenerator(
         Nil
       }
 
+      // declaration: make variable accessible for separated method
+      reusableMemberStatements.add(s"private $inputTypeTerm $input1Term;")
       (baseClass,
         s"void processElement(Object _in1, $contextTypeTerm $contextTerm, " +
           s"$collectorTypeTerm $collectorTerm)",
-        List(s"$inputTypeTerm $input1Term = ($inputTypeTerm) _in1;") ++ globalContext)
+        List(s"$input1Term = ($inputTypeTerm) _in1;") ++ globalContext)
     }
     else {
       // TODO more functions

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/MatchCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/MatchCodeGenerator.scala
@@ -545,11 +545,13 @@ class MatchCodeGenerator(
     } else {
       ""
     }
+
+    reusableMemberStatements.add(s"java.util.List $listName = new java.util.ArrayList();")
     val listCode = if (patternName == ALL_PATTERN_VARIABLE) {
       addReusablePatternNames()
       val patternTerm = newName("pattern")
       j"""
-         |java.util.List $listName = new java.util.ArrayList();
+         |$listName.clear();
          |for (String $patternTerm : $patternNamesTerm) {
          |  for ($eventTypeTerm $eventNameTerm :
          |  $contextTerm.getEventsForPattern($patternTerm)) {
@@ -560,7 +562,7 @@ class MatchCodeGenerator(
     } else {
       val escapedPatternName = EncodingUtils.escapeJava(patternName)
       j"""
-         |java.util.List $listName = new java.util.ArrayList();
+         |$listName.clear();
          |for ($eventTypeTerm $eventNameTerm :
          |  $contextTerm.getEventsForPattern("$escapedPatternName")) {
          |    $listName.add($eventNameTerm);
@@ -580,13 +582,14 @@ class MatchCodeGenerator(
   private def generateMeasurePatternVariableExp(patternName: String): GeneratedPatternList = {
     val listName = newName("patternEvents")
 
+    reusableMemberStatements.add(s"java.util.List $listName = new java.util.ArrayList();")
     val code = if (patternName == ALL_PATTERN_VARIABLE) {
       addReusablePatternNames()
 
       val patternTerm = newName("pattern")
 
       j"""
-         |java.util.List $listName = new java.util.ArrayList();
+         |$listName.clear();
          |for (String $patternTerm : $patternNamesTerm) {
          |  java.util.List rows = (java.util.List) $input1Term.get($patternTerm);
          |  if (rows != null) {
@@ -597,7 +600,7 @@ class MatchCodeGenerator(
     } else {
       val escapedPatternName = EncodingUtils.escapeJava(patternName)
       j"""
-         |java.util.List $listName = (java.util.List) $input1Term.get("$escapedPatternName");
+         |$listName = (java.util.List) $input1Term.get("$escapedPatternName");
          |if ($listName == null) {
          |  $listName = java.util.Collections.emptyList();
          |}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

When a resultant table is wide, the large number of non-trivial input unboxing code can push the generated byte code beyond the 64kb limit for some methods.  This PR splits them into individual methods.

## Brief change log

In CodeGen, when a split is needed, we create individual methods for each of the expressions inside `reusableInputUnboxingExprs`, which is in addition to the split of result setters.


## Verifying this change
The code path in this change is exercised at the same time when existing code split takes place and all existing unit tests that verify code splits should be able to verify this.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
