### PR TITLE
[FLINK-14019][python] add support for managing environment and dependencies of Python UDF in Flink Python API

### DIFF
--- a/flink-python/bin/pyflink-udf-runner.sh
+++ b/flink-python/bin/pyflink-udf-runner.sh
@@ -20,12 +20,22 @@ python=${python:-python}
 
 if [[ "$FLINK_TESTING" = "1" ]]; then
     ACTUAL_FLINK_HOME=`cd $FLINK_HOME; pwd -P`
-    FLINK_SOURCE_ROOT_DIR=`cd $ACTUAL_FLINK_HOME/../../../../../; pwd`
+    FLINK_SOURCE_ROOT_DIR=`cd $ACTUAL_FLINK_HOME/../../../../; pwd`
     FLINK_PYTHON="${FLINK_SOURCE_ROOT_DIR}/flink-python"
-    if [[ ! -f "${FLINK_PYTHON}/pyflink/fn_execution/boot.py" ]]; then
-      # use pyflink source code to override the pyflink.zip in PYTHONPATH
-      # to ensure loading latest code
-      export PYTHONPATH="$FLINK_PYTHON:$PYTHONPATH"
+    if [[ -f "${FLINK_PYTHON}/pyflink/fn_execution/boot.py" ]]; then
+        # use pyflink source code to override the pyflink.zip in PYTHONPATH
+        # to ensure loading latest code
+        export PYTHONPATH="$FLINK_PYTHON:$PYTHONPATH"
+    fi
+fi
+
+if [[ "$_PYTHON_WORKING_DIR" != "" ]]; then
+    # set current working directory to $_PYTHON_WORKING_DIR
+    cd "$_PYTHON_WORKING_DIR"
+    if [[ "$python" == ${_PYTHON_WORKING_DIR}* ]]; then
+        # The file extracted from archives may not preserve its original permission.
+        # Set minimum execution permission to prevent from permission denied error.
+        chmod +x "$python"
     fi
 fi
 

--- a/flink-python/pyflink/common/dependency_manager.py
+++ b/flink-python/pyflink/common/dependency_manager.py
@@ -1,0 +1,89 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import json
+import os
+import uuid
+
+__all__ = ['DependencyManager']
+
+
+class DependencyManager(object):
+    """
+    Utility class for dependency management. The dependencies will be registered at the distributed
+    cache.
+    """
+
+    PYTHON_FILE_PREFIX = "python_file"
+    PYTHON_REQUIREMENTS_FILE_PREFIX = "python_requirements_file"
+    PYTHON_REQUIREMENTS_CACHE_PREFIX = "python_requirements_cache"
+    PYTHON_ARCHIVE_PREFIX = "python_archive"
+
+    PYTHON_FILES = "python.files"
+    PYTHON_REQUIREMENTS_FILE = "python.requirements-file"
+    PYTHON_REQUIREMENTS_CACHE = "python.requirements-cache"
+    PYTHON_ARCHIVES = "python.archives"
+    PYTHON_EXEC = "python.exec"
+
+    def __init__(self, config, j_env):
+        self._config = config
+        self._j_env = j_env
+        self._python_file_map = dict()  # type: dict[str, str]
+        self._archives_map = dict()  # type: dict[str, str]
+        self._counter = -1
+
+    def add_python_file(self, file_path):
+        file_key = self._generate_unique_file_key(self.PYTHON_FILE_PREFIX)
+        self._j_env.registerCachedFile(file_path, file_key)
+        self._python_file_map[file_key] = os.path.basename(file_path)
+        self._config.set_string(
+            self.PYTHON_FILES, json.dumps(self._python_file_map))
+
+    def set_python_requirements(self, requirements_file_path, requirements_cached_dir=None):
+        self._remove_cached_file_if_exists(self.PYTHON_REQUIREMENTS_FILE)
+        self._remove_cached_file_if_exists(self.PYTHON_REQUIREMENTS_CACHE)
+
+        file_key = self._generate_unique_file_key(self.PYTHON_REQUIREMENTS_FILE_PREFIX)
+        self._j_env.registerCachedFile(requirements_file_path, file_key)
+        self._config.set_string(self.PYTHON_REQUIREMENTS_FILE, file_key)
+        if requirements_cached_dir is not None:
+            file_key = self._generate_unique_file_key(self.PYTHON_REQUIREMENTS_CACHE_PREFIX)
+            self._j_env.registerCachedFile(requirements_cached_dir, file_key)
+            self._config.set_string(self.PYTHON_REQUIREMENTS_CACHE, file_key)
+
+    def add_python_archive(self, archive_path, target_dir=None):
+        file_key = self._generate_unique_file_key(self.PYTHON_ARCHIVE_PREFIX)
+        self._j_env.registerCachedFile(archive_path, file_key)
+        if target_dir is not None:
+            self._archives_map[file_key] = target_dir
+        else:
+            self._archives_map[file_key] = os.path.basename(archive_path)
+        self._config.set_string(self.PYTHON_ARCHIVES, json.dumps(self._archives_map))
+
+    def _generate_unique_file_key(self, config_key):
+        self._counter += 1
+        return "%s_%d_%s" % (config_key, self._counter, uuid.uuid4())
+
+    def _remove_cached_file_if_exists(self, config_key):
+        if self._config.contains_key(config_key):
+            file_key = self._config.get_string(config_key, "")
+            cached_files = self._j_env.getCachedFiles()
+            for key_file_tuple in cached_files:
+                if file_key == key_file_tuple.f0:
+                    cached_files.remove(key_file_tuple)
+                    break
+            self._config.remove_config(config_key)

--- a/flink-python/pyflink/common/tests/test_dependency_manager.py
+++ b/flink-python/pyflink/common/tests/test_dependency_manager.py
@@ -1,0 +1,153 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import json
+import re
+import unittest
+
+from pyflink.common import Configuration
+from pyflink.common.dependency_manager import DependencyManager
+from pyflink.java_gateway import get_gateway
+from pyflink.table import TableConfig
+from pyflink.testing.test_case_utils import PyFlinkTestCase
+
+
+def replace_uuid(input_obj):
+    if isinstance(input_obj, str):
+        return re.sub(r'[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}',
+                      '{uuid}', input_obj)
+    elif isinstance(input_obj, dict):
+        input_obj_copy = dict()
+        for key in input_obj:
+            input_obj_copy[replace_uuid(key)] = replace_uuid(input_obj[key])
+        return input_obj_copy
+
+
+class DependencyManagerTests(PyFlinkTestCase):
+
+    def setUp(self):
+        self.j_env = MockedJavaEnv()
+        self.config = Configuration()
+        self.dependency_manager = DependencyManager(self.config, self.j_env)
+
+    def test_add_python_file(self):
+        self.dependency_manager.add_python_file("tmp_dir/test_file1.py")
+        self.dependency_manager.add_python_file("tmp_dir/test_file2.py")
+        self.dependency_manager.add_python_file("tmp_dir/test_dir")
+
+        self.assertEqual(
+            {"python_file_0_{uuid}": "test_file1.py",
+             "python_file_1_{uuid}": "test_file2.py",
+             "python_file_2_{uuid}": "test_dir"},
+            json.loads(replace_uuid(self.config.to_dict()[DependencyManager.PYTHON_FILES])))
+        self.assertEqual(
+            {"python_file_0_{uuid}": "tmp_dir/test_file1.py",
+             "python_file_1_{uuid}": "tmp_dir/test_file2.py",
+             "python_file_2_{uuid}": "tmp_dir/test_dir"},
+            replace_uuid(self.j_env.to_dict()))
+
+    def test_set_python_requirements(self):
+        self.dependency_manager.set_python_requirements("tmp_dir/requirements.txt",
+                                                        "tmp_dir/cache_dir")
+
+        self.assertEqual(
+            "python_requirements_file_0_{uuid}",
+            replace_uuid(self.config.to_dict()[DependencyManager.PYTHON_REQUIREMENTS_FILE]))
+        self.assertEqual(
+            "python_requirements_cache_1_{uuid}",
+            replace_uuid(self.config.to_dict()[DependencyManager.PYTHON_REQUIREMENTS_CACHE]))
+        self.assertEqual(
+            {"python_requirements_file_0_{uuid}": "tmp_dir/requirements.txt",
+             "python_requirements_cache_1_{uuid}": "tmp_dir/cache_dir"},
+            replace_uuid(self.j_env.to_dict()))
+
+        # test single parameter and remove old requirements_dir setting
+        self.dependency_manager.set_python_requirements("tmp_dir/requirements.txt")
+
+        self.assertEqual(
+            "python_requirements_file_2_{uuid}",
+            replace_uuid(self.config.to_dict()[DependencyManager.PYTHON_REQUIREMENTS_FILE]))
+        self.assertNotIn(DependencyManager.PYTHON_REQUIREMENTS_CACHE, self.config.to_dict())
+        self.assertEqual(
+            {"python_requirements_file_2_{uuid}": "tmp_dir/requirements.txt"},
+            replace_uuid(self.j_env.to_dict()))
+
+    def test_add_python_archive(self):
+        self.dependency_manager.add_python_archive("tmp_dir/py27.zip")
+        self.dependency_manager.add_python_archive("tmp_dir/venv2.zip", "py37")
+
+        self.assertEqual(
+            {"python_archive_0_{uuid}": "py27.zip", "python_archive_1_{uuid}": "py37"},
+            json.loads(replace_uuid(self.config.to_dict()[DependencyManager.PYTHON_ARCHIVES])))
+        self.assertEqual(
+            {"python_archive_0_{uuid}": "tmp_dir/py27.zip",
+             "python_archive_1_{uuid}": "tmp_dir/venv2.zip"},
+            replace_uuid(self.j_env.to_dict()))
+
+    def test_set_get_python_executable(self):
+        table_config = TableConfig()
+        table_config.set_python_executable("/usr/bin/python3")
+
+        self.assertEqual(
+            "/usr/bin/python3",
+            table_config.get_python_executable())
+
+    def test_constant_consistency(self):
+        JDependencyInfo = get_gateway().jvm.org.apache.flink.python.env.PythonDependencyInfo
+        self.assertEqual(DependencyManager.PYTHON_REQUIREMENTS_CACHE,
+                         JDependencyInfo.PYTHON_REQUIREMENTS_CACHE)
+        self.assertEqual(DependencyManager.PYTHON_REQUIREMENTS_FILE,
+                         JDependencyInfo.PYTHON_REQUIREMENTS_FILE)
+        self.assertEqual(DependencyManager.PYTHON_ARCHIVES,
+                         JDependencyInfo.PYTHON_ARCHIVES)
+        self.assertEqual(DependencyManager.PYTHON_FILES, JDependencyInfo.PYTHON_FILES)
+        self.assertEqual(DependencyManager.PYTHON_EXEC, JDependencyInfo.PYTHON_EXEC)
+
+
+class Tuple2(object):
+
+    def __init__(self, f0, f1):
+        self.f0 = f0
+        self.f1 = f1
+
+
+class MockedJavaEnv(object):
+
+    def __init__(self):
+        self.result = []
+
+    def registerCachedFile(self, file_path, key):
+        self.result.append(Tuple2(key, file_path))
+
+    def getCachedFiles(self):
+        return self.result
+
+    def to_dict(self):
+        result = dict()
+        for item in self.result:
+            result[item.f0] = item.f1
+        return result
+
+
+if __name__ == "__main__":
+    try:
+        import xmlrunner
+
+        testRunner = xmlrunner.XMLTestRunner(output='target/test-reports')
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/flink-python/pyflink/fn_execution/boot.py
+++ b/flink-python/pyflink/fn_execution/boot.py
@@ -27,6 +27,7 @@ project. So we add a python implementation which will be used when the python wo
 process mode. It downloads and installs users' python artifacts, then launches the python SDK
 harness of Apache Beam.
 """
+import shlex
 import argparse
 import hashlib
 import os
@@ -43,30 +44,11 @@ from apache_beam.portability.api.beam_artifact_api_pb2 import (GetManifestReques
                                                                GetArtifactRequest)
 from apache_beam.portability.api.endpoints_pb2 import ApiServiceDescriptor
 
+from distutils.dist import Distribution
+
 from google.protobuf import json_format, text_format
 
-parser = argparse.ArgumentParser()
-
-parser.add_argument("--id", default="", help="Local identifier (required).")
-parser.add_argument("--logging_endpoint", default="",
-                    help="Logging endpoint (required).")
-parser.add_argument("--artifact_endpoint", default="",
-                    help="Artifact endpoint (required).")
-parser.add_argument("--provision_endpoint", default="",
-                    help="Provision endpoint (required).")
-parser.add_argument("--control_endpoint", default="",
-                    help="Control endpoint (required).")
-parser.add_argument("--semi_persist_dir", default="/tmp",
-                    help="Local semi-persistent directory (optional).")
-
-args = parser.parse_args()
-
-worker_id = args.id
-logging_endpoint = args.logging_endpoint
-artifact_endpoint = args.artifact_endpoint
-provision_endpoint = args.provision_endpoint
-control_endpoint = args.control_endpoint
-semi_persist_dir = args.semi_persist_dir
+from pkg_resources import get_distribution, parse_version
 
 
 def check_not_empty(check_str, error_message):
@@ -75,75 +57,202 @@ def check_not_empty(check_str, error_message):
         exit(1)
 
 
-check_not_empty(worker_id, "No id provided.")
-check_not_empty(logging_endpoint, "No logging endpoint provided.")
-check_not_empty(artifact_endpoint, "No artifact endpoint provided.")
-check_not_empty(provision_endpoint, "No provision endpoint provided.")
-check_not_empty(control_endpoint, "No control endpoint provided.")
+python_exec = sys.executable
 
-logging.info("Initializing python harness: %s" % " ".join(sys.argv))
+PYTHON_REQUIREMENTS_FILE = "_PYTHON_REQUIREMENTS_FILE"
+PYTHON_REQUIREMENTS_CACHE = "_PYTHON_REQUIREMENTS_CACHE"
+PYTHON_REQUIREMENTS_INSTALL_DIR = "_PYTHON_REQUIREMENTS_INSTALL_DIR"
 
-metadata = [("worker_id", worker_id)]
 
-# read job information from provision stub
-with grpc.insecure_channel(provision_endpoint) as channel:
-    client = ProvisionServiceStub(channel=channel)
-    info = client.GetProvisionInfo(GetProvisionInfoRequest(), metadata=metadata).info
-    options = json_format.MessageToJson(info.pipeline_options)
+def append_path_to_env(env, name, value):
+    if name in env:
+        env[name] = os.pathsep.join([value, env[name]])
+    else:
+        env[name] = value
 
-staged_dir = os.path.join(semi_persist_dir, "staged")
 
-# download files
-with grpc.insecure_channel(artifact_endpoint) as channel:
-    client = ArtifactRetrievalServiceStub(channel=channel)
-    # get file list via retrieval token
-    response = client.GetManifest(GetManifestRequest(retrieval_token=info.retrieval_token),
-                                  metadata=metadata)
-    artifacts = response.manifest.artifact
-    # download files and check hash values
-    for artifact in artifacts:
-        name = artifact.name
-        permissions = artifact.permissions
-        sha256 = artifact.sha256
-        file_path = os.path.join(staged_dir, name)
-        if os.path.exists(file_path):
-            with open(file_path, "rb") as f:
-                sha256obj = hashlib.sha256()
-                sha256obj.update(f.read())
-                hash_value = sha256obj.hexdigest()
-            if hash_value == sha256:
-                logging.info("The file: %s already exists and its sha256 hash value: %s is the "
-                             "same as the expected hash value, skipped." % (file_path, sha256))
-                continue
+def get_next_command(requirements_file):
+    line_continuation = None
+    while True:
+        text_line = requirements_file.readline()
+        if text_line:
+            if line_continuation is not None:
+                text_line = text_line.strip("\n\r")
             else:
-                os.remove(file_path)
-        if not os.path.exists(os.path.dirname(file_path)):
-            os.makedirs(os.path.dirname(file_path), 0o755)
-        stream = client.GetArtifact(
-            GetArtifactRequest(name=name, retrieval_token=info.retrieval_token), metadata=metadata)
-        with open(file_path, "wb") as f:
-            sha256obj = hashlib.sha256()
-            for artifact_chunk in stream:
-                sha256obj.update(artifact_chunk.data)
-                f.write(artifact_chunk.data)
-            hash_value = sha256obj.hexdigest()
-        if hash_value != sha256:
-            raise Exception("The sha256 hash value: %s of the downloaded file: %s is not the same"
-                            " as the expected hash value: %s" % (hash_value, file_path, sha256))
-        os.chmod(file_path, int(str(permissions), 8))
+                text_line = text_line.strip()
+            if text_line.startswith("#"):
+                continue
+            if line_continuation is not None:
+                text_line = line_continuation + text_line
+            if text_line.strip().endswith("\\"):
+                line_continuation = text_line
+                continue
+            if len(text_line.strip()) == 0:
+                continue
+            return shlex.split(text_line)
+        else:
+            return None
 
-os.environ["WORKER_ID"] = worker_id
-os.environ["PIPELINE_OPTIONS"] = options
-os.environ["SEMI_PERSISTENT_DIRECTORY"] = semi_persist_dir
-os.environ["LOGGING_API_SERVICE_DESCRIPTOR"] = text_format.MessageToString(
-    ApiServiceDescriptor(url=logging_endpoint))
-os.environ["CONTROL_API_SERVICE_DESCRIPTOR"] = text_format.MessageToString(
-    ApiServiceDescriptor(url=control_endpoint))
 
-env = dict(os.environ)
+def get_site_packages_paths(prefix):
+    install_obj = Distribution().get_command_obj('install', create=True)
+    install_obj.prefix = prefix
+    install_obj.finalize_options()
+    installed_dir = [install_obj.install_purelib]
+    if install_obj.install_purelib != install_obj.install_platlib:
+        installed_dir.append(install_obj.install_platlib)
+    return installed_dir
 
-if "FLINK_BOOT_TESTING" in os.environ and os.environ["FLINK_BOOT_TESTING"] == "1":
-    exit(0)
 
-call([sys.executable, "-m", "pyflink.fn_execution.sdk_worker_main"],
-     stdout=sys.stdout, stderr=sys.stderr, env=env)
+def get_prefix_option(requirements_install_path):
+    pip_version = get_distribution("pip").version
+    # since '--prefix' option is only supported for pip 8.0+, so here we fallback to
+    # use '--install-option' when the pip version is lower than 8.0.0.
+    if parse_version(pip_version) >= parse_version('8.0.0'):
+        return ["--prefix", requirements_install_path]
+    else:
+        return ['--install-option', '--prefix=' + requirements_install_path]
+
+
+def pip_install_requirements():
+    if (PYTHON_REQUIREMENTS_FILE in os.environ
+            and PYTHON_REQUIREMENTS_INSTALL_DIR in os.environ):
+        requirements_file_path = os.environ[PYTHON_REQUIREMENTS_FILE]
+        requirements_install_path = os.environ[PYTHON_REQUIREMENTS_INSTALL_DIR]
+        if PYTHON_REQUIREMENTS_CACHE in os.environ:
+            requirements_cache_path = os.environ[PYTHON_REQUIREMENTS_CACHE]
+        else:
+            requirements_cache_path = None
+
+        env = dict(os.environ)
+        installed_python_path = os.pathsep.join(get_site_packages_paths(requirements_install_path))
+        installed_python_script_path = os.path.join(requirements_install_path, "bin")
+        append_path_to_env(env, "PYTHONPATH", installed_python_path)
+        append_path_to_env(env, "PATH", installed_python_script_path)
+
+        with open(requirements_file_path, "r") as f:
+            user_args = get_next_command(f)
+            while user_args is not None:
+                pip_install_commands = [python_exec, "-m", "pip", "install", "--ignore-installed"]
+                pip_install_commands.extend(user_args)
+                pip_install_commands.extend(get_prefix_option(requirements_install_path))
+                if requirements_cache_path is not None:
+                    pip_install_commands.extend(["--find-links", requirements_cache_path])
+
+                logging.info("Run command: %s\n" % " ".join(pip_install_commands))
+                exit_code = call(
+                    pip_install_commands, stdout=sys.stdout, stderr=sys.stderr, env=env)
+                if exit_code > 0:
+                    raise Exception(
+                        "Run command: %s error! exit code: %d" %
+                        (" ".join(pip_install_commands), exit_code))
+
+                user_args = get_next_command(f)
+
+        os.environ["PYTHONPATH"] = env["PYTHONPATH"]
+        os.environ["PATH"] = env["PATH"]
+
+
+if __name__ == "__main__":
+    # print INFO and higher level messages
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--id", default="", help="Local identifier (required).")
+    parser.add_argument("--logging_endpoint", default="",
+                        help="Logging endpoint (required).")
+    parser.add_argument("--artifact_endpoint", default="",
+                        help="Artifact endpoint (required).")
+    parser.add_argument("--provision_endpoint", default="",
+                        help="Provision endpoint (required).")
+    parser.add_argument("--control_endpoint", default="",
+                        help="Control endpoint (required).")
+    parser.add_argument("--semi_persist_dir", default="/tmp",
+                        help="Local semi-persistent directory (optional).")
+
+    args = parser.parse_args()
+
+    worker_id = args.id
+    logging_endpoint = args.logging_endpoint
+    artifact_endpoint = args.artifact_endpoint
+    provision_endpoint = args.provision_endpoint
+    control_endpoint = args.control_endpoint
+    semi_persist_dir = args.semi_persist_dir
+
+    check_not_empty(worker_id, "No id provided.")
+    check_not_empty(logging_endpoint, "No logging endpoint provided.")
+    check_not_empty(artifact_endpoint, "No artifact endpoint provided.")
+    check_not_empty(provision_endpoint, "No provision endpoint provided.")
+    check_not_empty(control_endpoint, "No control endpoint provided.")
+
+    logging.info("Initializing python harness: %s" % " ".join(sys.argv))
+
+    metadata = [("worker_id", worker_id)]
+
+    # read job information from provision stub
+    with grpc.insecure_channel(provision_endpoint) as channel:
+        client = ProvisionServiceStub(channel=channel)
+        info = client.GetProvisionInfo(GetProvisionInfoRequest(), metadata=metadata).info
+        options = json_format.MessageToJson(info.pipeline_options)
+
+    staged_dir = os.path.join(semi_persist_dir, "staged")
+
+    # download files
+    with grpc.insecure_channel(artifact_endpoint) as channel:
+        client = ArtifactRetrievalServiceStub(channel=channel)
+        # get file list via retrieval token
+        response = client.GetManifest(GetManifestRequest(retrieval_token=info.retrieval_token),
+                                      metadata=metadata)
+        artifacts = response.manifest.artifact
+        # download files and check hash values
+        for artifact in artifacts:
+            name = artifact.name
+            permissions = artifact.permissions
+            sha256 = artifact.sha256
+            file_path = os.path.join(staged_dir, name)
+            if os.path.exists(file_path):
+                with open(file_path, "rb") as f:
+                    sha256obj = hashlib.sha256()
+                    sha256obj.update(f.read())
+                    hash_value = sha256obj.hexdigest()
+                if hash_value == sha256:
+                    logging.info("The file: %s already exists and its sha256 hash value: %s is the "
+                                 "same as the expected hash value, skipped." % (file_path, sha256))
+                    continue
+                else:
+                    os.remove(file_path)
+            if not os.path.exists(os.path.dirname(file_path)):
+                os.makedirs(os.path.dirname(file_path), 0o755)
+            stream = client.GetArtifact(
+                GetArtifactRequest(name=name, retrieval_token=info.retrieval_token),
+                metadata=metadata)
+            with open(file_path, "wb") as f:
+                sha256obj = hashlib.sha256()
+                for artifact_chunk in stream:
+                    sha256obj.update(artifact_chunk.data)
+                    f.write(artifact_chunk.data)
+                hash_value = sha256obj.hexdigest()
+            if hash_value != sha256:
+                raise Exception("The sha256 hash value: %s of the downloaded file: %s is not the"
+                                " same as the expected hash value: %s" %
+                                (hash_value, file_path, sha256))
+            os.chmod(file_path, int(str(permissions), 8))
+
+    pip_install_requirements()
+
+    os.environ["WORKER_ID"] = worker_id
+    os.environ["PIPELINE_OPTIONS"] = options
+    os.environ["SEMI_PERSISTENT_DIRECTORY"] = semi_persist_dir
+    os.environ["LOGGING_API_SERVICE_DESCRIPTOR"] = text_format.MessageToString(
+        ApiServiceDescriptor(url=logging_endpoint))
+    os.environ["CONTROL_API_SERVICE_DESCRIPTOR"] = text_format.MessageToString(
+        ApiServiceDescriptor(url=control_endpoint))
+
+    env = dict(os.environ)
+
+    if "FLINK_BOOT_TESTING" in os.environ and os.environ["FLINK_BOOT_TESTING"] == "1":
+        exit(0)
+
+    call([python_exec, "-m", "pyflink.fn_execution.sdk_worker_main"],
+         stdout=sys.stdout, stderr=sys.stderr, env=env)

--- a/flink-python/pyflink/fn_execution/tests/process_mode_test_data.py
+++ b/flink-python/pyflink/fn_execution/tests/process_mode_test_data.py
@@ -30,7 +30,7 @@ manifest = """
     }, {
       "name": "python-package1-0.0.0.tar.gz",
       "permissions": 444,
-      "sha256": "e9514d5dd605546c8b17fb4213e12c79a4369e7d20804ecb2e20e41e1d1d79e9"
+      "sha256": "52e324d57abe35c97ba85c6c8e01c575aec71d9f820577b1b2dfbcb9ca6c986c"
     }, {
       "name": "python-package2-0.0.0.tar.gz",
       "permissions": 444,
@@ -82,7 +82,7 @@ file_data["requirements.txt"] = """
 """
 file_data["python-package1-0.0.0.tar.gz"] = """
 {
-  "data": "H4sICNhVXl0C/2Rpc3QvcHl0aG9uLXBhY2thZ2UxLTAuMC4wLnRhcgDtmF2Pk0AUhrnmV0z2ajcRdoABkia9MH5nlW5sVi+MISMMOFm+AkMVf71TELsSm5baYjXnaZqZOQwl9Mz7zoGiEZ/zTCtocE9jZmhYl59r5ahgiWvbXes4bYtN0rUdimHZpkvk18IKNmziYgXZygTUlaAlQso3+TfEXxjfNk9Oi6IdN7m+kb79Ryh+m//bmxfaK+/54nj5dwjZmn/TtQf5d2zXUBCG/J+cN0zQkAqqvWNlxfNshgwdqx5N2QwN1ob6c0q7SNRlnaa0bGbozrvxFu899WWeMjk7ZpvQ41r+RDkcayylPNlEX/OAZdWD056yKih5Idqr9cHbhIooL9NNRAFOo/8u6vdRncWxxrMovz5Y/6P83zRNywX/P8P8h6xgWciyoPETnt1Xuvgq/tj/MTYG+XcsbIP/TwF4KPj/CP0fVBiOrv9MyyIY9A/1H9R/Z6b/5eLu7ZNny722/f31L4/9qn9imBbofwoqJupCLxp1p+Wr+ywKdVTluH22yAs/YSuWjFtpwIn1f1Bextf/xHVg/4f6H/hL+u92hSCKj3KNnfp3rcH7X9cy4P3vJHyQ1u6vrf2jKmjsf6p5EqI5agfyuYDJPm4H1SrzS7bi6yeANgjO8b/rv2iUSfRvkH7/JyZZHzdcE0P9Pwk8LfJSoDbhIs+TSlU3fb3tXmY0ZfOLwUq5eIR+dKv5gzMinoV93VhdXl2BSwAAAAAAAJwX3wEf81Z/ACgAAA=="
+  "data": "H4sICNefrV0C/2Rpc3QvcHl0aG9uLXBhY2thZ2UxLTAuMC4wLnRhcgDtmVtv2jAYhnPtX2H1CrRCY+ckIXEx7axuUA11u5imyICTRc1JiVnHfv1MKKWjYxwKEdPehws7xkmUfH5f+3PyqfqWpa1cjG5EKFnLbOvfhXFQTI3nOPPSdavS5Pa8nGMwy3Esi3ke9wyTObbnGNQxamBSKlFQavzUryG8ldG6frpbEGx4yNmDLMp/hPyP8b+6fNN613vdP1z8XdteG3+ug/17/F3Hcw1qIv5H54NUYiyUaH2SRRllaYeytkl6IpEdujI2yH2XapCQwSRJRDHt0OveZa//uUfeZonUvUO5bHo+0ZcoVo9bMhFRvGx9H41kWj447aUsR0WUq+pui8arWKggK5JliwGOo/95q79ovXi6/nfyf246Dof/n078fT9KI+X77Xx6BP83bX4Xf5NxT7dz7toO/L8OxjKgeTwpG+KcDpsdQjWFVJMipYI+o0MCk4X/t2UYtqI0yPabCHb3f861XcD/Ty/+Y5nLdCzT0dSPo/SmbKsf6un+b7KV+LsW4/D/OoC9w/930P9eGwM75//csrD+Q/6P/P/k9D/oX3988Wqw1bS/tf6tR+s/m3EG/ddBqXO9XKf15C8pP9k4HZBtBgzZaVW5vrfKcj+W32W82ygEB9D/Xu9+4/qfP9L/rBv0X1v87yONKRX61/qfzwqjIDzIPTbv/7or3/88i0H/tfBFW7s/s/avRInQH06ieEy7tDrQeYHUdRN7wP+n/vf62LOH/pld7f9xz7a5Pfufedy0oP86iJI8KxStAq6yLC4JWdbbVbWRikR2z1ZGytk5vauW3QdnBFE6XqwmykazCesAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOBw/AJw5CHBAFAAAA=="
 }
 """
 file_data["python-package2-0.0.0.tar.gz"] = """

--- a/flink-python/pyflink/fn_execution/tests/test_process_mode_boot.py
+++ b/flink-python/pyflink/fn_execution/tests/test_process_mode_boot.py
@@ -217,7 +217,7 @@ class PythonBootTests(PyFlinkTestCase):
     def test_install_requirements_without_cached_dir(self):
         requirements_txt_path = os.path.join(self.tmp_dir, "requirements_txt_" + str(uuid.uuid4()))
         with open(requirements_txt_path, 'w') as f:
-            f.write("cloudpickle\\ \n#test line continuation\n==1.2.2\npy4j==0.10.8.1")
+            f.write("#test line continuation\ncloudpickle\\\n==1.2.2\npy4j==0.10.8.1")
 
         self.env[PYTHON_REQUIREMENTS_FILE] = requirements_txt_path
         requirements_target_dir_path = \

--- a/flink-python/pyflink/fn_execution/tests/test_process_mode_boot.py
+++ b/flink-python/pyflink/fn_execution/tests/test_process_mode_boot.py
@@ -24,6 +24,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import uuid
 from stat import ST_MODE
 
 import grpc
@@ -37,8 +38,12 @@ from apache_beam.portability.api.beam_provision_api_pb2_grpc import (
 from concurrent import futures
 from google.protobuf import json_format
 
+from pyflink.fn_execution.boot import (PYTHON_REQUIREMENTS_FILE,
+                                       PYTHON_REQUIREMENTS_CACHE,
+                                       PYTHON_REQUIREMENTS_INSTALL_DIR)
 from pyflink.fn_execution.tests.process_mode_test_data import (manifest, file_data,
                                                                test_provision_info_json)
+from pyflink.java_gateway import get_gateway
 from pyflink.testing.test_case_utils import PyFlinkTestCase
 
 
@@ -94,11 +99,21 @@ class PythonBootTests(PyFlinkTestCase):
         self.env["FLINK_BOOT_TESTING"] = "1"
         self.env["FLINK_LOG_DIR"] = os.path.join(self.env["FLINK_HOME"], "log")
 
-        self.tmp_dir = None
+        self.tmp_dir = tempfile.mkdtemp(str(time.time()), dir=self.tempdir)
         # assume that this file is in flink-python source code directory.
         flink_python_source_root = os.path.dirname(
             os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
         self.runner_path = os.path.join(flink_python_source_root, "bin", "pyflink-udf-runner.sh")
+
+    def run_boot_py(self):
+        args = [self.runner_path, "--id", "1",
+                "--logging_endpoint", "localhost:0000",
+                "--artifact_endpoint", "localhost:%d" % self.artifact_port,
+                "--provision_endpoint", "localhost:%d" % self.provision_port,
+                "--control_endpoint", "localhost:0000",
+                "--semi_persist_dir", self.tmp_dir]
+
+        return subprocess.call(args, stdout=sys.stdout, stderr=sys.stderr, env=self.env)
 
     def check_downloaded_files(self, staged_dir, manifest):
         expected_files_info = json.loads(manifest)["manifest"]["artifact"]
@@ -120,46 +135,113 @@ class PythonBootTests(PyFlinkTestCase):
                     break
         self.assertEqual(checked, len(files))
 
+    def check_installed_files(self, prefix_dir, package_list):
+        from distutils.dist import Distribution
+        install_obj = Distribution().get_command_obj('install', create=True)
+        install_obj.prefix = prefix_dir
+        install_obj.finalize_options()
+        installed_dir = [install_obj.install_purelib]
+        if install_obj.install_purelib != install_obj.install_platlib:
+            installed_dir.append(install_obj.install_platlib)
+        for package_name in package_list:
+            self.assertTrue(any([os.path.exists(os.path.join(package_dir, package_name))
+                                 for package_dir in installed_dir]))
+
     def test_python_boot(self):
-        self.tmp_dir = tempfile.mkdtemp(str(time.time()))
-        print("Using %s as the semi_persist_dir." % self.tmp_dir)
 
-        args = [self.runner_path, "--id", "1",
-                "--logging_endpoint", "localhost:0000",
-                "--artifact_endpoint", "localhost:%d" % self.artifact_port,
-                "--provision_endpoint", "localhost:%d" % self.provision_port,
-                "--control_endpoint", "localhost:0000",
-                "--semi_persist_dir", self.tmp_dir]
-
-        exit_code = subprocess.call(args, stdout=sys.stdout, stderr=sys.stderr, env=self.env)
+        exit_code = self.run_boot_py()
         self.assertTrue(exit_code == 0, "the boot.py exited with non-zero code.")
         self.check_downloaded_files(os.path.join(self.tmp_dir, "staged"), manifest)
 
     def test_param_validation(self):
         args = [self.runner_path]
         exit_message = subprocess.check_output(args, env=self.env).decode("utf-8")
-        self.assertTrue(exit_message.endswith("No id provided.\n"))
+        self.assertIn("No id provided.", exit_message)
 
         args = [self.runner_path, "--id", "1"]
         exit_message = subprocess.check_output(args, env=self.env).decode("utf-8")
-        self.assertTrue(exit_message.endswith("No logging endpoint provided.\n"))
+        self.assertIn("No logging endpoint provided.", exit_message)
 
         args = [self.runner_path, "--id", "1", "--logging_endpoint", "localhost:0000"]
         exit_message = subprocess.check_output(args, env=self.env).decode("utf-8")
-        self.assertTrue(exit_message.endswith("No artifact endpoint provided.\n"))
+        self.assertIn("No artifact endpoint provided.", exit_message)
 
         args = [self.runner_path, "--id", "1",
                 "--logging_endpoint", "localhost:0000",
                 "--artifact_endpoint", "localhost:%d" % self.artifact_port]
         exit_message = subprocess.check_output(args, env=self.env).decode("utf-8")
-        self.assertTrue(exit_message.endswith("No provision endpoint provided.\n"))
+        self.assertIn("No provision endpoint provided.", exit_message)
 
         args = [self.runner_path, "--id", "1",
                 "--logging_endpoint", "localhost:0000",
                 "--artifact_endpoint", "localhost:%d" % self.artifact_port,
                 "--provision_endpoint", "localhost:%d" % self.provision_port]
         exit_message = subprocess.check_output(args, env=self.env).decode("utf-8")
-        self.assertTrue(exit_message.endswith("No control endpoint provided.\n"))
+        self.assertIn("No control endpoint provided.", exit_message)
+
+    def test_constant_consistency(self):
+        JProcessPythonEnvironmentManager = \
+            get_gateway().jvm.org.apache.flink.python.env.ProcessPythonEnvironmentManager
+        self.assertEqual(PYTHON_REQUIREMENTS_FILE,
+                         JProcessPythonEnvironmentManager.PYTHON_REQUIREMENTS_FILE)
+        self.assertEqual(PYTHON_REQUIREMENTS_CACHE,
+                         JProcessPythonEnvironmentManager.PYTHON_REQUIREMENTS_CACHE)
+        self.assertEqual(PYTHON_REQUIREMENTS_INSTALL_DIR,
+                         JProcessPythonEnvironmentManager.PYTHON_REQUIREMENTS_INSTALL_DIR)
+
+    def test_set_working_directory(self):
+        JProcessPythonEnvironmentManager = \
+            get_gateway().jvm.org.apache.flink.python.env.ProcessPythonEnvironmentManager
+
+        pyflink_dir = os.path.join(self.tmp_dir, "pyflink")
+        os.mkdir(pyflink_dir)
+        # just create an empty file
+        open(os.path.join(pyflink_dir, "__init__.py"), 'a').close()
+        fn_execution_dir = os.path.join(pyflink_dir, "fn_execution")
+        os.mkdir(fn_execution_dir)
+        open(os.path.join(fn_execution_dir, "__init__.py"), 'a').close()
+        with open(os.path.join(fn_execution_dir, "boot.py"), "w") as f:
+            f.write("import os\nimport sys\nsys.stdout.write(os.getcwd())")
+
+        # test if the name of working directory variable of udf runner is consist with
+        # ProcessPythonEnvironmentManager.
+        self.env[JProcessPythonEnvironmentManager.PYTHON_WORKING_DIR] = self.tmp_dir
+        self.env["python"] = sys.executable
+        args = [self.runner_path]
+        process_cwd = subprocess.check_output(args, env=self.env).decode("utf-8")
+
+        self.assertEqual(os.path.realpath(self.tmp_dir),
+                         process_cwd,
+                         "setting working directory variable is not work!")
+
+    def test_install_requirements_without_cached_dir(self):
+        requirements_txt_path = os.path.join(self.tmp_dir, "requirements_txt_" + str(uuid.uuid4()))
+        with open(requirements_txt_path, 'w') as f:
+            f.write("cloudpickle\\ \n#test line continuation\n==1.2.2\npy4j==0.10.8.1")
+
+        self.env[PYTHON_REQUIREMENTS_FILE] = requirements_txt_path
+        requirements_target_dir_path = \
+            os.path.join(self.tmp_dir, "requirements_target_dir_" + str(uuid.uuid4()))
+        self.env[PYTHON_REQUIREMENTS_INSTALL_DIR] = requirements_target_dir_path
+
+        exit_code = self.run_boot_py()
+        self.assertTrue(exit_code == 0, "the boot.py exited with non-zero code.")
+        self.check_installed_files(requirements_target_dir_path, ["cloudpickle", "py4j"])
+
+    def test_install_requirements_with_cached_dir(self):
+        requirements_txt_path = os.path.join(self.tmp_dir, "requirements_txt_" + str(uuid.uuid4()))
+        with open(requirements_txt_path, 'w') as f:
+            f.write("python-package1==0.0.0")
+
+        self.env[PYTHON_REQUIREMENTS_FILE] = requirements_txt_path
+        self.env[PYTHON_REQUIREMENTS_CACHE] = os.path.join(self.tmp_dir, "staged")
+        requirements_target_dir_path = \
+            os.path.join(self.tmp_dir, "requirements_target_dir_" + str(uuid.uuid4()))
+        self.env[PYTHON_REQUIREMENTS_INSTALL_DIR] = requirements_target_dir_path
+
+        exit_code = self.run_boot_py()
+        self.assertTrue(exit_code == 0, "the boot.py exited with non-zero code.")
+        self.check_installed_files(requirements_target_dir_path, ["python_package1"])
 
     def tearDown(self):
         self.artifact_server.stop(0)

--- a/flink-python/pyflink/table/table_config.py
+++ b/flink-python/pyflink/table/table_config.py
@@ -19,6 +19,7 @@
 from py4j.compat import long
 
 from pyflink.common import Configuration
+from pyflink.common.dependency_manager import DependencyManager
 from pyflink.java_gateway import get_gateway
 from pyflink.table import SqlDialect
 
@@ -274,6 +275,54 @@ class TableConfig(object):
         :type sql_dialect: SqlDialect
         """
         self._j_table_config.setSqlDialect(SqlDialect._to_j_sql_dialect(sql_dialect))
+
+    def set_python_executable(self, python_exec):
+        """
+        Sets the path of the python interpreter which is used to execute the python udf workers.
+
+        e.g. "/usr/local/bin/python3".
+
+        If python UDF depends on a specific python version which does not exist in the cluster,
+        the method :func:`pyflink.table.TableEnvironment.add_python_archive` can be used to upload
+        a virtual environment. The path of the python interpreter contained in the uploaded
+        environment can be specified via this method.
+
+        Example:
+        ::
+
+            # command executed in shell
+            # assume that the relative path of python interpreter is py_env/bin/python
+            $ zip -r py_env.zip py_env
+
+            # python code
+            >>> table_env.add_python_archive("py_env.zip")
+            >>> table_env.get_config().set_python_executable("py_env.zip/py_env/bin/python")
+
+        .. note::
+
+            Please make sure the uploaded python environment matches the platform that the cluster
+            is running on and that the python version must be 3.5 or higher.
+
+        .. note::
+
+            The python udf worker depends on Apache Beam (version == 2.15.0),
+            Pip (version >= 7.1.0) and SetupTools (version >= 37.0.0).
+            Please ensure that the specified environment meets the above requirements.
+
+        :param python_exec: The path of python interpreter.
+        :type python_exec: str
+        """
+        self.get_configuration().set_string(DependencyManager.PYTHON_EXEC, python_exec)
+
+    def get_python_executable(self):
+        """
+        Gets the path of the python interpreter which is used to execute the python udf workers.
+        If no path is specified before, it will return a None value.
+
+        :return: The path of the python interpreter which is used to execute the python udf workers.
+        :rtype: str
+        """
+        return self.get_configuration().get_string(DependencyManager.PYTHON_EXEC, None)
 
     @staticmethod
     def get_default():

--- a/flink-python/pyflink/table/tests/test_dependency.py
+++ b/flink-python/pyflink/table/tests/test_dependency.py
@@ -1,0 +1,186 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import json
+import os
+import shutil
+import sys
+import unittest
+import uuid
+
+from pyflink.table import DataTypes
+from pyflink.table.udf import udf
+from pyflink.testing import source_sink_utils
+from pyflink.testing.test_case_utils import (PyFlinkBlinkStreamTableTestCase,
+                                             PyFlinkBlinkBatchTableTestCase)
+
+
+class PyFlinkDependencyTests(object):
+
+    def test_add_python_file(self):
+        python_file_dir = os.path.join(self.tempdir, "python_file_dir_" + str(uuid.uuid4()))
+        os.mkdir(python_file_dir)
+        python_file_path = os.path.join(python_file_dir, "test_dependency_manage_lib.py")
+        with open(python_file_path, 'w') as f:
+            f.write("def add_two(a):\n    return a + 2")
+        self.t_env.add_python_file(python_file_path)
+
+        def plus_two(i):
+            from test_dependency_manage_lib import add_two
+            return add_two(i)
+
+        self.t_env.register_function("add_two", udf(plus_two, DataTypes.BIGINT(),
+                                                    DataTypes.BIGINT()))
+        table_sink = source_sink_utils.TestAppendSink(
+            ['a', 'b'], [DataTypes.BIGINT(), DataTypes.BIGINT()])
+        self.t_env.register_table_sink("Results", table_sink)
+        t = self.t_env.from_elements([(1, 2), (2, 5), (3, 1)], ['a', 'b'])
+        t.select("add_two(a), a").insert_into("Results")
+        self.t_env.execute("test")
+
+        actual = source_sink_utils.results()
+        self.assert_equals(actual, ["3,1", "4,2", "5,3"])
+
+
+class PyFlinkBatchDependencyTests(PyFlinkDependencyTests, PyFlinkBlinkBatchTableTestCase):
+
+    pass
+
+
+class PyFlinkStreamDependencyTests(PyFlinkDependencyTests, PyFlinkBlinkStreamTableTestCase):
+
+    def test_set_requirements_without_cached_directory(self):
+        requirements_txt_path = os.path.join(self.tempdir, str(uuid.uuid4()))
+        with open(requirements_txt_path, 'w') as f:
+            f.write("cloudpickle==1.2.2")
+        self.t_env.set_python_requirements(requirements_txt_path)
+
+        def check_requirements(i):
+            import cloudpickle
+            assert os.path.abspath(cloudpickle.__file__).startswith(
+                os.environ['_PYTHON_REQUIREMENTS_INSTALL_DIR'])
+            return i
+
+        self.t_env.register_function("check_requirements",
+                                     udf(check_requirements, DataTypes.BIGINT(),
+                                         DataTypes.BIGINT()))
+        table_sink = source_sink_utils.TestAppendSink(
+            ['a', 'b'], [DataTypes.BIGINT(), DataTypes.BIGINT()])
+        self.t_env.register_table_sink("Results", table_sink)
+        t = self.t_env.from_elements([(1, 2), (2, 5), (3, 1)], ['a', 'b'])
+        t.select("check_requirements(a), a").insert_into("Results")
+        self.t_env.execute("test")
+
+        actual = source_sink_utils.results()
+        self.assert_equals(actual, ["1,1", "2,2", "3,3"])
+
+    def test_set_requirements_with_cached_directory(self):
+        tmp_dir = self.tempdir
+        requirements_txt_path = os.path.join(tmp_dir, "requirements_txt_" + str(uuid.uuid4()))
+        with open(requirements_txt_path, 'w') as f:
+            f.write("python-package1==0.0.0")
+
+        requirements_dir_path = os.path.join(tmp_dir, "requirements_dir_" + str(uuid.uuid4()))
+        os.mkdir(requirements_dir_path)
+        package_file_name = "python-package1-0.0.0.tar.gz"
+        with open(os.path.join(requirements_dir_path, package_file_name), 'wb') as f:
+            from pyflink.fn_execution.tests.process_mode_test_data import file_data
+            import base64
+            f.write(base64.b64decode(json.loads(file_data[package_file_name])["data"]))
+        self.t_env.set_python_requirements(requirements_txt_path, requirements_dir_path)
+
+        def add_one(i):
+            from python_package1 import plus
+            return plus(i, 1)
+
+        self.t_env.register_function("add_one",
+                                     udf(add_one, DataTypes.BIGINT(),
+                                         DataTypes.BIGINT()))
+        table_sink = source_sink_utils.TestAppendSink(
+            ['a', 'b'], [DataTypes.BIGINT(), DataTypes.BIGINT()])
+        self.t_env.register_table_sink("Results", table_sink)
+        t = self.t_env.from_elements([(1, 2), (2, 5), (3, 1)], ['a', 'b'])
+        t.select("add_one(a), a").insert_into("Results")
+        self.t_env.execute("test")
+
+        actual = source_sink_utils.results()
+        self.assert_equals(actual, ["2,1", "3,2", "4,3"])
+
+    def test_add_python_archive(self):
+        tmp_dir = self.tempdir
+        archive_dir_path = os.path.join(tmp_dir, "archive_" + str(uuid.uuid4()))
+        os.mkdir(archive_dir_path)
+        with open(os.path.join(archive_dir_path, "data.txt"), 'w') as f:
+            f.write("2")
+        archive_file_path = \
+            shutil.make_archive(os.path.dirname(archive_dir_path), 'zip', archive_dir_path)
+        self.t_env.add_python_archive(archive_file_path, "data")
+
+        def add_from_file(i):
+            with open("data/data.txt", 'r') as f:
+                return i + int(f.read())
+
+        self.t_env.register_function("add_from_file",
+                                     udf(add_from_file, DataTypes.BIGINT(),
+                                         DataTypes.BIGINT()))
+        table_sink = source_sink_utils.TestAppendSink(
+            ['a', 'b'], [DataTypes.BIGINT(), DataTypes.BIGINT()])
+        self.t_env.register_table_sink("Results", table_sink)
+        t = self.t_env.from_elements([(1, 2), (2, 5), (3, 1)], ['a', 'b'])
+        t.select("add_from_file(a), a").insert_into("Results")
+        self.t_env.execute("test")
+
+        actual = source_sink_utils.results()
+        self.assert_equals(actual, ["3,1", "4,2", "5,3"])
+
+    def test_set_python_exec(self):
+        if getattr(os, "symlink", None) is None:
+            self.skipTest("Symbolic link is not supported, skip testing 'test_set_python_exec'...")
+
+        python_exec = sys.executable
+        tmp_dir = self.tempdir
+        python_exec_link_path = os.path.join(tmp_dir, "py_exec")
+        os.symlink(python_exec, python_exec_link_path)
+        self.t_env.get_config().set_python_executable(python_exec_link_path)
+
+        def check_python_exec(i):
+            import os
+            assert os.environ["python"] == python_exec_link_path
+            return i
+
+        self.t_env.register_function("check_python_exec",
+                                     udf(check_python_exec, DataTypes.BIGINT(),
+                                         DataTypes.BIGINT()))
+        table_sink = source_sink_utils.TestAppendSink(
+            ['a', 'b'], [DataTypes.BIGINT(), DataTypes.BIGINT()])
+        self.t_env.register_table_sink("Results", table_sink)
+        t = self.t_env.from_elements([(1, 2), (2, 5), (3, 1)], ['a', 'b'])
+        t.select("check_python_exec(a), a").insert_into("Results")
+        self.t_env.execute("test")
+
+        actual = source_sink_utils.results()
+        self.assert_equals(actual, ["1,1", "2,2", "3,3"])
+
+
+if __name__ == "__main__":
+    try:
+        import xmlrunner
+
+        testRunner = xmlrunner.XMLTestRunner(output='target/test-reports')
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonDriverEnvUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonDriverEnvUtils.java
@@ -36,7 +36,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.python.util.ResourceUtil.extractBasicDependenciesFromResource;
+import static org.apache.flink.python.util.ResourceUtil.extractBuiltInDependencies;
 
 /**
  * The util class help to prepare Python env and run the python process.
@@ -108,7 +108,7 @@ public final class PythonDriverEnvUtils {
 
 		pythonPathEnv.append(env.workingDirectory);
 
-		List<File> internalLibs = extractBasicDependenciesFromResource(
+		List<File> internalLibs = extractBuiltInDependencies(
 			tmpDir,
 			UUID.randomUUID().toString(),
 			true);

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonResourceExtractor.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonResourceExtractor.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.python.util.ResourceUtil.extractBasicDependenciesFromResource;
+import static org.apache.flink.python.util.ResourceUtil.extractBuiltInDependencies;
 
 /**
  * The program that extracts the internal python libraries and join their absolute paths to append to PYTHONPATH. it can
@@ -35,7 +35,7 @@ public class PythonResourceExtractor {
 	public static void main(String[] args) throws IOException, InterruptedException {
 		String tmpdir = System.getProperty("java.io.tmpdir");
 
-		List<File> files = extractBasicDependenciesFromResource(
+		List<File> files = extractBuiltInDependencies(
 			tmpdir,
 			UUID.randomUUID().toString(),
 			true);

--- a/flink-python/src/main/java/org/apache/flink/python/AbstractPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/python/AbstractPythonFunctionRunner.java
@@ -199,9 +199,7 @@ public abstract class AbstractPythonFunctionRunner<IN, OUT> implements PythonFun
 			jobBundleFactory = null;
 		}
 
-		if (environmentManager != null) {
-			environmentManager.close();
-		}
+		environmentManager.close();
 	}
 
 	@Override

--- a/flink-python/src/main/java/org/apache/flink/python/AbstractPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/python/AbstractPythonFunctionRunner.java
@@ -25,13 +25,10 @@ import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
-import org.apache.flink.python.util.ResourceUtil;
-import org.apache.flink.table.functions.python.PythonEnv;
+import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.util.Preconditions;
-import org.apache.flink.util.StringUtils;
 
 import org.apache.beam.model.pipeline.v1.RunnerApi;
-import org.apache.beam.runners.core.construction.Environments;
 import org.apache.beam.runners.core.construction.PipelineOptionsTranslation;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
 import org.apache.beam.runners.fnexecution.control.BundleProgressHandler;
@@ -50,17 +47,8 @@ import org.apache.beam.vendor.grpc.v1p21p0.com.google.protobuf.Struct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 /**
  * An base class for {@link PythonFunctionRunner}.
@@ -84,9 +72,9 @@ public abstract class AbstractPythonFunctionRunner<IN, OUT> implements PythonFun
 	private final FnDataReceiver<OUT> resultReceiver;
 
 	/**
-	 * The Python execution environment.
+	 * The Python execution environment manager.
 	 */
-	private final PythonEnv pythonEnv;
+	private final PythonEnvironmentManager environmentManager;
 
 	/**
 	 * The bundle factory which has all job-scoped information and can be used to create a {@link StageBundleFactory}.
@@ -102,17 +90,6 @@ public abstract class AbstractPythonFunctionRunner<IN, OUT> implements PythonFun
 	 * Handler for state requests.
 	 */
 	private final StateRequestHandler stateRequestHandler;
-
-	/**
-	 * Temporary directories to store the retrieval token.
-	 */
-	private final String[] tempDirs;
-
-	/**
-	 * The file of the retrieval token representing the entirety of the staged artifacts.
-	 * Used during requesting the manifest of a job in Beam portability framework.
-	 */
-	private transient File retrievalToken;
 
 	/**
 	 * Handler for bundle progress messages, both during bundle execution and on its completion.
@@ -172,14 +149,12 @@ public abstract class AbstractPythonFunctionRunner<IN, OUT> implements PythonFun
 	public AbstractPythonFunctionRunner(
 		String taskName,
 		FnDataReceiver<OUT> resultReceiver,
-		PythonEnv pythonEnv,
-		StateRequestHandler stateRequestHandler,
-		String[] tempDirs) {
+		PythonEnvironmentManager environmentManager,
+		StateRequestHandler stateRequestHandler) {
 		this.taskName = Preconditions.checkNotNull(taskName);
 		this.resultReceiver = Preconditions.checkNotNull(resultReceiver);
-		this.pythonEnv = Preconditions.checkNotNull(pythonEnv);
+		this.environmentManager = Preconditions.checkNotNull(environmentManager);
 		this.stateRequestHandler = Preconditions.checkNotNull(stateRequestHandler);
-		this.tempDirs = Preconditions.checkNotNull(tempDirs);
 	}
 
 	@Override
@@ -190,6 +165,9 @@ public abstract class AbstractPythonFunctionRunner<IN, OUT> implements PythonFun
 		baosWrapper = new DataOutputViewStreamWrapper(baos);
 		inputTypeSerializer = getInputTypeSerializer();
 		outputTypeSerializer = getOutputTypeSerializer();
+
+		// The creation of stageBundleFactory depends on the initialized environment manager.
+		environmentManager.open();
 
 		PortablePipelineOptions portableOptions =
 			PipelineOptionsFactory.as(PortablePipelineOptions.class);
@@ -204,13 +182,6 @@ public abstract class AbstractPythonFunctionRunner<IN, OUT> implements PythonFun
 
 	@Override
 	public void close() throws Exception {
-		try {
-			if (retrievalToken != null) {
-				retrievalToken.delete();
-			}
-		} finally {
-			retrievalToken = null;
-		}
 
 		try {
 			if (pythonInternalLibs != null) {
@@ -226,6 +197,10 @@ public abstract class AbstractPythonFunctionRunner<IN, OUT> implements PythonFun
 			}
 		} finally {
 			jobBundleFactory = null;
+		}
+
+		if (environmentManager != null) {
+			environmentManager.close();
 		}
 	}
 
@@ -283,73 +258,15 @@ public abstract class AbstractPythonFunctionRunner<IN, OUT> implements PythonFun
 	@VisibleForTesting
 	public JobBundleFactory createJobBundleFactory(Struct pipelineOptions) throws Exception {
 		return DefaultJobBundleFactory.create(
-			JobInfo.create(taskName, taskName, createEmptyRetrievalToken(), pipelineOptions));
-	}
-
-	private String createEmptyRetrievalToken() throws Exception {
-		// try to find a unique file name for the retrieval token
-		final Random rnd = new Random();
-		for (int attempt = 0; attempt < 10; attempt++) {
-			String directory = tempDirs[rnd.nextInt(tempDirs.length)];
-			retrievalToken = new File(directory, randomString(rnd) + ".json");
-			if (retrievalToken.createNewFile()) {
-				final DataOutputStream dos = new DataOutputStream(new FileOutputStream(retrievalToken));
-				dos.writeBytes("{\"manifest\": {}}");
-				dos.flush();
-				dos.close();
-				return retrievalToken.getAbsolutePath();
-			}
-		}
-
-		throw new IOException(
-			"Could not find a unique file name in '" + Arrays.toString(tempDirs) + "' for retrieval token.");
-	}
-
-	private static String randomString(Random random) {
-		final byte[] bytes = new byte[20];
-		random.nextBytes(bytes);
-		return StringUtils.byteToHexString(bytes);
+			JobInfo.create(taskName, taskName, environmentManager.createRetrievalToken(), pipelineOptions));
 	}
 
 	/**
 	 * Creates a specification which specifies the portability Python execution environment.
 	 * It's used by Beam's portability framework to creates the actual Python execution environment.
 	 */
-	protected RunnerApi.Environment createPythonExecutionEnvironment() {
-		if (pythonEnv.getExecType() == PythonEnv.ExecType.PROCESS) {
-			Random rnd = new Random();
-			String tmpdir = tempDirs[rnd.nextInt(tempDirs.length)];
-			String prefix = UUID.randomUUID().toString() + "_";
-			try {
-				pythonInternalLibs = ResourceUtil.extractBasicDependenciesFromResource(
-					tmpdir,
-					prefix,
-					false);
-			} catch (IOException | InterruptedException e) {
-				throw new RuntimeException(e);
-			}
-			String pythonWorkerCommand = null;
-			for (File file: pythonInternalLibs) {
-				file.deleteOnExit();
-				if (file.getName().endsWith("pyflink-udf-runner.sh")) {
-					pythonWorkerCommand = file.getAbsolutePath();
-					pythonInternalLibs.remove(file);
-					break;
-				}
-			}
-			// TODO: provide taskmanager log directory here
-			Map<String, String> env = appendEnvironmentVariable(
-				System.getenv(),
-				pythonInternalLibs.stream().map(File::getAbsolutePath).collect(Collectors.toList()));
-			return Environments.createProcessEnvironment(
-				"",
-				"",
-				pythonWorkerCommand,
-				env);
-		} else {
-			throw new UnsupportedOperationException(String.format(
-				"Execution type '%s' is not supported.", pythonEnv.getExecType()));
-		}
+	protected RunnerApi.Environment createPythonExecutionEnvironment() throws Exception {
+		return environmentManager.createEnvironment();
 	}
 
 	/**
@@ -357,7 +274,7 @@ public abstract class AbstractPythonFunctionRunner<IN, OUT> implements PythonFun
 	 * and all the other information needed to execute them, such as the execution environment, the input
 	 * and output coder, etc.
 	 */
-	public abstract ExecutableStage createExecutableStage();
+	public abstract ExecutableStage createExecutableStage() throws Exception;
 
 	/**
 	 * Returns the TypeSerializer for input elements.
@@ -369,30 +286,4 @@ public abstract class AbstractPythonFunctionRunner<IN, OUT> implements PythonFun
 	 */
 	public abstract TypeSerializer<OUT> getOutputTypeSerializer();
 
-	private static Map<String, String> appendEnvironmentVariable(
-			Map<String, String> systemEnv,
-			List<String> pythonDependencies) {
-		String logDir = null;
-		if (System.getProperty("log.file") != null) {
-			try {
-				logDir = new File(System.getProperty("log.file")).getParentFile().getAbsolutePath();
-			} catch (NullPointerException | SecurityException e) {
-				// the opertion may throw NPE and SecurityException.
-				LOG.warn("Can not get the log directory from property log.file.", e);
-			}
-		}
-
-		Map<String, String> result = new HashMap<>(systemEnv);
-		String pythonPath = String.join(File.pathSeparator, pythonDependencies);
-		if (systemEnv.get("PYTHONPATH") != null) {
-			pythonPath = String.join(File.pathSeparator, pythonPath, systemEnv.get("PYTHONPATH"));
-		}
-		result.put("PYTHONPATH", pythonPath);
-
-		if (logDir != null) {
-			result.put("FLINK_LOG_DIR", logDir);
-		}
-
-		return result;
-	}
 }

--- a/flink-python/src/main/java/org/apache/flink/python/env/ProcessPythonEnvironmentManager.java
+++ b/flink-python/src/main/java/org/apache/flink/python/env/ProcessPythonEnvironmentManager.java
@@ -1,0 +1,338 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.python.env;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.python.util.ResourceUtil;
+import org.apache.flink.python.util.ZipUtil;
+import org.apache.flink.util.FileUtils;
+import org.apache.flink.util.ShutdownHookUtil;
+
+import org.apache.flink.shaded.guava18.com.google.common.base.Strings;
+
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.runners.core.construction.Environments;
+import org.codehaus.commons.nullanalysis.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * The ProcessPythonEnvironmentManager is used to prepare the working dir of python UDF worker and create
+ * ProcessEnvironment object of Beam Fn API. It's used when the python function runner is configured to run python UDF
+ * in process mode.
+ */
+@Internal
+public final class ProcessPythonEnvironmentManager implements PythonEnvironmentManager {
+
+	private static final Logger LOG = LoggerFactory.getLogger(ProcessPythonEnvironmentManager.class);
+
+	@VisibleForTesting
+	public static final String PYTHON_REQUIREMENTS_FILE = "_PYTHON_REQUIREMENTS_FILE";
+	@VisibleForTesting
+	public static final String PYTHON_REQUIREMENTS_CACHE = "_PYTHON_REQUIREMENTS_CACHE";
+	@VisibleForTesting
+	public static final String PYTHON_REQUIREMENTS_INSTALL_DIR = "_PYTHON_REQUIREMENTS_INSTALL_DIR";
+	@VisibleForTesting
+	public static final String PYTHON_WORKING_DIR = "_PYTHON_WORKING_DIR";
+
+	@VisibleForTesting
+	static final String PYTHON_REQUIREMENTS_DIR = "python-requirements";
+	@VisibleForTesting
+	static final String PYTHON_ARCHIVES_DIR = "python-archives";
+	@VisibleForTesting
+	static final String PYTHON_FILES_DIR = "python-files";
+
+	private transient String baseDirectory;
+
+	/**
+	 * Directory for storing the installation result of the requirements file.
+	 */
+	private transient String requirementsDirectory;
+
+	/**
+	 * Directory for storing the extracted result of the archive files.
+	 */
+	private transient String archivesDirectory;
+
+	/**
+	 * Directory for storing the uploaded python files.
+	 */
+	private transient String filesDirectory;
+
+	private transient Thread shutdownHook;
+
+	@NotNull private final PythonDependencyInfo dependencyInfo;
+	@NotNull private final Map<String, String> systemEnv;
+	@NotNull private final String[] tmpDirectories;
+	@Nullable private final String logDirectory;
+
+	public ProcessPythonEnvironmentManager(
+		@NotNull PythonDependencyInfo dependencyInfo,
+		@NotNull String[] tmpDirectories,
+		@Nullable String logDirectory,
+		@NotNull Map<String, String> systemEnv) {
+		this.dependencyInfo = Objects.requireNonNull(dependencyInfo);
+		this.tmpDirectories = Objects.requireNonNull(tmpDirectories);
+		this.logDirectory = logDirectory;
+		this.systemEnv = Objects.requireNonNull(systemEnv);
+	}
+
+	@Override
+	public void open() throws Exception {
+		baseDirectory = createBaseDirectory(tmpDirectories);
+		archivesDirectory = String.join(File.separator, baseDirectory, PYTHON_ARCHIVES_DIR);
+		requirementsDirectory = String.join(File.separator, baseDirectory, PYTHON_REQUIREMENTS_DIR);
+		filesDirectory = String.join(File.separator, baseDirectory, PYTHON_FILES_DIR);
+
+		File baseDirectoryFile = new File(baseDirectory);
+		if (!baseDirectoryFile.exists() && !baseDirectoryFile.mkdir()) {
+			throw new IOException(
+				"Could not create the base directory: " + baseDirectory);
+		}
+		shutdownHook = ShutdownHookUtil.addShutdownHook(
+			this, ProcessPythonEnvironmentManager.class.getSimpleName(), LOG);
+	}
+
+	@Override
+	public void close() {
+		FileUtils.deleteDirectoryQuietly(new File(baseDirectory));
+		if (shutdownHook != null) {
+			ShutdownHookUtil.removeShutdownHook(
+				shutdownHook, ProcessPythonEnvironmentManager.class.getSimpleName(), LOG);
+			shutdownHook = null;
+		}
+	}
+
+	@Override
+	public RunnerApi.Environment createEnvironment() throws IOException, InterruptedException {
+		Map<String, String> env = constructEnvironmentVariables();
+		String pythonWorkerCommand = String.join(File.separator, baseDirectory, "pyflink-udf-runner.sh");
+
+		return Environments.createProcessEnvironment(
+			"",
+			"",
+			pythonWorkerCommand,
+			env);
+	}
+
+	/**
+	 * Returns an empty RetrievalToken because no files will be transmit via ArtifactService in process mode.
+	 *
+	 * @return The path of empty RetrievalToken.
+	 */
+	@Override
+	public String createRetrievalToken() throws IOException {
+		File retrievalToken = new File(baseDirectory,
+			"retrieval_token_" + UUID.randomUUID().toString() + ".json");
+		if (retrievalToken.createNewFile()) {
+			final DataOutputStream dos = new DataOutputStream(new FileOutputStream(retrievalToken));
+			dos.writeBytes("{\"manifest\": {}}");
+			dos.flush();
+			dos.close();
+			return retrievalToken.getAbsolutePath();
+		} else {
+			throw new IOException(
+				"Could not create the RetrievalToken file: " + retrievalToken.getAbsolutePath());
+		}
+	}
+
+	/**
+	 * Constructs the environment variables which is used to launch the python UDF worker.
+	 *
+	 * <p>To avoid unnecessary IO, the artifacts will not be transmitted via the ArtifactService of Beam when running in
+	 * process mode. Instead, the paths of the artifacts will be passed to the Python UDF worker directly.
+	 *
+	 * @return The environment variables which contain the paths of the python dependencies.
+	 */
+	@VisibleForTesting
+	Map<String, String> constructEnvironmentVariables()
+			throws IOException, IllegalArgumentException, InterruptedException {
+		Map<String, String> env = new HashMap<>(this.systemEnv);
+
+		constructBuiltInDependencies(env);
+
+		constructFilesDirectory(env);
+
+		constructArchivesDirectory(env);
+
+		constructRequirementsDirectory(env);
+
+		// set FLINK_LOG_DIR if the log directory exists
+		if (!Strings.isNullOrEmpty(logDirectory)) {
+			env.put("FLINK_LOG_DIR", logDirectory);
+		}
+
+		// set the path of python interpreter, it will be used to execute the udf worker.
+		if (dependencyInfo.getPythonExec().isPresent()) {
+			env.put("python", dependencyInfo.getPythonExec().get());
+			LOG.info("Python interpreter path: {}", dependencyInfo.getPythonExec());
+		}
+		return env;
+	}
+
+	private void constructBuiltInDependencies(Map<String, String> env) throws IOException, InterruptedException {
+		// Extract built-in python dependencies and udf runner script.
+		ResourceUtil.extractBuiltInDependencies(baseDirectory, "", false);
+
+		// add the built-in python dependencies to PYTHONPATH
+		List<String> builtInDependencies = Arrays.stream(ResourceUtil.BUILT_IN_PYTHON_DEPENDENCIES)
+			.filter(file -> file.endsWith(".zip"))
+			.map(file -> String.join(File.separator, baseDirectory, file))
+			.collect(Collectors.toList());
+		appendToPythonPath(env, builtInDependencies);
+	}
+
+	private void constructFilesDirectory(Map<String, String> env) throws IOException {
+		// link or copy python files to filesDirectory and add them to PYTHONPATH
+		List<String> pythonFilePaths = new ArrayList<>();
+		for (Map.Entry<String, String> entry : dependencyInfo.getPythonFiles().entrySet()) {
+			// The origin file name will be wiped when downloaded from the distributed cache, restore the origin name to
+			// make sure the python files could be imported.
+			// The path of the restored python file will be as following:
+			// ${baseDirectory}/${PYTHON_FILES_DIR}/${distributedCacheFileName}/${originFileName}
+			String distributedCacheFileName = new File(entry.getKey()).getName();
+			String originFileName = entry.getValue();
+
+			Path target = FileSystems.getDefault().getPath(filesDirectory, distributedCacheFileName, originFileName);
+			if (!target.getParent().toFile().mkdirs()) {
+				throw new IOException(
+					String.format("Could not create the directory: %s !", target.getParent().toString()));
+			}
+			Path src = FileSystems.getDefault().getPath(entry.getKey());
+			try {
+				Files.createSymbolicLink(target, src);
+			} catch (IOException e) {
+				LOG.warn(String.format(
+					"Could not create the symbolic link of: %s, the link path is %s, fallback to copy.", src, target),
+					e);
+				FileUtils.copy(
+					new org.apache.flink.core.fs.Path(src.toUri()),
+					new org.apache.flink.core.fs.Path(target.toUri()), false);
+			}
+
+			File pythonFile = new File(entry.getKey());
+			String pythonPath;
+			if (pythonFile.isFile() && originFileName.endsWith(".py")) {
+				// If the python file is file with suffix .py, add the parent directory to PYTHONPATH.
+				pythonPath = String.join(File.separator, filesDirectory, distributedCacheFileName);
+			} else {
+				pythonPath = String.join(File.separator, filesDirectory, distributedCacheFileName, originFileName);
+			}
+			pythonFilePaths.add(pythonPath);
+		}
+		appendToPythonPath(env, pythonFilePaths);
+		LOG.info("PYTHONPATH of python worker: {}", env.get("PYTHONPATH"));
+	}
+
+	private void constructArchivesDirectory(Map<String, String> env) throws IOException {
+		if (!dependencyInfo.getArchives().isEmpty()) {
+			// set the archives directory as the working directory, then user could access the content of the archives
+			// via relative path
+			env.put(PYTHON_WORKING_DIR, archivesDirectory);
+			LOG.info("Python working dir of python worker: {}", archivesDirectory);
+
+			// extract archives to archives directory
+			for (Map.Entry<String, String> entry : dependencyInfo.getArchives().entrySet()) {
+				ZipUtil.extractZipFileWithPermissions(
+					entry.getKey(), String.join(File.separator, archivesDirectory, entry.getValue()));
+			}
+		}
+	}
+
+	private void constructRequirementsDirectory(Map<String, String> env) throws IOException {
+		// set the requirements file and the dependencies specified by the requirements file will be installed in
+		// boot.py during initialization
+		if (dependencyInfo.getRequirementsFilePath().isPresent()) {
+			File requirementsDirectoryFile = new File(requirementsDirectory);
+			if (!requirementsDirectoryFile.mkdirs()) {
+				throw new IOException(
+					String.format("Creating the requirements target directory: %s failed!", requirementsDirectory));
+			}
+
+			env.put(PYTHON_REQUIREMENTS_FILE, dependencyInfo.getRequirementsFilePath().get());
+			LOG.info("Requirements.txt of python worker: {}", dependencyInfo.getRequirementsFilePath().get());
+
+			if (dependencyInfo.getRequirementsCacheDir().isPresent()) {
+				env.put(PYTHON_REQUIREMENTS_CACHE, dependencyInfo.getRequirementsCacheDir().get());
+				LOG.info("Requirements cache dir of python worker: {}", dependencyInfo.getRequirementsCacheDir().get());
+			}
+
+			// the dependencies specified by the requirements file will be installed into this directory, and will be
+			// added to PYTHONPATH in boot.py
+			env.put(PYTHON_REQUIREMENTS_INSTALL_DIR, requirementsDirectory);
+			LOG.info("Requirements install directory of python worker: {}", requirementsDirectory);
+		}
+	}
+
+	@VisibleForTesting
+	String getBaseDirectory() {
+		return baseDirectory;
+	}
+
+	private static void appendToPythonPath(Map<String, String> env, List<String> pythonDependencies) {
+		if (pythonDependencies.isEmpty()) {
+			return;
+		}
+
+		String pythonDependencyPath = String.join(File.pathSeparator, pythonDependencies);
+		String pythonPath = env.get("PYTHONPATH");
+		if (Strings.isNullOrEmpty(pythonPath)) {
+			env.put("PYTHONPATH", pythonDependencyPath);
+		} else {
+			env.put("PYTHONPATH", String.join(File.pathSeparator, pythonDependencyPath, pythonPath));
+		}
+	}
+
+	private static String createBaseDirectory(String[] tmpDirectories) throws IOException {
+		Random rnd = new Random();
+		// try to find a unique file name for the base directory
+		int maxAttempts = 10;
+		for (int attempt = 0; attempt < maxAttempts; attempt++) {
+			String directory = tmpDirectories[rnd.nextInt(tmpDirectories.length)];
+			File baseDirectory = new File(directory, "python-dist-" + UUID.randomUUID().toString());
+			if (baseDirectory.mkdirs()) {
+				return baseDirectory.getAbsolutePath();
+			}
+		}
+
+		throw new IOException(
+			"Could not find a unique directory name in '" + Arrays.toString(tmpDirectories) +
+				"' for storing the generated files of python dependency.");
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/python/env/PythonDependencyInfo.java
+++ b/flink-python/src/main/java/org/apache/flink/python/env/PythonDependencyInfo.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.python.env;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.cache.DistributedCache;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * PythonDependencyInfo contains the information of third-party dependencies.
+ */
+@Internal
+public final class PythonDependencyInfo {
+
+	public static final String PYTHON_FILES = "python.files";
+	public static final String PYTHON_REQUIREMENTS_FILE = "python.requirements-file";
+	public static final String PYTHON_REQUIREMENTS_CACHE = "python.requirements-cache";
+	public static final String PYTHON_ARCHIVES = "python.archives";
+	public static final String PYTHON_EXEC = "python.exec";
+
+	/**
+	 * The python files uploaded by TableEnvironment#add_python_file() or command line option "-pyfs". The key is the
+	 * path of the python file and the value is the corresponding origin file name.
+	 */
+	@Nonnull private final Map<String, String> pythonFiles;
+
+	/**
+	 * The path of the requirements file specified by TableEnvironment#set_python_requirements() or command line option
+	 * "-pyreq".
+	 */
+	@Nullable private final String requirementsFilePath;
+
+	/**
+	 * The path of the requirements cached directory uploaded by TableEnvironment#set_python_requirements() or command
+	 * line option "-pyreq". It is used to support installing python packages offline.
+	 */
+	@Nullable private final String requirementsCacheDir;
+
+	/**
+	 * The python archives uploaded by TableEnvironment#add_python_archive() or command line option "-pyarch". The key
+	 * is the path of the archive file and the value is the name of the directory to extract to.
+	 */
+	@Nonnull private final Map<String, String> archives;
+
+	/**
+	 * The path of the python interpreter (e.g. /usr/local/bin/python) specified by
+	 * pyflink.table.TableConfig#set_python_executable() or command line option "-pyexec".
+	 */
+	@Nullable private final String pythonExec;
+
+	public PythonDependencyInfo(
+		@Nonnull Map<String, String> pythonFiles,
+		@Nullable String requirementsFilePath,
+		@Nullable String requirementsCacheDir,
+		@Nonnull Map<String, String> archives,
+		@Nullable String pythonExec) {
+		this.pythonFiles = Objects.requireNonNull(pythonFiles);
+		this.requirementsFilePath = requirementsFilePath;
+		this.requirementsCacheDir = requirementsCacheDir;
+		this.pythonExec = pythonExec;
+		this.archives = Objects.requireNonNull(archives);
+	}
+
+	public Map<String, String> getPythonFiles() {
+		return pythonFiles;
+	}
+
+	public Optional<String> getRequirementsFilePath() {
+		return Optional.ofNullable(requirementsFilePath);
+	}
+
+	public Optional<String> getRequirementsCacheDir() {
+		return Optional.ofNullable(requirementsCacheDir);
+	}
+
+	public Optional<String> getPythonExec() {
+		return Optional.ofNullable(pythonExec);
+	}
+
+	public Map<String, String> getArchives() {
+		return archives;
+	}
+
+	/**
+	 * Creates PythonDependencyInfo from GlobalJobParameters and DistributedCache.
+	 *
+	 * @param globalJobParameters The parameter map which contains information of python dependency.
+	 * @param distributedCache The DistributedCache object of current task.
+	 * @return The PythonDependencyInfo object that contains whole information of python dependency.
+	 */
+	public static PythonDependencyInfo create(
+		Map<String, String> globalJobParameters, DistributedCache distributedCache)
+		throws IOException {
+		ObjectMapper mapper = new ObjectMapper();
+
+		Map<String, String> pythonFiles = new HashMap<>();
+		if (globalJobParameters.containsKey(PYTHON_FILES)) {
+			Map<String, String> filesIdToFilesName =
+				mapper.readValue(globalJobParameters.get(PYTHON_FILES), HashMap.class);
+			for (Map.Entry<String, String> entry: filesIdToFilesName.entrySet()) {
+				File pythonFile = distributedCache.getFile(entry.getKey());
+				String filePath = pythonFile.getAbsolutePath();
+				pythonFiles.put(filePath, entry.getValue());
+			}
+		}
+
+		String requirementsFilePath = null;
+		String requirementsCacheDir = null;
+		if (globalJobParameters.containsKey(PYTHON_REQUIREMENTS_FILE)) {
+			requirementsFilePath = distributedCache.getFile(
+				globalJobParameters.get(PYTHON_REQUIREMENTS_FILE)).getAbsolutePath();
+			if (globalJobParameters.containsKey(PYTHON_REQUIREMENTS_CACHE)) {
+				requirementsCacheDir = distributedCache.getFile(
+					globalJobParameters.get(PYTHON_REQUIREMENTS_CACHE)).getAbsolutePath();
+			}
+		}
+
+		Map<String, String> archives = new HashMap<>();
+		if (globalJobParameters.containsKey(PYTHON_ARCHIVES)) {
+			Map<String, String> archivesMap =
+				mapper.readValue(globalJobParameters.get(PYTHON_ARCHIVES), HashMap.class);
+
+			for (Map.Entry<String, String> entry: archivesMap.entrySet()) {
+				String archiveFilePath = distributedCache.getFile(entry.getKey()).getAbsolutePath();
+				String targetPath = entry.getValue();
+				archives.put(archiveFilePath, targetPath);
+			}
+		}
+
+		String pythonExec = globalJobParameters.get(PYTHON_EXEC);
+
+		return new PythonDependencyInfo(
+			pythonFiles,
+			requirementsFilePath,
+			requirementsCacheDir,
+			archives,
+			pythonExec);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/python/env/PythonEnvironmentManager.java
+++ b/flink-python/src/main/java/org/apache/flink/python/env/PythonEnvironmentManager.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.python.env;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+
+/**
+ * The base interface of python environment manager which is used to create the Environment object and the
+ * RetrievalToken of Beam Fn API.
+ */
+@Internal
+public interface PythonEnvironmentManager extends AutoCloseable {
+
+	/**
+	 * Initialize the environment manager.
+	 */
+	void open() throws Exception;
+
+	/**
+	 * Creates the Environment object used in Apache Beam Fn API.
+	 *
+	 * @return The Environment object which represents the environment(process, docker, etc) the python worker would run
+	 *         in.
+	 */
+	RunnerApi.Environment createEnvironment() throws Exception;
+
+	/**
+	 * Creates the RetrievalToken used in Apache Beam Fn API. It contains a list of files which need to transmit through
+	 * ArtifactService provided by Apache Beam.
+	 *
+	 * @return The path of the RetrievalToken file.
+	 */
+	String createRetrievalToken() throws Exception;
+}

--- a/flink-python/src/main/java/org/apache/flink/python/util/ResourceUtil.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/ResourceUtil.java
@@ -31,19 +31,19 @@ import java.util.List;
  */
 public class ResourceUtil {
 
-	public static final String[] PYTHON_BASIC_DEPENDENCIES = {
+	public static final String[] BUILT_IN_PYTHON_DEPENDENCIES = {
 		"pyflink.zip",
 		"py4j-0.10.8.1-src.zip",
 		"cloudpickle-1.2.2-src.zip",
 		"pyflink-udf-runner.sh"
 	};
 
-	public static List<File> extractBasicDependenciesFromResource(
+	public static List<File> extractBuiltInDependencies(
 			String tmpdir,
 			String prefix,
 			boolean skipShellScript) throws IOException, InterruptedException {
 		List<File> extractedFiles = new ArrayList<>();
-		for (String fileName : PYTHON_BASIC_DEPENDENCIES) {
+		for (String fileName : BUILT_IN_PYTHON_DEPENDENCIES) {
 			if (skipShellScript && fileName.endsWith(".sh")) {
 				continue;
 			}
@@ -77,7 +77,7 @@ public class ResourceUtil {
 
 	/**
 	 * This main method is used to create the shell script in a subprocess, see the "TODO" hints in method
-	 * {@link ResourceUtil#extractBasicDependenciesFromResource}.
+	 * {@link ResourceUtil#extractBuiltInDependencies}.
 	 * @param args First argument is the directory where shell script will be created. Second argument is the prefix of
 	 *             the shell script. Third argument is the fileName of the shell script.
 	 * @throws IOException

--- a/flink-python/src/main/java/org/apache/flink/python/util/ZipUtil.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/ZipUtil.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.python.util;
+
+import org.apache.flink.util.IOUtils;
+import org.apache.flink.util.OperatingSystem;
+
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Utils used to extract zip files and try to restore the origin permissions of files.
+ */
+public class ZipUtil {
+
+	public static void extractZipFileWithPermissions(String zipFilePath, String targetPath) throws IOException {
+		try (ZipFile zipFile = new ZipFile(zipFilePath)) {
+			Enumeration<ZipArchiveEntry> entries = zipFile.getEntries();
+			boolean isUnix = isUnix();
+
+			while (entries.hasMoreElements()) {
+				ZipArchiveEntry entry = entries.nextElement();
+				File file;
+				if (entry.isDirectory()) {
+					file = new File(targetPath, entry.getName());
+					if (!file.exists()) {
+						if (!file.mkdirs()) {
+							throw new IOException("Create dir: " + file.getAbsolutePath() + "failed!");
+						}
+					}
+				} else {
+					file = new File(targetPath, entry.getName());
+					File parentDir = file.getParentFile();
+					if (!parentDir.exists()) {
+						if (!parentDir.mkdirs()) {
+							throw new IOException("Create dir: " + file.getAbsolutePath() + "failed!");
+						}
+					}
+					if (file.createNewFile()) {
+						OutputStream output = new FileOutputStream(file);
+						IOUtils.copyBytes(zipFile.getInputStream(entry), output);
+					} else {
+						throw new IOException("Create file: " + file.getAbsolutePath() + "failed!");
+					}
+				}
+				if (isUnix) {
+					int mode = entry.getUnixMode();
+					if (mode != 0) {
+						Path path = Paths.get(file.toURI());
+						Set<PosixFilePermission> permissions = new HashSet<>();
+						addIfBitSet(mode, 8, permissions, PosixFilePermission.OWNER_READ);
+						addIfBitSet(mode, 7, permissions, PosixFilePermission.OWNER_WRITE);
+						addIfBitSet(mode, 6, permissions, PosixFilePermission.OWNER_EXECUTE);
+						addIfBitSet(mode, 5, permissions, PosixFilePermission.GROUP_READ);
+						addIfBitSet(mode, 4, permissions, PosixFilePermission.GROUP_WRITE);
+						addIfBitSet(mode, 3, permissions, PosixFilePermission.GROUP_EXECUTE);
+						addIfBitSet(mode, 2, permissions, PosixFilePermission.OTHERS_READ);
+						addIfBitSet(mode, 1, permissions, PosixFilePermission.OTHERS_WRITE);
+						addIfBitSet(mode, 0, permissions, PosixFilePermission.OTHERS_EXECUTE);
+						Files.setPosixFilePermissions(path, permissions);
+					}
+				}
+			}
+		}
+	}
+
+	private static boolean isUnix() {
+		return OperatingSystem.isLinux() ||
+			OperatingSystem.isMac() ||
+			OperatingSystem.isFreeBSD() ||
+			OperatingSystem.isSolaris();
+	}
+
+	private static void addIfBitSet(
+		int mode,
+		int pos,
+		Set<PosixFilePermission> posixFilePermissions,
+		PosixFilePermission posixFilePermissionToAdd) {
+		if ((mode & 1L << pos) != 0L) {
+			posixFilePermissions.add(posixFilePermissionToAdd);
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/AbstractPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/AbstractPythonScalarFunctionOperator.java
@@ -20,15 +20,18 @@ package org.apache.flink.table.runtime.operators.python;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.python.PythonFunctionRunner;
+import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.streaming.api.operators.python.AbstractPythonFunctionOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.functions.python.PythonEnv;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.stream.Collectors;
@@ -146,13 +149,21 @@ public abstract class AbstractPythonScalarFunctionOperator<IN, OUT, UDFIN, UDFOU
 	}
 
 	@Override
-	public PythonFunctionRunner<IN> createPythonFunctionRunner() {
+	public PythonEnv getPythonEnv() {
+		return scalarFunctions[0].getPythonFunction().getPythonEnv();
+	}
+
+	@Override
+	public PythonFunctionRunner<IN> createPythonFunctionRunner() throws IOException {
 		final FnDataReceiver<UDFOUT> udfResultReceiver = input -> {
 			// handover to queue, do not block the result receiver thread
 			udfResultQueue.put(input);
 		};
 
-		return new ProjectUdfInputPythonScalarFunctionRunner(createPythonFunctionRunner(udfResultReceiver));
+		return new ProjectUdfInputPythonScalarFunctionRunner(
+			createPythonFunctionRunner(
+				udfResultReceiver,
+				createPythonEnvironmentManager()));
 	}
 
 	/**
@@ -163,7 +174,9 @@ public abstract class AbstractPythonScalarFunctionOperator<IN, OUT, UDFIN, UDFOU
 
 	public abstract UDFIN getUdfInput(IN element);
 
-	public abstract PythonFunctionRunner<UDFIN> createPythonFunctionRunner(FnDataReceiver<UDFOUT> resultReceiver);
+	public abstract PythonFunctionRunner<UDFIN> createPythonFunctionRunner(
+			FnDataReceiver<UDFOUT> resultReceiver,
+			PythonEnvironmentManager pythonEnvironmentManager);
 
 	private class ProjectUdfInputPythonScalarFunctionRunner implements PythonFunctionRunner<IN> {
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonScalarFunctionOperator.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.runtime.operators.python;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.python.PythonFunctionRunner;
+import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.dataformat.BaseRow;
@@ -113,15 +114,16 @@ public class BaseRowPythonScalarFunctionOperator
 	}
 
 	@Override
-	public PythonFunctionRunner<BaseRow> createPythonFunctionRunner(FnDataReceiver<BaseRow> resultReceiver) {
+	public PythonFunctionRunner<BaseRow> createPythonFunctionRunner(
+			FnDataReceiver<BaseRow> resultReceiver,
+			PythonEnvironmentManager pythonEnvironmentManager) {
 		return new BaseRowPythonScalarFunctionRunner(
 			getRuntimeContext().getTaskName(),
 			resultReceiver,
 			scalarFunctions,
-			scalarFunctions[0].getPythonFunction().getPythonEnv(),
+			pythonEnvironmentManager,
 			udfInputType,
-			udfOutputType,
-			getContainingTask().getEnvironment().getTaskManagerInfo().getTmpDirectories());
+			udfOutputType);
 	}
 
 	private Projection<BaseRow, BinaryRow> createUdfInputProjection() {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperator.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.python.PythonFunctionRunner;
+import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
@@ -106,15 +107,16 @@ public class PythonScalarFunctionOperator extends AbstractPythonScalarFunctionOp
 	}
 
 	@Override
-	public PythonFunctionRunner<Row> createPythonFunctionRunner(FnDataReceiver<Row> resultReceiver) {
+	public PythonFunctionRunner<Row> createPythonFunctionRunner(
+			FnDataReceiver<Row> resultReceiver,
+			PythonEnvironmentManager pythonEnvironmentManager) {
 		return new PythonScalarFunctionRunner(
 			getRuntimeContext().getTaskName(),
 			resultReceiver,
 			scalarFunctions,
-			scalarFunctions[0].getPythonFunction().getPythonEnv(),
+			pythonEnvironmentManager,
 			udfInputType,
-			udfOutputType,
-			getContainingTask().getEnvironment().getTaskManagerInfo().getTmpDirectories());
+			udfOutputType);
 	}
 
 	/**

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/AbstractPythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/AbstractPythonScalarFunctionRunner.java
@@ -23,8 +23,8 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.python.AbstractPythonFunctionRunner;
 import org.apache.flink.python.PythonFunctionRunner;
+import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.table.functions.ScalarFunction;
-import org.apache.flink.table.functions.python.PythonEnv;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.runtime.typeutils.PythonTypeUtils;
 import org.apache.flink.table.types.logical.RowType;
@@ -78,11 +78,10 @@ public abstract class AbstractPythonScalarFunctionRunner<IN, OUT> extends Abstra
 		String taskName,
 		FnDataReceiver<OUT> resultReceiver,
 		PythonFunctionInfo[] scalarFunctions,
-		PythonEnv pythonEnv,
+		PythonEnvironmentManager environmentManager,
 		RowType inputType,
-		RowType outputType,
-		String[] tempDirs) {
-		super(taskName, resultReceiver, pythonEnv, StateRequestHandler.unsupported(), tempDirs);
+		RowType outputType) {
+		super(taskName, resultReceiver, environmentManager, StateRequestHandler.unsupported());
 		this.scalarFunctions = Preconditions.checkNotNull(scalarFunctions);
 		this.inputType = Preconditions.checkNotNull(inputType);
 		this.outputType = Preconditions.checkNotNull(outputType);
@@ -104,7 +103,7 @@ public abstract class AbstractPythonScalarFunctionRunner<IN, OUT> extends Abstra
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public ExecutableStage createExecutableStage() {
+	public ExecutableStage createExecutableStage() throws Exception {
 		RunnerApi.Components components =
 			RunnerApi.Components.newBuilder()
 				.putPcollections(

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/BaseRowPythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/BaseRowPythonScalarFunctionRunner.java
@@ -20,9 +20,9 @@ package org.apache.flink.table.runtime.runners.python;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.python.PythonFunctionRunner;
+import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.functions.ScalarFunction;
-import org.apache.flink.table.functions.python.PythonEnv;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.runtime.typeutils.BaseRowSerializer;
 import org.apache.flink.table.runtime.typeutils.PythonTypeUtils;
@@ -41,11 +41,10 @@ public class BaseRowPythonScalarFunctionRunner extends AbstractPythonScalarFunct
 		String taskName,
 		FnDataReceiver<BaseRow> resultReceiver,
 		PythonFunctionInfo[] scalarFunctions,
-		PythonEnv pythonEnv,
+		PythonEnvironmentManager environmentManager,
 		RowType inputType,
-		RowType outputType,
-		String[] tempDirs) {
-		super(taskName, resultReceiver, scalarFunctions, pythonEnv, inputType, outputType, tempDirs);
+		RowType outputType) {
+		super(taskName, resultReceiver, scalarFunctions, environmentManager, inputType, outputType);
 	}
 
 	@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/PythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/PythonScalarFunctionRunner.java
@@ -21,8 +21,8 @@ package org.apache.flink.table.runtime.runners.python;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.java.typeutils.runtime.RowSerializer;
 import org.apache.flink.python.PythonFunctionRunner;
+import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.table.functions.ScalarFunction;
-import org.apache.flink.table.functions.python.PythonEnv;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.runtime.typeutils.PythonTypeUtils;
 import org.apache.flink.table.types.logical.RowType;
@@ -41,11 +41,10 @@ public class PythonScalarFunctionRunner extends AbstractPythonScalarFunctionRunn
 		String taskName,
 		FnDataReceiver<Row> resultReceiver,
 		PythonFunctionInfo[] scalarFunctions,
-		PythonEnv pythonEnv,
+		PythonEnvironmentManager environmentManager,
 		RowType inputType,
-		RowType outputType,
-		String[] tempDirs) {
-		super(taskName, resultReceiver, scalarFunctions, pythonEnv, inputType, outputType, tempDirs);
+		RowType outputType) {
+		super(taskName, resultReceiver, scalarFunctions, environmentManager, inputType, outputType);
 	}
 
 	@Override

--- a/flink-python/src/test/java/org/apache/flink/python/env/ProcessPythonEnvironmentManagerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/env/ProcessPythonEnvironmentManagerTest.java
@@ -1,0 +1,398 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.python.env;
+
+import org.apache.flink.util.FileUtils;
+import org.apache.flink.util.OperatingSystem;
+
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.flink.python.env.ProcessPythonEnvironmentManager.PYTHON_ARCHIVES_DIR;
+import static org.apache.flink.python.env.ProcessPythonEnvironmentManager.PYTHON_FILES_DIR;
+import static org.apache.flink.python.env.ProcessPythonEnvironmentManager.PYTHON_REQUIREMENTS_CACHE;
+import static org.apache.flink.python.env.ProcessPythonEnvironmentManager.PYTHON_REQUIREMENTS_DIR;
+import static org.apache.flink.python.env.ProcessPythonEnvironmentManager.PYTHON_REQUIREMENTS_FILE;
+import static org.apache.flink.python.env.ProcessPythonEnvironmentManager.PYTHON_REQUIREMENTS_INSTALL_DIR;
+import static org.apache.flink.python.env.ProcessPythonEnvironmentManager.PYTHON_WORKING_DIR;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the {@link ProcessPythonEnvironmentManager}.
+ */
+public class ProcessPythonEnvironmentManagerTest {
+
+	private static String tmpDir;
+	private static boolean isUnix;
+
+	@BeforeClass
+	public static void prepareTempDirectory() throws IOException {
+		File tmpFile = File.createTempFile("process_environment_manager_test", "");
+		if (tmpFile.delete() && tmpFile.mkdirs()) {
+			tmpDir = tmpFile.getAbsolutePath();
+		} else {
+			throw new IOException("Create temp directory: " + tmpFile.getAbsolutePath() + " failed!");
+		}
+
+		for (int i = 0; i < 6; i++) {
+			File distributedFile = new File(tmpDir, "file" + i);
+			try (FileOutputStream out = new FileOutputStream(distributedFile)) {
+				out.write(i);
+			}
+		}
+
+		for (int i = 0; i < 2; i++) {
+			File distributedDirectory = new File(tmpDir, "dir" + i);
+			if (distributedDirectory.mkdirs()) {
+				for (int j = 0; j < 2; j++) {
+					File fileInDirs = new File(tmpDir, "dir" + i + File.separator + "file" + j);
+					try (FileOutputStream out = new FileOutputStream(fileInDirs)) {
+						out.write(i);
+						out.write(j);
+					}
+				}
+			} else {
+				throw new IOException("Create temp dir: " + distributedDirectory.getAbsolutePath() + " failed!");
+			}
+		}
+
+		isUnix = OperatingSystem.isFreeBSD() ||
+			OperatingSystem.isLinux() ||
+			OperatingSystem.isMac() ||
+			OperatingSystem.isSolaris();
+		for (int i = 0; i < 2; i++) {
+			File zipFile = new File(tmpDir, "zip" + i);
+			try (ZipArchiveOutputStream zipOut = new ZipArchiveOutputStream(new FileOutputStream(zipFile))) {
+				ZipArchiveEntry zipfile0 = new ZipArchiveEntry("zipDir" + i + "/zipfile0");
+				zipfile0.setUnixMode(0711);
+				zipOut.putArchiveEntry(zipfile0);
+				zipOut.write(new byte[]{1, 1, 1, 1, 1});
+				zipOut.closeArchiveEntry();
+				ZipArchiveEntry zipfile1 = new ZipArchiveEntry("zipDir" + i + "/zipfile1");
+				zipfile1.setUnixMode(0644);
+				zipOut.putArchiveEntry(zipfile1);
+				zipOut.write(new byte[]{2, 2, 2, 2, 2});
+				zipOut.closeArchiveEntry();
+			}
+			File zipExpected = new File(String.join(File.separator, tmpDir, "zipExpected" + i, "zipDir" + i));
+			if (!zipExpected.mkdirs()) {
+				throw new IOException("Create temp dir: " + zipExpected.getAbsolutePath() + " failed!");
+			}
+			File zipfile0 = new File(zipExpected, "zipfile0");
+			try (FileOutputStream out = new FileOutputStream(zipfile0)) {
+				out.write(new byte[]{1, 1, 1, 1, 1});
+			}
+			File zipfile1 = new File(zipExpected, "zipfile1");
+			try (FileOutputStream out = new FileOutputStream(zipfile1)) {
+				out.write(new byte[]{2, 2, 2, 2, 2});
+			}
+
+			if (isUnix) {
+				if (!(zipfile0.setReadable(true, true) &&
+					zipfile0.setWritable(true, true) &&
+					zipfile0.setExecutable(true))) {
+					throw new IOException("Set unixmode 711 to temp file: " + zipfile0.getAbsolutePath() + "failed!");
+				}
+				if (!(zipfile1.setReadable(true) &&
+					zipfile1.setWritable(true, true) &&
+					zipfile1.setExecutable(false))) {
+					throw new IOException("Set unixmode 644 to temp file: " + zipfile1.getAbsolutePath() + "failed!");
+				}
+			}
+		}
+	}
+
+	@AfterClass
+	public static void cleanTempDirectory() {
+		if (tmpDir != null) {
+			FileUtils.deleteDirectoryQuietly(new File(tmpDir));
+			tmpDir = null;
+		}
+	}
+
+	@Test
+	public void testPythonFiles() throws Exception {
+		// use LinkedHashMap to preserve the path order in environment variable
+		Map<String, String> pythonFiles = new LinkedHashMap<>();
+		pythonFiles.put(String.join(File.separator, tmpDir, "file0"), "test_file1.py");
+		pythonFiles.put(String.join(File.separator, tmpDir, "file1"), "test_file2.zip");
+		pythonFiles.put(String.join(File.separator, tmpDir, "file2"), "test_file3.egg");
+		pythonFiles.put(String.join(File.separator, tmpDir, "dir0"), "test_dir");
+		PythonDependencyInfo dependencyInfo = new PythonDependencyInfo(
+			pythonFiles, null, null, new HashMap<>(), null);
+
+		try (ProcessPythonEnvironmentManager environmentManager = createBasicPythonEnvironmentManager(dependencyInfo)) {
+			environmentManager.open();
+			Map<String, String> environmentVariable = environmentManager.constructEnvironmentVariables();
+
+			String baseDir = environmentManager.getBaseDirectory();
+			String[] expectedUserPythonPaths = new String[] {
+				String.join(File.separator, baseDir, PYTHON_FILES_DIR, "file0"),
+				String.join(File.separator, baseDir, PYTHON_FILES_DIR, "file1", "test_file2.zip"),
+				String.join(File.separator, baseDir, PYTHON_FILES_DIR, "file2", "test_file3.egg"),
+				String.join(File.separator, baseDir, PYTHON_FILES_DIR, "dir0", "test_dir")
+			};
+			String expectedPythonPath = String.join(
+				File.pathSeparator,
+				String.join(File.pathSeparator, expectedUserPythonPaths),
+				getBasicExpectedEnv(environmentManager).get("PYTHONPATH"));
+
+			assertEquals(
+				expectedPythonPath,
+				environmentVariable.get("PYTHONPATH"));
+			assertFileEquals(
+				new File(String.join(File.separator, tmpDir, "file0")),
+				new File(String.join(File.separator, baseDir, PYTHON_FILES_DIR, "file0", "test_file1.py")));
+			assertFileEquals(
+				new File(String.join(File.separator, tmpDir, "file1")),
+				new File(String.join(File.separator, baseDir, PYTHON_FILES_DIR, "file1", "test_file2.zip")));
+			assertFileEquals(
+				new File(String.join(File.separator, tmpDir, "file2")),
+				new File(String.join(File.separator, baseDir, PYTHON_FILES_DIR, "file2", "test_file3.egg")));
+			assertFileEquals(
+				new File(String.join(File.separator, tmpDir, "dir0")),
+				new File(String.join(File.separator, baseDir, PYTHON_FILES_DIR, "dir0", "test_dir")));
+		}
+	}
+
+	@Test
+	public void testRequirements() throws Exception {
+		PythonDependencyInfo dependencyInfo = new PythonDependencyInfo(
+			new HashMap<>(),
+			String.join(File.separator, tmpDir, "file0"),
+			String.join(File.separator, tmpDir, "dir0"),
+			new HashMap<>(),
+			null);
+
+		try (ProcessPythonEnvironmentManager environmentManager = createBasicPythonEnvironmentManager(dependencyInfo)) {
+			environmentManager.open();
+			Map<String, String> environmentVariable = environmentManager.constructEnvironmentVariables();
+
+			String tmpBase = environmentManager.getBaseDirectory();
+			Map<String, String> expected = getBasicExpectedEnv(environmentManager);
+			expected.put(PYTHON_REQUIREMENTS_FILE, String.join(File.separator, tmpDir, "file0"));
+			expected.put(PYTHON_REQUIREMENTS_CACHE, String.join(File.separator, tmpDir, "dir0"));
+			expected.put(
+				PYTHON_REQUIREMENTS_INSTALL_DIR,
+				String.join(File.separator, tmpBase, PYTHON_REQUIREMENTS_DIR));
+			assertEquals(expected, environmentVariable);
+		}
+	}
+
+	@Test
+	public void testArchives() throws Exception {
+		// use LinkedHashMap to preserve the file order in python working directory
+		Map<String, String> archives = new LinkedHashMap<>();
+		archives.put(String.join(File.separator, tmpDir, "zip0"), "py27.zip");
+		archives.put(String.join(File.separator, tmpDir, "zip1"), "py37");
+		PythonDependencyInfo dependencyInfo = new PythonDependencyInfo(
+			new HashMap<>(), null, null, archives, null);
+
+		try (ProcessPythonEnvironmentManager environmentManager = createBasicPythonEnvironmentManager(dependencyInfo)) {
+			environmentManager.open();
+			Map<String, String> environmentVariable = environmentManager.constructEnvironmentVariables();
+
+			String tmpBase = environmentManager.getBaseDirectory();
+			Map<String, String> expected = getBasicExpectedEnv(environmentManager);
+			expected.put(PYTHON_WORKING_DIR, String.join(File.separator, tmpBase, PYTHON_ARCHIVES_DIR));
+			assertEquals(expected, environmentVariable);
+			assertFileEquals(
+				new File(String.join(File.separator, tmpDir, "zipExpected0")),
+				new File(String.join(File.separator, tmpBase, PYTHON_ARCHIVES_DIR, "py27.zip")), true);
+			assertFileEquals(
+				new File(String.join(File.separator, tmpDir, "zipExpected1")),
+				new File(String.join(File.separator, tmpBase, PYTHON_ARCHIVES_DIR, "py37")), true);
+		}
+	}
+
+	@Test
+	public void testPythonExecutable() throws Exception {
+		PythonDependencyInfo dependencyInfo = new PythonDependencyInfo(
+			new HashMap<>(), null, null, new HashMap<>(), "/usr/local/bin/python");
+
+		try (ProcessPythonEnvironmentManager environmentManager = createBasicPythonEnvironmentManager(dependencyInfo)) {
+			environmentManager.open();
+			Map<String, String> environmentVariable = environmentManager.constructEnvironmentVariables();
+
+			Map<String, String> expected = getBasicExpectedEnv(environmentManager);
+			expected.put("python", "/usr/local/bin/python");
+			assertEquals(expected, environmentVariable);
+		}
+	}
+
+	@Test
+	public void testCreateEnvironment() throws Exception {
+		PythonDependencyInfo dependencyInfo = new PythonDependencyInfo(
+			new HashMap<>(), null, null, new HashMap<>(), null);
+
+		try (ProcessPythonEnvironmentManager environmentManager = createBasicPythonEnvironmentManager(dependencyInfo)) {
+			environmentManager.open();
+			RunnerApi.Environment environment = environmentManager.createEnvironment();
+			RunnerApi.ProcessPayload payload = RunnerApi.ProcessPayload.parseFrom(environment.getPayload());
+
+			assertEquals(
+				String.join(File.separator, environmentManager.getBaseDirectory(), "pyflink-udf-runner.sh"),
+				payload.getCommand());
+			Map<String, String> expectedEnv = getBasicExpectedEnv(environmentManager);
+			assertEquals(expectedEnv, payload.getEnvMap());
+		}
+	}
+
+	@Test
+	public void testCreateRetrievalToken() throws Exception {
+		PythonDependencyInfo dependencyInfo = new PythonDependencyInfo(
+			new HashMap<>(),
+			null,
+			null,
+			new HashMap<>(),
+			null);
+		Map<String, String> sysEnv = new HashMap<>();
+		sysEnv.put("FLINK_HOME", "/flink");
+
+		try (ProcessPythonEnvironmentManager environmentManager =
+				new ProcessPythonEnvironmentManager(dependencyInfo, new String[] {tmpDir}, null, sysEnv)) {
+			environmentManager.open();
+			String retrievalToken = environmentManager.createRetrievalToken();
+
+			File retrievalTokenFile = new File(retrievalToken);
+			byte[] content = new byte[(int) retrievalTokenFile.length()];
+			try (DataInputStream input = new DataInputStream(new FileInputStream(retrievalToken))) {
+				input.readFully(content);
+			}
+			assertEquals("{\"manifest\": {}}", new String(content));
+		}
+	}
+
+	@Test
+	public void testSetLogDirectory() throws Exception {
+		PythonDependencyInfo dependencyInfo = new PythonDependencyInfo(
+			new HashMap<>(),
+			null,
+			null,
+			new HashMap<>(),
+			null);
+
+		try (ProcessPythonEnvironmentManager environmentManager = new ProcessPythonEnvironmentManager(
+				dependencyInfo, new String[] {tmpDir}, "/tmp/log", new HashMap<>())) {
+			environmentManager.open();
+			Map<String, String> env = environmentManager.constructEnvironmentVariables();
+			Map<String, String> expected = getBasicExpectedEnv(environmentManager);
+			expected.put("FLINK_LOG_DIR", "/tmp/log");
+			assertEquals(expected, env);
+		}
+	}
+
+	@Test
+	public void testOpenClose() throws Exception {
+		PythonDependencyInfo dependencyInfo = new PythonDependencyInfo(
+			new HashMap<>(),
+			null,
+			null,
+			new HashMap<>(),
+			null);
+
+		try (ProcessPythonEnvironmentManager environmentManager = createBasicPythonEnvironmentManager(dependencyInfo)) {
+			environmentManager.open();
+			environmentManager.createRetrievalToken();
+
+			String tmpBase = environmentManager.getBaseDirectory();
+			assertTrue(new File(tmpBase).isDirectory());
+			environmentManager.close();
+			assertFalse(new File(tmpBase).exists());
+		}
+	}
+
+	private static void assertFileEquals(File expectedFile, File actualFile)
+		throws IOException, NoSuchAlgorithmException {
+		assertFileEquals(expectedFile, actualFile, false);
+	}
+
+	private static void assertFileEquals(File expectedFile, File actualFile, boolean checkUnixMode)
+		throws IOException, NoSuchAlgorithmException {
+		assertTrue(actualFile.exists());
+		assertTrue(expectedFile.exists());
+		if (expectedFile.getAbsolutePath().equals(actualFile.getAbsolutePath())) {
+			return;
+		}
+
+		if (isUnix && checkUnixMode) {
+			Set<PosixFilePermission> expectedPerm = Files.getPosixFilePermissions(Paths.get(expectedFile.toURI()));
+			Set<PosixFilePermission> actualPerm = Files.getPosixFilePermissions(Paths.get(actualFile.toURI()));
+			assertEquals(expectedPerm, actualPerm);
+		}
+
+		if (expectedFile.isDirectory()) {
+			assertTrue(actualFile.isDirectory());
+			String[] expectedSubFiles = expectedFile.list();
+			assertArrayEquals(expectedSubFiles, actualFile.list());
+			if (expectedSubFiles != null) {
+				for (String fileName : expectedSubFiles) {
+					assertFileEquals(
+						new File(expectedFile.getAbsolutePath(), fileName),
+						new File(actualFile.getAbsolutePath(), fileName));
+				}
+			}
+		} else {
+			assertEquals(expectedFile.length(), actualFile.length());
+			if (expectedFile.length() > 0) {
+				assertTrue(org.apache.commons.io.FileUtils.contentEquals(expectedFile, actualFile));
+			}
+		}
+	}
+
+	private static Map<String, String> getBasicExpectedEnv(ProcessPythonEnvironmentManager environmentManager) {
+		Map<String, String> map = new HashMap<>();
+		String tmpBase = environmentManager.getBaseDirectory();
+		map.put(
+			"PYTHONPATH",
+			String.join(
+				File.pathSeparator,
+				String.join(File.separator, tmpBase, "pyflink.zip"),
+				String.join(File.separator, tmpBase, "py4j-0.10.8.1-src.zip"),
+				String.join(File.separator, tmpBase, "cloudpickle-1.2.2-src.zip")));
+		return map;
+	}
+
+	private static ProcessPythonEnvironmentManager createBasicPythonEnvironmentManager(
+			PythonDependencyInfo dependencyInfo) {
+		return new ProcessPythonEnvironmentManager(
+			dependencyInfo, new String[] {tmpDir}, null, new HashMap<>());
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/python/env/PythonDependencyInfoTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/env/PythonDependencyInfoTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.python.env;
+
+import org.apache.flink.api.common.cache.DistributedCache;
+import org.apache.flink.core.fs.Path;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Tests for {@link PythonDependencyInfo}.
+ */
+public class PythonDependencyInfoTest {
+
+	private DistributedCache distributedCache;
+
+	public PythonDependencyInfoTest() {
+		Map<String, Future<Path>> distributeCachedFiles = new HashMap<>();
+		distributeCachedFiles.put(
+			"python_file_0_{uuid}",
+			CompletableFuture.completedFuture(new Path("/distributed_cache/file0")));
+		distributeCachedFiles.put(
+			"python_file_1_{uuid}",
+			CompletableFuture.completedFuture(new Path("/distributed_cache/file1")));
+		distributeCachedFiles.put(
+			"python_requirements_file_2_{uuid}",
+			CompletableFuture.completedFuture(new Path("/distributed_cache/file2")));
+		distributeCachedFiles.put(
+			"python_requirements_cache_3_{uuid}",
+			CompletableFuture.completedFuture(new Path("/distributed_cache/file3")));
+		distributeCachedFiles.put(
+			"python_archive_4_{uuid}",
+			CompletableFuture.completedFuture(new Path("/distributed_cache/file4")));
+		distributeCachedFiles.put(
+			"python_archive_5_{uuid}",
+			CompletableFuture.completedFuture(new Path("/distributed_cache/file5")));
+		distributedCache = new DistributedCache(distributeCachedFiles);
+	}
+
+	@Test
+	public void testParsePythonFiles() throws IOException {
+		Map<String, String> pythonFileMetaData = new HashMap<>();
+		pythonFileMetaData.put(PythonDependencyInfo.PYTHON_FILES,
+			"{\"python_file_0_{uuid}\": \"test_file1.py\", \"python_file_1_{uuid}\": \"test_file2.py\"}");
+		PythonDependencyInfo dependencyInfo =
+			PythonDependencyInfo.create(pythonFileMetaData, distributedCache);
+
+		Map<String, String> expected = new HashMap<>();
+		expected.put("/distributed_cache/file0", "test_file1.py");
+		expected.put("/distributed_cache/file1", "test_file2.py");
+		assertEquals(expected, dependencyInfo.getPythonFiles());
+	}
+
+	@Test
+	public void testParsePythonRequirements() throws IOException {
+		Map<String, String> pythonRequirementsMetaData = new HashMap<>();
+		pythonRequirementsMetaData.put(
+			PythonDependencyInfo.PYTHON_REQUIREMENTS_FILE, "python_requirements_file_2_{uuid}");
+		PythonDependencyInfo dependencyInfo =
+			PythonDependencyInfo.create(pythonRequirementsMetaData, distributedCache);
+
+		assertEquals("/distributed_cache/file2", dependencyInfo.getRequirementsFilePath().get());
+		assertFalse(dependencyInfo.getRequirementsCacheDir().isPresent());
+
+		pythonRequirementsMetaData.put(
+			PythonDependencyInfo.PYTHON_REQUIREMENTS_CACHE, "python_requirements_cache_3_{uuid}");
+		dependencyInfo = PythonDependencyInfo.create(pythonRequirementsMetaData, distributedCache);
+
+		assertEquals("/distributed_cache/file2", dependencyInfo.getRequirementsFilePath().get());
+		assertEquals("/distributed_cache/file3", dependencyInfo.getRequirementsCacheDir().get());
+	}
+
+	@Test
+	public void testParsePythonArchives() throws IOException {
+		Map<String, String> pythonArchiveMetaData = new HashMap<>();
+		pythonArchiveMetaData.put(
+			PythonDependencyInfo.PYTHON_ARCHIVES,
+			"{\"python_archive_4_{uuid}\": \"py27.zip\", \"python_archive_5_{uuid}\": \"py37\"}");
+		PythonDependencyInfo dependencyInfo =
+			PythonDependencyInfo.create(pythonArchiveMetaData, distributedCache);
+
+		Map<String, String> expected = new HashMap<>();
+		expected.put("/distributed_cache/file4", "py27.zip");
+		expected.put("/distributed_cache/file5", "py37");
+		assertEquals(expected, dependencyInfo.getArchives());
+	}
+
+	@Test
+	public void testParsePythonExec() throws IOException {
+		Map<String, String> pythonFileMetaData = new HashMap<>();
+		pythonFileMetaData.put(PythonDependencyInfo.PYTHON_EXEC, "/usr/bin/python3");
+		PythonDependencyInfo dependencyInfo =
+			PythonDependencyInfo.create(pythonFileMetaData, distributedCache);
+
+		assertEquals("/usr/bin/python3", dependencyInfo.getPythonExec().get());
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/python/util/ResourceUtilTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/util/ResourceUtilTest.java
@@ -50,7 +50,7 @@ public class ResourceUtilTest {
 		Runtime.getRuntime().addShutdownHook(hook);
 		try {
 			String prefix = "tmp_";
-			List<File> files = ResourceUtil.extractBasicDependenciesFromResource(
+			List<File> files = ResourceUtil.extractBuiltInDependencies(
 				tmpdir.getAbsolutePath(),
 				prefix,
 				true);
@@ -60,7 +60,7 @@ public class ResourceUtilTest {
 				new File(tmpdir, "tmp_py4j-0.10.8.1-src.zip"),
 				new File(tmpdir, "tmp_cloudpickle-1.2.2-src.zip")}, files.toArray());
 			files.forEach(File::delete);
-			files = ResourceUtil.extractBasicDependenciesFromResource(
+			files = ResourceUtil.extractBuiltInDependencies(
 				tmpdir.getAbsolutePath(),
 				prefix,
 				false);

--- a/flink-python/src/test/java/org/apache/flink/table/functions/python/AbstractPythonScalarFunctionRunnerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/functions/python/AbstractPythonScalarFunctionRunnerTest.java
@@ -33,7 +33,7 @@ import java.util.Collections;
  */
 public abstract class AbstractPythonScalarFunctionRunnerTest<IN, OUT>  {
 
-	AbstractPythonScalarFunctionRunner<IN, OUT> createSingleUDFRunner() {
+	AbstractPythonScalarFunctionRunner<IN, OUT> createSingleUDFRunner() throws Exception {
 		PythonFunctionInfo[] pythonFunctionInfos = new PythonFunctionInfo[] {
 			new PythonFunctionInfo(
 				DummyPythonFunction.INSTANCE,
@@ -44,7 +44,7 @@ public abstract class AbstractPythonScalarFunctionRunnerTest<IN, OUT>  {
 		return createPythonScalarFunctionRunner(pythonFunctionInfos, rowType, rowType);
 	}
 
-	AbstractPythonScalarFunctionRunner<IN, OUT> createMultipleUDFRunner() {
+	AbstractPythonScalarFunctionRunner<IN, OUT> createMultipleUDFRunner() throws Exception {
 		PythonFunctionInfo[] pythonFunctionInfos = new PythonFunctionInfo[] {
 			new PythonFunctionInfo(
 				DummyPythonFunction.INSTANCE,
@@ -64,7 +64,7 @@ public abstract class AbstractPythonScalarFunctionRunnerTest<IN, OUT>  {
 		return createPythonScalarFunctionRunner(pythonFunctionInfos, inputType, outputType);
 	}
 
-	AbstractPythonScalarFunctionRunner<IN, OUT> createChainedUDFRunner() {
+	AbstractPythonScalarFunctionRunner<IN, OUT> createChainedUDFRunner() throws Exception {
 		PythonFunctionInfo[] pythonFunctionInfos = new PythonFunctionInfo[] {
 			new PythonFunctionInfo(
 				DummyPythonFunction.INSTANCE,
@@ -103,7 +103,7 @@ public abstract class AbstractPythonScalarFunctionRunnerTest<IN, OUT>  {
 	}
 
 	public abstract AbstractPythonScalarFunctionRunner<IN, OUT> createPythonScalarFunctionRunner(
-		PythonFunctionInfo[] pythonFunctionInfos, RowType inputType, RowType outputType);
+		PythonFunctionInfo[] pythonFunctionInfos, RowType inputType, RowType outputType) throws Exception;
 
 	/**
 	 * Dummy PythonFunction.

--- a/flink-python/src/test/java/org/apache/flink/table/functions/python/BaseRowPythonScalarFunctionRunnerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/functions/python/BaseRowPythonScalarFunctionRunnerTest.java
@@ -19,6 +19,9 @@
 package org.apache.flink.table.functions.python;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.python.env.ProcessPythonEnvironmentManager;
+import org.apache.flink.python.env.PythonDependencyInfo;
+import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.runtime.runners.python.AbstractPythonScalarFunctionRunner;
 import org.apache.flink.table.runtime.runners.python.BaseRowPythonScalarFunctionRunner;
@@ -27,6 +30,9 @@ import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -38,7 +44,7 @@ import static org.junit.Assert.assertTrue;
 public class BaseRowPythonScalarFunctionRunnerTest extends AbstractPythonScalarFunctionRunnerTest<BaseRow, BaseRow> {
 
 	@Test
-	public void testInputOutputDataTypeConstructedProperlyForSingleUDF() {
+	public void testInputOutputDataTypeConstructedProperlyForSingleUDF() throws Exception {
 		final AbstractPythonScalarFunctionRunner<BaseRow, BaseRow> runner = createSingleUDFRunner();
 
 		// check input TypeSerializer
@@ -54,7 +60,7 @@ public class BaseRowPythonScalarFunctionRunnerTest extends AbstractPythonScalarF
 	}
 
 	@Test
-	public void testInputOutputDataTypeConstructedProperlyForMultipleUDFs() {
+	public void testInputOutputDataTypeConstructedProperlyForMultipleUDFs() throws Exception {
 		final AbstractPythonScalarFunctionRunner<BaseRow, BaseRow> runner = createMultipleUDFRunner();
 
 		// check input TypeSerializer
@@ -70,7 +76,7 @@ public class BaseRowPythonScalarFunctionRunnerTest extends AbstractPythonScalarF
 	}
 
 	@Test
-	public void testInputOutputDataTypeConstructedProperlyForChainedUDFs() {
+	public void testInputOutputDataTypeConstructedProperlyForChainedUDFs() throws Exception {
 		final AbstractPythonScalarFunctionRunner<BaseRow, BaseRow> runner = createChainedUDFRunner();
 
 		// check input TypeSerializer
@@ -89,20 +95,24 @@ public class BaseRowPythonScalarFunctionRunnerTest extends AbstractPythonScalarF
 	public AbstractPythonScalarFunctionRunner<BaseRow, BaseRow> createPythonScalarFunctionRunner(
 		final PythonFunctionInfo[] pythonFunctionInfos,
 		RowType inputType,
-		RowType outputType) {
+		RowType outputType) throws IOException {
 		final FnDataReceiver<BaseRow> dummyReceiver = input -> {
 			// ignore the execution results
 		};
 
-		final PythonEnv pythonEnv = new PythonEnv(PythonEnv.ExecType.PROCESS);
+		final PythonEnvironmentManager environmentManager =
+			new ProcessPythonEnvironmentManager(
+				new PythonDependencyInfo(new HashMap<>(), null, null, new HashMap<>(), null),
+				new String[] {System.getProperty("java.io.tmpdir")},
+				null,
+				new HashMap<>());
 
 		return new BaseRowPythonScalarFunctionRunner(
 			"testPythonRunner",
 			dummyReceiver,
 			pythonFunctionInfos,
-			pythonEnv,
+			environmentManager,
 			inputType,
-			outputType,
-			new String[] {System.getProperty("java.io.tmpdir")});
+			outputType);
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonScalarFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonScalarFunctionOperatorTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.runtime.operators.python;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.python.PythonFunctionRunner;
+import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
@@ -99,7 +100,8 @@ public class BaseRowPythonScalarFunctionOperatorTest
 
 		@Override
 		public PythonFunctionRunner<BaseRow> createPythonFunctionRunner(
-			FnDataReceiver<BaseRow> resultReceiver) {
+				FnDataReceiver<BaseRow> resultReceiver,
+				PythonEnvironmentManager pythonEnvironmentManager) {
 			return new PassThroughPythonFunctionRunner<BaseRow>(resultReceiver) {
 				@Override
 				public BaseRow copy(BaseRow element) {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperatorTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.operators.python;
 
 import org.apache.flink.python.PythonFunctionRunner;
+import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.util.TestHarnessUtil;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
@@ -76,7 +77,8 @@ public class PythonScalarFunctionOperatorTest extends PythonScalarFunctionOperat
 
 		@Override
 		public PythonFunctionRunner<Row> createPythonFunctionRunner(
-			FnDataReceiver<Row> resultReceiver) {
+				FnDataReceiver<Row> resultReceiver,
+				PythonEnvironmentManager pythonEnvironmentManager) {
 			return new PassThroughPythonFunctionRunner<Row>(resultReceiver) {
 				@Override
 				public Row copy(Row element) {


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds support for managing environment and dependencies of Python UDF in Flink Python API.*


## Brief change log

  - *Add new APIs in flink-python to support upload users' python environment and dependencies to cluster.*
  - *Refactor the operator layer of flink-python to support different type of running mode(docker mode, process mode, etc).*
  - *Add ProcessEnvironmentManager to support managing environment and dependencies of Python UDF worker when running in process mode.*


## Verifying this change

This change is already covered by newly added tests, such as *ProcessEnvironmentManagerTest*, *PythonDependencyManagerTest*, and so on.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (python docs)
