### PR TITLE
[FLINK-14267][table] Introduce RowCsvOutputFormat to new CSV module

### DIFF
--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowSerializationSchema.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowSerializationSchema.java
@@ -199,11 +199,11 @@ public final class CsvRowSerializationSchema implements SerializationSchema<Row>
 
 	// --------------------------------------------------------------------------------------------
 
-	private interface RuntimeConverter extends Serializable {
+	interface RuntimeConverter extends Serializable {
 		JsonNode convert(CsvMapper csvMapper, ContainerNode<?> container, Object obj);
 	}
 
-	private static RuntimeConverter createRowRuntimeConverter(RowTypeInfo rowTypeInfo, boolean isTopLevel) {
+	static RuntimeConverter createRowRuntimeConverter(RowTypeInfo rowTypeInfo, boolean isTopLevel) {
 		final TypeInformation[] fieldTypes = rowTypeInfo.getFieldTypes();
 		final String[] fieldNames = rowTypeInfo.getFieldNames();
 

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/RowCsvOutputFormat.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/RowCsvOutputFormat.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.csv;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.io.FileOutputFormat;
+import org.apache.flink.api.common.io.OutputFormat;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.formats.csv.CsvRowSerializationSchema.RuntimeConverter;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.SequenceWriter;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.csv.CsvSchema;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+
+import static org.apache.flink.formats.csv.CsvRowSerializationSchema.createRowRuntimeConverter;
+
+/**
+ * Row {@link OutputFormat} that serializes {@link Row}s to text. The output is structured by line
+ * delimiters and field delimiters as common in CSV files. Line delimiter separate records from
+ * each other ('\n' is common). Field delimiters separate fields within a record.
+ */
+public class RowCsvOutputFormat extends FileOutputFormat<Row> {
+
+	/** Runtime instance that performs the actual work. */
+	private final RuntimeConverter runtimeConverter;
+	private final CsvSchema csvSchema;
+
+	/** CsvMapper used to write {@link JsonNode} into bytes. */
+	private transient CsvMapper csvMapper;
+
+	/** Sequence writer used to write rows. It is configured by {@link CsvSchema}. */
+	private transient SequenceWriter sequenceWriter;
+
+	/** Reusable object node. */
+	private transient ObjectNode root;
+
+	/**
+	 * @param typeInfo Type information describing the input CSV data.
+	 * @param csvSchema Schema describing the input CSV data.
+	 * @param path output path.
+	 */
+	public RowCsvOutputFormat(
+			RowTypeInfo typeInfo,
+			CsvSchema csvSchema,
+			Path path) {
+		super(path);
+		this.runtimeConverter = createRowRuntimeConverter(typeInfo, true);
+		this.csvSchema = csvSchema;
+	}
+
+	@Override
+	public void open(int taskNumber, int numTasks) throws IOException {
+		super.open(taskNumber, numTasks);
+		this.csvMapper = new CsvMapper();
+		this.root = this.csvMapper.createObjectNode();
+		this.sequenceWriter = this.csvMapper.writer(this.csvSchema).writeValues(
+				new BufferedOutputStream(this.stream, 4096));
+	}
+
+	@Override
+	public void writeRecord(Row record) throws IOException {
+		this.runtimeConverter.convert(csvMapper, root, record);
+		this.sequenceWriter.write(root);
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (this.sequenceWriter != null) {
+			this.sequenceWriter.flush();
+			this.sequenceWriter.close();
+			this.sequenceWriter = null;
+		}
+		super.close();
+	}
+
+	@Override
+	public String toString() {
+		return "RowCsvOutputFormat{" +
+				"outputFilePath=" + outputFilePath +
+				", csvSchema=" + csvSchema +
+				'}';
+	}
+
+	/**
+	 * A builder for creating a {@link RowCsvOutputFormat}.
+	 */
+	@PublicEvolving
+	public static class Builder implements Serializable {
+
+		private final RowTypeInfo typeInfo;
+		private final Path path;
+		private CsvSchema csvSchema;
+
+		/**
+		 * Creates a {@link RowCsvOutputFormat} expecting the given {@link TypeInformation}
+		 * and given {@link Path}.
+		 *
+		 * @param typeInfo type information used to create output format.
+		 * @param path output path used to create output format.
+		 */
+		public Builder(TypeInformation<Row> typeInfo, Path path) {
+			Preconditions.checkNotNull(typeInfo, "Type information must not be null.");
+			Preconditions.checkNotNull(path, "Path must not be null.");
+
+			if (!(typeInfo instanceof RowTypeInfo)) {
+				throw new IllegalArgumentException("Row type information expected.");
+			}
+
+			this.typeInfo = (RowTypeInfo) typeInfo;
+			this.path = path;
+			this.csvSchema = CsvRowSchemaConverter.convert((RowTypeInfo) typeInfo);
+		}
+
+		public Builder setFieldDelimiter(char c) {
+			this.csvSchema = this.csvSchema.rebuild().setColumnSeparator(c).build();
+			return this;
+		}
+
+		public Builder setLineDelimiter(String delimiter) {
+			Preconditions.checkNotNull(delimiter, "Delimiter must not be null.");
+			if (!delimiter.equals("\n") && !delimiter.equals("\r") && !delimiter.equals("\r\n")) {
+				throw new IllegalArgumentException(
+						"Unsupported new line delimiter. Only \\n, \\r, or \\r\\n are supported.");
+			}
+			this.csvSchema = this.csvSchema.rebuild().setLineSeparator(delimiter).build();
+			return this;
+		}
+
+		public Builder setArrayElementDelimiter(String delimiter) {
+			Preconditions.checkNotNull(delimiter, "Delimiter must not be null.");
+			this.csvSchema = this.csvSchema.rebuild().setArrayElementSeparator(delimiter).build();
+			return this;
+		}
+
+		public Builder setQuoteCharacter(char c) {
+			this.csvSchema = this.csvSchema.rebuild().setQuoteChar(c).build();
+			return this;
+		}
+
+		public Builder setEscapeCharacter(char c) {
+			this.csvSchema = this.csvSchema.rebuild().setEscapeChar(c).build();
+			return this;
+		}
+
+		public Builder setNullLiteral(String s) {
+			this.csvSchema = this.csvSchema.rebuild().setNullValue(s).build();
+			return this;
+		}
+
+		public RowCsvOutputFormat build() {
+			return new RowCsvOutputFormat(
+					typeInfo,
+					csvSchema,
+					path);
+		}
+	}
+}

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/RowCsvOutputFormat.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/RowCsvOutputFormat.java
@@ -44,6 +44,10 @@ import static org.apache.flink.formats.csv.CsvRowSerializationSchema.createRowRu
  * Row {@link OutputFormat} that serializes {@link Row}s to text. The output is structured by line
  * delimiters and field delimiters as common in CSV files. Line delimiter separate records from
  * each other ('\n' is common). Field delimiters separate fields within a record.
+ *
+ * <p>These can be continuously improved in this csv output format:
+ * 1.Not support configure multi chars field delimiter.
+ * 2.Only support configure line delimiter: "\r" or "\n" or "\r\n".
  */
 public class RowCsvOutputFormat extends FileOutputFormat<Row> {
 

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/RowCsvOutputFormatTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/RowCsvOutputFormatTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.csv;
+
+import org.apache.flink.api.common.io.FileOutputFormat;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.types.Row;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+/**
+ * Tests for {@link RowCsvOutputFormat}.
+ */
+public class RowCsvOutputFormatTest {
+
+	private String path = null;
+
+	@Before
+	public void createFile() throws Exception {
+		path = File.createTempFile("csv_output_test_file", ".csv").getAbsolutePath();
+	}
+
+	@Test
+	public void test() throws Exception {
+		RowCsvOutputFormat.Builder builder = new RowCsvOutputFormat.Builder(
+				new RowTypeInfo(Types.STRING, Types.STRING, Types.INT),
+				new Path(path))
+				.setEscapeCharacter('*')
+				.setFieldDelimiter(';')
+				.setLineDelimiter("\r\n")
+				.setNullLiteral("null")
+				.setQuoteCharacter('#');
+		RowCsvOutputFormat csvOutputFormat = builder.build();
+		try {
+			csvOutputFormat.setWriteMode(FileSystem.WriteMode.OVERWRITE);
+			csvOutputFormat.setOutputDirectoryMode(FileOutputFormat.OutputDirectoryMode.PARONLY);
+			csvOutputFormat.open(0, 1);
+			csvOutputFormat.writeRecord(Row.of("One", null, 8));
+			csvOutputFormat.writeRecord(Row.of("123'4*", "123", 8));
+			csvOutputFormat.writeRecord(Row.of("a;b'c", "123", 8));
+			csvOutputFormat.writeRecord(Row.of("Two", null, 8));
+		} finally {
+			csvOutputFormat.close();
+		}
+
+		java.nio.file.Path p = Paths.get(path);
+		Assert.assertTrue(Files.exists(p));
+		Assert.assertEquals(
+				Arrays.asList(
+						"One;null;8",
+						"#123'4**#;#123#;8",
+						"#a;b'c#;#123#;8",
+						"Two;null;8"),
+				Files.readAllLines(Paths.get(path), StandardCharsets.UTF_8));
+
+		csvOutputFormat = builder.build();
+		try {
+			csvOutputFormat.setWriteMode(FileSystem.WriteMode.OVERWRITE);
+			csvOutputFormat.setOutputDirectoryMode(FileOutputFormat.OutputDirectoryMode.PARONLY);
+			csvOutputFormat.open(0, 1);
+			csvOutputFormat.writeRecord(Row.of("newV1", "newV1", 8));
+			csvOutputFormat.writeRecord(Row.of("newV2", "newV2", 8));
+		} finally {
+			csvOutputFormat.close();
+		}
+
+		Assert.assertEquals(
+				Arrays.asList("#newV1#;#newV1#;8", "#newV2#;#newV2#;8"),
+				Files.readAllLines(Paths.get(path), StandardCharsets.UTF_8));
+	}
+
+	@After
+	public void cleanUp() throws IOException {
+		Files.deleteIfExists(Paths.get(path));
+	}
+}


### PR DESCRIPTION
# What is the purpose of the change

Now, we have an old CSV, but that is not standard CSV support. we should support the RFC-compliant CSV format for table/sql.

## Verifying this change

RowCsvOutputFormatTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper:no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? JavaDocs
