### PR TITLE
[FLINK-14561] Don't write FLINK_PLUGINS_DIR env variable to Configuration

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -2012,6 +2012,9 @@ public final class ConfigConstants {
 	/** The environment variable name which contains the location of the plugins folder. */
 	public static final String ENV_FLINK_PLUGINS_DIR = "FLINK_PLUGINS_DIR";
 
+	/** The default Flink plugins directory if none has been specified via {@link #ENV_FLINK_PLUGINS_DIR}. */
+	public static final String DEFAULT_FLINK_PLUGINS_DIRS = "plugins";
+
 	/** The environment variable name which contains the location of the bin directory. */
 	public static final String ENV_FLINK_BIN_DIR = "FLINK_BIN_DIR";
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
@@ -130,32 +130,7 @@ public final class GlobalConfiguration {
 			configuration.addAll(dynamicProperties);
 		}
 
-		return enrichWithEnvironmentVariables(configuration);
-	}
-
-	private static Configuration enrichWithEnvironmentVariables(Configuration configuration) {
-		enrichWithEnvironmentVariable(ConfigConstants.ENV_FLINK_PLUGINS_DIR, configuration);
 		return configuration;
-	}
-
-	private static void enrichWithEnvironmentVariable(String environmentVariable, Configuration configuration) {
-		String valueFromEnv = System.getenv(environmentVariable);
-
-		if (valueFromEnv == null) {
-			return;
-		}
-
-		String valueFromConfig = configuration.getString(environmentVariable, valueFromEnv);
-
-		if (!valueFromEnv.equals(valueFromConfig)) {
-			throw new IllegalConfigurationException(
-				"The given configuration file already contains a value (" + valueFromEnv +
-					") for the key (" + environmentVariable +
-					") that would have been overwritten with (" + valueFromConfig +
-					") by an environment with the same name.");
-		}
-
-		configuration.setString(environmentVariable, valueFromEnv);
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/core/plugin/PluginConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/PluginConfig.java
@@ -55,23 +55,20 @@ public class PluginConfig {
 
 	public static PluginConfig fromConfiguration(Configuration configuration) {
 		return new PluginConfig(
-			getPluginsDirPath(configuration),
+			getPluginsDir().map(File::toPath),
 			CoreOptions.getParentFirstLoaderPatterns(configuration));
 	}
 
-	private static Optional<Path> getPluginsDirPath(Configuration configuration) {
-		String pluginsDir = configuration.getString(ConfigConstants.ENV_FLINK_PLUGINS_DIR, null);
-		if (pluginsDir == null) {
-			LOG.info("Environment variable [{}] is not set", ConfigConstants.ENV_FLINK_PLUGINS_DIR);
-			return Optional.empty();
-		}
+	public static Optional<File> getPluginsDir() {
+		String pluginsDir = System.getenv().getOrDefault(
+			ConfigConstants.ENV_FLINK_PLUGINS_DIR,
+			ConfigConstants.DEFAULT_FLINK_PLUGINS_DIRS);
+
 		File pluginsDirFile = new File(pluginsDir);
 		if (!pluginsDirFile.isDirectory()) {
-			LOG.warn("Environment variable [{}] is set to [{}] but the directory doesn't exist",
-				ConfigConstants.ENV_FLINK_PLUGINS_DIR,
-				pluginsDir);
+			LOG.warn("The plugins directory [{}] does not exist.", pluginsDirFile);
 			return Optional.empty();
 		}
-		return Optional.of(pluginsDirFile.toPath());
+		return Optional.of(pluginsDirFile);
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/core/plugin/PluginConfigTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/plugin/PluginConfigTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.plugin;
+
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableMap;
+
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the {@link PluginConfig} utility class.
+ */
+public class PluginConfigTest extends TestLogger {
+
+	@ClassRule
+	public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private static Map<String, String> oldEnvVariables;
+
+	@BeforeClass
+	public static void setup() {
+		oldEnvVariables = System.getenv();
+	}
+
+	@After
+	public void teardown() {
+		if (oldEnvVariables != null) {
+			CommonTestUtils.setEnv(oldEnvVariables, true);
+		}
+	}
+
+	@Test
+	public void getPluginsDir_existingDirectory_returnsDirectoryFile() throws IOException {
+		final File pluginsDirectory = temporaryFolder.newFolder();
+		final Map<String, String> envVariables = ImmutableMap.of(ConfigConstants.ENV_FLINK_PLUGINS_DIR, pluginsDirectory.getAbsolutePath());
+		CommonTestUtils.setEnv(envVariables);
+
+		assertThat(PluginConfig.getPluginsDir().get(), is(pluginsDirectory));
+	}
+
+	@Test
+	public void getPluginsDir_nonExistingDirectory_returnsEmpty() {
+		final Map<String, String> envVariables = ImmutableMap.of(ConfigConstants.ENV_FLINK_PLUGINS_DIR, new File(temporaryFolder.getRoot().getAbsoluteFile(), "should_not_exist").getAbsolutePath());
+		CommonTestUtils.setEnv(envVariables);
+
+		assertFalse(PluginConfig.getPluginsDir().isPresent());
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlay.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlay.java
@@ -20,10 +20,13 @@ package org.apache.flink.runtime.clusterframework.overlays;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.plugin.PluginConfig;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,7 +35,6 @@ import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_BIN_DIR;
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_CONF_DIR;
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_HOME_DIR;
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_LIB_DIR;
-import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_PLUGINS_DIR;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -57,13 +59,14 @@ public class FlinkDistributionOverlay extends AbstractContainerOverlay {
 	final File flinkBinPath;
 	final File flinkConfPath;
 	final File flinkLibPath;
+	@Nullable
 	final File flinkPluginsPath;
 
-	public FlinkDistributionOverlay(File flinkBinPath, File flinkConfPath, File flinkLibPath, File flinkPluginsPath) {
+	FlinkDistributionOverlay(File flinkBinPath, File flinkConfPath, File flinkLibPath, @Nullable File flinkPluginsPath) {
 		this.flinkBinPath = checkNotNull(flinkBinPath);
 		this.flinkConfPath = checkNotNull(flinkConfPath);
 		this.flinkLibPath = checkNotNull(flinkLibPath);
-		this.flinkPluginsPath = checkNotNull(flinkPluginsPath);
+		this.flinkPluginsPath = flinkPluginsPath;
 	}
 
 	@Override
@@ -75,11 +78,8 @@ public class FlinkDistributionOverlay extends AbstractContainerOverlay {
 		addPathRecursively(flinkBinPath, TARGET_ROOT, container);
 		addPathRecursively(flinkConfPath, TARGET_ROOT, container);
 		addPathRecursively(flinkLibPath, TARGET_ROOT, container);
-		if (flinkPluginsPath.isDirectory()) {
+		if (flinkPluginsPath != null) {
 			addPathRecursively(flinkPluginsPath, TARGET_ROOT, container);
-		}
-		else {
-			LOG.warn("The plugins directory '" + flinkPluginsPath + "' doesn't exist.");
 		}
 	}
 
@@ -94,6 +94,7 @@ public class FlinkDistributionOverlay extends AbstractContainerOverlay {
 		File flinkBinPath;
 		File flinkConfPath;
 		File flinkLibPath;
+		@Nullable
 		File flinkPluginsPath;
 
 		/**
@@ -107,7 +108,7 @@ public class FlinkDistributionOverlay extends AbstractContainerOverlay {
 			flinkBinPath = getObligatoryFileFromEnvironment(ENV_FLINK_BIN_DIR);
 			flinkConfPath = getObligatoryFileFromEnvironment(ENV_FLINK_CONF_DIR);
 			flinkLibPath = getObligatoryFileFromEnvironment(ENV_FLINK_LIB_DIR);
-			flinkPluginsPath = getObligatoryFileFromEnvironment(ENV_FLINK_PLUGINS_DIR);
+			flinkPluginsPath = PluginConfig.getPluginsDir().orElse(null);
 
 			return this;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlay.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlay.java
@@ -23,9 +23,6 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.plugin.PluginConfig;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.annotation.Nullable;
 
 import java.io.File;
@@ -41,26 +38,24 @@ import static org.apache.flink.util.Preconditions.checkState;
 /**
  * Overlays Flink into a container, based on supplied bin/conf/lib directories.
  *
- * The overlayed Flink is indistinguishable from (and interchangeable with)
+ * <p>The overlayed Flink is indistinguishable from (and interchangeable with)
  * a normal installation of Flink.  For a docker image-based container, it should be
  * possible to bypass this overlay and rely on the normal installation method.
  *
- * The following files are copied to the container:
+ * <p>The following files are copied to the container:
  *  - flink/bin/
  *  - flink/conf/
  *  - flink/lib/
  */
 public class FlinkDistributionOverlay extends AbstractContainerOverlay {
 
-	private static final Logger LOG = LoggerFactory.getLogger(FlinkDistributionOverlay.class);
-
 	static final Path TARGET_ROOT = new Path("flink");
 
-	final File flinkBinPath;
-	final File flinkConfPath;
-	final File flinkLibPath;
+	private final File flinkBinPath;
+	private final File flinkConfPath;
+	private final File flinkLibPath;
 	@Nullable
-	final File flinkPluginsPath;
+	private final File flinkPluginsPath;
 
 	FlinkDistributionOverlay(File flinkBinPath, File flinkConfPath, File flinkLibPath, @Nullable File flinkPluginsPath) {
 		this.flinkBinPath = checkNotNull(flinkBinPath);
@@ -100,7 +95,7 @@ public class FlinkDistributionOverlay extends AbstractContainerOverlay {
 		/**
 		 * Configures the overlay using the current environment.
 		 *
-		 * Locates Flink using FLINK_???_DIR environment variables as provided to all Flink processes by config.sh.
+		 * <p>Locates Flink using FLINK_???_DIR environment variables as provided to all Flink processes by config.sh.
 		 *
 		 * @param globalConfiguration the current configuration.
 		 */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlayTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlayTest.java
@@ -82,7 +82,7 @@ public class FlinkDistributionOverlayTest extends ContainerOverlayTestBase {
 			pluginsFolder);
 		overlay.configure(containerSpecification);
 
-		for(Path file : files) {
+		for (Path file : files) {
 			checkArtifact(containerSpecification, new Path(TARGET_ROOT, file.toString()));
 		}
 	}
@@ -102,7 +102,7 @@ public class FlinkDistributionOverlayTest extends ContainerOverlayTestBase {
 		map.put(ENV_FLINK_LIB_DIR, libFolder.getAbsolutePath());
 		map.put(ENV_FLINK_PLUGINS_DIR, pluginsFolder.getAbsolutePath());
 		map.put(ENV_FLINK_CONF_DIR, confFolder.getAbsolutePath());
- 		CommonTestUtils.setEnv(map);
+		CommonTestUtils.setEnv(map);
 
 		FlinkDistributionOverlay.Builder builder = FlinkDistributionOverlay.newBuilder().fromEnvironment(conf);
 
@@ -133,8 +133,7 @@ public class FlinkDistributionOverlayTest extends ContainerOverlayTestBase {
 		try {
 			FlinkDistributionOverlay.Builder builder = FlinkDistributionOverlay.newBuilder().fromEnvironment(conf);
 			fail();
-		}
-		catch(IllegalStateException e) {
+		} catch (IllegalStateException e) {
 			// expected
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlayTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlayTest.java
@@ -29,7 +29,6 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -39,6 +38,7 @@ import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_LIB_DIR;
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_PLUGINS_DIR;
 import static org.apache.flink.runtime.clusterframework.overlays.FlinkDistributionOverlay.TARGET_ROOT;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 public class FlinkDistributionOverlayTest extends ContainerOverlayTestBase {
@@ -64,25 +64,6 @@ public class FlinkDistributionOverlayTest extends ContainerOverlayTestBase {
 			"plugins/P1/plugin1a.jar",
 			"plugins/P1/plugin1b.jar",
 			"plugins/P2/plugin2.jar");
-
-		testConfigure(binFolder, libFolder, pluginsFolder, confFolder, files);
-	}
-
-	@Test
-	public void testConfigureWithMissingPlugins() throws Exception {
-		File binFolder = tempFolder.newFolder("bin");
-		File libFolder = tempFolder.newFolder("lib");
-		File pluginsFolder = Paths.get(tempFolder.getRoot().getAbsolutePath(), "s0m3_p4th_th4t_sh0uld_n0t_3x1sts").toFile();
-		File confFolder = tempFolder.newFolder("conf");
-
-		Path[] files = createPaths(
-			tempFolder.getRoot(),
-			"bin/config.sh",
-			"bin/taskmanager.sh",
-			"lib/foo.jar",
-			"lib/A/foo.jar",
-			"lib/B/foo.jar",
-			"lib/B/bar.jar");
 
 		testConfigure(binFolder, libFolder, pluginsFolder, confFolder, files);
 	}
@@ -127,7 +108,9 @@ public class FlinkDistributionOverlayTest extends ContainerOverlayTestBase {
 
 		assertEquals(binFolder.getAbsolutePath(), builder.flinkBinPath.getAbsolutePath());
 		assertEquals(libFolder.getAbsolutePath(), builder.flinkLibPath.getAbsolutePath());
-		assertEquals(pluginsFolder.getAbsolutePath(), builder.flinkPluginsPath.getAbsolutePath());
+		final File flinkPluginsPath = builder.flinkPluginsPath;
+		assertNotNull(flinkPluginsPath);
+		assertEquals(pluginsFolder.getAbsolutePath(), flinkPluginsPath.getAbsolutePath());
 		assertEquals(confFolder.getAbsolutePath(), builder.flinkConfPath.getAbsolutePath());
 	}
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -36,6 +36,7 @@ import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.plugin.PluginConfig;
 import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
@@ -101,11 +102,11 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_LIB_DIR;
-import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_PLUGINS_DIR;
 import static org.apache.flink.runtime.entrypoint.component.FileJobGraphRetriever.JOB_GRAPH_FILE_PATH;
 import static org.apache.flink.yarn.cli.FlinkYarnSessionCli.CONFIG_FILE_LOG4J_NAME;
 import static org.apache.flink.yarn.cli.FlinkYarnSessionCli.CONFIG_FILE_LOGBACK_NAME;
@@ -1581,16 +1582,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 	}
 
 	private void addPluginsFoldersToShipFiles(Collection<File> effectiveShipFiles) {
-		String pluginsDir = System.getenv().get(ENV_FLINK_PLUGINS_DIR);
-		if (pluginsDir != null) {
-			File directoryFile = new File(pluginsDir);
-			if (directoryFile.isDirectory()) {
-				effectiveShipFiles.add(directoryFile);
-			} else {
-				LOG.warn("The environment variable '" + ENV_FLINK_PLUGINS_DIR +
-						"' is set to '" + pluginsDir + "' but the directory doesn't exist.");
-			}
-		}
+		final Optional<File> pluginsDir = PluginConfig.getPluginsDir();
+		pluginsDir.ifPresent(effectiveShipFiles::add);
 	}
 
 	ContainerLaunchContext setupApplicationMasterContainer(


### PR DESCRIPTION
## What is the purpose of the change

This commit reads the FLINK_PLUGINS_DIR env variable directly instead of first
writing it first to the Flink Configuration and then reading it from there. This
has the advantage that the plugins env variable which is intended for the local
process only is not being leaked to other processes. The latter can happen if
we start a new Flink process based on the read Flink Configuration (e.g. Yarn,
Mesos TaskExecutor).

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
