### PR TITLE
[FLINK-14312][runtime] Support building logical pipelined regions from JobGraph

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/IntermediateDataSetID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/IntermediateDataSetID.java
@@ -18,10 +18,13 @@
 
 package org.apache.flink.runtime.jobgraph;
 
-import java.util.UUID;
-
 import org.apache.flink.util.AbstractID;
 
+import java.util.UUID;
+
+/**
+ * Id identifying {@link IntermediateDataSet}.
+ */
 public class IntermediateDataSetID extends AbstractID {
 
 	private static final long serialVersionUID = 1L;
@@ -32,19 +35,19 @@ public class IntermediateDataSetID extends AbstractID {
 	public IntermediateDataSetID() {
 		super();
 	}
-	
+
 	/**
 	 * Creates a new intermediate data set ID with the bytes of the given ID.
-	 * 
+	 *
 	 * @param from The ID to create this ID from.
 	 */
 	public IntermediateDataSetID(AbstractID from) {
 		super(from);
 	}
-	
+
 	/**
 	 * Creates a new intermediate data set ID with the bytes of the given UUID.
-	 * 
+	 *
 	 * @param from The UUID to create this ID from.
 	 */
 	public IntermediateDataSetID(UUID from) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/IntermediateDataSetID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/IntermediateDataSetID.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.jobgraph;
 
+import org.apache.flink.runtime.topology.ResultID;
 import org.apache.flink.util.AbstractID;
 
 import java.util.UUID;
@@ -25,7 +26,7 @@ import java.util.UUID;
 /**
  * Id identifying {@link IntermediateDataSet}.
  */
-public class IntermediateDataSetID extends AbstractID {
+public class IntermediateDataSetID extends AbstractID implements ResultID {
 
 	private static final long serialVersionUID = 1L;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertexID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertexID.java
@@ -25,12 +25,13 @@ import org.apache.flink.util.StringUtils;
  * A class for statistically unique job vertex IDs.
  */
 public class JobVertexID extends AbstractID {
-	
+
 	private static final long serialVersionUID = 1L;
-	
+
 	public JobVertexID() {
 		super();
 	}
+
 	public JobVertexID(byte[] bytes) {
 		super(bytes);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertexID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertexID.java
@@ -18,13 +18,14 @@
 
 package org.apache.flink.runtime.jobgraph;
 
+import org.apache.flink.runtime.topology.VertexID;
 import org.apache.flink.util.AbstractID;
 import org.apache.flink.util.StringUtils;
 
 /**
  * A class for statistically unique job vertex IDs.
  */
-public class JobVertexID extends AbstractID {
+public class JobVertexID extends AbstractID implements VertexID {
 
 	private static final long serialVersionUID = 1L;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalResult.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobgraph.topology;
+
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobEdge;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Default implementation of {@link LogicalResult}.
+ * It is an adapter of {@link IntermediateDataSet}.
+ */
+public class DefaultLogicalResult implements LogicalResult<DefaultLogicalVertex, DefaultLogicalResult> {
+
+	private final IntermediateDataSet intermediateDataSet;
+
+	private final Function<JobVertexID, DefaultLogicalVertex> vertexRetriever;
+
+	DefaultLogicalResult(
+			final IntermediateDataSet intermediateDataSet,
+			final Function<JobVertexID, DefaultLogicalVertex> vertexRetriever) {
+
+		this.intermediateDataSet = checkNotNull(intermediateDataSet);
+		this.vertexRetriever = checkNotNull(vertexRetriever);
+	}
+
+	@Override
+	public IntermediateDataSetID getId() {
+		return intermediateDataSet.getId();
+	}
+
+	@Override
+	public ResultPartitionType getResultType() {
+		return intermediateDataSet.getResultType();
+	}
+
+	@Override
+	public DefaultLogicalVertex getProducer() {
+		return vertexRetriever.apply(intermediateDataSet.getProducer().getID());
+	}
+
+	@Override
+	public Iterable<DefaultLogicalVertex> getConsumers() {
+		return intermediateDataSet.getConsumers().stream()
+			.map(JobEdge::getTarget)
+			.map(JobVertex::getID)
+			.map(vertexRetriever)
+			.collect(Collectors.toList());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalTopology.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobgraph.topology;
+
+import org.apache.flink.runtime.executiongraph.failover.flip1.PipelinedRegionComputeUtil;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.util.IterableUtils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Default implementation of {@link LogicalTopology}.
+ * It is an adapter of {@link JobGraph}.
+ */
+public class DefaultLogicalTopology implements LogicalTopology<DefaultLogicalVertex, DefaultLogicalResult> {
+
+	private final boolean containsCoLocationConstraints;
+
+	private final List<DefaultLogicalVertex> verticesSorted;
+
+	private final Map<JobVertexID, DefaultLogicalVertex> idToVertexMap;
+
+	private final Map<IntermediateDataSetID, DefaultLogicalResult> idToResultMap;
+
+	public DefaultLogicalTopology(final JobGraph jobGraph) {
+		checkNotNull(jobGraph);
+
+		this.containsCoLocationConstraints = IterableUtils.toStream(jobGraph.getVertices())
+			.map(JobVertex::getCoLocationGroup)
+			.anyMatch(Objects::nonNull);
+
+		this.verticesSorted = new ArrayList<>(jobGraph.getNumberOfVertices());
+		this.idToVertexMap = new HashMap<>();
+		this.idToResultMap = new HashMap<>();
+
+		buildVerticesAndResults(jobGraph);
+	}
+
+	private void buildVerticesAndResults(final JobGraph jobGraph) {
+		final Function<JobVertexID, DefaultLogicalVertex> vertexRetriever = this::getVertex;
+		final Function<IntermediateDataSetID, DefaultLogicalResult> resultRetriever = this::getResult;
+
+		for (JobVertex jobVertex : jobGraph.getVerticesSortedTopologicallyFromSources()) {
+			final DefaultLogicalVertex logicalVertex = new DefaultLogicalVertex(jobVertex, resultRetriever);
+			this.verticesSorted.add(logicalVertex);
+			this.idToVertexMap.put(logicalVertex.getId(), logicalVertex);
+
+			for (IntermediateDataSet intermediateDataSet : jobVertex.getProducedDataSets()) {
+				final DefaultLogicalResult logicalResult = new DefaultLogicalResult(intermediateDataSet, vertexRetriever);
+				idToResultMap.put(logicalResult.getId(), logicalResult);
+			}
+		}
+	}
+
+	@Override
+	public Iterable<DefaultLogicalVertex> getVertices() {
+		return verticesSorted;
+	}
+
+	@Override
+	public boolean containsCoLocationConstraints() {
+		return containsCoLocationConstraints;
+	}
+
+	private DefaultLogicalVertex getVertex(final JobVertexID vertexId) {
+		return Optional.ofNullable(idToVertexMap.get(vertexId))
+			.orElseThrow(() -> new IllegalArgumentException("can not find vertex: " + vertexId));
+	}
+
+	private DefaultLogicalResult getResult(final IntermediateDataSetID resultId) {
+		return Optional.ofNullable(idToResultMap.get(resultId))
+			.orElseThrow(() -> new IllegalArgumentException("can not find result: " + resultId));
+	}
+
+	public Set<LogicalPipelinedRegion> getLogicalPipelinedRegions() {
+		final Set<Set<DefaultLogicalVertex>> regionsRaw = PipelinedRegionComputeUtil.computePipelinedRegions(this);
+
+		final Set<LogicalPipelinedRegion> regions = new HashSet<>();
+		for (Set<DefaultLogicalVertex> regionVertices : regionsRaw) {
+			regions.add(new LogicalPipelinedRegion(regionVertices));
+		}
+		return regions;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalVertex.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobgraph.topology;
+
+import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobEdge;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Default implementation of {@link LogicalVertex}.
+ * It is an adapter of {@link JobVertex}.
+ */
+public class DefaultLogicalVertex implements LogicalVertex<DefaultLogicalVertex, DefaultLogicalResult> {
+
+	private final JobVertex jobVertex;
+
+	private final Function<IntermediateDataSetID, DefaultLogicalResult> resultRetriever;
+
+	DefaultLogicalVertex(
+			final JobVertex jobVertex,
+			final Function<IntermediateDataSetID, DefaultLogicalResult> resultRetriever) {
+
+		this.jobVertex = checkNotNull(jobVertex);
+		this.resultRetriever = checkNotNull(resultRetriever);
+	}
+
+	@Override
+	public JobVertexID getId() {
+		return jobVertex.getID();
+	}
+
+	@Override
+	public Iterable<DefaultLogicalResult> getConsumedResults() {
+		return jobVertex.getInputs().stream()
+			.map(JobEdge::getSource)
+			.map(IntermediateDataSet::getId)
+			.map(resultRetriever)
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	public Iterable<DefaultLogicalResult> getProducedResults() {
+		return jobVertex.getProducedDataSets().stream()
+			.map(IntermediateDataSet::getId)
+			.map(resultRetriever)
+			.collect(Collectors.toList());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/LogicalPipelinedRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/LogicalPipelinedRegion.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.runtime.jobgraph.topology;
+
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Set of {@link LogicalVertex} that are connected through pipelined {@link LogicalResult}.
+ */
+public class LogicalPipelinedRegion {
+
+	private final Set<JobVertexID> vertexIDs;
+
+	public LogicalPipelinedRegion(final Set<? extends LogicalVertex<?, ?>> logicalVertices) {
+		checkNotNull(logicalVertices);
+
+		this.vertexIDs = logicalVertices.stream()
+			.map(LogicalVertex::getId)
+			.collect(Collectors.toSet());
+	}
+
+	public Set<JobVertexID> getVertexIDs() {
+		return vertexIDs;
+	}
+
+	@Override
+	public String toString() {
+		return "LogicalPipelinedRegion{" +
+			"vertexIDs=" + vertexIDs +
+			'}';
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/LogicalResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/LogicalResult.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobgraph.topology;
+
+import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.topology.Result;
+
+/**
+ * Represents a data set produced by a {@link LogicalVertex}, i.e. {@link IntermediateDataSet}.
+ */
+public interface LogicalResult<V extends LogicalVertex<V, R>, R extends LogicalResult<V, R>>
+	extends Result<JobVertexID, IntermediateDataSetID, V, R> {
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/LogicalTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/LogicalTopology.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobgraph.topology;
+
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.topology.Topology;
+
+/**
+ * Represents a logical topology, i.e. {@link JobGraph}.
+ */
+public interface LogicalTopology<V extends LogicalVertex<V, R>, R extends LogicalResult<V, R>>
+	extends Topology<JobVertexID, IntermediateDataSetID, V, R> {
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/LogicalVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/LogicalVertex.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobgraph.topology;
+
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.topology.Vertex;
+
+/**
+ * Represents a vertex in {@link LogicalTopology}, i.e. {@link JobVertex}.
+ */
+public interface LogicalVertex<V extends LogicalVertex<V, R>, R extends LogicalResult<V, R>>
+	extends Vertex<JobVertexID, IntermediateDataSetID, V, R> {
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalResultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalResultTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobgraph.topology;
+
+import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.util.IterableUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createNoOpVertex;
+import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.PIPELINED;
+import static org.apache.flink.runtime.jobgraph.DistributionPattern.ALL_TO_ALL;
+import static org.apache.flink.runtime.jobgraph.topology.DefaultLogicalVertexTest.assertVertexInfoEquals;
+import static org.apache.flink.runtime.jobgraph.topology.DefaultLogicalVertexTest.assertVerticesEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Unit tests for {@link DefaultLogicalResult}.
+ */
+public class DefaultLogicalResultTest extends TestLogger {
+
+	private IntermediateDataSet result;
+
+	private DefaultLogicalResult logicalResult;
+
+	private Map<JobVertexID, JobVertex> vertexMap;
+
+	private JobVertex producerVertex;
+
+	private Set<JobVertex> consumerVertices;
+
+	@Before
+	public void setUp() throws Exception {
+		buildVerticesAndResults();
+
+		logicalResult = new DefaultLogicalResult(
+			result,
+			vid -> new DefaultLogicalVertex(vertexMap.get(vid), rid -> null));
+	}
+
+	@Test
+	public void testConstructor() {
+		assertResultInfoEquals(result, logicalResult);
+	}
+
+	@Test
+	public void testGetProducer() {
+		assertVertexInfoEquals(producerVertex, logicalResult.getProducer());
+	}
+
+	@Test
+	public void testGetConsumers() {
+		assertVerticesEquals(consumerVertices, logicalResult.getConsumers());
+	}
+
+	private void buildVerticesAndResults() {
+		vertexMap = new HashMap<>();
+		consumerVertices = new HashSet<>();
+
+		final int parallelism = 3;
+		producerVertex = createNoOpVertex(parallelism);
+		vertexMap.put(producerVertex.getID(), producerVertex);
+
+		result = producerVertex.createAndAddResultDataSet(PIPELINED);
+
+		for (int i = 0; i < 5; i++) {
+			final JobVertex consumerVertex = createNoOpVertex(parallelism);
+			consumerVertex.connectDataSetAsInput(result, ALL_TO_ALL);
+			consumerVertices.add(consumerVertex);
+			vertexMap.put(consumerVertex.getID(), consumerVertex);
+		}
+	}
+
+	static void assertResultsEquals(
+		final Iterable<IntermediateDataSet> results,
+		final Iterable<DefaultLogicalResult> logicalResults) {
+
+		final Map<IntermediateDataSetID, DefaultLogicalResult> logicalResultMap = IterableUtils
+			.toStream(logicalResults)
+			.collect(Collectors.toMap(DefaultLogicalResult::getId, Function.identity()));
+
+		for (IntermediateDataSet result : results) {
+			final DefaultLogicalResult logicalResult = logicalResultMap.remove(result.getId());
+
+			assertNotNull(logicalResult);
+			assertResultInfoEquals(result, logicalResult);
+		}
+
+		// this ensures the two collections exactly matches
+		assertEquals(0, logicalResultMap.size());
+	}
+
+	static void assertResultInfoEquals(
+			final IntermediateDataSet result,
+			final DefaultLogicalResult logicalResult) {
+
+		assertEquals(result.getId(), logicalResult.getId());
+		assertEquals(result.getResultType(), logicalResult.getResultType());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalTopologyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalTopologyTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobgraph.topology;
+
+import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
+import org.apache.flink.runtime.jobgraph.JobEdge;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createNoOpVertex;
+import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.BLOCKING;
+import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.PIPELINED;
+import static org.apache.flink.runtime.jobgraph.DistributionPattern.ALL_TO_ALL;
+import static org.apache.flink.runtime.jobgraph.topology.DefaultLogicalResultTest.assertResultsEquals;
+import static org.apache.flink.runtime.jobgraph.topology.DefaultLogicalVertexTest.assertVertexInfoEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Unit tests for {@link DefaultLogicalTopology}.
+ */
+public class DefaultLogicalTopologyTest extends TestLogger {
+
+	private JobGraph jobGraph;
+
+	private DefaultLogicalTopology logicalTopology;
+
+	@Before
+	public void setUp() throws Exception {
+		jobGraph = createJobGraph(false);
+		logicalTopology = new DefaultLogicalTopology(jobGraph);
+	}
+
+	@Test
+	public void testGetVertices() {
+		// vertices from getVertices() should be topologically sorted
+		final Iterable<JobVertex> jobVertices = jobGraph.getVerticesSortedTopologicallyFromSources();
+		final Iterable<DefaultLogicalVertex> logicalVertices = logicalTopology.getVertices();
+
+		assertEquals(Iterables.size(jobVertices), Iterables.size(logicalVertices));
+
+		final Iterator<JobVertex> jobVertexIterator = jobVertices.iterator();
+		final Iterator<DefaultLogicalVertex> logicalVertexIterator = logicalVertices.iterator();
+		while (jobVertexIterator.hasNext()) {
+			assertVertexAndConnectedResultsEquals(jobVertexIterator.next(), logicalVertexIterator.next());
+		}
+	}
+
+	@Test
+	public void testWithCoLocationConstraints() {
+		final DefaultLogicalTopology topology = new DefaultLogicalTopology(createJobGraph(true));
+		assertTrue(topology.containsCoLocationConstraints());
+	}
+
+	@Test
+	public void testWithoutCoLocationConstraints() {
+		assertFalse(logicalTopology.containsCoLocationConstraints());
+	}
+
+	@Test
+	public void testGetLogicalPipelinedRegions() {
+		final Set<LogicalPipelinedRegion> regions = logicalTopology.getLogicalPipelinedRegions();
+		assertEquals(2, regions.size());
+	}
+
+	private JobGraph createJobGraph(final boolean containsCoLocationConstraint) {
+		final JobVertex[] jobVertices = new JobVertex[3];
+		final int parallelism = 3;
+		jobVertices[0] = createNoOpVertex("v1", parallelism);
+		jobVertices[1] = createNoOpVertex("v2", parallelism);
+		jobVertices[2] = createNoOpVertex("v3", parallelism);
+		jobVertices[1].connectNewDataSetAsInput(jobVertices[0], ALL_TO_ALL, PIPELINED);
+		jobVertices[2].connectNewDataSetAsInput(jobVertices[1], ALL_TO_ALL, BLOCKING);
+
+		if (containsCoLocationConstraint) {
+			final SlotSharingGroup slotSharingGroup = new SlotSharingGroup();
+			jobVertices[0].setSlotSharingGroup(slotSharingGroup);
+			jobVertices[1].setSlotSharingGroup(slotSharingGroup);
+
+			final CoLocationGroup coLocationGroup = new CoLocationGroup();
+			coLocationGroup.addVertex(jobVertices[0]);
+			coLocationGroup.addVertex(jobVertices[1]);
+			jobVertices[0].updateCoLocationGroup(coLocationGroup);
+			jobVertices[1].updateCoLocationGroup(coLocationGroup);
+		}
+
+		return new JobGraph(jobVertices);
+	}
+
+	private static void assertVertexAndConnectedResultsEquals(
+		final JobVertex jobVertex,
+		final DefaultLogicalVertex logicalVertex) {
+
+		assertVertexInfoEquals(jobVertex, logicalVertex);
+
+		final List<IntermediateDataSet> consumedResults = jobVertex.getInputs().stream()
+			.map(JobEdge::getSource)
+			.collect(Collectors.toList());
+		assertResultsEquals(consumedResults, logicalVertex.getConsumedResults());
+
+		final List<IntermediateDataSet> producedResults = jobVertex.getProducedDataSets();
+		assertResultsEquals(producedResults, logicalVertex.getProducedResults());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalVertexTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobgraph.topology;
+
+import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.util.IterableUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createNoOpVertex;
+import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.BLOCKING;
+import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.PIPELINED;
+import static org.apache.flink.runtime.jobgraph.DistributionPattern.ALL_TO_ALL;
+import static org.apache.flink.runtime.jobgraph.topology.DefaultLogicalResultTest.assertResultsEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Unit tests for {@link DefaultLogicalVertex}.
+ */
+public class DefaultLogicalVertexTest extends TestLogger {
+
+	private JobVertex jobVertex;
+
+	private DefaultLogicalVertex logicalVertex;
+
+	private Map<IntermediateDataSetID, IntermediateDataSet> resultMap;
+
+	private Set<IntermediateDataSet> consumedResults;
+
+	private Set<IntermediateDataSet> producedResults;
+
+	@Before
+	public void setUp() throws Exception {
+		buildVerticesAndResults();
+
+		logicalVertex = new DefaultLogicalVertex(
+			jobVertex,
+			rid -> new DefaultLogicalResult(resultMap.get(rid), vid -> null));
+	}
+
+	@Test
+	public void testConstructor() {
+		assertVertexInfoEquals(jobVertex, logicalVertex);
+	}
+
+	@Test
+	public void testGetConsumedResults() {
+		assertResultsEquals(consumedResults, logicalVertex.getConsumedResults());
+	}
+
+	@Test
+	public void testGetProducedResults() {
+		assertResultsEquals(producedResults, logicalVertex.getProducedResults());
+	}
+
+	private void buildVerticesAndResults() {
+		resultMap = new HashMap<>();
+		producedResults = new HashSet<>();
+		consumedResults = new HashSet<>();
+
+		final int parallelism = 3;
+		jobVertex = createNoOpVertex(parallelism);
+
+		for (int i = 0; i < 5; i++) {
+			final IntermediateDataSet producedDataSet = jobVertex.createAndAddResultDataSet(BLOCKING);
+			producedResults.add(producedDataSet);
+			resultMap.put(producedDataSet.getId(), producedDataSet);
+		}
+
+		final JobVertex upStreamJobVertex = createNoOpVertex(parallelism);
+		for (int i = 0; i < 5; i++) {
+			final IntermediateDataSet consumedDataSet = upStreamJobVertex.createAndAddResultDataSet(PIPELINED);
+			jobVertex.connectDataSetAsInput(consumedDataSet, ALL_TO_ALL);
+			consumedResults.add(consumedDataSet);
+			resultMap.put(consumedDataSet.getId(), consumedDataSet);
+		}
+	}
+
+	static void assertVerticesEquals(
+		final Iterable<JobVertex> jobVertices,
+		final Iterable<DefaultLogicalVertex> logicalVertices) {
+
+		final Map<JobVertexID, DefaultLogicalVertex> logicalVertextMap = IterableUtils
+			.toStream(logicalVertices)
+			.collect(Collectors.toMap(DefaultLogicalVertex::getId, Function.identity()));
+
+		for (JobVertex jobVertex : jobVertices) {
+			final DefaultLogicalVertex logicalVertex = logicalVertextMap.remove(jobVertex.getID());
+
+			assertNotNull(logicalVertex);
+			assertVertexInfoEquals(jobVertex, logicalVertex);
+		}
+
+		// this ensures the two collections exactly matches
+		assertEquals(0, logicalVertextMap.size());
+	}
+
+	static void assertVertexInfoEquals(
+		final JobVertex jobVertex,
+		final DefaultLogicalVertex logicalVertex) {
+
+		assertEquals(jobVertex.getID(), logicalVertex.getId());
+	}
+}


### PR DESCRIPTION

## What is the purpose of the change

Logical pipelined region partitioning is needed by FLINK-14060 to determine JobVertex slot sharing group.
We can leverage PipelinedRegionComputeUtil#computePipelinedRegions to do this by adapting JobGraph to a base Topology.

## Brief change log

  - *Introduced LogicalTopology which extends Topology*
  - *Introduced LogicalPipelinedRegion*
  - *Implemented DefaultLogicalTopology as an adapter of JobGraph to LogicalTopology*
  - *Added DefaultLogicalTopology#getLogicalPipelinedRegions to return the logical pipelined regions of a JobGraph*


## Verifying this change

This change added tests and can be verified as follows:
  - *Added tests for DefaultLogicalTopology/DefaultLogicalVertex/DefaultLogicalResult*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
