### PR TITLE
[hotfix] Rename TimeReaderFunction to TimerReaderFunction

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/input/KeyedStateInputFormatTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/input/KeyedStateInputFormatTest.java
@@ -145,10 +145,10 @@ public class KeyedStateInputFormatTest {
 		OperatorState operatorState = new OperatorState(operatorID, 1, 128);
 		operatorState.putState(0, state);
 
-		KeyedStateInputFormat<?, ?> format = new KeyedStateInputFormat<>(operatorState, new MemoryStateBackend(), Types.INT, new TimeReaderFunction());
+		KeyedStateInputFormat<?, ?> format = new KeyedStateInputFormat<>(operatorState, new MemoryStateBackend(), Types.INT, new TimerReaderFunction());
 		KeyGroupRangeInputSplit split = format.createInputSplits(1)[0];
 
-		KeyedStateReaderFunction<Integer, Integer> userFunction = new TimeReaderFunction();
+		KeyedStateReaderFunction<Integer, Integer> userFunction = new TimerReaderFunction();
 
 		List<Integer> data = readInputSplit(split, userFunction);
 
@@ -269,7 +269,7 @@ public class KeyedStateInputFormatTest {
 		}
 	}
 
-	static class TimeReaderFunction extends KeyedStateReaderFunction<Integer, Integer> {
+	static class TimerReaderFunction extends KeyedStateReaderFunction<Integer, Integer> {
 		ValueState<Integer> state;
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change

*This pull request renames TimeReaderFunction to TimerReaderFunction*


## Brief change log

  - *Rename TimeReaderFunction to TimerReaderFunction*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
