### PR TITLE
[FLINK-14533][flink-table-planner] Fix LOWER/UPPER not being pushed down to TableSource

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -251,6 +251,14 @@ public final class BuiltInFunctionDefinitions {
 			.kind(SCALAR)
 			.outputTypeStrategy(TypeStrategies.MISSING)
 			.build();
+	// we need LOWERCASE here to maintain compatibility for the string-based expression DSL
+	// which exposes LOWER as lowerCase()
+	public static final BuiltInFunctionDefinition LOWERCASE =
+			new BuiltInFunctionDefinition.Builder()
+					.name("lowerCase")
+					.kind(SCALAR)
+					.outputTypeStrategy(TypeStrategies.MISSING)
+					.build();
 	public static final BuiltInFunctionDefinition SIMILAR =
 		new BuiltInFunctionDefinition.Builder()
 			.name("similar")
@@ -281,6 +289,14 @@ public final class BuiltInFunctionDefinitions {
 			.kind(SCALAR)
 			.outputTypeStrategy(TypeStrategies.MISSING)
 			.build();
+	// we need UPPERCASE here to maintain compatibility for the string-based expression DSL
+	// which exposes UPPER as upperCase()
+	public static final BuiltInFunctionDefinition UPPERCASE =
+			new BuiltInFunctionDefinition.Builder()
+					.name("upperCase")
+					.kind(SCALAR)
+					.outputTypeStrategy(TypeStrategies.MISSING)
+					.build();
 	public static final BuiltInFunctionDefinition POSITION =
 		new BuiltInFunctionDefinition.Builder()
 			.name("position")

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -247,7 +247,7 @@ public final class BuiltInFunctionDefinitions {
 			.build();
 	public static final BuiltInFunctionDefinition LOWER =
 		new BuiltInFunctionDefinition.Builder()
-			.name("lowerCase")
+			.name("lower")
 			.kind(SCALAR)
 			.outputTypeStrategy(TypeStrategies.MISSING)
 			.build();
@@ -277,7 +277,7 @@ public final class BuiltInFunctionDefinitions {
 			.build();
 	public static final BuiltInFunctionDefinition UPPER =
 		new BuiltInFunctionDefinition.Builder()
-			.name("upperCase")
+			.name("upper")
 			.kind(SCALAR)
 			.outputTypeStrategy(TypeStrategies.MISSING)
 			.build();

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/DirectConvertRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/DirectConvertRule.java
@@ -67,9 +67,11 @@ public class DirectConvertRule implements CallExpressionConvertRule {
 		DEFINITION_OPERATOR_MAP.put(BuiltInFunctionDefinitions.INIT_CAP, FlinkSqlOperatorTable.INITCAP);
 		DEFINITION_OPERATOR_MAP.put(BuiltInFunctionDefinitions.LIKE, FlinkSqlOperatorTable.LIKE);
 		DEFINITION_OPERATOR_MAP.put(BuiltInFunctionDefinitions.LOWER, FlinkSqlOperatorTable.LOWER);
+		DEFINITION_OPERATOR_MAP.put(BuiltInFunctionDefinitions.LOWERCASE, FlinkSqlOperatorTable.LOWER);
 		DEFINITION_OPERATOR_MAP.put(BuiltInFunctionDefinitions.SIMILAR, FlinkSqlOperatorTable.SIMILAR_TO);
 		DEFINITION_OPERATOR_MAP.put(BuiltInFunctionDefinitions.SUBSTRING, FlinkSqlOperatorTable.SUBSTRING);
 		DEFINITION_OPERATOR_MAP.put(BuiltInFunctionDefinitions.UPPER, FlinkSqlOperatorTable.UPPER);
+		DEFINITION_OPERATOR_MAP.put(BuiltInFunctionDefinitions.UPPERCASE, FlinkSqlOperatorTable.UPPER);
 		DEFINITION_OPERATOR_MAP.put(BuiltInFunctionDefinitions.POSITION, FlinkSqlOperatorTable.POSITION);
 		DEFINITION_OPERATOR_MAP.put(BuiltInFunctionDefinitions.OVERLAY, FlinkSqlOperatorTable.OVERLAY);
 		DEFINITION_OPERATOR_MAP.put(BuiltInFunctionDefinitions.CONCAT, FlinkSqlOperatorTable.CONCAT_FUNCTION);

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
@@ -290,6 +290,10 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
             assert(args.size == 1)
             Lower(args.head)
 
+          case LOWERCASE =>
+            assert(args.size == 1)
+            Lower(args.head)
+
           case SIMILAR =>
             assert(args.size == 2)
             Similar(args.head, args.last)
@@ -323,6 +327,10 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
             Trim(trimMode, args(2), args(3))
 
           case UPPER =>
+            assert(args.size == 1)
+            Upper(args.head)
+
+          case UPPERCASE =>
             assert(args.size == 1)
             Upper(args.head)
 

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
@@ -293,39 +293,21 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testLowerPushdown">
+  <TestCase name="testLowerUpperPushdown">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MTable WHERE LOWER(a) like 'foo']]>
+      <![CDATA[SELECT * FROM MTable WHERE LOWER(a) = 'foo' AND UPPER(b) = 'bar']]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1])
-+- LogicalFilter(condition=[LIKE(LOWER($0), _UTF-16LE'foo')])
++- LogicalFilter(condition=[AND(=(LOWER($0), _UTF-16LE'foo'), =(UPPER($1), _UTF-16LE'bar'))])
    +- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filterPushedDown=[false], filter=[]]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1])
-+- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filterPushedDown=[true], filter=[like(lower(a), 'foo')]]]])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testUpperPushdown">
-    <Resource name="sql">
-      <![CDATA[SELECT * FROM MTable WHERE UPPER(a) like 'foo']]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(a=[$0], b=[$1])
-+- LogicalFilter(condition=[LIKE(UPPER($0), _UTF-16LE'foo')])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filterPushedDown=[false], filter=[]]]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-LogicalProject(a=[$0], b=[$1])
-+- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filterPushedDown=[true], filter=[like(upper(a), 'foo')]]]])
++- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filterPushedDown=[true], filter=[and(equals(lower(a), 'foo'), equals(upper(b), 'bar'))]]]])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
@@ -299,16 +299,16 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-  LogicalProject(a=[$0], b=[$1])
-  +- LogicalFilter(condition=[LIKE(LOWER($0), _UTF-16LE'foo')])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MTable]])
-  ]]>
+LogicalProject(a=[$0], b=[$1])
++- LogicalFilter(condition=[LIKE(LOWER($0), _UTF-16LE'foo')])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filterPushedDown=[false], filter=[]]]])
+]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-  LogicalProject(a=[$0], b=[$1])
-  +- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filter=[like(lower(a), 'foo')]]]])
-  ]]>
+LogicalProject(a=[$0], b=[$1])
++- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filterPushedDown=[true], filter=[like(lower(a), 'foo')]]]])
+]]>
     </Resource>
   </TestCase>
   <TestCase name="testUpperPushdown">
@@ -317,16 +317,16 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-  LogicalProject(a=[$0], b=[$1])
-  +- LogicalFilter(condition=[LIKE(UPPER($0), _UTF-16LE'foo')])
-  +- LogicalTableScan(table=[[default_catalog, default_database, MTable]])
-  ]]>
+LogicalProject(a=[$0], b=[$1])
++- LogicalFilter(condition=[LIKE(UPPER($0), _UTF-16LE'foo')])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filterPushedDown=[false], filter=[]]]])
+]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-  LogicalProject(a=[$0], b=[$1])
-  +- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filter=[like(upper(a), 'foo')]]]])
-  ]]>
+LogicalProject(a=[$0], b=[$1])
++- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filterPushedDown=[true], filter=[like(upper(a), 'foo')]]]])
+]]>
     </Resource>
   </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
@@ -293,25 +293,25 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
 ]]>
     </Resource>
   </TestCase>
-	<TestCase name="testLowerPushdown">
-		<Resource name="sql">
-			<![CDATA[SELECT * FROM MTable WHERE LOWER(a) like 'foo']]>
-		</Resource>
-		<Resource name="planBefore">
-			<![CDATA[
-LogicalProject(a=[$0], b=[$1])
-+- LogicalFilter(condition=[LIKE(LOWER($0), _UTF-16LE'foo')])
+  <TestCase name="testLowerPushdown">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MTable WHERE LOWER(a) like 'foo']]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+  LogicalProject(a=[$0], b=[$1])
+  +- LogicalFilter(condition=[LIKE(LOWER($0), _UTF-16LE'foo')])
    +- LogicalTableScan(table=[[default_catalog, default_database, MTable]])
-]]>
-		</Resource>
-		<Resource name="planAfter">
-			<![CDATA[
-LogicalProject(a=[$0], b=[$1])
-+- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filter=[like(lower(a), 'foo')]]]])
-]]>
-		</Resource>
-	</TestCase>
-	<TestCase name="testUpperPushdown">
+  ]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+  LogicalProject(a=[$0], b=[$1])
+  +- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filter=[like(lower(a), 'foo')]]]])
+  ]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpperPushdown">
     <Resource name="sql">
       <![CDATA[SELECT * FROM MTable WHERE UPPER(a) like 'foo']]>
     </Resource>
@@ -328,5 +328,5 @@ LogicalProject(a=[$0], b=[$1])
   +- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filter=[like(upper(a), 'foo')]]]])
   ]]>
     </Resource>
-    </TestCase>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
@@ -293,4 +293,40 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
 ]]>
     </Resource>
   </TestCase>
+	<TestCase name="testLowerPushdown">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM MTable WHERE LOWER(a) like 'foo']]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalProject(a=[$0], b=[$1])
++- LogicalFilter(condition=[LIKE(LOWER($0), _UTF-16LE'foo')])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(a=[$0], b=[$1])
++- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filter=[like(lower(a), 'foo')]]]])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testUpperPushdown">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MTable WHERE UPPER(a) like 'foo']]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+  LogicalProject(a=[$0], b=[$1])
+  +- LogicalFilter(condition=[LIKE(UPPER($0), _UTF-16LE'foo')])
+  +- LogicalTableScan(table=[[default_catalog, default_database, MTable]])
+  ]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+  LogicalProject(a=[$0], b=[$1])
+  +- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filter=[like(upper(a), 'foo')]]]])
+  ]]>
+    </Resource>
+    </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.scala
@@ -20,10 +20,13 @@ package org.apache.flink.table.planner.plan.rules.logical
 import org.apache.flink.table.planner.expressions.utils.Func1
 import org.apache.flink.table.planner.plan.optimize.program.{FlinkBatchProgram, FlinkHepRuleSetProgramBuilder, HEP_RULES_EXECUTION_TYPE}
 import org.apache.flink.table.planner.utils.{TableConfigUtils, TableTestBase, TestFilterableTableSource}
-
 import org.apache.calcite.plan.hep.HepMatchOrder
 import org.apache.calcite.rel.rules.FilterProjectTransposeRule
 import org.apache.calcite.tools.RuleSets
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.table.api.Types
+import org.apache.flink.types.Row
 import org.junit.{Before, Test}
 
 /**
@@ -141,5 +144,36 @@ class PushFilterIntoTableSourceScanRuleTest extends TableTestBase {
     util.addFunction("myUdf", Func1)
     util.verifyPlan("SELECT * FROM MyTable WHERE amount > 2 AND myUdf(amount) < 32")
   }
+  @Test
+  def testLowerPushdown(): Unit = {
+    val rti =
+      new RowTypeInfo(Array[TypeInformation[_]](Types.STRING, Types.STRING), Array("a", "b"))
+    val rows = List(Row.of("foo", "bar"))
+    util.tableEnv
+      .registerTableSource(
+        "MTable",
+        TestFilterableTableSource(true, rti, rows, Set("a", "b"), Set("lower"))
+      )
 
+    util.verifyPlan("SELECT * FROM MTable WHERE LOWER(a) like 'foo'")
+  }
+
+  @Test
+  def testUpperPushdown(): Unit = {
+    val rti =
+      new RowTypeInfo(Array[TypeInformation[_]](Types.STRING, Types.STRING), Array("a", "b"))
+    val rows = List(Row.of("foo", "bar"))
+    util.tableEnv
+      .registerTableSource(
+        "MTable",
+        TestFilterableTableSource(true, rti, rows, Set("a", "b"), Set("upper"))
+      )
+
+    util.verifyPlan("SELECT * FROM MTable WHERE UPPER(a) like 'foo'")
+  }
+
+  @Test
+  def testGreatThanPushdown(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable WHERE a > 10")
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.scala
@@ -171,9 +171,4 @@ class PushFilterIntoTableSourceScanRuleTest extends TableTestBase {
 
     util.verifyPlan("SELECT * FROM MTable WHERE UPPER(a) like 'foo'")
   }
-
-  @Test
-  def testGreatThanPushdown(): Unit = {
-    util.verifyPlan("SELECT * FROM MyTable WHERE a > 10")
-  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.scala
@@ -144,31 +144,19 @@ class PushFilterIntoTableSourceScanRuleTest extends TableTestBase {
     util.addFunction("myUdf", Func1)
     util.verifyPlan("SELECT * FROM MyTable WHERE amount > 2 AND myUdf(amount) < 32")
   }
+
   @Test
-  def testLowerPushdown(): Unit = {
-    val rti =
-      new RowTypeInfo(Array[TypeInformation[_]](Types.STRING, Types.STRING), Array("a", "b"))
-    val rows = List(Row.of("foo", "bar"))
+  def testLowerUpperPushdown(): Unit = {
+    val rti = new RowTypeInfo(Array[TypeInformation[_]](
+      Types.STRING, Types.STRING),
+      Array("a", "b"))
+    val data = List(Row.of("foo", "bar"))
     util.tableEnv
       .registerTableSource(
         "MTable",
-        TestFilterableTableSource(true, rti, rows, Set("a", "b"), Set("lower"))
+        TestFilterableTableSource(true, rti, data, Set("a", "b"))
       )
 
-    util.verifyPlan("SELECT * FROM MTable WHERE LOWER(a) like 'foo'")
-  }
-
-  @Test
-  def testUpperPushdown(): Unit = {
-    val rti =
-      new RowTypeInfo(Array[TypeInformation[_]](Types.STRING, Types.STRING), Array("a", "b"))
-    val rows = List(Row.of("foo", "bar"))
-    util.tableEnv
-      .registerTableSource(
-        "MTable",
-        TestFilterableTableSource(true, rti, rows, Set("a", "b"), Set("upper"))
-      )
-
-    util.verifyPlan("SELECT * FROM MTable WHERE UPPER(a) like 'foo'")
+    util.verifyPlan("SELECT * FROM MTable WHERE LOWER(a) = 'foo' AND UPPER(b) = 'bar'")
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSourceITCase.scala
@@ -28,6 +28,7 @@ import org.apache.flink.table.planner.utils.{TestDataTypeTableSource, TestFileIn
 import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter
 import org.apache.flink.types.Row
 import org.junit.{Before, Test}
+
 import java.io.FileWriter
 import java.lang.{Boolean => JBool, Integer => JInt, Long => JLong}
 import java.math.{BigDecimal => JDecimal}
@@ -152,6 +153,23 @@ class TableSourceITCase extends BatchTestBase {
         row(6, "Record_6"),
         row(7, "Record_7"),
         row(8, "Record_8"))
+    )
+  }
+
+  @Test
+  def testTableSourceWithFunctionFilterable(): Unit = {
+    tEnv.registerTableSource(
+      "FilterableTable",
+      TestFilterableTableSource(
+        true,
+        TestFilterableTableSource.defaultTypeInfo,
+        TestFilterableTableSource.defaultRows,
+        Set("amount", "name")))
+    checkResult(
+      "SELECT id, name FROM FilterableTable " +
+        "WHERE amount > 4 AND price < 9 AND upper(name) = 'RECORD_5'",
+      Seq(
+        row(5, "Record_5"))
     )
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/testTableSources.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/testTableSources.scala
@@ -376,6 +376,9 @@ class TestProjectableTableSourceFactory extends StreamTableSourceFactory[Row] {
   * A data source that implements some very basic filtering in-memory in order to test
   * expression push-down logic.
   *
+  * <p>NOTE: Currently, only `>, >=, &lt;, <=, =, &lt;>` operators and UPPER and LOWER functions
+  * are allowed to be pushed down into this source.
+  *
   * @param isBounded whether this is a bounded source
   * @param rowTypeInfo The type info for the rows.
   * @param data The data that filtering is applied to in order to get the final dataset.

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/testTableSources.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/testTableSources.scala
@@ -32,9 +32,9 @@ import org.apache.flink.table.catalog.{CatalogPartitionImpl, CatalogPartitionSpe
 import org.apache.flink.table.descriptors.ConnectorDescriptorValidator.{CONNECTOR, CONNECTOR_TYPE}
 import org.apache.flink.table.descriptors.{DescriptorProperties, Schema}
 import org.apache.flink.table.expressions.utils.ApiExpressionUtils.unresolvedCall
-import org.apache.flink.table.expressions.{CallExpression, Expression, FieldReferenceExpression, ValueLiteralExpression}
+import org.apache.flink.table.expressions.{CallExpression, Expression, FieldReferenceExpression, UnresolvedCallExpression, ValueLiteralExpression}
 import org.apache.flink.table.factories.{StreamTableSourceFactory, TableSourceFactory}
-import org.apache.flink.table.functions.BuiltInFunctionDefinitions
+import org.apache.flink.table.functions.{BuiltInFunctionDefinition, BuiltInFunctionDefinitions}
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions.AND
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TimeTestUtil.EventTimeSourceFunction
@@ -45,7 +45,6 @@ import org.apache.flink.table.sources.wmstrategies.{AscendingTimestamps, Preserv
 import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType
 import org.apache.flink.types.Row
-
 import java.io.{File, FileOutputStream, OutputStreamWriter}
 import java.util
 import java.util.{Collections, function, ArrayList => JArrayList, List => JList, Map => JMap}
@@ -390,6 +389,7 @@ class TestFilterableTableSource(
     data: Seq[Row],
     filterableFields: Set[String] = Set(),
     filterPredicates: Seq[Expression] = Seq(),
+    filterBuiltInFunctions: Set[String] = Set(),
     val filterPushedDown: Boolean = false)
   extends StreamTableSource[Row]
   with FilterableTableSource[Row] {
@@ -431,7 +431,8 @@ class TestFilterableTableSource(
       data,
       filterableFields,
       predicatesToUse,
-      filterPushedDown = true)
+      filterPushedDown = true,
+      filterBuiltInFunctions = filterBuiltInFunctions)
   }
 
   override def isFilterPushedDown: Boolean = filterPushedDown
@@ -451,6 +452,12 @@ class TestFilterableTableSource(
     (children.head, children.last) match {
       case (f: FieldReferenceExpression, _: ValueLiteralExpression) =>
         filterableFields.contains(f.getName)
+      case (f: UnresolvedCallExpression, _: ValueLiteralExpression) =>
+        f.getFunctionDefinition match {
+          case b: BuiltInFunctionDefinition =>
+            filterBuiltInFunctions.contains(b.getName)
+          case _ => false
+        }
       case (_: ValueLiteralExpression, f: FieldReferenceExpression) =>
         filterableFields.contains(f.getName)
       case (f1: FieldReferenceExpression, f2: FieldReferenceExpression) =>
@@ -557,6 +564,31 @@ object TestFilterableTableSource {
       filterableFields: Set[String]): TestFilterableTableSource = {
     new TestFilterableTableSource(isBounded, rowTypeInfo, rows, filterableFields)
   }
+
+  /**
+    * A filterable data source with custom data.
+    *
+    * @param isBounded whether this is a bounded source
+    * @param rowTypeInfo The type of the data. Its expected that both types and field
+    *                    names are provided.
+    * @param rows The data as a sequence of rows.
+    * @param filterableFields The fields that are allowed to be filtered on.
+    * @param filterableBuiltInFunctions Allow pushdown for
+    *                                   BuiltInFunctionDefinition names
+    * @return The table source.
+    */
+  def apply(isBounded: Boolean,
+            rowTypeInfo: RowTypeInfo,
+            rows: Seq[Row],
+            filterableFields: Set[String],
+            filterableBuiltInFunctions: Set[String]): TestFilterableTableSource =
+    new TestFilterableTableSource(
+      isBounded,
+      rowTypeInfo,
+      rows,
+      filterableFields,
+      filterBuiltInFunctions = filterableBuiltInFunctions
+    )
 
   private lazy val defaultFilterableFields = Set("amount")
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/testTableSources.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/testTableSources.scala
@@ -452,7 +452,7 @@ class TestFilterableTableSource(
     (children.head, children.last) match {
       case (f: FieldReferenceExpression, _: ValueLiteralExpression) =>
         filterableFields.contains(f.getName)
-      case (f: UnresolvedCallExpression, _: ValueLiteralExpression) =>
+      case (f: CallExpression, _: ValueLiteralExpression) =>
         f.getFunctionDefinition match {
           case b: BuiltInFunctionDefinition =>
             filterBuiltInFunctions.contains(b.getName)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionConverter.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionConverter.scala
@@ -272,6 +272,10 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
             assert(args.size == 1)
             Lower(args.head)
 
+          case LOWERCASE =>
+            assert(args.size == 1)
+            Lower(args.head)
+
           case SIMILAR =>
             assert(args.size == 2)
             Similar(args.head, args.last)
@@ -305,6 +309,10 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
             Trim(trimMode, args(2), args(3))
 
           case UPPER =>
+            assert(args.size == 1)
+            Upper(args.head)
+
+          case UPPERCASE =>
             assert(args.size == 1)
             Upper(args.head)
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix issue [FLINK-14533](https://issues.apache.org/jira/browse/FLINK-14533) where using `LOWER/UPPER` in predicate would cause predicate pushdown to fail

## Brief change log

Change `BuiltInFunctionDefinition` to match the `SqlFunction` string.

## Verifying this change

Added tests

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
