### PR TITLE
[FLINK-12527] Remove GLOBAL_VERSION_UPDATER in ExecutionGraph

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -118,7 +118,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -169,11 +168,6 @@ import static org.apache.flink.util.Preconditions.checkState;
  * yield before the global failover.
  */
 public class ExecutionGraph implements AccessExecutionGraph {
-
-	/** In place updater for the execution graph's current global recovery version.
-	 * Avoids having to use an AtomicLong and thus makes the frequent read access a bit faster */
-	private static final AtomicLongFieldUpdater<ExecutionGraph> GLOBAL_VERSION_UPDATER =
-			AtomicLongFieldUpdater.newUpdater(ExecutionGraph.class, "globalModVersion");
 
 	/** The log object used for debugging. */
 	static final Logger LOG = LoggerFactory.getLogger(ExecutionGraph.class);
@@ -1386,7 +1380,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 
 	private long incrementGlobalModVersion() {
 		incrementRestarts();
-		return GLOBAL_VERSION_UPDATER.incrementAndGet(this);
+		return ++globalModVersion;
 	}
 
 	public void incrementRestarts() {


### PR DESCRIPTION
## What is the purpose of the change

*This pull request removed GLOBAL_VERSION_UPDATER in ExecutionGraph*


## Brief change log

  - *Remove GLOBAL_VERSION_UPDATER in ExecutionGraph*


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
