### PR TITLE
[FLINK-14465][runtime] Let `StandaloneJobClusterEntrypoint` use user code class loader

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -796,9 +796,12 @@ public class CliFrontend {
 			jarFile = getJarFile(jarFilePath);
 		}
 
-		PackagedProgram program = entryPointClass == null ?
-				new PackagedProgram(jarFile, classpaths, programArgs) :
-				new PackagedProgram(jarFile, classpaths, entryPointClass, programArgs);
+		PackagedProgram program = PackagedProgram.newBuilder()
+			.setJarFile(jarFile)
+			.setUserClassPaths(classpaths)
+			.setEntryPointClassName(entryPointClass)
+			.setArguments(programArgs)
+			.build();
 
 		program.setSavepointRestoreSettings(executionParameters.getSavepointRestoreSettings());
 

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
@@ -33,6 +33,9 @@ import javax.annotation.Nullable;
  */
 public class PackagedProgramUtils {
 
+	private static final String PYTHON_DRIVER_CLASS_NAME = "org.apache.flink.client.python.PythonDriver";
+
+	private static final String PYTHON_GATEWAY_CLASS_NAME = "org.apache.flink.client.python.PythonGatewayServer";
 	/**
 	 * Creates a {@link JobGraph} with a specified {@link JobID}
 	 * from the given {@link PackagedProgram}.
@@ -100,6 +103,11 @@ public class PackagedProgramUtils {
 		} finally {
 			Thread.currentThread().setContextClassLoader(contextClassLoader);
 		}
+	}
+
+	public static Boolean isPython(String entryPointClassName) {
+		return (entryPointClassName != null) &&
+			(entryPointClassName.equals(PYTHON_DRIVER_CLASS_NAME) || entryPointClassName.equals(PYTHON_GATEWAY_CLASS_NAME));
 	}
 
 	private PackagedProgramUtils() {}

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendPackageProgramTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendPackageProgramTest.java
@@ -97,6 +97,7 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 		ProgramOptions programOptions = mock(ProgramOptions.class);
 		ExecutionConfigAccessor executionOptions = mock(ExecutionConfigAccessor.class);
 		when(executionOptions.getJarFilePath()).thenReturn(getNonJarFilePath());
+		when(programOptions.getProgramArgs()).thenReturn(new String[0]);
 
 		try {
 			frontend.buildProgram(programOptions, executionOptions);

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -99,7 +99,7 @@ public class ClientTest extends TestLogger {
 	public void testDetachedMode() throws Exception{
 		final ClusterClient<?> clusterClient = new MiniClusterClient(new Configuration(), MINI_CLUSTER_RESOURCE.getMiniCluster());
 		try {
-			PackagedProgram prg = new PackagedProgram(TestExecuteTwice.class);
+			PackagedProgram prg = PackagedProgram.newBuilder().setEntryPointClassName(TestExecuteTwice.class.getName()).build();
 			ClientUtils.executeProgram(clusterClient, prg, 1, true);
 			fail(FAIL_MESSAGE);
 		} catch (ProgramInvocationException e) {
@@ -109,7 +109,7 @@ public class ClientTest extends TestLogger {
 		}
 
 		try {
-			PackagedProgram prg = new PackagedProgram(TestEager.class);
+			PackagedProgram prg = PackagedProgram.newBuilder().setEntryPointClassName(TestEager.class.getName()).build();
 			ClientUtils.executeProgram(clusterClient, prg, 1, true);
 			fail(FAIL_MESSAGE);
 		} catch (ProgramInvocationException e) {
@@ -119,7 +119,7 @@ public class ClientTest extends TestLogger {
 		}
 
 		try {
-			PackagedProgram prg = new PackagedProgram(TestGetRuntime.class);
+			PackagedProgram prg = PackagedProgram.newBuilder().setEntryPointClassName(TestGetRuntime.class.getName()).build();
 			ClientUtils.executeProgram(clusterClient, prg, 1, true);
 			fail(FAIL_MESSAGE);
 		} catch (ProgramInvocationException e) {
@@ -129,7 +129,7 @@ public class ClientTest extends TestLogger {
 		}
 
 		try {
-			PackagedProgram prg = new PackagedProgram(TestGetAccumulator.class);
+			PackagedProgram prg = PackagedProgram.newBuilder().setEntryPointClassName(TestGetAccumulator.class.getName()).build();
 			ClientUtils.executeProgram(clusterClient, prg, 1, true);
 			fail(FAIL_MESSAGE);
 		} catch (ProgramInvocationException e) {
@@ -139,7 +139,7 @@ public class ClientTest extends TestLogger {
 		}
 
 		try {
-			PackagedProgram prg = new PackagedProgram(TestGetAllAccumulator.class);
+			PackagedProgram prg = PackagedProgram.newBuilder().setEntryPointClassName(TestGetAllAccumulator.class.getName()).build();
 			ClientUtils.executeProgram(clusterClient, prg, 1, true);
 			fail(FAIL_MESSAGE);
 		} catch (ProgramInvocationException e) {
@@ -194,7 +194,10 @@ public class ClientTest extends TestLogger {
 
 	@Test
 	public void testGetExecutionPlan() throws ProgramInvocationException {
-		PackagedProgram prg = new PackagedProgram(TestOptimizerPlan.class, "/dev/random", "/tmp");
+		PackagedProgram prg = PackagedProgram.newBuilder()
+			.setEntryPointClassName(TestOptimizerPlan.class.getName())
+			.setArguments("/dev/random", "/tmp")
+			.build();
 
 		Optimizer optimizer = new Optimizer(new DataStatistics(), new DefaultCostEstimator(), config);
 		Plan plan = (Plan) PackagedProgramUtils.getPipelineFromProgram(prg, 1);

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ExecutionPlanCreationTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ExecutionPlanCreationTest.java
@@ -49,7 +49,10 @@ public class ExecutionPlanCreationTest {
 	@Test
 	public void testGetExecutionPlan() {
 		try {
-			PackagedProgram prg = new PackagedProgram(TestOptimizerPlan.class, "/dev/random", "/tmp");
+			PackagedProgram prg = PackagedProgram.newBuilder()
+				.setEntryPointClassName(TestOptimizerPlan.class.getName())
+				.setArguments("/dev/random", "/tmp")
+				.build();
 
 			InetAddress mockAddress = InetAddress.getLocalHost();
 			InetSocketAddress mockJmAddress = new InetSocketAddress(mockAddress, 12345);

--- a/flink-clients/src/test/java/org/apache/flink/client/program/PackagedProgramTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/PackagedProgramTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.client.program;
 
+import org.apache.flink.client.cli.CliFrontendTestUtils;
 import org.apache.flink.configuration.ConfigConstants;
 
 import org.junit.Assert;
@@ -28,9 +29,12 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.nio.file.Files;
+import java.util.Collections;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+
+import static org.apache.flink.client.cli.CliFrontendTestUtils.TEST_JAR_MAIN_CLASS;
 
 /**
  * Tests for the {@link PackagedProgram}.
@@ -57,8 +61,15 @@ public class PackagedProgramTest {
 		Assert.assertArrayEquals(nestedJarContent, Files.readAllBytes(files.iterator().next().toPath()));
 	}
 
-	private static final class NullOutputStream extends java.io.OutputStream {
-		@Override
-		public void write(int b) {}
+	@Test
+	public void testNotThrowExceptionWhenJarFileIsNull() throws Exception {
+		PackagedProgram.newBuilder()
+			.setUserClassPaths(Collections.singletonList(new File(CliFrontendTestUtils.getTestJarPath()).toURI().toURL()))
+			.setEntryPointClassName(TEST_JAR_MAIN_CLASS);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testBuilderThrowExceptionIfjarFileAndEntryPointClassNameAreBothNull() throws ProgramInvocationException {
+		PackagedProgram.newBuilder().build();
 	}
 }

--- a/flink-container/docker/Dockerfile
+++ b/flink-container/docker/Dockerfile
@@ -28,6 +28,7 @@ ENV FLINK_LIB_DIR $FLINK_HOME/lib
 ENV FLINK_PLUGINS_DIR $FLINK_HOME/plugins
 ENV FLINK_OPT_DIR $FLINK_HOME/opt
 ENV FLINK_JOB_ARTIFACTS_DIR $FLINK_INSTALL_PATH/artifacts
+ENV FLINK_USR_LIB_DIR $FLINK_HOME/usrlib
 ENV PATH $PATH:$FLINK_HOME/bin
 
 # flink-dist can point to a directory or a tarball on the local system
@@ -51,7 +52,7 @@ ADD $job_artifacts/* $FLINK_JOB_ARTIFACTS_DIR/
 
 RUN set -x && \
   ln -s $FLINK_INSTALL_PATH/flink-[0-9]* $FLINK_HOME && \
-  for jar in $FLINK_JOB_ARTIFACTS_DIR/*.jar; do [ -f "$jar" ] || continue; ln -s $jar $FLINK_LIB_DIR; done && \
+  ln -s $FLINK_JOB_ARTIFACTS_DIR $FLINK_USR_LIB_DIR && \
   if [ -n "$python_version" ]; then ln -s $FLINK_OPT_DIR/flink-python*.jar $FLINK_LIB_DIR; fi && \
   if [ -f ${FLINK_INSTALL_PATH}/flink-shaded-hadoop* ]; then ln -s ${FLINK_INSTALL_PATH}/flink-shaded-hadoop* $FLINK_LIB_DIR; fi && \
   addgroup -S flink && adduser -D -S -H -G flink -h $FLINK_HOME flink && \

--- a/flink-container/docker/docker-entrypoint.sh
+++ b/flink-container/docker/docker-entrypoint.sh
@@ -19,7 +19,7 @@
 ################################################################################
 
 ### If unspecified, the hostname of the container is taken as the JobManager address
-FLINK_HOME=${FLINK_HOME:-"/opt/flink/bin"}
+FLINK_HOME=${FLINK_HOME:-"/opt/flink"}
 
 JOB_CLUSTER="job-cluster"
 TASK_MANAGER="task-manager"

--- a/flink-container/pom.xml
+++ b/flink-container/pom.xml
@@ -95,6 +95,66 @@ under the License.
 							</descriptors>
 						</configuration>
 					</execution>
+					<execution>
+						<id>create-test-dependency-user-jar</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<archive>
+								<manifest>
+									<mainClass>org.apache.flink.container.entrypoint.testjar.TestUserClassLoaderJob</mainClass>
+								</manifest>
+							</archive>
+							<finalName>maven</finalName>
+							<attach>false</attach>
+							<descriptors>
+								<descriptor>src/test/assembly/test-assembly-test-user-classloader-job-jar.xml</descriptor>
+							</descriptors>
+						</configuration>
+					</execution>
+					<execution>
+						<id>create-test-dependency-user-jar-depend</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<finalName>maven</finalName>
+							<attach>false</attach>
+							<descriptors>
+								<descriptor>src/test/assembly/test-assembly-test-user-classloader-job-lib-jar.xml</descriptor>
+							</descriptors>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<!--Remove the external jar test code from the test-classes directory since it mustn't be in the
+			classpath when running the tests to actually test whether the user code class loader
+			is properly used.-->
+			<plugin>
+				<artifactId>maven-clean-plugin</artifactId>
+				<version>2.5</version><!--$NO-MVN-MAN-VER$-->
+				<executions>
+					<execution>
+						<id>remove-externaltestclasses</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>clean</goal>
+						</goals>
+						<configuration>
+							<excludeDefaultDirectories>true</excludeDefaultDirectories>
+							<filesets>
+								<fileset>
+									<directory>${project.build.testOutputDirectory}</directory>
+									<includes>
+										<include>**/testjar/TestUser*.class</include>
+									</includes>
+								</fileset>
+							</filesets>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 		</plugins>

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetriever.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetriever.java
@@ -26,9 +26,12 @@ import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.container.entrypoint.JarManifestParser.JarFileWithEntryClass;
+import org.apache.flink.runtime.entrypoint.component.AbstractUserClassPathJobGraphRetriever;
 import org.apache.flink.runtime.entrypoint.component.JobGraphRetriever;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.FlinkException;
 
 import org.slf4j.Logger;
@@ -39,9 +42,14 @@ import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.NoSuchElementException;
 import java.util.function.Supplier;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
@@ -50,7 +58,7 @@ import static java.util.Objects.requireNonNull;
  * {@link JobGraphRetriever} which creates the {@link JobGraph} from a class
  * on the class path.
  */
-class ClassPathJobGraphRetriever implements JobGraphRetriever {
+class ClassPathJobGraphRetriever extends AbstractUserClassPathJobGraphRetriever {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ClassPathJobGraphRetriever.class);
 
@@ -69,26 +77,23 @@ class ClassPathJobGraphRetriever implements JobGraphRetriever {
 	@Nonnull
 	private final Supplier<Iterable<File>> jarsOnClassPath;
 
-	ClassPathJobGraphRetriever(
-			@Nonnull JobID jobId,
-			@Nonnull SavepointRestoreSettings savepointRestoreSettings,
-			@Nonnull String[] programArguments,
-			@Nullable String jobClassName) {
-		this(jobId, savepointRestoreSettings, programArguments, jobClassName, JarsOnClassPath.INSTANCE);
-	}
+	@Nullable
+	private final File userLibDirectory;
 
-	@VisibleForTesting
-	ClassPathJobGraphRetriever(
-			@Nonnull JobID jobId,
-			@Nonnull SavepointRestoreSettings savepointRestoreSettings,
-			@Nonnull String[] programArguments,
-			@Nullable String jobClassName,
-			@Nonnull Supplier<Iterable<File>> jarsOnClassPath) {
+	private ClassPathJobGraphRetriever(
+		@Nonnull JobID jobId,
+		@Nonnull SavepointRestoreSettings savepointRestoreSettings,
+		@Nonnull String[] programArguments,
+		@Nullable String jobClassName,
+		@Nonnull Supplier<Iterable<File>> jarsOnClassPath,
+		@Nullable File userLibDirectory) throws IOException {
+		super(userLibDirectory);
+		this.userLibDirectory = userLibDirectory;
 		this.jobId = requireNonNull(jobId, "jobId");
 		this.savepointRestoreSettings = requireNonNull(savepointRestoreSettings, "savepointRestoreSettings");
 		this.programArguments = requireNonNull(programArguments, "programArguments");
 		this.jobClassName = jobClassName;
-		this.jarsOnClassPath = requireNonNull(jarsOnClassPath, "jarsOnClassPath");
+		this.jarsOnClassPath = requireNonNull(jarsOnClassPath);
 	}
 
 	@Override
@@ -112,15 +117,28 @@ class ClassPathJobGraphRetriever implements JobGraphRetriever {
 	private PackagedProgram createPackagedProgram() throws FlinkException {
 		final String entryClass = getJobClassNameOrScanClassPath();
 		try {
-			final Class<?> mainClass = getClass().getClassLoader().loadClass(entryClass);
-			return new PackagedProgram(mainClass, programArguments);
-		} catch (ClassNotFoundException | ProgramInvocationException e) {
+			return PackagedProgram.newBuilder()
+				.setUserClassPaths(new ArrayList<>(getUserClassPaths()))
+				.setEntryPointClassName(entryClass)
+				.setArguments(programArguments)
+				.build();
+		} catch (ProgramInvocationException e) {
 			throw new FlinkException("Could not load the provided entrypoint class.", e);
 		}
 	}
 
 	private String getJobClassNameOrScanClassPath() throws FlinkException {
 		if (jobClassName != null) {
+			if (userLibDirectory != null) {
+				// check that we find the entrypoint class in the user lib directory.
+				if (!userClassPathContainsJobClass(jobClassName)) {
+					throw new FlinkException(
+						String.format(
+							"Could not find the provided job class (%s) in the user lib directory (%s).",
+							jobClassName,
+							userLibDirectory));
+				}
+			}
 			return jobClassName;
 		}
 
@@ -131,10 +149,47 @@ class ClassPathJobGraphRetriever implements JobGraphRetriever {
 		}
 	}
 
-	private String scanClassPathForJobJar() throws IOException {
-		LOG.info("Scanning class path for job JAR");
-		JarFileWithEntryClass jobJar = JarManifestParser.findOnlyEntryClass(jarsOnClassPath.get());
+	private boolean userClassPathContainsJobClass(String jobClassName) {
+		for (URL userClassPath : getUserClassPaths()) {
+			try (final JarFile jarFile = new JarFile(userClassPath.getFile())) {
+				if (jarContainsJobClass(jobClassName, jarFile)) {
+					return true;
+				}
+			} catch (IOException e) {
+				ExceptionUtils.rethrow(
+					e,
+					String.format(
+						"Failed to open user class path %s. Make sure that all files on the user class path can be accessed.",
+						userClassPath));
+			}
+		}
+		return false;
+	}
 
+	private boolean jarContainsJobClass(String jobClassName, JarFile jarFile) {
+		return jarFile
+			.stream()
+			.map(JarEntry::getName)
+			.filter(fileName -> fileName.endsWith(FileUtils.CLASS_FILE_EXTENSION))
+			.map(FileUtils::stripFileExtension)
+			.map(fileName -> fileName.replaceAll(Pattern.quote(File.separator), FileUtils.PACKAGE_SEPARATOR))
+			.anyMatch(name -> name.equals(jobClassName));
+	}
+
+	private String scanClassPathForJobJar() throws IOException {
+		final Iterable<File> jars;
+		if (userLibDirectory == null) {
+			LOG.info("Scanning system class path for job JAR");
+			jars = jarsOnClassPath.get();
+		} else {
+			LOG.info("Scanning user class path for job JAR");
+			jars = getUserClassPaths()
+				.stream()
+				.map(url -> new File(url.getFile()))
+				.collect(Collectors.toList());
+		}
+
+		final JarFileWithEntryClass jobJar = JarManifestParser.findOnlyEntryClass(jars);
 		LOG.info("Using {} as job jar", jobJar);
 		return jobJar.getEntryClass();
 	}
@@ -162,6 +217,58 @@ class ClassPathJobGraphRetriever implements JobGraphRetriever {
 		private static boolean notNullAndNotEmpty(String string) {
 			return string != null && !string.equals("");
 		}
+	}
+
+	static class Builder {
+
+		private final JobID jobId;
+
+		private final SavepointRestoreSettings savepointRestoreSettings;
+
+		private final String[] programArguments;
+
+		@Nullable
+		private String jobClassName;
+
+		@Nullable
+		private File userLibDirectory;
+
+		private Supplier<Iterable<File>> jarsOnClassPath = JarsOnClassPath.INSTANCE;
+
+		private Builder(JobID jobId, SavepointRestoreSettings savepointRestoreSettings, String[] programArguments) {
+			this.jobId = requireNonNull(jobId);
+			this.savepointRestoreSettings = requireNonNull(savepointRestoreSettings);
+			this.programArguments = requireNonNull(programArguments);
+		}
+
+		Builder setJobClassName(@Nullable String jobClassName) {
+			this.jobClassName = jobClassName;
+			return this;
+		}
+
+		Builder setUserLibDirectory(File userLibDirectory) {
+			this.userLibDirectory = userLibDirectory;
+			return this;
+		}
+
+		Builder setJarsOnClassPath(Supplier<Iterable<File>> jarsOnClassPath) {
+			this.jarsOnClassPath = jarsOnClassPath;
+			return this;
+		}
+
+		ClassPathJobGraphRetriever build() throws IOException {
+			return new ClassPathJobGraphRetriever(
+				jobId,
+				savepointRestoreSettings,
+				programArguments,
+				jobClassName,
+				jarsOnClassPath,
+				userLibDirectory);
+		}
+	}
+
+	static Builder newBuilder(JobID jobId, SavepointRestoreSettings savepointRestoreSettings, String[] programArguments) {
+		return new Builder(jobId, savepointRestoreSettings, programArguments);
 	}
 
 }

--- a/flink-container/src/test/assembly/test-assembly-test-user-classloader-job-jar.xml
+++ b/flink-container/src/test/assembly/test-assembly-test-user-classloader-job-jar.xml
@@ -1,0 +1,35 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<assembly>
+	<id>test-user-classloader-job-jar</id>
+	<formats>
+		<format>jar</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.testOutputDirectory}</directory>
+			<outputDirectory>/</outputDirectory>
+			<includes>
+				<include>org/apache/flink/container/entrypoint/testjar/TestUserClassLoaderJob.class</include>
+			</includes>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/flink-container/src/test/assembly/test-assembly-test-user-classloader-job-lib-jar.xml
+++ b/flink-container/src/test/assembly/test-assembly-test-user-classloader-job-lib-jar.xml
@@ -1,0 +1,35 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<assembly>
+	<id>test-user-classloader-job-lib-jar</id>
+	<formats>
+		<format>jar</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.testOutputDirectory}</directory>
+			<outputDirectory>/</outputDirectory>
+			<includes>
+				<include>org/apache/flink/container/entrypoint/testjar/TestUserClassLoaderJobLib.class</include>
+			</includes>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetrieverTest.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetrieverTest.java
@@ -22,21 +22,34 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.container.entrypoint.ClassPathJobGraphRetriever.JarsOnClassPath;
+import org.apache.flink.container.entrypoint.testjar.TestJobInfo;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.FunctionUtils;
 
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -44,6 +57,7 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for the {@link ClassPathJobGraphRetriever}.
@@ -53,20 +67,69 @@ public class ClassPathJobGraphRetrieverTest extends TestLogger {
 	@Rule
 	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
+	@ClassRule
+	public static final TemporaryFolder JOB_DIRS = new TemporaryFolder();
+
 	private static final String[] PROGRAM_ARGUMENTS = {"--arg", "suffix"};
 
+	/*
+	 * The directory structure used to test
+	 *
+	 * userDirHasEntryClass/
+	 *                    |_jarWithEntryClass
+	 *                    |_jarWithoutEntryClass
+	 *                    |_textFile
+	 *
+	 * userDirHasNotEntryClass/
+	 *                       |_jarWithoutEntryClass
+	 *                       |_textFile
+	 */
+
+	private static final Collection<URL> expectedURLs = new ArrayList<>();
+
+	private static File userDirHasEntryClass;
+
+	private static File userDirHasNotEntryClass;
+
+	@BeforeClass
+	public static void init() throws IOException {
+		final String textFileName = "test.txt";
+		final String userDirHasEntryClassName = "_test_user_dir_has_entry_class";
+		final String userDirHasNotEntryClassName = "_test_user_dir_has_not_entry_class";
+
+		userDirHasEntryClass = JOB_DIRS.newFolder(userDirHasEntryClassName);
+		final Path userJarPath = userDirHasEntryClass.toPath().resolve(TestJobInfo.JOB_JAR_PATH.toFile().getName());
+		final Path userLibJarPath =
+			userDirHasEntryClass.toPath().resolve(TestJobInfo.JOB_LIB_JAR_PATH.toFile().getName());
+		userDirHasNotEntryClass = JOB_DIRS.newFolder(userDirHasNotEntryClassName);
+
+		//create files
+		Files.copy(TestJobInfo.JOB_JAR_PATH, userJarPath);
+		Files.copy(TestJobInfo.JOB_LIB_JAR_PATH, userLibJarPath);
+		Files.createFile(userDirHasEntryClass.toPath().resolve(textFileName));
+
+		Files.copy(TestJobInfo.JOB_LIB_JAR_PATH, userDirHasNotEntryClass.toPath().resolve(TestJobInfo.JOB_LIB_JAR_PATH.toFile().getName()));
+		Files.createFile(userDirHasNotEntryClass.toPath().resolve(textFileName));
+
+		final Path workingDirectory = FileUtils.getCurrentWorkingDirectory();
+		Arrays.asList(userJarPath, userLibJarPath)
+			.stream()
+			.map(path -> FileUtils.relativizePath(workingDirectory, path))
+			.map(FunctionUtils.uncheckedFunction(FileUtils::toURL))
+			.forEach(expectedURLs::add);
+	}
+
 	@Test
-	public void testJobGraphRetrieval() throws FlinkException {
+	public void testJobGraphRetrieval() throws FlinkException, IOException {
 		final int parallelism = 42;
 		final Configuration configuration = new Configuration();
 		configuration.setInteger(CoreOptions.DEFAULT_PARALLELISM, parallelism);
 		final JobID jobId = new JobID();
 
-		final ClassPathJobGraphRetriever classPathJobGraphRetriever = new ClassPathJobGraphRetriever(
-			jobId,
-			SavepointRestoreSettings.none(),
-			PROGRAM_ARGUMENTS,
-			TestJob.class.getCanonicalName());
+		final ClassPathJobGraphRetriever classPathJobGraphRetriever =
+			ClassPathJobGraphRetriever.newBuilder(jobId, SavepointRestoreSettings.none(), PROGRAM_ARGUMENTS)
+				.setJobClassName(TestJob.class.getCanonicalName())
+				.build();
 
 		final JobGraph jobGraph = classPathJobGraphRetriever.retrieveJobGraph(configuration);
 
@@ -76,15 +139,12 @@ public class ClassPathJobGraphRetrieverTest extends TestLogger {
 	}
 
 	@Test
-	public void testJobGraphRetrievalFromJar() throws FlinkException, FileNotFoundException {
+	public void testJobGraphRetrievalFromJar() throws FlinkException, IOException {
 		final File testJar = TestJob.getTestJobJar();
-		final ClassPathJobGraphRetriever classPathJobGraphRetriever = new ClassPathJobGraphRetriever(
-			new JobID(),
-			SavepointRestoreSettings.none(),
-			PROGRAM_ARGUMENTS,
-			// No class name specified, but the test JAR "is" on the class path
-			null,
-			() -> Collections.singleton(testJar));
+		final ClassPathJobGraphRetriever classPathJobGraphRetriever =
+			ClassPathJobGraphRetriever.newBuilder(new JobID(), SavepointRestoreSettings.none(), PROGRAM_ARGUMENTS)
+				.setJarsOnClassPath(() -> Collections.singleton(testJar))
+				.build();
 
 		final JobGraph jobGraph = classPathJobGraphRetriever.retrieveJobGraph(new Configuration());
 
@@ -92,17 +152,16 @@ public class ClassPathJobGraphRetrieverTest extends TestLogger {
 	}
 
 	@Test
-	public void testJobGraphRetrievalJobClassNameHasPrecedenceOverClassPath() throws FlinkException, FileNotFoundException {
+	public void testJobGraphRetrievalJobClassNameHasPrecedenceOverClassPath() throws FlinkException, IOException {
 		final File testJar = new File("non-existing");
 
-		final ClassPathJobGraphRetriever classPathJobGraphRetriever = new ClassPathJobGraphRetriever(
-			new JobID(),
-			SavepointRestoreSettings.none(),
-			PROGRAM_ARGUMENTS,
-			// Both a class name is specified and a JAR "is" on the class path
-			// The class name should have precedence.
-			TestJob.class.getCanonicalName(),
-			() -> Collections.singleton(testJar));
+		final ClassPathJobGraphRetriever classPathJobGraphRetriever =
+			ClassPathJobGraphRetriever.newBuilder(new JobID(), SavepointRestoreSettings.none(), PROGRAM_ARGUMENTS)
+				// Both a class name is specified and a JAR "is" on the class path
+				// The class name should have precedence.
+			.setJobClassName(TestJob.class.getCanonicalName())
+			.setJarsOnClassPath(() -> Collections.singleton(testJar))
+			.build();
 
 		final JobGraph jobGraph = classPathJobGraphRetriever.retrieveJobGraph(new Configuration());
 
@@ -110,16 +169,15 @@ public class ClassPathJobGraphRetrieverTest extends TestLogger {
 	}
 
 	@Test
-	public void testSavepointRestoreSettings() throws FlinkException {
+	public void testSavepointRestoreSettings() throws FlinkException, IOException {
 		final Configuration configuration = new Configuration();
 		final SavepointRestoreSettings savepointRestoreSettings = SavepointRestoreSettings.forPath("foobar", true);
 		final JobID jobId = new JobID();
 
-		final ClassPathJobGraphRetriever classPathJobGraphRetriever = new ClassPathJobGraphRetriever(
-			jobId,
-			savepointRestoreSettings,
-			PROGRAM_ARGUMENTS,
-			TestJob.class.getCanonicalName());
+		final ClassPathJobGraphRetriever classPathJobGraphRetriever =
+			ClassPathJobGraphRetriever.newBuilder(jobId, savepointRestoreSettings, PROGRAM_ARGUMENTS)
+			.setJobClassName(TestJob.class.getCanonicalName())
+			.build();
 
 		final JobGraph jobGraph = classPathJobGraphRetriever.retrieveJobGraph(configuration);
 
@@ -160,6 +218,68 @@ public class ClassPathJobGraphRetrieverTest extends TestLogger {
 		assertThat(jarFiles, contains(file1, file2));
 	}
 
+	@Test
+	public void testJobGraphRetrievalFailIfJobDirDoesNotHaveEntryClass() throws IOException {
+		final File testJar = TestJob.getTestJobJar();
+		final ClassPathJobGraphRetriever classPathJobGraphRetriever =
+			ClassPathJobGraphRetriever.newBuilder(new JobID(), SavepointRestoreSettings.none(), PROGRAM_ARGUMENTS)
+				.setJarsOnClassPath(() -> Collections.singleton(testJar))
+				.setUserLibDirectory(userDirHasNotEntryClass)
+				.build();
+		try {
+			classPathJobGraphRetriever.retrieveJobGraph(new Configuration());
+			Assert.fail("This case should throw exception !");
+		} catch (FlinkException e) {
+			assertTrue(ExceptionUtils
+				.findThrowableWithMessage(e, "Failed to find job JAR on class path")
+				.isPresent());
+		}
+	}
+
+	@Test
+	public void testJobGraphRetrievalFailIfDoesNotFindTheEntryClassInTheJobDir() throws IOException {
+		final ClassPathJobGraphRetriever classPathJobGraphRetriever =
+			ClassPathJobGraphRetriever.newBuilder(new JobID(), SavepointRestoreSettings.none(), PROGRAM_ARGUMENTS)
+				.setJobClassName(TestJobInfo.JOB_CLASS)
+				.setJarsOnClassPath(Collections::emptyList)
+				.setUserLibDirectory(userDirHasNotEntryClass)
+				.build();
+		try {
+			classPathJobGraphRetriever.retrieveJobGraph(new Configuration());
+			Assert.fail("This case should throw class not found exception!!");
+		} catch (FlinkException e) {
+			assertTrue(ExceptionUtils
+				.findThrowableWithMessage(e, "Could not find the provided job class")
+				.isPresent());
+		}
+
+	}
+
+	@Test
+	public void testRetrieveCorrectUserClasspathsWithoutSpecifiedEntryClass() throws IOException, FlinkException {
+		final ClassPathJobGraphRetriever classPathJobGraphRetriever =
+			ClassPathJobGraphRetriever.newBuilder(new JobID(), SavepointRestoreSettings.none(), PROGRAM_ARGUMENTS)
+				.setJarsOnClassPath(Collections::emptyList)
+				.setUserLibDirectory(userDirHasEntryClass)
+				.build();
+		final JobGraph jobGraph = classPathJobGraphRetriever.retrieveJobGraph(new Configuration());
+
+		assertThat(jobGraph.getClasspaths(), containsInAnyOrder(expectedURLs.toArray()));
+	}
+
+	@Test
+	public void testRetrieveCorrectUserClasspathsWithSpecifiedEntryClass() throws IOException, FlinkException {
+		final ClassPathJobGraphRetriever classPathJobGraphRetriever =
+			ClassPathJobGraphRetriever.newBuilder(new JobID(), SavepointRestoreSettings.none(), PROGRAM_ARGUMENTS)
+				.setJobClassName(TestJobInfo.JOB_CLASS)
+				.setJarsOnClassPath(Collections::emptyList)
+				.setUserLibDirectory(userDirHasEntryClass)
+				.build();
+		final JobGraph jobGraph = classPathJobGraphRetriever.retrieveJobGraph(new Configuration());
+
+		assertThat(jobGraph.getClasspaths(), containsInAnyOrder(expectedURLs.toArray()));
+	}
+
 	private static String javaClassPath(String... entries) {
 		String pathSeparator = System.getProperty(JarsOnClassPath.PATH_SEPARATOR);
 		return String.join(pathSeparator, entries);
@@ -175,5 +295,4 @@ public class ClassPathJobGraphRetrieverTest extends TestLogger {
 			System.setProperty(JarsOnClassPath.JAVA_CLASS_PATH, originalClassPath);
 		}
 	}
-
 }

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/testjar/TestJobInfo.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/testjar/TestJobInfo.java
@@ -16,24 +16,18 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.webmonitor.handlers;
+package org.apache.flink.container.entrypoint.testjar;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
- * Query parameter specifying the arguments for the program.
- * @deprecated please, use {@link JarRequestBody#FIELD_NAME_PROGRAM_ARGUMENTS_LIST}
- * @see org.apache.flink.client.program.PackagedProgram.Builder#setArguments(String...)
+ * The test job information.
  */
-@Deprecated
-public class ProgramArgsQueryParameter extends StringQueryParameter {
+public class TestJobInfo {
 
-	public ProgramArgsQueryParameter() {
-		super("program-args", MessageParameterRequisiteness.OPTIONAL);
-	}
-
-	@Override
-	public String getDescription() {
-		return String.format("Deprecated, please use '%s' instead. " +
-			"String value that specifies the arguments for the program or plan",
-			ProgramArgQueryParameter.PROGRAM_ARG_PARAMETER_NAME);
-	}
+	public static final String JOB_CLASS = "org.apache.flink.container.entrypoint.testjar.TestUserClassLoaderJob";
+	public static final String JOB_LIB_CLASS = "org.apache.flink.container.entrypoint.testjar.TestUserClassLoaderJobLib";
+	public static final Path JOB_JAR_PATH = Paths.get("target", "maven-test-user-classloader-job-jar.jar");
+	public static final Path JOB_LIB_JAR_PATH = Paths.get("target", "maven-test-user-classloader-job-lib-jar.jar");
 }

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/testjar/TestUserClassLoaderJob.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/testjar/TestUserClassLoaderJob.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.container.entrypoint.testjar;
+
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+
+/**
+ * This class can used to test situation that the jar is not in the system classpath.
+ */
+public class TestUserClassLoaderJob {
+	public static void main(String[] args) throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		final DataStreamSource<Integer> source = env.fromElements(new TestUserClassLoaderJobLib().getValue(), 1, 2, 3, 4);
+		final SingleOutputStreamOperator<Integer> mapper = source.map(element -> 2 * element);
+		mapper.addSink(new DiscardingSink<>());
+
+		ParameterTool parameterTool = ParameterTool.fromArgs(args);
+		env.execute(TestUserClassLoaderJob.class.getCanonicalName() + "-" + parameterTool.getRequired("arg"));
+	}
+}

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/testjar/TestUserClassLoaderJobLib.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/testjar/TestUserClassLoaderJobLib.java
@@ -16,24 +16,17 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.webmonitor.handlers;
+package org.apache.flink.container.entrypoint.testjar;
 
 /**
- * Query parameter specifying the arguments for the program.
- * @deprecated please, use {@link JarRequestBody#FIELD_NAME_PROGRAM_ARGUMENTS_LIST}
- * @see org.apache.flink.client.program.PackagedProgram.Builder#setArguments(String...)
+ * This class is depended by {@link TestUserClassLoaderJob}.
  */
-@Deprecated
-public class ProgramArgsQueryParameter extends StringQueryParameter {
+class TestUserClassLoaderJobLib {
 
-	public ProgramArgsQueryParameter() {
-		super("program-args", MessageParameterRequisiteness.OPTIONAL);
+	int getValue() {
+		return 0;
 	}
 
-	@Override
-	public String getDescription() {
-		return String.format("Deprecated, please use '%s' instead. " +
-			"String value that specifies the arguments for the program or plan",
-			ProgramArgQueryParameter.PROGRAM_ARG_PARAMETER_NAME);
+	public static void main(String[] args) {
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -2021,6 +2021,9 @@ public final class ConfigConstants {
 	/** The environment variable name which contains the Flink installation root directory. */
 	public static final String ENV_FLINK_HOME_DIR = "FLINK_HOME";
 
+	/** The user lib directory name. */
+	public static final String DEFAULT_FLINK_USR_LIB_DIR = "usrlib";
+
 	// ---------------------------- Encoding ------------------------------
 
 	public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;

--- a/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
@@ -84,6 +84,11 @@ public final class FileUtils {
 
 	private static final String JAR_FILE_EXTENSION = "jar";
 
+	public static final String CLASS_FILE_EXTENSION = "class";
+
+	public static final String PACKAGE_SEPARATOR = ".";
+
+
 	// ------------------------------------------------------------------------
 
 	public static void writeCompletely(WritableByteChannel channel, ByteBuffer src) throws IOException {
@@ -596,6 +601,16 @@ public final class FileUtils {
 	}
 
 	/**
+	 * Checks whether the given file has a class extension.
+	 *
+	 * @param file to check
+	 * @return true if the file has a class extension, otherwise false
+	 */
+	public static boolean isClassFile(java.nio.file.Path file) {
+		return CLASS_FILE_EXTENSION.equals(org.apache.flink.shaded.guava18.com.google.common.io.Files.getFileExtension(file.toString()));
+	}
+
+	/**
 	 * Checks whether the given file has a jar extension.
 	 *
 	 * @param file to check
@@ -603,6 +618,19 @@ public final class FileUtils {
 	 */
 	public static boolean isJarFile(java.nio.file.Path file) {
 		return JAR_FILE_EXTENSION.equals(org.apache.flink.shaded.guava18.com.google.common.io.Files.getFileExtension(file.toString()));
+	}
+
+	/**
+	 * Remove the extension of the file name.
+	 * @param fileName to strip
+	 * @return the file name without extension
+	 */
+	public static String stripFileExtension(String fileName) {
+		final String extension = org.apache.flink.shaded.guava18.com.google.common.io.Files.getFileExtension(fileName);
+		if (!extension.isEmpty()) {
+			return fileName.substring(0, fileName.lastIndexOf(extension) - 1);
+		}
+		return fileName;
 	}
 
 	/**

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/WordCount.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/WordCount.java
@@ -84,7 +84,6 @@ public class WordCount {
 			System.out.println("Printing result to stdout. Use --output to specify output path.");
 			counts.print();
 		}
-
 		// execute program
 		env.execute("Streaming WordCount");
 	}

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroExternalJarProgramITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroExternalJarProgramITCase.java
@@ -81,7 +81,10 @@ public class AvroExternalJarProgramITCase extends TestLogger {
 
 		String testData = getClass().getResource(TEST_DATA_FILE).toString();
 
-		PackagedProgram program = new PackagedProgram(new File(jarFile), new String[]{testData});
+		PackagedProgram program = PackagedProgram.newBuilder()
+			.setJarFile(new File(jarFile))
+			.setArguments(new String[]{testData})
+			.build();
 
 		program.invokeInteractiveModeForExecution();
 	}

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/EntryClassQueryParameter.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/EntryClassQueryParameter.java
@@ -18,11 +18,9 @@
 
 package org.apache.flink.runtime.webmonitor.handlers;
 
-import java.io.File;
-
 /**
  * Query parameter specifying the name of the entry point class.
- * @see org.apache.flink.client.program.PackagedProgram#PackagedProgram(File, String, String...)
+ * @see org.apache.flink.client.program.PackagedProgram.Builder#setEntryPointClassName(String)
  */
 public class EntryClassQueryParameter extends StringQueryParameter {
 	public EntryClassQueryParameter() {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarListHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarListHandler.java
@@ -129,7 +129,7 @@ public class JarListHandler extends AbstractRestHandler<RestfulGateway, EmptyReq
 
 						PackagedProgram program = null;
 						try {
-							program = new PackagedProgram(f, clazz, new String[0]);
+							program = PackagedProgram.newBuilder().setJarFile(f).setEntryPointClassName(clazz).build();
 						} catch (Exception ignored) {
 							// ignore jar files which throw an error upon creating a PackagedProgram
 						}

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/ProgramArgQueryParameter.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/ProgramArgQueryParameter.java
@@ -20,11 +20,9 @@ package org.apache.flink.runtime.webmonitor.handlers;
 
 import org.apache.flink.runtime.rest.messages.MessageParameter;
 
-import java.io.File;
-
 /**
  * Query parameter specifying one or more arguments for the program.
- * @see org.apache.flink.client.program.PackagedProgram#PackagedProgram(File, String, String...)
+ * @see org.apache.flink.client.program.PackagedProgram.Builder#setArguments(String...)
  */
 public class ProgramArgQueryParameter extends StringQueryParameter {
 	static final String PROGRAM_ARG_PARAMETER_NAME = "programArg";

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/utils/JarHandlerUtils.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/utils/JarHandlerUtils.java
@@ -119,10 +119,11 @@ public class JarHandlerUtils {
 			}
 
 			try {
-				final PackagedProgram packagedProgram = new PackagedProgram(
-					jarFile.toFile(),
-					entryClass,
-					programArgs.toArray(new String[0]));
+				final PackagedProgram packagedProgram = PackagedProgram.newBuilder()
+					.setJarFile(jarFile.toFile())
+					.setEntryPointClassName(entryClass)
+					.setArguments(programArgs.toArray(new String[0]))
+					.build();
 				return PackagedProgramUtils.createJobGraph(packagedProgram, configuration, parallelism, jobId);
 			} catch (final ProgramInvocationException e) {
 				throw new CompletionException(e);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -476,7 +476,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 	// Abstract methods
 	// --------------------------------------------------
 
-	protected abstract DispatcherResourceManagerComponentFactory createDispatcherResourceManagerComponentFactory(Configuration configuration);
+	protected abstract DispatcherResourceManagerComponentFactory createDispatcherResourceManagerComponentFactory(Configuration configuration) throws IOException;
 
 	protected abstract ArchivedExecutionGraphStore createSerializableExecutionGraphStore(
 		Configuration configuration,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ClusterEntrypointUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ClusterEntrypointUtils.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.configuration.ConfigConstants;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.util.Optional;
+
+/**
+ * Utility class for {@link org.apache.flink.runtime.entrypoint.ClusterEntrypoint}.
+ */
+public final class ClusterEntrypointUtils {
+
+	private ClusterEntrypointUtils() {
+		throw new UnsupportedOperationException("This class should not be instantiated.");
+	}
+
+	/**
+	 * Tries to find the user library directory.
+	 *
+	 * @return the user library directory if it exits, returns {@link Optional#empty()} if there is none
+	 */
+	public static Optional<File> tryFindUserLibDirectory() {
+		final File flinkHomeDirectory = deriveFlinkHomeDirectoryFromLibDirectory();
+		final File usrLibDirectory = new File(flinkHomeDirectory, ConfigConstants.DEFAULT_FLINK_USR_LIB_DIR);
+
+		if (!usrLibDirectory.isDirectory()) {
+			return Optional.empty();
+		}
+		return Optional.of(usrLibDirectory);
+	}
+
+	@Nullable
+	private static File deriveFlinkHomeDirectoryFromLibDirectory() {
+		final String libDirectory = System.getenv().get(ConfigConstants.ENV_FLINK_LIB_DIR);
+
+		if (libDirectory == null) {
+			return null;
+		} else {
+			return new File(libDirectory).getParentFile();
+		}
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
@@ -140,7 +140,9 @@ public class ClassLoaderITCase extends TestLogger {
 	@Test
 	public void testCustomSplitJobWithCustomClassLoaderJar() throws ProgramInvocationException {
 
-		PackagedProgram inputSplitTestProg = new PackagedProgram(new File(INPUT_SPLITS_PROG_JAR_FILE));
+		PackagedProgram inputSplitTestProg = PackagedProgram.newBuilder()
+			.setJarFile(new File(INPUT_SPLITS_PROG_JAR_FILE))
+			.build();
 
 		TestEnvironment.setAsContext(
 			miniClusterResource.getMiniCluster(),
@@ -153,7 +155,9 @@ public class ClassLoaderITCase extends TestLogger {
 
 	@Test
 	public void testStreamingCustomSplitJobWithCustomClassLoader() throws ProgramInvocationException {
-		PackagedProgram streamingInputSplitTestProg = new PackagedProgram(new File(STREAMING_INPUT_SPLITS_PROG_JAR_FILE));
+		PackagedProgram streamingInputSplitTestProg = PackagedProgram.newBuilder()
+			.setJarFile(new File(STREAMING_INPUT_SPLITS_PROG_JAR_FILE))
+			.build();
 
 		TestStreamEnvironment.setAsContext(
 			miniClusterResource.getMiniCluster(),
@@ -167,7 +171,9 @@ public class ClassLoaderITCase extends TestLogger {
 	@Test
 	public void testCustomSplitJobWithCustomClassLoaderPath() throws IOException, ProgramInvocationException {
 		URL classpath = new File(INPUT_SPLITS_PROG_JAR_FILE).toURI().toURL();
-		PackagedProgram inputSplitTestProg2 = new PackagedProgram(new File(INPUT_SPLITS_PROG_JAR_FILE));
+		PackagedProgram inputSplitTestProg2 = PackagedProgram.newBuilder()
+			.setJarFile(new File(INPUT_SPLITS_PROG_JAR_FILE))
+			.build();
 
 		TestEnvironment.setAsContext(
 			miniClusterResource.getMiniCluster(),
@@ -181,7 +187,7 @@ public class ClassLoaderITCase extends TestLogger {
 	@Test
 	public void testStreamingClassloaderJobWithCustomClassLoader() throws ProgramInvocationException {
 		// regular streaming job
-		PackagedProgram streamingProg = new PackagedProgram(new File(STREAMING_PROG_JAR_FILE));
+		PackagedProgram streamingProg = PackagedProgram.newBuilder().setJarFile(new File(STREAMING_PROG_JAR_FILE)).build();
 
 		TestStreamEnvironment.setAsContext(
 			miniClusterResource.getMiniCluster(),
@@ -196,7 +202,9 @@ public class ClassLoaderITCase extends TestLogger {
 	public void testCheckpointedStreamingClassloaderJobWithCustomClassLoader() throws ProgramInvocationException {
 		// checkpointed streaming job with custom classes for the checkpoint (FLINK-2543)
 		// the test also ensures that user specific exceptions are serializable between JobManager <--> JobClient.
-		PackagedProgram streamingCheckpointedProg = new PackagedProgram(new File(STREAMING_CHECKPOINTED_PROG_JAR_FILE));
+		PackagedProgram streamingCheckpointedProg = PackagedProgram.newBuilder()
+			.setJarFile(new File(STREAMING_CHECKPOINTED_PROG_JAR_FILE))
+			.build();
 
 		TestStreamEnvironment.setAsContext(
 			miniClusterResource.getMiniCluster(),
@@ -230,13 +238,13 @@ public class ClassLoaderITCase extends TestLogger {
 
 	@Test
 	public void testKMeansJobWithCustomClassLoader() throws ProgramInvocationException {
-		PackagedProgram kMeansProg = new PackagedProgram(
-			new File(KMEANS_JAR_PATH),
-			new String[] {
+		PackagedProgram kMeansProg = PackagedProgram.newBuilder()
+			.setJarFile(new File(KMEANS_JAR_PATH))
+			.setArguments(new String[] {
 				KMeansData.DATAPOINTS,
 				KMeansData.INITIAL_CENTERS,
-				"25"
-			});
+				"25"})
+			.build();
 
 		TestEnvironment.setAsContext(
 			miniClusterResource.getMiniCluster(),
@@ -249,7 +257,9 @@ public class ClassLoaderITCase extends TestLogger {
 
 	@Test
 	public void testUserCodeTypeJobWithCustomClassLoader() throws ProgramInvocationException {
-		PackagedProgram userCodeTypeProg = new PackagedProgram(new File(USERCODETYPE_JAR_PATH));
+		PackagedProgram userCodeTypeProg = PackagedProgram.newBuilder()
+			.setJarFile(new File(USERCODETYPE_JAR_PATH))
+			.build();
 
 		TestEnvironment.setAsContext(
 			miniClusterResource.getMiniCluster(),
@@ -265,12 +275,10 @@ public class ClassLoaderITCase extends TestLogger {
 		File checkpointDir = FOLDER.newFolder();
 		File outputDir = FOLDER.newFolder();
 
-		final PackagedProgram program = new PackagedProgram(
-			new File(CHECKPOINTING_CUSTOM_KV_STATE_JAR_PATH),
-			new String[] {
-				checkpointDir.toURI().toString(),
-				outputDir.toURI().toString()
-			});
+		final PackagedProgram program = PackagedProgram.newBuilder()
+			.setJarFile(new File(CHECKPOINTING_CUSTOM_KV_STATE_JAR_PATH))
+			.setArguments(new String[] { checkpointDir.toURI().toString(), outputDir.toURI().toString()})
+			.build();
 
 		TestStreamEnvironment.setAsContext(
 			miniClusterResource.getMiniCluster(),
@@ -298,14 +306,14 @@ public class ClassLoaderITCase extends TestLogger {
 		File checkpointDir = FOLDER.newFolder();
 		File outputDir = FOLDER.newFolder();
 
-		final PackagedProgram program = new PackagedProgram(
-				new File(CUSTOM_KV_STATE_JAR_PATH),
-				new String[] {
-						String.valueOf(parallelism),
-						checkpointDir.toURI().toString(),
-						"5000",
-						outputDir.toURI().toString()
-				});
+		final PackagedProgram program = PackagedProgram.newBuilder()
+			.setJarFile(new File(CUSTOM_KV_STATE_JAR_PATH))
+			.setArguments(new String[] {
+				String.valueOf(parallelism),
+				checkpointDir.toURI().toString(),
+				"5000",
+				outputDir.toURI().toString()})
+			.build();
 
 		TestStreamEnvironment.setAsContext(
 			miniClusterResource.getMiniCluster(),

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
@@ -108,7 +108,7 @@ public class YarnConfigurationITCase extends YarnTestBase {
 
 			final File streamingWordCountFile = getTestJarPath("WindowJoin.jar");
 
-			final PackagedProgram packagedProgram = new PackagedProgram(streamingWordCountFile);
+			final PackagedProgram packagedProgram = PackagedProgram.newBuilder().setJarFile(streamingWordCountFile).build();
 			final JobGraph jobGraph = PackagedProgramUtils.createJobGraph(packagedProgram, configuration, 1);
 
 			try {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
This pull requests make the `StandaloneJobClusterEntrypoint` use the user code class loader.

## Brief change log
  - link the `FLINK_JOB_ARTIFACTS_DIR` to the `FLINK_HOME/job` dir
  - `ClassPathJobGraphRetriever` constructs a user code classpath from `FLINK_HOME/job`
  - `ClassPathJobGraphRetriever` sets the user code classpath to `PacakgeProgram`
  - `ClassPathJobGraphRetriever` uses the `packageProgram` to build a jobgraph with the user clode classpath


## Verifying this change

  - Extended the test that validates`ClassPathJobGraphRetriever` can retrieve a `JobGraph` with correct user classpath
 - Extended the test that validates `PackagedProgram` can create a `JobGraph` even if the `jarFile` param of the constructor is null
  - execute the `test_docker_embedded_job.sh` manually to verify the StandaloneJobCluster runs well.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
