### PR TITLE
[FLINK-14478][python] optimize current python test cases to reduce test time.

### DIFF
--- a/flink-python/pyflink/table/tests/test_descriptor.py
+++ b/flink-python/pyflink/table/tests/test_descriptor.py
@@ -950,6 +950,7 @@ class AbstractTableDescriptorTests(object):
         assert properties == expected
 
     def test_register_table_source_and_register_table_sink(self):
+        self.env.set_parallelism(1)
         source_path = os.path.join(self.tempdir + '/streaming.csv')
         field_names = ["a", "b", "c"]
         field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING()]
@@ -996,6 +997,7 @@ class AbstractTableDescriptorTests(object):
             assert lines == '2,Hi,Hello\n' + '3,Hello,Hello\n'
 
     def test_register_table_source_and_sink(self):
+        self.env.set_parallelism(1)
         source_path = os.path.join(self.tempdir + '/streaming.csv')
         field_names = ["a", "b", "c"]
         field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING()]

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -208,6 +208,7 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
             "org.apache.flink.table.planner.delegation.StreamPlanner")
 
     def test_table_environment_with_blink_planner(self):
+        self.env.set_parallelism(1)
         t_env = StreamTableEnvironment.create(
             self.env,
             environment_settings=EnvironmentSettings.new_instance().use_blink_planner().build())

--- a/flink-python/pyflink/table/tests/test_udf.py
+++ b/flink-python/pyflink/table/tests/test_udf.py
@@ -267,6 +267,11 @@ class UserDefinedFunctionTests(object):
 
 class PyFlinkStreamUserDefinedFunctionTests(UserDefinedFunctionTests,
                                             PyFlinkStreamTableTestCase):
+    pass
+
+
+class PyFlinkBlinkStreamUserDefinedFunctionTests(UserDefinedFunctionTests,
+                                                 PyFlinkBlinkStreamTableTestCase):
     def test_deterministic(self):
         add_one = udf(lambda i: i + 1, DataTypes.BIGINT(), DataTypes.BIGINT())
         self.assertTrue(add_one._deterministic)
@@ -331,11 +336,6 @@ class PyFlinkStreamUserDefinedFunctionTests(UserDefinedFunctionTests,
             # test non-callable function
             self.t_env.register_function(
                 "non-callable-udf", udf(Plus(), DataTypes.BIGINT(), DataTypes.BIGINT()))
-
-
-class PyFlinkBlinkStreamUserDefinedFunctionTests(UserDefinedFunctionTests,
-                                                 PyFlinkBlinkStreamTableTestCase):
-    pass
 
 
 class PyFlinkBlinkBatchUserDefinedFunctionTests(UserDefinedFunctionTests,

--- a/flink-python/pyflink/table/tests/test_udf.py
+++ b/flink-python/pyflink/table/tests/test_udf.py
@@ -248,6 +248,25 @@ class UserDefinedFunctionTests(object):
         actual = source_sink_utils.results()
         self.assert_equals(actual, ["1,1", "2,4", "3,3"])
 
+    def test_udf_without_arguments(self):
+        self.t_env.register_function("one", udf(
+            lambda: 1, input_types=[], result_type=DataTypes.BIGINT(), deterministic=True))
+        self.t_env.register_function("two", udf(
+            lambda: 2, input_types=[], result_type=DataTypes.BIGINT(), deterministic=False))
+
+        table_sink = source_sink_utils.TestAppendSink(['a', 'b'],
+                                                      [DataTypes.BIGINT(), DataTypes.BIGINT()])
+        self.t_env.register_table_sink("Results", table_sink)
+
+        t = self.t_env.from_elements([(1, 2), (2, 5), (3, 1)], ['a', 'b'])
+        t.select("one(), two()").insert_into("Results")
+        self.t_env.execute("test")
+        actual = source_sink_utils.results()
+        self.assert_equals(actual, ["1,2", "1,2", "1,2"])
+
+
+class PyFlinkStreamUserDefinedFunctionTests(UserDefinedFunctionTests,
+                                            PyFlinkStreamTableTestCase):
     def test_deterministic(self):
         add_one = udf(lambda i: i + 1, DataTypes.BIGINT(), DataTypes.BIGINT())
         self.assertTrue(add_one._deterministic)
@@ -312,27 +331,6 @@ class UserDefinedFunctionTests(object):
             # test non-callable function
             self.t_env.register_function(
                 "non-callable-udf", udf(Plus(), DataTypes.BIGINT(), DataTypes.BIGINT()))
-
-    def test_udf_without_arguments(self):
-        self.t_env.register_function("one", udf(
-            lambda: 1, input_types=[], result_type=DataTypes.BIGINT(), deterministic=True))
-        self.t_env.register_function("two", udf(
-            lambda: 2, input_types=[], result_type=DataTypes.BIGINT(), deterministic=False))
-
-        table_sink = source_sink_utils.TestAppendSink(['a', 'b'],
-                                                      [DataTypes.BIGINT(), DataTypes.BIGINT()])
-        self.t_env.register_table_sink("Results", table_sink)
-
-        t = self.t_env.from_elements([(1, 2), (2, 5), (3, 1)], ['a', 'b'])
-        t.select("one(), two()").insert_into("Results")
-        self.t_env.execute("test")
-        actual = source_sink_utils.results()
-        self.assert_equals(actual, ["1,2", "1,2", "1,2"])
-
-
-class PyFlinkStreamUserDefinedFunctionTests(UserDefinedFunctionTests,
-                                            PyFlinkStreamTableTestCase):
-    pass
 
 
 class PyFlinkBlinkStreamUserDefinedFunctionTests(UserDefinedFunctionTests,

--- a/flink-python/pyflink/testing/test_case_utils.py
+++ b/flink-python/pyflink/testing/test_case_utils.py
@@ -120,7 +120,7 @@ class PyFlinkStreamTableTestCase(PyFlinkTestCase):
     def setUp(self):
         super(PyFlinkStreamTableTestCase, self).setUp()
         self.env = StreamExecutionEnvironment.get_execution_environment()
-        self.env.set_parallelism(1)
+        self.env.set_parallelism(2)
         self.t_env = StreamTableEnvironment.create(self.env)
 
 
@@ -132,7 +132,7 @@ class PyFlinkBatchTableTestCase(PyFlinkTestCase):
     def setUp(self):
         super(PyFlinkBatchTableTestCase, self).setUp()
         self.env = ExecutionEnvironment.get_execution_environment()
-        self.env.set_parallelism(1)
+        self.env.set_parallelism(2)
         self.t_env = BatchTableEnvironment.create(self.env)
 
     def collect(self, table):
@@ -152,7 +152,7 @@ class PyFlinkBlinkStreamTableTestCase(PyFlinkTestCase):
     def setUp(self):
         super(PyFlinkBlinkStreamTableTestCase, self).setUp()
         self.env = StreamExecutionEnvironment.get_execution_environment()
-
+        self.env.set_parallelism(2)
         self.t_env = StreamTableEnvironment.create(
             self.env, environment_settings=EnvironmentSettings.new_instance()
                 .in_streaming_mode().use_blink_planner().build())
@@ -168,6 +168,7 @@ class PyFlinkBlinkBatchTableTestCase(PyFlinkTestCase):
         self.t_env = BatchTableEnvironment.create(
             environment_settings=EnvironmentSettings.new_instance()
             .in_batch_mode().use_blink_planner().build())
+        self.t_env._j_tenv.getPlanner().getExecEnv().setParallelism(2)
 
 
 class PythonAPICompletenessTestCase(object):

--- a/flink-python/tox.ini
+++ b/flink-python/tox.ini
@@ -30,7 +30,7 @@ deps =
     pytest
 commands =
     python --version
-    pytest
+    pytest --durations=0
     bash ./dev/run_pip_test.sh
 
 [flake8]


### PR DESCRIPTION
## What is the purpose of the change

*This pull request optimizes current python test cases to reduce the test time from 24 minutes to 16 minutes.*


## Brief change log

  - *Limit parallelism of ExecutionEnvironment/StreamExecutionEnvironment used in test cases to 2 except for test cases that use CSV table sink.*
  - *Remove some unnecessary tests from `PyFlinkBlinkStreamUserDefinedFunctionTests` and `PyFlinkBlinkBatchUserDefinedFunctionTests`.*
  - *Add durations option in `tox.ini` to display the time used in each test case.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
