### PR TITLE
[hotfix][typo] Rename withNewBucketAssignerAnd[Rolling]Policy

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
@@ -273,8 +273,8 @@ public class StreamingFileSink<IN>
 			return self();
 		}
 
-		public <ID> StreamingFileSink.RowFormatBuilder<IN, ID, ? extends RowFormatBuilder<IN, ID, ?>> withNewBucketAssignerAndPolicy(final BucketAssigner<IN, ID> assigner, final RollingPolicy<IN, ID> policy) {
-			Preconditions.checkState(bucketFactory.getClass() == DefaultBucketFactoryImpl.class, "newBuilderWithBucketAssignerAndPolicy() cannot be called after specifying a customized bucket factory");
+		public <ID> StreamingFileSink.RowFormatBuilder<IN, ID, ? extends RowFormatBuilder<IN, ID, ?>> withNewBucketAssignerAndRollingPolicy(final BucketAssigner<IN, ID> assigner, final RollingPolicy<IN, ID> policy) {
+			Preconditions.checkState(bucketFactory.getClass() == DefaultBucketFactoryImpl.class, "newBuilderWithBucketAssignerAndRollingPolicy() cannot be called after specifying a customized bucket factory");
 			return new RowFormatBuilder<>(basePath, encoder, Preconditions.checkNotNull(assigner), Preconditions.checkNotNull(policy), bucketCheckInterval, new DefaultBucketFactoryImpl<>(), partFilePrefix, partFileSuffix);
 		}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
@@ -115,7 +115,7 @@ public class TestUtils {
 
 		StreamingFileSink<Tuple2<String, Integer>> sink = StreamingFileSink
 				.forRowFormat(new Path(outDir.toURI()), writer)
-				.withNewBucketAssignerAndPolicy(bucketer, rollingPolicy)
+				.withNewBucketAssignerAndRollingPolicy(bucketer, rollingPolicy)
 				.withBucketCheckInterval(bucketCheckInterval)
 				.withBucketFactory(bucketFactory)
 				.build();


### PR DESCRIPTION
## What is the purpose of the change
There are two existing methods in StreamingFileSink:
withRollingPolicy and withBucketAssigner which can be used separately. Also there is method withNewBucketAssignerAndPolicy which can be used as replacement for two mentioned methods. 
It seems that this method should be named as withNewBucketAssignerAndRollingPolicy.

## Brief change log
Rename method withNewBucketAssignerAndPolicy to withNewBucketAssignerAnd**Rolling**Policy

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes (?)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no