### PR TITLE
[FLINK-14060][runtime] Set slot sharing groups according to logical pipelined regions

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -114,8 +114,6 @@ public class StreamGraphGenerator {
 
 	private boolean chaining = true;
 
-	private boolean isSlotSharingEnabled = true;
-
 	private ScheduleMode scheduleMode = DEFAULT_SCHEDULE_MODE;
 
 	private Collection<Tuple2<String, DistributedCache.DistributedCacheEntry>> userArtifacts;
@@ -158,11 +156,6 @@ public class StreamGraphGenerator {
 
 	public StreamGraphGenerator setChaining(boolean chaining) {
 		this.chaining = chaining;
-		return this;
-	}
-
-	public StreamGraphGenerator setSlotSharingEnabled(boolean isSlotSharingEnabled) {
-		this.isSlotSharingEnabled = isSlotSharingEnabled;
 		return this;
 	}
 
@@ -749,10 +742,6 @@ public class StreamGraphGenerator {
 	 * @param inputIds The IDs of the input operations.
 	 */
 	private String determineSlotSharingGroup(String specifiedGroup, Collection<Integer> inputIds) {
-		if (!isSlotSharingEnabled) {
-			return null;
-		}
-
 		if (specifiedGroup != null) {
 			return specifiedGroup;
 		} else {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -118,10 +118,6 @@ public class StreamingJobGraphGenerator {
 	private final StreamGraphHasher defaultStreamGraphHasher;
 	private final List<StreamGraphHasher> legacyStreamGraphHashers;
 
-	private StreamingJobGraphGenerator(StreamGraph streamGraph) {
-		this(streamGraph, null);
-	}
-
 	private StreamingJobGraphGenerator(StreamGraph streamGraph, @Nullable JobID jobID) {
 		this.streamGraph = streamGraph;
 		this.defaultStreamGraphHasher = new StreamGraphHasherV2();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.api.graph;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.api.common.operators.ResourceSpec;
@@ -39,6 +40,8 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
+import org.apache.flink.runtime.jobgraph.topology.DefaultLogicalTopology;
+import org.apache.flink.runtime.jobgraph.topology.LogicalPipelinedRegion;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.operators.util.TaskConfig;
@@ -74,6 +77,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import static org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration.MINIMAL_CHECKPOINT_TIME;
 
@@ -596,25 +600,71 @@ public class StreamingJobGraphGenerator {
 	}
 
 	private void setSlotSharingAndCoLocation() {
-		final HashMap<String, SlotSharingGroup> slotSharingGroups = new HashMap<>();
-		final HashMap<String, Tuple2<SlotSharingGroup, CoLocationGroup>> coLocationGroups = new HashMap<>();
+		setSlotSharing();
+		setCoLocation();
+	}
+
+	private void setSlotSharing() {
+		final Map<String, SlotSharingGroup> specifiedSlotSharingGroups = new HashMap<>();
+		final Map<JobVertexID, SlotSharingGroup> vertexRegionSlotSharingGroups = buildVertexRegionSlotSharingGroups();
+
+		for (Entry<Integer, JobVertex> entry : jobVertices.entrySet()) {
+
+			final JobVertex vertex = entry.getValue();
+			final String slotSharingGroupKey = streamGraph.getStreamNode(entry.getKey()).getSlotSharingGroup();
+
+			final SlotSharingGroup effectiveSlotSharingGroup;
+			if (slotSharingGroupKey == null) {
+				effectiveSlotSharingGroup = null;
+			} else if (slotSharingGroupKey.equals(StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP)) {
+				// fallback to the region slot sharing group by default
+				effectiveSlotSharingGroup = vertexRegionSlotSharingGroups.get(vertex.getID());
+			} else {
+				effectiveSlotSharingGroup = specifiedSlotSharingGroups.computeIfAbsent(
+					slotSharingGroupKey, k -> new SlotSharingGroup());
+			}
+
+			vertex.setSlotSharingGroup(effectiveSlotSharingGroup);
+		}
+	}
+
+	/**
+	 * Maps a vertex to its region slot sharing group.
+	 * If {@link ExecutionConfig#isAllVerticesInSameSlotSharingGroupByDefault()}
+	 * returns true, all regions will be in the same slot sharing group.
+	 */
+	private Map<JobVertexID, SlotSharingGroup> buildVertexRegionSlotSharingGroups() {
+		final Map<JobVertexID, SlotSharingGroup> vertexRegionSlotSharingGroups = new HashMap<>();
+		final SlotSharingGroup defaultSlotSharingGroup = new SlotSharingGroup();
+
+		final boolean allRegionsInSameSlotSharingGroup = streamGraph.getExecutionConfig()
+			.isAllVerticesInSameSlotSharingGroupByDefault();
+
+		final Set<LogicalPipelinedRegion> regions = new DefaultLogicalTopology(jobGraph).getLogicalPipelinedRegions();
+		for (LogicalPipelinedRegion region : regions) {
+			final SlotSharingGroup regionSlotSharingGroup;
+			if (allRegionsInSameSlotSharingGroup) {
+				regionSlotSharingGroup = defaultSlotSharingGroup;
+			} else {
+				regionSlotSharingGroup = new SlotSharingGroup();
+			}
+
+			for (JobVertexID jobVertexID : region.getVertexIDs()) {
+				vertexRegionSlotSharingGroups.put(jobVertexID, regionSlotSharingGroup);
+			}
+		}
+
+		return vertexRegionSlotSharingGroups;
+	}
+
+	private void setCoLocation() {
+		final Map<String, Tuple2<SlotSharingGroup, CoLocationGroup>> coLocationGroups = new HashMap<>();
 
 		for (Entry<Integer, JobVertex> entry : jobVertices.entrySet()) {
 
 			final StreamNode node = streamGraph.getStreamNode(entry.getKey());
 			final JobVertex vertex = entry.getValue();
-
-			// configure slot sharing group
-			final String slotSharingGroupKey = node.getSlotSharingGroup();
-			final SlotSharingGroup sharingGroup;
-
-			if (slotSharingGroupKey != null) {
-				sharingGroup = slotSharingGroups.computeIfAbsent(
-						slotSharingGroupKey, (k) -> new SlotSharingGroup());
-				vertex.setSlotSharingGroup(sharingGroup);
-			} else {
-				sharingGroup = null;
-			}
+			final SlotSharingGroup sharingGroup = vertex.getSlotSharingGroup();
 
 			// configure co-location constraint
 			final String coLocationGroupKey = node.getCoLocationGroup();
@@ -624,7 +674,7 @@ public class StreamingJobGraphGenerator {
 				}
 
 				Tuple2<SlotSharingGroup, CoLocationGroup> constraint = coLocationGroups.computeIfAbsent(
-						coLocationGroupKey, (k) -> new Tuple2<>(sharingGroup, new CoLocationGroup()));
+						coLocationGroupKey, k -> new Tuple2<>(sharingGroup, new CoLocationGroup()));
 
 				if (constraint.f0 != sharingGroup) {
 					throw new IllegalStateException("Cannot co-locate operators from different slot sharing groups");

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -56,6 +56,7 @@ import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
 import org.apache.flink.streaming.api.transformations.ShuffleMode;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
+import org.apache.flink.streaming.runtime.partitioner.RebalancePartitioner;
 import org.apache.flink.streaming.runtime.partitioner.RescalePartitioner;
 import org.apache.flink.streaming.util.TestAnyModeReadingStreamOperator;
 import org.apache.flink.util.Collector;
@@ -72,6 +73,7 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
@@ -653,5 +655,87 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 			.print();
 
 		StreamingJobGraphGenerator.createJobGraph(env.getStreamGraph());
+	}
+
+	@Test
+	public void testSlotSharingOnAllVerticesInSameSlotSharingGroupByDefaultEnabled() {
+		final StreamGraph streamGraph = createStreamGraphForSlotSharingTest();
+		// specify slot sharing group for map1
+		streamGraph.getStreamNodes().stream()
+			.filter(n -> "map1".equals(n.getOperatorName()))
+			.findFirst()
+			.get()
+			.setSlotSharingGroup("testSlotSharingGroup");
+		streamGraph.getExecutionConfig().enableAllVerticesInSameSlotSharingGroupByDefault();
+		final JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);
+
+		final List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();
+		assertEquals(4, verticesSorted.size());
+
+		final JobVertex source1Vertex = verticesSorted.get(0);
+		final JobVertex source2Vertex = verticesSorted.get(1);
+		final JobVertex map1Vertex = verticesSorted.get(2);
+		final JobVertex map2Vertex = verticesSorted.get(3);
+
+		// all vertices should be in the same default slot sharing group
+		// except for map1 which has a specified slot sharing group
+		assertSameSlotSharingGroup(source1Vertex, source2Vertex, map2Vertex);
+		assertDistinctSharingGroups(source1Vertex, map1Vertex);
+	}
+
+	@Test
+	public void testSlotSharingOnAllVerticesInSameSlotSharingGroupByDefaultDisabled() {
+		final StreamGraph streamGraph = createStreamGraphForSlotSharingTest();
+		streamGraph.getExecutionConfig().disableAllVerticesInSameSlotSharingGroupByDefault();
+		final JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);
+
+		final List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();
+		assertEquals(4, verticesSorted.size());
+
+		final JobVertex source1Vertex = verticesSorted.get(0);
+		final JobVertex source2Vertex = verticesSorted.get(1);
+		final JobVertex map1Vertex = verticesSorted.get(2);
+		final JobVertex map2Vertex = verticesSorted.get(3);
+
+		// vertices in the same region should be in the same slot sharing group
+		assertSameSlotSharingGroup(source1Vertex, map1Vertex);
+
+		// vertices in different regions should be in different slot sharing groups
+		assertDistinctSharingGroups(source1Vertex, source2Vertex, map2Vertex);
+	}
+
+	/**
+	 * Create a StreamGraph as below.
+	 *
+	 * <p>source1 --(rebalance & pipelined)--> Map1
+	 *
+	 * <p>source2 --(rebalance & blocking)--> Map2
+	 */
+	private StreamGraph createStreamGraphForSlotSharingTest() {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		final DataStream<Integer> source1 = env.fromElements(1, 2, 3).name("source1");
+		source1.rebalance().map(v -> v).name("map1");
+
+		final DataStream<Integer> source2 = env.fromElements(4, 5, 6).name("source2");
+		final DataStream<Integer> partitioned = new DataStream<>(env, new PartitionTransformation<>(
+			source2.getTransformation(), new RebalancePartitioner<>(), ShuffleMode.BATCH));
+		partitioned.map(v -> v).name("map2");
+
+		return env.getStreamGraph();
+	}
+
+	private void assertSameSlotSharingGroup(JobVertex... vertices) {
+		for (int i = 0; i < vertices.length - 1; i++) {
+			assertEquals(vertices[i].getSlotSharingGroup(), vertices[i + 1].getSlotSharingGroup());
+		}
+	}
+
+	private void assertDistinctSharingGroups(JobVertex... vertices) {
+		for (int i = 0; i < vertices.length - 1; i++) {
+			for (int j = i + 1; j < vertices.length; j++) {
+				assertNotEquals(vertices[i].getSlotSharingGroup(), vertices[j].getSlotSharingGroup());
+			}
+		}
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/BatchAbstractTestBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/BatchAbstractTestBase.java
@@ -39,7 +39,7 @@ public class BatchAbstractTestBase {
 			new MiniClusterResourceConfiguration.Builder()
 					.setConfiguration(getConfiguration())
 					.setNumberTaskManagers(1)
-					.setNumberSlotsPerTaskManager(DEFAULT_PARALLELISM)
+					.setNumberSlotsPerTaskManager(DEFAULT_PARALLELISM * 2)
 					.build());
 
 	@ClassRule

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateITCaseBase.scala
@@ -328,6 +328,10 @@ abstract class AggregateITCaseBase(testName: String) extends BatchTestBase {
       "select f0, count(*) from TableName group by f0",
       Seq((1, 2L), (2, 2L), (3, 2L)) // count=>long
     )
+  }
+
+  @Test
+  def testGroupBy2(): Unit = {
     checkQuery(
       Seq(("a", 1, 0), ("b", 2, 4), ("a", 2, 3)),
       "select f0, min(f1), min(f2) from TableName group by f0",


### PR DESCRIPTION
## What is the purpose of the change

This PR is to set vertex slot sharing groups according to logical pipelined regions.
It is a pre-requisite of FLINK-14062: Set managed memory fractions according to slot sharing groups.
The changes are based on #9797 and #10006

The slot sharing group of a vertex is determined as:
- if a vertex slot sharing group is specified to be null, the slot sharing group is null
- if a vertex slot sharing group is specified to be a non-default value(the group name not "default"), it will be respected
- if a vertex slot sharing group is "default", it will be the slot sharing group of the vertex's logical pipelined region

The slot sharing group of a region is determined as:
- if allVerticesInSameSlotSharingGroupByDefault is true, all regions are in the same "default" slot sharing group
- if allVerticesInSameSlotSharingGroupByDefault is false, all regions will be in distinct slot sharing groups

## Brief change log

  - *set vertex slot sharing group according to its logical pipelined regions.*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests to verify slot sharing group assigning*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
