### PR TITLE
[FLINK-14400] Shrink scope of MemoryManager from TaskExecutor to slot

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -93,6 +93,18 @@ public class MemoryManager {
 	 * Creates a memory manager with the given memory types, capacity and given page size.
 	 *
 	 * @param memorySizeByType The total size of the memory to be managed by this memory manager for each type (heap / off-heap).
+	 * @param pageSize The size of the pages handed out by the memory manager.
+	 */
+	public MemoryManager(
+			Map<MemoryType, Long> memorySizeByType,
+			int pageSize) {
+		this(memorySizeByType, 1, pageSize);
+	}
+
+	/**
+	 * Creates a memory manager with the given memory types, capacity and given page size.
+	 *
+	 * @param memorySizeByType The total size of the memory to be managed by this memory manager for each type (heap / off-heap).
 	 * @param numberOfSlots The number of slots of the task manager.
 	 * @param pageSize The size of the pages handed out by the memory manager.
 	 */
@@ -180,7 +192,6 @@ public class MemoryManager {
 	 *
 	 * @return True, if the memory manager is empty and valid, false if it is not empty or corrupted.
 	 */
-	@VisibleForTesting
 	public boolean verifyEmpty() {
 		return budgetByType.totalAvailableBudget() == budgetByType.maxTotalBudget();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -255,7 +255,6 @@ public class TaskManagerServices {
 
 		final BroadcastVariableManager broadcastVariableManager = new BroadcastVariableManager();
 
-		// this call has to happen strictly after the network stack has been initialized
 		Map<MemoryType, Long> memorySizeByType = calculateMemorySizeByType(taskManagerServicesConfiguration);
 		final TaskSlotTable taskSlotTable = createTaskSlotTable(
 			taskManagerServicesConfiguration.getNumberOfSlots(),
@@ -344,7 +343,6 @@ public class TaskManagerServices {
 	private static Map<MemoryType, Long> calculateMemorySizeByType(
 			TaskManagerServicesConfiguration taskManagerServicesConfiguration) {
 		// computing the amount of memory to use depends on how much memory is available
-		// it strictly needs to happen AFTER the network stack has been initialized
 
 		// check if a value has been configured
 		long configuredMemory = taskManagerServicesConfiguration.getConfiguredMemory();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
@@ -68,7 +68,7 @@ public class TaskSlot {
 	/** Allocation id of this slot; null if not allocated. */
 	private AllocationID allocationId;
 
-	TaskSlot(final int index, final ResourceProfile resourceProfile) {
+	public TaskSlot(final int index, final ResourceProfile resourceProfile) {
 		Preconditions.checkArgument(0 <= index, "The index must be greater than 0.");
 		this.index = index;
 		this.resourceProfile = Preconditions.checkNotNull(resourceProfile);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
@@ -35,8 +34,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -82,24 +81,15 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 	private boolean started;
 
 	public TaskSlotTable(
-		final Collection<ResourceProfile> resourceProfiles,
+		final List<TaskSlot> taskSlots,
 		final TimerService<AllocationID> timerService) {
 
-		int numberSlots = resourceProfiles.size();
+		int numberSlots = taskSlots.size();
 
 		Preconditions.checkArgument(0 < numberSlots, "The number of task slots must be greater than 0.");
 
+		this.taskSlots = new ArrayList<>(taskSlots);
 		this.timerService = Preconditions.checkNotNull(timerService);
-
-		taskSlots = Arrays.asList(new TaskSlot[numberSlots]);
-
-		int index = 0;
-
-		// create the task slots for the given resource profiles
-		for (ResourceProfile resourceProfile: resourceProfiles) {
-			taskSlots.set(index, new TaskSlot(index, resourceProfile));
-			++index;
-		}
 
 		allocationIDTaskSlotMap = new HashMap<>(numberSlots);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerBuilder.java
@@ -30,7 +30,6 @@ public class MemoryManagerBuilder {
 	private static final long DEFAULT_MEMORY_SIZE = 32L * DEFAULT_PAGE_SIZE;
 
 	private final Map<MemoryType, Long> memoryPools = new EnumMap<>(MemoryType.class);
-	private int numberOfSlots = 1;
 	private int pageSize = DEFAULT_PAGE_SIZE;
 
 	private MemoryManagerBuilder() {
@@ -47,18 +46,13 @@ public class MemoryManagerBuilder {
 		return this;
 	}
 
-	public MemoryManagerBuilder setNumberOfSlots(int numberOfSlots) {
-		this.numberOfSlots = numberOfSlots;
-		return this;
-	}
-
 	public MemoryManagerBuilder setPageSize(int pageSize) {
 		this.pageSize = pageSize;
 		return this;
 	}
 
 	public MemoryManager build() {
-		return new MemoryManager(memoryPools, numberOfSlots, pageSize);
+		return new MemoryManager(memoryPools, pageSize);
 	}
 
 	public static MemoryManagerBuilder newBuilder() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
@@ -66,9 +65,8 @@ import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.shuffle.ShuffleIOOwnerContext;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
-import org.apache.flink.runtime.taskexecutor.slot.TimerService;
+import org.apache.flink.runtime.taskexecutor.slot.TaskSlotUtils;
 import org.apache.flink.runtime.taskmanager.NoOpTaskManagerActions;
-import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
@@ -512,9 +510,7 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 	}
 
 	private static TaskSlotTable createTaskSlotTable() {
-		return new TaskSlotTable(
-			Collections.singletonList(ResourceProfile.ANY),
-			new TimerService<>(TestingUtils.defaultExecutor(), timeout.toMilliseconds()));
+		return TaskSlotUtils.createTaskSlotTable(1, timeout);
 
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -91,6 +91,7 @@ import org.apache.flink.runtime.taskexecutor.exceptions.TaskManagerException;
 import org.apache.flink.runtime.taskexecutor.slot.SlotNotFoundException;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
+import org.apache.flink.runtime.taskexecutor.slot.TaskSlotUtils;
 import org.apache.flink.runtime.taskexecutor.slot.TimerService;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.NoOpTaskManagerActions;
@@ -268,7 +269,7 @@ public class TaskExecutorTest extends TestLogger {
 
 	@Test
 	public void testShouldShutDownTaskManagerServicesInPostStop() throws Exception {
-		final TaskSlotTable taskSlotTable = new TaskSlotTable(Collections.singleton(ResourceProfile.ANY), timerService);
+		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
 
 		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
 
@@ -316,7 +317,7 @@ public class TaskExecutorTest extends TestLogger {
 
 	@Test
 	public void testHeartbeatTimeoutWithJobManager() throws Exception {
-		final TaskSlotTable taskSlotTable = new TaskSlotTable(Arrays.asList(ResourceProfile.ANY), timerService);
+		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
 
 		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
 
@@ -558,7 +559,7 @@ public class TaskExecutorTest extends TestLogger {
 
 		rpc.registerGateway(resourceManagerAddress, testingResourceManagerGateway);
 
-		final TaskSlotTable taskSlotTable = new TaskSlotTable(Collections.singleton(ResourceProfile.ANY), timerService);
+		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
 		final TaskExecutorLocalStateStoresManager localStateStoresManager = createTaskExecutorLocalStateStoresManager();
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
 			.setTaskManagerLocation(taskManagerLocation)
@@ -782,7 +783,7 @@ public class TaskExecutorTest extends TestLogger {
 	private TaskExecutor createTaskExecutorWithJobManagerTable(JobManagerTable jobManagerTable) throws IOException {
 		final TaskExecutorLocalStateStoresManager localStateStoresManager = createTaskExecutorLocalStateStoresManager();
 		return createTaskExecutor(new TaskManagerServicesBuilder()
-			.setTaskSlotTable(new TaskSlotTable(Collections.singletonList(ResourceProfile.ANY), timerService))
+			.setTaskSlotTable(TaskSlotUtils.createTaskSlotTable(1))
 			.setJobManagerTable(jobManagerTable)
 			.setTaskStateManager(localStateStoresManager)
 			.build());
@@ -831,7 +832,7 @@ public class TaskExecutorTest extends TestLogger {
 	 */
 	@Test
 	public void testJobLeaderDetection() throws Exception {
-		final TaskSlotTable taskSlotTable = new TaskSlotTable(Collections.singleton(ResourceProfile.ANY), timerService);
+		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
 		final JobManagerTable jobManagerTable = new JobManagerTable();
 		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
 
@@ -908,7 +909,7 @@ public class TaskExecutorTest extends TestLogger {
 	 */
 	@Test
 	public void testSlotAcceptance() throws Exception {
-		final TaskSlotTable taskSlotTable = new TaskSlotTable(Arrays.asList(mock(ResourceProfile.class), mock(ResourceProfile.class)), timerService);
+		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(2);
 		final JobManagerTable jobManagerTable = new JobManagerTable();
 		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
 
@@ -1001,7 +1002,7 @@ public class TaskExecutorTest extends TestLogger {
 	 */
 	@Test
 	public void testSubmitTaskBeforeAcceptSlot() throws Exception {
-		final TaskSlotTable taskSlotTable = new TaskSlotTable(Arrays.asList(mock(ResourceProfile.class), mock(ResourceProfile.class)), timerService);
+		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(2);
 		final JobManagerTable jobManagerTable = new JobManagerTable();
 		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
 
@@ -1155,7 +1156,7 @@ public class TaskExecutorTest extends TestLogger {
 		final RecordingHeartbeatServices heartbeatServices = new RecordingHeartbeatServices(heartbeatInterval, heartbeatTimeout);
 		final ResourceID rmResourceID = ResourceID.generate();
 
-		final TaskSlotTable taskSlotTable = new TaskSlotTable(Collections.singleton(ResourceProfile.ANY), timerService);
+		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
 
 		final String rmAddress = "rm";
 		final TestingResourceManagerGateway rmGateway = new TestingResourceManagerGateway(
@@ -1207,9 +1208,7 @@ public class TaskExecutorTest extends TestLogger {
 	 */
 	@Test
 	public void testRemoveJobFromJobLeaderService() throws Exception {
-		final TaskSlotTable taskSlotTable = new TaskSlotTable(
-			Collections.singleton(ResourceProfile.ANY),
-			timerService);
+		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
 
 		final TaskExecutorLocalStateStoresManager localStateStoresManager = createTaskExecutorLocalStateStoresManager();
 
@@ -1300,7 +1299,7 @@ public class TaskExecutorTest extends TestLogger {
 	@Test
 	public void testMaximumRegistrationDurationAfterConnectionLoss() throws Exception {
 		configuration.setString(TaskManagerOptions.REGISTRATION_TIMEOUT, "100 ms");
-		final TaskSlotTable taskSlotTable = new TaskSlotTable(Collections.singleton(ResourceProfile.ANY), timerService);
+		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
 
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder().setTaskSlotTable(taskSlotTable).build();
 
@@ -1351,7 +1350,7 @@ public class TaskExecutorTest extends TestLogger {
 	 */
 	@Test
 	public void testIgnoringSlotRequestsIfNotRegistered() throws Exception {
-		final TaskSlotTable taskSlotTable = new TaskSlotTable(Collections.singleton(ResourceProfile.ANY), timerService);
+		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder().setTaskSlotTable(taskSlotTable).build();
 
 		final TaskExecutor taskExecutor = createTaskExecutor(taskManagerServices);
@@ -1396,7 +1395,7 @@ public class TaskExecutorTest extends TestLogger {
 	 */
 	@Test
 	public void testReconnectionAttemptIfExplicitlyDisconnected() throws Exception {
-		final TaskSlotTable taskSlotTable = new TaskSlotTable(Collections.singleton(ResourceProfile.ANY), timerService);
+		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
 		final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
 		final TaskExecutor taskExecutor = createTaskExecutor(new TaskManagerServicesBuilder()
 			.setTaskSlotTable(taskSlotTable)
@@ -1444,7 +1443,7 @@ public class TaskExecutorTest extends TestLogger {
 	 */
 	@Test
 	public void testInitialSlotReport() throws Exception {
-		final TaskSlotTable taskSlotTable = new TaskSlotTable(Collections.singleton(ResourceProfile.ANY), timerService);
+		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
 		final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
 			.setTaskSlotTable(taskSlotTable)
@@ -1479,7 +1478,7 @@ public class TaskExecutorTest extends TestLogger {
 	 */
 	@Test
 	public void testInitialSlotReportFailure() throws Exception {
-		final TaskSlotTable taskSlotTable = new TaskSlotTable(Collections.singleton(ResourceProfile.ANY), timerService);
+		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
 		final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
 			.setTaskSlotTable(taskSlotTable)
@@ -1536,9 +1535,7 @@ public class TaskExecutorTest extends TestLogger {
 	 */
 	@Test
 	public void testOfferSlotToJobMasterAfterTimeout() throws Exception {
-		final TaskSlotTable taskSlotTable = new TaskSlotTable(
-			Arrays.asList(ResourceProfile.ANY, ResourceProfile.ANY),
-			timerService);
+		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(2);
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
 			.setTaskSlotTable(taskSlotTable)
 			.build();
@@ -1608,7 +1605,7 @@ public class TaskExecutorTest extends TestLogger {
 	@Test
 	public void testDisconnectFromJobMasterWhenNewLeader() throws Exception {
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
-			.setTaskSlotTable(new TaskSlotTable(Collections.singleton(ResourceProfile.ANY), timerService))
+			.setTaskSlotTable(TaskSlotUtils.createTaskSlotTable(1))
 			.build();
 		final TaskExecutor taskExecutor = createTaskExecutor(taskManagerServices);
 
@@ -1717,7 +1714,7 @@ public class TaskExecutorTest extends TestLogger {
 	public void testSyncSlotsWithJobMasterByHeartbeat() throws Exception {
 		final CountDownLatch activeSlots = new CountDownLatch(2);
 		final TaskSlotTable taskSlotTable = new ActivateSlotNotifyingTaskSlotTable(
-				Arrays.asList(ResourceProfile.ANY, ResourceProfile.ANY),
+				2,
 				timerService,
 				activeSlots);
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder().setTaskSlotTable(taskSlotTable).build();
@@ -1834,7 +1831,7 @@ public class TaskExecutorTest extends TestLogger {
 		resourceManagerLeaderRetriever.notifyListener(testingResourceManagerGateway.getAddress(), testingResourceManagerGateway.getFencingToken().toUUID());
 
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
-			.setTaskSlotTable(new AllocateSlotNotifyingTaskSlotTable(Collections.singleton(ResourceProfile.ANY), timerService, receivedSlotRequest))
+			.setTaskSlotTable(new AllocateSlotNotifyingTaskSlotTable(timerService, receivedSlotRequest))
 			.build();
 		final TaskExecutor taskExecutor = createTaskExecutor(taskManagerServices);
 		final ResourceID taskExecutorResourceId = taskManagerServices.getTaskManagerLocation().getResourceID();
@@ -2027,7 +2024,7 @@ public class TaskExecutorTest extends TestLogger {
 		private final Queue<SlotReport> slotReports;
 
 		private TestingTaskSlotTable(Queue<SlotReport> slotReports) {
-			super(Collections.singleton(ResourceProfile.ANY), new TimerService<>(TestingUtils.defaultExecutor(), 10000L));
+			super(TaskSlotUtils.createDefaultSlotProfiles(1), new TimerService<>(TestingUtils.defaultExecutor(), 10000L));
 			this.slotReports = slotReports;
 		}
 
@@ -2042,10 +2039,9 @@ public class TaskExecutorTest extends TestLogger {
 		private final OneShotLatch allocateSlotLatch;
 
 		private AllocateSlotNotifyingTaskSlotTable(
-				Collection<ResourceProfile> resourceProfiles,
 				TimerService<AllocationID> timerService,
 				OneShotLatch allocateSlotLatch) {
-			super(resourceProfiles, timerService);
+			super(TaskSlotUtils.createDefaultSlotProfiles(1), timerService);
 			this.allocateSlotLatch = allocateSlotLatch;
 		}
 
@@ -2062,8 +2058,8 @@ public class TaskExecutorTest extends TestLogger {
 
 		private final CountDownLatch slotsToActivate;
 
-		private ActivateSlotNotifyingTaskSlotTable(Collection<ResourceProfile> resourceProfiles, TimerService<AllocationID> timerService, CountDownLatch slotsToActivate) {
-			super(resourceProfiles, timerService);
+		private ActivateSlotNotifyingTaskSlotTable(int numberOfDefaultSlots, TimerService<AllocationID> timerService, CountDownLatch slotsToActivate) {
+			super(TaskSlotUtils.createDefaultSlotProfiles(numberOfDefaultSlots), timerService);
 			this.slotsToActivate = slotsToActivate;
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -2024,7 +2024,7 @@ public class TaskExecutorTest extends TestLogger {
 		private final Queue<SlotReport> slotReports;
 
 		private TestingTaskSlotTable(Queue<SlotReport> slotReports) {
-			super(TaskSlotUtils.createDefaultSlotProfiles(1), new TimerService<>(TestingUtils.defaultExecutor(), 10000L));
+			super(TaskSlotUtils.createDefaultSlots(1), new TimerService<>(TestingUtils.defaultExecutor(), 10000L));
 			this.slotReports = slotReports;
 		}
 
@@ -2041,7 +2041,7 @@ public class TaskExecutorTest extends TestLogger {
 		private AllocateSlotNotifyingTaskSlotTable(
 				TimerService<AllocationID> timerService,
 				OneShotLatch allocateSlotLatch) {
-			super(TaskSlotUtils.createDefaultSlotProfiles(1), timerService);
+			super(TaskSlotUtils.createDefaultSlots(1), timerService);
 			this.allocateSlotLatch = allocateSlotLatch;
 		}
 
@@ -2059,7 +2059,7 @@ public class TaskExecutorTest extends TestLogger {
 		private final CountDownLatch slotsToActivate;
 
 		private ActivateSlotNotifyingTaskSlotTable(int numberOfDefaultSlots, TimerService<AllocationID> timerService, CountDownLatch slotsToActivate) {
-			super(TaskSlotUtils.createDefaultSlotProfiles(numberOfDefaultSlots), timerService);
+			super(TaskSlotUtils.createDefaultSlots(numberOfDefaultSlots), timerService);
 			this.slotsToActivate = slotsToActivate;
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -68,8 +68,6 @@ import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGatewayBuilder;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
-import org.apache.flink.runtime.memory.MemoryManager;
-import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
@@ -280,12 +278,6 @@ public class TaskExecutorTest extends TestLogger {
 			ioManager.getSpillingDirectories(),
 			Executors.directExecutor());
 
-		final MemoryManager memoryManager = MemoryManagerBuilder
-			.newBuilder()
-			.setMemorySize(4096)
-			.setPageSize(4096)
-			.build();
-
 		nettyShuffleEnvironment.start();
 
 		final KvStateService kvStateService = new KvStateService(new KvStateRegistry(), null, null);
@@ -293,7 +285,6 @@ public class TaskExecutorTest extends TestLogger {
 
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
 			.setTaskManagerLocation(taskManagerLocation)
-			.setMemoryManager(memoryManager)
 			.setIoManager(ioManager)
 			.setShuffleEnvironment(nettyShuffleEnvironment)
 			.setKvStateService(kvStateService)
@@ -310,7 +301,7 @@ public class TaskExecutorTest extends TestLogger {
 			RpcUtils.terminateRpcEndpoint(taskManager, timeout);
 		}
 
-		assertThat(memoryManager.isShutdown(), is(true));
+		assertThat(taskSlotTable.isStopped(), is(true));
 		assertThat(nettyShuffleEnvironment.isClosed(), is(true));
 		assertThat(kvStateService.isShutdown(), is(true));
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
-import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.memory.MemoryManager;
@@ -40,7 +39,6 @@ public class TaskManagerServicesBuilder {
 
 	/** TaskManager services. */
 	private TaskManagerLocation taskManagerLocation;
-	private MemoryManager memoryManager;
 	private IOManager ioManager;
 	private ShuffleEnvironment<?, ?> shuffleEnvironment;
 	private KvStateService kvStateService;
@@ -53,11 +51,6 @@ public class TaskManagerServicesBuilder {
 
 	public TaskManagerServicesBuilder() {
 		taskManagerLocation = new LocalTaskManagerLocation();
-		memoryManager = MemoryManagerBuilder
-			.newBuilder()
-			.setMemorySize(MemoryManager.MIN_PAGE_SIZE)
-			.setPageSize(MemoryManager.MIN_PAGE_SIZE)
-			.build();
 		ioManager = mock(IOManager.class);
 		shuffleEnvironment = mock(ShuffleEnvironment.class);
 		kvStateService = new KvStateService(new KvStateRegistry(), null, null);
@@ -71,11 +64,6 @@ public class TaskManagerServicesBuilder {
 
 	public TaskManagerServicesBuilder setTaskManagerLocation(TaskManagerLocation taskManagerLocation) {
 		this.taskManagerLocation = taskManagerLocation;
-		return this;
-	}
-
-	public TaskManagerServicesBuilder setMemoryManager(MemoryManager memoryManager) {
-		this.memoryManager = memoryManager;
 		return this;
 	}
 
@@ -122,7 +110,7 @@ public class TaskManagerServicesBuilder {
 	public TaskManagerServices build() {
 		return new TaskManagerServices(
 			taskManagerLocation,
-			memoryManager,
+			MemoryManager.MIN_PAGE_SIZE,
 			ioManager,
 			shuffleEnvironment,
 			kvStateService,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
@@ -49,6 +48,7 @@ import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
 import org.apache.flink.runtime.taskexecutor.rpc.RpcResultPartitionConsumableNotifier;
+import org.apache.flink.runtime.taskexecutor.slot.TaskSlotUtils;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.runtime.taskexecutor.slot.TimerService;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
@@ -68,7 +68,6 @@ import java.io.File;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -118,7 +117,7 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
 		this.jobMasterId = jobMasterId;
 
 		if (slotSize > 0) {
-			this.taskSlotTable = generateTaskSlotTable(slotSize);
+			this.taskSlotTable = TaskSlotUtils.createTaskSlotTable(slotSize);
 		} else {
 			this.taskSlotTable = mock(TaskSlotTable.class);
 			when(taskSlotTable.tryMarkSlotActive(eq(jobId), any())).thenReturn(true);
@@ -186,14 +185,6 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
 
 	public TestingFatalErrorHandler getTestingFatalErrorHandler() {
 		return testingFatalErrorHandler;
-	}
-
-	private TaskSlotTable generateTaskSlotTable(int numSlot) {
-		Collection<ResourceProfile> resourceProfiles = new ArrayList<>();
-		for (int i = 0; i < numSlot; i++) {
-			resourceProfiles.add(ResourceProfile.ANY);
-		}
-		return new TaskSlotTable(resourceProfiles, timerService);
 	}
 
 	@Nonnull

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableTest.java
@@ -77,6 +77,7 @@ public class TaskSlotTableTest extends TestLogger {
 			assertThat(Sets.newHashSet(taskSlotTable.getActiveSlots(jobId1)), is(equalTo(new HashSet<>(Arrays.asList(allocationId2, allocationId1)))));
 		} finally {
 			taskSlotTable.stop();
+			assertThat(taskSlotTable.isStopped(), is(true));
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableTest.java
@@ -21,8 +21,6 @@ package org.apache.flink.runtime.taskexecutor.slot;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
-import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Sets;
@@ -30,11 +28,7 @@ import org.apache.flink.shaded.guava18.com.google.common.collect.Sets;
 import org.apache.commons.collections.IteratorUtils;
 import org.junit.Test;
 
-import javax.annotation.Nonnull;
-
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 
@@ -54,7 +48,7 @@ public class TaskSlotTableTest extends TestLogger {
 	 */
 	@Test
 	public void testTryMarkSlotActive() throws SlotNotFoundException {
-		final TaskSlotTable taskSlotTable = createTaskSlotTable(Collections.nCopies(3, ResourceProfile.ANY));
+		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(3);
 
 		try {
 			taskSlotTable.start(new TestingSlotActionsBuilder().build());
@@ -91,7 +85,7 @@ public class TaskSlotTableTest extends TestLogger {
 	 */
 	@Test
 	public void testRedundantSlotAllocation() {
-		final TaskSlotTable taskSlotTable = createTaskSlotTable(Collections.nCopies(2, ResourceProfile.UNKNOWN));
+		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(2);
 
 		try {
 			taskSlotTable.start(new TestingSlotActionsBuilder().build());
@@ -112,12 +106,4 @@ public class TaskSlotTableTest extends TestLogger {
 			taskSlotTable.stop();
 		}
 	}
-
-	@Nonnull
-	private TaskSlotTable createTaskSlotTable(final Collection<ResourceProfile> resourceProfiles) {
-		return new TaskSlotTable(
-			resourceProfiles,
-			new TimerService<>(TestingUtils.defaultExecutor(), 10000L));
-	}
-
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor.slot;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+
+import java.util.Collections;
+import java.util.List;
+
+/** Testing utility and factory methods for {@link TaskSlotTable} and {@link TaskSlot}s. */
+public enum TaskSlotUtils {
+	;
+
+	private static final long DEFAULT_SLOT_TIMEOUT = 10000L;
+
+	private static final ResourceProfile DEFAULT_RESOURCE_PROFILE =
+		new ResourceProfile(
+			Double.MAX_VALUE,
+			MemorySize.MAX_VALUE,
+			MemorySize.MAX_VALUE,
+			new MemorySize(10 * MemoryManager.MIN_PAGE_SIZE),
+			new MemorySize(0),
+			MemorySize.MAX_VALUE,
+			Collections.emptyMap());
+
+	public static TaskSlotTable createTaskSlotTable(int numberOfSlots) {
+		return createTaskSlotTable(
+			numberOfSlots,
+			createDefaultTimerService(DEFAULT_SLOT_TIMEOUT));
+	}
+
+	public static TaskSlotTable createTaskSlotTable(int numberOfSlots, Time timeout) {
+		return createTaskSlotTable(
+			numberOfSlots,
+			createDefaultTimerService(timeout.toMilliseconds()));
+	}
+
+	private static TaskSlotTable createTaskSlotTable(
+			int numberOfSlots,
+			TimerService<AllocationID> timerService) {
+		return new TaskSlotTable(createDefaultSlotProfiles(numberOfSlots), timerService);
+	}
+
+	private static TimerService<AllocationID> createDefaultTimerService(long shutdownTimeout) {
+		return new TimerService<>(TestingUtils.defaultExecutor(), shutdownTimeout);
+	}
+
+	public static List<ResourceProfile> createDefaultSlotProfiles(int numberOfSlots) {
+		return Collections.nCopies(numberOfSlots, DEFAULT_RESOURCE_PROFILE);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotUtils.java
@@ -64,7 +64,7 @@ public enum TaskSlotUtils {
 		return new TaskSlotTable(createDefaultSlots(numberOfSlots), timerService);
 	}
 
-	private static TimerService<AllocationID> createDefaultTimerService(long shutdownTimeout) {
+	public static TimerService<AllocationID> createDefaultTimerService(long shutdownTimeout) {
 		return new TimerService<>(TestingUtils.defaultExecutor(), shutdownTimeout);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotUtils.java
@@ -71,7 +71,7 @@ public enum TaskSlotUtils {
 	public static List<TaskSlot> createDefaultSlots(int numberOfSlots) {
 		return IntStream
 			.range(0, numberOfSlots)
-			.mapToObj(index -> new TaskSlot(index, DEFAULT_RESOURCE_PROFILE))
+			.mapToObj(index -> new TaskSlot(index, DEFAULT_RESOURCE_PROFILE, MemoryManager.MIN_PAGE_SIZE))
 			.collect(Collectors.toList());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotUtils.java
@@ -27,6 +27,8 @@ import org.apache.flink.runtime.testingUtils.TestingUtils;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /** Testing utility and factory methods for {@link TaskSlotTable} and {@link TaskSlot}s. */
 public enum TaskSlotUtils {
@@ -59,14 +61,17 @@ public enum TaskSlotUtils {
 	private static TaskSlotTable createTaskSlotTable(
 			int numberOfSlots,
 			TimerService<AllocationID> timerService) {
-		return new TaskSlotTable(createDefaultSlotProfiles(numberOfSlots), timerService);
+		return new TaskSlotTable(createDefaultSlots(numberOfSlots), timerService);
 	}
 
 	private static TimerService<AllocationID> createDefaultTimerService(long shutdownTimeout) {
 		return new TimerService<>(TestingUtils.defaultExecutor(), shutdownTimeout);
 	}
 
-	public static List<ResourceProfile> createDefaultSlotProfiles(int numberOfSlots) {
-		return Collections.nCopies(numberOfSlots, DEFAULT_RESOURCE_PROFILE);
+	public static List<TaskSlot> createDefaultSlots(int numberOfSlots) {
+		return IntStream
+			.range(0, numberOfSlots)
+			.mapToObj(index -> new TaskSlot(index, DEFAULT_RESOURCE_PROFILE))
+			.collect(Collectors.toList());
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/aggregate/BytesHashMapTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/aggregate/BytesHashMapTest.java
@@ -98,7 +98,6 @@ public class BytesHashMapTest {
 		MemoryManager memoryManager = MemoryManagerBuilder
 			.newBuilder()
 			.setMemorySize(numMemSegments * PAGE_SIZE)
-			.setNumberOfSlots(32)
 			.build();
 
 		BytesHashMap table = new BytesHashMap(this, memoryManager,
@@ -124,7 +123,6 @@ public class BytesHashMapTest {
 		MemoryManager memoryManager = MemoryManagerBuilder
 			.newBuilder()
 			.setMemorySize(memorySize)
-			.setNumberOfSlots(32)
 			.build();
 
 		BytesHashMap table = new BytesHashMap(this, memoryManager,
@@ -152,7 +150,6 @@ public class BytesHashMapTest {
 		MemoryManager memoryManager = MemoryManagerBuilder
 			.newBuilder()
 			.setMemorySize(memorySize)
-			.setNumberOfSlots(32)
 			.build();
 
 		BytesHashMap table = new BytesHashMap(this, memoryManager,
@@ -180,7 +177,6 @@ public class BytesHashMapTest {
 		MemoryManager memoryManager = MemoryManagerBuilder
 			.newBuilder()
 			.setMemorySize(memorySize)
-			.setNumberOfSlots(32)
 			.build();
 
 		BytesHashMap table = new BytesHashMap(this, memoryManager,
@@ -210,7 +206,6 @@ public class BytesHashMapTest {
 		MemoryManager memoryManager = MemoryManagerBuilder
 			.newBuilder()
 			.setMemorySize(minMemorySize)
-			.setNumberOfSlots(32)
 			.build();
 		BytesHashMap table = new BytesHashMap(this, memoryManager,
 				minMemorySize, keyTypes, valueTypes, true);
@@ -286,7 +281,6 @@ public class BytesHashMapTest {
 		MemoryManager memoryManager = MemoryManagerBuilder
 			.newBuilder()
 			.setMemorySize(memorySize)
-			.setNumberOfSlots(32)
 			.build();
 		BytesHashMap table = new BytesHashMap(this, memoryManager,
 				memorySize, keyTypes, valueTypes);


### PR DESCRIPTION
## What is the purpose of the change

`MemoryManager` currently manages the memory bookkeeping for all slots/tasks inside one `TaskExecutor`. For better abstraction and isolation of slots, we can shrink its scope and make it per slot. The memory limits are fixed now per slot at the moment of slot creation. All operators, sharing the slot, will get their fixed fractional limits.

In future, we might make it possible for operators to over-allocate beyond their fraction limit if there is some available free memory in the slot but it should be possible to reclaim the over-allocated memory at any time if other operator decides to claim its fair share within its limit.

## Brief change log

  - introduce `TaskSlotTableBuilder` for tests
  - Refactor out slots creation from the `TaskSlotTable` constructor to the factory method in `TaskManagerServices`
  - `TaskSlot` has its own memory manager and `close` method to shutdown the memory manager and release all left unreleased memory (with a warning check whether everything has been already released)
  - When the `TaskSlotTable` is stopped, all slots are closed as well. Currently, it basically happens only if the TM is completely stoped, same as for the former TM's global memory manager
  - Remove the global memory manager from `TaskManagerServices`, keep only memory size
  - Remove now redundant number of slots from the `MemoryManager`.
  - Adjust unit tests

## Verifying this change

Existing unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
