### PR TITLE
[FLINK-14488][python] Update python table API with temporary tables & views methods

### DIFF
--- a/flink-python/pyflink/table/descriptors.py
+++ b/flink-python/pyflink/table/descriptors.py
@@ -15,6 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import warnings
 from abc import ABCMeta
 
 from py4j.java_gateway import get_method
@@ -1272,7 +1273,10 @@ class ConnectTableDescriptor(Descriptor):
 
         :param name: Table name to be registered in the table environment.
         :return: This object.
+
+        .. note:: Deprecated in 1.10. Use :func:`create_temporary_table` instead.
         """
+        warnings.warn("Deprecated in 1.10. Use create_temporary_table instead.", DeprecationWarning)
         self._j_connect_table_descriptor = self._j_connect_table_descriptor.registerTableSink(name)
         return self
 
@@ -1283,7 +1287,10 @@ class ConnectTableDescriptor(Descriptor):
 
         :param name: Table name to be registered in the table environment.
         :return: This object.
+
+        .. note:: Deprecated in 1.10. Use :func:`create_temporary_table` instead.
         """
+        warnings.warn("Deprecated in 1.10. Use create_temporary_table instead.", DeprecationWarning)
         self._j_connect_table_descriptor = \
             self._j_connect_table_descriptor.registerTableSource(name)
         return self
@@ -1295,9 +1302,31 @@ class ConnectTableDescriptor(Descriptor):
 
         :param name: Table name to be registered in the table environment.
         :return: This object.
+
+        .. note:: Deprecated in 1.10. Use :func:`create_temporary_table` instead.
         """
+        warnings.warn("Deprecated in 1.10. Use create_temporary_table instead.", DeprecationWarning)
         self._j_connect_table_descriptor = \
             self._j_connect_table_descriptor.registerTableSourceAndSink(name)
+        return self
+
+    def create_temporary_table(self, path):
+        """
+        Registers the table described by underlying properties in a given path.
+
+        There is no distinction between source and sink at the descriptor level anymore as this
+        method does not perform actual class lookup. It only stores the underlying properties. The
+        actual source/sink lookup is performed when the table is used.
+
+        Temporary objects can shadow permanent ones. If a permanent object in a given path exists,
+        it will be inaccessible in the current session. To make the permanent object available
+        again you can drop the corresponding temporary object.
+
+        .. note:: The schema must be explicitly defined.
+
+        :param path: path where to register the temporary table
+        """
+        self._j_connect_table_descriptor.createTemporaryTable(path)
         return self
 
 

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -154,7 +154,10 @@ class TableEnvironment(object):
 
         :param name: The name under which the :class:`TableSource` is registered.
         :param table_source: The :class:`TableSource` to register.
+
+        .. note:: Deprecated in 1.10. Use :func:`connect` instead.
         """
+        warnings.warn("Deprecated in 1.10. Use connect instead.", DeprecationWarning)
         self._j_tenv.registerTableSource(name, table_source._j_table_source)
 
     def register_table_sink(self, name, table_sink):
@@ -174,7 +177,10 @@ class TableEnvironment(object):
 
         :param name: The name under which the :class:`TableSink` is registered.
         :param table_sink: The :class:`TableSink` to register.
+
+        .. note:: Deprecated in 1.10. Use :func:`connect` instead.
         """
+        warnings.warn("Deprecated in 1.10. Use connect instead.", DeprecationWarning)
         self._j_tenv.registerTableSink(name, table_sink._j_table_sink)
 
     def scan(self, *table_path):

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -245,28 +245,24 @@ class TableEnvironment(object):
         """
         return Table(get_method(self._j_tenv, "from")(path))
 
-    def insert_into(self, table, table_path, *table_path_continued):
+    def insert_into(self, target_path, table):
         """
-        Writes the :class:`Table` to a :class:`TableSink` that was registered under
-        the specified name. For the path resolution algorithm see
-        :func:`~TableEnvironment.use_database`.
+        Instructs to write the content of a :class:`Table` API object into a table.
+
+        See the documentation of :func:`use_database` or :func:`use_catalog` for the rules on the
+        path resolution.
 
         Example:
         ::
 
             >>> tab = table_env.scan("tableName")
-            >>> table_env.insert_into(tab, "sink")
+            >>> table_env.insert_into("sink", tab)
 
-        :param table: :class:`Table` to write to the sink.
-        :param table_path: The first part of the path of the registered :class:`TableSink` to which
-               the :class:`Table` is written. This is to ensure at least the name of the
-               :class:`Table` is provided.
-        :param table_path_continued: The remaining part of the path of the registered
-                :class:`TableSink` to which the :class:`Table`  is written.
+        :param target_path: The path of the registered :class:`TableSink` to which the
+                            :class:`Table` is written.
+        :param table: table The Table to write to the sink.
         """
-        gateway = get_gateway()
-        j_table_path = utils.to_jarray(gateway.jvm.String, table_path_continued)
-        self._j_tenv.insertInto(table._j_table, table_path, j_table_path)
+        self._j_tenv.insertInto(target_path, table._j_table)
 
     def list_catalogs(self):
         """

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -17,6 +17,7 @@
 ################################################################################
 import os
 import tempfile
+import warnings
 from abc import ABCMeta, abstractmethod
 
 from py4j.java_gateway import get_java_class
@@ -42,7 +43,33 @@ __all__ = [
 
 class TableEnvironment(object):
     """
-    The abstract base class for batch and stream TableEnvironments.
+    A table environment is the base class, entry point, and central context for creating Table
+    and SQL API programs.
+
+    It is unified for bounded and unbounded data processing.
+
+    A table environment is responsible for:
+
+        - Connecting to external systems.
+        - Registering and retrieving :class:`Table` and other meta objects from a catalog.
+        - Executing SQL statements.
+        - Offering further configuration options.
+
+    The path in methods such as :func:`create_temporary_view`
+    should be a proper SQL identifier. The syntax is following
+    [[catalog-name.]database-name.]object-name, where the catalog name and database are optional.
+    For path resolution see :func:`use_catalog` and :func:`use_database`. All keywords or other
+    special characters need to be escaped.
+
+    Example: `cat.1`.`db`.`Table` resolves to an object named 'Table' (table is a reserved
+    keyword, thus must be escaped) in a catalog named 'cat.1' and database named 'db'.
+
+    .. note::
+
+        This environment is meant for pure table programs. If you would like to convert from or to
+        other Flink APIs, it might be necessary to use one of the available language-specific table
+        environments in the corresponding bridging modules.
+
     """
 
     __metaclass__ = ABCMeta
@@ -105,7 +132,10 @@ class TableEnvironment(object):
 
         :param name: The name under which the table will be registered.
         :param table: The table to register.
+
+        .. note:: Deprecated in 1.10. Use :func:`create_temporary_view` instead.
         """
+        warnings.warn("Deprecated in 1.10. Use create_temporary_view instead.", DeprecationWarning)
         self._j_tenv.registerTable(name, table._j_table)
 
     def register_table_source(self, name, table_source):
@@ -255,6 +285,54 @@ class TableEnvironment(object):
         """
         j_function_name_array = self._j_tenv.listFunctions()
         return [item for item in j_function_name_array]
+
+    def list_temporary_tables(self):
+        """
+        Gets the names of all temporary tables and views available in the current namespace
+        (the current database of the current catalog).
+
+        :return: A list of the names of all registered temporary tables and views in the current
+                 database of the current catalog.
+
+        .. seealso:: :func:`list_tables`
+        """
+        j_table_name_array = self._j_tenv.listTemporaryTables()
+        return [item for item in j_table_name_array]
+
+    def list_temporary_views(self):
+        """
+        Gets the names of all temporary views available in the current namespace (the current
+        database of the current catalog).
+
+        :return: A list of the names of all registered temporary views in the current database
+                 of the current catalog.
+
+        .. seealso:: :func:`list_tables`
+        """
+        j_view_name_array = self._j_tenv.listTemporaryViews()
+        return [item for item in j_view_name_array]
+
+    def drop_temporary_table(self, table_path):
+        """
+        Drops a temporary table registered in the given path.
+
+        If a permanent table with a given path exists, it will be used
+        from now on for any queries that reference this path.
+
+        :return: true if a table existed in the given path and was removed
+        """
+        return self._j_tenv.dropTemporaryTable(table_path)
+
+    def drop_temporary_view(self, view_path):
+        """
+        Drops a temporary view registered in the given path.
+
+        If a permanent table or view with a given path exists, it will be used
+        from now on for any queries that reference this path.
+
+        :return: true if a view existed in the given path and was removed
+        """
+        return self._j_tenv.dropTemporaryView(view_path)
 
     def explain(self, table=None, extended=False):
         """
@@ -582,6 +660,20 @@ class TableEnvironment(object):
         """
         self._j_tenv.registerFunction(name, function._judf(self._is_blink_planner,
                                                            self.get_config()._j_table_config))
+
+    def create_temporary_view(self, view_path, table):
+        """
+        Registers a :class:`Table` API object as a temporary view similar to SQL temporary views.
+
+        Temporary objects can shadow permanent ones. If a permanent object in a given path exists,
+        it will be inaccessible in the current session. To make the permanent object available
+        again you can drop the corresponding temporary object.
+
+        :param view_path: The path under which the view will be registered. See also the
+                          :class:`TableEnvironment` class description for the format of the path.
+        :param table: The view to register.
+        """
+        self._j_tenv.createTemporaryView(view_path, table._j_table)
 
     def execute(self, job_name):
         """

--- a/flink-python/pyflink/table/tests/test_environment_completeness.py
+++ b/flink-python/pyflink/table/tests/test_environment_completeness.py
@@ -48,8 +48,18 @@ class EnvironmentAPICompletenessTests(PythonAPICompletenessTestCase, unittest.Te
             'getCompletionHints',
             'create',
             'loadModule',
-            'unloadModule',
-            'from'}
+            'unloadModule'}
+
+    @classmethod
+    def java_method_name(cls, python_method_name):
+        """
+        Due to 'from' is python keyword, so we use 'from_path'
+        in Python API corresponding 'from' in Java API.
+
+        :param python_method_name:
+        :return:
+        """
+        return {'from_path': 'from'}.get(python_method_name, python_method_name)
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/table/tests/test_environment_completeness.py
+++ b/flink-python/pyflink/table/tests/test_environment_completeness.py
@@ -37,14 +37,9 @@ class EnvironmentAPICompletenessTests(PythonAPICompletenessTestCase, unittest.Te
 
     @classmethod
     def excluded_methods(cls):
-        # registerFunction and listUserDefinedFunctions should be supported when UDFs supported.
-        # registerCatalog, getCatalog and listTables should be supported when catalog supported in
-        # python. getCompletionHints has been deprecated. It will be removed in the next release.
+        # getCompletionHints has been deprecated. It will be removed in the next release.
         # TODO add TableEnvironment#create method with EnvironmentSettings as a parameter
         return {
-            'registerCatalog',
-            'getCatalog',
-            'listTables',
             'getCompletionHints',
             'create',
             'loadModule',

--- a/flink-python/pyflink/table/tests/test_environment_completeness.py
+++ b/flink-python/pyflink/table/tests/test_environment_completeness.py
@@ -49,12 +49,7 @@ class EnvironmentAPICompletenessTests(PythonAPICompletenessTestCase, unittest.Te
             'create',
             'loadModule',
             'unloadModule',
-            'listTemporaryTables',
-            'createTemporaryView',
-            'dropTemporaryTable',
-            'listTemporaryViews',
-            'from',
-            'dropTemporaryView'}
+            'from'}
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -151,6 +151,21 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
             ', fields: [a, b, c])',
             result._j_table.getQueryOperation().asSummaryString())
 
+    def test_insert_into(self):
+        t_env = self.t_env
+        field_names = ["a", "b", "c"]
+        field_types = [DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.STRING()]
+        t_env.register_table_sink(
+            "Sinks",
+            source_sink_utils.TestAppendSink(field_names, field_types))
+
+        t_env.insert_into("Sinks", t_env.from_elements([(1, "Hi", "Hello")], ["a", "b", "c"]))
+        self.t_env.execute("test")
+
+        actual = source_sink_utils.results()
+        expected = ['1,Hi,Hello']
+        self.assert_equals(actual, expected)
+
     def test_explain(self):
         schema = RowType()\
             .add('a', DataTypes.INT())\

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -140,6 +140,17 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
         expected = ['temporary_view_2']
         self.assert_equals(actual, expected)
 
+    def test_from_path(self):
+        t_env = self.t_env
+        t_env.create_temporary_view(
+            "temporary_view_1",
+            t_env.from_elements([(1, 'Hi', 'Hello')], ['a', 'b', 'c']))
+        result = t_env.from_path("temporary_view_1")
+        self.assertEqual(
+            'CatalogTable: (identifier: [`default_catalog`.`default_database`.`temporary_view_1`]'
+            ', fields: [a, b, c])',
+            result._j_table.getQueryOperation().asSummaryString())
+
     def test_explain(self):
         schema = RowType()\
             .add('a', DataTypes.INT())\


### PR DESCRIPTION
## What is the purpose of the change

*This pull request update the Python table API with temporary tables & views methods*

## Brief change log

  - *Update python table API with temporary tables & views methods*
  - *Update python table API adding from_path method*
  - *Update python table API with insert_into*
  - *Deprecate TableEnvironment.register_table_source and TableEnvironment.register_table_sink*
  - *Clean up test_environment_completeness by removing the legacy excluded methods which are already supported*

## Verifying this change

This change added tests and can be verified as follows:
  - *Added tests in StreamTableEnvironmentTests and existing test in EnvironmentAPICompletenessTests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (PythonDocs)
