### PR TITLE
[FLINK-14074][mesos] Forward configuration to Mesos TaskExecutor

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -2012,6 +2012,9 @@ public final class ConfigConstants {
 	/** The environment variable name which contains the location of the plugins folder. */
 	public static final String ENV_FLINK_PLUGINS_DIR = "FLINK_PLUGINS_DIR";
 
+	/** The default Flink plugins directory if none has been specified via {@link #ENV_FLINK_PLUGINS_DIR}. */
+	public static final String DEFAULT_FLINK_PLUGINS_DIRS = "plugins";
+
 	/** The environment variable name which contains the location of the bin directory. */
 	public static final String ENV_FLINK_BIN_DIR = "FLINK_BIN_DIR";
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
@@ -130,32 +130,7 @@ public final class GlobalConfiguration {
 			configuration.addAll(dynamicProperties);
 		}
 
-		return enrichWithEnvironmentVariables(configuration);
-	}
-
-	private static Configuration enrichWithEnvironmentVariables(Configuration configuration) {
-		enrichWithEnvironmentVariable(ConfigConstants.ENV_FLINK_PLUGINS_DIR, configuration);
 		return configuration;
-	}
-
-	private static void enrichWithEnvironmentVariable(String environmentVariable, Configuration configuration) {
-		String valueFromEnv = System.getenv(environmentVariable);
-
-		if (valueFromEnv == null) {
-			return;
-		}
-
-		String valueFromConfig = configuration.getString(environmentVariable, valueFromEnv);
-
-		if (!valueFromEnv.equals(valueFromConfig)) {
-			throw new IllegalConfigurationException(
-				"The given configuration file already contains a value (" + valueFromEnv +
-					") for the key (" + environmentVariable +
-					") that would have been overwritten with (" + valueFromConfig +
-					") by an environment with the same name.");
-		}
-
-		configuration.setString(environmentVariable, valueFromEnv);
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/core/plugin/PluginConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/PluginConfig.java
@@ -55,23 +55,20 @@ public class PluginConfig {
 
 	public static PluginConfig fromConfiguration(Configuration configuration) {
 		return new PluginConfig(
-			getPluginsDirPath(configuration),
+			getPluginsDir().map(File::toPath),
 			CoreOptions.getParentFirstLoaderPatterns(configuration));
 	}
 
-	private static Optional<Path> getPluginsDirPath(Configuration configuration) {
-		String pluginsDir = configuration.getString(ConfigConstants.ENV_FLINK_PLUGINS_DIR, null);
-		if (pluginsDir == null) {
-			LOG.info("Environment variable [{}] is not set", ConfigConstants.ENV_FLINK_PLUGINS_DIR);
-			return Optional.empty();
-		}
+	public static Optional<File> getPluginsDir() {
+		String pluginsDir = System.getenv().getOrDefault(
+			ConfigConstants.ENV_FLINK_PLUGINS_DIR,
+			ConfigConstants.DEFAULT_FLINK_PLUGINS_DIRS);
+
 		File pluginsDirFile = new File(pluginsDir);
 		if (!pluginsDirFile.isDirectory()) {
-			LOG.warn("Environment variable [{}] is set to [{}] but the directory doesn't exist",
-				ConfigConstants.ENV_FLINK_PLUGINS_DIR,
-				pluginsDir);
+			LOG.warn("The plugins directory [{}] does not exist.", pluginsDirFile);
 			return Optional.empty();
 		}
-		return Optional.of(pluginsDirFile.toPath());
+		return Optional.of(pluginsDirFile);
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/core/plugin/PluginConfigTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/plugin/PluginConfigTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.plugin;
+
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableMap;
+
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the {@link PluginConfig} utility class.
+ */
+public class PluginConfigTest extends TestLogger {
+
+	@ClassRule
+	public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private static Map<String, String> oldEnvVariables;
+
+	@BeforeClass
+	public static void setup() {
+		oldEnvVariables = System.getenv();
+	}
+
+	@After
+	public void teardown() {
+		if (oldEnvVariables != null) {
+			CommonTestUtils.setEnv(oldEnvVariables, true);
+		}
+	}
+
+	@Test
+	public void getPluginsDir_existingDirectory_returnsDirectoryFile() throws IOException {
+		final File pluginsDirectory = temporaryFolder.newFolder();
+		final Map<String, String> envVariables = ImmutableMap.of(ConfigConstants.ENV_FLINK_PLUGINS_DIR, pluginsDirectory.getAbsolutePath());
+		CommonTestUtils.setEnv(envVariables);
+
+		assertThat(PluginConfig.getPluginsDir().get(), is(pluginsDirectory));
+	}
+
+	@Test
+	public void getPluginsDir_nonExistingDirectory_returnsEmpty() {
+		final Map<String, String> envVariables = ImmutableMap.of(ConfigConstants.ENV_FLINK_PLUGINS_DIR, new File(temporaryFolder.getRoot().getAbsoluteFile(), "should_not_exist").getAbsolutePath());
+		CommonTestUtils.setEnv(envVariables);
+
+		assertFalse(PluginConfig.getPluginsDir().isPresent());
+	}
+
+}

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
@@ -21,13 +21,11 @@ package org.apache.flink.mesos.entrypoint;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.mesos.runtime.clusterframework.MesosResourceManagerFactory;
-import org.apache.flink.mesos.runtime.clusterframework.MesosTaskManagerParameters;
 import org.apache.flink.mesos.runtime.clusterframework.services.MesosServices;
 import org.apache.flink.mesos.runtime.clusterframework.services.MesosServicesUtils;
 import org.apache.flink.mesos.util.MesosConfiguration;
 import org.apache.flink.mesos.util.MesosUtils;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
-import org.apache.flink.runtime.clusterframework.ContainerSpecification;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
 import org.apache.flink.runtime.entrypoint.JobClusterEntrypoint;
@@ -65,10 +63,6 @@ public class MesosJobClusterEntrypoint extends JobClusterEntrypoint {
 
 	private MesosServices mesosServices;
 
-	private MesosTaskManagerParameters taskManagerParameters;
-
-	private ContainerSpecification taskManagerContainerSpec;
-
 	public MesosJobClusterEntrypoint(Configuration config) {
 		super(config);
 	}
@@ -84,10 +78,6 @@ public class MesosJobClusterEntrypoint extends JobClusterEntrypoint {
 
 		// services
 		mesosServices = MesosServicesUtils.createMesosServices(config, hostname);
-
-		// TM configuration
-		taskManagerParameters = MesosUtils.createTmParameters(config, LOG);
-		taskManagerContainerSpec = MesosUtils.createContainerSpec(config);
 	}
 
 	@Override
@@ -108,9 +98,7 @@ public class MesosJobClusterEntrypoint extends JobClusterEntrypoint {
 		return DefaultDispatcherResourceManagerComponentFactory.createJobComponentFactory(
 			new MesosResourceManagerFactory(
 				mesosServices,
-				schedulerConfiguration,
-				taskManagerParameters,
-				taskManagerContainerSpec),
+				schedulerConfiguration),
 			FileJobGraphRetriever.createFrom(configuration));
 	}
 

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
@@ -25,6 +25,7 @@ import org.apache.flink.mesos.runtime.clusterframework.MesosTaskManagerParameter
 import org.apache.flink.mesos.runtime.clusterframework.services.MesosServices;
 import org.apache.flink.mesos.runtime.clusterframework.services.MesosServicesUtils;
 import org.apache.flink.mesos.util.MesosConfiguration;
+import org.apache.flink.mesos.util.MesosUtils;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
 import org.apache.flink.runtime.concurrent.FutureUtils;
@@ -84,14 +85,14 @@ public class MesosJobClusterEntrypoint extends JobClusterEntrypoint {
 		final String hostname = config.getString(JobManagerOptions.ADDRESS);
 
 		// Mesos configuration
-		schedulerConfiguration = MesosEntrypointUtils.createMesosSchedulerConfiguration(config, hostname);
+		schedulerConfiguration = MesosUtils.createMesosSchedulerConfiguration(config, hostname);
 
 		// services
 		mesosServices = MesosServicesUtils.createMesosServices(config, hostname);
 
 		// TM configuration
-		taskManagerParameters = MesosEntrypointUtils.createTmParameters(config, LOG);
-		taskManagerContainerSpec = MesosEntrypointUtils.createContainerSpec(config, dynamicProperties);
+		taskManagerParameters = MesosUtils.createTmParameters(config, LOG);
+		taskManagerContainerSpec = MesosUtils.createContainerSpec(config, dynamicProperties);
 	}
 
 	@Override
@@ -137,7 +138,7 @@ public class MesosJobClusterEntrypoint extends JobClusterEntrypoint {
 		}
 
 		Configuration dynamicProperties = BootstrapTools.parseDynamicProperties(cmd);
-		Configuration configuration = MesosEntrypointUtils.loadConfiguration(dynamicProperties, LOG);
+		Configuration configuration = MesosUtils.loadConfiguration(dynamicProperties, LOG);
 
 		MesosJobClusterEntrypoint clusterEntrypoint = new MesosJobClusterEntrypoint(configuration, dynamicProperties);
 

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
@@ -36,7 +36,6 @@ import org.apache.flink.runtime.entrypoint.component.FileJobGraphRetriever;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.JvmShutdownSafeguard;
 import org.apache.flink.runtime.util.SignalHandler;
-import org.apache.flink.util.Preconditions;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -62,8 +61,6 @@ public class MesosJobClusterEntrypoint extends JobClusterEntrypoint {
 				.addOption(BootstrapTools.newDynamicPropertiesOption());
 	}
 
-	private final Configuration dynamicProperties;
-
 	private MesosConfiguration schedulerConfiguration;
 
 	private MesosServices mesosServices;
@@ -72,10 +69,8 @@ public class MesosJobClusterEntrypoint extends JobClusterEntrypoint {
 
 	private ContainerSpecification taskManagerContainerSpec;
 
-	public MesosJobClusterEntrypoint(Configuration config, Configuration dynamicProperties) {
+	public MesosJobClusterEntrypoint(Configuration config) {
 		super(config);
-
-		this.dynamicProperties = Preconditions.checkNotNull(dynamicProperties);
 	}
 
 	@Override
@@ -92,7 +87,7 @@ public class MesosJobClusterEntrypoint extends JobClusterEntrypoint {
 
 		// TM configuration
 		taskManagerParameters = MesosUtils.createTmParameters(config, LOG);
-		taskManagerContainerSpec = MesosUtils.createContainerSpec(config, dynamicProperties);
+		taskManagerContainerSpec = MesosUtils.createContainerSpec(config);
 	}
 
 	@Override
@@ -140,7 +135,7 @@ public class MesosJobClusterEntrypoint extends JobClusterEntrypoint {
 		Configuration dynamicProperties = BootstrapTools.parseDynamicProperties(cmd);
 		Configuration configuration = MesosUtils.loadConfiguration(dynamicProperties, LOG);
 
-		MesosJobClusterEntrypoint clusterEntrypoint = new MesosJobClusterEntrypoint(configuration, dynamicProperties);
+		MesosJobClusterEntrypoint clusterEntrypoint = new MesosJobClusterEntrypoint(configuration);
 
 		ClusterEntrypoint.runClusterEntrypoint(clusterEntrypoint);
 	}

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosSessionClusterEntrypoint.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosSessionClusterEntrypoint.java
@@ -35,7 +35,6 @@ import org.apache.flink.runtime.entrypoint.component.DefaultDispatcherResourceMa
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.JvmShutdownSafeguard;
 import org.apache.flink.runtime.util.SignalHandler;
-import org.apache.flink.util.Preconditions;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -61,8 +60,6 @@ public class MesosSessionClusterEntrypoint extends SessionClusterEntrypoint {
 				.addOption(BootstrapTools.newDynamicPropertiesOption());
 	}
 
-	private final Configuration dynamicProperties;
-
 	private MesosConfiguration mesosConfig;
 
 	private MesosServices mesosServices;
@@ -71,10 +68,8 @@ public class MesosSessionClusterEntrypoint extends SessionClusterEntrypoint {
 
 	private ContainerSpecification taskManagerContainerSpec;
 
-	public MesosSessionClusterEntrypoint(Configuration config, Configuration dynamicProperties) {
+	public MesosSessionClusterEntrypoint(Configuration config) {
 		super(config);
-
-		this.dynamicProperties = Preconditions.checkNotNull(dynamicProperties);
 	}
 
 	@Override
@@ -91,7 +86,7 @@ public class MesosSessionClusterEntrypoint extends SessionClusterEntrypoint {
 
 		// TM configuration
 		taskManagerParameters = MesosUtils.createTmParameters(config, LOG);
-		taskManagerContainerSpec = MesosUtils.createContainerSpec(config, dynamicProperties);
+		taskManagerContainerSpec = MesosUtils.createContainerSpec(config);
 	}
 
 	@Override
@@ -138,7 +133,7 @@ public class MesosSessionClusterEntrypoint extends SessionClusterEntrypoint {
 		Configuration dynamicProperties = BootstrapTools.parseDynamicProperties(cmd);
 		Configuration configuration = MesosUtils.loadConfiguration(dynamicProperties, LOG);
 
-		MesosSessionClusterEntrypoint clusterEntrypoint = new MesosSessionClusterEntrypoint(configuration, dynamicProperties);
+		MesosSessionClusterEntrypoint clusterEntrypoint = new MesosSessionClusterEntrypoint(configuration);
 
 		ClusterEntrypoint.runClusterEntrypoint(clusterEntrypoint);
 	}

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosSessionClusterEntrypoint.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosSessionClusterEntrypoint.java
@@ -25,6 +25,7 @@ import org.apache.flink.mesos.runtime.clusterframework.MesosTaskManagerParameter
 import org.apache.flink.mesos.runtime.clusterframework.services.MesosServices;
 import org.apache.flink.mesos.runtime.clusterframework.services.MesosServicesUtils;
 import org.apache.flink.mesos.util.MesosConfiguration;
+import org.apache.flink.mesos.util.MesosUtils;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
 import org.apache.flink.runtime.concurrent.FutureUtils;
@@ -83,14 +84,14 @@ public class MesosSessionClusterEntrypoint extends SessionClusterEntrypoint {
 		final String hostname = config.getString(JobManagerOptions.ADDRESS);
 
 		// Mesos configuration
-		mesosConfig = MesosEntrypointUtils.createMesosSchedulerConfiguration(config, hostname);
+		mesosConfig = MesosUtils.createMesosSchedulerConfiguration(config, hostname);
 
 		// services
 		mesosServices = MesosServicesUtils.createMesosServices(config, hostname);
 
 		// TM configuration
-		taskManagerParameters = MesosEntrypointUtils.createTmParameters(config, LOG);
-		taskManagerContainerSpec = MesosEntrypointUtils.createContainerSpec(config, dynamicProperties);
+		taskManagerParameters = MesosUtils.createTmParameters(config, LOG);
+		taskManagerContainerSpec = MesosUtils.createContainerSpec(config, dynamicProperties);
 	}
 
 	@Override
@@ -135,7 +136,7 @@ public class MesosSessionClusterEntrypoint extends SessionClusterEntrypoint {
 		}
 
 		Configuration dynamicProperties = BootstrapTools.parseDynamicProperties(cmd);
-		Configuration configuration = MesosEntrypointUtils.loadConfiguration(dynamicProperties, LOG);
+		Configuration configuration = MesosUtils.loadConfiguration(dynamicProperties, LOG);
 
 		MesosSessionClusterEntrypoint clusterEntrypoint = new MesosSessionClusterEntrypoint(configuration, dynamicProperties);
 

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosSessionClusterEntrypoint.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosSessionClusterEntrypoint.java
@@ -21,13 +21,11 @@ package org.apache.flink.mesos.entrypoint;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.mesos.runtime.clusterframework.MesosResourceManagerFactory;
-import org.apache.flink.mesos.runtime.clusterframework.MesosTaskManagerParameters;
 import org.apache.flink.mesos.runtime.clusterframework.services.MesosServices;
 import org.apache.flink.mesos.runtime.clusterframework.services.MesosServicesUtils;
 import org.apache.flink.mesos.util.MesosConfiguration;
 import org.apache.flink.mesos.util.MesosUtils;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
-import org.apache.flink.runtime.clusterframework.ContainerSpecification;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
 import org.apache.flink.runtime.entrypoint.SessionClusterEntrypoint;
@@ -64,10 +62,6 @@ public class MesosSessionClusterEntrypoint extends SessionClusterEntrypoint {
 
 	private MesosServices mesosServices;
 
-	private MesosTaskManagerParameters taskManagerParameters;
-
-	private ContainerSpecification taskManagerContainerSpec;
-
 	public MesosSessionClusterEntrypoint(Configuration config) {
 		super(config);
 	}
@@ -83,10 +77,6 @@ public class MesosSessionClusterEntrypoint extends SessionClusterEntrypoint {
 
 		// services
 		mesosServices = MesosServicesUtils.createMesosServices(config, hostname);
-
-		// TM configuration
-		taskManagerParameters = MesosUtils.createTmParameters(config, LOG);
-		taskManagerContainerSpec = MesosUtils.createContainerSpec(config);
 	}
 
 	@Override
@@ -107,9 +97,7 @@ public class MesosSessionClusterEntrypoint extends SessionClusterEntrypoint {
 		return DefaultDispatcherResourceManagerComponentFactory.createSessionComponentFactory(
 			new MesosResourceManagerFactory(
 				mesosServices,
-				mesosConfig,
-				taskManagerParameters,
-				taskManagerContainerSpec));
+				mesosConfig));
 	}
 
 	public static void main(String[] args) {

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.mesos.runtime.clusterframework.MesosConfigKeys;
+import org.apache.flink.mesos.util.MesosUtils;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.security.SecurityConfiguration;
@@ -75,7 +76,7 @@ public class MesosTaskExecutorRunner {
 			Configuration dynamicProperties = BootstrapTools.parseDynamicProperties(cmd);
 			LOG.debug("Mesos dynamic properties: {}", dynamicProperties);
 
-			configuration = MesosEntrypointUtils.loadConfiguration(dynamicProperties, LOG);
+			configuration = MesosUtils.loadConfiguration(dynamicProperties, LOG);
 		}
 		catch (Throwable t) {
 			LOG.error("Failed to load the TaskManager configuration and dynamic properties.", t);

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -150,7 +150,7 @@ public class LaunchableMesosWorker implements LaunchableTask {
 
 		@Override
 		public int getPorts() {
-			return extractPortKeys(containerSpec.getDynamicConfiguration()).size();
+			return extractPortKeys(containerSpec.getFlinkConfiguration()).size();
 		}
 
 		@Override
@@ -209,7 +209,7 @@ public class LaunchableMesosWorker implements LaunchableTask {
 		final Configuration dynamicProperties = new Configuration();
 
 		// incorporate the dynamic properties set by the template
-		dynamicProperties.addAll(containerSpec.getDynamicConfiguration());
+		dynamicProperties.addAll(containerSpec.getFlinkConfiguration());
 
 		// build a TaskInfo with assigned resources, environment variables, etc
 		final Protos.TaskInfo.Builder taskInfo = Protos.TaskInfo.newBuilder()
@@ -244,7 +244,7 @@ public class LaunchableMesosWorker implements LaunchableTask {
 		}
 
 		// take needed ports for the TM
-		Set<String> tmPortKeys = extractPortKeys(containerSpec.getDynamicConfiguration());
+		Set<String> tmPortKeys = extractPortKeys(containerSpec.getFlinkConfiguration());
 		List<Protos.Resource> portResources = allocation.takeRanges("ports", tmPortKeys.size(), roles);
 		taskInfo.addAllResources(portResources);
 		Iterator<String> portsToAssign = tmPortKeys.iterator();

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -339,6 +339,8 @@ public class LaunchableMesosWorker implements LaunchableTask {
 		containerInfo.addAllVolumes(params.containerVolumes());
 		taskInfo.setContainer(containerInfo);
 
+		LOG.debug("Starting TaskExecutor {} with command: {}", slaveId, taskInfo.getCommand().getValue());
+
 		return taskInfo.build();
 	}
 

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerFactory.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerFactory.java
@@ -21,6 +21,7 @@ package org.apache.flink.mesos.runtime.clusterframework;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.mesos.runtime.clusterframework.services.MesosServices;
 import org.apache.flink.mesos.util.MesosConfiguration;
+import org.apache.flink.mesos.util.MesosUtils;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
@@ -35,6 +36,9 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerRuntimeServicesCo
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -43,23 +47,17 @@ import javax.annotation.Nullable;
  */
 public class MesosResourceManagerFactory extends ActiveResourceManagerFactory<RegisteredMesosWorkerNode> {
 
+	private static final Logger LOG = LoggerFactory.getLogger(MesosResourceManagerFactory.class);
+
 	@Nonnull
 	private final MesosServices mesosServices;
 
 	@Nonnull
 	private final MesosConfiguration schedulerConfiguration;
 
-	@Nonnull
-	private final MesosTaskManagerParameters taskManagerParameters;
-
-	@Nonnull
-	private final ContainerSpecification taskManagerContainerSpec;
-
-	public MesosResourceManagerFactory(@Nonnull MesosServices mesosServices, @Nonnull MesosConfiguration schedulerConfiguration, @Nonnull MesosTaskManagerParameters taskManagerParameters, @Nonnull ContainerSpecification taskManagerContainerSpec) {
+	public MesosResourceManagerFactory(@Nonnull MesosServices mesosServices, @Nonnull MesosConfiguration schedulerConfiguration) {
 		this.mesosServices = mesosServices;
 		this.schedulerConfiguration = schedulerConfiguration;
-		this.taskManagerParameters = taskManagerParameters;
-		this.taskManagerContainerSpec = taskManagerContainerSpec;
 	}
 
 	@Override
@@ -78,6 +76,9 @@ public class MesosResourceManagerFactory extends ActiveResourceManagerFactory<Re
 			rmServicesConfiguration,
 			highAvailabilityServices,
 			rpcService.getScheduledExecutor());
+
+		final MesosTaskManagerParameters taskManagerParameters = MesosUtils.createTmParameters(configuration, LOG);
+		final ContainerSpecification taskManagerContainerSpec = MesosUtils.createContainerSpec(configuration);
 
 		return new MesosResourceManager(
 			rpcService,

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosUtils.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosUtils.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.mesos.entrypoint;
+package org.apache.flink.mesos.util;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
@@ -24,7 +24,6 @@ import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.mesos.configuration.MesosOptions;
 import org.apache.flink.mesos.runtime.clusterframework.MesosConfigKeys;
 import org.apache.flink.mesos.runtime.clusterframework.MesosTaskManagerParameters;
-import org.apache.flink.mesos.util.MesosConfiguration;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
 import org.apache.flink.runtime.clusterframework.overlays.CompositeContainerOverlay;
@@ -46,9 +45,9 @@ import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 
 /**
- * Utils for Mesos entry points.
+ * Utils for Mesos.
  */
-public class MesosEntrypointUtils {
+public class MesosUtils {
 
 	/**
 	 * Loads and validates the Mesos scheduler configuration.

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosUtils.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosUtils.java
@@ -125,7 +125,7 @@ public class MesosUtils {
 		ContainerSpecification spec = new ContainerSpecification();
 
 		// propagate the AM dynamic configuration to the TM
-		spec.getDynamicConfiguration().addAll(dynamicProperties);
+		spec.getFlinkConfiguration().addAll(dynamicProperties);
 
 		applyOverlays(configuration, spec);
 

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosUtils.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosUtils.java
@@ -119,15 +119,14 @@ public class MesosUtils {
 		return taskManagerParameters;
 	}
 
-	public static ContainerSpecification createContainerSpec(Configuration configuration, Configuration dynamicProperties)
+	public static ContainerSpecification createContainerSpec(Configuration flinkConfiguration)
 		throws Exception {
 		// generate a container spec which conveys the artifacts/vars needed to launch a TM
 		ContainerSpecification spec = new ContainerSpecification();
 
-		// propagate the AM dynamic configuration to the TM
-		spec.getFlinkConfiguration().addAll(dynamicProperties);
+		spec.getFlinkConfiguration().addAll(flinkConfiguration);
 
-		applyOverlays(configuration, spec);
+		applyOverlays(flinkConfiguration, spec);
 
 		return spec;
 	}

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosUtils.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosUtils.java
@@ -122,9 +122,7 @@ public class MesosUtils {
 	public static ContainerSpecification createContainerSpec(Configuration flinkConfiguration)
 		throws Exception {
 		// generate a container spec which conveys the artifacts/vars needed to launch a TM
-		ContainerSpecification spec = new ContainerSpecification();
-
-		spec.getFlinkConfiguration().addAll(flinkConfiguration);
+		ContainerSpecification spec = ContainerSpecification.from(flinkConfiguration);
 
 		applyOverlays(flinkConfiguration, spec);
 

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorkerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorkerTest.java
@@ -19,15 +19,29 @@
 package org.apache.flink.mesos.runtime.clusterframework;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.mesos.configuration.MesosOptions;
+import org.apache.flink.mesos.scheduler.LaunchableTask;
+import org.apache.flink.mesos.util.MesosResourceAllocation;
+import org.apache.flink.mesos.util.MesosUtils;
+import org.apache.flink.runtime.clusterframework.ContainerSpecification;
 import org.apache.flink.util.TestLogger;
 
+import org.apache.mesos.Protos;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import scala.Option;
+
+import static org.apache.flink.mesos.Utils.ports;
+import static org.apache.flink.mesos.Utils.range;
 import static org.apache.flink.mesos.configuration.MesosOptions.PORT_ASSIGNMENTS;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -64,6 +78,29 @@ public class LaunchableMesosWorkerTest extends TestLogger {
 
 		// Assert
 		assertThat(portKeys, is(equalTo(LaunchableMesosWorker.TM_PORT_KEYS)));
+	}
+
+	@Test
+	public void launch_withNonDefaultConfiguration_forwardsConfigurationValues() {
+		final Configuration configuration = new Configuration();
+		configuration.setString(MesosOptions.MASTER_URL, "foobar");
+		final MemorySize memorySize = new MemorySize(1337L);
+		configuration.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, memorySize.toString());
+
+		final LaunchableTask launchableTask = new LaunchableMesosWorker(
+			ignored -> Option.empty(),
+			MesosTaskManagerParameters.create(configuration),
+			ContainerSpecification.from(configuration),
+			Protos.TaskID.newBuilder().setValue("test-task-id").build(),
+			MesosUtils.createMesosSchedulerConfiguration(configuration, "localhost"));
+
+		final Protos.TaskInfo taskInfo = launchableTask.launch(
+			Protos.SlaveID.newBuilder().setValue("test-slave-id").build(),
+			new MesosResourceAllocation(Collections.singleton(ports(range(1000, 2000)))));
+
+		assertThat(
+			taskInfo.getCommand().getValue(),
+			containsString(ContainerSpecification.createDynamicProperty(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE.key(), memorySize.toString())));
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ContainerSpecification.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ContainerSpecification.java
@@ -32,14 +32,14 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  * Encapsulates a container specification, including artifacts, environment variables,
  * system properties, and Flink configuration settings.
  *
- * The specification is mutable.
+ * <p>The specification is mutable.
  *
- * Note that the Flink configuration settings are considered dynamic overrides of whatever
+ * <p>Note that the Flink configuration settings are considered dynamic overrides of whatever
  * static configuration file is present in the container.  For example, a container might be
  * based on a Docker image with a normal Flink installation with customized settings, which these
  * settings would (partially) override.
  *
- * Artifacts are copied into a sandbox directory within the container, which any Flink process
+ * <p>Artifacts are copied into a sandbox directory within the container, which any Flink process
  * launched in the container is assumed to use as a working directory.  This assumption allows
  * for relative paths to be used in certain environment variables.
  */
@@ -51,13 +51,13 @@ public class ContainerSpecification implements java.io.Serializable {
 
 	private final List<Artifact> artifacts;
 
-	private final Map<String,String> environmentVariables;
+	private final Map<String, String> environmentVariables;
 
 	private final Configuration dynamicConfiguration;
 
 	public ContainerSpecification() {
 		this.artifacts = new LinkedList<>();
-		this.environmentVariables = new HashMap<String,String>();
+		this.environmentVariables = new HashMap<String, String>();
 		this.systemProperties = new Configuration();
 		this.dynamicConfiguration = new Configuration();
 	}
@@ -142,7 +142,9 @@ public class ContainerSpecification implements java.io.Serializable {
 				'}';
 		}
 
-		public static Builder newBuilder() { return new Builder(); }
+		public static Builder newBuilder() {
+			return new Builder();
+		}
 
 		public static class Builder {
 
@@ -188,8 +190,8 @@ public class ContainerSpecification implements java.io.Serializable {
      */
 	public static String formatSystemProperties(Configuration jvmArgs) {
 		StringBuilder sb = new StringBuilder();
-		for(Map.Entry<String,String> entry : jvmArgs.toMap().entrySet()) {
-			if(sb.length() > 0) {
+		for (Map.Entry<String, String> entry : jvmArgs.toMap().entrySet()) {
+			if (sb.length() > 0) {
 				sb.append(" ");
 			}
 			final String dynamicProperty = createDynamicProperty(entry.getKey(), entry.getValue());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ContainerSpecification.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ContainerSpecification.java
@@ -175,6 +175,12 @@ public class ContainerSpecification implements java.io.Serializable {
 		}
 	}
 
+	public static ContainerSpecification from(Configuration flinkConfiguration) {
+		final ContainerSpecification containerSpecification = new ContainerSpecification();
+		containerSpecification.getFlinkConfiguration().addAll(flinkConfiguration);
+		return containerSpecification;
+	}
+
 	/**
 	 * Format the system properties as a shell-compatible command-line argument.
      */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ContainerSpecification.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ContainerSpecification.java
@@ -91,16 +91,6 @@ public class ContainerSpecification implements java.io.Serializable {
 	}
 
 	@Override
-	protected Object clone() throws CloneNotSupportedException {
-		ContainerSpecification clone = new ContainerSpecification();
-		clone.artifacts.addAll(this.artifacts);
-		clone.environmentVariables.putAll(this.environmentVariables);
-		clone.systemProperties.addAll(this.systemProperties);
-		clone.flinkConfiguration.addAll(this.flinkConfiguration);
-		return clone;
-	}
-
-	@Override
 	public String toString() {
 		return "ContainerSpecification{" +
 			"environmentVariables=" + environmentVariables +

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ContainerSpecification.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ContainerSpecification.java
@@ -192,15 +192,29 @@ public class ContainerSpecification implements java.io.Serializable {
 			if(sb.length() > 0) {
 				sb.append(" ");
 			}
-			boolean quoted = entry.getValue().contains(" ");
-			if(quoted) {
-				sb.append("\"");
-			}
-			sb.append("-D").append(entry.getKey()).append('=').append(entry.getValue());
-			if(quoted) {
-				sb.append("\"");
-			}
+			final String dynamicProperty = createDynamicProperty(entry.getKey(), entry.getValue());
+			sb.append(dynamicProperty);
 		}
 		return sb.toString();
+	}
+
+	/**
+	 * Create a dynamic property from the given key and value of the format {@code -Dkey=value}.
+	 *
+	 * @param key of the dynamic property
+	 * @param value of the dynamic property
+	 * @return dynamic property
+	 */
+	public static String createDynamicProperty(String key, String value) {
+		final String keyPart = "-D" + key + '=';
+		final String valuePart;
+
+		if (value.contains(" ")) {
+			valuePart = "\"" + value + "\"";
+		} else {
+			valuePart = value;
+		}
+
+		return  keyPart + valuePart;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ContainerSpecification.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ContainerSpecification.java
@@ -53,13 +53,13 @@ public class ContainerSpecification implements java.io.Serializable {
 
 	private final Map<String, String> environmentVariables;
 
-	private final Configuration dynamicConfiguration;
+	private final Configuration flinkConfiguration;
 
 	public ContainerSpecification() {
 		this.artifacts = new LinkedList<>();
 		this.environmentVariables = new HashMap<String, String>();
 		this.systemProperties = new Configuration();
-		this.dynamicConfiguration = new Configuration();
+		this.flinkConfiguration = new Configuration();
 	}
 
 	/**
@@ -79,8 +79,8 @@ public class ContainerSpecification implements java.io.Serializable {
 	/**
 	 * Get the dynamic configuration.
      */
-	public Configuration getDynamicConfiguration() {
-		return dynamicConfiguration;
+	public Configuration getFlinkConfiguration() {
+		return flinkConfiguration;
 	}
 
 	/**
@@ -96,7 +96,7 @@ public class ContainerSpecification implements java.io.Serializable {
 		clone.artifacts.addAll(this.artifacts);
 		clone.environmentVariables.putAll(this.environmentVariables);
 		clone.systemProperties.addAll(this.systemProperties);
-		clone.dynamicConfiguration.addAll(this.dynamicConfiguration);
+		clone.flinkConfiguration.addAll(this.flinkConfiguration);
 		return clone;
 	}
 
@@ -105,7 +105,7 @@ public class ContainerSpecification implements java.io.Serializable {
 		return "ContainerSpecification{" +
 			"environmentVariables=" + environmentVariables +
 			", systemProperties=" + systemProperties +
-			", dynamicConfiguration=" + dynamicConfiguration +
+			", dynamicConfiguration=" + flinkConfiguration +
 			", artifacts=" + artifacts +
 			'}';
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlay.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlay.java
@@ -20,10 +20,13 @@ package org.apache.flink.runtime.clusterframework.overlays;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.plugin.PluginConfig;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,7 +35,6 @@ import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_BIN_DIR;
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_CONF_DIR;
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_HOME_DIR;
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_LIB_DIR;
-import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_PLUGINS_DIR;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -57,13 +59,14 @@ public class FlinkDistributionOverlay extends AbstractContainerOverlay {
 	final File flinkBinPath;
 	final File flinkConfPath;
 	final File flinkLibPath;
+	@Nullable
 	final File flinkPluginsPath;
 
-	public FlinkDistributionOverlay(File flinkBinPath, File flinkConfPath, File flinkLibPath, File flinkPluginsPath) {
+	FlinkDistributionOverlay(File flinkBinPath, File flinkConfPath, File flinkLibPath, @Nullable File flinkPluginsPath) {
 		this.flinkBinPath = checkNotNull(flinkBinPath);
 		this.flinkConfPath = checkNotNull(flinkConfPath);
 		this.flinkLibPath = checkNotNull(flinkLibPath);
-		this.flinkPluginsPath = checkNotNull(flinkPluginsPath);
+		this.flinkPluginsPath = flinkPluginsPath;
 	}
 
 	@Override
@@ -75,11 +78,8 @@ public class FlinkDistributionOverlay extends AbstractContainerOverlay {
 		addPathRecursively(flinkBinPath, TARGET_ROOT, container);
 		addPathRecursively(flinkConfPath, TARGET_ROOT, container);
 		addPathRecursively(flinkLibPath, TARGET_ROOT, container);
-		if (flinkPluginsPath.isDirectory()) {
+		if (flinkPluginsPath != null) {
 			addPathRecursively(flinkPluginsPath, TARGET_ROOT, container);
-		}
-		else {
-			LOG.warn("The plugins directory '" + flinkPluginsPath + "' doesn't exist.");
 		}
 	}
 
@@ -94,6 +94,7 @@ public class FlinkDistributionOverlay extends AbstractContainerOverlay {
 		File flinkBinPath;
 		File flinkConfPath;
 		File flinkLibPath;
+		@Nullable
 		File flinkPluginsPath;
 
 		/**
@@ -107,7 +108,7 @@ public class FlinkDistributionOverlay extends AbstractContainerOverlay {
 			flinkBinPath = getObligatoryFileFromEnvironment(ENV_FLINK_BIN_DIR);
 			flinkConfPath = getObligatoryFileFromEnvironment(ENV_FLINK_CONF_DIR);
 			flinkLibPath = getObligatoryFileFromEnvironment(ENV_FLINK_LIB_DIR);
-			flinkPluginsPath = getObligatoryFileFromEnvironment(ENV_FLINK_PLUGINS_DIR);
+			flinkPluginsPath = PluginConfig.getPluginsDir().orElse(null);
 
 			return this;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlay.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlay.java
@@ -23,9 +23,6 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.plugin.PluginConfig;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.annotation.Nullable;
 
 import java.io.File;
@@ -41,26 +38,24 @@ import static org.apache.flink.util.Preconditions.checkState;
 /**
  * Overlays Flink into a container, based on supplied bin/conf/lib directories.
  *
- * The overlayed Flink is indistinguishable from (and interchangeable with)
+ * <p>The overlayed Flink is indistinguishable from (and interchangeable with)
  * a normal installation of Flink.  For a docker image-based container, it should be
  * possible to bypass this overlay and rely on the normal installation method.
  *
- * The following files are copied to the container:
+ * <p>The following files are copied to the container:
  *  - flink/bin/
  *  - flink/conf/
  *  - flink/lib/
  */
 public class FlinkDistributionOverlay extends AbstractContainerOverlay {
 
-	private static final Logger LOG = LoggerFactory.getLogger(FlinkDistributionOverlay.class);
-
 	static final Path TARGET_ROOT = new Path("flink");
 
-	final File flinkBinPath;
-	final File flinkConfPath;
-	final File flinkLibPath;
+	private final File flinkBinPath;
+	private final File flinkConfPath;
+	private final File flinkLibPath;
 	@Nullable
-	final File flinkPluginsPath;
+	private final File flinkPluginsPath;
 
 	FlinkDistributionOverlay(File flinkBinPath, File flinkConfPath, File flinkLibPath, @Nullable File flinkPluginsPath) {
 		this.flinkBinPath = checkNotNull(flinkBinPath);
@@ -100,7 +95,7 @@ public class FlinkDistributionOverlay extends AbstractContainerOverlay {
 		/**
 		 * Configures the overlay using the current environment.
 		 *
-		 * Locates Flink using FLINK_???_DIR environment variables as provided to all Flink processes by config.sh.
+		 * <p>Locates Flink using FLINK_???_DIR environment variables as provided to all Flink processes by config.sh.
 		 *
 		 * @param globalConfiguration the current configuration.
 		 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/HadoopConfOverlay.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/HadoopConfOverlay.java
@@ -69,7 +69,7 @@ public class HadoopConfOverlay implements ContainerOverlay {
 		File hdfsSitePath = new File(hadoopConfDir, "hdfs-site.xml");
 
 		container.getEnvironmentVariables().put("HADOOP_CONF_DIR", TARGET_CONF_DIR.toString());
-		container.getDynamicConfiguration().setString(ConfigConstants.PATH_HADOOP_CONFIG, TARGET_CONF_DIR.toString());
+		container.getFlinkConfiguration().setString(ConfigConstants.PATH_HADOOP_CONFIG, TARGET_CONF_DIR.toString());
 
 		container.getArtifacts().add(ContainerSpecification.Artifact
 			.newBuilder()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/KeytabOverlay.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/KeytabOverlay.java
@@ -60,7 +60,7 @@ public class KeytabOverlay extends AbstractContainerOverlay {
 				.setDest(TARGET_PATH)
 				.setCachable(false)
 				.build());
-			container.getDynamicConfiguration().setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, TARGET_PATH.getPath());
+			container.getFlinkConfiguration().setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, TARGET_PATH.getPath());
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/SSLStoreOverlay.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/SSLStoreOverlay.java
@@ -64,7 +64,7 @@ public class SSLStoreOverlay extends AbstractContainerOverlay {
 				.setDest(TARGET_KEYSTORE_PATH)
 				.setCachable(false)
 				.build());
-			container.getDynamicConfiguration().setString(SecurityOptions.SSL_KEYSTORE, TARGET_KEYSTORE_PATH.getPath());
+			container.getFlinkConfiguration().setString(SecurityOptions.SSL_KEYSTORE, TARGET_KEYSTORE_PATH.getPath());
 		}
 		if(truststore != null) {
 			container.getArtifacts().add(ContainerSpecification.Artifact.newBuilder()
@@ -72,7 +72,7 @@ public class SSLStoreOverlay extends AbstractContainerOverlay {
 				.setDest(TARGET_TRUSTSTORE_PATH)
 				.setCachable(false)
 				.build());
-			container.getDynamicConfiguration().setString(SecurityOptions.SSL_TRUSTSTORE, TARGET_TRUSTSTORE_PATH.getPath());
+			container.getFlinkConfiguration().setString(SecurityOptions.SSL_TRUSTSTORE, TARGET_TRUSTSTORE_PATH.getPath());
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlayTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlayTest.java
@@ -82,7 +82,7 @@ public class FlinkDistributionOverlayTest extends ContainerOverlayTestBase {
 			pluginsFolder);
 		overlay.configure(containerSpecification);
 
-		for(Path file : files) {
+		for (Path file : files) {
 			checkArtifact(containerSpecification, new Path(TARGET_ROOT, file.toString()));
 		}
 	}
@@ -102,7 +102,7 @@ public class FlinkDistributionOverlayTest extends ContainerOverlayTestBase {
 		map.put(ENV_FLINK_LIB_DIR, libFolder.getAbsolutePath());
 		map.put(ENV_FLINK_PLUGINS_DIR, pluginsFolder.getAbsolutePath());
 		map.put(ENV_FLINK_CONF_DIR, confFolder.getAbsolutePath());
- 		CommonTestUtils.setEnv(map);
+		CommonTestUtils.setEnv(map);
 
 		FlinkDistributionOverlay.Builder builder = FlinkDistributionOverlay.newBuilder().fromEnvironment(conf);
 
@@ -133,8 +133,7 @@ public class FlinkDistributionOverlayTest extends ContainerOverlayTestBase {
 		try {
 			FlinkDistributionOverlay.Builder builder = FlinkDistributionOverlay.newBuilder().fromEnvironment(conf);
 			fail();
-		}
-		catch(IllegalStateException e) {
+		} catch (IllegalStateException e) {
 			// expected
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlayTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlayTest.java
@@ -29,7 +29,6 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -39,6 +38,7 @@ import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_LIB_DIR;
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_PLUGINS_DIR;
 import static org.apache.flink.runtime.clusterframework.overlays.FlinkDistributionOverlay.TARGET_ROOT;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 public class FlinkDistributionOverlayTest extends ContainerOverlayTestBase {
@@ -64,25 +64,6 @@ public class FlinkDistributionOverlayTest extends ContainerOverlayTestBase {
 			"plugins/P1/plugin1a.jar",
 			"plugins/P1/plugin1b.jar",
 			"plugins/P2/plugin2.jar");
-
-		testConfigure(binFolder, libFolder, pluginsFolder, confFolder, files);
-	}
-
-	@Test
-	public void testConfigureWithMissingPlugins() throws Exception {
-		File binFolder = tempFolder.newFolder("bin");
-		File libFolder = tempFolder.newFolder("lib");
-		File pluginsFolder = Paths.get(tempFolder.getRoot().getAbsolutePath(), "s0m3_p4th_th4t_sh0uld_n0t_3x1sts").toFile();
-		File confFolder = tempFolder.newFolder("conf");
-
-		Path[] files = createPaths(
-			tempFolder.getRoot(),
-			"bin/config.sh",
-			"bin/taskmanager.sh",
-			"lib/foo.jar",
-			"lib/A/foo.jar",
-			"lib/B/foo.jar",
-			"lib/B/bar.jar");
 
 		testConfigure(binFolder, libFolder, pluginsFolder, confFolder, files);
 	}
@@ -127,7 +108,9 @@ public class FlinkDistributionOverlayTest extends ContainerOverlayTestBase {
 
 		assertEquals(binFolder.getAbsolutePath(), builder.flinkBinPath.getAbsolutePath());
 		assertEquals(libFolder.getAbsolutePath(), builder.flinkLibPath.getAbsolutePath());
-		assertEquals(pluginsFolder.getAbsolutePath(), builder.flinkPluginsPath.getAbsolutePath());
+		final File flinkPluginsPath = builder.flinkPluginsPath;
+		assertNotNull(flinkPluginsPath);
+		assertEquals(pluginsFolder.getAbsolutePath(), flinkPluginsPath.getAbsolutePath());
 		assertEquals(confFolder.getAbsolutePath(), builder.flinkConfPath.getAbsolutePath());
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/HadoopConfOverlayTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/HadoopConfOverlayTest.java
@@ -52,7 +52,7 @@ public class HadoopConfOverlayTest extends ContainerOverlayTestBase {
 		overlay.configure(spec);
 
 		assertEquals(TARGET_CONF_DIR.getPath(), spec.getEnvironmentVariables().get("HADOOP_CONF_DIR"));
-		assertEquals(TARGET_CONF_DIR.getPath(), spec.getDynamicConfiguration().getString(ConfigConstants.PATH_HADOOP_CONFIG, null));
+		assertEquals(TARGET_CONF_DIR.getPath(), spec.getFlinkConfiguration().getString(ConfigConstants.PATH_HADOOP_CONFIG, null));
 
 		checkArtifact(spec, new Path(TARGET_CONF_DIR, "core-site.xml"));
 		checkArtifact(spec, new Path(TARGET_CONF_DIR, "hdfs-site.xml"));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/KeytabOverlayTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/KeytabOverlayTest.java
@@ -46,7 +46,7 @@ public class KeytabOverlayTest extends ContainerOverlayTestBase {
 		ContainerSpecification spec = new ContainerSpecification();
 		overlay.configure(spec);
 
-		assertEquals(TARGET_PATH.getPath(), spec.getDynamicConfiguration().getString(SecurityOptions.KERBEROS_LOGIN_KEYTAB));
+		assertEquals(TARGET_PATH.getPath(), spec.getFlinkConfiguration().getString(SecurityOptions.KERBEROS_LOGIN_KEYTAB));
 		checkArtifact(spec, TARGET_PATH);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/SSLStoreOverlayTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/SSLStoreOverlayTest.java
@@ -46,10 +46,10 @@ public class SSLStoreOverlayTest extends ContainerOverlayTestBase {
 		ContainerSpecification spec = new ContainerSpecification();
 		overlay.configure(spec);
 
-		assertEquals(TARGET_KEYSTORE_PATH.getPath(), spec.getDynamicConfiguration().getString(SecurityOptions.SSL_KEYSTORE));
+		assertEquals(TARGET_KEYSTORE_PATH.getPath(), spec.getFlinkConfiguration().getString(SecurityOptions.SSL_KEYSTORE));
 		checkArtifact(spec, TARGET_KEYSTORE_PATH);
 
-		assertEquals(TARGET_TRUSTSTORE_PATH.getPath(), spec.getDynamicConfiguration().getString(SecurityOptions.SSL_TRUSTSTORE));
+		assertEquals(TARGET_TRUSTSTORE_PATH.getPath(), spec.getFlinkConfiguration().getString(SecurityOptions.SSL_TRUSTSTORE));
 		checkArtifact(spec, TARGET_TRUSTSTORE_PATH);
 	}
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -36,6 +36,7 @@ import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.plugin.PluginConfig;
 import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
@@ -101,11 +102,11 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_LIB_DIR;
-import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_PLUGINS_DIR;
 import static org.apache.flink.runtime.entrypoint.component.FileJobGraphRetriever.JOB_GRAPH_FILE_PATH;
 import static org.apache.flink.yarn.cli.FlinkYarnSessionCli.CONFIG_FILE_LOG4J_NAME;
 import static org.apache.flink.yarn.cli.FlinkYarnSessionCli.CONFIG_FILE_LOGBACK_NAME;
@@ -1581,16 +1582,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 	}
 
 	private void addPluginsFoldersToShipFiles(Collection<File> effectiveShipFiles) {
-		String pluginsDir = System.getenv().get(ENV_FLINK_PLUGINS_DIR);
-		if (pluginsDir != null) {
-			File directoryFile = new File(pluginsDir);
-			if (directoryFile.isDirectory()) {
-				effectiveShipFiles.add(directoryFile);
-			} else {
-				LOG.warn("The environment variable '" + ENV_FLINK_PLUGINS_DIR +
-						"' is set to '" + pluginsDir + "' but the directory doesn't exist.");
-			}
-		}
+		final Optional<File> pluginsDir = PluginConfig.getPluginsDir();
+		pluginsDir.ifPresent(effectiveShipFiles::add);
 	}
 
 	ContainerLaunchContext setupApplicationMasterContainer(


### PR DESCRIPTION
## What is the purpose of the change

This commit forwards the Flink configuration to a Mesos `TaskExecutor` by
creating the `ContainerSpecification` with it. This will forward all options
which are dynamically configured until the `ResourceManager` has been started
to the Mesos `TaskExecutor`.

## Verifying this change

- Added `LaunchableMesosWorkerTest#launch_withNonDefaultConfiguration_forwardsConfigurationValues`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
