### PR TITLE
[FLINK-14543][FLINK-15901][table] Support partition for temporary table and HiveCatalog

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -65,6 +65,7 @@ import org.apache.flink.table.catalog.hive.util.HiveTableUtil;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
 import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
 import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.descriptors.Schema;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.factories.FunctionDefinitionFactory;
 import org.apache.flink.table.factories.TableFactory;
@@ -548,12 +549,11 @@ public class HiveCatalog extends AbstractCatalog {
 			DescriptorProperties tableSchemaProps = new DescriptorProperties(true);
 			tableSchemaProps.putProperties(properties);
 			ObjectPath tablePath = new ObjectPath(hiveTable.getDbName(), hiveTable.getTableName());
-			tableSchema = tableSchemaProps.getOptionalTableSchema(HiveCatalogConfig.GENERIC_TABLE_SCHEMA_PREFIX)
+			tableSchema = tableSchemaProps.getOptionalTableSchema(Schema.SCHEMA)
 					.orElseThrow(() -> new CatalogException("Failed to get table schema from properties for generic table " + tablePath));
+			partitionKeys = tableSchemaProps.getPartitionKeys();
 			// remove the schema from properties
-			properties = properties.entrySet().stream()
-					.filter(e -> !e.getKey().startsWith(HiveCatalogConfig.GENERIC_TABLE_SCHEMA_PREFIX))
-					.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+			properties = CatalogTableImpl.removeRedundant(properties, tableSchema, partitionKeys);
 		} else {
 			properties.put(CatalogConfig.IS_GENERIC, String.valueOf(false));
 			// Table schema
@@ -630,16 +630,13 @@ public class HiveCatalog extends AbstractCatalog {
 
 		if (isGeneric) {
 			DescriptorProperties tableSchemaProps = new DescriptorProperties(true);
-			tableSchemaProps.putTableSchema(HiveCatalogConfig.GENERIC_TABLE_SCHEMA_PREFIX, table.getSchema());
-			properties.putAll(tableSchemaProps.asMap());
+			tableSchemaProps.putTableSchema(Schema.SCHEMA, table.getSchema());
 
-			if (table instanceof CatalogTableImpl) {
-				List<String> partColNames = ((CatalogTableImpl) table).getPartitionKeys();
-				if (!partColNames.isEmpty()) {
-					throw new CatalogException("Partitioned generic table is not supported yet by HiveCatalog");
-				}
+			if (table instanceof CatalogTable) {
+				tableSchemaProps.putPartitionKeys(((CatalogTable) table).getPartitionKeys());
 			}
 
+			properties.putAll(tableSchemaProps.asMap());
 			properties = maskFlinkProperties(properties);
 		} else {
 			List<FieldSchema> allColumns = HiveTableUtil.createHiveColumns(table.getSchema());

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogConfig.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogConfig.java
@@ -32,7 +32,4 @@ public class HiveCatalogConfig {
 
 	// Partition related configs
 	public static final String PARTITION_LOCATION = "partition.location";
-
-	// config prefix for the table schema of a generic table
-	public static final String GENERIC_TABLE_SCHEMA_PREFIX = "generic.table.schema";
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogGenericMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogGenericMetadataTest.java
@@ -176,15 +176,7 @@ public class HiveCatalogGenericMetadataTest extends HiveCatalogMetadataTestBase 
 	}
 
 	@Override
-	public void testAlterPartitionedTable() throws Exception {
-	}
-
-	@Override
 	public void testAlterTableStats_partitionedTable() throws Exception {
-	}
-
-	@Override
-	public void testCreatePartitionedTable_Batch() throws Exception {
 	}
 
 	// ------ test utils ------

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogTableBuilder.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogTableBuilder.java
@@ -27,7 +27,9 @@ import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.descriptors.TableDescriptor;
 import org.apache.flink.util.Preconditions;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -66,6 +68,8 @@ public final class CatalogTableBuilder extends TableDescriptor<CatalogTableBuild
 
 	private final boolean isGeneric;
 
+	private List<String> partitionKeys = new ArrayList<>();
+
 	private Map<String, String> properties = Collections.emptyMap();
 
 	public CatalogTableBuilder(ConnectorDescriptor connectorDescriptor, TableSchema tableSchema) {
@@ -86,12 +90,18 @@ public final class CatalogTableBuilder extends TableDescriptor<CatalogTableBuild
 		return this;
 	}
 
+	public CatalogTableBuilder withPartitionKeys(List<String> partitionKeys) {
+		this.partitionKeys = Preconditions.checkNotNull(partitionKeys, "PartitionKeys must not be null.");
+		return this;
+	}
+
 	/**
 	 * Builds a {@link CatalogTable}.
 	 */
 	public CatalogTable build() {
 		return new CatalogTableImpl(
 			tableSchema,
+			partitionKeys,
 			toProperties(),
 			comment);
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogTableImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogTableImpl.java
@@ -73,6 +73,7 @@ public class CatalogTableImpl extends AbstractCatalogTable {
 		DescriptorProperties descriptor = new DescriptorProperties();
 
 		descriptor.putTableSchema(Schema.SCHEMA, getSchema());
+		descriptor.putPartitionKeys(getPartitionKeys());
 
 		Map<String, String> properties = new HashMap<>(getProperties());
 		properties.remove(CatalogConfig.IS_GENERIC);
@@ -91,24 +92,29 @@ public class CatalogTableImpl extends AbstractCatalogTable {
 	 * Construct a {@link CatalogTableImpl} from complete properties that contains table schema.
 	 */
 	public static CatalogTableImpl fromProperties(Map<String, String> properties) {
-		TableSchema tableSchema = extractTableSchema(properties);
+		DescriptorProperties descriptorProperties = new DescriptorProperties();
+		descriptorProperties.putProperties(properties);
+		TableSchema tableSchema = descriptorProperties.getTableSchema(Schema.SCHEMA);
+		List<String> partitionKeys = descriptorProperties.getPartitionKeys();
 		return new CatalogTableImpl(
 				tableSchema,
-				removeTableSchema(properties, tableSchema),
+				partitionKeys,
+				removeRedundant(properties, tableSchema, partitionKeys),
 				""
 		);
 	}
 
-	private static TableSchema extractTableSchema(Map<String, String> properties) {
-		DescriptorProperties descriptorProperties = new DescriptorProperties();
-		descriptorProperties.putProperties(properties);
-		return descriptorProperties.getTableSchema(Schema.SCHEMA);
-	}
-
-	private static Map<String, String> removeTableSchema(Map<String, String> properties, TableSchema schema) {
+	/**
+	 * Construct catalog table properties from {@link #toProperties()}.
+	 */
+	public static Map<String, String> removeRedundant(
+			Map<String, String> properties,
+			TableSchema schema,
+			List<String> partitionKeys) {
 		Map<String, String> ret = new HashMap<>(properties);
 		DescriptorProperties descriptorProperties = new DescriptorProperties();
 		descriptorProperties.putTableSchema(Schema.SCHEMA, schema);
+		descriptorProperties.putPartitionKeys(partitionKeys);
 		descriptorProperties.asMap().keySet().forEach(ret::remove);
 		return ret;
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/descriptors/ConnectTableDescriptor.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/descriptors/ConnectTableDescriptor.java
@@ -27,7 +27,8 @@ import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -43,6 +44,8 @@ public abstract class ConnectTableDescriptor
 
 	private @Nullable Schema schemaDescriptor;
 
+	private List<String> partitionKeys = new ArrayList<>();
+
 	public ConnectTableDescriptor(Registration registration, ConnectorDescriptor connectorDescriptor) {
 		super(connectorDescriptor);
 		this.registration = registration;
@@ -53,6 +56,14 @@ public abstract class ConnectTableDescriptor
 	 */
 	public ConnectTableDescriptor withSchema(Schema schema) {
 		schemaDescriptor = Preconditions.checkNotNull(schema, "Schema must not be null.");
+		return this;
+	}
+
+	/**
+	 * Specifies the partition keys of this table.
+	 */
+	public ConnectTableDescriptor withPartitionKeys(List<String> partitionKeys) {
+		this.partitionKeys = Preconditions.checkNotNull(partitionKeys, "PartitionKeys must not be null.");
 		return this;
 	}
 
@@ -83,9 +94,11 @@ public abstract class ConnectTableDescriptor
 
 	@Override
 	protected Map<String, String> additionalProperties() {
+		DescriptorProperties properties = new DescriptorProperties();
 		if (schemaDescriptor != null) {
-			return schemaDescriptor.toProperties();
+			properties.putProperties(schemaDescriptor.toProperties());
 		}
-		return Collections.emptyMap();
+		properties.putPartitionKeys(partitionKeys);
+		return properties.asMap();
 	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/DescriptorProperties.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/DescriptorProperties.java
@@ -87,6 +87,10 @@ public class DescriptorProperties {
 
 	public static final String TABLE_SCHEMA_EXPR = "expr";
 
+	public static final String PARTITION_KEYS = "partition.keys";
+
+	public static final String PARTITION_KEYS_NAME = "name";
+
 	public static final String WATERMARK = "watermark";
 
 	public static final String WATERMARK_ROWTIME = "rowtime";
@@ -237,6 +241,18 @@ public class DescriptorProperties {
 				Arrays.asList(WATERMARK_ROWTIME, WATERMARK_STRATEGY_EXPR, WATERMARK_STRATEGY_DATA_TYPE),
 				watermarkValues);
 		}
+	}
+
+	/**
+	 * Adds table partition keys.
+	 */
+	public void putPartitionKeys(List<String> keys) {
+		checkNotNull(keys);
+
+		putIndexedFixedProperties(
+				PARTITION_KEYS,
+				Collections.singletonList(PARTITION_KEYS_NAME),
+				keys.stream().map(Collections::singletonList).collect(Collectors.toList()));
 	}
 
 	/**
@@ -661,6 +677,17 @@ public class DescriptorProperties {
 	 */
 	public TableSchema getTableSchema(String key) {
 		return getOptionalTableSchema(key).orElseThrow(exceptionSupplier(key));
+	}
+
+	/**
+	 * Returns partition keys.
+	 */
+	public List<String> getPartitionKeys() {
+		return getFixedIndexedProperties(
+				PARTITION_KEYS, Collections.singletonList(PARTITION_KEYS_NAME))
+				.stream()
+				.map(map -> map.values().iterator().next())
+				.map(this::getString).collect(Collectors.toList());
 	}
 
 	/**

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableFactory.java
@@ -89,6 +89,9 @@ public class FileSystemTableFactory implements
 		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_DATA_TYPE);
 		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_NAME);
 
+		// partition
+		properties.add(DescriptorProperties.PARTITION_KEYS + ".#." +
+				DescriptorProperties.PARTITION_KEYS_NAME);
 		properties.add(PARTITION_DEFAULT_NAME.key());
 
 		// format


### PR DESCRIPTION
## What is the purpose of the change

Now, temporary table not carry partition keys information. We need add these information to support partition for temporary table.

## Brief change log

- CatalogTableBuilder should have partition keys interface
- The toProperties of CatalogTableImpl should carry partition keys
- The createTemporaryTable of ConnectTableDescriptor should carry correct partition keys informations.
- Add temporary partition table support in blink planner.

## Verifying this change

Add tests in blink planner.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
