### PR TITLE
[FLINK-14439][runtime] Enable RestartPipelinedRegionStrategy to leverage JM tracked partition availability in DefaultScheduler

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategy.java
@@ -48,8 +48,11 @@ public interface FailoverStrategy {
 		 * Instantiates the {@link FailoverStrategy}.
 		 *
 		 * @param topology of the graph to failover
+		 * @param resultPartitionAvailabilityChecker to check whether a result partition is available
 		 * @return The instantiated failover strategy.
 		 */
-		FailoverStrategy create(FailoverTopology<?, ?> topology);
+		FailoverStrategy create(
+			FailoverTopology<?, ?> topology,
+			ResultPartitionAvailabilityChecker resultPartitionAvailabilityChecker);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionStrategy.java
@@ -267,8 +267,11 @@ public class RestartPipelinedRegionStrategy implements FailoverStrategy {
 	public static class Factory implements FailoverStrategy.Factory {
 
 		@Override
-		public FailoverStrategy create(final FailoverTopology<?, ?> topology) {
-			return new RestartPipelinedRegionStrategy(topology);
+		public FailoverStrategy create(
+				final FailoverTopology<?, ?> topology,
+				final ResultPartitionAvailabilityChecker resultPartitionAvailabilityChecker) {
+
+			return new RestartPipelinedRegionStrategy(topology, resultPartitionAvailabilityChecker);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -141,7 +141,7 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 
 		this.executionFailureHandler = new ExecutionFailureHandler(
 			getFailoverTopology(),
-			failoverStrategyFactory.create(getFailoverTopology()),
+			failoverStrategyFactory.create(getFailoverTopology(), getResultPartitionAvailabilityChecker()),
 			restartBackoffTimeStrategy);
 		this.schedulingStrategy = schedulingStrategyFactory.createInstance(this, getSchedulingTopology(), getJobGraph());
 		this.executionSlotAllocator = checkNotNull(executionSlotAllocatorFactory).createInstance(getInputsLocationsRetriever());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -51,6 +51,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.IntermediateResult;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverTopology;
+import org.apache.flink.runtime.executiongraph.failover.flip1.ResultPartitionAvailabilityChecker;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategyFactory;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategyResolving;
@@ -333,6 +334,10 @@ public abstract class SchedulerBase implements SchedulerNG {
 
 	protected final SchedulingTopology<?, ?> getSchedulingTopology() {
 		return schedulingTopology;
+	}
+
+	protected final ResultPartitionAvailabilityChecker getResultPartitionAvailabilityChecker() {
+		return getExecutionGraph().getResultPartitionAvailabilityChecker();
 	}
 
 	protected final InputsLocationsRetriever getInputsLocationsRetriever() {


### PR DESCRIPTION

## What is the purpose of the change

In current region failover when using DefaultScheduler, most of the input result partition states are unknown. Even though the failure cause is a PartitionException, only one unhealthy partition can be identified.

The may lead to multiple unsuccessful failovers before all the unhealthy but needed partitions are identified and their producers are involved in the failover as well. (unsuccessful failover here means the recovered tasks get failed again soon due to some missing input partitions.)

This PR is to enable failover strategy in DefaultScheduler to leverage JM side tracked partition availability for better failover experience.


## Brief change log

- Change FailoverStrategy.Factory#create(FailoverTopology) to FailoverStrategy.Factory#create(FailoverTopology, ResultPartitionAvailabilityChecker).
- Add schedulerBase#getResultPartitionAvailabilityChecker which returns getExecutionGraph().getResultPartitionAvailabilityChecker()
- In DefaultScheduler use the resultPartitionAvailabilityChecker from SchedulerBase to create the failover strategy from the factory


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
The PR of FLINK-14440 which is based on this one also proves it works.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
