### PR TITLE
[FLINK-14573][python] Support time data types in Python user-defined functions

### DIFF
--- a/flink-python/pyflink/fn_execution/coder_impl.py
+++ b/flink-python/pyflink/fn_execution/coder_impl.py
@@ -177,3 +177,26 @@ class DateCoderImpl(StreamCoderImpl):
 
     def internal_to_date(self, v):
         return datetime.date.fromordinal(v + self.EPOCH_ORDINAL)
+
+
+class TimeCoderImpl(StreamCoderImpl):
+
+    def encode_to_stream(self, value, out_stream, nested):
+        out_stream.write_bigendian_int32(self.time_to_internal(value))
+
+    def decode_from_stream(self, in_stream, nested):
+        value = in_stream.read_bigendian_int32()
+        return self.internal_to_time(value)
+
+    def time_to_internal(self, t):
+        milliseconds = (t.hour * 3600000
+                        + t.minute * 60000
+                        + t.second * 1000
+                        + t.microsecond // 1000)
+        return milliseconds
+
+    def internal_to_time(self, v):
+        seconds, milliseconds = divmod(v, 1000)
+        minutes, seconds = divmod(seconds, 60)
+        hours, minutes = divmod(minutes, 60)
+        return datetime.time(hours, minutes, seconds, milliseconds * 1000)

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -31,7 +31,7 @@ FLINK_SCHEMA_CODER_URN = "flink:coder:schema:v1"
 
 __all__ = ['RowCoder', 'BigIntCoder', 'TinyIntCoder', 'BooleanCoder',
            'SmallIntCoder', 'IntCoder', 'FloatCoder', 'DoubleCoder',
-           'BinaryCoder', 'CharCoder', 'DateCoder']
+           'BinaryCoder', 'CharCoder', 'DateCoder', 'TimeCoder']
 
 
 class RowCoder(FastCoder):
@@ -196,6 +196,18 @@ class DateCoder(DeterministicCoder):
         return datetime.date
 
 
+class TimeCoder(DeterministicCoder):
+    """
+    Coder for Time.
+    """
+
+    def _create_impl(self):
+        return coder_impl.TimeCoderImpl()
+
+    def to_type_hint(self):
+        return datetime.time
+
+
 @Coder.register_urn(FLINK_SCHEMA_CODER_URN, flink_fn_execution_pb2.Schema)
 def _pickle_from_runner_api_parameter(schema_proto, unused_components, unused_context):
     return RowCoder([from_proto(f.type) for f in schema_proto.fields])
@@ -215,6 +227,7 @@ _type_name_mappings = {
     type_name.CHAR: CharCoder(),
     type_name.VARCHAR: CharCoder(),
     type_name.DATE: DateCoder(),
+    type_name.TIME: TimeCoder(),
 }
 
 

--- a/flink-python/pyflink/fn_execution/flink_fn_execution_pb2.py
+++ b/flink-python/pyflink/fn_execution/flink_fn_execution_pb2.py
@@ -36,7 +36,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='flink-fn-execution.proto',
   package='org.apache.flink.fn_execution.v1',
   syntax='proto3',
-  serialized_pb=_b('\n\x18\x66link-fn-execution.proto\x12 org.apache.flink.fn_execution.v1\"\xfc\x01\n\x13UserDefinedFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12K\n\x06inputs\x18\x02 \x03(\x0b\x32;.org.apache.flink.fn_execution.v1.UserDefinedFunction.Input\x1a\x86\x01\n\x05Input\x12\x44\n\x03udf\x18\x01 \x01(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunctionH\x00\x12\x15\n\x0binputOffset\x18\x02 \x01(\x05H\x00\x12\x17\n\rinputConstant\x18\x03 \x01(\x0cH\x00\x42\x07\n\x05input\"[\n\x14UserDefinedFunctions\x12\x43\n\x04udfs\x18\x01 \x03(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunction\"\x8d\x07\n\x06Schema\x12>\n\x06\x66ields\x18\x01 \x03(\x0b\x32..org.apache.flink.fn_execution.v1.Schema.Field\x1a\x97\x01\n\x07MapType\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\xcd\x02\n\tFieldType\x12\x44\n\ttype_name\x18\x01 \x01(\x0e\x32\x31.org.apache.flink.fn_execution.v1.Schema.TypeName\x12\x10\n\x08nullable\x18\x02 \x01(\x08\x12U\n\x17\x63ollection_element_type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeH\x00\x12\x44\n\x08map_type\x18\x04 \x01(\x0b\x32\x30.org.apache.flink.fn_execution.v1.Schema.MapTypeH\x00\x12>\n\nrow_schema\x18\x05 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.SchemaH\x00\x42\x0b\n\ttype_info\x1al\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12@\n\x04type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\"\xea\x01\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\x0b\n\x07TINYINT\x10\x01\x12\x0c\n\x08SMALLINT\x10\x02\x12\x07\n\x03INT\x10\x03\x12\n\n\x06\x42IGINT\x10\x04\x12\x0b\n\x07\x44\x45\x43IMAL\x10\x05\x12\t\n\x05\x46LOAT\x10\x06\x12\n\n\x06\x44OUBLE\x10\x07\x12\x08\n\x04\x44\x41TE\x10\x08\x12\x08\n\x04TIME\x10\t\x12\x0c\n\x08\x44\x41TETIME\x10\n\x12\x0b\n\x07\x42OOLEAN\x10\x0b\x12\n\n\x06\x42INARY\x10\x0c\x12\r\n\tVARBINARY\x10\r\x12\x08\n\x04\x43HAR\x10\x0e\x12\x0b\n\x07VARCHAR\x10\x0f\x12\t\n\x05\x41RRAY\x10\x10\x12\x07\n\x03MAP\x10\x11\x12\x0c\n\x08MULTISET\x10\x12\x42-\n\x1forg.apache.flink.fnexecution.v1B\nFlinkFnApib\x06proto3')
+  serialized_pb=_b('\n\x18\x66link-fn-execution.proto\x12 org.apache.flink.fn_execution.v1\"\xfc\x01\n\x13UserDefinedFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12K\n\x06inputs\x18\x02 \x03(\x0b\x32;.org.apache.flink.fn_execution.v1.UserDefinedFunction.Input\x1a\x86\x01\n\x05Input\x12\x44\n\x03udf\x18\x01 \x01(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunctionH\x00\x12\x15\n\x0binputOffset\x18\x02 \x01(\x05H\x00\x12\x17\n\rinputConstant\x18\x03 \x01(\x0cH\x00\x42\x07\n\x05input\"[\n\x14UserDefinedFunctions\x12\x43\n\x04udfs\x18\x01 \x03(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunction\"\x81\x08\n\x06Schema\x12>\n\x06\x66ields\x18\x01 \x03(\x0b\x32..org.apache.flink.fn_execution.v1.Schema.Field\x1a\x97\x01\n\x07MapType\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a!\n\x0c\x44\x61teTimeType\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\x9e\x03\n\tFieldType\x12\x44\n\ttype_name\x18\x01 \x01(\x0e\x32\x31.org.apache.flink.fn_execution.v1.Schema.TypeName\x12\x10\n\x08nullable\x18\x02 \x01(\x08\x12U\n\x17\x63ollection_element_type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeH\x00\x12\x44\n\x08map_type\x18\x04 \x01(\x0b\x32\x30.org.apache.flink.fn_execution.v1.Schema.MapTypeH\x00\x12>\n\nrow_schema\x18\x05 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.SchemaH\x00\x12O\n\x0e\x64\x61te_time_type\x18\x06 \x01(\x0b\x32\x35.org.apache.flink.fn_execution.v1.Schema.DateTimeTypeH\x00\x42\x0b\n\ttype_info\x1al\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12@\n\x04type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\"\xea\x01\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\x0b\n\x07TINYINT\x10\x01\x12\x0c\n\x08SMALLINT\x10\x02\x12\x07\n\x03INT\x10\x03\x12\n\n\x06\x42IGINT\x10\x04\x12\x0b\n\x07\x44\x45\x43IMAL\x10\x05\x12\t\n\x05\x46LOAT\x10\x06\x12\n\n\x06\x44OUBLE\x10\x07\x12\x08\n\x04\x44\x41TE\x10\x08\x12\x08\n\x04TIME\x10\t\x12\x0c\n\x08\x44\x41TETIME\x10\n\x12\x0b\n\x07\x42OOLEAN\x10\x0b\x12\n\n\x06\x42INARY\x10\x0c\x12\r\n\tVARBINARY\x10\r\x12\x08\n\x04\x43HAR\x10\x0e\x12\x0b\n\x07VARCHAR\x10\x0f\x12\t\n\x05\x41RRAY\x10\x10\x12\x07\n\x03MAP\x10\x11\x12\x0c\n\x08MULTISET\x10\x12\x42-\n\x1forg.apache.flink.fnexecution.v1B\nFlinkFnApib\x06proto3')
 )
 
 
@@ -126,8 +126,8 @@ _SCHEMA_TYPENAME = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1086,
-  serialized_end=1320,
+  serialized_start=1202,
+  serialized_end=1436,
 )
 _sym_db.RegisterEnumDescriptor(_SCHEMA_TYPENAME)
 
@@ -285,6 +285,36 @@ _SCHEMA_MAPTYPE = _descriptor.Descriptor(
   serialized_end=637,
 )
 
+_SCHEMA_DATETIMETYPE = _descriptor.Descriptor(
+  name='DateTimeType',
+  full_name='org.apache.flink.fn_execution.v1.Schema.DateTimeType',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='precision', full_name='org.apache.flink.fn_execution.v1.Schema.DateTimeType.precision', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=639,
+  serialized_end=672,
+)
+
 _SCHEMA_FIELDTYPE = _descriptor.Descriptor(
   name='FieldType',
   full_name='org.apache.flink.fn_execution.v1.Schema.FieldType',
@@ -327,6 +357,13 @@ _SCHEMA_FIELDTYPE = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='date_time_type', full_name='org.apache.flink.fn_execution.v1.Schema.FieldType.date_time_type', index=5,
+      number=6, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -342,8 +379,8 @@ _SCHEMA_FIELDTYPE = _descriptor.Descriptor(
       name='type_info', full_name='org.apache.flink.fn_execution.v1.Schema.FieldType.type_info',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=640,
-  serialized_end=973,
+  serialized_start=675,
+  serialized_end=1089,
 )
 
 _SCHEMA_FIELD = _descriptor.Descriptor(
@@ -386,8 +423,8 @@ _SCHEMA_FIELD = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=975,
-  serialized_end=1083,
+  serialized_start=1091,
+  serialized_end=1199,
 )
 
 _SCHEMA = _descriptor.Descriptor(
@@ -407,7 +444,7 @@ _SCHEMA = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_SCHEMA_MAPTYPE, _SCHEMA_FIELDTYPE, _SCHEMA_FIELD, ],
+  nested_types=[_SCHEMA_MAPTYPE, _SCHEMA_DATETIMETYPE, _SCHEMA_FIELDTYPE, _SCHEMA_FIELD, ],
   enum_types=[
     _SCHEMA_TYPENAME,
   ],
@@ -418,7 +455,7 @@ _SCHEMA = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=411,
-  serialized_end=1320,
+  serialized_end=1436,
 )
 
 _USERDEFINEDFUNCTION_INPUT.fields_by_name['udf'].message_type = _USERDEFINEDFUNCTION
@@ -437,10 +474,12 @@ _USERDEFINEDFUNCTIONS.fields_by_name['udfs'].message_type = _USERDEFINEDFUNCTION
 _SCHEMA_MAPTYPE.fields_by_name['key_type'].message_type = _SCHEMA_FIELDTYPE
 _SCHEMA_MAPTYPE.fields_by_name['value_type'].message_type = _SCHEMA_FIELDTYPE
 _SCHEMA_MAPTYPE.containing_type = _SCHEMA
+_SCHEMA_DATETIMETYPE.containing_type = _SCHEMA
 _SCHEMA_FIELDTYPE.fields_by_name['type_name'].enum_type = _SCHEMA_TYPENAME
 _SCHEMA_FIELDTYPE.fields_by_name['collection_element_type'].message_type = _SCHEMA_FIELDTYPE
 _SCHEMA_FIELDTYPE.fields_by_name['map_type'].message_type = _SCHEMA_MAPTYPE
 _SCHEMA_FIELDTYPE.fields_by_name['row_schema'].message_type = _SCHEMA
+_SCHEMA_FIELDTYPE.fields_by_name['date_time_type'].message_type = _SCHEMA_DATETIMETYPE
 _SCHEMA_FIELDTYPE.containing_type = _SCHEMA
 _SCHEMA_FIELDTYPE.oneofs_by_name['type_info'].fields.append(
   _SCHEMA_FIELDTYPE.fields_by_name['collection_element_type'])
@@ -451,6 +490,9 @@ _SCHEMA_FIELDTYPE.fields_by_name['map_type'].containing_oneof = _SCHEMA_FIELDTYP
 _SCHEMA_FIELDTYPE.oneofs_by_name['type_info'].fields.append(
   _SCHEMA_FIELDTYPE.fields_by_name['row_schema'])
 _SCHEMA_FIELDTYPE.fields_by_name['row_schema'].containing_oneof = _SCHEMA_FIELDTYPE.oneofs_by_name['type_info']
+_SCHEMA_FIELDTYPE.oneofs_by_name['type_info'].fields.append(
+  _SCHEMA_FIELDTYPE.fields_by_name['date_time_type'])
+_SCHEMA_FIELDTYPE.fields_by_name['date_time_type'].containing_oneof = _SCHEMA_FIELDTYPE.oneofs_by_name['type_info']
 _SCHEMA_FIELD.fields_by_name['type'].message_type = _SCHEMA_FIELDTYPE
 _SCHEMA_FIELD.containing_type = _SCHEMA
 _SCHEMA.fields_by_name['fields'].message_type = _SCHEMA_FIELD
@@ -491,6 +533,13 @@ Schema = _reflection.GeneratedProtocolMessageType('Schema', (_message.Message,),
     ))
   ,
 
+  DateTimeType = _reflection.GeneratedProtocolMessageType('DateTimeType', (_message.Message,), dict(
+    DESCRIPTOR = _SCHEMA_DATETIMETYPE,
+    __module__ = 'flink_fn_execution_pb2'
+    # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.Schema.DateTimeType)
+    ))
+  ,
+
   FieldType = _reflection.GeneratedProtocolMessageType('FieldType', (_message.Message,), dict(
     DESCRIPTOR = _SCHEMA_FIELDTYPE,
     __module__ = 'flink_fn_execution_pb2'
@@ -510,6 +559,7 @@ Schema = _reflection.GeneratedProtocolMessageType('Schema', (_message.Message,),
   ))
 _sym_db.RegisterMessage(Schema)
 _sym_db.RegisterMessage(Schema.MapType)
+_sym_db.RegisterMessage(Schema.DateTimeType)
 _sym_db.RegisterMessage(Schema.FieldType)
 _sym_db.RegisterMessage(Schema.Field)
 

--- a/flink-python/pyflink/fn_execution/tests/coders_test_common.py
+++ b/flink-python/pyflink/fn_execution/tests/coders_test_common.py
@@ -84,7 +84,7 @@ class CodersTest(unittest.TestCase):
     def test_time_coder(self):
         import datetime
         coder = TimeCoder()
-        self.check_coder(coder, datetime.time(hour=11, minute=11, second=11))
+        self.check_coder(coder, datetime.time(hour=11, minute=11, second=11, microsecond=123000))
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/fn_execution/tests/coders_test_common.py
+++ b/flink-python/pyflink/fn_execution/tests/coders_test_common.py
@@ -21,7 +21,8 @@ import logging
 import unittest
 
 from pyflink.fn_execution.coders import BigIntCoder, TinyIntCoder, BooleanCoder, \
-    SmallIntCoder, IntCoder, FloatCoder, DoubleCoder, BinaryCoder, CharCoder, DateCoder
+    SmallIntCoder, IntCoder, FloatCoder, DoubleCoder, BinaryCoder, CharCoder, DateCoder, \
+    TimeCoder
 
 
 class CodersTest(unittest.TestCase):
@@ -79,6 +80,11 @@ class CodersTest(unittest.TestCase):
         import datetime
         coder = DateCoder()
         self.check_coder(coder, datetime.date(2019, 9, 10))
+
+    def test_time_coder(self):
+        import datetime
+        coder = TimeCoder()
+        self.check_coder(coder, datetime.time(hour=11, minute=11, second=11))
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/fn_execution/tests/coders_test_common.py
+++ b/flink-python/pyflink/fn_execution/tests/coders_test_common.py
@@ -22,7 +22,7 @@ import unittest
 
 from pyflink.fn_execution.coders import BigIntCoder, TinyIntCoder, BooleanCoder, \
     SmallIntCoder, IntCoder, FloatCoder, DoubleCoder, BinaryCoder, CharCoder, DateCoder, \
-    TimeCoder
+    TimeCoder, TimestampCoder
 
 
 class CodersTest(unittest.TestCase):
@@ -85,6 +85,13 @@ class CodersTest(unittest.TestCase):
         import datetime
         coder = TimeCoder()
         self.check_coder(coder, datetime.time(hour=11, minute=11, second=11, microsecond=123000))
+
+    def test_timestamp_coder(self):
+        import datetime
+        coder = TimestampCoder(3)
+        self.check_coder(coder, datetime.datetime(2019, 9, 10, 18, 30, 20, 123000))
+        coder = TimestampCoder(6)
+        self.check_coder(coder, datetime.datetime(2019, 9, 10, 18, 30, 20, 123456))
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/proto/flink-fn-execution.proto
+++ b/flink-python/pyflink/proto/flink-fn-execution.proto
@@ -80,6 +80,10 @@ message Schema {
     FieldType value_type = 2;
   }
 
+  message DateTimeType {
+    int32 precision = 1;
+  }
+
   message FieldType {
     TypeName type_name = 1;
     bool nullable = 2;
@@ -87,6 +91,7 @@ message Schema {
       FieldType collection_element_type = 3;
       MapType map_type = 4;
       Schema row_schema = 5;
+      DateTimeType date_time_type = 6;
     }
   }
 

--- a/flink-python/pyflink/table/tests/test_udf.py
+++ b/flink-python/pyflink/table/tests/test_udf.py
@@ -325,6 +325,12 @@ class UserDefinedFunctionTests(object):
                 'time_param is wrong value %s !' % time_param
             return time_param
 
+        def timestamp_func(timestamp_param):
+            from datetime import datetime
+            assert timestamp_param == datetime(2018, 3, 11, 3, 0, 0, 123000), \
+                'timestamp_param is wrong value %s !' % timestamp_param
+            return timestamp_param
+
         self.t_env.register_function(
             "boolean_func", udf(boolean_func, [DataTypes.BOOLEAN()], DataTypes.BOOLEAN()))
 
@@ -361,19 +367,24 @@ class UserDefinedFunctionTests(object):
         self.t_env.register_function(
             "time_func", udf(time_func, [DataTypes.TIME(3)], DataTypes.TIME(3)))
 
+        self.t_env.register_function(
+            "timestamp_func", udf(timestamp_func, [DataTypes.TIMESTAMP()], DataTypes.TIMESTAMP()))
+
         table_sink = source_sink_utils.TestAppendSink(
-            ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'],
+            ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'],
             [DataTypes.BIGINT(), DataTypes.BIGINT(), DataTypes.TINYINT(),
              DataTypes.BOOLEAN(), DataTypes.SMALLINT(), DataTypes.INT(),
              DataTypes.FLOAT(), DataTypes.DOUBLE(), DataTypes.BYTES(),
-             DataTypes.STRING(), DataTypes.DATE(), DataTypes.TIME(3)])
+             DataTypes.STRING(), DataTypes.DATE(), DataTypes.TIME(3),
+             DataTypes.TIMESTAMP()])
         self.t_env.register_table_sink("Results", table_sink)
 
         import datetime
         t = self.t_env.from_elements(
             [(1, None, 1, True, 32767, -2147483648, 1.23, 1.98932,
               bytearray(b'flink'), 'pyflink', datetime.date(2014, 9, 13),
-              datetime.time(hour=12, minute=0, second=0, microsecond=123000))],
+              datetime.time(hour=12, minute=0, second=0, microsecond=123000),
+              datetime.datetime(2018, 3, 11, 3, 0, 0, 123000))],
             DataTypes.ROW(
                 [DataTypes.FIELD("a", DataTypes.BIGINT()),
                  DataTypes.FIELD("b", DataTypes.BIGINT()),
@@ -386,14 +397,16 @@ class UserDefinedFunctionTests(object):
                  DataTypes.FIELD("i", DataTypes.BYTES()),
                  DataTypes.FIELD("j", DataTypes.STRING()),
                  DataTypes.FIELD("k", DataTypes.DATE()),
-                 DataTypes.FIELD("l", DataTypes.TIME(3))]))
+                 DataTypes.FIELD("l", DataTypes.TIME(3)),
+                 DataTypes.FIELD("m", DataTypes.TIMESTAMP())]))
 
         t.select("bigint_func(a), bigint_func_none(b),"
                  "tinyint_func(c), boolean_func(d),"
                  "smallint_func(e),int_func(f),"
                  "float_func(g),double_func(h),"
                  "bytes_func(i),str_func(j),"
-                 "date_func(k),time_func(l)") \
+                 "date_func(k),time_func(l),"
+                 "timestamp_func(m)") \
             .insert_into("Results")
         self.t_env.execute("test")
         actual = source_sink_utils.results()
@@ -401,7 +414,7 @@ class UserDefinedFunctionTests(object):
         self.assert_equals(actual,
                            ["1,null,1,true,32767,-2147483648,1.23,1.98932,"
                             "[102, 108, 105, 110, 107],pyflink,2014-09-13,"
-                            "12:00:00"])
+                            "12:00:00,2018-03-11 03:00:00.123"])
 
 
 # decide whether two floats are equal

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtils.java
@@ -194,7 +194,7 @@ public final class PythonTypeUtils {
 
 		@Override
 		public TypeSerializer visit(TimestampType timestampType) {
-			return LongSerializer.INSTANCE;
+			return new SqlTimestampSerializer(timestampType.getPrecision());
 		}
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtils.java
@@ -34,6 +34,7 @@ import org.apache.flink.table.runtime.typeutils.serializers.python.BaseRowSerial
 import org.apache.flink.table.runtime.typeutils.serializers.python.DateSerializer;
 import org.apache.flink.table.runtime.typeutils.serializers.python.StringSerializer;
 import org.apache.flink.table.runtime.typeutils.serializers.python.TimeSerializer;
+import org.apache.flink.table.runtime.typeutils.serializers.python.TimestampSerializer;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.BooleanType;
@@ -46,6 +47,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
@@ -139,6 +141,11 @@ public final class PythonTypeUtils {
 		}
 
 		@Override
+		public TypeSerializer visit(TimestampType timestampType) {
+			return new TimestampSerializer(timestampType.getPrecision());
+		}
+
+		@Override
 		public TypeSerializer visit(RowType rowType) {
 			final TypeSerializer[] fieldTypeSerializers = rowType.getFields()
 				.stream()
@@ -183,6 +190,11 @@ public final class PythonTypeUtils {
 		@Override
 		public TypeSerializer visit(TimeType timeType) {
 			return IntSerializer.INSTANCE;
+		}
+
+		@Override
+		public TypeSerializer visit(TimestampType timestampType) {
+			return LongSerializer.INSTANCE;
 		}
 	}
 
@@ -289,6 +301,20 @@ public final class PythonTypeUtils {
 				.setTypeName(FlinkFnApi.Schema.TypeName.TIME)
 				.setNullable(timeType.isNullable())
 				.build();
+		}
+
+		@Override
+		public FlinkFnApi.Schema.FieldType visit(TimestampType timestampType) {
+			FlinkFnApi.Schema.FieldType.Builder builder =
+				FlinkFnApi.Schema.FieldType.newBuilder()
+					.setTypeName(FlinkFnApi.Schema.TypeName.DATETIME)
+					.setNullable(timestampType.isNullable());
+
+			FlinkFnApi.Schema.DateTimeType.Builder dateTimeBuilder =
+				FlinkFnApi.Schema.DateTimeType.newBuilder()
+					.setPrecision(timestampType.getPrecision());
+			builder.setDateTimeType(dateTimeBuilder.build());
+			return builder.build();
 		}
 
 		@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtils.java
@@ -33,6 +33,7 @@ import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.table.runtime.typeutils.serializers.python.BaseRowSerializer;
 import org.apache.flink.table.runtime.typeutils.serializers.python.DateSerializer;
 import org.apache.flink.table.runtime.typeutils.serializers.python.StringSerializer;
+import org.apache.flink.table.runtime.typeutils.serializers.python.TimeSerializer;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.BooleanType;
@@ -44,6 +45,7 @@ import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
@@ -132,6 +134,11 @@ public final class PythonTypeUtils {
 		}
 
 		@Override
+		public TypeSerializer visit(TimeType timeType) {
+			return TimeSerializer.INSTANCE;
+		}
+
+		@Override
 		public TypeSerializer visit(RowType rowType) {
 			final TypeSerializer[] fieldTypeSerializers = rowType.getFields()
 				.stream()
@@ -170,6 +177,11 @@ public final class PythonTypeUtils {
 
 		@Override
 		public TypeSerializer visit(DateType dateType) {
+			return IntSerializer.INSTANCE;
+		}
+
+		@Override
+		public TypeSerializer visit(TimeType timeType) {
 			return IntSerializer.INSTANCE;
 		}
 	}
@@ -268,6 +280,14 @@ public final class PythonTypeUtils {
 			return FlinkFnApi.Schema.FieldType.newBuilder()
 				.setTypeName(FlinkFnApi.Schema.TypeName.DATE)
 				.setNullable(dateType.isNullable())
+				.build();
+		}
+
+		@Override
+		public FlinkFnApi.Schema.FieldType visit(TimeType timeType) {
+			return FlinkFnApi.Schema.FieldType.newBuilder()
+				.setTypeName(FlinkFnApi.Schema.TypeName.TIME)
+				.setNullable(timeType.isNullable())
 				.build();
 		}
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/TimeSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/TimeSerializer.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.serializers.python;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+import java.sql.Time;
+import java.util.TimeZone;
+
+/**
+ * Uses int instead of long as the serialized value. It not only reduces the length of the serialized
+ * value, but also makes the serialized value consistent between the legacy planner and the blink
+ * planner.
+ */
+@Internal
+public class TimeSerializer extends TypeSerializerSingleton<Time> {
+
+	private static final long serialVersionUID = 1L;
+
+	// The local time zone.
+	private static final TimeZone LOCAL_TZ = TimeZone.getDefault();
+
+	private static final long MILLIS_PER_DAY = 86400000L; // = 24 * 60 * 60 * 1000
+
+	public static final TimeSerializer INSTANCE = new TimeSerializer();
+
+	@Override
+	public boolean isImmutableType() {
+		return false;
+	}
+
+	@Override
+	public Time createInstance() {
+		return new Time(0L);
+	}
+
+	@Override
+	public Time copy(Time from) {
+		if (from == null) {
+			return null;
+		}
+		return new Time(from.getTime());
+	}
+
+	@Override
+	public Time copy(Time from, Time reuse) {
+		if (from == null) {
+			return null;
+		}
+		reuse.setTime(from.getTime());
+		return reuse;
+	}
+
+	@Override
+	public int getLength() {
+		return 4;
+	}
+
+	@Override
+	public void serialize(Time record, DataOutputView target) throws IOException {
+		if (record == null) {
+			throw new IllegalArgumentException("The Time record must not be null.");
+		}
+		target.writeInt(timeToInternal(record));
+	}
+
+	@Override
+	public Time deserialize(DataInputView source) throws IOException {
+		return internalToTime(source.readInt());
+	}
+
+	private int timeToInternal(Time time) {
+		long ts = time.getTime() + LOCAL_TZ.getOffset(time.getTime());
+		return (int) (ts % MILLIS_PER_DAY);
+	}
+
+	private Time internalToTime(int time) {
+		return new Time(time - LOCAL_TZ.getOffset(time));
+	}
+
+	@Override
+	public Time deserialize(Time reuse, DataInputView source) throws IOException {
+		return deserialize(source);
+	}
+
+	@Override
+	public void copy(DataInputView source, DataOutputView target) throws IOException {
+		serialize(deserialize(source), target);
+	}
+
+	@Override
+	public TypeSerializerSnapshot<Time> snapshotConfiguration() {
+		return new TimeSerializerSnapshot();
+	}
+
+	/**
+	 * Serializer configuration snapshot for compatibility and format evolution.
+	 */
+	@SuppressWarnings("WeakerAccess")
+	public static final class TimeSerializerSnapshot extends SimpleTypeSerializerSnapshot<Time> {
+
+		public TimeSerializerSnapshot() {
+			super(() -> INSTANCE);
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/TimeSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/TimeSerializer.java
@@ -102,7 +102,9 @@ public class TimeSerializer extends TypeSerializerSingleton<Time> {
 
 	@Override
 	public Time deserialize(Time reuse, DataInputView source) throws IOException {
-		return deserialize(source);
+		int time = source.readInt();
+		reuse.setTime(time - LOCAL_TZ.getOffset(time));
+		return reuse;
 	}
 
 	@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/TimestampSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/TimestampSerializer.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.serializers.python;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.table.dataformat.SqlTimestamp;
+import org.apache.flink.table.runtime.typeutils.SqlTimestampSerializer;
+
+import java.io.IOException;
+import java.sql.Timestamp;
+
+/**
+ * Uses SqlTimestampSerializer to serialize Timestamp. It not only deals with Daylight saving time
+ * problem and precision problem, but also makes the serialized value consistent between the legacy
+ * planner and the blink planner.
+ */
+@Internal
+public class TimestampSerializer extends TypeSerializerSingleton<Timestamp> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final transient SqlTimestampSerializer sqlTimestampSerializer;
+
+	private final int precision;
+
+	public TimestampSerializer(int precision) {
+		this.precision = precision;
+		this.sqlTimestampSerializer = new SqlTimestampSerializer(precision);
+	}
+
+	@Override
+	public boolean isImmutableType() {
+		return false;
+	}
+
+	@Override
+	public Timestamp createInstance() {
+		return new Timestamp(0L);
+	}
+
+	@Override
+	public Timestamp copy(Timestamp from) {
+		if (from == null) {
+			return null;
+		}
+		Timestamp t = new Timestamp(from.getTime());
+		t.setNanos(from.getNanos());
+		return t;
+	}
+
+	@Override
+	public Timestamp copy(Timestamp from, Timestamp reuse) {
+		if (from == null) {
+			return null;
+		}
+		reuse.setTime(from.getTime());
+		reuse.setNanos(from.getNanos());
+		return reuse;
+	}
+
+	@Override
+	public int getLength() {
+		return sqlTimestampSerializer.getLength();
+	}
+
+	@Override
+	public void serialize(Timestamp record, DataOutputView target) throws IOException {
+		if (record == null) {
+			throw new IllegalArgumentException("The Timestamp record must not be null.");
+		}
+		sqlTimestampSerializer.serialize(SqlTimestamp.fromTimestamp(record), target);
+	}
+
+	@Override
+	public Timestamp deserialize(DataInputView source) throws IOException {
+		return sqlTimestampSerializer.deserialize(source).toTimestamp();
+	}
+
+	@Override
+	public Timestamp deserialize(Timestamp reuse, DataInputView source) throws IOException {
+		return deserialize(source);
+	}
+
+	@Override
+	public void copy(DataInputView source, DataOutputView target) throws IOException {
+		serialize(deserialize(source), target);
+	}
+
+	@Override
+	public TypeSerializerSnapshot<Timestamp> snapshotConfiguration() {
+		return new TimestampSerializerSnapshot(precision);
+	}
+
+	/**
+	 * {@link TypeSerializerSnapshot} for {@link TimestampSerializer}.
+	 */
+	public static final class TimestampSerializerSnapshot implements TypeSerializerSnapshot<Timestamp> {
+
+		private static final int CURRENT_VERSION = 1;
+
+		private int previousPrecision;
+
+		public TimestampSerializerSnapshot() {
+			// this constructor is used when restoring from a checkpoint/savepoint.
+		}
+
+		TimestampSerializerSnapshot(int precision) {
+			this.previousPrecision = precision;
+		}
+
+		@Override
+		public int getCurrentVersion() {
+			return CURRENT_VERSION;
+		}
+
+		@Override
+		public void writeSnapshot(DataOutputView out) throws IOException {
+			out.writeInt(previousPrecision);
+		}
+
+		@Override
+		public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) throws IOException {
+			this.previousPrecision = in.readInt();
+		}
+
+		@Override
+		public TypeSerializer<Timestamp> restoreSerializer() {
+			return new TimestampSerializer(previousPrecision);
+		}
+
+		@Override
+		public TypeSerializerSchemaCompatibility<Timestamp> resolveSchemaCompatibility(TypeSerializer<Timestamp> newSerializer) {
+			if (!(newSerializer instanceof TimestampSerializer)) {
+				return TypeSerializerSchemaCompatibility.incompatible();
+			}
+
+			TimestampSerializer timestampSerializer = (TimestampSerializer) newSerializer;
+			if (previousPrecision != timestampSerializer.precision) {
+				return TypeSerializerSchemaCompatibility.incompatible();
+			} else {
+				return TypeSerializerSchemaCompatibility.compatibleAsIs();
+			}
+		}
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/serializers/python/TimeSerializerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/serializers/python/TimeSerializerTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.serializers.python;
+
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import java.sql.Time;
+
+/**
+ * Test for {@link TimeSerializer}.
+ */
+public class TimeSerializerTest extends SerializerTestBase<Time> {
+	@Override
+	protected TypeSerializer<Time> createSerializer() {
+		return TimeSerializer.INSTANCE;
+	}
+
+	@Override
+	protected int getLength() {
+		return 4;
+	}
+
+	@Override
+	protected Class<Time> getTypeClass() {
+		return Time.class;
+	}
+
+	@Override
+	protected Time[] getTestData() {
+		return new Time[]{Time.valueOf("11:11:11")};
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/serializers/python/TimestampSerializerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/serializers/python/TimestampSerializerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils.serializers.python;
+
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Test for {@link TimestampSerializer}.
+ */
+@RunWith(Parameterized.class)
+public class TimestampSerializerTest extends SerializerTestBase<Timestamp> {
+
+	@Parameterized.Parameters
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][]{{0}, {3}, {6}, {9}});
+	}
+
+	private int precision;
+
+	public TimestampSerializerTest(int precision) {
+		super();
+		this.precision = precision;
+	}
+
+	@Override
+	protected TypeSerializer<Timestamp> createSerializer() {
+		return new TimestampSerializer(precision);
+	}
+
+	@Override
+	protected int getLength() {
+		return (precision <= 3) ? 8 : 12;
+	}
+
+	@Override
+	protected Class<Timestamp> getTypeClass() {
+		return Timestamp.class;
+	}
+
+	@Override
+	protected Timestamp[] getTestData() {
+		return new Timestamp[]{Timestamp.valueOf("2018-03-11 03:00:00.123")};
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

*This pr supports TimeType and TimestampType In Python UDF.*


## Brief change log

*(for example:)*
  - *Add TimeSerializer and TimestampSerializer*
  - *Add TimeCoder and TimestampCoder*

## Verifying this change

This change added tests and can be verified as follows:

  - *TimeSerializerTest and TimestampSerializerTest*
  - *test_time_coder and test_timestamp_coder in coders_test_common.py*
  - *test_all_data_types in test_udf.py*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
