### PR TITLE
[FLINK-14375][runtime] Avoid to notify scheduler about fake or outdated state update

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -417,12 +417,15 @@ public abstract class SchedulerBase implements SchedulerNG {
 	@Override
 	public final boolean updateTaskExecutionState(final TaskExecutionState taskExecutionState) {
 		final Optional<ExecutionVertexID> executionVertexId = getExecutionVertexId(taskExecutionState.getID());
-		if (executionVertexId.isPresent()) {
-			executionGraph.updateState(taskExecutionState);
+
+		boolean updateSuccess = executionGraph.updateState(taskExecutionState);
+
+		if (updateSuccess && executionVertexId.isPresent()) {
 			updateTaskExecutionStateInternal(executionVertexId.get(), taskExecutionState);
 			return true;
+		} else {
+			return false;
 		}
-		return false;
 	}
 
 	protected void updateTaskExecutionStateInternal(final ExecutionVertexID executionVertexId, final TaskExecutionState taskExecutionState) {


### PR DESCRIPTION

## What is the purpose of the change

This PR is to avoid fake or outdated state update, which may lead to more failovers than expected for even JM inconsistency.
More details see LFINK-14375.


## Brief change log

  - *Added a process to check the state update and only notify it when it is not fake or outdated*


## Verifying this change

This change is already covered by existing tests, such as DefaultSchedulerTests.
FLINK-14371 would also help to verify it.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
