### PR TITLE
[FLINK-14535][table-planner-blink] Fix distinct key type for DecimalT…

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.utils
 import org.apache.flink.api.common.typeinfo.Types
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.api.{DataTypes, TableConfig, TableException}
-import org.apache.flink.table.dataformat.BaseRow
+import org.apache.flink.table.dataformat.{BaseRow, Decimal}
 import org.apache.flink.table.dataview.MapViewTypeInfo
 import org.apache.flink.table.expressions.ExpressionUtils.extractValue
 import org.apache.flink.table.expressions._
@@ -46,14 +46,12 @@ import org.apache.flink.table.types.logical.utils.LogicalTypeChecks
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot
 import org.apache.flink.table.types.logical.{LogicalTypeRoot, _}
 import org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType
-
 import org.apache.calcite.rel.`type`._
 import org.apache.calcite.rel.core.{Aggregate, AggregateCall}
 import org.apache.calcite.sql.fun._
 import org.apache.calcite.sql.validate.SqlMonotonicity
 import org.apache.calcite.sql.{SqlKind, SqlRankFunction}
 import org.apache.calcite.tools.RelBuilder
-
 import java.time.Duration
 import java.util
 
@@ -505,7 +503,7 @@ object AggregateUtil extends Enumeration {
       case VARCHAR | CHAR => fromLegacyInfoToDataType(BinaryStringTypeInfo.INSTANCE)
       case DECIMAL =>
         val dt = argTypes(0).asInstanceOf[DecimalType]
-        DataTypes.DECIMAL(dt.getPrecision, dt.getScale)
+        DataTypes.DECIMAL(dt.getPrecision, dt.getScale).bridgedTo(classOf[Decimal])
       case t =>
         throw new TableException(s"Distinct aggregate function does not support type: $t.\n" +
           s"Please re-check the data type.")

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.utils
 import org.apache.flink.api.common.typeinfo.Types
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.api.{DataTypes, TableConfig, TableException}
-import org.apache.flink.table.dataformat.{BaseRow, Decimal}
+import org.apache.flink.table.dataformat.{BaseRow, BinaryString, Decimal}
 import org.apache.flink.table.dataview.MapViewTypeInfo
 import org.apache.flink.table.expressions.ExpressionUtils.extractValue
 import org.apache.flink.table.expressions._
@@ -39,7 +39,6 @@ import org.apache.flink.table.planner.plan.`trait`.RelModifiedMonotonicity
 import org.apache.flink.table.runtime.operators.bundle.trigger.CountBundleTrigger
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.{fromDataTypeToLogicalType, fromLogicalTypeToDataType}
 import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter.fromDataTypeToTypeInfo
-import org.apache.flink.table.runtime.typeutils.BinaryStringTypeInfo
 import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks
@@ -500,7 +499,12 @@ object AggregateUtil extends Enumeration {
       case INTERVAL_YEAR_MONTH => DataTypes.INT
       case INTERVAL_DAY_TIME => DataTypes.BIGINT
 
-      case VARCHAR | CHAR => fromLegacyInfoToDataType(BinaryStringTypeInfo.INSTANCE)
+      case VARCHAR =>
+        val dt = argTypes(0).asInstanceOf[VarCharType]
+        DataTypes.VARCHAR(dt.getLength).bridgedTo(classOf[BinaryString])
+      case CHAR =>
+        val dt = argTypes(0).asInstanceOf[CharType]
+        DataTypes.CHAR(dt.getLength).bridgedTo(classOf[BinaryString])
       case DECIMAL =>
         val dt = argTypes(0).asInstanceOf[DecimalType]
         DataTypes.DECIMAL(dt.getPrecision, dt.getScale).bridgedTo(classOf[Decimal])

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
@@ -179,61 +179,105 @@ class AggregateITCase(
 
   @Test
   def testCountDistinct(): Unit = {
-    val data = new mutable.MutableList[Row]
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:01"), localDate("1970-01-01"),
-      mLocalTime("00:00:01"), BigDecimal(1).bigDecimal, JInt.valueOf(1), JLong.valueOf(1L),
-      Long.box(1L), "A"))
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:02"), localDate("1970-01-02"),
-      mLocalTime("00:00:02"), BigDecimal(2).bigDecimal, JInt.valueOf(2), JLong.valueOf(2L),
-      Long.box(2L), "B"))
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:03"), localDate("1970-01-03"),
-      mLocalTime("00:00:03"), BigDecimal(3).bigDecimal, null, JLong.valueOf(3L),
-      Long.box(2L), "B"))
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:04"), localDate("1970-01-04"),
-      mLocalTime("00:00:04"), BigDecimal(4).bigDecimal, JInt.valueOf(4), JLong.valueOf(4L),
-      Long.box(3L), "C"))
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:05"), localDate("1970-01-05"),
-      mLocalTime("00:00:05"), BigDecimal(5).bigDecimal, JInt.valueOf(5), JLong.valueOf(5L),
-      Long.box(3L), "C"))
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:06"), localDate("1970-01-06"),
-      mLocalTime("00:00:06"), BigDecimal(6).bigDecimal, JInt.valueOf(6), JLong.valueOf(6L),
-      Long.box(3L), "C"))
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:07"), localDate("1970-01-07"),
-      mLocalTime("00:00:07"), BigDecimal(7).bigDecimal, JInt.valueOf(7), JLong.valueOf(7L),
-      Long.box(4L), "B"))
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:08"), localDate("1970-01-08"),
-      mLocalTime("00:00:08"), BigDecimal(8).bigDecimal, JInt.valueOf(8), JLong.valueOf(8L),
-      Long.box(4L), "A"))
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:09"), localDate("1970-01-09"),
-      mLocalTime("00:00:09"), BigDecimal(9).bigDecimal, JInt.valueOf(9), JLong.valueOf(9L),
-      Long.box(4L), "D"))
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:10"), localDate("1970-01-10"),
-      mLocalTime("00:00:10"), BigDecimal(10).bigDecimal, null, JLong.valueOf(10L),
-      Long.box(4L), "E"))
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:11"), localDate("1970-01-11"),
-      mLocalTime("00:00:11"), BigDecimal(11).bigDecimal, JInt.valueOf(11), JLong.valueOf(11L),
-      Long.box(5L), "A"))
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:12"), localDate("1970-01-12"),
-      mLocalTime("00:00:12"), BigDecimal(12).bigDecimal, JInt.valueOf(12), JLong.valueOf(12L),
-      Long.box(5L), "B"))
+    val ids = List(
+      Int.box(1),
+      Int.box(2), Int.box(2),
+      Int.box(3), Int.box(3), Int.box(3),
+      Int.box(4), Int.box(4), Int.box(4), Int.box(4),
+      Int.box(5), Int.box(5), Int.box(5), Int.box(5), Int.box(5))
 
-    val t = failingDataSource(data)(new RowTypeInfo(
-      Types.LOCAL_DATE_TIME, Types.LOCAL_DATE, Types.LOCAL_TIME, Types.DECIMAL,
-      Types.INT, Types.LONG, Types.LONG, Types.STRING)).toTable(
-        tEnv, 'a, 'b, 'c, 'd, 'e, 'f, 'x, 'y)
+    val dateTimes = List(
+      localDateTime("1970-01-01 00:00:01"),
+      localDateTime("1970-01-01 00:00:02"), null,
+
+      localDateTime("1970-01-01 00:00:04"), localDateTime("1970-01-01 00:00:05"),
+        localDateTime("1970-01-01 00:00:06"),
+
+      localDateTime("1970-01-01 00:00:07"), null, null, localDateTime("1970-01-01 00:00:10"),
+
+      localDateTime("1970-01-01 00:00:11"), localDateTime("1970-01-01 00:00:11"),
+        localDateTime("1970-01-01 00:00:13"), localDateTime("1970-01-01 00:00:14"),
+        localDateTime("1970-01-01 00:00:15"))
+
+    val dates = List(
+      localDate("1970-01-01"),
+      localDate("1970-01-02"), null,
+      localDate("1970-01-04"), localDate("1970-01-05"), localDate("1970-01-06"),
+
+      localDate("1970-01-07"), null, null, localDate("1970-01-10"),
+
+      localDate("1970-01-11"), localDate("1970-01-11"), localDate("1970-01-13"),
+        localDate("1970-01-14"), localDate("1970-01-15"))
+
+    val times = List(
+      mLocalTime("00:00:01"),
+      mLocalTime("00:00:02"), null,
+      mLocalTime("00:00:04"), mLocalTime("00:00:05"), mLocalTime("00:00:06"),
+
+      mLocalTime("00:00:07"), null, null, mLocalTime("00:00:10"),
+
+      mLocalTime("00:00:11"), mLocalTime("00:00:11"), mLocalTime("00:00:13"),
+        mLocalTime("00:00:14"), mLocalTime("00:00:15"))
+
+    val decimals = List(
+      BigDecimal(1).bigDecimal,
+      BigDecimal(2).bigDecimal, null,
+      BigDecimal(4).bigDecimal, BigDecimal(5).bigDecimal, BigDecimal(6).bigDecimal,
+
+      BigDecimal(7).bigDecimal, null, null, BigDecimal(10).bigDecimal,
+
+      BigDecimal(11).bigDecimal, BigDecimal(11).bigDecimal, BigDecimal(13).bigDecimal,
+        BigDecimal(14).bigDecimal, BigDecimal(15).bigDecimal
+    )
+
+    val ints = List(
+      JInt.valueOf(1),
+      JInt.valueOf(2), null,
+      JInt.valueOf(4), JInt.valueOf(5), JInt.valueOf(6),
+      JInt.valueOf(7), null, null, JInt.valueOf(10),
+      JInt.valueOf(11), JInt.valueOf(11), JInt.valueOf(13), JInt.valueOf(14), JInt.valueOf(15))
+
+    val longs = List(
+      JLong.valueOf(1L),
+      JLong.valueOf(2L), null,
+      JLong.valueOf(4L), JLong.valueOf(5L), JLong.valueOf(6L),
+      JLong.valueOf(7L), null, null, JLong.valueOf(10L),
+
+      JLong.valueOf(11L), JLong.valueOf(11L), JLong.valueOf(13L), JLong.valueOf(14L),
+        JLong.valueOf(15L))
+
+    val chars = List(
+      "A",
+      "B", null,
+      "D", "E", "F",
+      "H", null, null, "K",
+      "L", "L", "N", "O", "P")
+
+    val data = new mutable.MutableList[Row]
+
+    for (i <- ids.indices) {
+      data.+=(Row.of(
+        ids(i), dateTimes(i), dates(i), times(i), decimals(i), ints(i), longs(i), chars(i)))
+    }
+
+    val rowType = new RowTypeInfo(
+      Types.INT, Types.LOCAL_DATE_TIME, Types.LOCAL_DATE, Types.LOCAL_TIME, Types.DECIMAL,
+      Types.INT, Types.LONG, Types.STRING)
+
+    val t = failingDataSource(data)(rowType).toTable(tEnv, 'id, 'a, 'b, 'c, 'd, 'e, 'f, 'g)
     tEnv.registerTable("T", t)
     val t1 = tEnv.sqlQuery(
       s"""
          |SELECT
-         | x,
-         | count(distinct y),
+         | id,
          | count(distinct a),
          | count(distinct b),
          | count(distinct c),
          | count(distinct d),
          | count(distinct e),
-         | count(distinct f)
-         |FROM T GROUP BY x
+         | count(distinct f),
+         | count(distinct g)
+         |FROM T GROUP BY id
        """.stripMargin)
 
     val sink = new TestingRetractSink
@@ -241,7 +285,11 @@ class AggregateITCase(
     env.execute()
 
     val expected = List(
-      "1,1,1,1,1,1,1,1", "2,1,2,2,2,2,1,2", "3,1,3,3,3,3,3,3", "4,4,4,4,4,4,3,4", "5,2,2,2,2,2,2,2")
+      "1,1,1,1,1,1,1,1",
+      "2,1,1,1,1,1,1,1",
+      "3,3,3,3,3,3,3,3",
+      "4,2,2,2,2,2,2,2",
+      "5,4,4,4,4,4,4,4")
     assertEquals(expected.sorted, sink.getRetractResults.sorted)
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/SplitAggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/SplitAggregateITCase.scala
@@ -83,63 +83,105 @@ class SplitAggregateITCase(
 
   @Test
   def testCountDistinct(): Unit = {
+    val ids = List(
+      Int.box(1),
+      Int.box(2), Int.box(2),
+      Int.box(3), Int.box(3), Int.box(3),
+      Int.box(4), Int.box(4), Int.box(4), Int.box(4),
+      Int.box(5), Int.box(5), Int.box(5), Int.box(5), Int.box(5))
+
+    val dateTimes = List(
+      localDateTime("1970-01-01 00:00:01"),
+      localDateTime("1970-01-01 00:00:02"), null,
+
+      localDateTime("1970-01-01 00:00:04"), localDateTime("1970-01-01 00:00:05"),
+      localDateTime("1970-01-01 00:00:06"),
+
+      localDateTime("1970-01-01 00:00:07"), null, null, localDateTime("1970-01-01 00:00:10"),
+
+      localDateTime("1970-01-01 00:00:11"), localDateTime("1970-01-01 00:00:11"),
+      localDateTime("1970-01-01 00:00:13"), localDateTime("1970-01-01 00:00:14"),
+      localDateTime("1970-01-01 00:00:15"))
+
+    val dates = List(
+      localDate("1970-01-01"),
+      localDate("1970-01-02"), null,
+      localDate("1970-01-04"), localDate("1970-01-05"), localDate("1970-01-06"),
+
+      localDate("1970-01-07"), null, null, localDate("1970-01-10"),
+
+      localDate("1970-01-11"), localDate("1970-01-11"), localDate("1970-01-13"),
+      localDate("1970-01-14"), localDate("1970-01-15"))
+
+    val times = List(
+      mLocalTime("00:00:01"),
+      mLocalTime("00:00:02"), null,
+      mLocalTime("00:00:04"), mLocalTime("00:00:05"), mLocalTime("00:00:06"),
+
+      mLocalTime("00:00:07"), null, null, mLocalTime("00:00:10"),
+
+      mLocalTime("00:00:11"), mLocalTime("00:00:11"), mLocalTime("00:00:13"),
+      mLocalTime("00:00:14"), mLocalTime("00:00:15"))
+
+    val decimals = List(
+      BigDecimal(1).bigDecimal,
+      BigDecimal(2).bigDecimal, null,
+      BigDecimal(4).bigDecimal, BigDecimal(5).bigDecimal, BigDecimal(6).bigDecimal,
+
+      BigDecimal(7).bigDecimal, null, null, BigDecimal(10).bigDecimal,
+
+      BigDecimal(11).bigDecimal, BigDecimal(11).bigDecimal, BigDecimal(13).bigDecimal,
+      BigDecimal(14).bigDecimal, BigDecimal(15).bigDecimal
+    )
+
+    val ints = List(
+      JInt.valueOf(1),
+      JInt.valueOf(2), null,
+      JInt.valueOf(4), JInt.valueOf(5), JInt.valueOf(6),
+      JInt.valueOf(7), null, null, JInt.valueOf(10),
+      JInt.valueOf(11), JInt.valueOf(11), JInt.valueOf(13), JInt.valueOf(14), JInt.valueOf(15))
+
+    val longs = List(
+      JLong.valueOf(1L),
+      JLong.valueOf(2L), null,
+      JLong.valueOf(4L), JLong.valueOf(5L), JLong.valueOf(6L),
+      JLong.valueOf(7L), null, null, JLong.valueOf(10L),
+
+      JLong.valueOf(11L), JLong.valueOf(11L), JLong.valueOf(13L), JLong.valueOf(14L),
+      JLong.valueOf(15L))
+
+    val chars = List(
+      "A",
+      "B", null,
+      "D", "E", "F",
+      "H", null, null, "K",
+      "L", "L", "N", "O", "P")
 
     val data = new mutable.MutableList[Row]
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:01"), localDate("1970-01-01"),
-      mLocalTime("00:00:01"), BigDecimal(1).bigDecimal, JInt.valueOf(1), JLong.valueOf(1L),
-      Long.box(1L), "A"))
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:02"), localDate("1970-01-02"),
-      mLocalTime("00:00:02"), BigDecimal(2).bigDecimal, JInt.valueOf(2), JLong.valueOf(2L),
-      Long.box(2L), "B"))
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:03"), localDate("1970-01-03"),
-      mLocalTime("00:00:03"), BigDecimal(3).bigDecimal, null, JLong.valueOf(3L),
-      Long.box(2L), "B"))
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:04"), localDate("1970-01-04"),
-      mLocalTime("00:00:04"), BigDecimal(4).bigDecimal, JInt.valueOf(4), JLong.valueOf(4L),
-      Long.box(3L), "C"))
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:05"), localDate("1970-01-05"),
-      mLocalTime("00:00:05"), BigDecimal(5).bigDecimal, JInt.valueOf(5), JLong.valueOf(5L),
-      Long.box(3L), "C"))
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:06"), localDate("1970-01-06"),
-      mLocalTime("00:00:06"), BigDecimal(6).bigDecimal, JInt.valueOf(6), JLong.valueOf(6L),
-      Long.box(3L), "C"))
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:07"), localDate("1970-01-07"),
-      mLocalTime("00:00:07"), BigDecimal(7).bigDecimal, JInt.valueOf(7), JLong.valueOf(7L),
-      Long.box(4L), "B"))
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:08"), localDate("1970-01-08"),
-      mLocalTime("00:00:08"), BigDecimal(8).bigDecimal, JInt.valueOf(8), JLong.valueOf(8L),
-      Long.box(4L), "A"))
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:09"), localDate("1970-01-09"),
-      mLocalTime("00:00:09"), BigDecimal(9).bigDecimal, JInt.valueOf(9), JLong.valueOf(9L),
-      Long.box(4L), "D"))
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:10"), localDate("1970-01-10"),
-      mLocalTime("00:00:10"), BigDecimal(10).bigDecimal, null, JLong.valueOf(10L),
-      Long.box(4L), "E"))
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:11"), localDate("1970-01-11"),
-      mLocalTime("00:00:11"), BigDecimal(11).bigDecimal, JInt.valueOf(11), JLong.valueOf(11L),
-      Long.box(5L), "A"))
-    data.+=(Row.of(localDateTime("1970-01-01 00:00:12"), localDate("1970-01-12"),
-      mLocalTime("00:00:12"), BigDecimal(12).bigDecimal, JInt.valueOf(12), JLong.valueOf(12L),
-      Long.box(5L), "B"))
 
-    val t = failingDataSource(data)(new RowTypeInfo(
-      Types.LOCAL_DATE_TIME, Types.LOCAL_DATE, Types.LOCAL_TIME, Types.DECIMAL,
-      Types.INT, Types.LONG, Types.LONG, Types.STRING)).toTable(
-      tEnv, 'a, 'b, 'c, 'd, 'e, 'f, 'x, 'y)
+    for (i <- ids.indices) {
+      data.+=(Row.of(
+        ids(i), dateTimes(i), dates(i), times(i), decimals(i), ints(i), longs(i), chars(i)))
+    }
+
+    val rowType = new RowTypeInfo(
+      Types.INT, Types.LOCAL_DATE_TIME, Types.LOCAL_DATE, Types.LOCAL_TIME, Types.DECIMAL,
+      Types.INT, Types.LONG, Types.STRING)
+
+    val t = failingDataSource(data)(rowType).toTable(tEnv, 'id, 'a, 'b, 'c, 'd, 'e, 'f, 'g)
     tEnv.registerTable("MyTable", t)
-
     val t1 = tEnv.sqlQuery(
       s"""
          |SELECT
-         | x,
-         | count(distinct y),
+         | id,
          | count(distinct a),
          | count(distinct b),
          | count(distinct c),
          | count(distinct d),
          | count(distinct e),
-         | count(distinct f)
-         |FROM MyTable GROUP BY x
+         | count(distinct f),
+         | count(distinct g)
+         |FROM MyTable GROUP BY id
        """.stripMargin)
 
     val sink = new TestingRetractSink
@@ -147,9 +189,14 @@ class SplitAggregateITCase(
     env.execute()
 
     val expected = List(
-      "1,1,1,1,1,1,1,1", "2,1,2,2,2,2,1,2", "3,1,3,3,3,3,3,3", "4,4,4,4,4,4,3,4", "5,2,2,2,2,2,2,2")
+      "1,1,1,1,1,1,1,1",
+      "2,1,1,1,1,1,1,1",
+      "3,3,3,3,3,3,3,3",
+      "4,2,2,2,2,2,2,2",
+      "5,4,4,4,4,4,4,4")
     assertEquals(expected.sorted, sink.getRetractResults.sorted)
   }
+
 
   @Test
   def testSingleDistinctAgg(): Unit = {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/SplitAggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/SplitAggregateITCase.scala
@@ -18,25 +18,27 @@
 
 package org.apache.flink.table.planner.runtime.stream.sql
 
+import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.api.scala._
+import org.apache.flink.table.api.Types
 import org.apache.flink.table.planner.runtime.stream.sql.SplitAggregateITCase.PartialAggMode
 import org.apache.flink.table.planner.runtime.utils.StreamingWithAggTestBase.{AggMode, LocalGlobalOff, LocalGlobalOn}
 import org.apache.flink.table.planner.runtime.utils.StreamingWithMiniBatchTestBase.MiniBatchOn
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.{HEAP_BACKEND, ROCKSDB_BACKEND, StateBackendMode}
 import org.apache.flink.table.planner.runtime.utils.{StreamingWithAggTestBase, TestingRetractSink}
+import org.apache.flink.table.planner.utils.DateTimeTestUtil.{localDate, localDateTime, localTime => mLocalTime}
 import org.apache.flink.types.Row
-
 import org.junit.Assert.assertEquals
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.junit.{Before, Ignore, Test}
-
+import java.lang.{Integer => JInt, Long => JLong}
 import java.util
 
 import scala.collection.JavaConversions._
-import scala.collection.Seq
+import scala.collection.{Seq, mutable}
 
 @RunWith(classOf[Parameterized])
 class SplitAggregateITCase(
@@ -77,6 +79,76 @@ class SplitAggregateITCase(
 
     val t = failingDataSource(data).toTable(tEnv, 'a, 'b, 'c)
     tEnv.registerTable("T", t)
+  }
+
+  @Test
+  def testCountDistinct(): Unit = {
+
+    val data = new mutable.MutableList[Row]
+    data.+=(Row.of(localDateTime("1970-01-01 00:00:01"), localDate("1970-01-01"),
+      mLocalTime("00:00:01"), BigDecimal(1).bigDecimal, JInt.valueOf(1), JLong.valueOf(1L),
+      Long.box(1L), "A"))
+    data.+=(Row.of(localDateTime("1970-01-01 00:00:02"), localDate("1970-01-02"),
+      mLocalTime("00:00:02"), BigDecimal(2).bigDecimal, JInt.valueOf(2), JLong.valueOf(2L),
+      Long.box(2L), "B"))
+    data.+=(Row.of(localDateTime("1970-01-01 00:00:03"), localDate("1970-01-03"),
+      mLocalTime("00:00:03"), BigDecimal(3).bigDecimal, null, JLong.valueOf(3L),
+      Long.box(2L), "B"))
+    data.+=(Row.of(localDateTime("1970-01-01 00:00:04"), localDate("1970-01-04"),
+      mLocalTime("00:00:04"), BigDecimal(4).bigDecimal, JInt.valueOf(4), JLong.valueOf(4L),
+      Long.box(3L), "C"))
+    data.+=(Row.of(localDateTime("1970-01-01 00:00:05"), localDate("1970-01-05"),
+      mLocalTime("00:00:05"), BigDecimal(5).bigDecimal, JInt.valueOf(5), JLong.valueOf(5L),
+      Long.box(3L), "C"))
+    data.+=(Row.of(localDateTime("1970-01-01 00:00:06"), localDate("1970-01-06"),
+      mLocalTime("00:00:06"), BigDecimal(6).bigDecimal, JInt.valueOf(6), JLong.valueOf(6L),
+      Long.box(3L), "C"))
+    data.+=(Row.of(localDateTime("1970-01-01 00:00:07"), localDate("1970-01-07"),
+      mLocalTime("00:00:07"), BigDecimal(7).bigDecimal, JInt.valueOf(7), JLong.valueOf(7L),
+      Long.box(4L), "B"))
+    data.+=(Row.of(localDateTime("1970-01-01 00:00:08"), localDate("1970-01-08"),
+      mLocalTime("00:00:08"), BigDecimal(8).bigDecimal, JInt.valueOf(8), JLong.valueOf(8L),
+      Long.box(4L), "A"))
+    data.+=(Row.of(localDateTime("1970-01-01 00:00:09"), localDate("1970-01-09"),
+      mLocalTime("00:00:09"), BigDecimal(9).bigDecimal, JInt.valueOf(9), JLong.valueOf(9L),
+      Long.box(4L), "D"))
+    data.+=(Row.of(localDateTime("1970-01-01 00:00:10"), localDate("1970-01-10"),
+      mLocalTime("00:00:10"), BigDecimal(10).bigDecimal, null, JLong.valueOf(10L),
+      Long.box(4L), "E"))
+    data.+=(Row.of(localDateTime("1970-01-01 00:00:11"), localDate("1970-01-11"),
+      mLocalTime("00:00:11"), BigDecimal(11).bigDecimal, JInt.valueOf(11), JLong.valueOf(11L),
+      Long.box(5L), "A"))
+    data.+=(Row.of(localDateTime("1970-01-01 00:00:12"), localDate("1970-01-12"),
+      mLocalTime("00:00:12"), BigDecimal(12).bigDecimal, JInt.valueOf(12), JLong.valueOf(12L),
+      Long.box(5L), "B"))
+
+    val t = failingDataSource(data)(new RowTypeInfo(
+      Types.LOCAL_DATE_TIME, Types.LOCAL_DATE, Types.LOCAL_TIME, Types.DECIMAL,
+      Types.INT, Types.LONG, Types.LONG, Types.STRING)).toTable(
+      tEnv, 'a, 'b, 'c, 'd, 'e, 'f, 'x, 'y)
+    tEnv.registerTable("MyTable", t)
+
+    val t1 = tEnv.sqlQuery(
+      s"""
+         |SELECT
+         | x,
+         | count(distinct y),
+         | count(distinct a),
+         | count(distinct b),
+         | count(distinct c),
+         | count(distinct d),
+         | count(distinct e),
+         | count(distinct f)
+         |FROM MyTable GROUP BY x
+       """.stripMargin)
+
+    val sink = new TestingRetractSink
+    t1.toRetractStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = List(
+      "1,1,1,1,1,1,1,1", "2,1,2,2,2,2,1,2", "3,1,3,3,3,3,3,3", "4,4,4,4,4,4,3,4", "5,2,2,2,2,2,2,2")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
   }
 
   @Test


### PR DESCRIPTION
…ype in DistinctInfo

## What is the purpose of the change

Fix count distinct on decimal type

## Brief change log

- Bridged Decimal to DecimalType in DistinctInfo for generating proper key type. 

## Verifying this change

This change added tests and can be verified by AggregateITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
