### PR TITLE
[FLINK-14558][python] Fix ClassNotFoundException of PythonScalarFunctionOperator

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCalc.scala
@@ -37,7 +37,11 @@ import scala.collection.mutable
 trait CommonPythonCalc {
 
   private lazy val convertLiteralToPython = {
-    val clazz = Class.forName("org.apache.flink.api.common.python.PythonBridgeUtils")
+    val clazz = Class.forName(
+      "org.apache.flink.api.common.python.PythonBridgeUtils",
+      false,
+      Thread.currentThread.getContextClassLoader
+    )
     clazz.getMethod("convertLiteralToPython", classOf[RexLiteral], classOf[SqlTypeName])
   }
 
@@ -95,7 +99,8 @@ trait CommonPythonCalc {
       udfInputOffsets: Array[Int],
       pythonFunctionInfos: Array[PythonFunctionInfo],
       forwardedFields: Array[Int])= {
-    val clazz = Class.forName(PYTHON_SCALAR_FUNCTION_OPERATOR_NAME)
+    val clazz = Class.forName(
+      PYTHON_SCALAR_FUNCTION_OPERATOR_NAME, false, Thread.currentThread.getContextClassLoader)
     val ctor = clazz.getConstructor(
       classOf[Array[PythonFunctionInfo]],
       classOf[RowType],

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCalc.scala
@@ -23,6 +23,7 @@ import org.apache.calcite.sql.`type`.SqlTypeName
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.streaming.api.transformations.OneInputTransformation
+import org.apache.flink.table.api.TableException
 import org.apache.flink.table.dataformat.BaseRow
 import org.apache.flink.table.functions.python.{PythonFunction, PythonFunctionInfo, SimplePythonFunction}
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
@@ -36,12 +37,17 @@ import scala.collection.mutable
 
 trait CommonPythonCalc {
 
+  private def loadClass(className: String): Class[_] = {
+    try {
+      Class.forName(className, false, Thread.currentThread.getContextClassLoader)
+    } catch {
+      case ex: ClassNotFoundException => throw new TableException(
+        "flink-python dependency is not present on the classpath.", ex)
+    }
+  }
+
   private lazy val convertLiteralToPython = {
-    val clazz = Class.forName(
-      "org.apache.flink.api.common.python.PythonBridgeUtils",
-      false,
-      Thread.currentThread.getContextClassLoader
-    )
+    val clazz = loadClass("org.apache.flink.api.common.python.PythonBridgeUtils")
     clazz.getMethod("convertLiteralToPython", classOf[RexLiteral], classOf[SqlTypeName])
   }
 
@@ -99,8 +105,7 @@ trait CommonPythonCalc {
       udfInputOffsets: Array[Int],
       pythonFunctionInfos: Array[PythonFunctionInfo],
       forwardedFields: Array[Int])= {
-    val clazz = Class.forName(
-      PYTHON_SCALAR_FUNCTION_OPERATOR_NAME, false, Thread.currentThread.getContextClassLoader)
+    val clazz = loadClass(PYTHON_SCALAR_FUNCTION_OPERATOR_NAME)
     val ctor = clazz.getConstructor(
       classOf[Array[PythonFunctionInfo]],
       classOf[RowType],

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
@@ -19,6 +19,7 @@ package org.apache.flink.table.plan.nodes
 
 import org.apache.calcite.rex.{RexCall, RexInputRef, RexLiteral, RexNode}
 import org.apache.calcite.sql.`type`.SqlTypeName
+import org.apache.flink.table.api.TableException
 import org.apache.flink.table.functions.python.{PythonFunction, PythonFunctionInfo, SimplePythonFunction}
 import org.apache.flink.table.functions.utils.ScalarSqlFunction
 
@@ -27,12 +28,17 @@ import scala.collection.mutable
 
 trait CommonPythonCalc {
 
+  def loadClass(className: String): Class[_] = {
+    try {
+      Class.forName(className, false, Thread.currentThread.getContextClassLoader)
+    } catch {
+      case ex: ClassNotFoundException => throw new TableException(
+        "flink-python dependency is not present on the classpath.", ex)
+    }
+  }
+
   private lazy val convertLiteralToPython = {
-    val clazz = Class.forName(
-      "org.apache.flink.api.common.python.PythonBridgeUtils",
-      false,
-      Thread.currentThread.getContextClassLoader
-    )
+    val clazz = loadClass("org.apache.flink.api.common.python.PythonBridgeUtils")
     clazz.getMethod("convertLiteralToPython", classOf[RexLiteral], classOf[SqlTypeName])
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
@@ -28,7 +28,11 @@ import scala.collection.mutable
 trait CommonPythonCalc {
 
   private lazy val convertLiteralToPython = {
-    val clazz = Class.forName("org.apache.flink.api.common.python.PythonBridgeUtils")
+    val clazz = Class.forName(
+      "org.apache.flink.api.common.python.PythonBridgeUtils",
+      false,
+      Thread.currentThread.getContextClassLoader
+    )
     clazz.getMethod("convertLiteralToPython", classOf[RexLiteral], classOf[SqlTypeName])
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCalc.scala
@@ -116,8 +116,7 @@ class DataStreamPythonCalc(
       inputRowType: RowType,
       outputRowType: RowType,
       udfInputOffsets: Array[Int]) = {
-    val clazz = Class.forName(
-      PYTHON_SCALAR_FUNCTION_OPERATOR_NAME, false, Thread.currentThread.getContextClassLoader)
+    val clazz = loadClass(PYTHON_SCALAR_FUNCTION_OPERATOR_NAME)
     val ctor = clazz.getConstructor(
       classOf[Array[PythonFunctionInfo]],
       classOf[RowType],

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCalc.scala
@@ -116,7 +116,8 @@ class DataStreamPythonCalc(
       inputRowType: RowType,
       outputRowType: RowType,
       udfInputOffsets: Array[Int]) = {
-    val clazz = Class.forName(PYTHON_SCALAR_FUNCTION_OPERATOR_NAME)
+    val clazz = Class.forName(
+      PYTHON_SCALAR_FUNCTION_OPERATOR_NAME, false, Thread.currentThread.getContextClassLoader)
     val ctor = clazz.getConstructor(
       classOf[Array[PythonFunctionInfo]],
       classOf[RowType],


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fixes the ClassNotFoundException of PythonScalarFunctionOperator. Currently the jar of flink-python is loaded with user classloader and could not be found with the system classloader.*

## Brief change log

  - *Uses ContextClassLoader to load the classes located in flink-python module*

## Verifying this change

Test manually in a standalone cluster.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
