### PR TITLE
[FLINK-14440][tests] Annotate BatchFineGrainedRecoveryITCase to enable scheduler NG testing for it

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategy.java
@@ -48,8 +48,11 @@ public interface FailoverStrategy {
 		 * Instantiates the {@link FailoverStrategy}.
 		 *
 		 * @param topology of the graph to failover
+		 * @param resultPartitionAvailabilityChecker to check whether a result partition is available
 		 * @return The instantiated failover strategy.
 		 */
-		FailoverStrategy create(FailoverTopology<?, ?> topology);
+		FailoverStrategy create(
+			FailoverTopology<?, ?> topology,
+			ResultPartitionAvailabilityChecker resultPartitionAvailabilityChecker);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionStrategy.java
@@ -267,8 +267,11 @@ public class RestartPipelinedRegionStrategy implements FailoverStrategy {
 	public static class Factory implements FailoverStrategy.Factory {
 
 		@Override
-		public FailoverStrategy create(final FailoverTopology<?, ?> topology) {
-			return new RestartPipelinedRegionStrategy(topology);
+		public FailoverStrategy create(
+				final FailoverTopology<?, ?> topology,
+				final ResultPartitionAvailabilityChecker resultPartitionAvailabilityChecker) {
+
+			return new RestartPipelinedRegionStrategy(topology, resultPartitionAvailabilityChecker);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -141,7 +141,7 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 
 		this.executionFailureHandler = new ExecutionFailureHandler(
 			getFailoverTopology(),
-			failoverStrategyFactory.create(getFailoverTopology()),
+			failoverStrategyFactory.create(getFailoverTopology(), getResultPartitionAvailabilityChecker()),
 			restartBackoffTimeStrategy);
 		this.schedulingStrategy = schedulingStrategyFactory.createInstance(this, getSchedulingTopology(), getJobGraph());
 		this.executionSlotAllocator = checkNotNull(executionSlotAllocatorFactory).createInstance(getInputsLocationsRetriever());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -51,6 +51,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.IntermediateResult;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverTopology;
+import org.apache.flink.runtime.executiongraph.failover.flip1.ResultPartitionAvailabilityChecker;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategyFactory;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategyResolving;
@@ -333,6 +334,10 @@ public abstract class SchedulerBase implements SchedulerNG {
 
 	protected final SchedulingTopology<?, ?> getSchedulingTopology() {
 		return schedulingTopology;
+	}
+
+	protected final ResultPartitionAvailabilityChecker getResultPartitionAvailabilityChecker() {
+		return getExecutionGraph().getResultPartitionAvailabilityChecker();
 	}
 
 	protected final InputsLocationsRetriever getInputsLocationsRetriever() {

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/BatchFineGrainedRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/BatchFineGrainedRecoveryITCase.java
@@ -54,6 +54,7 @@ import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
 import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptDetailsInfo;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
 import org.apache.flink.test.util.TestEnvironment;
+import org.apache.flink.testutils.junit.category.AlsoRunWithSchedulerNG;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.ExceptionUtils;
@@ -64,6 +65,7 @@ import org.apache.flink.util.TestLogger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,6 +122,7 @@ import static org.junit.Assert.assertThat;
  *   lost results.
  * </ul>
  */
+@Category(AlsoRunWithSchedulerNG.class)
 public class BatchFineGrainedRecoveryITCase extends TestLogger {
 	private static final Logger LOG = LoggerFactory.getLogger(BatchFineGrainedRecoveryITCase.class);
 


### PR DESCRIPTION

## What is the purpose of the change

This change is based on #10043 which fixes FLINK-14439.
With that fix, BatchFineGrainedRecoveryITCase can pass scheduler NG test.
This PR is to annotate it with AlsoRunWithSchedulerNG to enable scheduler NG testing for it.


## Brief change log

  - *Annotate BatchFineGrainedRecoveryITCase with AlsoRunWithSchedulerNG*


## Verifying this change

This change is already covered by itself*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
