### PR TITLE
 [FLINK-14553][runtime] Respect non-blocking output in StreamTask#processInput

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/PullingAsyncDataInput.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/PullingAsyncDataInput.java
@@ -27,7 +27,7 @@ import java.util.concurrent.CompletableFuture;
  *
  * <p>For the most efficient usage, user of this class is supposed to call {@link #pollNext()}
  * until it returns that no more elements are available. If that happens, he should check if
- * input {@link #isFinished()}. If not, he should wait for {@link #isAvailable()}
+ * input {@link #isFinished()}. If not, he should wait for {@link #getAvailableFuture()}
  * {@link CompletableFuture} to be completed. For example:
  *
  * <pre>
@@ -44,7 +44,7 @@ import java.util.concurrent.CompletableFuture;
  *			// do something with next
  *		}
  *
- *		input.isAvailable().get();
+ *		input.getAvailableFuture().get();
  *	}
  * }
  * </pre>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/MultipleRecordWriters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/MultipleRecordWriters.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.api.writer;
+
+import org.apache.flink.core.io.IOReadableWritable;
+import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.util.ExceptionUtils;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The specific delegate implementation for the multiple outputs case.
+ */
+public class MultipleRecordWriters<T extends IOReadableWritable> implements RecordWriterDelegate<T> {
+
+	/** The real record writer instances for this delegate. */
+	private final List<RecordWriter<T>> recordWriters;
+
+	/**
+	 * Maintains the respective record writer futures to avoid allocating new arrays every time
+	 * in {@link #getAvailableFuture()}.
+	 */
+	private final CompletableFuture<?>[] futures;
+
+	public MultipleRecordWriters(List<RecordWriter<T>> recordWriters) {
+		this.recordWriters = checkNotNull(recordWriters);
+		this.futures = new CompletableFuture[recordWriters.size()];
+	}
+
+	@Override
+	public void broadcastEvent(AbstractEvent event) throws IOException {
+		IOException exception = null;
+		for (RecordWriter recordWriter : recordWriters) {
+			try {
+				recordWriter.broadcastEvent(event);
+			} catch (IOException e) {
+				exception = ExceptionUtils.firstOrSuppressed(
+					new IOException("Could not send event to downstream tasks.", e), exception);
+			}
+		}
+
+		if (exception != null) {
+			throw exception;
+		}
+	}
+
+	@Override
+	public RecordWriter<T> getRecordWriter(int outputIndex) {
+		return recordWriters.get(outputIndex);
+	}
+
+	@Override
+	public CompletableFuture<?> getAvailableFuture() {
+		for (int i = 0; i < futures.length; i++) {
+			futures[i] = recordWriters.get(i).getAvailableFuture();
+		}
+		return CompletableFuture.allOf(futures);
+	}
+
+	@Override
+	public boolean isAvailable() {
+		for (RecordWriter recordWriter : recordWriters) {
+			if (!recordWriter.isAvailable()) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public void close() {
+		for (RecordWriter recordWriter : recordWriters) {
+			recordWriter.close();
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/NonRecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/NonRecordWriter.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.api.writer;
+
+import org.apache.flink.core.io.IOReadableWritable;
+import org.apache.flink.runtime.event.AbstractEvent;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * The specific delegate implementation for the non output case like sink task.
+ */
+public class NonRecordWriter<T extends IOReadableWritable> implements RecordWriterDelegate<T> {
+
+	public NonRecordWriter() {
+	}
+
+	@Override
+	public void broadcastEvent(AbstractEvent event) throws IOException {
+	}
+
+	@Override
+	public RecordWriter<T> getRecordWriter(int outputIndex) {
+		throw new UnsupportedOperationException("No record writer instance.");
+	}
+
+	@Override
+	public CompletableFuture<?> getAvailableFuture() {
+		throw new UnsupportedOperationException("No record writer instance.");
+	}
+
+	@Override
+	public boolean isAvailable() {
+		return true;
+	}
+
+	@Override
+	public void close() {
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
@@ -190,8 +190,8 @@ public abstract class RecordWriter<T extends IOReadableWritable> implements Avai
 	}
 
 	@Override
-	public CompletableFuture<?> isAvailable() {
-		return targetPartition.isAvailable();
+	public CompletableFuture<?> getAvailableFuture() {
+		return targetPartition.getAvailableFuture();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterDelegate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterDelegate.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.api.writer;
+
+import org.apache.flink.core.io.IOReadableWritable;
+import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.io.AvailabilityProvider;
+
+import java.io.IOException;
+
+/**
+ * The record writer delegate provides the availability function for task processor, and it might represent
+ * a single {@link RecordWriter} or multiple {@link RecordWriter} instances in specific implementations.
+ */
+public interface RecordWriterDelegate<T extends IOReadableWritable> extends AvailabilityProvider, AutoCloseable {
+
+	/**
+	 * Broadcasts the provided event to all the internal record writer instances.
+	 *
+	 * @param event the event to be emitted to all the output channels.
+	 */
+	void broadcastEvent(AbstractEvent event) throws IOException;
+
+	/**
+	 * Returns the internal actual record writer instance based on the output index.
+	 *
+	 * @param outputIndex the index respective to the record writer instance.
+	 */
+	RecordWriter<T> getRecordWriter(int outputIndex);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.api.writer;
 
+import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -25,7 +26,6 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * A buffer-oriented runtime result writer API for producing results.
@@ -35,7 +35,7 @@ import java.util.concurrent.CompletableFuture;
  * In this case {@link ResultPartitionWriter#fail(Throwable)} still needs to be called afterwards to fully release
  * all resources associated the the partition and propagate failure cause to the consumer if possible.
  */
-public interface ResultPartitionWriter extends AutoCloseable {
+public interface ResultPartitionWriter extends AutoCloseable, AvailabilityProvider {
 
 	/**
 	 * Setup partition, potentially heavy-weight, blocking operation comparing to just creation.
@@ -93,11 +93,4 @@ public interface ResultPartitionWriter extends AutoCloseable {
 	 * <p>Closing of partition is still needed afterwards.
 	 */
 	void finish() throws IOException;
-
-	/**
-	 * Check whether the writer is available for output or not.
-	 *
-	 * @return a future that is completed if it is available for output.
-	 */
-	CompletableFuture<?> getAvailableFuture();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
@@ -99,6 +99,5 @@ public interface ResultPartitionWriter extends AutoCloseable {
 	 *
 	 * @return a future that is completed if it is available for output.
 	 */
-
-	CompletableFuture<?> isAvailable();
+	CompletableFuture<?> getAvailableFuture();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/SingleRecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/SingleRecordWriter.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.api.writer;
+
+import org.apache.flink.core.io.IOReadableWritable;
+import org.apache.flink.runtime.event.AbstractEvent;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The specific delegate implementation for the single output case.
+ */
+public class SingleRecordWriter<T extends IOReadableWritable> implements RecordWriterDelegate<T> {
+
+	private final RecordWriter<T> recordWriter;
+
+	public SingleRecordWriter(RecordWriter<T> recordWriter) {
+		this.recordWriter = checkNotNull(recordWriter);
+	}
+
+	@Override
+	public void broadcastEvent(AbstractEvent event) throws IOException {
+		recordWriter.broadcastEvent(event);
+	}
+
+	@Override
+	public RecordWriter<T> getRecordWriter(int outputIndex) {
+		checkArgument(outputIndex == 0, "The index should always be 0 for the single record writer delegate.");
+
+		return recordWriter;
+	}
+
+	@Override
+	public CompletableFuture<?> getAvailableFuture() {
+		return recordWriter.getAvailableFuture();
+	}
+
+	@Override
+	public boolean isAvailable() {
+		return recordWriter.isAvailable();
+	}
+
+	@Override
+	public void close() {
+		recordWriter.close();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -304,8 +304,8 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 	 * in this pool.
 	 */
 	@Override
-	public CompletableFuture<?> isAvailable() {
-		return availabilityHelper.isAvailable();
+	public CompletableFuture<?> getAvailableFuture() {
+		return availabilityHelper.getAvailableFuture();
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -324,8 +324,8 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 	}
 
 	@Override
-	public CompletableFuture<?> isAvailable() {
-		return bufferPool.isAvailable();
+	public CompletableFuture<?> getAvailableFuture() {
+		return bufferPool.getAvailableFuture();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -99,8 +99,8 @@ public abstract class InputGate implements PullingAsyncDataInput<BufferOrEvent>,
 	 * not completed futures should become completed once there are more records available.
 	 */
 	@Override
-	public CompletableFuture<?> isAvailable() {
-		return availabilityHelper.isAvailable();
+	public CompletableFuture<?> getAvailableFuture() {
+		return availabilityHelper.getAvailableFuture();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -108,7 +108,7 @@ public class UnionInputGate extends InputGate {
 
 				currentNumberOfInputChannels += inputGate.getNumberOfInputChannels();
 
-				CompletableFuture<?> available = inputGate.isAvailable();
+				CompletableFuture<?> available = inputGate.getAvailableFuture();
 
 				if (available.isDone()) {
 					inputGatesWithData.add(inputGate);
@@ -185,7 +185,7 @@ public class UnionInputGate extends InputGate {
 					// enqueue the inputGate at the end to avoid starvation
 					inputGatesWithData.add(inputGate.get());
 				} else if (!inputGate.get().isFinished()) {
-					inputGate.get().isAvailable().thenRun(() -> queueInputGate(inputGate.get()));
+					inputGate.get().getAvailableFuture().thenRun(() -> queueInputGate(inputGate.get()));
 				}
 
 				if (inputGatesWithData.isEmpty()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/ConsumableNotifyingResultPartitionWriterDecorator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/ConsumableNotifyingResultPartitionWriterDecorator.java
@@ -121,8 +121,8 @@ public class ConsumableNotifyingResultPartitionWriterDecorator implements Result
 	}
 
 	@Override
-	public CompletableFuture<?> isAvailable() {
-		return partitionWriter.isAvailable();
+	public CompletableFuture<?> getAvailableFuture() {
+		return partitionWriter.getAvailableFuture();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
@@ -46,8 +46,8 @@ public class InputGateWithMetrics extends InputGate {
 	}
 
 	@Override
-	public CompletableFuture<?> isAvailable() {
-		return inputGate.isAvailable();
+	public CompletableFuture<?> getAvailableFuture() {
+		return inputGate.getAvailableFuture();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -469,7 +469,7 @@ public class Task implements Runnable, TaskActions, PartitionProducerStateProvid
 		}
 		final CompletableFuture<?>[] outputFutures = new CompletableFuture[consumableNotifyingPartitionWriters.length];
 		for (int i = 0; i < outputFutures.length; ++i) {
-			outputFutures[i] = consumableNotifyingPartitionWriters[i].isAvailable();
+			outputFutures[i] = consumableNotifyingPartitionWriters[i].getAvailableFuture();
 		}
 		return !CompletableFuture.allOf(outputFutures).isDone();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentTest.java
@@ -94,10 +94,10 @@ public class NettyShuffleEnvironmentTest extends TestLogger {
 		// outgoing: 1 buffer per channel (always)
 		if (!enableCreditBasedFlowControl) {
 			// incoming: 1 buffer per channel
-			bufferCount = 20;
+			bufferCount = 24;
 		} else {
 			// incoming: 2 exclusive buffers per channel
-			bufferCount = 10 + 10 * NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL.defaultValue();
+			bufferCount = 14 + 10 * NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL.defaultValue();
 		}
 
 		testRegisterTaskWithLimitedBuffers(bufferCount);
@@ -178,8 +178,8 @@ public class NettyShuffleEnvironmentTest extends TestLogger {
 		assertEquals(expectedRp4Buffers, rp4.getBufferPool().getMaxNumberOfMemorySegments());
 
 		for (ResultPartition rp : resultPartitions) {
-			assertEquals(rp.getNumberOfSubpartitions(), rp.getBufferPool().getNumberOfRequiredMemorySegments());
-			assertEquals(rp.getNumberOfSubpartitions(), rp.getBufferPool().getNumBuffers());
+			assertEquals(rp.getNumberOfSubpartitions() + 1, rp.getBufferPool().getNumberOfRequiredMemorySegments());
+			assertEquals(rp.getNumberOfSubpartitions() + 1, rp.getBufferPool().getNumBuffers());
 		}
 
 		// verify buffer pools for the input gates (NOTE: credit-based uses minimum required buffers

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AbstractCollectingResultPartitionWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AbstractCollectingResultPartitionWriter.java
@@ -125,7 +125,7 @@ public abstract class AbstractCollectingResultPartitionWriter implements ResultP
 	}
 
 	@Override
-	public CompletableFuture<?> isAvailable() {
+	public CompletableFuture<?> getAvailableFuture() {
 		return AvailabilityProvider.AVAILABLE;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AvailabilityTestResultPartitionWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AvailabilityTestResultPartitionWriter.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.api.writer;
+
+import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
+import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+
+import javax.annotation.Nullable;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A specific result partition writer implementation only used to control the output
+ * availability state in tests.
+ */
+public class AvailabilityTestResultPartitionWriter implements ResultPartitionWriter {
+
+	/** This state is only valid in the first call of {@link #isAvailable()}. */
+	private final boolean isAvailable;
+
+	private final CompletableFuture future = new CompletableFuture();
+
+	/** The counter used to record how many calls of {@link #isAvailable()}. */
+	private int counter;
+
+	public AvailabilityTestResultPartitionWriter(boolean isAvailable) {
+		this.isAvailable = isAvailable;
+	}
+
+	@Override
+	public void setup() {
+	}
+
+	@Override
+	public ResultPartitionID getPartitionId() {
+		return new ResultPartitionID();
+	}
+
+	@Override
+	public int getNumberOfSubpartitions() {
+		return 1;
+	}
+
+	@Override
+	public int getNumTargetKeyGroups() {
+		return 1;
+	}
+
+	@Override
+	public BufferBuilder getBufferBuilder() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean addBufferConsumer(BufferConsumer bufferConsumer, int targetChannel) {
+		return true;
+	}
+
+	@Override
+	public void flushAll() {
+	}
+
+	@Override
+	public void flush(int subpartitionIndex) {
+	}
+
+	@Override
+	public void close() {
+	}
+
+	@Override
+	public void fail(@Nullable Throwable throwable) {
+	}
+
+	@Override
+	public void finish() {
+	}
+
+	@Override
+	public CompletableFuture<?> getAvailableFuture() {
+		return isAvailable ? AVAILABLE : future;
+	}
+
+	@Override
+	public boolean isAvailable() {
+		return counter++ == 0 ? isAvailable : true;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterDelegateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterDelegateTest.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.api.writer;
+
+import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
+import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionBuilder;
+import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
+import org.apache.flink.runtime.io.network.util.TestPooledBufferProvider;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the {@link SingleRecordWriter} and {@link MultipleRecordWriters}.
+ */
+public class RecordWriterDelegateTest extends TestLogger {
+
+	private static final int numberOfBuffers = 10;
+
+	private static final int memorySegmentSize = 128;
+
+	private static final int numberOfSegmentsToRequest = 2;
+
+	private NetworkBufferPool globalPool;
+
+	@Before
+	public void setup() {
+		globalPool = new NetworkBufferPool(numberOfBuffers, memorySegmentSize, numberOfSegmentsToRequest);
+	}
+
+	@After
+	public void teardown() {
+		globalPool.destroyAllBufferPools();
+		globalPool.destroy();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testSingleRecordWriterAvailability() throws Exception {
+		final RecordWriter recordWriter = createRecordWriter(globalPool);
+		final RecordWriterDelegate writerDelegate = new SingleRecordWriter(recordWriter);
+
+		assertEquals(recordWriter, writerDelegate.getRecordWriter(0));
+		verifyAvailability(writerDelegate);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testMultipleRecordWritersAvailability() throws Exception {
+		// setup
+		final int numRecordWriters = 2;
+		final List<RecordWriter> recordWriters = new ArrayList<>(numRecordWriters);
+
+		for (int i = 0; i < numRecordWriters; i++) {
+			recordWriters.add(createRecordWriter(globalPool));
+		}
+
+		RecordWriterDelegate writerDelegate = new MultipleRecordWriters(recordWriters);
+		for (int i = 0; i < numRecordWriters; i++) {
+			assertEquals(recordWriters.get(i), writerDelegate.getRecordWriter(i));
+		}
+
+		verifyAvailability(writerDelegate);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testSingleRecordWriterBroadcastEvent() throws Exception {
+		// setup
+		final ArrayDeque<BufferConsumer>[] queues = new ArrayDeque[] { new ArrayDeque(), new ArrayDeque() };
+		final RecordWriter recordWriter = createRecordWriter(queues);
+		final RecordWriterDelegate writerDelegate = new SingleRecordWriter(recordWriter);
+
+		verifyBroadcastEvent(writerDelegate, queues, 1);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testMultipleRecordWritersBroadcastEvent() throws Exception {
+		// setup
+		final int numRecordWriters = 2;
+		final List<RecordWriter> recordWriters = new ArrayList<>(numRecordWriters);
+		final ArrayDeque<BufferConsumer>[] queues = new ArrayDeque[] { new ArrayDeque(), new ArrayDeque() };
+
+		for (int i = 0; i < numRecordWriters; i++) {
+			recordWriters.add(createRecordWriter(queues));
+		}
+		final RecordWriterDelegate writerDelegate = new MultipleRecordWriters(recordWriters);
+
+		verifyBroadcastEvent(writerDelegate, queues, numRecordWriters);
+	}
+
+	private RecordWriter createRecordWriter(NetworkBufferPool globalPool) throws Exception {
+		final BufferPool localPool = globalPool.createBufferPool(1, 1);
+		final ResultPartitionWriter partition = new ResultPartitionBuilder()
+			.setBufferPoolFactory(p -> localPool)
+			.build();
+		partition.setup();
+
+		return new RecordWriterBuilder().build(partition);
+	}
+
+	private RecordWriter createRecordWriter(ArrayDeque<BufferConsumer>[] queues) {
+		final ResultPartitionWriter partition = new RecordWriterTest.CollectingPartitionWriter(
+			queues,
+			new TestPooledBufferProvider(1));
+
+		return new RecordWriterBuilder().build(partition);
+	}
+
+	private void verifyAvailability(RecordWriterDelegate writerDelegate) throws Exception {
+		// writer is available at the beginning
+		assertTrue(writerDelegate.isAvailable());
+		assertTrue(writerDelegate.getAvailableFuture().isDone());
+
+		// request one buffer from the local pool to make it unavailable
+		final BufferBuilder bufferBuilder = checkNotNull(writerDelegate.getRecordWriter(0).getBufferBuilder(0));
+		assertFalse(writerDelegate.isAvailable());
+		CompletableFuture future = writerDelegate.getAvailableFuture();
+		assertFalse(future.isDone());
+
+		// recycle the buffer to make the local pool available again
+		final Buffer buffer = BufferBuilderTestUtils.buildSingleBuffer(bufferBuilder);
+		buffer.recycleBuffer();
+		assertTrue(future.isDone());
+		assertTrue(writerDelegate.isAvailable());
+		assertTrue(writerDelegate.getAvailableFuture().isDone());
+	}
+
+	private void verifyBroadcastEvent(
+			RecordWriterDelegate writerDelegate,
+			ArrayDeque<BufferConsumer>[] queues,
+			int numRecordWriters) throws Exception {
+
+		final CancelCheckpointMarker message = new CancelCheckpointMarker(1);
+		writerDelegate.broadcastEvent(message);
+
+		// verify the added messages in all the queues
+		for (int i = 0; i < queues.length; i++) {
+			assertEquals(numRecordWriters, queues[i].size());
+
+			for (int j = 0; j < numRecordWriters; j++) {
+				BufferOrEvent boe = RecordWriterTest.parseBuffer(queues[i].remove(), i);
+				assertTrue(boe.isEvent());
+				assertEquals(message, boe.getEvent());
+			}
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
@@ -450,18 +450,18 @@ public class RecordWriterTest {
 
 		try {
 			// record writer is available because of initial available global pool
-			assertTrue(recordWriter.isAvailable().isDone());
+			assertTrue(recordWriter.getAvailableFuture().isDone());
 
 			// request one buffer from the local pool to make it unavailable afterwards
 			final BufferBuilder bufferBuilder = resultPartition.getBufferBuilder();
 			assertNotNull(bufferBuilder);
-			assertFalse(recordWriter.isAvailable().isDone());
+			assertFalse(recordWriter.getAvailableFuture().isDone());
 
 			// recycle the buffer to make the local pool available again
 			final Buffer buffer = BufferBuilderTestUtils.buildSingleBuffer(bufferBuilder);
 			buffer.recycleBuffer();
-			assertTrue(recordWriter.isAvailable().isDone());
-			assertEquals(recordWriter.AVAILABLE, recordWriter.isAvailable());
+			assertTrue(recordWriter.getAvailableFuture().isDone());
+			assertEquals(recordWriter.AVAILABLE, recordWriter.getAvailableFuture());
 		} finally {
 			localPool.lazyDestroy();
 			globalPool.destroy();
@@ -595,7 +595,7 @@ public class RecordWriterTest {
 		}
 
 		@Override
-		public CompletableFuture<?> isAvailable() {
+		public CompletableFuture<?> getAvailableFuture() {
 			return AVAILABLE;
 		}
 
@@ -676,7 +676,7 @@ public class RecordWriterTest {
 		}
 
 		@Override
-		public CompletableFuture<?> isAvailable() {
+		public CompletableFuture<?> getAvailableFuture() {
 			return AVAILABLE;
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
@@ -604,7 +604,7 @@ public class RecordWriterTest {
 		}
 	}
 
-	private static BufferOrEvent parseBuffer(BufferConsumer bufferConsumer, int targetChannel) throws IOException {
+	static BufferOrEvent parseBuffer(BufferConsumer bufferConsumer, int targetChannel) throws IOException {
 		Buffer buffer = buildSingleBuffer(bufferConsumer);
 		if (buffer.isBuffer()) {
 			return new BufferOrEvent(buffer, targetChannel);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
@@ -410,39 +410,39 @@ public class LocalBufferPoolTest extends TestLogger {
 	public void testIsAvailableOrNot() throws Exception {
 
 		// the local buffer pool should be in available state initially
-		assertTrue(localBufferPool.isAvailable().isDone());
+		assertTrue(localBufferPool.getAvailableFuture().isDone());
 
 		// request one buffer
 		final BufferBuilder bufferBuilder = checkNotNull(localBufferPool.requestBufferBuilderBlocking());
-		CompletableFuture<?> availableFuture = localBufferPool.isAvailable();
+		CompletableFuture<?> availableFuture = localBufferPool.getAvailableFuture();
 		assertFalse(availableFuture.isDone());
 
 		// set the pool size
 		localBufferPool.setNumBuffers(2);
 		assertTrue(availableFuture.isDone());
-		assertTrue(localBufferPool.isAvailable().isDone());
+		assertTrue(localBufferPool.getAvailableFuture().isDone());
 
 		// drain the global buffer pool
 		final List<MemorySegment> segments = new ArrayList<>(numBuffers);
 		while (networkBufferPool.getNumberOfAvailableMemorySegments() > 0) {
 			segments.add(checkNotNull(networkBufferPool.requestMemorySegment()));
 		}
-		assertFalse(localBufferPool.isAvailable().isDone());
+		assertFalse(localBufferPool.getAvailableFuture().isDone());
 
 		// recycle the requested segments to global buffer pool
 		for (final MemorySegment segment: segments) {
 			networkBufferPool.recycle(segment);
 		}
-		assertTrue(localBufferPool.isAvailable().isDone());
+		assertTrue(localBufferPool.getAvailableFuture().isDone());
 
 		// reset the pool size
 		localBufferPool.setNumBuffers(1);
-		availableFuture = localBufferPool.isAvailable();
+		availableFuture = localBufferPool.getAvailableFuture();
 		assertFalse(availableFuture.isDone());
 
 		// recycle the requested buffer
 		bufferBuilder.createBufferConsumer().close();
-		assertTrue(localBufferPool.isAvailable().isDone());
+		assertTrue(localBufferPool.getAvailableFuture().isDone());
 		assertTrue(availableFuture.isDone());
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
@@ -541,26 +541,26 @@ public class NetworkBufferPoolTest extends TestLogger {
 
 		try {
 			// the global pool should be in available state initially
-			assertTrue(globalPool.isAvailable().isDone());
+			assertTrue(globalPool.getAvailableFuture().isDone());
 
 			// request the first segment
 			final MemorySegment segment1 = checkNotNull(globalPool.requestMemorySegment());
-			assertTrue(globalPool.isAvailable().isDone());
+			assertTrue(globalPool.getAvailableFuture().isDone());
 
 			// request the second segment
 			final MemorySegment segment2 = checkNotNull(globalPool.requestMemorySegment());
-			assertFalse(globalPool.isAvailable().isDone());
+			assertFalse(globalPool.getAvailableFuture().isDone());
 
-			final CompletableFuture<?> availableFuture = globalPool.isAvailable();
+			final CompletableFuture<?> availableFuture = globalPool.getAvailableFuture();
 
 			// recycle the first segment
 			globalPool.recycle(segment1);
 			assertTrue(availableFuture.isDone());
-			assertTrue(globalPool.isAvailable().isDone());
+			assertTrue(globalPool.getAvailableFuture().isDone());
 
 			// recycle the second segment
 			globalPool.recycle(segment2);
-			assertTrue(globalPool.isAvailable().isDone());
+			assertTrue(globalPool.getAvailableFuture().isDone());
 
 		} finally {
 			globalPool.destroy();
@@ -581,16 +581,16 @@ public class NetworkBufferPoolTest extends TestLogger {
 
 		try {
 			// the global pool should be in available state initially
-			assertTrue(globalPool.isAvailable().isDone());
+			assertTrue(globalPool.getAvailableFuture().isDone());
 
 			// request 5 segments
 			List<MemorySegment> segments1 = globalPool.requestMemorySegments();
-			assertTrue(globalPool.isAvailable().isDone());
+			assertTrue(globalPool.getAvailableFuture().isDone());
 			assertEquals(numberOfSegmentsToRequest, segments1.size());
 
 			// request another 5 segments
 			List<MemorySegment> segments2 = globalPool.requestMemorySegments();
-			assertFalse(globalPool.isAvailable().isDone());
+			assertFalse(globalPool.getAvailableFuture().isDone());
 			assertEquals(numberOfSegmentsToRequest, segments2.size());
 
 			// request another 5 segments
@@ -607,22 +607,22 @@ public class NetworkBufferPoolTest extends TestLogger {
 			asyncRequest.start();
 
 			// recycle 5 segments
-			CompletableFuture<?> availableFuture = globalPool.isAvailable();
+			CompletableFuture<?> availableFuture = globalPool.getAvailableFuture();
 			globalPool.recycleMemorySegments(segments1);
 			assertTrue(availableFuture.isDone());
 
 			// wait util the third request is fulfilled
 			latch.await();
-			assertFalse(globalPool.isAvailable().isDone());
+			assertFalse(globalPool.getAvailableFuture().isDone());
 			assertEquals(numberOfSegmentsToRequest, segments3.size());
 
 			// recycle another 5 segments
 			globalPool.recycleMemorySegments(segments2);
-			assertTrue(globalPool.isAvailable().isDone());
+			assertTrue(globalPool.getAvailableFuture().isDone());
 
 			// recycle the last 5 segments
 			globalPool.recycleMemorySegments(segments3);
-			assertTrue(globalPool.isAvailable().isDone());
+			assertTrue(globalPool.getAvailableFuture().isDone());
 
 		} finally {
 			globalPool.destroy();
@@ -650,7 +650,7 @@ public class NetworkBufferPoolTest extends TestLogger {
 			for (int i  = 0; i < numLocalBufferPool; ++i) {
 				final BufferPool localPool = globalPool.createBufferPool(localPoolRequiredSize, localPoolMaxSize);
 				localBufferPools.add(localPool);
-				assertTrue(localPool.isAvailable().isDone());
+				assertTrue(localPool.getAvailableFuture().isDone());
 			}
 
 			// request some segments from the global pool in two different ways
@@ -659,9 +659,9 @@ public class NetworkBufferPoolTest extends TestLogger {
 				segments.add(globalPool.requestMemorySegment());
 			}
 			final List<MemorySegment> exclusiveSegments = globalPool.requestMemorySegments();
-			assertTrue(globalPool.isAvailable().isDone());
+			assertTrue(globalPool.getAvailableFuture().isDone());
 			for (final BufferPool localPool: localBufferPools) {
-				assertTrue(localPool.isAvailable().isDone());
+				assertTrue(localPool.getAvailableFuture().isDone());
 			}
 
 			// blocking request buffers form local buffer pools
@@ -688,12 +688,12 @@ public class NetworkBufferPoolTest extends TestLogger {
 				assertNull(cause.get());
 			}
 
-			final CompletableFuture<?> globalPoolAvailableFuture = globalPool.isAvailable();
+			final CompletableFuture<?> globalPoolAvailableFuture = globalPool.getAvailableFuture();
 			assertFalse(globalPoolAvailableFuture.isDone());
 
 			final List<CompletableFuture<?>> localPoolAvailableFutures = new ArrayList<>(numLocalBufferPool);
 			for (BufferPool localPool: localBufferPools) {
-				CompletableFuture<?> localPoolAvailableFuture = localPool.isAvailable();
+				CompletableFuture<?> localPoolAvailableFuture = localPool.getAvailableFuture();
 				localPoolAvailableFutures.add(localPoolAvailableFuture);
 				assertFalse(localPoolAvailableFuture.isDone());
 			}
@@ -714,9 +714,9 @@ public class NetworkBufferPoolTest extends TestLogger {
 
 			assertNull(cause.get());
 			assertEquals(0, globalPool.getNumberOfAvailableMemorySegments());
-			assertFalse(globalPool.isAvailable().isDone());
+			assertFalse(globalPool.getAvailableFuture().isDone());
 			for (BufferPool localPool: localBufferPools) {
-				assertFalse(localPool.isAvailable().isDone());
+				assertFalse(localPool.getAvailableFuture().isDone());
 				assertEquals(localPoolMaxSize, localPool.bestEffortGetNumOfUsedBuffers());
 			}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NoOpBufferPool.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NoOpBufferPool.java
@@ -90,7 +90,7 @@ public class NoOpBufferPool implements BufferPool {
 	}
 
 	@Override
-	public CompletableFuture<?> isAvailable() {
+	public CompletableFuture<?> getAvailableFuture() {
 		return AVAILABLE;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
@@ -103,12 +103,12 @@ public class ResultPartitionBuilder {
 		return this;
 	}
 
-	private ResultPartitionBuilder setNetworkBuffersPerChannel(int networkBuffersPerChannel) {
+	public ResultPartitionBuilder setNetworkBuffersPerChannel(int networkBuffersPerChannel) {
 		this.networkBuffersPerChannel = networkBuffersPerChannel;
 		return this;
 	}
 
-	private ResultPartitionBuilder setFloatingNetworkBuffersPerGate(int floatingNetworkBuffersPerGate) {
+	public ResultPartitionBuilder setFloatingNetworkBuffersPerGate(int floatingNetworkBuffersPerGate) {
 		this.floatingNetworkBuffersPerGate = floatingNetworkBuffersPerGate;
 		return this;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateTestBase.java
@@ -54,29 +54,29 @@ public abstract class InputGateTestBase {
 			SingleInputGate inputGateToNotify,
 			TestInputChannel inputChannelWithNewData) throws Exception {
 
-		assertFalse(inputGateToTest.isAvailable().isDone());
+		assertFalse(inputGateToTest.getAvailableFuture().isDone());
 		assertFalse(inputGateToTest.pollNext().isPresent());
 
-		CompletableFuture<?> isAvailable = inputGateToTest.isAvailable();
+		CompletableFuture<?> future = inputGateToTest.getAvailableFuture();
 
-		assertFalse(inputGateToTest.isAvailable().isDone());
+		assertFalse(inputGateToTest.getAvailableFuture().isDone());
 		assertFalse(inputGateToTest.pollNext().isPresent());
 
-		assertEquals(isAvailable, inputGateToTest.isAvailable());
+		assertEquals(future, inputGateToTest.getAvailableFuture());
 
 		inputChannelWithNewData.readBuffer();
 		inputGateToNotify.notifyChannelNonEmpty(inputChannelWithNewData);
 
-		assertTrue(isAvailable.isDone());
-		assertTrue(inputGateToTest.isAvailable().isDone());
-		assertEquals(PullingAsyncDataInput.AVAILABLE, inputGateToTest.isAvailable());
+		assertTrue(future.isDone());
+		assertTrue(inputGateToTest.getAvailableFuture().isDone());
+		assertEquals(PullingAsyncDataInput.AVAILABLE, inputGateToTest.getAvailableFuture());
 	}
 
 	protected void testIsAvailableAfterFinished(
 		InputGate inputGateToTest,
 		Runnable endOfPartitionEvent) throws Exception {
 
-		CompletableFuture<?> available = inputGateToTest.isAvailable();
+		CompletableFuture<?> available = inputGateToTest.getAvailableFuture();
 		assertFalse(available.isDone());
 		assertFalse(inputGateToTest.pollNext().isPresent());
 
@@ -85,8 +85,8 @@ public abstract class InputGateTestBase {
 		assertTrue(inputGateToTest.pollNext().isPresent()); // EndOfPartitionEvent
 
 		assertTrue(available.isDone());
-		assertTrue(inputGateToTest.isAvailable().isDone());
-		assertEquals(PullingAsyncDataInput.AVAILABLE, inputGateToTest.isAvailable());
+		assertTrue(inputGateToTest.getAvailableFuture().isDone());
+		assertEquals(PullingAsyncDataInput.AVAILABLE, inputGateToTest.getAvailableFuture());
 	}
 
 	protected SingleInputGate createInputGate() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestPooledBufferProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestPooledBufferProvider.java
@@ -97,7 +97,7 @@ public class TestPooledBufferProvider implements BufferProvider {
 	}
 
 	@Override
-	public CompletableFuture<?> isAvailable() {
+	public CompletableFuture<?> getAvailableFuture() {
 		return AVAILABLE;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -188,6 +188,10 @@ public class MockEnvironment implements Environment, AutoCloseable {
 		}
 	}
 
+	public void addOutputs(List<ResultPartitionWriter> writers) {
+		outputs.addAll(writers);
+	}
+
 	@Override
 	public Configuration getTaskConfiguration() {
 		return this.taskConfiguration;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointedInputGate.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointedInputGate.java
@@ -109,9 +109,9 @@ public class CheckpointedInputGate implements PullingAsyncDataInput<BufferOrEven
 	}
 
 	@Override
-	public CompletableFuture<?> isAvailable() {
+	public CompletableFuture<?> getAvailableFuture() {
 		if (bufferStorage.isEmpty()) {
-			return inputGate.isAvailable();
+			return inputGate.getAvailableFuture();
 		}
 		return AVAILABLE;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
@@ -31,7 +31,7 @@ public interface StreamInputProcessor extends AvailabilityProvider, Closeable {
 	/**
 	 * @return input status to estimate whether more records can be processed immediately or not.
 	 * If there are no more records available at the moment and the caller should check finished
-	 * state and/or {@link #isAvailable()}.
+	 * state and/or {@link #getAvailableFuture()}.
 	 */
 	InputStatus processInput() throws Exception;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
@@ -60,8 +60,8 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
 	}
 
 	@Override
-	public CompletableFuture<?> isAvailable() {
-		return input.isAvailable();
+	public CompletableFuture<?> getAvailableFuture() {
+		return input.getAvailableFuture();
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
@@ -135,7 +135,7 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
 				processBufferOrEvent(bufferOrEvent.get());
 			} else {
 				if (checkpointedInputGate.isFinished()) {
-					checkState(checkpointedInputGate.isAvailable().isDone(), "Finished BarrierHandler should be available");
+					checkState(checkpointedInputGate.getAvailableFuture().isDone(), "Finished BarrierHandler should be available");
 					if (!checkpointedInputGate.isEmpty()) {
 						throw new IllegalStateException("Trailing data in checkpoint barrier handler.");
 					}
@@ -190,11 +190,11 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
 	}
 
 	@Override
-	public CompletableFuture<?> isAvailable() {
+	public CompletableFuture<?> getAvailableFuture() {
 		if (currentRecordDeserializer != null) {
 			return AVAILABLE;
 		}
-		return checkpointedInputGate.isAvailable();
+		return checkpointedInputGate.getAvailableFuture();
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
@@ -46,8 +46,8 @@ public final class StreamTaskSourceInput<T> implements StreamTaskInput<T> {
 	}
 
 	@Override
-	public CompletableFuture<?> isAvailable() {
-		return operator.isAvailable();
+	public CompletableFuture<?> getAvailableFuture() {
+		return operator.getAvailableFuture();
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -152,12 +152,12 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 	}
 
 	@Override
-	public CompletableFuture<?> isAvailable() {
+	public CompletableFuture<?> getAvailableFuture() {
 		if (inputSelectionHandler.areAllInputsSelected()) {
 			return isAnyInputAvailable();
 		} else {
 			StreamTaskInput input = (inputSelectionHandler.isFirstInputSelected()) ? input1 : input2;
-			return input.isAvailable();
+			return input.getAvailableFuture();
 		}
 	}
 
@@ -283,7 +283,7 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 	}
 
 	private void updateAvailability(InputStatus status, StreamTaskInput input) {
-		if (status == InputStatus.MORE_AVAILABLE || (status != InputStatus.END_OF_INPUT && input.isAvailable() == AVAILABLE)) {
+		if (status == InputStatus.MORE_AVAILABLE || (status != InputStatus.END_OF_INPUT && input.isApproximatelyAvailable())) {
 			inputSelectionHandler.setAvailableInput(input.getInputIndex());
 		} else {
 			inputSelectionHandler.setUnavailableInput(input.getInputIndex());
@@ -295,29 +295,26 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 		if (status == InputStatus.END_OF_INPUT) {
 			return;
 		}
-		CompletableFuture<?> inputAvailable = getInput(inputIndex).isAvailable();
-		// TODO: inputAvailable.isDone() can be a costly operation (checking volatile). If one of
+
+		// TODO: isAvailable() can be a costly operation (checking volatile). If one of
 		// the input is constantly available and another is not, we will be checking this volatile
 		// once per every record. This might be optimized to only check once per processed NetworkBuffer
-		if (inputAvailable == AVAILABLE || inputAvailable.isDone()) {
+		if (getInput(inputIndex).isAvailable()) {
 			inputSelectionHandler.setAvailableInput(inputIndex);
 		}
 	}
 
 	private CompletableFuture<?> isAnyInputAvailable() {
 		if (firstInputStatus == InputStatus.END_OF_INPUT) {
-			return input2.isAvailable();
+			return input2.getAvailableFuture();
 		}
 
 		if (secondInputStatus == InputStatus.END_OF_INPUT) {
-			return input1.isAvailable();
+			return input1.getAvailableFuture();
 		}
 
-		CompletableFuture<?> input1Available = input1.isAvailable();
-		CompletableFuture<?> input2Available = input2.isAvailable();
-
-		return (input1Available == AVAILABLE || input2Available == AVAILABLE) ?
-			AVAILABLE : CompletableFuture.anyOf(input1Available, input2Available);
+		return (input1.isApproximatelyAvailable() || input2.isApproximatelyAvailable()) ?
+			AVAILABLE : CompletableFuture.anyOf(input1.getAvailableFuture(), input2.getAvailableFuture());
 	}
 
 	private StreamTaskInput getInput(int inputIndex) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
+import org.apache.flink.runtime.io.network.api.writer.RecordWriterDelegate;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.groups.OperatorIOMetricGroup;
 import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
@@ -106,7 +107,7 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 
 	public OperatorChain(
 			StreamTask<OUT, OP> containingTask,
-			List<RecordWriter<SerializationDelegate<StreamRecord<OUT>>>> recordWriters) {
+			RecordWriterDelegate<SerializationDelegate<StreamRecord<OUT>>> recordWriterDelegate) {
 
 		final ClassLoader userCodeClassloader = containingTask.getUserCodeClassLoader();
 		final StreamConfig configuration = containingTask.getConfiguration();
@@ -129,7 +130,7 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 				StreamEdge outEdge = outEdgesInOrder.get(i);
 
 				RecordWriterOutput<?> streamOutput = createStreamOutput(
-					recordWriters.get(i),
+					recordWriterDelegate.getRecordWriter(i),
 					outEdge,
 					chainedConfigs.get(outEdge.getSourceId()),
 					containingTask.getEnvironment());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -282,7 +282,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		}
 		else if (status == InputStatus.NOTHING_AVAILABLE) {
 			MailboxDefaultAction.Suspension suspendedDefaultAction = controller.suspendDefaultAction();
-			inputProcessor.isAvailable().thenRun(suspendedDefaultAction::resume);
+			inputProcessor.getAvailableFuture().thenRun(suspendedDefaultAction::resume);
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -35,9 +35,13 @@ import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
+import org.apache.flink.runtime.io.network.api.writer.MultipleRecordWriters;
+import org.apache.flink.runtime.io.network.api.writer.NonRecordWriter;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriterBuilder;
+import org.apache.flink.runtime.io.network.api.writer.RecordWriterDelegate;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.api.writer.SingleRecordWriter;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
@@ -84,6 +88,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -199,7 +204,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	/** Thread pool for async snapshot workers. */
 	private ExecutorService asyncOperationsThreadPool;
 
-	private final List<RecordWriter<SerializationDelegate<StreamRecord<OUT>>>> recordWriters;
+	private final RecordWriterDelegate<SerializationDelegate<StreamRecord<OUT>>> recordWriter;
 
 	protected final MailboxProcessor mailboxProcessor;
 
@@ -248,7 +253,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		this.uncaughtExceptionHandler = Preconditions.checkNotNull(uncaughtExceptionHandler);
 		this.configuration = new StreamConfig(getTaskConfiguration());
 		this.accumulatorMap = getEnvironment().getAccumulatorRegistry().getUserMap();
-		this.recordWriters = createRecordWriters(configuration, environment);
+		this.recordWriter = createRecordWriterDelegate(configuration, environment);
 		this.mailboxProcessor = new MailboxProcessor(this::processInput);
 		this.asyncExceptionHandler = new StreamTaskAsyncExceptionHandler(environment);
 	}
@@ -277,12 +282,31 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	 */
 	protected void processInput(MailboxDefaultAction.Controller controller) throws Exception {
 		InputStatus status = inputProcessor.processInput();
+		if (status == InputStatus.MORE_AVAILABLE && recordWriter.isAvailable()) {
+			return;
+		}
 		if (status == InputStatus.END_OF_INPUT) {
 			controller.allActionsCompleted();
+			return;
 		}
-		else if (status == InputStatus.NOTHING_AVAILABLE) {
-			MailboxDefaultAction.Suspension suspendedDefaultAction = controller.suspendDefaultAction();
-			inputProcessor.getAvailableFuture().thenRun(suspendedDefaultAction::resume);
+		CompletableFuture<?> jointFuture = getInputOutputJointFuture(status);
+		MailboxDefaultAction.Suspension suspendedDefaultAction = controller.suspendDefaultAction();
+		jointFuture.thenRun(suspendedDefaultAction::resume);
+	}
+
+	/**
+	 * Considers three scenarios to combine input and output futures:
+	 * 1. Both input and output are unavailable.
+	 * 2. Only input is unavailable.
+	 * 3. Only output is unavailable.
+	 */
+	private CompletableFuture<?> getInputOutputJointFuture(InputStatus status) {
+		if (status == InputStatus.NOTHING_AVAILABLE && !recordWriter.isAvailable()) {
+			return CompletableFuture.allOf(inputProcessor.getAvailableFuture(), recordWriter.getAvailableFuture());
+		} else if (status == InputStatus.NOTHING_AVAILABLE) {
+			return inputProcessor.getAvailableFuture();
+		} else {
+			return recordWriter.getAvailableFuture();
 		}
 	}
 
@@ -383,7 +407,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 					timerThreadFactory);
 			}
 
-			operatorChain = new OperatorChain<>(this, recordWriters);
+			operatorChain = new OperatorChain<>(this, recordWriter);
 			headOperator = operatorChain.getHeadOperator();
 
 			// check environment for selective reading
@@ -514,9 +538,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 				}
 			} else {
 				// failed to allocate operatorChain, clean up record writers
-				for (RecordWriter<SerializationDelegate<StreamRecord<OUT>>> writer: recordWriters) {
-					writer.close();
-				}
+				recordWriter.close();
 			}
 
 			mailboxProcessor.close();
@@ -852,21 +874,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 				// we cannot broadcast the cancellation markers on the 'operator chain', because it may not
 				// yet be created
 				final CancelCheckpointMarker message = new CancelCheckpointMarker(checkpointMetaData.getCheckpointId());
-				Exception exception = null;
-
-				for (RecordWriter<SerializationDelegate<StreamRecord<OUT>>> recordWriter : recordWriters) {
-					try {
-						recordWriter.broadcastEvent(message);
-					} catch (Exception e) {
-						exception = ExceptionUtils.firstOrSuppressed(
-							new Exception("Could not send cancel checkpoint marker to downstream tasks.", e),
-							exception);
-					}
-				}
-
-				if (exception != null) {
-					throw exception;
-				}
+				recordWriter.broadcastEvent(message);
 
 				return false;
 			}
@@ -1396,7 +1404,22 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	}
 
 	@VisibleForTesting
-	public static <OUT> List<RecordWriter<SerializationDelegate<StreamRecord<OUT>>>> createRecordWriters(
+	public static <OUT> RecordWriterDelegate<SerializationDelegate<StreamRecord<OUT>>> createRecordWriterDelegate(
+			StreamConfig configuration,
+			Environment environment) {
+		List<RecordWriter<SerializationDelegate<StreamRecord<OUT>>>> recordWrites = createRecordWriters(
+			configuration,
+			environment);
+		if (recordWrites.size() == 1) {
+			return new SingleRecordWriter<>(recordWrites.get(0));
+		} else if (recordWrites.size() == 0) {
+			return new NonRecordWriter<>();
+		} else {
+			return new MultipleRecordWriters<>(recordWrites);
+		}
+	}
+
+	private static <OUT> List<RecordWriter<SerializationDelegate<StreamRecord<OUT>>>> createRecordWriters(
 			StreamConfig configuration,
 			Environment environment) {
 		List<RecordWriter<SerializationDelegate<StreamRecord<OUT>>>> recordWriters = new ArrayList<>();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.runtime.tasks.mailbox;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.streaming.api.operators.MailboxExecutor;
 import org.apache.flink.util.Preconditions;
@@ -231,7 +232,8 @@ public class MailboxProcessor {
 		return suspendedDefaultAction;
 	}
 
-	private boolean isDefaultActionUnavailable() {
+	@VisibleForTesting
+	public boolean isDefaultActionUnavailable() {
 		return suspendedDefaultAction != null;
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
@@ -143,7 +143,7 @@ public class StreamTaskNetworkInputTest {
 	}
 
 	private static void assertHasNextElement(StreamTaskNetworkInput input, DataOutput output) throws Exception {
-		assertTrue(input.isAvailable().isDone());
+		assertTrue(input.getAvailableFuture().isDone());
 		InputStatus status = input.emitNext(output);
 		assertThat(status, is(InputStatus.MORE_AVAILABLE));
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmarkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmarkTest.java
@@ -103,7 +103,7 @@ public class StreamNetworkThroughputBenchmarkTest {
 		int writers = 2;
 		int channels = 2;
 
-		env.setUp(writers, channels, 100, false, writers * channels, writers * channels *
+		env.setUp(writers, channels, 100, false, writers * channels + writers, writers * channels *
 			NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL.defaultValue());
 		env.executeBenchmark(10_000);
 		env.tearDown();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamOperatorChainingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamOperatorChainingTest.java
@@ -274,7 +274,7 @@ public class StreamOperatorChainingTest {
 			StreamConfig streamConfig,
 			Environment environment,
 			StreamTask<IN, OT> task) {
-		return new OperatorChain<>(task, StreamTask.createRecordWriters(streamConfig, environment));
+		return new OperatorChain<>(task, StreamTask.createRecordWriterDelegate(streamConfig, environment));
 	}
 
 	private <IN, OT extends StreamOperator<IN>> StreamTask<IN, OT> createMockTask(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
@@ -167,7 +167,7 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
 		// run and wait to be stopped
 		OperatorChain<?, ?> operatorChain = new OperatorChain<>(
 			operator.getContainingTask(),
-			StreamTask.createRecordWriters(operator.getOperatorConfig(), new MockEnvironmentBuilder().build()));
+			StreamTask.createRecordWriterDelegate(operator.getOperatorConfig(), new MockEnvironmentBuilder().build()));
 		try {
 			operator.run(new Object(), mock(StreamStatusMaintainer.class), new CollectorOutput<>(output), operatorChain);
 			operator.close();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceReaderStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceReaderStreamTaskTest.java
@@ -106,7 +106,7 @@ public class SourceReaderStreamTaskTest {
 		CheckpointMetaData checkpointMetaData = new CheckpointMetaData(checkpointId, checkpointId);
 
 		// wait with triggering the checkpoint until we emit all of the data
-		while (testHarness.getTask().inputProcessor.isAvailable().isDone()) {
+		while (testHarness.getTask().inputProcessor.getAvailableFuture().isDone()) {
 			Thread.sleep(1);
 		}
 
@@ -195,7 +195,7 @@ public class SourceReaderStreamTaskTest {
 		}
 
 		@Override
-		public CompletableFuture<?> isAvailable() {
+		public CompletableFuture<?> getAvailableFuture() {
 			if (hasEmittedEverything()) {
 				return new CompletableFuture<>();
 			}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -1213,7 +1213,7 @@ public class StreamTaskTest extends TestLogger {
 		}
 
 		@Override
-		public CompletableFuture<?> isAvailable() {
+		public CompletableFuture<?> getAvailableFuture() {
 			return AVAILABLE;
 		}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -54,7 +54,9 @@ import org.apache.flink.runtime.filecache.FileCache;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
+import org.apache.flink.runtime.io.network.api.writer.AvailabilityTestResultPartitionWriter;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.partition.NoOpResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
@@ -106,6 +108,7 @@ import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.InternalTimeServiceManager;
+import org.apache.flink.streaming.api.operators.MailboxExecutor;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.StreamOperator;
@@ -118,6 +121,7 @@ import org.apache.flink.streaming.runtime.io.StreamInputProcessor;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxDefaultAction;
+import org.apache.flink.streaming.util.MockStreamConfig;
 import org.apache.flink.streaming.util.TestSequentialReadingStreamOperator;
 import org.apache.flink.util.CloseableIterable;
 import org.apache.flink.util.ExceptionUtils;
@@ -889,6 +893,57 @@ public class StreamTaskTest extends TestLogger {
 				.noneMatch(thread -> thread.getName().startsWith(RecordWriter.DEFAULT_OUTPUT_FLUSH_THREAD_NAME)));
 	}
 
+	@Test
+	public void testProcessWithAvailableOutput() throws Exception {
+		try (final MockEnvironment environment = setupEnvironment(new boolean[] {true, true})) {
+			final int numberOfProcessCalls = 10;
+			final AvailabilityTestInputProcessor inputProcessor = new AvailabilityTestInputProcessor(numberOfProcessCalls);
+			final AvailabilityTestStreamTask task = new AvailabilityTestStreamTask<>(environment, inputProcessor);
+
+			task.invoke();
+			assertEquals(numberOfProcessCalls, inputProcessor.currentNumProcessCalls);
+		}
+	}
+
+	@Test
+	public void testProcessWithUnAvailableOutput() throws Exception {
+		try (final MockEnvironment environment = setupEnvironment(new boolean[] {true, false})) {
+			final int numberOfProcessCalls = 10;
+			final AvailabilityTestInputProcessor inputProcessor = new AvailabilityTestInputProcessor(numberOfProcessCalls);
+			final AvailabilityTestStreamTask task = new AvailabilityTestStreamTask<>(environment, inputProcessor);
+			final MailboxExecutor executor = task.mailboxProcessor.getMainMailboxExecutor();
+
+			final Runnable completeFutureTask = () -> {
+				assertEquals(1, inputProcessor.currentNumProcessCalls);
+				assertTrue(task.mailboxProcessor.isDefaultActionUnavailable());
+				environment.getWriter(1).getAvailableFuture().complete(null);
+			};
+
+			executor.submit(() -> {
+				executor.submit(completeFutureTask, "This task will complete the future to resume process input action."); },
+				"This task will submit another task to execute after processing input once.");
+
+			task.invoke();
+			assertEquals(numberOfProcessCalls, inputProcessor.currentNumProcessCalls);
+		}
+	}
+
+	private MockEnvironment setupEnvironment(boolean[] outputAvailabilities) {
+		final Configuration configuration = new Configuration();
+		new MockStreamConfig(configuration, outputAvailabilities.length);
+
+		final List<ResultPartitionWriter> writers = new ArrayList<>(outputAvailabilities.length);
+		for (int i = 0; i < outputAvailabilities.length; i++) {
+			writers.add(new AvailabilityTestResultPartitionWriter(outputAvailabilities[i]));
+		}
+
+		final MockEnvironment environment = new MockEnvironmentBuilder()
+			.setTaskConfiguration(configuration)
+			.build();
+		environment.addOutputs(writers);
+		return environment;
+	}
+
 	// ------------------------------------------------------------------------
 	//  Test Utilities
 	// ------------------------------------------------------------------------
@@ -986,6 +1041,49 @@ public class StreamTaskTest extends TestLogger {
 
 		@Override
 		protected void cleanup() throws Exception {}
+	}
+
+	/**
+	 * A stream task implementation used to construct a specific {@link StreamInputProcessor} for tests.
+	 */
+	private static class AvailabilityTestStreamTask<T, OP extends StreamOperator<T>> extends StreamTask<T, OP> {
+
+		AvailabilityTestStreamTask(Environment environment, StreamInputProcessor inputProcessor) {
+			super(environment);
+
+			this.inputProcessor = inputProcessor;
+		}
+
+		@Override
+		protected void init() {
+		}
+	}
+
+	/**
+	 * A stream input processor implementation used to control the returned input status based on
+	 * the total number of processing calls.
+	 */
+	private static class AvailabilityTestInputProcessor implements StreamInputProcessor {
+		private final int totalProcessCalls;
+		private int currentNumProcessCalls;
+
+		AvailabilityTestInputProcessor(int totalProcessCalls) {
+			this.totalProcessCalls = totalProcessCalls;
+		}
+
+		@Override
+		public InputStatus processInput()  {
+			return ++currentNumProcessCalls < totalProcessCalls ? InputStatus.MORE_AVAILABLE : InputStatus.END_OF_INPUT;
+		}
+
+		@Override
+		public void close() throws IOException {
+		}
+
+		@Override
+		public CompletableFuture<?> getAvailableFuture() {
+			return AVAILABLE;
+		}
 	}
 
 	private static class BlockingCloseStreamOperator extends AbstractStreamOperator<Void> {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamConfig.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamConfig.java
@@ -17,17 +17,50 @@
 
 package org.apache.flink.streaming.util;
 
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.graph.StreamEdge;
+import org.apache.flink.streaming.api.graph.StreamNode;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
+import org.apache.flink.streaming.runtime.tasks.SourceStreamTask;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
- * Handy mock for {@link StreamConfig}.
+ * A dummy stream config implementation for specifying the number of outputs in tests.
  */
 public class MockStreamConfig extends StreamConfig {
-	public MockStreamConfig() {
-		super(new Configuration());
 
+	public MockStreamConfig(Configuration configuration, int numberOfOutputs) {
+		super(configuration);
+
+		setChainStart();
+		setOutputSelectors(Collections.emptyList());
+		setNumberOfOutputs(numberOfOutputs);
+		setTypeSerializerOut(new StringSerializer());
+		setVertexID(0);
+		setStreamOperator(new TestSequentialReadingStreamOperator("test operator"));
 		setOperatorID(new OperatorID());
+
+		StreamOperator dummyOperator = new AbstractStreamOperator() {
+			private static final long serialVersionUID = 1L;
+		};
+
+		StreamNode sourceVertex = new StreamNode(0, null, null, dummyOperator, "source", new ArrayList<>(), SourceStreamTask.class);
+		StreamNode targetVertex = new StreamNode(1, null, null, dummyOperator, "target", new ArrayList<>(), SourceStreamTask.class);
+
+		List<StreamEdge> outEdgesInOrder = new ArrayList<>(numberOfOutputs);
+		for (int i = 0; i < numberOfOutputs; i++) {
+			outEdgesInOrder.add(
+				new StreamEdge(sourceVertex, targetVertex, numberOfOutputs, new ArrayList<>(), new BroadcastPartitioner<>(), null));
+		}
+		setOutEdgesInOrder(outEdgesInOrder);
+		setNonChainedOutputs(outEdgesInOrder);
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BackPressureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BackPressureITCase.java
@@ -94,7 +94,7 @@ public class BackPressureITCase extends TestLogger {
 		final Configuration configuration = new Configuration();
 
 		final int memorySegmentSizeKb = 32;
-		final String networkBuffersMemory = (memorySegmentSizeKb * NUM_TASKS) + "kb";
+		final String networkBuffersMemory = memorySegmentSizeKb * (NUM_TASKS + 2) + "kb";
 
 		configuration.setString(TaskManagerOptions.MEMORY_SEGMENT_SIZE, memorySegmentSizeKb + "kb");
 		configuration.setString(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MIN, networkBuffersMemory);


### PR DESCRIPTION
## What is the purpose of the change

The non-blocking output was introduced in FLINK-14396 and FLINK-14498 to solve the problem of handling the checkpoint barrier in the case of backpressure.
    
In order to make the whole process through, `StreamInputProcessor` should be allowed to process input elements if the output is also available.
   
The default core size of `LocalBufferPool` for `ResultPartition` should also be increased by 1 for two considerations:

- `StreamTask` can only process input if there is at-least one available buffer on output side, so it might cause stuck problem if the minimum pool size is exactly equal to the number of subpartitions, because every subpartition might maintain a partial unfilled buffer.

- Increases one more buffer for every output `LocalBufferPool` to void performance regression if processing input is based on at-least one buffer available on output side.

## Brief change log

  - *Rename `AvailabilityProvider#isAvailable` as `AvailabilityProvider#getAvailableFuture`*
  - *Refactor `ResultPartitionWriter` interface to abstract class*
  - *Refactor `AvailabilityProvider` to provide default `#isAvailable` and `#isVolatileAvailable` methods*
  - *Adjust `StreamTask` stack to consider output status while `processInput`
  - *Increase one more minimum size for output `LocalBufferPool`*

## Verifying this change

Some new unit tests would be added later after confirming the core process make sense.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / `no`)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / `no`)
  - The serializers: (yes / `no` / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / `no` / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / `no` / don't know)
  - The S3 file system connector: (yes / `no` / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / `no`)
  - If yes, how is the feature documented? (`not applicable` / docs / JavaDocs / not documented)