### PR TITLE
[FLINK-12147] [metrics] Update influxdb-java to remove writes of invalid values to InfluxDB

### DIFF
--- a/flink-metrics/flink-metrics-influxdb/pom.xml
+++ b/flink-metrics/flink-metrics-influxdb/pom.xml
@@ -57,7 +57,7 @@ under the License.
 		<dependency>
 			<groupId>org.influxdb</groupId>
 			<artifactId>influxdb-java</artifactId>
-			<version>2.14</version>
+			<version>2.16</version>
 		</dependency>
 
 		<!-- test dependencies -->


### PR DESCRIPTION
## What is the purpose of the change

Some metric sources (e.g. Kafka) expose metrics with infinity values, which causes for each reporting period:
* errors logged on InfluxDB side
* warnings logged in Flink

Moreover logs can't be pushed via Telegraf because Telegraf parser rejects writes that contain invalid data.

Upgraded dependency filters out unsupported field values.

Replaces #8513.

## Brief change log

Upgrade influxdb-java dependency (2.14 -> 2.16).

## Verifying this change

This change upgrades a dependency and is covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
