### PR TITLE
[FLINK-14498][runtime]Introduce NetworkBufferPool#isAvailable() for interacting with LocalBufferPool.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.core.memory.MemorySegmentProvider;
+import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.MathUtils;
 import org.apache.flink.util.Preconditions;
@@ -35,13 +36,14 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -54,7 +56,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * the buffers for the network data transfer. When new local buffer pools are created, the
  * NetworkBufferPool dynamically redistributes the buffers between the pools.
  */
-public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvider {
+public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvider, AvailabilityProvider {
 
 	private static final Logger LOG = LoggerFactory.getLogger(NetworkBufferPool.class);
 
@@ -62,7 +64,7 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 
 	private final int memorySegmentSize;
 
-	private final ArrayBlockingQueue<MemorySegment> availableMemorySegments;
+	private final ArrayDeque<MemorySegment> availableMemorySegments;
 
 	private volatile boolean isDestroyed;
 
@@ -77,6 +79,8 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 	private final int numberOfSegmentsToRequest;
 
 	private final Duration requestSegmentsTimeout;
+
+	private final AvailabilityHelper availabilityHelper = new AvailabilityHelper();
 
 	@VisibleForTesting
 	public NetworkBufferPool(int numberOfSegmentsToAllocate, int segmentSize, int numberOfSegmentsToRequest) {
@@ -106,7 +110,7 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 		final long sizeInLong = (long) segmentSize;
 
 		try {
-			this.availableMemorySegments = new ArrayBlockingQueue<>(numberOfSegmentsToAllocate);
+			this.availableMemorySegments = new ArrayDeque<>(numberOfSegmentsToAllocate);
 		}
 		catch (OutOfMemoryError err) {
 			throw new OutOfMemoryError("Could not allocate buffer queue of length "
@@ -134,6 +138,8 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 					", missing (Mb): " + missingMb + "). Cause: " + err.getMessage());
 		}
 
+		availabilityHelper.resetAvailable();
+
 		long allocatedMb = (sizeInLong * availableMemorySegments.size()) >> 20;
 
 		LOG.info("Allocated {} MB for network buffer pool (number of memory segments: {}, bytes per segment: {}).",
@@ -142,14 +148,16 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 
 	@Nullable
 	public MemorySegment requestMemorySegment() {
-		return availableMemorySegments.poll();
+		synchronized (availableMemorySegments) {
+			return internalRequestMemorySegment();
+		}
 	}
 
 	public void recycle(MemorySegment segment) {
 		// Adds the segment back to the queue, which does not immediately free the memory
 		// however, since this happens when references to the global pool are also released,
 		// making the availableMemorySegments queue and its contained object reclaimable
-		availableMemorySegments.add(checkNotNull(segment));
+		internalRecycleMemorySegments(Collections.singleton(checkNotNull(segment)));
 	}
 
 	@Override
@@ -170,7 +178,12 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 					throw new IllegalStateException("Buffer pool is destroyed.");
 				}
 
-				final MemorySegment segment = availableMemorySegments.poll(2, TimeUnit.SECONDS);
+				MemorySegment segment;
+				synchronized (availableMemorySegments) {
+					if ((segment = internalRequestMemorySegment()) == null) {
+						availableMemorySegments.wait(2000);
+					}
+				}
 				if (segment != null) {
 					segments.add(segment);
 				}
@@ -199,6 +212,17 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 		return segments;
 	}
 
+	@Nullable
+	private MemorySegment internalRequestMemorySegment() {
+		assert Thread.holdsLock(availableMemorySegments);
+
+		final MemorySegment segment = availableMemorySegments.poll();
+		if (availableMemorySegments.isEmpty() && segment != null) {
+			availabilityHelper.resetUnavailable();
+		}
+		return segment;
+	}
+
 	@Override
 	public void recycleMemorySegments(Collection<MemorySegment> segments) throws IOException {
 		recycleMemorySegments(segments, segments.size());
@@ -208,17 +232,34 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 		synchronized (factoryLock) {
 			numTotalRequiredBuffers -= size;
 
-			availableMemorySegments.addAll(segments);
-
 			// note: if this fails, we're fine for the buffer pool since we already recycled the segments
 			redistributeBuffers();
+		}
+
+		internalRecycleMemorySegments(segments);
+	}
+
+	private void internalRecycleMemorySegments(Collection<MemorySegment> segments) {
+		CompletableFuture<?> toNotify = null;
+		synchronized (availableMemorySegments) {
+			if (availableMemorySegments.isEmpty() && !segments.isEmpty()) {
+				toNotify = availabilityHelper.getUnavailableToResetAvailable();
+			}
+			availableMemorySegments.addAll(segments);
+			availableMemorySegments.notifyAll();
+		}
+
+		if (toNotify != null) {
+			toNotify.complete(null);
 		}
 	}
 
 	public void destroy() {
 		synchronized (factoryLock) {
 			isDestroyed = true;
+		}
 
+		synchronized (availableMemorySegments) {
 			MemorySegment segment;
 			while ((segment = availableMemorySegments.poll()) != null) {
 				segment.free();
@@ -235,7 +276,9 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 	}
 
 	public int getNumberOfAvailableMemorySegments() {
-		return availableMemorySegments.size();
+		synchronized (availableMemorySegments) {
+			return availableMemorySegments.size();
+		}
 	}
 
 	public int getNumberOfRegisteredBufferPools() {
@@ -254,6 +297,15 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 		}
 
 		return buffers;
+	}
+
+	/**
+	 * Returns a future that is completed when there are free segments
+	 * in this pool.
+	 */
+	@Override
+	public CompletableFuture<?> isAvailable() {
+		return availabilityHelper.isAvailable();
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTrackerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTrackerImpl.java
@@ -68,7 +68,7 @@ public class BackPressureStatsTrackerImpl implements BackPressureStatsTracker {
 	private static final Logger LOG = LoggerFactory.getLogger(BackPressureStatsTrackerImpl.class);
 
 	/** Maximum stack trace depth for samples. */
-	static final int MAX_STACK_TRACE_DEPTH = 3;
+	static final int MAX_STACK_TRACE_DEPTH = 8;
 
 	/** Expected class name for back pressure indicating stack trace element. */
 	static final String EXPECTED_CLASS_NAME = "org.apache.flink.runtime.io.network.buffer.LocalBufferPool";

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
@@ -449,9 +449,8 @@ public class RecordWriterTest {
 		final RecordWriter recordWriter = createRecordWriter(partitionWrapper);
 
 		try {
-			// record writer is available because of initial available local pool
+			// record writer is available because of initial available global pool
 			assertTrue(recordWriter.isAvailable().isDone());
-			assertEquals(recordWriter.AVAILABLE, recordWriter.isAvailable());
 
 			// request one buffer from the local pool to make it unavailable afterwards
 			final BufferBuilder bufferBuilder = resultPartition.getBufferBuilder();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolDestroyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolDestroyTest.java
@@ -108,9 +108,9 @@ public class LocalBufferPoolDestroyTest {
 	 * request or not
 	 */
 	public static boolean isInBlockingBufferRequest(StackTraceElement[] stackTrace) {
-		if (stackTrace.length >= 7) {
+		if (stackTrace.length >= 8) {
 			return stackTrace[5].getMethodName().equals("get") &&
-					stackTrace[6].getClassName().equals(LocalBufferPool.class.getName());
+					stackTrace[7].getClassName().equals(LocalBufferPool.class.getName());
 		} else {
 			return false;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolDestroyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolDestroyTest.java
@@ -108,9 +108,9 @@ public class LocalBufferPoolDestroyTest {
 	 * request or not
 	 */
 	public static boolean isInBlockingBufferRequest(StackTraceElement[] stackTrace) {
-		if (stackTrace.length >= 3) {
-			return stackTrace[0].getMethodName().equals("wait") &&
-					stackTrace[1].getClassName().equals(LocalBufferPool.class.getName());
+		if (stackTrace.length >= 7) {
+			return stackTrace[5].getMethodName().equals("get") &&
+					stackTrace[6].getClassName().equals(LocalBufferPool.class.getName());
 		} else {
 			return false;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
@@ -30,9 +30,18 @@ import org.junit.rules.ExpectedException;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.hasProperty;
@@ -515,6 +524,212 @@ public class NetworkBufferPoolTest extends TestLogger {
 		try {
 			asyncRequest.sync();
 		} finally {
+			globalPool.destroy();
+		}
+	}
+
+	/**
+	 * Tests {@link NetworkBufferPool#isAvailable()}, verifying that the buffer availability is correctly
+	 * maintained after memory segments are requested by {@link NetworkBufferPool#requestMemorySegment()}
+	 * and recycled by {@link NetworkBufferPool#recycle(MemorySegment)}.
+	 */
+	@Test
+	public void testIsAvailableOrNotAfterRequestAndRecycleSingleSegment() throws Exception {
+		final int numBuffers = 2;
+
+		final NetworkBufferPool globalPool = new NetworkBufferPool(numBuffers, 128, 1);
+
+		try {
+			// the global pool should be in available state initially
+			assertTrue(globalPool.isAvailable().isDone());
+
+			// request the first segment
+			final MemorySegment segment1 = checkNotNull(globalPool.requestMemorySegment());
+			assertTrue(globalPool.isAvailable().isDone());
+
+			// request the second segment
+			final MemorySegment segment2 = checkNotNull(globalPool.requestMemorySegment());
+			assertFalse(globalPool.isAvailable().isDone());
+
+			final CompletableFuture<?> availableFuture = globalPool.isAvailable();
+
+			// recycle the first segment
+			globalPool.recycle(segment1);
+			assertTrue(availableFuture.isDone());
+			assertTrue(globalPool.isAvailable().isDone());
+
+			// recycle the second segment
+			globalPool.recycle(segment2);
+			assertTrue(globalPool.isAvailable().isDone());
+
+		} finally {
+			globalPool.destroy();
+		}
+	}
+
+	/**
+	 * Tests {@link NetworkBufferPool#isAvailable()}, verifying that the buffer availability is correctly
+	 * maintained after memory segments are requested by {@link NetworkBufferPool#requestMemorySegments()}
+	 * and recycled by {@link NetworkBufferPool#recycleMemorySegments(Collection)}.
+	 */
+	@Test(timeout = 10000L)
+	public void testIsAvailableOrNotAfterRequestAndRecycleMultiSegments() throws Exception {
+		final int numberOfSegmentsToRequest = 5;
+		final int numBuffers = 2 * numberOfSegmentsToRequest;
+
+		final NetworkBufferPool globalPool = new NetworkBufferPool(numBuffers, 128, numberOfSegmentsToRequest);
+
+		try {
+			// the global pool should be in available state initially
+			assertTrue(globalPool.isAvailable().isDone());
+
+			// request 5 segments
+			List<MemorySegment> segments1 = globalPool.requestMemorySegments();
+			assertTrue(globalPool.isAvailable().isDone());
+			assertEquals(numberOfSegmentsToRequest, segments1.size());
+
+			// request another 5 segments
+			List<MemorySegment> segments2 = globalPool.requestMemorySegments();
+			assertFalse(globalPool.isAvailable().isDone());
+			assertEquals(numberOfSegmentsToRequest, segments2.size());
+
+			// request another 5 segments
+			final CountDownLatch latch = new CountDownLatch(1);
+			final List<MemorySegment> segments3 = new ArrayList<>(numberOfSegmentsToRequest);
+			CheckedThread asyncRequest = new CheckedThread() {
+				@Override
+				public void go() throws Exception {
+					// this request should be blocked until at least 5 segments are recycled
+					segments3.addAll(globalPool.requestMemorySegments());
+					latch.countDown();
+				}
+			};
+			asyncRequest.start();
+
+			// recycle 5 segments
+			CompletableFuture<?> availableFuture = globalPool.isAvailable();
+			globalPool.recycleMemorySegments(segments1);
+			assertTrue(availableFuture.isDone());
+
+			// wait util the third request is fulfilled
+			latch.await();
+			assertFalse(globalPool.isAvailable().isDone());
+			assertEquals(numberOfSegmentsToRequest, segments3.size());
+
+			// recycle another 5 segments
+			globalPool.recycleMemorySegments(segments2);
+			assertTrue(globalPool.isAvailable().isDone());
+
+			// recycle the last 5 segments
+			globalPool.recycleMemorySegments(segments3);
+			assertTrue(globalPool.isAvailable().isDone());
+
+		} finally {
+			globalPool.destroy();
+		}
+	}
+
+	/**
+	 * Tests that blocking request of multi local buffer pools can be fulfilled by recycled segments
+	 * to the global network buffer pool.
+	 */
+	@Test(timeout = 10000L)
+	public void testBlockingRequestFromMultiLocalBufferPool() throws Exception {
+		final int localPoolRequiredSize = 5;
+		final int localPoolMaxSize = 10;
+		final int numLocalBufferPool = 2;
+		final int numberOfSegmentsToRequest = 10;
+		final int numBuffers = numLocalBufferPool * localPoolMaxSize;
+
+		final ExecutorService executorService = Executors.newFixedThreadPool(numLocalBufferPool);
+		final NetworkBufferPool globalPool = new NetworkBufferPool(numBuffers, 128, numberOfSegmentsToRequest);
+		final List<BufferPool> localBufferPools = new ArrayList<>(numLocalBufferPool);
+
+		try {
+			// create local buffer pools
+			for (int i  = 0; i < numLocalBufferPool; ++i) {
+				final BufferPool localPool = globalPool.createBufferPool(localPoolRequiredSize, localPoolMaxSize);
+				localBufferPools.add(localPool);
+				assertTrue(localPool.isAvailable().isDone());
+			}
+
+			// request some segments from the global pool in two different ways
+			final List<MemorySegment> segments = new ArrayList<>(numberOfSegmentsToRequest - 1);
+			for (int i = 0; i < numberOfSegmentsToRequest - 1; ++i) {
+				segments.add(globalPool.requestMemorySegment());
+			}
+			final List<MemorySegment> exclusiveSegments = globalPool.requestMemorySegments();
+			assertTrue(globalPool.isAvailable().isDone());
+			for (final BufferPool localPool: localBufferPools) {
+				assertTrue(localPool.isAvailable().isDone());
+			}
+
+			// blocking request buffers form local buffer pools
+			final CountDownLatch latch = new CountDownLatch(numLocalBufferPool);
+			final BlockingQueue<BufferBuilder> segmentsRequested = new ArrayBlockingQueue<>(numBuffers);
+			final AtomicReference<Throwable> cause = new AtomicReference<>();
+			for (final BufferPool localPool: localBufferPools) {
+				executorService.submit(() -> {
+					try {
+						for (int num = localPoolMaxSize; num > 0; --num) {
+							segmentsRequested.add(localPool.requestBufferBuilderBlocking());
+						}
+					} catch (Exception e) {
+						cause.set(e);
+					} finally {
+						latch.countDown();
+					}
+				});
+			}
+
+			// wait until all available buffers are requested
+			while (globalPool.getNumberOfAvailableMemorySegments() > 0) {
+				Thread.sleep(100);
+				assertNull(cause.get());
+			}
+
+			final CompletableFuture<?> globalPoolAvailableFuture = globalPool.isAvailable();
+			assertFalse(globalPoolAvailableFuture.isDone());
+
+			final List<CompletableFuture<?>> localPoolAvailableFutures = new ArrayList<>(numLocalBufferPool);
+			for (BufferPool localPool: localBufferPools) {
+				CompletableFuture<?> localPoolAvailableFuture = localPool.isAvailable();
+				localPoolAvailableFutures.add(localPoolAvailableFuture);
+				assertFalse(localPoolAvailableFuture.isDone());
+			}
+
+			// recycle the previously requested segments
+			for (MemorySegment segment: segments) {
+				globalPool.recycle(segment);
+			}
+			globalPool.recycleMemorySegments(exclusiveSegments);
+
+			assertTrue(globalPoolAvailableFuture.isDone());
+			for (CompletableFuture<?> localPoolAvailableFuture: localPoolAvailableFutures) {
+				assertTrue(localPoolAvailableFuture.isDone());
+			}
+
+			// wait until all blocking buffer requests finish
+			latch.await();
+
+			assertNull(cause.get());
+			assertEquals(0, globalPool.getNumberOfAvailableMemorySegments());
+			assertFalse(globalPool.isAvailable().isDone());
+			for (BufferPool localPool: localBufferPools) {
+				assertFalse(localPool.isAvailable().isDone());
+				assertEquals(localPoolMaxSize, localPool.bestEffortGetNumOfUsedBuffers());
+			}
+
+			// recycle all the requested buffers
+			for (BufferBuilder bufferBuilder: segmentsRequested) {
+				bufferBuilder.createBufferConsumer().close();
+			}
+
+		} finally {
+			for (BufferPool bufferPool: localBufferPools) {
+				bufferPool.lazyDestroy();
+			}
+			executorService.shutdown();
 			globalPool.destroy();
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

In order to best-effort implement non-blocking output, we need to further improve the interaction between LocalBufferPool and NetworkBufferPool in non-blocking way as a supplementation of FLINK-14396.

In detail, we provide the NetworkBufferPool#isAvailable to indicate the global pool state, then we could combine its state via LocalBufferPool#isAvailable method to avoid blocking in global request while task processing.

Meanwhile we would refactor the process when LocalBufferPool requests global buffer. If there are no available buffers in NetworkBufferPool, the LocalBufferPool should monitor the global's available future instead of waiting 2 seconds currently in every loop retry. So we can solve the wait delay and cleanup the codes in a unified way.

## Brief change log

 - A new interface isAvailable which returns a CompletableFuture is added to the NetworkBufferPool. The future is completed when there are free segments in the pool.
 - LocalBufferPool will monitor the future returned by isAvailable and will be notified to retry to request MemorySegment from NetworkBufferPool when the future is complete.
 - Network buffer pool will maintain the state of buffer availability. The future will be transited to uncompleted state when there are no available segments and will be completed once there are available segments.
 - Two ut cases are added to verify the change.

## Verifying this change

Two new ut cases are added to verify the change. One is for the new added isAvailable interface of NetworkBufferPool to verify that the buffer availability is correctly maintained and the future callback is correctly processed. And the other is for the interaction between LocalBufferPool and NetworkBufferPool to verify that blocking requests of multi local buffer pools can be fulfilled by recycled segments to the global network buffer pool.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
