### PR TITLE
[hotfix][doc]Correct S3 path prefix key in documentation

### DIFF
--- a/docs/ops/filesystems/s3.md
+++ b/docs/ops/filesystems/s3.md
@@ -114,7 +114,7 @@ s3.endpoint: your-endpoint-hostname
 Some of the S3 compliant object stores might not have virtual host style addressing enabled by default. In such cases, you will have to provide the property to enable path style access in  in `flink-conf.yaml`.
 
 {% highlight yaml %}
-s3.path.style.access: true
+s3.path-style-access: true
 {% endhighlight %}
 
 ## Entropy injection for S3 file systems

--- a/docs/ops/filesystems/s3.zh.md
+++ b/docs/ops/filesystems/s3.zh.md
@@ -114,7 +114,7 @@ s3.endpoint: your-endpoint-hostname
 Some of the S3 compliant object stores might not have virtual host style addressing enabled by default. In such cases, you will have to provide the property to enable path style access in  in `flink-conf.yaml`.
 
 {% highlight yaml %}
-s3.path.style.access: true
+s3.path-style-access: true
 {% endhighlight %}
 
 ## Entropy injection for S3 file systems


### PR DESCRIPTION
In `flink-conf.yaml`, the S3 path style access is configured with the key `s3.path-style-access`.