### PR TITLE
[FLINK-14549][Table SQL/Planner] Bring more detail by using logicalTy…

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/sinks/TableSinkUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/sinks/TableSinkUtils.scala
@@ -64,10 +64,10 @@ object TableSinkUtils {
 
       // format table and table sink schema strings
       val srcSchema = srcFieldNames.zip(srcLogicalTypes)
-        .map { case (n, t) => s"$n: ${t}" }
+        .map { case (n, t) => s"$n: $t" }
         .mkString("[", ", ", "]")
       val sinkSchema = sinkFieldNames.zip(sinkLogicalTypes)
-        .map { case (n, t) => s"$n: ${t}" }
+        .map { case (n, t) => s"$n: $t" }
         .mkString("[", ", ", "]")
 
       throw new ValidationException(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/sinks/TableSinkUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/sinks/TableSinkUtils.scala
@@ -50,21 +50,24 @@ object TableSinkUtils {
     val srcFieldTypes = query.getTableSchema.getFieldDataTypes
     val sinkFieldTypes = sink.getTableSchema.getFieldDataTypes
 
-    if (srcFieldTypes.length != sinkFieldTypes.length ||
-      srcFieldTypes.zip(sinkFieldTypes).exists { case (srcF, snkF) =>
-        !PlannerTypeUtils.isInteroperable(
-          fromDataTypeToLogicalType(srcF), fromDataTypeToLogicalType(snkF))
+    val srcLogicalTypes = srcFieldTypes.map(t => fromDataTypeToLogicalType(t))
+    val sinkLogicalTypes = sinkFieldTypes.map(t => fromDataTypeToLogicalType(t))
+
+    if (srcLogicalTypes.length != sinkLogicalTypes.length ||
+      srcLogicalTypes.zip(sinkLogicalTypes).exists {
+        case (srcType, sinkType) =>
+          !PlannerTypeUtils.isInteroperable(srcType, sinkType)
       }) {
 
       val srcFieldNames = query.getTableSchema.getFieldNames
       val sinkFieldNames = sink.getTableSchema.getFieldNames
 
       // format table and table sink schema strings
-      val srcSchema = srcFieldNames.zip(srcFieldTypes)
-        .map { case (n, t) => s"$n: ${t.getConversionClass.getSimpleName}" }
+      val srcSchema = srcFieldNames.zip(srcLogicalTypes)
+        .map { case (n, t) => s"$n: ${t}" }
         .mkString("[", ", ", "]")
-      val sinkSchema = sinkFieldNames.zip(sinkFieldTypes)
-        .map { case (n, t) => s"$n: ${t.getConversionClass.getSimpleName}" }
+      val sinkSchema = sinkFieldNames.zip(sinkLogicalTypes)
+        .map { case (n, t) => s"$n: ${t}" }
         .mkString("[", ", ", "]")
 
       throw new ValidationException(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/TableSinkValidationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/TableSinkValidationTest.scala
@@ -22,8 +22,9 @@ import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableException, ValidationException}
+import org.apache.flink.table.api.{TableException, ValidationException, DataTypes, TableSchema}
 import org.apache.flink.table.planner.runtime.utils.{TestData, TestingAppendSink, TestingUpsertTableSink}
+import org.apache.flink.table.planner.utils.MemoryTableSourceSinkUtil.DataTypeOutputFormatTableSink
 import org.apache.flink.table.planner.utils.{TableTestBase, TableTestUtil}
 import org.apache.flink.types.Row
 import org.junit.Test
@@ -83,4 +84,36 @@ class TableSinkValidationTest extends TableTestBase {
     // must fail because table is not append-only
     env.execute()
   }
+
+  @Test
+  def testValidateSink(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage(
+      "Field types of query result and registered TableSink `default_catalog`." +
+      "`default_database`.`testSink` do not match.\n" +
+      "Query result schema: [a: INT, b: BIGINT, c: STRING, d: DECIMAL(10, 8)]\n" +
+      "TableSink schema:    [a: INT, b: BIGINT, c: STRING, d: DECIMAL(10, 7)]")
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = StreamTableEnvironment.create(env, TableTestUtil.STREAM_SETTING)
+
+    val sourceTable = env.fromCollection(TestData.tupleData3).toTable(tEnv, 'a, 'b, 'c)
+    tEnv.registerTable("source", sourceTable)
+    val resultTable = tEnv.sqlQuery("select a, b, c, cast(b as decimal(10, 8)) as d from source")
+
+    val sinkSchema = TableSchema.builder()
+      .field("a", DataTypes.INT())
+      .field("b", DataTypes.BIGINT())
+      .field("c", DataTypes.STRING())
+      .field("d", DataTypes.DECIMAL(10, 7))
+      .build()
+    val sink = new DataTypeOutputFormatTableSink(sinkSchema)
+    tEnv.registerTableSink("testSink", sink)
+
+    tEnv.insertInto(resultTable, "testSink")
+
+    // must fail because query result table schema is different with sink table schema
+    tEnv.execute("testJob")
+  }
+
 }


### PR DESCRIPTION
Bring more detail by using logicalType rather than conversionClass in exception msg

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*This pull request makes exception message  more clear by using logicalType's toString() function rather than the name of conversionClass.*


## Brief change log

  - *update file org.apache.flink.table.planner.sinks.TableSinkUtils.scala*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
