### PR TITLE
[FLINK-14524] [flink-jdbc] Correct syntax for PostgreSQL dialect "upsert" statement

### DIFF
--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialects.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialects.java
@@ -129,7 +129,7 @@ public final class JDBCDialects {
 					.map(f -> quoteIdentifier(f) + "=EXCLUDED." + quoteIdentifier(f))
 					.collect(Collectors.joining(", "));
 			return Optional.of(getInsertIntoStatement(tableName, fieldNames) +
-							" ON CONFLICT (" + uniqueColumns +
+							" ON CONFLICT (" + uniqueColumns + ")"
 							" DO UPDATE SET " + updateClause
 			);
 		}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialects.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialects.java
@@ -129,7 +129,7 @@ public final class JDBCDialects {
 					.map(f -> quoteIdentifier(f) + "=EXCLUDED." + quoteIdentifier(f))
 					.collect(Collectors.joining(", "));
 			return Optional.of(getInsertIntoStatement(tableName, fieldNames) +
-							" ON CONFLICT (" + uniqueColumns + ")"
+							" ON CONFLICT (" + uniqueColumns + ")" +
 							" DO UPDATE SET " + updateClause
 			);
 		}


### PR DESCRIPTION
## What is the purpose of the change

* This pull request adds a missing closing parenthesis in the INSERT statement generated for PostgreSQL in upsert mode.

## Brief change log
- *Added missing parenthesis in generated SQL statement*

## Verifying this change

The effect of this change was verified against a local postgresql database where the sink was erroring out without the fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)