### PR TITLE
[FLINK-14544][runtime] Fixing race condition during task cancellation

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailbox.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailbox.java
@@ -74,4 +74,15 @@ public interface TaskMailbox extends Mailbox {
 	 * Returns <code>true</code> if the mailbox contains mail.
 	 */
 	boolean hasMail();
+
+	/**
+	 * Runs the given code exclusively on this mailbox. No synchronized operations can be run concurrently to the
+	 * given runnable (e.g., {@link #put(Mail)} or modifying lifecycle methods).
+	 *
+	 * <p>Use this methods when you want to atomically execute code that uses different methods (e.g., check for
+	 * state and then put message if open).
+	 *
+	 * @param runnable the runnable to execute
+	 */
+	void runExclusively(Runnable runnable);
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxImpl.java
@@ -245,4 +245,14 @@ public class TaskMailboxImpl implements TaskMailbox {
 	public State getState() {
 		return state;
 	}
+
+	@Override
+	public void runExclusively(Runnable runnable) {
+		lock.lock();
+		try {
+			runnable.run();
+		} finally {
+			lock.unlock();
+		}
+	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/execution/TaskMailboxProcessorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/execution/TaskMailboxProcessorTest.java
@@ -201,6 +201,16 @@ public class TaskMailboxProcessorTest {
 		mailboxThread.checkException();
 	}
 
+	/**
+	 * Testing that canceling after closing will not lead to an exception.
+	 */
+	@Test
+	public void testCancelAfterClose() {
+		MailboxProcessor mailboxProcessor = new MailboxProcessor((ctx) -> {});
+		mailboxProcessor.close();
+		mailboxProcessor.allActionsCompleted();
+	}
+
 	private static MailboxProcessor start(MailboxThread mailboxThread) {
 		mailboxThread.start();
 		final MailboxProcessor mailboxProcessor = mailboxThread.getMailboxProcessor();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The race condition occurred because `StreamTask#cancel` will stop
`TaskMailboxProcessor#runMainLoop` by sending a poison letter. That loop,
however, can also be left by receiving EOI from upstream tasks, such
that the normal cleanup in `StreamTask#invoke` will close the
mailbox(processor). Sending a (poison) letter with a closed mailbox will
trigger an `MailboxStateException`, which acts as a safety net and reports
illegal mailbox accesses in respect to its state.

To avoid the situation, the enqueuing of the poison letter is more now
robust. It checks for the mailbox being in the correct state (OPEN) or
else will not enqueue the poison letter, which would not have an effect
anyways as the mailbox loop has already been terminated.
Since the check and the enqueuing of the letter are non-atomic, another
(much more unlikely) race condition would have been introduced. Hence,
there is now a convenience method to `TaskMailbox` to run code under the
internal lock, such that `MailboxProcessor` can atomically check if
mailbox is still open and enqueuing poison letter.

## Brief change log

*(for example:)*
  - Adds convenience method in `TaskMailbox` to execute code under the internal lock.
 - `MailboxProcessor` uses that method to perform an atomic operation that checks for the mailbox state and enqueues poison letter when open.

## Verifying this change

Added 2 unit tests for testing the exclusive lock and the robust stop of the mailbox loop.
The failing e2e tests the overall interplay.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
