### PR TITLE
[FLINK-14375][runtime] Refactor task state updating to only notify scheduler about state changes that really happened

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -1041,17 +1041,9 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 		processFail(t, true);
 	}
 
-	/**
-	 * @deprecated Only used in tests.
-	 */
-	@Deprecated
 	@VisibleForTesting
 	void markFailed(Throwable t, Map<String, Accumulator<?, ?>> userAccumulators, IOMetrics metrics) {
-		markFailed(t, userAccumulators, metrics, false);
-	}
-
-	void markFailed(Throwable t, Map<String, Accumulator<?, ?>> userAccumulators, IOMetrics metrics, boolean fromSchedulerNg) {
-		processFail(t, true, userAccumulators, metrics, false, fromSchedulerNg);
+		processFail(t, true, userAccumulators, metrics, false);
 	}
 
 	@VisibleForTesting
@@ -1201,10 +1193,10 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	}
 
 	private void processFail(Throwable t, boolean isCallback) {
-		processFail(t, isCallback, null, null, true, false);
+		processFail(t, isCallback, null, null, true);
 	}
 
-	private void processFail(Throwable t, boolean isCallback, Map<String, Accumulator<?, ?>> userAccumulators, IOMetrics metrics, boolean releasePartitions, boolean fromSchedulerNg) {
+	private void processFail(Throwable t, boolean isCallback, Map<String, Accumulator<?, ?>> userAccumulators, IOMetrics metrics, boolean releasePartitions) {
 		// damn, we failed. This means only that we keep our books and notify our parent JobExecutionVertex
 		// the actual computation on the task manager is cleaned up by the TaskManager that noticed the failure
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -1232,15 +1232,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 				return;
 			}
 
-			if (!fromSchedulerNg && !isLegacyScheduling()) {
-				vertex.getExecutionGraph().notifySchedulerNgAboutInternalTaskFailure(attemptId, t);
-				// HACK: We informed the new generation scheduler about an internally detected task
-				// failure. The scheduler will call processFail() again with releasePartitions
-				// always set to false and fromSchedulerNg set to true. Because the original value
-				// of releasePartitions will be lost, we need to invoke handlePartitionCleanup() here.
-				handlePartitionCleanup(releasePartitions, releasePartitions);
-				return;
-			} else if (transitionState(current, FAILED, t)) {
+			if (transitionState(current, FAILED, t)) {
 				// success (in a manner of speaking)
 				this.failureCause = t;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -1643,7 +1643,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 			case FAILED:
 				// this deserialization is exception-free
 				accumulators = deserializeAccumulators(state);
-				attempt.markFailed(state.getError(userClassLoader), accumulators, state.getIOMetrics(), !isLegacyScheduling());
+				attempt.markFailed(state.getError(userClassLoader), accumulators, state.getIOMetrics());
 				return true;
 
 			default:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -63,6 +63,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.IntStream;
 
+import static org.apache.flink.runtime.execution.ExecutionState.CREATED;
 import static org.apache.flink.runtime.execution.ExecutionState.FINISHED;
 
 /**
@@ -676,6 +677,11 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 			for (IntermediateResultPartition resultPartition : resultPartitions.values()) {
 				resultPartition.resetForNewExecution();
 			}
+
+			getExecutionGraph().notifySchedulerNgAboutInternalStateChange(
+				executionVertexId,
+				CREATED,
+				null);
 
 			return newExecution;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -45,7 +45,6 @@ import org.apache.flink.runtime.scheduler.strategy.LazyFromSourcesSchedulingStra
 import org.apache.flink.runtime.scheduler.strategy.SchedulingStrategy;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingStrategyFactory;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
-import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.util.ExceptionUtils;
 
 import org.slf4j.Logger;
@@ -159,14 +158,14 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 	}
 
 	@Override
-	protected void updateTaskExecutionStateInternal(final ExecutionVertexID executionVertexId, final TaskExecutionState taskExecutionState) {
-		schedulingStrategy.onExecutionStateChange(executionVertexId, taskExecutionState.getExecutionState());
-		maybeHandleTaskFailure(taskExecutionState, executionVertexId);
-	}
+	public void handleInternalTaskExecutionStateChange(
+			final ExecutionVertexID executionVertexId,
+			final ExecutionState executionState,
+			final Throwable error) {
 
-	private void maybeHandleTaskFailure(final TaskExecutionState taskExecutionState, final ExecutionVertexID executionVertexId) {
-		if (taskExecutionState.getExecutionState() == ExecutionState.FAILED) {
-			final Throwable error = taskExecutionState.getError(userCodeLoader);
+		schedulingStrategy.onExecutionStateChange(executionVertexId, executionState);
+
+		if (executionState == ExecutionState.FAILED) {
 			handleTaskFailure(executionVertexId, error);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/InternalStateAndFailureListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/InternalStateAndFailureListener.java
@@ -19,20 +19,16 @@
 
 package org.apache.flink.runtime.scheduler;
 
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
-import org.apache.flink.runtime.jobmaster.JobMasterGateway;
-import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 
 /**
- * This interface enables subscribing to failures that are detected from the JobMaster side
- * (e.g., from within the {@link ExecutionGraph}).
- * In contrast, there are also failures that are detected by the TaskManager, which are communicated
- * via {@link JobMasterGateway#updateTaskExecutionState(TaskExecutionState)}.
+ * This interface enables subscribing to failures and state changes in the {@link ExecutionGraph}).
  */
-public interface InternalFailuresListener {
-
-	void notifyTaskFailure(ExecutionAttemptID attemptId, Throwable t);
+public interface InternalStateAndFailureListener {
 
 	void notifyGlobalFailure(Throwable t);
+
+	void notifyInternalExecutionStateChange(ExecutionVertexID vertexID, ExecutionState state, Throwable error);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategyFactory;
 import org.apache.flink.runtime.io.network.partition.PartitionTracker;
@@ -30,6 +31,7 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 
 import org.slf4j.Logger;
@@ -95,5 +97,14 @@ public class LegacyScheduler extends SchedulerBase {
 	@Override
 	public void handleGlobalFailure(Throwable cause) {
 		throw new IllegalStateException("Unexpected handleGlobalFailure(...) call");
+	}
+
+	@Override
+	public void handleInternalTaskExecutionStateChange(
+			final ExecutionVertexID executionVertexId,
+			final ExecutionState executionState,
+			final Throwable error) {
+
+		throw new IllegalStateException("Unexpected handleInternalTaskExecutionStateChange(...) call");
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -381,12 +381,15 @@ public abstract class SchedulerBase implements SchedulerNG {
 	@Override
 	public final boolean updateTaskExecutionState(final TaskExecutionState taskExecutionState) {
 		final Optional<ExecutionVertexID> executionVertexId = getExecutionVertexId(taskExecutionState.getID());
-		if (executionVertexId.isPresent()) {
-			executionGraph.updateState(taskExecutionState);
+
+		boolean updateSuccess = executionGraph.updateState(taskExecutionState);
+
+		if (updateSuccess && executionVertexId.isPresent()) {
 			updateTaskExecutionStateInternal(executionVertexId.get(), taskExecutionState);
 			return true;
+		} else {
+			return false;
 		}
-		return false;
 	}
 
 	protected void updateTaskExecutionStateInternal(final ExecutionVertexID executionVertexId, final TaskExecutionState taskExecutionState) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -309,7 +309,7 @@ public abstract class SchedulerBase implements SchedulerNG {
 	}
 
 	protected final void prepareExecutionGraphForNgScheduling() {
-		executionGraph.enableNgScheduling(new UpdateSchedulerNgOnInternalFailuresListener(this, jobGraph.getJobID()));
+		executionGraph.enableNgScheduling(new UpdateSchedulerNgOnInternalStateAndFailureListener(this));
 		executionGraph.transitionToRunning();
 	}
 
@@ -380,20 +380,13 @@ public abstract class SchedulerBase implements SchedulerNG {
 
 	@Override
 	public final boolean updateTaskExecutionState(final TaskExecutionState taskExecutionState) {
-		final Optional<ExecutionVertexID> executionVertexId = getExecutionVertexId(taskExecutionState.getID());
-
-		boolean updateSuccess = executionGraph.updateState(taskExecutionState);
-
-		if (updateSuccess && executionVertexId.isPresent()) {
-			updateTaskExecutionStateInternal(executionVertexId.get(), taskExecutionState);
-			return true;
-		} else {
-			return false;
-		}
+		return executionGraph.updateState(taskExecutionState);
 	}
 
-	protected void updateTaskExecutionStateInternal(final ExecutionVertexID executionVertexId, final TaskExecutionState taskExecutionState) {
-	}
+	public abstract void handleInternalTaskExecutionStateChange(
+			final ExecutionVertexID executionVertexId,
+			final ExecutionState executionState,
+			final Throwable error);
 
 	@Override
 	public SerializedInputSplit requestNextInputSplit(JobVertexID vertexID, ExecutionAttemptID executionAttempt) throws IOException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
@@ -42,6 +42,7 @@ import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.query.KvStateLocation;
 import org.apache.flink.runtime.query.UnknownKvStateLocation;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.util.FlinkException;
@@ -80,6 +81,8 @@ public interface SchedulerNG {
 	void handleGlobalFailure(Throwable cause);
 
 	boolean updateTaskExecutionState(TaskExecutionState taskExecutionState);
+
+	void handleInternalTaskExecutionStateChange(ExecutionVertexID executionVertexId, ExecutionState executionState, Throwable error);
 
 	SerializedInputSplit requestNextInputSplit(JobVertexID vertexID, ExecutionAttemptID executionAttempt) throws IOException;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/UpdateSchedulerNgOnInternalStateAndFailureListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/UpdateSchedulerNgOnInternalStateAndFailureListener.java
@@ -19,38 +19,30 @@
 
 package org.apache.flink.runtime.scheduler;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.execution.ExecutionState;
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * Calls {@link SchedulerNG#updateTaskExecutionState(TaskExecutionState)} on task failure.
- * Calls {@link SchedulerNG#handleGlobalFailure(Throwable)} on global failures.
+ * Calls {@link SchedulerNG#handleInternalTaskExecutionStateChange} on task state changes.
+ * Calls {@link SchedulerNG#handleGlobalFailure} on global failures.
  */
-class UpdateSchedulerNgOnInternalFailuresListener implements InternalFailuresListener {
+class UpdateSchedulerNgOnInternalStateAndFailureListener implements InternalStateAndFailureListener {
 
 	private final SchedulerNG schedulerNg;
 
-	private final JobID jobId;
-
-	public UpdateSchedulerNgOnInternalFailuresListener(
-		final SchedulerNG schedulerNg,
-		final JobID jobId) {
-
+	public UpdateSchedulerNgOnInternalStateAndFailureListener(final SchedulerNG schedulerNg) {
 		this.schedulerNg = checkNotNull(schedulerNg);
-		this.jobId = checkNotNull(jobId);
 	}
 
 	@Override
-	public void notifyTaskFailure(final ExecutionAttemptID attemptId, final Throwable t) {
-		schedulerNg.updateTaskExecutionState(new TaskExecutionState(
-			jobId,
-			attemptId,
-			ExecutionState.FAILED,
-			t));
+	public void notifyInternalExecutionStateChange(
+			final ExecutionVertexID vertexID,
+			final ExecutionState state,
+			final Throwable error) {
+
+		schedulerNg.handleInternalTaskExecutionStateChange(vertexID, state, error);
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

This PR is to avoid fake state update. More details see FLINK-14375.
Besides that, it also has a few other benefits:
1. we can get rid of the hack code in Execution#processFail
2. all states are possible to be notified to SchedulingStrategy, i.e. it solves FLINK-14233


## Brief change log

  - *Change DefaultScheduler to not handle the state update in SchedulerBase#updateTaskExecutionState*
  - *Change ExecutionGraph to notify all execution state changes to scheduler*


## Verifying this change

This change is already covered by existing tests in DefaultSchedulerTest and IT cases.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
