### PR TITLE
[hotfix] Fix wrong Java doc comment of BroadcastStateBootstrapFunction.Context

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/functions/BroadcastStateBootstrapFunction.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/functions/BroadcastStateBootstrapFunction.java
@@ -43,7 +43,7 @@ public abstract class BroadcastStateBootstrapFunction<IN> extends AbstractRichFu
 	public abstract void processElement(IN value, Context ctx) throws Exception;
 
 	/**
-	 * Context that {@link StateBootstrapFunction}'s can use for getting additional data about an input
+	 * Context that {@link BroadcastStateBootstrapFunction}'s can use for getting additional data about an input
 	 * record.
 	 *
 	 * <p>The context is only valid for the duration of a {@link


### PR DESCRIPTION


## What is the purpose of the change

*This pull request fixed wrong Java doc comment of BroadcastStateBootstrapFunction.Context*

## Brief change log

  - *Fix wrong Java doc comment of BroadcastStateBootstrapFunction.Context*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
