### PR TITLE
[FLINK-14565][metric] Shut down SystemResourcesCounter on Metric closed to prevent thread leak

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
@@ -81,7 +81,9 @@ public class MetricUtils {
 
 		createAndInitializeStatusMetricGroup(processMetricGroup);
 
-		systemResourceProbeInterval.ifPresent(interval -> instantiateSystemMetrics(processMetricGroup, interval));
+		systemResourceProbeInterval.ifPresent(interval -> instantiateSystemMetrics(
+			processMetricGroup,
+			processMetricGroup.createSystemResourcesCounter(interval)));
 
 		return processMetricGroup;
 	}
@@ -108,9 +110,9 @@ public class MetricUtils {
 
 		MetricGroup statusGroup = createAndInitializeStatusMetricGroup(taskManagerMetricGroup);
 
-		if (systemResourceProbeInterval.isPresent()) {
-			instantiateSystemMetrics(taskManagerMetricGroup, systemResourceProbeInterval.get());
-		}
+		systemResourceProbeInterval.ifPresent(time -> instantiateSystemMetrics(
+			taskManagerMetricGroup,
+			taskManagerMetricGroup.createSystemResourcesCounter(time)));
 		return Tuple2.of(taskManagerMetricGroup, statusGroup);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/SystemResourcesMetricsInitializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/SystemResourcesMetricsInitializer.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.metrics.util;
 
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
 
@@ -34,13 +33,9 @@ import oshi.hardware.HardwareAbstractionLayer;
 public class SystemResourcesMetricsInitializer {
 	private static final Logger LOG = LoggerFactory.getLogger(SystemResourcesMetricsInitializer.class);
 
-	public static void instantiateSystemMetrics(MetricGroup metricGroup, Time probeInterval) {
+	public static void instantiateSystemMetrics(MetricGroup metricGroup, SystemResourcesCounter systemResourcesCounter) {
 		try {
 			MetricGroup system = metricGroup.addGroup("System");
-
-			SystemResourcesCounter systemResourcesCounter = new SystemResourcesCounter(probeInterval);
-			systemResourcesCounter.start();
-
 			SystemInfo systemInfo = new SystemInfo();
 			HardwareAbstractionLayer hardwareAbstractionLayer = systemInfo.getHardware();
 


### PR DESCRIPTION
## What is the purpose of the change

Solve potentially thread leak described in [FLINK-14565](https://issues.apache.org/jira/browse/FLINK-14565).

## Brief change log

When create `SystemResourcesCounter`, hold the ref in (JM|TM)MetricGroup and on closed shut down the `SystemResourcesCounter` thread.


## Verifying this change

Straightforward and manually verify previous leak threads disappear in case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
