### PR TITLE
[FLINK-14554] Correct the comment of ExistingSavepoint#readKeyedState to generate java doc

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/ExistingSavepoint.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/ExistingSavepoint.java
@@ -214,13 +214,14 @@ public class ExistingSavepoint extends WritableSavepoint<ExistingSavepoint> {
 		return env.createInput(inputFormat, new TupleTypeInfo<>(keyTypeInfo, valueTypeInfo));
 	}
 
-	/*
+	/**
 	 * Read keyed state from an operator in a {@code Savepoint}.
 	 * @param uid The uid of the operator.
 	 * @param function The {@link KeyedStateReaderFunction} that is called for each key in state.
 	 * @param <K> The type of the key in state.
 	 * @param <OUT> The output type of the transform function.
 	 * @return A {@code DataSet} of objects read from keyed state.
+	 * @throws IOException If the savepoint does not contain operator state with the given uid.
 	 */
 	public <K, OUT> DataSet<OUT> readKeyedState(String uid, KeyedStateReaderFunction<K, OUT> function) throws IOException {
 
@@ -265,6 +266,7 @@ public class ExistingSavepoint extends WritableSavepoint<ExistingSavepoint> {
 	 * @param <K> The type of the key in state.
 	 * @param <OUT> The output type of the transform function.
 	 * @return A {@code DataSet} of objects read from keyed state.
+	 * @throws IOException If the savepoint does not contain operator state with the given uid.
 	 */
 	public <K, OUT> DataSet<OUT> readKeyedState(
 		String uid,


### PR DESCRIPTION

## What is the purpose of the change

*This pull request corrects the comment of ExistingSavepoint#readKeyedState to generate java doc*

## Brief change log

  - *Correct the comment of ExistingSavepoint#readKeyedState to generate java doc*


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
