### PR TITLE
[FLINK-9495][kubernetes] Implement ResourceManager for Kubernetes.

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
@@ -1,0 +1,338 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
+import org.apache.flink.kubernetes.kubeclient.KubeClientFactory;
+import org.apache.flink.kubernetes.kubeclient.TaskManagerPodParameter;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesPod;
+import org.apache.flink.kubernetes.taskmanager.KubernetesTaskExecutorRunner;
+import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.kubernetes.utils.KubernetesUtils;
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
+import org.apache.flink.runtime.clusterframework.BootstrapTools;
+import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.entrypoint.ClusterInformation;
+import org.apache.flink.runtime.entrypoint.parser.CommandLineOptions;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
+import org.apache.flink.runtime.resourcemanager.ActiveResourceManager;
+import org.apache.flink.runtime.resourcemanager.JobLeaderIdService;
+import org.apache.flink.runtime.resourcemanager.ResourceManager;
+import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Kubernetes specific implementation of the {@link ResourceManager}.
+ */
+public class KubernetesResourceManager extends ActiveResourceManager<KubernetesWorkerNode>
+	implements FlinkKubeClient.PodCallbackHandler {
+
+	private static final Logger LOG = LoggerFactory.getLogger(KubernetesResourceManager.class);
+
+	/** The taskmanager pod name pattern is {clusterId}-{taskmanager}-{attemptId}-{podIndex}. */
+	private static final String TASK_MANAGER_POD_FORMAT = "%s-taskmanager-%d-%d";
+
+	private final Map<ResourceID, KubernetesWorkerNode> workerNodes = new HashMap<>();
+
+	private final double defaultCpus;
+
+	/** When ResourceManager failover, the max attempt should recover. */
+	private long currentMaxAttemptId = 0;
+
+	/** Current max pod index. When creating a new pod, it should increase one. */
+	private long currentMaxPodId = 0;
+
+	private final String clusterId;
+
+	private final FlinkKubeClient kubeClient;
+
+	private final ContaineredTaskManagerParameters taskManagerParameters;
+
+	private final List<String> taskManagerStartCommand;
+
+	/** The number of pods requested, but not yet granted. */
+	private int numPendingPodRequests = 0;
+
+	public KubernetesResourceManager(
+			RpcService rpcService,
+			String resourceManagerEndpointId,
+			ResourceID resourceId,
+			Configuration flinkConfig,
+			HighAvailabilityServices highAvailabilityServices,
+			HeartbeatServices heartbeatServices,
+			SlotManager slotManager,
+			JobLeaderIdService jobLeaderIdService,
+			ClusterInformation clusterInformation,
+			FatalErrorHandler fatalErrorHandler,
+			ResourceManagerMetricGroup resourceManagerMetricGroup) {
+		super(
+			flinkConfig,
+			System.getenv(),
+			rpcService,
+			resourceManagerEndpointId,
+			resourceId,
+			highAvailabilityServices,
+			heartbeatServices,
+			slotManager,
+			jobLeaderIdService,
+			clusterInformation,
+			fatalErrorHandler,
+			resourceManagerMetricGroup);
+		this.clusterId = flinkConfig.getString(KubernetesConfigOptions.CLUSTER_ID);
+		this.defaultCpus = flinkConfig.getDouble(KubernetesConfigOptions.TASK_MANAGER_CPU, numSlotsPerTaskManager);
+
+		this.kubeClient = createFlinkKubeClient();
+
+		this.taskManagerParameters =
+			ContaineredTaskManagerParameters.create(flinkConfig, taskExecutorResourceSpec, numSlotsPerTaskManager);
+
+		this.taskManagerStartCommand = getTaskManagerStartCommand();
+	}
+
+	@Override
+	protected Configuration loadClientConfiguration() {
+		return GlobalConfiguration.loadConfiguration();
+	}
+
+	@Override
+	protected void initialize() throws ResourceManagerException {
+		recoverWorkerNodesFromPreviousAttempts();
+
+		kubeClient.watchPodsAndDoCallback(getTaskManagerLabels(), this);
+	}
+
+	@Override
+	public CompletableFuture<Void> onStop() {
+		// shut down all components
+		Throwable exception = null;
+
+		try {
+			kubeClient.close();
+		} catch (Throwable t) {
+			exception = t;
+		}
+
+		return getStopTerminationFutureOrCompletedExceptionally(exception);
+	}
+
+	@Override
+	protected void internalDeregisterApplication(ApplicationStatus finalStatus, @Nullable String diagnostics) {
+		LOG.info(
+			"Stopping kubernetes cluster, clusterId: {}, diagnostics: {}",
+			clusterId,
+			diagnostics == null ? "" : diagnostics);
+		kubeClient.stopAndCleanupCluster(clusterId);
+	}
+
+	@Override
+	public Collection<ResourceProfile> startNewWorker(ResourceProfile resourceProfile) {
+		LOG.info("Starting new worker with resource profile, {}", resourceProfile);
+		if (!resourceProfilesPerWorker.iterator().next().isMatching(resourceProfile)) {
+			return Collections.emptyList();
+		}
+		requestKubernetesPod();
+		return resourceProfilesPerWorker;
+	}
+
+	@Override
+	protected KubernetesWorkerNode workerStarted(ResourceID resourceID) {
+		return workerNodes.get(resourceID);
+	}
+
+	@Override
+	public boolean stopWorker(final KubernetesWorkerNode worker) {
+		LOG.info("Stopping Worker {}.", worker.getResourceID());
+		workerNodes.remove(worker.getResourceID());
+		try {
+			kubeClient.stopPod(worker.getResourceID().toString());
+		} catch (Exception e) {
+			kubeClient.handleException(e);
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public void onAdded(List<KubernetesPod> pods) {
+		runAsync(() -> {
+			for (KubernetesPod pod : pods) {
+				if (numPendingPodRequests > 0) {
+					numPendingPodRequests--;
+					final KubernetesWorkerNode worker = new KubernetesWorkerNode(new ResourceID(pod.getName()));
+					workerNodes.putIfAbsent(worker.getResourceID(), worker);
+				}
+
+				log.info("Received new TaskManager pod: {} - Remaining pending pod requests: {}",
+					pod.getName(), numPendingPodRequests);
+			}
+		});
+	}
+
+	@Override
+	public void onModified(List<KubernetesPod> pods) {
+		runAsync(() -> pods.forEach(this::removePodIfTerminated));
+	}
+
+	@Override
+	public void onDeleted(List<KubernetesPod> pods) {
+		runAsync(() -> pods.forEach(this::removePodIfTerminated));
+	}
+
+	@Override
+	public void onError(List<KubernetesPod> pods) {
+		runAsync(() -> pods.forEach(this::removePodIfTerminated));
+	}
+
+	@VisibleForTesting
+	Map<ResourceID, KubernetesWorkerNode> getWorkerNodes() {
+		return workerNodes;
+	}
+
+	private void recoverWorkerNodesFromPreviousAttempts() throws ResourceManagerException {
+		final List<KubernetesPod> podList = kubeClient.getPodsWithLabels(getTaskManagerLabels());
+		for (KubernetesPod pod : podList) {
+			final KubernetesWorkerNode worker = new KubernetesWorkerNode(new ResourceID(pod.getName()));
+			workerNodes.put(worker.getResourceID(), worker);
+			final long attempt = worker.getAttempt();
+			if (attempt > currentMaxAttemptId) {
+				currentMaxAttemptId = attempt;
+			}
+		}
+
+		log.info("Recovered {} pods from previous attempts, current attempt id is {}.",
+			workerNodes.size(),
+			++currentMaxAttemptId);
+	}
+
+	private void requestKubernetesPod() {
+		numPendingPodRequests++;
+
+		log.info("Requesting new TaskManager pod with <{},{}>. Number pending requests {}.",
+			defaultMemoryMB,
+			defaultCpus,
+			numPendingPodRequests);
+
+		final String podName = String.format(
+			TASK_MANAGER_POD_FORMAT,
+			clusterId,
+			currentMaxAttemptId,
+			++currentMaxPodId);
+
+		final HashMap<String, String> env = new HashMap<>();
+		env.put(Constants.ENV_FLINK_POD_NAME, podName);
+		env.putAll(taskManagerParameters.taskManagerEnv());
+
+		final TaskManagerPodParameter parameter = new TaskManagerPodParameter(
+			podName,
+			taskManagerStartCommand,
+			defaultMemoryMB,
+			defaultCpus,
+			env);
+
+		log.info("TaskManager {} will be started with {}.", podName, taskExecutorResourceSpec);
+		kubeClient.createTaskManagerPod(parameter);
+	}
+
+	/**
+	 * Request new pod if pending pods cannot satisfy pending slot requests.
+	 */
+	private void requestKubernetesPodIfRequired() {
+		final int requiredTaskManagerSlots = getNumberRequiredTaskManagerSlots();
+		final int pendingTaskManagerSlots = numPendingPodRequests * numSlotsPerTaskManager;
+
+		if (requiredTaskManagerSlots > pendingTaskManagerSlots) {
+			requestKubernetesPod();
+		}
+	}
+
+	private void removePodIfTerminated(KubernetesPod pod) {
+		if (pod.isTerminated()) {
+			kubeClient.stopPod(pod.getName());
+			final KubernetesWorkerNode kubernetesWorkerNode = workerNodes.remove(new ResourceID(pod.getName()));
+			if (kubernetesWorkerNode != null) {
+				requestKubernetesPodIfRequired();
+			}
+		}
+	}
+
+	private List<String> getTaskManagerStartCommand() {
+		final String confDir = flinkConfig.getString(KubernetesConfigOptions.FLINK_CONF_DIR);
+		final boolean hasLogback = new File(confDir, Constants.CONFIG_FILE_LOGBACK_NAME).exists();
+		final boolean hasLog4j = new File(confDir, Constants.CONFIG_FILE_LOG4J_NAME).exists();
+
+		final String logDir = flinkConfig.getString(KubernetesConfigOptions.FLINK_LOG_DIR);
+
+		final String mainClassArgs = "--" + CommandLineOptions.CONFIG_DIR_OPTION.getLongOpt() + " " +
+			flinkConfig.getString(KubernetesConfigOptions.FLINK_CONF_DIR) + " " +
+			BootstrapTools.getDynamicProperties(flinkClientConfig, flinkConfig);
+
+		final String command = KubernetesUtils.getTaskManagerStartCommand(
+			flinkConfig,
+			taskManagerParameters,
+			confDir,
+			logDir,
+			hasLogback,
+			hasLog4j,
+			KubernetesTaskExecutorRunner.class.getCanonicalName(),
+			mainClassArgs);
+
+		return Arrays.asList("/bin/bash", "-c", command);
+	}
+
+	/**
+	 * Get task manager labels for the current Flink cluster. They could be used to watch the pods status.
+	 *
+	 * @return Task manager labels.
+	 */
+	private Map<String, String> getTaskManagerLabels() {
+		final Map<String, String> labels = new HashMap<>();
+		labels.put(Constants.LABEL_TYPE_KEY, Constants.LABEL_TYPE_NATIVE_TYPE);
+		labels.put(Constants.LABEL_APP_KEY, clusterId);
+		labels.put(Constants.LABEL_COMPONENT_KEY, Constants.LABEL_COMPONENT_TASK_MANAGER);
+		return labels;
+	}
+
+	protected FlinkKubeClient createFlinkKubeClient() {
+		return KubeClientFactory.fromConfiguration(flinkConfig);
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesWorkerNode.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesWorkerNode.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
+import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A stored Kubernetes worker, which contains the kubernetes pod.
+ */
+public class KubernetesWorkerNode implements ResourceIDRetrievable {
+	private final ResourceID resourceID;
+
+	/**
+	 * This pattern should be updated when {@link KubernetesResourceManager#TASK_MANAGER_POD_FORMAT} changed.
+	 */
+	private static final Pattern TASK_MANAGER_POD_PATTERN = Pattern.compile("\\S+-taskmanager-([\\d]+)-([\\d]+)");
+
+	KubernetesWorkerNode(ResourceID resourceID) {
+		this.resourceID = checkNotNull(resourceID);
+	}
+
+	@Override
+	public ResourceID getResourceID() {
+		return resourceID;
+	}
+
+	public long getAttempt() throws ResourceManagerException {
+		Matcher matcher = TASK_MANAGER_POD_PATTERN.matcher(resourceID.toString());
+		if (matcher.find()) {
+			return Long.parseLong(matcher.group(1));
+		} else {
+			throw new ResourceManagerException("Error to parse KubernetesWorkerNode from " + resourceID + ".");
+		}
+	}
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerTest.java
@@ -1,0 +1,359 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
+import org.apache.flink.kubernetes.kubeclient.TaskManagerPodParameter;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesPod;
+import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.entrypoint.ClusterInformation;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.instance.HardwareDescription;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.registration.RegistrationResponse;
+import org.apache.flink.runtime.resourcemanager.JobLeaderIdService;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.resourcemanager.SlotRequest;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
+import org.apache.flink.runtime.resourcemanager.utils.MockResourceManagerRuntimeServices;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.TestingRpcService;
+import org.apache.flink.runtime.taskexecutor.SlotReport;
+import org.apache.flink.runtime.taskexecutor.SlotStatus;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorRegistrationSuccess;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
+import org.apache.flink.runtime.util.TestingFatalErrorHandler;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerStateBuilder;
+import io.fabric8.kubernetes.api.model.ContainerStatusBuilder;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.PodStatusBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test cases for {@link KubernetesResourceManager}.
+ */
+public class KubernetesResourceManagerTest extends KubernetesTestBase {
+
+	private static final Time TIMEOUT = Time.seconds(10L);
+
+	private TestingFatalErrorHandler testingFatalErrorHandler;
+
+	private final String jobManagerHost = "jm-host1";
+
+	private Configuration flinkConfig;
+
+	private TestingKubernetesResourceManager resourceManager;
+
+	private FlinkKubeClient flinkKubeClient;
+
+	@Before
+	public void setup() throws Exception {
+		testingFatalErrorHandler = new TestingFatalErrorHandler();
+		flinkConfig = new Configuration(FLINK_CONFIG);
+		flinkConfig.setString(TaskManagerOptions.TOTAL_PROCESS_MEMORY, "1024m");
+
+		flinkKubeClient = getFabric8FlinkKubeClient();
+		resourceManager = createAndStartResourceManager(flinkConfig);
+	}
+
+	@After
+	public void teardown() throws Exception {
+		resourceManager.close();
+		if (testingFatalErrorHandler != null) {
+			testingFatalErrorHandler.rethrowError();
+		}
+	}
+
+	class TestingKubernetesResourceManager extends KubernetesResourceManager {
+
+		private final SlotManager slotManager;
+
+		TestingKubernetesResourceManager(
+				RpcService rpcService,
+				String resourceManagerEndpointId,
+				ResourceID resourceId,
+				Configuration flinkConfig,
+				HighAvailabilityServices highAvailabilityServices,
+				HeartbeatServices heartbeatServices,
+				SlotManager slotManager,
+				JobLeaderIdService jobLeaderIdService,
+				ClusterInformation clusterInformation,
+				FatalErrorHandler fatalErrorHandler,
+				ResourceManagerMetricGroup resourceManagerMetricGroup) {
+			super(
+				rpcService,
+				resourceManagerEndpointId,
+				resourceId,
+				flinkConfig,
+				highAvailabilityServices,
+				heartbeatServices,
+				slotManager,
+				jobLeaderIdService,
+				clusterInformation,
+				fatalErrorHandler,
+				resourceManagerMetricGroup
+			);
+			this.slotManager = slotManager;
+		}
+
+		<T> CompletableFuture<T> runInMainThread(Callable<T> callable) {
+			return callAsync(callable, TIMEOUT);
+		}
+
+		@Override
+		protected void runAsync(Runnable runnable) {
+			runnable.run();
+		}
+
+		@Override
+		protected FlinkKubeClient createFlinkKubeClient() {
+			return flinkKubeClient;
+		}
+
+		MainThreadExecutor getMainThreadExecutorForTesting() {
+			return super.getMainThreadExecutor();
+		}
+
+		SlotManager getSlotManager() {
+			return this.slotManager;
+		}
+	}
+
+	@Test
+	public void testStartAndStopWorker() throws Exception {
+		registerSlotRequest();
+
+		final KubernetesClient client = getKubeClient();
+		final PodList list = client.pods().list();
+		assertEquals(1, list.getItems().size());
+		final Pod pod = list.getItems().get(0);
+
+		final Map<String, String> labels = getCommonLabels();
+		labels.put(Constants.LABEL_COMPONENT_KEY, Constants.LABEL_COMPONENT_TASK_MANAGER);
+		assertEquals(labels, pod.getMetadata().getLabels());
+
+		assertEquals(1, pod.getSpec().getContainers().size());
+		final Container tmContainer = pod.getSpec().getContainers().get(0);
+		assertEquals(CONTAINER_IMAGE, tmContainer.getImage());
+
+		final String podName = CLUSTER_ID + "-taskmanager-1-1";
+		assertEquals(podName, pod.getMetadata().getName());
+
+		// Check environments
+		assertThat(tmContainer.getEnv(), Matchers.contains(
+			new EnvVarBuilder().withName(Constants.ENV_FLINK_POD_NAME).withValue(podName).build()));
+
+		// Check task manager main class args.
+		assertEquals(3, tmContainer.getArgs().size());
+		final String confDirOption = "--configDir " + flinkConfig.getString(KubernetesConfigOptions.FLINK_CONF_DIR);
+		assertTrue(tmContainer.getArgs().get(2).contains(confDirOption));
+
+		resourceManager.onAdded(Collections.singletonList(new KubernetesPod(flinkConfig, pod)));
+		final ResourceID resourceID = new ResourceID(podName);
+		assertThat(resourceManager.getWorkerNodes().keySet(), Matchers.contains(resourceID));
+
+		registerTaskExecutor(resourceID);
+
+		// Unregister all task executors and release all task managers.
+		CompletableFuture<?> unregisterAndReleaseFuture = resourceManager.runInMainThread(() -> {
+			resourceManager.getSlotManager().unregisterTaskManagersAndReleaseResources();
+			return null;
+		});
+		unregisterAndReleaseFuture.get();
+		assertEquals(0, client.pods().list().getItems().size());
+		assertEquals(0, resourceManager.getWorkerNodes().size());
+	}
+
+	@Test
+	public void testTaskManagerPodTerminated() throws Exception {
+		registerSlotRequest();
+
+		final KubernetesClient client = getKubeClient();
+		final Pod pod1 = client.pods().list().getItems().get(0);
+		final String taskManagerPrefix = CLUSTER_ID + "-taskmanager-1-";
+
+		resourceManager.onAdded(Collections.singletonList(new KubernetesPod(flinkConfig, pod1)));
+
+		// General modification event
+		resourceManager.onModified(Collections.singletonList(new KubernetesPod(flinkConfig, pod1)));
+		assertEquals(1, client.pods().list().getItems().size());
+		assertEquals(taskManagerPrefix + 1, client.pods().list().getItems().get(0).getMetadata().getName());
+
+		// Terminate the pod.
+		terminatePod(pod1);
+		resourceManager.onModified(Collections.singletonList(new KubernetesPod(flinkConfig, pod1)));
+
+		// Old pod should be deleted and a new task manager should be created
+		assertEquals(1, client.pods().list().getItems().size());
+		final Pod pod2 = client.pods().list().getItems().get(0);
+		assertEquals(taskManagerPrefix + 2, pod2.getMetadata().getName());
+
+		// Error happens in the pod.
+		resourceManager.onAdded(Collections.singletonList(new KubernetesPod(flinkConfig, pod2)));
+		terminatePod(pod2);
+		resourceManager.onError(Collections.singletonList(new KubernetesPod(flinkConfig, pod2)));
+		final Pod pod3 = client.pods().list().getItems().get(0);
+		assertEquals(taskManagerPrefix + 3, pod3.getMetadata().getName());
+
+		// Delete the pod.
+		resourceManager.onAdded(Collections.singletonList(new KubernetesPod(flinkConfig, pod3)));
+		terminatePod(pod3);
+		resourceManager.onDeleted(Collections.singletonList(new KubernetesPod(flinkConfig, pod3)));
+		assertEquals(taskManagerPrefix + 4, client.pods().list().getItems().get(0).getMetadata().getName());
+	}
+
+	@Test
+	public void testGetWorkerNodesFromPreviousAttempts() throws Exception {
+		// Prepare pod of previous attempt
+		final String previewPodName = CLUSTER_ID + "-taskmanager-1-1";
+		flinkKubeClient.createTaskManagerPod(new TaskManagerPodParameter(
+			previewPodName,
+			new ArrayList<>(),
+			1024,
+			1,
+			new HashMap<>()));
+		final KubernetesClient client = getKubeClient();
+		assertEquals(1, client.pods().list().getItems().size());
+
+		// Call initialize method to recover worker nodes from previous attempt.
+		resourceManager.initialize();
+
+		final String taskManagerPrefix = CLUSTER_ID + "-taskmanager-";
+		// Register the previous taskmanager, no new pod should be created
+		registerTaskExecutor(new ResourceID(previewPodName));
+		registerSlotRequest();
+		assertEquals(1, client.pods().list().getItems().size());
+
+		// Register a new slot request, a new taskmanger pod will be created with attempt2
+		registerSlotRequest();
+		assertEquals(2, client.pods().list().getItems().size());
+		assertThat(client.pods().list().getItems().stream()
+				.map(e -> e.getMetadata().getName())
+				.collect(Collectors.toList()),
+			Matchers.containsInAnyOrder(taskManagerPrefix + "1-1", taskManagerPrefix + "2-1"));
+	}
+
+	private TestingKubernetesResourceManager createAndStartResourceManager(Configuration configuration) throws Exception {
+
+		final TestingRpcService rpcService = new TestingRpcService(configuration);
+		final MockResourceManagerRuntimeServices rmServices = new MockResourceManagerRuntimeServices(rpcService, TIMEOUT);
+
+		final TestingKubernetesResourceManager kubernetesResourceManager = new TestingKubernetesResourceManager(
+			rpcService,
+			"kubernetesResourceManager",
+			ResourceID.generate(),
+			configuration,
+			rmServices.highAvailabilityServices,
+			rmServices.heartbeatServices,
+			rmServices.slotManager,
+			rmServices.jobLeaderIdService,
+			new ClusterInformation("localhost", 1234),
+			testingFatalErrorHandler,
+			UnregisteredMetricGroups.createUnregisteredResourceManagerMetricGroup()
+		);
+		kubernetesResourceManager.start();
+		rmServices.grantLeadership();
+		return kubernetesResourceManager;
+	}
+
+	private void registerSlotRequest() throws Exception {
+		CompletableFuture<?> registerSlotRequestFuture = resourceManager.runInMainThread(() -> {
+			resourceManager.getSlotManager().registerSlotRequest(
+				new SlotRequest(new JobID(), new AllocationID(), ResourceProfile.UNKNOWN, jobManagerHost));
+			return null;
+		});
+		registerSlotRequestFuture.get();
+	}
+
+	private void registerTaskExecutor(ResourceID resourceID) throws Exception {
+		final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
+			.createTestingTaskExecutorGateway();
+		((TestingRpcService) resourceManager.getRpcService()).registerGateway(resourceID.toString(), taskExecutorGateway);
+
+		final ResourceManagerGateway rmGateway = resourceManager.getSelfGateway(ResourceManagerGateway.class);
+
+		final SlotReport slotReport = new SlotReport(new SlotStatus(new SlotID(resourceID, 1), ResourceProfile.ZERO));
+
+		CompletableFuture<Integer> numberRegisteredSlotsFuture = rmGateway
+			.registerTaskExecutor(
+				resourceID.toString(),
+				resourceID,
+				1234,
+				new HardwareDescription(1, 2L, 3L, 4L),
+				TIMEOUT)
+			.thenCompose(
+				(RegistrationResponse response) -> {
+					assertThat(response, instanceOf(TaskExecutorRegistrationSuccess.class));
+					final TaskExecutorRegistrationSuccess success = (TaskExecutorRegistrationSuccess) response;
+					return rmGateway.sendSlotReport(
+						resourceID,
+						success.getRegistrationId(),
+						slotReport,
+						TIMEOUT);
+				})
+			.handleAsync(
+				(Acknowledge ignored, Throwable throwable) -> resourceManager.getSlotManager().getNumberRegisteredSlots(),
+				resourceManager.getMainThreadExecutorForTesting());
+		Assert.assertEquals(1, numberRegisteredSlotsFuture.get().intValue());
+	}
+
+	private void terminatePod(Pod pod) {
+		pod.setStatus(new PodStatusBuilder()
+			.withContainerStatuses(new ContainerStatusBuilder().withState(
+				new ContainerStateBuilder().withNewTerminated().endTerminated().build())
+				.build())
+			.build());
+	}
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesWorkerNodeTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesWorkerNodeTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Tests for {@link KubernetesWorkerNode}.
+ */
+public class KubernetesWorkerNodeTest extends TestLogger {
+
+	@Rule
+	public final ExpectedException exception = ExpectedException.none();
+
+	@Test
+	public void testGetAttemptFromWorkerNode() throws Exception {
+		final String correctPodName = "flink-on-kubernetes-taskmanager-11-5";
+		final KubernetesWorkerNode workerNode = new KubernetesWorkerNode(new ResourceID(correctPodName));
+		Assert.assertEquals(11L, workerNode.getAttempt());
+
+		final String wrongPodName = "flink-on-kubernetes-xxxtaskmanager-11-5";
+		final KubernetesWorkerNode workerNode1 = new KubernetesWorkerNode(new ResourceID(wrongPodName));
+		exception.expect(Exception.class);
+		exception.expectMessage("Error to parse KubernetesWorkerNode from " + wrongPodName + ".");
+		workerNode1.getAttempt();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.entrypoint.ClusterInformation;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.util.FlinkException;
+
+import javax.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Base class for {@link ResourceManager} implementations which contains some common variables and methods.
+ */
+public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrievable>
+		extends ResourceManager<WorkerType> {
+
+	/** The process environment variables. */
+	protected final Map<String, String> env;
+
+	protected final int numSlotsPerTaskManager;
+
+	protected final TaskExecutorResourceSpec taskExecutorResourceSpec;
+
+	protected final int defaultMemoryMB;
+
+	protected final Collection<ResourceProfile> resourceProfilesPerWorker;
+
+	/**
+	 * The updated Flink configuration. The client uploaded configuration may be updated before passed on to
+	 * {@link ResourceManager}. For example, {@link TaskManagerOptions#MANAGED_MEMORY_SIZE}.
+	 */
+	protected final Configuration flinkConfig;
+
+	/** Flink configuration uploaded by client. */
+	protected final Configuration flinkClientConfig;
+
+	public ActiveResourceManager(
+			Configuration flinkConfig,
+			Map<String, String> env,
+			RpcService rpcService,
+			String resourceManagerEndpointId,
+			ResourceID resourceId,
+			HighAvailabilityServices highAvailabilityServices,
+			HeartbeatServices heartbeatServices,
+			SlotManager slotManager,
+			JobLeaderIdService jobLeaderIdService,
+			ClusterInformation clusterInformation,
+			FatalErrorHandler fatalErrorHandler,
+			ResourceManagerMetricGroup resourceManagerMetricGroup) {
+		super(
+			rpcService,
+			resourceManagerEndpointId,
+			resourceId,
+			highAvailabilityServices,
+			heartbeatServices,
+			slotManager,
+			jobLeaderIdService,
+			clusterInformation,
+			fatalErrorHandler,
+			resourceManagerMetricGroup);
+
+		this.flinkConfig = flinkConfig;
+		this.env = env;
+
+		this.numSlotsPerTaskManager = flinkConfig.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
+		this.taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(flinkConfig);
+		this.defaultMemoryMB = taskExecutorResourceSpec.getTotalProcessMemorySize().getMebiBytes();
+
+		this.resourceProfilesPerWorker = createWorkerSlotProfiles(flinkConfig);
+
+		// Load the flink config uploaded by flink client
+		this.flinkClientConfig = loadClientConfiguration();
+	}
+
+	protected CompletableFuture<Void> getStopTerminationFutureOrCompletedExceptionally(@Nullable Throwable exception) {
+		final CompletableFuture<Void> terminationFuture = super.onStop();
+
+		if (exception != null) {
+			return FutureUtils.completedExceptionally(new FlinkException(
+				"Error while shutting down resource manager", exception));
+		} else {
+			return terminationFuture;
+		}
+	}
+
+	protected abstract Configuration loadClientConfiguration();
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
@@ -407,4 +407,18 @@ public class BootstrapToolsTest extends TestLogger {
 			portOccupier.close();
 		}
 	}
+
+	@Test
+	public void testGetDynamicProperties() {
+		Configuration baseConfig = new Configuration();
+		baseConfig.setString("key.a", "a");
+		baseConfig.setString("key.b", "b1");
+
+		Configuration targetConfig = new Configuration();
+		targetConfig.setString("key.b", "b2");
+		targetConfig.setString("key.c", "c");
+
+		String dynamicProperties = BootstrapTools.getDynamicProperties(baseConfig, targetConfig);
+		assertEquals("-Dkey.b=b2 -Dkey.c=c", dynamicProperties);
+	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -19,11 +19,9 @@
 package org.apache.flink.yarn;
 
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
-import org.apache.flink.runtime.entrypoint.parser.CommandLineOptions;
 import org.apache.flink.runtime.util.HadoopUtils;
 import org.apache.flink.util.StringUtils;
 
@@ -64,7 +62,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 
 import static org.apache.flink.yarn.YarnConfigKeys.ENV_FLINK_CLASSPATH;
 
@@ -635,34 +632,6 @@ public final class Utils {
 		if (!condition) {
 			throw new RuntimeException(String.format(message, values));
 		}
-	}
-
-	/**
-	 * Get dynamic properties based on two Flink configuration. If base config does not contain and target config
-	 * contains the key or the value is different, it should be added to results. Otherwise, if the base config contains
-	 * and target config does not contain the key, it will be ignored.
-	 * @param baseConfig The base configuration.
-	 * @param targetConfig The target configuration.
-	 * @return Dynamic properties as string, separated by space.
-	 */
-	static String getDynamicProperties(
-		org.apache.flink.configuration.Configuration baseConfig,
-		org.apache.flink.configuration.Configuration targetConfig) {
-
-		String[] newAddedConfigs = targetConfig.keySet().stream().flatMap(
-			(String key) -> {
-				final String baseValue = baseConfig.getString(ConfigOptions.key(key).stringType().noDefaultValue());
-				final String targetValue = targetConfig.getString(ConfigOptions.key(key).stringType().noDefaultValue());
-
-				if (!baseConfig.keySet().contains(key) || !baseValue.equals(targetValue)) {
-					return Stream.of("-" + CommandLineOptions.DYNAMIC_PROPERTY_OPTION.getOpt() + key +
-						CommandLineOptions.DYNAMIC_PROPERTY_OPTION.getValueSeparator() + targetValue);
-				} else {
-					return Stream.empty();
-				}
-			})
-			.toArray(String[]::new);
-		return String.join(" ", newAddedConfigs);
 	}
 
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -603,7 +603,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 
 		Configuration taskManagerConfig = BootstrapTools.cloneConfiguration(flinkConfig);
 
-		String taskManagerDynamicProperties = Utils.getDynamicProperties(flinkClientConfig, taskManagerConfig);
+		String taskManagerDynamicProperties = BootstrapTools.getDynamicProperties(flinkClientConfig, taskManagerConfig);
 
 		log.debug("TaskManager configuration: {}", taskManagerConfig);
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -554,7 +554,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 	}
 
 	/**
-	 * Request new container if pending containers cannot satisfies pending slot requests.
+	 * Request new container if pending containers cannot satisfy pending slot requests.
 	 */
 	private void requestYarnContainerIfRequired() {
 		int requiredTaskManagerSlots = getNumberRequiredTaskManagerSlots();

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/UtilsTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/UtilsTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.yarn;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Rule;
@@ -31,7 +30,6 @@ import java.util.Collections;
 import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -59,19 +57,5 @@ public class UtilsTest extends TestLogger {
 		try (Stream<Path> files = Files.list(temporaryFolder.getRoot().toPath())) {
 			assertThat(files.count(), equalTo(0L));
 		}
-	}
-
-	@Test
-	public void testGetDynamicProperties() {
-		Configuration baseConfig = new Configuration();
-		baseConfig.setString("key.a", "a");
-		baseConfig.setString("key.b", "b1");
-
-		Configuration targetConfig = new Configuration();
-		targetConfig.setString("key.b", "b2");
-		targetConfig.setString("key.c", "c");
-
-		String dynamicProperties = Utils.getDynamicProperties(baseConfig, targetConfig);
-		assertEquals("-Dkey.b=b2 -Dkey.c=c", dynamicProperties);
 	}
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR is part of FLINK-9953(Active Kubernetes integration). `KubernetesResourceManager` is introduced. It is responsible for allocating task manager pod dynamically on demand. A watcher is added to watch all the events of task manager pods. It filters the task manager pods by labels.

`ServiceAccount` is used to start job manager pod. So the kubeClient could get the configuration by default. The kube config should not be taken from client for security reason.

This PR is based on #9957 #9965 #9973 .

## Brief change log
* Add KubernetesResourceManager implementation
* Add test for start/stop worker


## Verifying this change

This change added unit tests in `KubernetesResourceManagerTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
