### PR TITLE
[FLINK-14486][table-api, docs] Update documentation regarding Temporary Objects

### DIFF
--- a/docs/dev/table/catalogs.md
+++ b/docs/dev/table/catalogs.md
@@ -36,7 +36,7 @@ Or permanent metadata, like that in a Hive Metastore. Catalogs provide a unified
 
 ### GenericInMemoryCatalog
 
-Flink sessions always have a built-in `GenericInMemoryCatalog` named `default_catalog`, which has a built-in default database named `default_database`. 
+The `GenericInMemoryCatalog` is an in-memory implementation of a catalog. All objects will be available only for the lifetime of the session.
 
 ### HiveCatalog
 
@@ -58,7 +58,8 @@ The set of properties will be passed to a discovery service where the service tr
 
 ### Registering a Catalog
 
-Users can register additional catalogs into an existing Flink session.
+Users have access to a default in-memory catalog named `default_catalog`, that is always created by default. This catalog by default has a single database called `default_database`.
+Users can also register additional catalogs into an existing Flink session.
 
 <div class="codetabs" markdown="1">
 <div data-lang="Java/Scala" markdown="1">
@@ -123,7 +124,7 @@ Metadata from catalogs that are not the current catalog are accessible by provid
 <div class="codetabs" markdown="1">
 <div data-lang="Java/Scala" markdown="1">
 {% highlight java %}
-tableEnv.from("not_the_current_catalog", "not_the_current_db", "my_table");
+tableEnv.from("not_the_current_catalog.not_the_current_db.my_table");
 {% endhighlight %}
 </div>
 <div data-lang="SQL" markdown="1">

--- a/docs/dev/table/catalogs.md
+++ b/docs/dev/table/catalogs.md
@@ -36,8 +36,7 @@ Or permanent metadata, like that in a Hive Metastore. Catalogs provide a unified
 
 ### GenericInMemoryCatalog
 
-Flink sessions always have a built-in `GenericInMemoryCatalog` named `default_catalog`, which has a built-in default database named `default_database`.
-All temporary metadata, such tables defined using `TableEnvironment#registerTable` is registered to this catalog. 
+Flink sessions always have a built-in `GenericInMemoryCatalog` named `default_catalog`, which has a built-in default database named `default_database`. 
 
 ### HiveCatalog
 
@@ -124,7 +123,7 @@ Metadata from catalogs that are not the current catalog are accessible by provid
 <div class="codetabs" markdown="1">
 <div data-lang="Java/Scala" markdown="1">
 {% highlight java %}
-tableEnv.scan("not_the_current_catalog", "not_the_current_db", "my_table");
+tableEnv.from("not_the_current_catalog", "not_the_current_db", "my_table");
 {% endhighlight %}
 </div>
 <div data-lang="SQL" markdown="1">

--- a/docs/dev/table/catalogs.zh.md
+++ b/docs/dev/table/catalogs.zh.md
@@ -36,7 +36,7 @@ Or permanent metadata, like that in a Hive Metastore. Catalogs provide a unified
 
 ### GenericInMemoryCatalog
 
-Flink sessions always have a built-in `GenericInMemoryCatalog` named `default_catalog`, which has a built-in default database named `default_database`. 
+The `GenericInMemoryCatalog` is an in-memory implementation of a catalog. All objects will be available only for the lifetime of the session.
 
 ### HiveCatalog
 
@@ -58,7 +58,8 @@ The set of properties will be passed to a discovery service where the service tr
 
 ### Registering a Catalog
 
-Users can register additional catalogs into an existing Flink session.
+Users have access to a default in-memory catalog named `default_catalog`, that is always created by default. This catalog by default has a single database called `default_database`.
+Users can also register additional catalogs into an existing Flink session.
 
 <div class="codetabs" markdown="1">
 <div data-lang="Java/Scala" markdown="1">
@@ -123,7 +124,7 @@ Metadata from catalogs that are not the current catalog are accessible by provid
 <div class="codetabs" markdown="1">
 <div data-lang="Java/Scala" markdown="1">
 {% highlight java %}
-tableEnv.from("not_the_current_catalog", "not_the_current_db", "my_table");
+tableEnv.from("not_the_current_catalog.not_the_current_db.my_table");
 {% endhighlight %}
 </div>
 <div data-lang="SQL" markdown="1">

--- a/docs/dev/table/catalogs.zh.md
+++ b/docs/dev/table/catalogs.zh.md
@@ -36,8 +36,7 @@ Or permanent metadata, like that in a Hive Metastore. Catalogs provide a unified
 
 ### GenericInMemoryCatalog
 
-Flink sessions always have a built-in `GenericInMemoryCatalog` named `default_catalog`, which has a built-in default database named `default_database`.
-All temporary metadata, such tables defined using `TableEnvironment#registerTable` is registered to this catalog. 
+Flink sessions always have a built-in `GenericInMemoryCatalog` named `default_catalog`, which has a built-in default database named `default_database`. 
 
 ### HiveCatalog
 
@@ -124,7 +123,7 @@ Metadata from catalogs that are not the current catalog are accessible by provid
 <div class="codetabs" markdown="1">
 <div data-lang="Java/Scala" markdown="1">
 {% highlight java %}
-tableEnv.scan("not_the_current_catalog", "not_the_current_db", "my_table");
+tableEnv.from("not_the_current_catalog", "not_the_current_db", "my_table");
 {% endhighlight %}
 </div>
 <div data-lang="SQL" markdown="1">

--- a/docs/dev/table/common.md
+++ b/docs/dev/table/common.md
@@ -52,15 +52,15 @@ All Table API and SQL programs for batch and streaming follow the same pattern. 
 // create a TableEnvironment for specific planner batch or streaming
 TableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
 
-// register a Table
-tableEnv.registerTable("table1", ...)            // or
-tableEnv.registerTableSource("table2", ...);
+// create a (virtual) Table
+tableEnv.createTemporaryView("table1", ...)            // or
+tableEnv.connect(...).createTemporaryTable("table2");
 // register an output Table
-tableEnv.registerTableSink("outputTable", ...);
+tableEnv.connect(...).createTemporaryTable("outputTable");
 
-// create a Table from a Table API query
-Table tapiResult = tableEnv.scan("table1").select(...);
-// create a Table from a SQL query
+// create a Table API object from a Table API query
+Table tapiResult = tableEnv.from("table1").select(...);
+// create a Table API object from a SQL query
 Table sqlResult  = tableEnv.sqlQuery("SELECT ... FROM table2 ... ");
 
 // emit a Table API result Table to a TableSink, same for SQL result
@@ -79,13 +79,13 @@ tableEnv.execute("java_job");
 val tableEnv = ... // see "Create a TableEnvironment" section
 
 // register a Table
-tableEnv.registerTable("table1", ...)           // or
-tableEnv.registerTableSource("table2", ...)
+tableEnv.createTemporaryView("table1", ...)           // or
+tableEnv.connect(...).createTemporaryView("table2")
 // register an output Table
-tableEnv.registerTableSink("outputTable", ...);
+tableEnv.connect(...).createTemporaryView("outputTable")
 
 // create a Table from a Table API query
-val tapiResult = tableEnv.scan("table1").select(...)
+val tapiResult = tableEnv.from("table1").select(...)
 // create a Table from a SQL query
 val sqlResult  = tableEnv.sqlQuery("SELECT ... FROM table2 ...")
 
@@ -112,7 +112,7 @@ table_env.register_table_source("table2", ...)
 table_env.register_table_sink("outputTable", ...);
 
 # create a Table from a Table API query
-tapi_result = table_env.scan("table1").select(...)
+tapi_result = table_env.from_path("table1").select(...)
 # create a Table from a SQL query
 sql_result  = table_env.sql_query("SELECT ... FROM table2 ...")
 
@@ -292,25 +292,39 @@ b_b_t_env = BatchTableEnvironment.create(environment_settings=b_b_settings)
 
 **Note:** If there is only one planner jar in `/lib` directory, you can use `useAnyPlanner` (`use_any_planner` for python) to create specific `EnvironmentSettings`.
 
-
 {% top %}
 
-Register Tables in the Catalog
+Create Tables in the Catalog
 -------------------------------
 
-A `TableEnvironment` maintains a catalog of tables which are registered by name. There are two types of tables, *input tables* and *output tables*. Input tables can be referenced in Table API and SQL queries and provide input data. Output tables can be used to emit the result of a Table API or SQL query to an external system.
+A `TableEnvironment` maintains a map of catalogs of tables which are created with an identifier. Each
+identifier consists of 3 parts: catalog name, database name and object name. If a catalog or database was not
+specified current default value will be used (see examples in the [Table identifier expanding](#table-identifier-expanding) section).
 
-An input table can be registered from various sources:
+Tables can be either virtual (`VIEWS`) or regular(`TABLES`). `VIEWS` can be created e.g. from an an
+existing `Table` object, usually the result of a Table API or SQL query. `TABLES` describe an
+external data, such as a file, database, or messaging system.
 
-* an existing `Table` object, usually the result of a Table API or SQL query.
-* a `TableSource`, which accesses external data, such as a file, database, or messaging system. 
-* a `DataStream` or `DataSet` from a DataStream (only for stream job) or DataSet (only for batch job translated from old planner) program. Registering a `DataStream` or `DataSet` is discussed in the [Integration with DataStream and DataSet API](#integration-with-datastream-and-dataset-api) section.
+### Temporary vs permanent tables.
 
-An output table can be registered using a `TableSink`.
+Permanent tables are tables which meta information is stored in a [catalog]({{ site.baseurl }}/dev/table/catalogs.html). Usually
+it means it is persisted in an external metastore such as e.g. Hive. This implies that there must exist a serializable representation
+of such table. They will be available across multiple sessions/jobs as long as the connection to the metastore is maintained. 
 
-### Register a Table
+On the other hand temporary tables are always stored in memory and exist only for a single session/job.
+Temporary tables are not bound to any catalog or database. They can be created in a namespace of a catalog and database
+that does not exist. They are also not dropped if a corresponding database is removed.
+Moreover temporary tables can shadow permanent tables. It is possible to register a temporary table
+with exactly the same identifier as an existing permanent table. Such a permanent table becomes
+inaccessible as long as the temporary table exists. All queries with that identifier will be executed
+against the temporary table.
 
-A `Table` is registered in a `TableEnvironment` as follows:
+### Create a Table
+
+#### Virtual tables
+
+A `Table` API object corresponds to a `VIEW` (virtual table) in a SQL terms. It encapsulates a logical
+query plan. It can be created in a catalog as follows:
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -319,10 +333,10 @@ A `Table` is registered in a `TableEnvironment` as follows:
 TableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
 
 // table is the result of a simple projection query 
-Table projTable = tableEnv.scan("X").select(...);
+Table projTable = tableEnv.from("X").select(...);
 
 // register the Table projTable as table "projectedTable"
-tableEnv.registerTable("projectedTable", projTable);
+tableEnv.createTemporaryView("projectedTable", projTable);
 {% endhighlight %}
 </div>
 
@@ -332,10 +346,10 @@ tableEnv.registerTable("projectedTable", projTable);
 val tableEnv = ... // see "Create a TableEnvironment" section
 
 // table is the result of a simple projection query 
-val projTable: Table = tableEnv.scan("X").select(...)
+val projTable: Table = tableEnv.from("X").select(...)
 
 // register the Table projTable as table "projectedTable"
-tableEnv.registerTable("projectedTable", projTable)
+tableEnv.createTemporaryView("projectedTable", projTable)
 {% endhighlight %}
 </div>
 
@@ -345,7 +359,7 @@ tableEnv.registerTable("projectedTable", projTable)
 table_env = ... # see "Create a TableEnvironment" section
 
 # table is the result of a simple projection query 
-proj_table = table_env.scan("X").select(...)
+proj_table = table_env.from_path("X").select(...)
 
 # register the Table projTable as table "projectedTable"
 table_env.register_table("projectedTable", proj_table)
@@ -353,125 +367,131 @@ table_env.register_table("projectedTable", proj_table)
 </div>
 </div>
 
-**Note:** A registered `Table` is treated similarly to a `VIEW` as known from relational database systems, i.e., the query that defines the `Table` is not optimized but will be inlined when another query references the registered `Table`. If multiple queries reference the same registered `Table`, it will be inlined for each referencing query and executed multiple times, i.e., the result of the registered `Table` will *not* be shared.
+**Note:** A `Table` object similarly to a `VIEW` from relational database
+systems, i.e., the query that defines the `Table` is not optimized but will be inlined when another
+query references the registered `Table`. If multiple queries reference the same registered `Table`,
+it will be inlined for each referencing query and executed multiple times, i.e., the result of the
+registered `Table` will *not* be shared.
 
 {% top %}
 
-### Register a TableSource
+#### Connector tables
 
-A `TableSource` provides access to external data which is stored in a storage system such as a database (MySQL, HBase, ...), a file with a specific encoding (CSV, Apache \[Parquet, Avro, ORC\], ...), or a messaging system (Apache Kafka, RabbitMQ, ...). 
-
-Flink aims to provide TableSources for common data formats and storage systems. Please have a look at the [Table Sources and Sinks]({{ site.baseurl }}/dev/table/sourceSinks.html) page for a list of supported TableSources and instructions for how to build a custom `TableSource`.
-
-A `TableSource` is registered in a `TableEnvironment` as follows:
+It is also possible to create a `TABLE` as known from relational databases from a [connector]({{ site.baseurl }}/dev/table/connect.html) declaration.
+The connector describes the external system that stores the data of a table. Storage systems such as Apacha Kafka or a regular file system can be declared here.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-// get a TableEnvironment
-TableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
+tableEnvironment
+  .connect(...)
+  .withFormat(...)
+  .withSchema(...)
+  .inAppendMode()
+  .createTemporaryTable("MyTable")
+{% endhighlight %}
+</div>
 
-// create a TableSource
-TableSource csvSource = new CsvTableSource("/path/to/file", ...);
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+tableEnvironment
+  .connect(...)
+  .withFormat(...)
+  .withSchema(...)
+  .inAppendMode()
+  .createTemporaryTable("MyTable")
+{% endhighlight %}
+</div>
 
-// register the TableSource as table "CsvTable"
-tableEnv.registerTableSource("CsvTable", csvSource);
+<div data-lang="python" markdown="1">
+{% highlight python %}
+table_environment \
+    .connect(...) \
+    .with_format(...) \
+    .with_schema(...) \
+    .in_append_mode() \
+    .create_temporary_table("MyTable")
+{% endhighlight %}
+</div>
+
+<div data-lang="DDL" markdown="1">
+{% highlight sql %}
+tableEnvironment.sqlUpdate("CREATE [TEMPORARY] TABLE MyTable (...) WITH (...)")
+{% endhighlight %}
+</div>
+</div>
+
+### Expanding table identifiers
+
+Tables are always registered with a 3 part identifiers consisting of catalog name, database name and
+table name. The first two parts are optional. If they are not provided the current default values will
+be used. Identifiers follow SQL requirements. That means that they can be escaped with ``` character.
+Additionally all SQL reserved keywords must be escaped.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+TableEnvironment tEnv = ...;
+tEnv.useCatalog("default_catalog");
+tEnv.useDatabase("default_database");
+
+Table table = ...;
+
+// register the view named 'exampleView' in the catalog named 'default_catalog'
+// in the database named 'default_database' 
+tableEnv.createTemporaryView("exampleView", table);
+
+// register the view named 'exampleView' in the catalog named 'default_catalog'
+// in the database named 'other_database' 
+tableEnv.createTemporaryView("other_database.exampleView", table);
+
+// register the view named 'View' in the catalog named 'default_catalog' in the
+// database named 'default_database'. 'View' is a reserved keyword and must be escaped.  
+tableEnv.createTemporaryView("`View`", table);
+
+// register the view named 'example.View' in the catalog named 'default_catalog'
+// in the database named 'default_database' 
+tableEnv.createTemporaryView("`example.View`", table);
+
+// register the view named 'exampleView' in the catalog named 'other_catalog'
+// in the database named 'other_database' 
+tableEnv.createTemporaryView("other_catalog.other_database.exampleView", table);
+
 {% endhighlight %}
 </div>
 
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 // get a TableEnvironment
-val tableEnv = ... // see "Create a TableEnvironment" section
+val tEnv: TableEnvironment = ...;
+tEnv.useCatalog("default_catalog")
+tEnv.useDatabase("default_database")
 
-// create a TableSource
-val csvSource: TableSource = new CsvTableSource("/path/to/file", ...)
+val table: Table = ...;
 
-// register the TableSource as table "CsvTable"
-tableEnv.registerTableSource("CsvTable", csvSource)
+// register the view named 'exampleView' in the catalog named 'default_catalog'
+// in the database named 'default_database' 
+tableEnv.createTemporaryView("exampleView", table)
+
+// register the view named 'exampleView' in the catalog named 'default_catalog'
+// in the database named 'other_database' 
+tableEnv.createTemporaryView("other_database.exampleView", table)
+
+// register the view named 'View' in the catalog named 'default_catalog' in the
+// database named 'default_database'. 'View' is a reserved keyword and must be escaped.  
+tableEnv.createTemporaryView("`View`", table)
+
+// register the view named 'example.View' in the catalog named 'default_catalog'
+// in the database named 'default_database' 
+tableEnv.createTemporaryView("`example.View`", table)
+
+// register the view named 'exampleView' in the catalog named 'other_catalog'
+// in the database named 'other_database' 
+tableEnv.createTemporaryView("other_catalog.other_database.exampleView", table)
 {% endhighlight %}
 </div>
 
-<div data-lang="python" markdown="1">
-{% highlight python %}
-# get a TableEnvironment
-table_env = ... # see "Create a TableEnvironment" section
-
-# create a TableSource
-csv_source = CsvTableSource("/path/to/file", ...)
-
-# register the TableSource as table "csvTable"
-table_env.register_table_source("csvTable", csv_source)
-{% endhighlight %}
 </div>
-</div>
-
-**Note:** A `TableEnvironment` used for Blink planner only accepts `StreamTableSource`, `LookupableTableSource` and `InputFormatTableSource`, and a `StreamTableSource` used for Blink planner on batch must be bounded.
-
-{% top %}
-
-### Register a TableSink
-
-A registered `TableSink` can be used to [emit the result of a Table API or SQL query](common.html#emit-a-table) to an external storage system, such as a database, key-value store, message queue, or file system (in different encodings, e.g., CSV, Apache \[Parquet, Avro, ORC\], ...).
-
-Flink aims to provide TableSinks for common data formats and storage systems. Please see the documentation about [Table Sources and Sinks]({{ site.baseurl }}/dev/table/sourceSinks.html) page for details about available sinks and instructions for how to implement a custom `TableSink`.
-
-A `TableSink` is registered in a `TableEnvironment` as follows:
-
-<div class="codetabs" markdown="1">
-<div data-lang="java" markdown="1">
-{% highlight java %}
-// get a TableEnvironment
-TableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
-
-// create a TableSink
-TableSink csvSink = new CsvTableSink("/path/to/file", ...);
-
-// define the field names and types
-String[] fieldNames = {"a", "b", "c"};
-TypeInformation[] fieldTypes = {Types.INT, Types.STRING, Types.LONG};
-
-// register the TableSink as table "CsvSinkTable"
-tableEnv.registerTableSink("CsvSinkTable", fieldNames, fieldTypes, csvSink);
-{% endhighlight %}
-</div>
-
-<div data-lang="scala" markdown="1">
-{% highlight scala %}
-// get a TableEnvironment
-val tableEnv = ... // see "Create a TableEnvironment" section
-
-// create a TableSink
-val csvSink: TableSink = new CsvTableSink("/path/to/file", ...)
-
-// define the field names and types
-val fieldNames: Array[String] = Array("a", "b", "c")
-val fieldTypes: Array[TypeInformation[_]] = Array(Types.INT, Types.STRING, Types.LONG)
-
-// register the TableSink as table "CsvSinkTable"
-tableEnv.registerTableSink("CsvSinkTable", fieldNames, fieldTypes, csvSink)
-{% endhighlight %}
-</div>
-
-<div data-lang="python" markdown="1">
-{% highlight python %}
-# get a TableEnvironment
-table_env = ... # see "Create a TableEnvironment" section
-
-# define the field names and types
-field_names = ["a", "b", "c"]
-field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.BIGINT()]
-
-# create a TableSink
-csv_sink = CsvTableSink(field_names, field_types, "/path/to/file", ...)
-
-# register the TableSink as table "CsvSinkTable"
-table_env.register_table_sink("CsvSinkTable", csv_sink)
-{% endhighlight %}
-</div>
-</div>
-
-{% top %}
 
 Query a Table
 -------------
@@ -495,7 +515,7 @@ TableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
 // register Orders table
 
 // scan registered Orders table
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 // compute revenue for all customers from France
 Table revenue = orders
   .filter("cCountry === 'FRANCE'")
@@ -515,7 +535,7 @@ val tableEnv = ... // see "Create a TableEnvironment" section
 // register Orders table
 
 // scan registered Orders table
-val orders = tableEnv.scan("Orders")
+val orders = tableEnv.from("Orders")
 // compute revenue for all customers from France
 val revenue = orders
   .filter('cCountry === "FRANCE")
@@ -537,7 +557,7 @@ table_env = # see "Create a TableEnvironment" section
 # register Orders table
 
 # scan registered Orders table
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 # compute revenue for all customers from France
 revenue = orders \
     .filter("cCountry === 'FRANCE'") \
@@ -721,13 +741,16 @@ The following examples shows how to emit a `Table`:
 // get a TableEnvironment
 TableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
 
-// create a TableSink
-TableSink sink = new CsvTableSink("/path/to/file", fieldDelim = "|");
+// create an output Table
+final Schema schema = new Schema()
+    .field("a", DataTypes.INT())
+    .field("b", DataTypes.STRING())
+    .field("c", DataTypes.LONG());
 
-// register the TableSink with a specific schema
-String[] fieldNames = {"a", "b", "c"};
-TypeInformation[] fieldTypes = {Types.INT, Types.STRING, Types.LONG};
-tableEnv.registerTableSink("CsvSinkTable", fieldNames, fieldTypes, sink);
+tableEnv.connect(new FileSystem("/path/to/file"))
+    .withFormat(new Csv().fieldDelimiter('|').deriveSchema())
+    .withSchema(schema)
+    .createTemporaryTable("CsvSinkTable");
 
 // compute a result Table using Table API operators and/or SQL queries
 Table result = ...
@@ -743,13 +766,16 @@ result.insertInto("CsvSinkTable");
 // get a TableEnvironment
 val tableEnv = ... // see "Create a TableEnvironment" section
 
-// create a TableSink
-val sink: TableSink = new CsvTableSink("/path/to/file", fieldDelim = "|")
+// create an output Table
+val schema = new Schema()
+    .field("a", DataTypes.INT())
+    .field("b", DataTypes.STRING())
+    .field("c", DataTypes.LONG())
 
-// register the TableSink with a specific schema
-val fieldNames: Array[String] = Array("a", "b", "c")
-val fieldTypes: Array[TypeInformation] = Array(Types.INT, Types.STRING, Types.LONG)
-tableEnv.registerTableSink("CsvSinkTable", fieldNames, fieldTypes, sink)
+tableEnv.connect(new FileSystem("/path/to/file"))
+    .withFormat(new Csv().fieldDelimiter('|').deriveSchema())
+    .withSchema(schema)
+    .createTemporaryTable("CsvSinkTable")
 
 // compute a result Table using Table API operators and/or SQL queries
 val result: Table = ...
@@ -766,13 +792,16 @@ result.insertInto("CsvSinkTable")
 # get a TableEnvironment
 table_env = ... # see "Create a TableEnvironment" section
 
-field_names = ["a", "b", "c"]
-field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.BIGINT()]
-
 # create a TableSink
-sink = CsvTableSink(field_names, field_types, "/path/to/file", "|")
-
-table_env.register_table_sink("CsvSinkTable", sink)
+t_env.connect(FileSystem().path("/path/to/file")))
+    .with_format(Csv()
+                 .field_delimiter(',')
+                 .deriveSchema())
+    .with_schema(Schema()
+                 .field("a", DataTypes.INT())
+                 .field("b", DataTypes.STRING())
+                 .field("c", DataTypes.BIGINT()))
+    .create_temporary_table("CsvSinkTable")
 
 # compute a result Table using Table API operators and/or SQL queries
 result = ...
@@ -847,9 +876,9 @@ This interaction can be achieved by converting a `DataStream` or `DataSet` into 
 
 The Scala Table API features implicit conversions for the `DataSet`, `DataStream`, and `Table` classes. These conversions are enabled by importing the package `org.apache.flink.table.api.scala._` in addition to `org.apache.flink.api.scala._` for the Scala DataStream API.
 
-### Register a DataStream or DataSet as Table
+### Creates a View from a DataStream or DataSet
 
-A `DataStream` or `DataSet` can be registered in a `TableEnvironment` as a Table. The schema of the resulting table depends on the data type of the registered `DataStream` or `DataSet`. Please check the section about [mapping of data types to table schema](#mapping-of-data-types-to-table-schema) for details.
+A `DataStream` or `DataSet` can be registered in a `TableEnvironment` as a View. The schema of the resulting view depends on the data type of the registered `DataStream` or `DataSet`. Please check the section about [mapping of data types to table schema](#mapping-of-data-types-to-table-schema) for details.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -860,11 +889,11 @@ StreamTableEnvironment tableEnv = ...; // see "Create a TableEnvironment" sectio
 
 DataStream<Tuple2<Long, String>> stream = ...
 
-// register the DataStream as Table "myTable" with fields "f0", "f1"
-tableEnv.registerDataStream("myTable", stream);
+// register the DataStream as View "myTable" with fields "f0", "f1"
+tableEnv.createTemporaryView("myTable", stream);
 
-// register the DataStream as table "myTable2" with fields "myLong", "myString"
-tableEnv.registerDataStream("myTable2", stream, "myLong, myString");
+// register the DataStream as View "myTable2" with fields "myLong", "myString"
+tableEnv.createTemporaryView("myTable2", stream, "myLong, myString");
 {% endhighlight %}
 </div>
 
@@ -876,16 +905,14 @@ val tableEnv: StreamTableEnvironment = ... // see "Create a TableEnvironment" se
 
 val stream: DataStream[(Long, String)] = ...
 
-// register the DataStream as Table "myTable" with fields "f0", "f1"
-tableEnv.registerDataStream("myTable", stream)
+// register the DataStream as View "myTable" with fields "f0", "f1"
+tableEnv.createTemporaryView("myTable", stream)
 
-// register the DataStream as table "myTable2" with fields "myLong", "myString"
-tableEnv.registerDataStream("myTable2", stream, 'myLong, 'myString)
+// register the DataStream as View "myTable2" with fields "myLong", "myString"
+tableEnv.createTemporaryView("myTable2", stream, 'myLong, 'myString)
 {% endhighlight %}
 </div>
 </div>
-
-**Note:** The name of a `DataStream` `Table` must not match the `^_DataStreamTable_[0-9]+` pattern and the name of a `DataSet` `Table` must not match the `^_DataSetTable_[0-9]+` pattern. These patterns are reserved for internal use only.
 
 {% top %}
 
@@ -1601,17 +1628,31 @@ The following code shows an example and the corresponding output for multiple-si
 EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
 TableEnvironment tEnv = TableEnvironment.create(settings);
 
-String[] fieldNames = { "count", "word" };
-TypeInformation[] fieldTypes = { Types.INT, Types.STRING };
-tEnv.registerTableSource("MySource1", new CsvTableSource("/source/path1", fieldNames, fieldTypes));
-tEnv.registerTableSource("MySource2", new CsvTableSource("/source/path2", fieldNames, fieldTypes));
-tEnv.registerTableSink("MySink1", new CsvTableSink("/sink/path1").configure(fieldNames, fieldTypes));
-tEnv.registerTableSink("MySink2", new CsvTableSink("/sink/path2").configure(fieldNames, fieldTypes));
+final Schema schema = new Schema()
+    .field("count", DataTypes.INT())
+    .field("word", DataTypes.STRING());
 
-Table table1 = tEnv.scan("MySource1").where("LIKE(word, 'F%')");
+tEnv.connect(new FileSystem("/source/path1"))
+    .withFormat(new Csv().deriveSchema())
+    .withSchema(schema)
+    .createTemporaryTable("MySource1");
+tEnv.connect(new FileSystem("/source/path2"))
+    .withFormat(new Csv().deriveSchema())
+    .withSchema(schema)
+    .createTemporaryTable("MySource2");
+tEnv.connect(new FileSystem("/sink/path1"))
+    .withFormat(new Csv().deriveSchema())
+    .withSchema(schema)
+    .createTemporaryTable("MySink1");
+tEnv.connect(new FileSystem("/sink/path2"))
+    .withFormat(new Csv().deriveSchema())
+    .withSchema(schema)
+    .createTemporaryTable("MySink2");
+
+Table table1 = tEnv.from("MySource1").where("LIKE(word, 'F%')");
 table1.insertInto("MySink1");
 
-Table table2 = table1.unionAll(tEnv.scan("MySource2"));
+Table table2 = table1.unionAll(tEnv.from("MySource2"));
 table2.insertInto("MySink2");
 
 String explanation = tEnv.explain(false);
@@ -1625,17 +1666,31 @@ System.out.println(explanation);
 val settings = EnvironmentSettings.newInstance.useBlinkPlanner.inStreamingMode.build
 val tEnv = TableEnvironment.create(settings)
 
-val fieldNames = Array("count", "word")
-val fieldTypes = Array[TypeInformation[_]](Types.INT, Types.STRING)
-tEnv.registerTableSource("MySource1", new CsvTableSource("/source/path1", fieldNames, fieldTypes))
-tEnv.registerTableSource("MySource2", new CsvTableSource("/source/path2",fieldNames, fieldTypes))
-tEnv.registerTableSink("MySink1", new CsvTableSink("/sink/path1").configure(fieldNames, fieldTypes))
-tEnv.registerTableSink("MySink2", new CsvTableSink("/sink/path2").configure(fieldNames, fieldTypes))
+val schema = new Schema()
+    .field("count", DataTypes.INT())
+    .field("word", DataTypes.STRING())
 
-val table1 = tEnv.scan("MySource1").where("LIKE(word, 'F%')")
+tEnv.connect(new FileSystem("/source/path1"))
+    .withFormat(new Csv().deriveSchema())
+    .withSchema(schema)
+    .createTemporaryTable("MySource1")
+tEnv.connect(new FileSystem("/source/path2"))
+    .withFormat(new Csv().deriveSchema())
+    .withSchema(schema)
+    .createTemporaryTable("MySource2")
+tEnv.connect(new FileSystem("/sink/path1"))
+    .withFormat(new Csv().deriveSchema())
+    .withSchema(schema)
+    .createTemporaryTable("MySink1")
+tEnv.connect(new FileSystem("/sink/path2"))
+    .withFormat(new Csv().deriveSchema())
+    .withSchema(schema)
+    .createTemporaryTable("MySink2")
+
+val table1 = tEnv.from("MySource1").where("LIKE(word, 'F%')")
 table1.insertInto("MySink1")
 
-val table2 = table1.unionAll(tEnv.scan("MySource2"))
+val table2 = table1.unionAll(tEnv.from("MySource2"))
 table2.insertInto("MySink2")
 
 val explanation = tEnv.explain(false)
@@ -1649,17 +1704,31 @@ println(explanation)
 settings = EnvironmentSettings.new_instance().use_blink_planner().in_streaming_mode().build()
 t_env = TableEnvironment.create(environment_settings=settings)
 
-field_names = ["count", "word"]
-field_types = [DataTypes.INT(), DataTypes.STRING()]
-t_env.register_table_source("MySource1", CsvTableSource("/source/path1", field_names, field_types))
-t_env.register_table_source("MySource2", CsvTableSource("/source/path2", field_names, field_types))
-t_env.register_table_sink("MySink1", CsvTableSink("/sink/path1", field_names, field_types))
-t_env.register_table_sink("MySink2", CsvTableSink("/sink/path2", field_names, field_types))
+schema = Schema()
+    .field("count", DataTypes.INT())
+    .field("word", DataTypes.STRING())
 
-table1 = t_env.scan("MySource1").where("LIKE(word, 'F%')")
+t_env.connect(FileSystem().path("/source/path1")))
+    .with_format(Csv().deriveSchema())
+    .with_schema(schema)
+    .create_temporary_table("MySource1")
+t_env.connect(FileSystem().path("/source/path2")))
+    .with_format(Csv().deriveSchema())
+    .with_schema(schema)
+    .create_temporary_table("MySource2")
+t_env.connect(FileSystem().path("/sink/path1")))
+    .with_format(Csv().deriveSchema())
+    .with_schema(schema)
+    .create_temporary_table("MySink1")
+t_env.connect(FileSystem().path("/sink/path2")))
+    .with_format(Csv().deriveSchema())
+    .with_schema(schema)
+    .create_temporary_table("MySink2")
+
+table1 = t_env.from_path("MySource1").where("LIKE(word, 'F%')")
 table1.insert_into("MySink1")
 
-table2 = table1.union_all(t_env.scan("MySource2"))
+table2 = table1.union_all(t_env.from_path("MySource2"))
 table2.insert_into("MySink2")
 
 explanation = t_env.explain()

--- a/docs/dev/table/common.zh.md
+++ b/docs/dev/table/common.zh.md
@@ -52,16 +52,15 @@ All Table API and SQL programs for batch and streaming follow the same pattern. 
 // create a TableEnvironment for specific planner batch or streaming
 TableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
 
-// create a (virtual) Table
-tableEnv.createTemporaryView("table1", ...)            // or
-tableEnv.connect(...).createTemporaryTable("table2");
+// create a Table
+tableEnv.connect(...).createTemporaryTable("table1");
 // register an output Table
 tableEnv.connect(...).createTemporaryTable("outputTable");
 
-// create a Table API object from a Table API query
+// create a Table object from a Table API query
 Table tapiResult = tableEnv.from("table1").select(...);
-// create a Table API object from a SQL query
-Table sqlResult  = tableEnv.sqlQuery("SELECT ... FROM table2 ... ");
+// create a Table object from a SQL query
+Table sqlResult  = tableEnv.sqlQuery("SELECT ... FROM table1 ... ");
 
 // emit a Table API result Table to a TableSink, same for SQL result
 tapiResult.insertInto("outputTable");
@@ -78,16 +77,15 @@ tableEnv.execute("java_job");
 // create a TableEnvironment for specific planner batch or streaming
 val tableEnv = ... // see "Create a TableEnvironment" section
 
-// register a Table
-tableEnv.createTemporaryView("table1", ...)           // or
-tableEnv.connect(...).createTemporaryView("table2")
+// create a Table
+tableEnv.connect(...).createTemporaryTable("table1")
 // register an output Table
-tableEnv.connect(...).createTemporaryView("outputTable")
+tableEnv.connect(...).createTemporaryTable("outputTable")
 
 // create a Table from a Table API query
 val tapiResult = tableEnv.from("table1").select(...)
 // create a Table from a SQL query
-val sqlResult  = tableEnv.sqlQuery("SELECT ... FROM table2 ...")
+val sqlResult  = tableEnv.sqlQuery("SELECT ... FROM table1 ...")
 
 // emit a Table API result Table to a TableSink, same for SQL result
 tapiResult.insertInto("outputTable")
@@ -105,16 +103,15 @@ tableEnv.execute("scala_job")
 table_env = ... # see "Create a TableEnvironment" section
 
 # register a Table
-table_env.register_table("table1", ...)           # or
-table_env.register_table_source("table2", ...)
+table_env.connect(...).create_temporary_table("table1")
 
 # register an output Table
-table_env.register_table_sink("outputTable", ...);
+table_env.connect(...).create_temporary_table("outputTable")
 
 # create a Table from a Table API query
 tapi_result = table_env.from_path("table1").select(...)
 # create a Table from a SQL query
-sql_result  = table_env.sql_query("SELECT ... FROM table2 ...")
+sql_result  = table_env.sql_query("SELECT ... FROM table1 ...")
 
 # emit a Table API result Table to a TableSink, same for SQL result
 tapi_result.insert_into("outputTable")
@@ -298,30 +295,42 @@ Create Tables in the Catalog
 -------------------------------
 
 A `TableEnvironment` maintains a map of catalogs of tables which are created with an identifier. Each
-identifier consists of 3 parts: catalog name, database name and object name. If a catalog or database was not
-specified current default value will be used (see examples in the [Table identifier expanding](#table-identifier-expanding) section).
+identifier consists of 3 parts: catalog name, database name and object name. If a catalog or database is not
+specified, the current default value will be used (see examples in the [Table identifier expanding](#table-identifier-expanding) section).
 
-Tables can be either virtual (`VIEWS`) or regular(`TABLES`). `VIEWS` can be created e.g. from an an
-existing `Table` object, usually the result of a Table API or SQL query. `TABLES` describe an
-external data, such as a file, database, or messaging system.
+Tables can be either virtual (`VIEWS`) or regular (`TABLES`). `VIEWS` can be created from an
+existing `Table` object, usually the result of a Table API or SQL query. `TABLES` describe
+external data, such as a file, database table, or message queue.
 
-### Temporary vs permanent tables.
+### Temporary vs Permanent tables.
 
-Permanent tables are tables which meta information is stored in a [catalog]({{ site.baseurl }}/dev/table/catalogs.html). Usually
-it means it is persisted in an external metastore such as e.g. Hive. This implies that there must exist a serializable representation
-of such table. They will be available across multiple sessions/jobs as long as the connection to the metastore is maintained. 
+Tables may either be temporary, and tied to the lifecycle of a single Flink session, or permanent,
+and visible across multiple Flink sessions and clusters.
 
-On the other hand temporary tables are always stored in memory and exist only for a single session/job.
-Temporary tables are not bound to any catalog or database. They can be created in a namespace of a catalog and database
-that does not exist. They are also not dropped if a corresponding database is removed.
-Moreover temporary tables can shadow permanent tables. It is possible to register a temporary table
-with exactly the same identifier as an existing permanent table. Such a permanent table becomes
-inaccessible as long as the temporary table exists. All queries with that identifier will be executed
-against the temporary table.
+Permanent tables require a [catalog]({{ site.baseurl }}/dev/table/catalogs.html) (such as Hive Metastore)
+to maintain metadata about the table. Once a permanent table is created, it is visible to any Flink
+session that is connected to the catalog and will continue to exist until the table is explicitly
+dropped.
+
+On the other hand, temporary tables are always stored in memory and only exist for the duration of
+the Flink session they are created within. These tables are not visible to other sessions. They are
+not bound to any catalog or database but can be created in the namespace of one. Temporary tables
+are not dropped if their corresponding database is removed.
+
+#### Shadowing
+
+It is possible to register a temporary table with the same identifier as an existing permanent
+table. The temporary table shadows the permanent one and makes the permanent table inaccessible as
+long as the temporary one exists. All queries with that identifier will be executed against the
+temporary table.
+
+This might be useful for experimentation. It allows running exactly the same query first against a
+temporary table that e.g. has just a subset of data, or the data is obfuscated. Once verified that
+the query is correct it can be run against the real production table.
 
 ### Create a Table
 
-#### Virtual tables
+#### Virtual Tables
 
 A `Table` API object corresponds to a `VIEW` (virtual table) in a SQL terms. It encapsulates a logical
 query plan. It can be created in a catalog as follows:
@@ -367,7 +376,7 @@ table_env.register_table("projectedTable", proj_table)
 </div>
 </div>
 
-**Note:** A `Table` object similarly to a `VIEW` from relational database
+**Note:** `Table` objects are similar to `VIEW`'s from relational database
 systems, i.e., the query that defines the `Table` is not optimized but will be inlined when another
 query references the registered `Table`. If multiple queries reference the same registered `Table`,
 it will be inlined for each referencing query and executed multiple times, i.e., the result of the
@@ -375,7 +384,7 @@ registered `Table` will *not* be shared.
 
 {% top %}
 
-#### Connector tables
+#### Connector Tables
 
 It is also possible to create a `TABLE` as known from relational databases from a [connector]({{ site.baseurl }}/dev/table/connect.html) declaration.
 The connector describes the external system that stores the data of a table. Storage systems such as Apacha Kafka or a regular file system can be declared here.
@@ -421,36 +430,36 @@ tableEnvironment.sqlUpdate("CREATE [TEMPORARY] TABLE MyTable (...) WITH (...)")
 </div>
 </div>
 
-### Expanding table identifiers
+### Expanding Table identifiers
 
-Tables are always registered with a 3 part identifiers consisting of catalog name, database name and
-table name. The first two parts are optional. If they are not provided the current default values will
-be used. Identifiers follow SQL requirements. That means that they can be escaped with ``` character.
+Tables are always registered with a 3 part identifier consisting of catalog, database, and
+table name. The first two parts are optional and if they are not provided the set default values will
+be used. Identifiers follow SQL requirements which means that they can be escaped with a backtick character (`` ` ``).
 Additionally all SQL reserved keywords must be escaped.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
 TableEnvironment tEnv = ...;
-tEnv.useCatalog("default_catalog");
-tEnv.useDatabase("default_database");
+tEnv.useCatalog("custom_catalog");
+tEnv.useDatabase("custom_database");
 
 Table table = ...;
 
-// register the view named 'exampleView' in the catalog named 'default_catalog'
-// in the database named 'default_database' 
+// register the view named 'exampleView' in the catalog named 'custom_catalog'
+// in the database named 'custom_database' 
 tableEnv.createTemporaryView("exampleView", table);
 
-// register the view named 'exampleView' in the catalog named 'default_catalog'
+// register the view named 'exampleView' in the catalog named 'custom_catalog'
 // in the database named 'other_database' 
 tableEnv.createTemporaryView("other_database.exampleView", table);
 
-// register the view named 'View' in the catalog named 'default_catalog' in the
-// database named 'default_database'. 'View' is a reserved keyword and must be escaped.  
+// register the view named 'View' in the catalog named 'custom_catalog' in the
+// database named 'custom_database'. 'View' is a reserved keyword and must be escaped.  
 tableEnv.createTemporaryView("`View`", table);
 
-// register the view named 'example.View' in the catalog named 'default_catalog'
-// in the database named 'default_database' 
+// register the view named 'example.View' in the catalog named 'custom_catalog'
+// in the database named 'custom_database' 
 tableEnv.createTemporaryView("`example.View`", table);
 
 // register the view named 'exampleView' in the catalog named 'other_catalog'
@@ -464,25 +473,25 @@ tableEnv.createTemporaryView("other_catalog.other_database.exampleView", table);
 {% highlight scala %}
 // get a TableEnvironment
 val tEnv: TableEnvironment = ...;
-tEnv.useCatalog("default_catalog")
-tEnv.useDatabase("default_database")
+tEnv.useCatalog("custom_catalog")
+tEnv.useDatabase("custom_database")
 
 val table: Table = ...;
 
-// register the view named 'exampleView' in the catalog named 'default_catalog'
-// in the database named 'default_database' 
+// register the view named 'exampleView' in the catalog named 'custom_catalog'
+// in the database named 'custom_database' 
 tableEnv.createTemporaryView("exampleView", table)
 
-// register the view named 'exampleView' in the catalog named 'default_catalog'
+// register the view named 'exampleView' in the catalog named 'custom_catalog'
 // in the database named 'other_database' 
 tableEnv.createTemporaryView("other_database.exampleView", table)
 
-// register the view named 'View' in the catalog named 'default_catalog' in the
-// database named 'default_database'. 'View' is a reserved keyword and must be escaped.  
+// register the view named 'View' in the catalog named 'custom_catalog' in the
+// database named 'custom_database'. 'View' is a reserved keyword and must be escaped.  
 tableEnv.createTemporaryView("`View`", table)
 
-// register the view named 'example.View' in the catalog named 'default_catalog'
-// in the database named 'default_database' 
+// register the view named 'example.View' in the catalog named 'custom_catalog'
+// in the database named 'custom_database' 
 tableEnv.createTemporaryView("`example.View`", table)
 
 // register the view named 'exampleView' in the catalog named 'other_catalog'
@@ -792,9 +801,6 @@ result.insertInto("CsvSinkTable")
 # get a TableEnvironment
 table_env = ... # see "Create a TableEnvironment" section
 
-field_names = ["a", "b", "c"]
-field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.BIGINT()]
-
 # create a TableSink
 t_env.connect(FileSystem().path("/path/to/file")))
     .with_format(Csv()
@@ -879,9 +885,11 @@ This interaction can be achieved by converting a `DataStream` or `DataSet` into 
 
 The Scala Table API features implicit conversions for the `DataSet`, `DataStream`, and `Table` classes. These conversions are enabled by importing the package `org.apache.flink.table.api.scala._` in addition to `org.apache.flink.api.scala._` for the Scala DataStream API.
 
-### Creates a View from a DataStream or DataSet
+### Create a View from a DataStream or DataSet
 
 A `DataStream` or `DataSet` can be registered in a `TableEnvironment` as a View. The schema of the resulting view depends on the data type of the registered `DataStream` or `DataSet`. Please check the section about [mapping of data types to table schema](#mapping-of-data-types-to-table-schema) for details.
+
+**Note:** Views created from a `DataStream` or `DataSet` can be registered as temporary views only.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">

--- a/docs/dev/table/common.zh.md
+++ b/docs/dev/table/common.zh.md
@@ -1,5 +1,5 @@
 ---
-title: "概念与通用 API"
+title: "Concepts & Common API"
 nav-parent_id: tableapi
 nav-pos: 0
 ---
@@ -30,8 +30,8 @@ The Table API and SQL are integrated in a joint API. The central concept of this
 Main Differences Between the Two Planners
 -----------------------------------------
 
-1. Blink treats batch jobs as a special case of streaming. As such, the conversion between Table and DataSet is not supported, and batch jobs will not be translated into `DateSet` programs but translated into `DataStream` programs, the same as the streaming jobs.
-2. The Blink planner does not support `BatchTableSource`, uses bounded `StreamTableSource` instead of it.
+1. Blink treats batch jobs as a special case of streaming. As such, the conversion between Table and DataSet is also not supported, and batch jobs will not be translated into `DateSet` programs but translated into `DataStream` programs, the same as the streaming jobs.
+2. The Blink planner does not support `BatchTableSource`, use bounded `StreamTableSource` instead of it.
 3. The Blink planner only support the brand new `Catalog` and does not support `ExternalCatalog` which is deprecated.
 4. The implementations of `FilterableTableSource` for the old planner and the Blink planner are incompatible. The old planner will push down `PlannerExpression`s into `FilterableTableSource`, while the Blink planner will push down `Expression`s.
 5. String based key-value config options (Please see the documentation about [Configuration]({{ site.baseurl }}/dev/table/config.html) for details) are only used for the Blink planner.
@@ -52,15 +52,15 @@ All Table API and SQL programs for batch and streaming follow the same pattern. 
 // create a TableEnvironment for specific planner batch or streaming
 TableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
 
-// register a Table
-tableEnv.registerTable("table1", ...)            // or
-tableEnv.registerTableSource("table2", ...);
+// create a (virtual) Table
+tableEnv.createTemporaryView("table1", ...)            // or
+tableEnv.connect(...).createTemporaryTable("table2");
 // register an output Table
-tableEnv.registerTableSink("outputTable", ...);
+tableEnv.connect(...).createTemporaryTable("outputTable");
 
-// create a Table from a Table API query
-Table tapiResult = tableEnv.scan("table1").select(...);
-// create a Table from a SQL query
+// create a Table API object from a Table API query
+Table tapiResult = tableEnv.from("table1").select(...);
+// create a Table API object from a SQL query
 Table sqlResult  = tableEnv.sqlQuery("SELECT ... FROM table2 ... ");
 
 // emit a Table API result Table to a TableSink, same for SQL result
@@ -79,13 +79,13 @@ tableEnv.execute("java_job");
 val tableEnv = ... // see "Create a TableEnvironment" section
 
 // register a Table
-tableEnv.registerTable("table1", ...)           // or
-tableEnv.registerTableSource("table2", ...)
+tableEnv.createTemporaryView("table1", ...)           // or
+tableEnv.connect(...).createTemporaryView("table2")
 // register an output Table
-tableEnv.registerTableSink("outputTable", ...);
+tableEnv.connect(...).createTemporaryView("outputTable")
 
 // create a Table from a Table API query
-val tapiResult = tableEnv.scan("table1").select(...)
+val tapiResult = tableEnv.from("table1").select(...)
 // create a Table from a SQL query
 val sqlResult  = tableEnv.sqlQuery("SELECT ... FROM table2 ...")
 
@@ -112,7 +112,7 @@ table_env.register_table_source("table2", ...)
 table_env.register_table_sink("outputTable", ...);
 
 # create a Table from a Table API query
-tapi_result = table_env.scan("table1").select(...)
+tapi_result = table_env.from_path("table1").select(...)
 # create a Table from a SQL query
 sql_result  = table_env.sql_query("SELECT ... FROM table2 ...")
 
@@ -292,25 +292,39 @@ b_b_t_env = BatchTableEnvironment.create(environment_settings=b_b_settings)
 
 **Note:** If there is only one planner jar in `/lib` directory, you can use `useAnyPlanner` (`use_any_planner` for python) to create specific `EnvironmentSettings`.
 
-
 {% top %}
 
-Register Tables in the Catalog
+Create Tables in the Catalog
 -------------------------------
 
-A `TableEnvironment` maintains a catalog of tables which are registered by name. There are two types of tables, *input tables* and *output tables*. Input tables can be referenced in Table API and SQL queries and provide input data. Output tables can be used to emit the result of a Table API or SQL query to an external system.
+A `TableEnvironment` maintains a map of catalogs of tables which are created with an identifier. Each
+identifier consists of 3 parts: catalog name, database name and object name. If a catalog or database was not
+specified current default value will be used (see examples in the [Table identifier expanding](#table-identifier-expanding) section).
 
-An input table can be registered from various sources:
+Tables can be either virtual (`VIEWS`) or regular(`TABLES`). `VIEWS` can be created e.g. from an an
+existing `Table` object, usually the result of a Table API or SQL query. `TABLES` describe an
+external data, such as a file, database, or messaging system.
 
-* an existing `Table` object, usually the result of a Table API or SQL query.
-* a `TableSource`, which accesses external data, such as a file, database, or messaging system. 
-* a `DataStream` or `DataSet` from a DataStream (only for stream job) or DataSet (only for batch job translated from old planner) program. Registering a `DataStream` or `DataSet` is discussed in the [Integration with DataStream and DataSet API](#integration-with-datastream-and-dataset-api) section.
+### Temporary vs permanent tables.
 
-An output table can be registered using a `TableSink`.
+Permanent tables are tables which meta information is stored in a [catalog]({{ site.baseurl }}/dev/table/catalogs.html). Usually
+it means it is persisted in an external metastore such as e.g. Hive. This implies that there must exist a serializable representation
+of such table. They will be available across multiple sessions/jobs as long as the connection to the metastore is maintained. 
 
-### Register a Table
+On the other hand temporary tables are always stored in memory and exist only for a single session/job.
+Temporary tables are not bound to any catalog or database. They can be created in a namespace of a catalog and database
+that does not exist. They are also not dropped if a corresponding database is removed.
+Moreover temporary tables can shadow permanent tables. It is possible to register a temporary table
+with exactly the same identifier as an existing permanent table. Such a permanent table becomes
+inaccessible as long as the temporary table exists. All queries with that identifier will be executed
+against the temporary table.
 
-A `Table` is registered in a `TableEnvironment` as follows:
+### Create a Table
+
+#### Virtual tables
+
+A `Table` API object corresponds to a `VIEW` (virtual table) in a SQL terms. It encapsulates a logical
+query plan. It can be created in a catalog as follows:
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -318,11 +332,11 @@ A `Table` is registered in a `TableEnvironment` as follows:
 // get a TableEnvironment
 TableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
 
-// table is the result of a simple projection query
-Table projTable = tableEnv.scan("X").select(...);
+// table is the result of a simple projection query 
+Table projTable = tableEnv.from("X").select(...);
 
 // register the Table projTable as table "projectedTable"
-tableEnv.registerTable("projectedTable", projTable);
+tableEnv.createTemporaryView("projectedTable", projTable);
 {% endhighlight %}
 </div>
 
@@ -331,11 +345,11 @@ tableEnv.registerTable("projectedTable", projTable);
 // get a TableEnvironment
 val tableEnv = ... // see "Create a TableEnvironment" section
 
-// table is the result of a simple projection query
-val projTable: Table = tableEnv.scan("X").select(...)
+// table is the result of a simple projection query 
+val projTable: Table = tableEnv.from("X").select(...)
 
 // register the Table projTable as table "projectedTable"
-tableEnv.registerTable("projectedTable", projTable)
+tableEnv.createTemporaryView("projectedTable", projTable)
 {% endhighlight %}
 </div>
 
@@ -344,8 +358,8 @@ tableEnv.registerTable("projectedTable", projTable)
 # get a TableEnvironment
 table_env = ... # see "Create a TableEnvironment" section
 
-# table is the result of a simple projection query
-proj_table = table_env.scan("X").select(...)
+# table is the result of a simple projection query 
+proj_table = table_env.from_path("X").select(...)
 
 # register the Table projTable as table "projectedTable"
 table_env.register_table("projectedTable", proj_table)
@@ -353,127 +367,133 @@ table_env.register_table("projectedTable", proj_table)
 </div>
 </div>
 
-**Note:** A registered `Table` is treated similarly to a `VIEW` as known from relational database systems, i.e., the query that defines the `Table` is not optimized but will be inlined when another query references the registered `Table`. If multiple queries reference the same registered `Table`, it will be inlined for each referencing query and executed multiple times, i.e., the result of the registered `Table` will *not* be shared.
+**Note:** A `Table` object similarly to a `VIEW` from relational database
+systems, i.e., the query that defines the `Table` is not optimized but will be inlined when another
+query references the registered `Table`. If multiple queries reference the same registered `Table`,
+it will be inlined for each referencing query and executed multiple times, i.e., the result of the
+registered `Table` will *not* be shared.
 
 {% top %}
 
-### Register a TableSource
+#### Connector tables
 
-A `TableSource` provides access to external data which is stored in a storage system such as a database (MySQL, HBase, ...), a file with a specific encoding (CSV, Apache \[Parquet, Avro, ORC\], ...), or a messaging system (Apache Kafka, RabbitMQ, ...). 
-
-Flink aims to provide TableSources for common data formats and storage systems. Please have a look at the [Table Sources and Sinks]({{ site.baseurl }}/dev/table/sourceSinks.html) page for a list of supported TableSources and instructions for how to build a custom `TableSource`.
-
-A `TableSource` is registered in a `TableEnvironment` as follows:
+It is also possible to create a `TABLE` as known from relational databases from a [connector]({{ site.baseurl }}/dev/table/connect.html) declaration.
+The connector describes the external system that stores the data of a table. Storage systems such as Apacha Kafka or a regular file system can be declared here.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-// get a TableEnvironment
-TableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
+tableEnvironment
+  .connect(...)
+  .withFormat(...)
+  .withSchema(...)
+  .inAppendMode()
+  .createTemporaryTable("MyTable")
+{% endhighlight %}
+</div>
 
-// create a TableSource
-TableSource csvSource = new CsvTableSource("/path/to/file", ...);
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+tableEnvironment
+  .connect(...)
+  .withFormat(...)
+  .withSchema(...)
+  .inAppendMode()
+  .createTemporaryTable("MyTable")
+{% endhighlight %}
+</div>
 
-// register the TableSource as table "CsvTable"
-tableEnv.registerTableSource("CsvTable", csvSource);
+<div data-lang="python" markdown="1">
+{% highlight python %}
+table_environment \
+    .connect(...) \
+    .with_format(...) \
+    .with_schema(...) \
+    .in_append_mode() \
+    .create_temporary_table("MyTable")
+{% endhighlight %}
+</div>
+
+<div data-lang="DDL" markdown="1">
+{% highlight sql %}
+tableEnvironment.sqlUpdate("CREATE [TEMPORARY] TABLE MyTable (...) WITH (...)")
+{% endhighlight %}
+</div>
+</div>
+
+### Expanding table identifiers
+
+Tables are always registered with a 3 part identifiers consisting of catalog name, database name and
+table name. The first two parts are optional. If they are not provided the current default values will
+be used. Identifiers follow SQL requirements. That means that they can be escaped with ``` character.
+Additionally all SQL reserved keywords must be escaped.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+TableEnvironment tEnv = ...;
+tEnv.useCatalog("default_catalog");
+tEnv.useDatabase("default_database");
+
+Table table = ...;
+
+// register the view named 'exampleView' in the catalog named 'default_catalog'
+// in the database named 'default_database' 
+tableEnv.createTemporaryView("exampleView", table);
+
+// register the view named 'exampleView' in the catalog named 'default_catalog'
+// in the database named 'other_database' 
+tableEnv.createTemporaryView("other_database.exampleView", table);
+
+// register the view named 'View' in the catalog named 'default_catalog' in the
+// database named 'default_database'. 'View' is a reserved keyword and must be escaped.  
+tableEnv.createTemporaryView("`View`", table);
+
+// register the view named 'example.View' in the catalog named 'default_catalog'
+// in the database named 'default_database' 
+tableEnv.createTemporaryView("`example.View`", table);
+
+// register the view named 'exampleView' in the catalog named 'other_catalog'
+// in the database named 'other_database' 
+tableEnv.createTemporaryView("other_catalog.other_database.exampleView", table);
+
 {% endhighlight %}
 </div>
 
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 // get a TableEnvironment
-val tableEnv = ... // see "Create a TableEnvironment" section
+val tEnv: TableEnvironment = ...;
+tEnv.useCatalog("default_catalog")
+tEnv.useDatabase("default_database")
 
-// create a TableSource
-val csvSource: TableSource = new CsvTableSource("/path/to/file", ...)
+val table: Table = ...;
 
-// register the TableSource as table "CsvTable"
-tableEnv.registerTableSource("CsvTable", csvSource)
+// register the view named 'exampleView' in the catalog named 'default_catalog'
+// in the database named 'default_database' 
+tableEnv.createTemporaryView("exampleView", table)
+
+// register the view named 'exampleView' in the catalog named 'default_catalog'
+// in the database named 'other_database' 
+tableEnv.createTemporaryView("other_database.exampleView", table)
+
+// register the view named 'View' in the catalog named 'default_catalog' in the
+// database named 'default_database'. 'View' is a reserved keyword and must be escaped.  
+tableEnv.createTemporaryView("`View`", table)
+
+// register the view named 'example.View' in the catalog named 'default_catalog'
+// in the database named 'default_database' 
+tableEnv.createTemporaryView("`example.View`", table)
+
+// register the view named 'exampleView' in the catalog named 'other_catalog'
+// in the database named 'other_database' 
+tableEnv.createTemporaryView("other_catalog.other_database.exampleView", table)
 {% endhighlight %}
 </div>
 
-<div data-lang="python" markdown="1">
-{% highlight python %}
-# get a TableEnvironment
-table_env = ... # see "Create a TableEnvironment" section
-
-# create a TableSource
-csv_source = CsvTableSource("/path/to/file", ...)
-
-# register the TableSource as table "csvTable"
-table_env.register_table_source("csvTable", csv_source)
-{% endhighlight %}
-</div>
 </div>
 
-**Note:** A `TableEnvironment` used for Blink planner only accepts `StreamTableSource`, `LookupableTableSource` and `InputFormatTableSource`, and a `StreamTableSource` used for Blink planner on batch must be bounded.
-
-{% top %}
-
-### Register a TableSink
-
-A registered `TableSink` can be used to [emit the result of a Table API or SQL query](common.html#emit-a-table) to an external storage system, such as a database, key-value store, message queue, or file system (in different encodings, e.g., CSV, Apache \[Parquet, Avro, ORC\], ...).
-
-Flink aims to provide TableSinks for common data formats and storage systems. Please see the documentation about [Table Sources and Sinks]({{ site.baseurl }}/dev/table/sourceSinks.html) page for details about available sinks and instructions for how to implement a custom `TableSink`.
-
-A `TableSink` is registered in a `TableEnvironment` as follows:
-
-<div class="codetabs" markdown="1">
-<div data-lang="java" markdown="1">
-{% highlight java %}
-// get a TableEnvironment
-TableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
-
-// create a TableSink
-TableSink csvSink = new CsvTableSink("/path/to/file", ...);
-
-// define the field names and types
-String[] fieldNames = {"a", "b", "c"};
-TypeInformation[] fieldTypes = {Types.INT, Types.STRING, Types.LONG};
-
-// register the TableSink as table "CsvSinkTable"
-tableEnv.registerTableSink("CsvSinkTable", fieldNames, fieldTypes, csvSink);
-{% endhighlight %}
-</div>
-
-<div data-lang="scala" markdown="1">
-{% highlight scala %}
-// get a TableEnvironment
-val tableEnv = ... // see "Create a TableEnvironment" section
-
-// create a TableSink
-val csvSink: TableSink = new CsvTableSink("/path/to/file", ...)
-
-// define the field names and types
-val fieldNames: Array[String] = Array("a", "b", "c")
-val fieldTypes: Array[TypeInformation[_]] = Array(Types.INT, Types.STRING, Types.LONG)
-
-// register the TableSink as table "CsvSinkTable"
-tableEnv.registerTableSink("CsvSinkTable", fieldNames, fieldTypes, csvSink)
-{% endhighlight %}
-</div>
-
-<div data-lang="python" markdown="1">
-{% highlight python %}
-# get a TableEnvironment
-table_env = ... # see "Create a TableEnvironment" section
-
-# define the field names and types
-field_names = ["a", "b", "c"]
-field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.BIGINT()]
-
-# create a TableSink
-csv_sink = CsvTableSink(field_names, field_types, "/path/to/file", ...)
-
-# register the TableSink as table "CsvSinkTable"
-table_env.register_table_sink("CsvSinkTable", csv_sink)
-{% endhighlight %}
-</div>
-</div>
-
-{% top %}
-
-Query a Table 
+Query a Table
 -------------
 
 ### Table API
@@ -495,7 +515,7 @@ TableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
 // register Orders table
 
 // scan registered Orders table
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 // compute revenue for all customers from France
 Table revenue = orders
   .filter("cCountry === 'FRANCE'")
@@ -515,7 +535,7 @@ val tableEnv = ... // see "Create a TableEnvironment" section
 // register Orders table
 
 // scan registered Orders table
-val orders = tableEnv.scan("Orders")
+val orders = tableEnv.from("Orders")
 // compute revenue for all customers from France
 val revenue = orders
   .filter('cCountry === "FRANCE")
@@ -537,7 +557,7 @@ table_env = # see "Create a TableEnvironment" section
 # register Orders table
 
 # scan registered Orders table
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 # compute revenue for all customers from France
 revenue = orders \
     .filter("cCountry === 'FRANCE'") \
@@ -721,13 +741,16 @@ The following examples shows how to emit a `Table`:
 // get a TableEnvironment
 TableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
 
-// create a TableSink
-TableSink sink = new CsvTableSink("/path/to/file", fieldDelim = "|");
+// create an output Table
+final Schema schema = new Schema()
+    .field("a", DataTypes.INT())
+    .field("b", DataTypes.STRING())
+    .field("c", DataTypes.LONG());
 
-// register the TableSink with a specific schema
-String[] fieldNames = {"a", "b", "c"};
-TypeInformation[] fieldTypes = {Types.INT, Types.STRING, Types.LONG};
-tableEnv.registerTableSink("CsvSinkTable", fieldNames, fieldTypes, sink);
+tableEnv.connect(new FileSystem("/path/to/file"))
+    .withFormat(new Csv().fieldDelimiter('|').deriveSchema())
+    .withSchema(schema)
+    .createTemporaryTable("CsvSinkTable");
 
 // compute a result Table using Table API operators and/or SQL queries
 Table result = ...
@@ -743,13 +766,16 @@ result.insertInto("CsvSinkTable");
 // get a TableEnvironment
 val tableEnv = ... // see "Create a TableEnvironment" section
 
-// create a TableSink
-val sink: TableSink = new CsvTableSink("/path/to/file", fieldDelim = "|")
+// create an output Table
+val schema = new Schema()
+    .field("a", DataTypes.INT())
+    .field("b", DataTypes.STRING())
+    .field("c", DataTypes.LONG())
 
-// register the TableSink with a specific schema
-val fieldNames: Array[String] = Array("a", "b", "c")
-val fieldTypes: Array[TypeInformation] = Array(Types.INT, Types.STRING, Types.LONG)
-tableEnv.registerTableSink("CsvSinkTable", fieldNames, fieldTypes, sink)
+tableEnv.connect(new FileSystem("/path/to/file"))
+    .withFormat(new Csv().fieldDelimiter('|').deriveSchema())
+    .withSchema(schema)
+    .createTemporaryTable("CsvSinkTable")
 
 // compute a result Table using Table API operators and/or SQL queries
 val result: Table = ...
@@ -770,9 +796,15 @@ field_names = ["a", "b", "c"]
 field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.BIGINT()]
 
 # create a TableSink
-sink = CsvTableSink(field_names, field_types, "/path/to/file", "|")
-
-table_env.register_table_sink("CsvSinkTable", sink)
+t_env.connect(FileSystem().path("/path/to/file")))
+    .with_format(Csv()
+                 .field_delimiter(',')
+                 .deriveSchema())
+    .with_schema(Schema()
+                 .field("a", DataTypes.INT())
+                 .field("b", DataTypes.STRING())
+                 .field("c", DataTypes.BIGINT()))
+    .create_temporary_table("CsvSinkTable")
 
 # compute a result Table using Table API operators and/or SQL queries
 result = ...
@@ -847,9 +879,9 @@ This interaction can be achieved by converting a `DataStream` or `DataSet` into 
 
 The Scala Table API features implicit conversions for the `DataSet`, `DataStream`, and `Table` classes. These conversions are enabled by importing the package `org.apache.flink.table.api.scala._` in addition to `org.apache.flink.api.scala._` for the Scala DataStream API.
 
-### Register a DataStream or DataSet as Table
+### Creates a View from a DataStream or DataSet
 
-A `DataStream` or `DataSet` can be registered in a `TableEnvironment` as a Table. The schema of the resulting table depends on the data type of the registered `DataStream` or `DataSet`. Please check the section about [mapping of data types to table schema](#mapping-of-data-types-to-table-schema) for details.
+A `DataStream` or `DataSet` can be registered in a `TableEnvironment` as a View. The schema of the resulting view depends on the data type of the registered `DataStream` or `DataSet`. Please check the section about [mapping of data types to table schema](#mapping-of-data-types-to-table-schema) for details.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -860,11 +892,11 @@ StreamTableEnvironment tableEnv = ...; // see "Create a TableEnvironment" sectio
 
 DataStream<Tuple2<Long, String>> stream = ...
 
-// register the DataStream as Table "myTable" with fields "f0", "f1"
-tableEnv.registerDataStream("myTable", stream);
+// register the DataStream as View "myTable" with fields "f0", "f1"
+tableEnv.createTemporaryView("myTable", stream);
 
-// register the DataStream as table "myTable2" with fields "myLong", "myString"
-tableEnv.registerDataStream("myTable2", stream, "myLong, myString");
+// register the DataStream as View "myTable2" with fields "myLong", "myString"
+tableEnv.createTemporaryView("myTable2", stream, "myLong, myString");
 {% endhighlight %}
 </div>
 
@@ -876,16 +908,14 @@ val tableEnv: StreamTableEnvironment = ... // see "Create a TableEnvironment" se
 
 val stream: DataStream[(Long, String)] = ...
 
-// register the DataStream as Table "myTable" with fields "f0", "f1"
-tableEnv.registerDataStream("myTable", stream)
+// register the DataStream as View "myTable" with fields "f0", "f1"
+tableEnv.createTemporaryView("myTable", stream)
 
-// register the DataStream as table "myTable2" with fields "myLong", "myString"
-tableEnv.registerDataStream("myTable2", stream, 'myLong, 'myString)
+// register the DataStream as View "myTable2" with fields "myLong", "myString"
+tableEnv.createTemporaryView("myTable2", stream, 'myLong, 'myString)
 {% endhighlight %}
 </div>
 </div>
-
-**Note:** The name of a `DataStream` `Table` must not match the `^_DataStreamTable_[0-9]+` pattern and the name of a `DataSet` `Table` must not match the `^_DataSetTable_[0-9]+` pattern. These patterns are reserved for internal use only.
 
 {% top %}
 
@@ -1601,17 +1631,31 @@ The following code shows an example and the corresponding output for multiple-si
 EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
 TableEnvironment tEnv = TableEnvironment.create(settings);
 
-String[] fieldNames = { "count", "word" };
-TypeInformation[] fieldTypes = { Types.INT, Types.STRING };
-tEnv.registerTableSource("MySource1", new CsvTableSource("/source/path1", fieldNames, fieldTypes));
-tEnv.registerTableSource("MySource2", new CsvTableSource("/source/path2", fieldNames, fieldTypes));
-tEnv.registerTableSink("MySink1", new CsvTableSink("/sink/path1").configure(fieldNames, fieldTypes));
-tEnv.registerTableSink("MySink2", new CsvTableSink("/sink/path2").configure(fieldNames, fieldTypes));
+final Schema schema = new Schema()
+    .field("count", DataTypes.INT())
+    .field("word", DataTypes.STRING());
 
-Table table1 = tEnv.scan("MySource1").where("LIKE(word, 'F%')");
+tEnv.connect(new FileSystem("/source/path1"))
+    .withFormat(new Csv().deriveSchema())
+    .withSchema(schema)
+    .createTemporaryTable("MySource1");
+tEnv.connect(new FileSystem("/source/path2"))
+    .withFormat(new Csv().deriveSchema())
+    .withSchema(schema)
+    .createTemporaryTable("MySource2");
+tEnv.connect(new FileSystem("/sink/path1"))
+    .withFormat(new Csv().deriveSchema())
+    .withSchema(schema)
+    .createTemporaryTable("MySink1");
+tEnv.connect(new FileSystem("/sink/path2"))
+    .withFormat(new Csv().deriveSchema())
+    .withSchema(schema)
+    .createTemporaryTable("MySink2");
+
+Table table1 = tEnv.from("MySource1").where("LIKE(word, 'F%')");
 table1.insertInto("MySink1");
 
-Table table2 = table1.unionAll(tEnv.scan("MySource2"));
+Table table2 = table1.unionAll(tEnv.from("MySource2"));
 table2.insertInto("MySink2");
 
 String explanation = tEnv.explain(false);
@@ -1625,17 +1669,31 @@ System.out.println(explanation);
 val settings = EnvironmentSettings.newInstance.useBlinkPlanner.inStreamingMode.build
 val tEnv = TableEnvironment.create(settings)
 
-val fieldNames = Array("count", "word")
-val fieldTypes = Array[TypeInformation[_]](Types.INT, Types.STRING)
-tEnv.registerTableSource("MySource1", new CsvTableSource("/source/path1", fieldNames, fieldTypes))
-tEnv.registerTableSource("MySource2", new CsvTableSource("/source/path2",fieldNames, fieldTypes))
-tEnv.registerTableSink("MySink1", new CsvTableSink("/sink/path1").configure(fieldNames, fieldTypes))
-tEnv.registerTableSink("MySink2", new CsvTableSink("/sink/path2").configure(fieldNames, fieldTypes))
+val schema = new Schema()
+    .field("count", DataTypes.INT())
+    .field("word", DataTypes.STRING())
 
-val table1 = tEnv.scan("MySource1").where("LIKE(word, 'F%')")
+tEnv.connect(new FileSystem("/source/path1"))
+    .withFormat(new Csv().deriveSchema())
+    .withSchema(schema)
+    .createTemporaryTable("MySource1")
+tEnv.connect(new FileSystem("/source/path2"))
+    .withFormat(new Csv().deriveSchema())
+    .withSchema(schema)
+    .createTemporaryTable("MySource2")
+tEnv.connect(new FileSystem("/sink/path1"))
+    .withFormat(new Csv().deriveSchema())
+    .withSchema(schema)
+    .createTemporaryTable("MySink1")
+tEnv.connect(new FileSystem("/sink/path2"))
+    .withFormat(new Csv().deriveSchema())
+    .withSchema(schema)
+    .createTemporaryTable("MySink2")
+
+val table1 = tEnv.from("MySource1").where("LIKE(word, 'F%')")
 table1.insertInto("MySink1")
 
-val table2 = table1.unionAll(tEnv.scan("MySource2"))
+val table2 = table1.unionAll(tEnv.from("MySource2"))
 table2.insertInto("MySink2")
 
 val explanation = tEnv.explain(false)
@@ -1649,17 +1707,31 @@ println(explanation)
 settings = EnvironmentSettings.new_instance().use_blink_planner().in_streaming_mode().build()
 t_env = TableEnvironment.create(environment_settings=settings)
 
-field_names = ["count", "word"]
-field_types = [DataTypes.INT(), DataTypes.STRING()]
-t_env.register_table_source("MySource1", CsvTableSource("/source/path1", field_names, field_types))
-t_env.register_table_source("MySource2", CsvTableSource("/source/path2", field_names, field_types))
-t_env.register_table_sink("MySink1", CsvTableSink("/sink/path1", field_names, field_types))
-t_env.register_table_sink("MySink2", CsvTableSink("/sink/path2", field_names, field_types))
+schema = Schema()
+    .field("count", DataTypes.INT())
+    .field("word", DataTypes.STRING())
 
-table1 = t_env.scan("MySource1").where("LIKE(word, 'F%')")
+t_env.connect(FileSystem().path("/source/path1")))
+    .with_format(Csv().deriveSchema())
+    .with_schema(schema)
+    .create_temporary_table("MySource1")
+t_env.connect(FileSystem().path("/source/path2")))
+    .with_format(Csv().deriveSchema())
+    .with_schema(schema)
+    .create_temporary_table("MySource2")
+t_env.connect(FileSystem().path("/sink/path1")))
+    .with_format(Csv().deriveSchema())
+    .with_schema(schema)
+    .create_temporary_table("MySink1")
+t_env.connect(FileSystem().path("/sink/path2")))
+    .with_format(Csv().deriveSchema())
+    .with_schema(schema)
+    .create_temporary_table("MySink2")
+
+table1 = t_env.from_path("MySource1").where("LIKE(word, 'F%')")
 table1.insert_into("MySink1")
 
-table2 = table1.union_all(t_env.scan("MySource2"))
+table2 = table1.union_all(t_env.from_path("MySource2"))
 table2.insert_into("MySink2")
 
 explanation = t_env.explain()

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -110,7 +110,7 @@ table_environment \
     .with_format(...) \
     .with_schema(...) \
     .in_append_mode() \
-    .register_table_source("MyTable")
+    .create_temporary_table("MyTable")
 {% endhighlight %}
 </div>
 
@@ -227,7 +227,7 @@ table_environment \
         .field("message", DataTypes.STRING())
     ) \
     .in_append_mode() \
-    .register_table_source("MyUserTable")  
+    .create_temporary_table("MyUserTable")  
     # specify the update-mode for streaming tables and
     # register as source, sink, or both and under a name
 {% endhighlight %}

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -99,7 +99,7 @@ tableEnvironment
   .withFormat(...)
   .withSchema(...)
   .inAppendMode()
-  .registerTableSource("MyTable")
+  .createTemporaryTable("MyTable")
 {% endhighlight %}
 </div>
 
@@ -184,8 +184,8 @@ tableEnvironment
   // specify the update-mode for streaming tables
   .inAppendMode()
 
-  // register as source, sink, or both and under a name
-  .registerTableSource("MyUserTable");
+  // create a table with given name
+  .createTemporaryTable("MyUserTable");
 {% endhighlight %}
 </div>
 

--- a/docs/dev/table/connect.zh.md
+++ b/docs/dev/table/connect.zh.md
@@ -99,7 +99,7 @@ tableEnvironment
   .withFormat(...)
   .withSchema(...)
   .inAppendMode()
-  .registerTableSource("MyTable")
+  .createTemporaryTable("MyTable")
 {% endhighlight %}
 </div>
 
@@ -110,7 +110,7 @@ table_environment \
     .with_format(...) \
     .with_schema(...) \
     .in_append_mode() \
-    .register_table_source("MyTable")
+    .createTemporaryTable("MyTable")
 {% endhighlight %}
 </div>
 

--- a/docs/dev/table/connect.zh.md
+++ b/docs/dev/table/connect.zh.md
@@ -110,7 +110,7 @@ table_environment \
     .with_format(...) \
     .with_schema(...) \
     .in_append_mode() \
-    .createTemporaryTable("MyTable")
+    .create_temporary_table("MyTable")
 {% endhighlight %}
 </div>
 
@@ -184,8 +184,8 @@ tableEnvironment
   // specify the update-mode for streaming tables
   .inAppendMode()
 
-  // register as source, sink, or both and under a name
-  .registerTableSource("MyUserTable");
+  // create a table with given name
+  .createTemporaryTable("MyUserTable");
 {% endhighlight %}
 </div>
 
@@ -227,7 +227,7 @@ table_environment \
         .field("message", DataTypes.STRING())
     ) \
     .in_append_mode() \
-    .register_table_source("MyUserTable")
+    .create_temporary_table("MyUserTable")  
     # specify the update-mode for streaming tables and
     # register as source, sink, or both and under a name
 {% endhighlight %}
@@ -1857,6 +1857,7 @@ Use the old one for stream/batch filesystem operations for now.
   new OldCsv()
     .field("field1", Types.STRING)    // required: ordered format fields
     .field("field2", Types.TIMESTAMP)
+    .deriveSchema()                   // or use the table's schema
     .fieldDelimiter(",")              // optional: string delimiter "," by default
     .lineDelimiter("\n")              // optional: string delimiter "\n" by default
     .quoteCharacter('"')              // optional: single character for string values, empty by default
@@ -1892,6 +1893,7 @@ format:
       type: VARCHAR
     - name: field2
       type: TIMESTAMP
+  derive-schema: true        # or use the table's schema
   field-delimiter: ","       # optional: string delimiter "," by default
   line-delimiter: "\n"       # optional: string delimiter "\n" by default
   quote-character: '"'       # optional: single character for string values, empty by default
@@ -1912,6 +1914,8 @@ CREATE TABLE MyUserTable (
   'format.fields.0.type' = 'FLOAT',
   'format.fields.1.name' = 'rideTime',
   'format.fields.1.type' = 'TIMESTAMP',
+
+  'format.derive-schema' = 'true',        -- or use the table's schema'
 
   'format.field-delimiter' = ',',         -- optional: string delimiter "," by default
   'format.line-delimiter' = '\n',         -- optional: string delimiter "\n" by default

--- a/docs/dev/table/sourceSinks.md
+++ b/docs/dev/table/sourceSinks.md
@@ -775,8 +775,9 @@ StreamTableEnvironment tableEnv = // ...
 
 tableEnv
   .connect(new MySystemConnector(true))
+  .withSchema(...)
   .inAppendMode()
-  .registerTableSource("MySystemTable");
+  .createTemporaryTable("MySystemTable");
 {% endhighlight %}
 </div>
 
@@ -786,8 +787,9 @@ val tableEnv: StreamTableEnvironment = // ...
 
 tableEnv
   .connect(new MySystemConnector(isDebug = true))
+  .withSchema(...)
   .inAppendMode()
-  .registerTableSource("MySystemTable")
+  .createTemporaryTable("MySystemTable")
 {% endhighlight %}
 </div>
 </div>

--- a/docs/dev/table/sourceSinks.zh.md
+++ b/docs/dev/table/sourceSinks.zh.md
@@ -36,9 +36,9 @@ Have a look at the [common concepts and API](common.html) page for details how t
 Define a TableSource
 --------------------
 
-A `TableSource` is a generic interface that gives Table API and SQL queries access to data stored in an external system. It provides the schema of the table and the records that are mapped to rows with the table's schema. Depending on whether the `TableSource` is used in a streaming or batch query, the records are produced as a `DataSet` or `DataStream`.
+A `TableSource` is a generic interface that gives Table API and SQL queries access to data stored in an external system. It provides the schema of the table and the records that are mapped to rows with the table's schema. Depending on whether the `TableSource` is used in a streaming or batch query, the records are produced as a `DataSet` or `DataStream`. 
 
-If a `TableSource` is used in a streaming query it must implement the `StreamTableSource` interface, if it is used in a batch query it must implement the `BatchTableSource` interface. A `TableSource` can also implement both interfaces and be used in streaming and batch queries.
+If a `TableSource` is used in a streaming query it must implement the `StreamTableSource` interface, if it is used in a batch query it must implement the `BatchTableSource` interface. A `TableSource` can also implement both interfaces and be used in streaming and batch queries. 
 
 `StreamTableSource` and `BatchTableSource` extend the base interface `TableSource` that defines the following methods:
 
@@ -77,7 +77,7 @@ TableSource[T] {
 
 * `explainSource()`: Returns a String that describes the `TableSource`. This method is optional and used for display purposes only.
 
-The `TableSource` interface separates the logical table schema from the physical type of the returned `DataStream` or `DataSet`. As a consequence, all fields of the table schema (`getTableSchema()`) must be mapped to a field with corresponding type of the physical return type (`getReturnType()`). By default, this mapping is done based on field names. For example, a `TableSource` that defines a table schema with two fields `[name: String, size: Integer]` requires a `TypeInformation` with at least two fields called `name` and `size` of type `String` and `Integer`, respectively. This could be a `PojoTypeInfo` or a `RowTypeInfo` that have two fields named `name` and `size` with matching types.
+The `TableSource` interface separates the logical table schema from the physical type of the returned `DataStream` or `DataSet`. As a consequence, all fields of the table schema (`getTableSchema()`) must be mapped to a field with corresponding type of the physical return type (`getReturnType()`). By default, this mapping is done based on field names. For example, a `TableSource` that defines a table schema with two fields `[name: String, size: Integer]` requires a `TypeInformation` with at least two fields called `name` and `size` of type `String` and `Integer`, respectively. This could be a `PojoTypeInfo` or a `RowTypeInfo` that have two fields named `name` and `size` with matching types. 
 
 However, some types, such as Tuple or CaseClass types, do support custom field names. If a `TableSource` returns a `DataStream` or `DataSet` of a type with fixed field names, it can implement the `DefinedFieldMapping` interface to map field names from the table schema to field names of the physical return type.
 
@@ -111,7 +111,7 @@ BatchTableSource[T] extends TableSource[T] {
 
 ### Defining a StreamTableSource
 
-The `StreamTableSource` interface extends the `TableSource` interface and defines one additional method:
+The `StreamTableSource` interface extends the `TableSource` interface and defines one additional method: 
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -175,9 +175,9 @@ DefinedProctimeAttribute {
 
 [Rowtime attributes](streaming/time_attributes.html#event-time) are attributes of type `TIMESTAMP` and handled in a unified way in stream and batch queries.
 
-A table schema field of type `SQL_TIMESTAMP` can be declared as rowtime attribute by specifying
+A table schema field of type `SQL_TIMESTAMP` can be declared as rowtime attribute by specifying 
 
-* the name of the field,
+* the name of the field, 
 * a `TimestampExtractor` that computes the actual value for the attribute (usually from one or more other fields), and
 * a `WatermarkStrategy` that specifies how watermarks are generated for the the rowtime attribute.
 
@@ -263,7 +263,7 @@ ProjectableTableSource[T] {
 
 * `projectFields(fields)`: Returns a *copy* of the `TableSource` with adjusted physical return type. The `fields` parameter provides the indexes of the fields that must be provided by the `TableSource`. The indexes relate to the `TypeInformation` of the physical return type, *not* to the logical table schema. The copied `TableSource` must adjust its return type and the returned `DataStream` or `DataSet`. The `TableSchema` of the copied `TableSource` must not be changed, i.e, it must be the same as the original `TableSource`. If the `TableSource` implements the `DefinedFieldMapping` interface, the field mapping must be adjusted to the new return type.
 
-<span class="label label-danger">Attention</span> In order for Flink to distinguish a projection push-down table source from its original form, `explainSource` method must be override to include information regarding the projected fields.
+<span class="label label-danger">Attention</span> In order for Flink to distinguish a projection push-down table source from its original form, `explainSource` method must be override to include information regarding the projected fields.   
 
 The `ProjectableTableSource` adds support to project flat fields. If the `TableSource` defines a table with nested schema, it can implement the `NestedFieldsProjectableTableSource` to extend the projection to nested fields. The `NestedFieldsProjectableTableSource` is defined as follows:
 
@@ -287,7 +287,7 @@ NestedFieldsProjectableTableSource[T] {
 </div>
 </div>
 
-* `projectNestedField(fields, nestedFields)`: Returns a *copy* of the `TableSource` with adjusted physical return type. Fields of the physical return type may be removed or reordered but their type must not be changed. The contract of this method is essentially the same as for the `ProjectableTableSource.projectFields()` method. In addition, the `nestedFields` parameter contains for each field index in the `fields` list, a list of paths to all nested fields that are accessed by the query. All other nested fields do not need to be read, parsed, and set in the records that are produced by the `TableSource`.
+* `projectNestedField(fields, nestedFields)`: Returns a *copy* of the `TableSource` with adjusted physical return type. Fields of the physical return type may be removed or reordered but their type must not be changed. The contract of this method is essentially the same as for the `ProjectableTableSource.projectFields()` method. In addition, the `nestedFields` parameter contains for each field index in the `fields` list, a list of paths to all nested fields that are accessed by the query. All other nested fields do not need to be read, parsed, and set in the records that are produced by the `TableSource`. 
 
 <span class="label label-danger">Attention</span> the types of the projected fields must not be changed but unused fields may be set to null or to a default value.
 
@@ -323,7 +323,7 @@ FilterableTableSource[T] {
 </div>
 </div>
 
-* `applyPredicate(predicates)`: Returns a *copy* of the `TableSource` with added predicates. The `predicates` parameter is a mutable list of conjunctive predicates that are "offered" to the `TableSource`. The `TableSource` accepts to evaluate a predicate by removing it from the list. Predicates that are left in the list will be evaluated by a subsequent filter operator.
+* `applyPredicate(predicates)`: Returns a *copy* of the `TableSource` with added predicates. The `predicates` parameter is a mutable list of conjunctive predicates that are "offered" to the `TableSource`. The `TableSource` accepts to evaluate a predicate by removing it from the list. Predicates that are left in the list will be evaluated by a subsequent filter operator. 
 * `isFilterPushedDown()`: Returns true if the `applyPredicate()` method was called before. Hence, `isFilterPushedDown()` must return true for all `TableSource` instances returned from a `applyPredicate()` call.
 
 <span class="label label-danger">Attention</span> In order for Flink to distinguish a filter push-down table source from its original form, `explainSource` method must be override to include information regarding the push-down filters.
@@ -775,8 +775,9 @@ StreamTableEnvironment tableEnv = // ...
 
 tableEnv
   .connect(new MySystemConnector(true))
+  .withSchema(...)
   .inAppendMode()
-  .registerTableSource("MySystemTable");
+  .createTemporaryTable("MySystemTable");
 {% endhighlight %}
 </div>
 
@@ -786,8 +787,9 @@ val tableEnv: StreamTableEnvironment = // ...
 
 tableEnv
   .connect(new MySystemConnector(isDebug = true))
+  .withSchema(...)
   .inAppendMode()
-  .registerTableSource("MySystemTable")
+  .createTemporaryTable("MySystemTable")
 {% endhighlight %}
 </div>
 </div>

--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -54,18 +54,23 @@ Table result = tableEnv.sqlQuery(
   "SELECT SUM(amount) FROM " + table + " WHERE product LIKE '%Rubber%'");
 
 // SQL query with a registered table
-// register the DataStream as table "Orders"
-tableEnv.registerDataStream("Orders", ds, "user, product, amount");
+// register the DataStream as view "Orders"
+tableEnv.createTemporaryView("Orders", ds, "user, product, amount");
 // run a SQL query on the Table and retrieve the result as a new Table
 Table result2 = tableEnv.sqlQuery(
   "SELECT product, amount FROM Orders WHERE product LIKE '%Rubber%'");
 
 // SQL update with a registered table
 // create and register a TableSink
-TableSink csvSink = new CsvTableSink("/path/to/file", ...);
-String[] fieldNames = {"product", "amount"};
-TypeInformation[] fieldTypes = {Types.STRING, Types.INT};
-tableEnv.registerTableSink("RubberOrders", fieldNames, fieldTypes, csvSink);
+final Schema schema = new Schema()
+    .field("product", DataTypes.STRING())
+    .field("amount", DataTypes.INT());
+
+tableEnv.connect(new FileSystem("/path/to/file"))
+    .withFormat(...)
+    .withSchema(schema)
+    .createTemporaryTable("RubberOrders");
+
 // run a SQL update query on the Table and emit the result to the TableSink
 tableEnv.sqlUpdate(
   "INSERT INTO RubberOrders SELECT product, amount FROM Orders WHERE product LIKE '%Rubber%'");
@@ -87,17 +92,22 @@ val result = tableEnv.sqlQuery(
 
 // SQL query with a registered table
 // register the DataStream under the name "Orders"
-tableEnv.registerDataStream("Orders", ds, 'user, 'product, 'amount)
+tableEnv.createTemporaryView("Orders", ds, 'user, 'product, 'amount)
 // run a SQL query on the Table and retrieve the result as a new Table
 val result2 = tableEnv.sqlQuery(
   "SELECT product, amount FROM Orders WHERE product LIKE '%Rubber%'")
 
 // SQL update with a registered table
 // create and register a TableSink
-val csvSink: CsvTableSink = new CsvTableSink("/path/to/file", ...)
-val fieldNames: Array[String] = Array("product", "amount")
-val fieldTypes: Array[TypeInformation[_]] = Array(Types.STRING, Types.INT)
-tableEnv.registerTableSink("RubberOrders", fieldNames, fieldTypes, csvSink)
+val schema = new Schema()
+    .field("product", DataTypes.STRING())
+    .field("amount", DataTypes.INT())
+
+tableEnv.connect(new FileSystem("/path/to/file"))
+    .withFormat(...)
+    .withSchema(schema)
+    .createTemporaryTable("RubberOrders")
+
 // run a SQL update query on the Table and emit the result to the TableSink
 tableEnv.sqlUpdate(
   "INSERT INTO RubberOrders SELECT product, amount FROM Orders WHERE product LIKE '%Rubber%'")
@@ -117,11 +127,15 @@ result = table_env \
 
 # SQL update with a registered table
 # create and register a TableSink
-table_env.register_table("Orders", table)
-field_names = ["product", "amount"]
-field_types = [DataTypes.STRING(), DataTypes.BIGINT()]
-csv_sink = CsvTableSink(field_names, field_types, "/path/to/file", ...)
-table_env.register_table_sink("RubberOrders", csv_sink)
+t_env.connect(FileSystem().path("/path/to/file")))
+    .with_format(Csv()
+                 .field_delimiter(',')
+                 .deriveSchema())
+    .with_schema(Schema()
+                 .field("product", DataTypes.STRING())
+                 .field("amount", DataTypes.BIGINT()))
+    .create_temporary_table("RubberOrders")
+
 # run a SQL update query on the Table and emit the result to the TableSink
 table_env \
     .sql_update("INSERT INTO RubberOrders SELECT product, amount FROM Orders WHERE product LIKE '%Rubber%'")
@@ -880,7 +894,7 @@ StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
 // ingest a DataStream from an external source
 DataStream<Tuple3<String, String, String, Long>> ds = env.addSource(...);
 // register the DataStream as table "ShopSales"
-tableEnv.registerDataStream("ShopSales", ds, "product_id, category, product_name, sales");
+tableEnv.createTemporaryView("ShopSales", ds, "product_id, category, product_name, sales");
 
 // select top-5 products per category which have the maximum sales.
 Table result1 = tableEnv.sqlQuery(
@@ -901,7 +915,7 @@ val tableEnv = TableEnvironment.getTableEnvironment(env)
 // read a DataStream from an external source
 val ds: DataStream[(String, String, String, Long)] = env.addSource(...)
 // register the DataStream under the name "ShopSales"
-tableEnv.registerDataStream("ShopSales", ds, 'product_id, 'category, 'product_name, 'sales)
+tableEnv.createTemporaryView("ShopSales", ds, 'product_id, 'category, 'product_name, 'sales)
 
 
 // select top-5 products per category which have the maximum sales.
@@ -935,7 +949,7 @@ StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
 // ingest a DataStream from an external source
 DataStream<Tuple3<String, String, String, Long>> ds = env.addSource(...);
 // register the DataStream as table "ShopSales"
-tableEnv.registerDataStream("ShopSales", ds, "product_id, category, product_name, sales");
+tableEnv.createTemporaryView("ShopSales", ds, "product_id, category, product_name, sales");
 
 // select top-5 products per category which have the maximum sales.
 Table result1 = tableEnv.sqlQuery(
@@ -956,7 +970,7 @@ val tableEnv = TableEnvironment.getTableEnvironment(env)
 // read a DataStream from an external source
 val ds: DataStream[(String, String, String, Long)] = env.addSource(...)
 // register the DataStream under the name "ShopSales"
-tableEnv.registerDataStream("ShopSales", ds, 'product_id, 'category, 'product_name, 'sales)
+tableEnv.createTemporaryView("ShopSales", ds, 'product_id, 'category, 'product_name, 'sales)
 
 
 // select top-5 products per category which have the maximum sales.
@@ -1015,7 +1029,7 @@ StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
 // ingest a DataStream from an external source
 DataStream<Tuple3<String, String, String, Integer>> ds = env.addSource(...);
 // register the DataStream as table "Orders"
-tableEnv.registerDataStream("Orders", ds, "order_id, user, product, number, proctime.proctime");
+tableEnv.createTemporaryView("Orders", ds, "order_id, user, product, number, proctime.proctime");
 
 // remove duplicate rows on order_id and keep the first occurrence row,
 // because there shouldn't be two orders with the same order_id.
@@ -1037,7 +1051,7 @@ val tableEnv = TableEnvironment.getTableEnvironment(env)
 // read a DataStream from an external source
 val ds: DataStream[(String, String, String, Int)] = env.addSource(...)
 // register the DataStream under the name "Orders"
-tableEnv.registerDataStream("Orders", ds, 'order_id, 'user, 'product, 'number, 'proctime.proctime)
+tableEnv.createTemporaryView("Orders", ds, 'order_id, 'user, 'product, 'number, 'proctime.proctime)
 
 // remove duplicate rows on order_id and keep the first occurrence row,
 // because there shouldn't be two orders with the same order_id.
@@ -1186,7 +1200,7 @@ StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 // ingest a DataStream from an external source
 DataStream<Tuple3<Long, String, Integer>> ds = env.addSource(...);
 // register the DataStream as table "Orders"
-tableEnv.registerDataStream("Orders", ds, "user, product, amount, proctime.proctime, rowtime.rowtime");
+tableEnv.createTemporaryView("Orders", ds, "user, product, amount, proctime.proctime, rowtime.rowtime");
 
 // compute SUM(amount) per day (in event-time)
 Table result1 = tableEnv.sqlQuery(
@@ -1223,7 +1237,7 @@ val tableEnv = StreamTableEnvironment.create(env)
 // read a DataStream from an external source
 val ds: DataStream[(Long, String, Int)] = env.addSource(...)
 // register the DataStream under the name "Orders"
-tableEnv.registerDataStream("Orders", ds, 'user, 'product, 'amount, 'proctime.proctime, 'rowtime.rowtime)
+tableEnv.createTemporaryView("Orders", ds, 'user, 'product, 'amount, 'proctime.proctime, 'rowtime.rowtime)
 
 // compute SUM(amount) per day (in event-time)
 val result1 = tableEnv.sqlQuery(

--- a/docs/dev/table/sql.zh.md
+++ b/docs/dev/table/sql.zh.md
@@ -54,18 +54,23 @@ Table result = tableEnv.sqlQuery(
   "SELECT SUM(amount) FROM " + table + " WHERE product LIKE '%Rubber%'");
 
 // SQL query with a registered table
-// register the DataStream as table "Orders"
-tableEnv.registerDataStream("Orders", ds, "user, product, amount");
+// register the DataStream as view "Orders"
+tableEnv.createTemporaryView("Orders", ds, "user, product, amount");
 // run a SQL query on the Table and retrieve the result as a new Table
 Table result2 = tableEnv.sqlQuery(
   "SELECT product, amount FROM Orders WHERE product LIKE '%Rubber%'");
 
 // SQL update with a registered table
 // create and register a TableSink
-TableSink csvSink = new CsvTableSink("/path/to/file", ...);
-String[] fieldNames = {"product", "amount"};
-TypeInformation[] fieldTypes = {Types.STRING, Types.INT};
-tableEnv.registerTableSink("RubberOrders", fieldNames, fieldTypes, csvSink);
+final Schema schema = new Schema()
+    .field("product", DataTypes.STRING())
+    .field("amount", DataTypes.INT());
+
+tableEnv.connect(new FileSystem("/path/to/file"))
+    .withFormat(...)
+    .withSchema(schema)
+    .createTemporaryTable("RubberOrders");
+
 // run a SQL update query on the Table and emit the result to the TableSink
 tableEnv.sqlUpdate(
   "INSERT INTO RubberOrders SELECT product, amount FROM Orders WHERE product LIKE '%Rubber%'");
@@ -87,17 +92,22 @@ val result = tableEnv.sqlQuery(
 
 // SQL query with a registered table
 // register the DataStream under the name "Orders"
-tableEnv.registerDataStream("Orders", ds, 'user, 'product, 'amount)
+tableEnv.createTemporaryView("Orders", ds, 'user, 'product, 'amount)
 // run a SQL query on the Table and retrieve the result as a new Table
 val result2 = tableEnv.sqlQuery(
   "SELECT product, amount FROM Orders WHERE product LIKE '%Rubber%'")
 
 // SQL update with a registered table
 // create and register a TableSink
-val csvSink: CsvTableSink = new CsvTableSink("/path/to/file", ...)
-val fieldNames: Array[String] = Array("product", "amount")
-val fieldTypes: Array[TypeInformation[_]] = Array(Types.STRING, Types.INT)
-tableEnv.registerTableSink("RubberOrders", fieldNames, fieldTypes, csvSink)
+val schema = new Schema()
+    .field("product", DataTypes.STRING())
+    .field("amount", DataTypes.INT())
+
+tableEnv.connect(new FileSystem("/path/to/file"))
+    .withFormat(...)
+    .withSchema(schema)
+    .createTemporaryTable("RubberOrders")
+
 // run a SQL update query on the Table and emit the result to the TableSink
 tableEnv.sqlUpdate(
   "INSERT INTO RubberOrders SELECT product, amount FROM Orders WHERE product LIKE '%Rubber%'")
@@ -117,11 +127,15 @@ result = table_env \
 
 # SQL update with a registered table
 # create and register a TableSink
-table_env.register_table("Orders", table)
-field_names = ["product", "amount"]
-field_types = [DataTypes.STRING(), DataTypes.BIGINT()]
-csv_sink = CsvTableSink(field_names, field_types, "/path/to/file", ...)
-table_env.register_table_sink("RubberOrders", csv_sink)
+t_env.connect(FileSystem().path("/path/to/file")))
+    .with_format(Csv()
+                 .field_delimiter(',')
+                 .deriveSchema())
+    .with_schema(Schema()
+                 .field("product", DataTypes.STRING())
+                 .field("amount", DataTypes.BIGINT()))
+    .create_temporary_table("RubberOrders")
+
 # run a SQL update query on the Table and emit the result to the TableSink
 table_env \
     .sql_update("INSERT INTO RubberOrders SELECT product, amount FROM Orders WHERE product LIKE '%Rubber%'")
@@ -142,7 +156,7 @@ The following BNF-grammar describes the superset of supported SQL features in ba
 insert:
   INSERT INTO tableReference
   query
-
+  
 query:
   values
   | {
@@ -168,7 +182,7 @@ select:
   [ GROUP BY { groupItem [, groupItem ]* } ]
   [ HAVING booleanExpression ]
   [ WINDOW windowName AS windowSpec [, windowName AS windowSpec ]* ]
-
+  
 selectWithoutFrom:
   SELECT [ ALL | DISTINCT ]
   { * | projectItem [, projectItem ]* }
@@ -440,11 +454,11 @@ SELECT COUNT(amount) OVER (
 FROM Orders
 
 SELECT COUNT(amount) OVER w, SUM(amount) OVER w
-FROM Orders
+FROM Orders 
 WINDOW w AS (
   PARTITION BY user
   ORDER BY proctime
-  ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)
+  ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)  
 {% endhighlight %}
       </td>
     </tr>
@@ -819,7 +833,7 @@ ORDER BY orderTime
         <span class="label label-primary">Batch</span>
       </td>
       <td>
-<b>Note:</b> The LIMIT clause requires an ORDER BY clause.
+<b>Note:</b> The LIMIT clause requires an ORDER BY clause. 
 {% highlight sql %}
 SELECT *
 FROM Orders
@@ -880,7 +894,7 @@ StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
 // ingest a DataStream from an external source
 DataStream<Tuple3<String, String, String, Long>> ds = env.addSource(...);
 // register the DataStream as table "ShopSales"
-tableEnv.registerDataStream("ShopSales", ds, "product_id, category, product_name, sales");
+tableEnv.createTemporaryView("ShopSales", ds, "product_id, category, product_name, sales");
 
 // select top-5 products per category which have the maximum sales.
 Table result1 = tableEnv.sqlQuery(
@@ -901,7 +915,7 @@ val tableEnv = TableEnvironment.getTableEnvironment(env)
 // read a DataStream from an external source
 val ds: DataStream[(String, String, String, Long)] = env.addSource(...)
 // register the DataStream under the name "ShopSales"
-tableEnv.registerDataStream("ShopSales", ds, 'product_id, 'category, 'product_name, 'sales)
+tableEnv.createTemporaryView("ShopSales", ds, 'product_id, 'category, 'product_name, 'sales)
 
 
 // select top-5 products per category which have the maximum sales.
@@ -935,7 +949,7 @@ StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
 // ingest a DataStream from an external source
 DataStream<Tuple3<String, String, String, Long>> ds = env.addSource(...);
 // register the DataStream as table "ShopSales"
-tableEnv.registerDataStream("ShopSales", ds, "product_id, category, product_name, sales");
+tableEnv.createTemporaryView("ShopSales", ds, "product_id, category, product_name, sales");
 
 // select top-5 products per category which have the maximum sales.
 Table result1 = tableEnv.sqlQuery(
@@ -956,7 +970,7 @@ val tableEnv = TableEnvironment.getTableEnvironment(env)
 // read a DataStream from an external source
 val ds: DataStream[(String, String, String, Long)] = env.addSource(...)
 // register the DataStream under the name "ShopSales"
-tableEnv.registerDataStream("ShopSales", ds, 'product_id, 'category, 'product_name, 'sales)
+tableEnv.createTemporaryView("ShopSales", ds, 'product_id, 'category, 'product_name, 'sales)
 
 
 // select top-5 products per category which have the maximum sales.
@@ -1015,7 +1029,7 @@ StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
 // ingest a DataStream from an external source
 DataStream<Tuple3<String, String, String, Integer>> ds = env.addSource(...);
 // register the DataStream as table "Orders"
-tableEnv.registerDataStream("Orders", ds, "order_id, user, product, number, proctime.proctime");
+tableEnv.createTemporaryView("Orders", ds, "order_id, user, product, number, proctime.proctime");
 
 // remove duplicate rows on order_id and keep the first occurrence row,
 // because there shouldn't be two orders with the same order_id.
@@ -1037,7 +1051,7 @@ val tableEnv = TableEnvironment.getTableEnvironment(env)
 // read a DataStream from an external source
 val ds: DataStream[(String, String, String, Int)] = env.addSource(...)
 // register the DataStream under the name "Orders"
-tableEnv.registerDataStream("Orders", ds, 'order_id, 'user, 'product, 'number, 'proctime.proctime)
+tableEnv.createTemporaryView("Orders", ds, 'order_id, 'user, 'product, 'number, 'proctime.proctime)
 
 // remove duplicate rows on order_id and keep the first occurrence row,
 // because there shouldn't be two orders with the same order_id.
@@ -1186,7 +1200,7 @@ StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 // ingest a DataStream from an external source
 DataStream<Tuple3<Long, String, Integer>> ds = env.addSource(...);
 // register the DataStream as table "Orders"
-tableEnv.registerDataStream("Orders", ds, "user, product, amount, proctime.proctime, rowtime.rowtime");
+tableEnv.createTemporaryView("Orders", ds, "user, product, amount, proctime.proctime, rowtime.rowtime");
 
 // compute SUM(amount) per day (in event-time)
 Table result1 = tableEnv.sqlQuery(
@@ -1223,7 +1237,7 @@ val tableEnv = StreamTableEnvironment.create(env)
 // read a DataStream from an external source
 val ds: DataStream[(Long, String, Int)] = env.addSource(...)
 // register the DataStream under the name "Orders"
-tableEnv.registerDataStream("Orders", ds, 'user, 'product, 'amount, 'proctime.proctime, 'rowtime.rowtime)
+tableEnv.createTemporaryView("Orders", ds, 'user, 'product, 'amount, 'proctime.proctime, 'rowtime.rowtime)
 
 // compute SUM(amount) per day (in event-time)
 val result1 = tableEnv.sqlQuery(

--- a/docs/dev/table/streaming/temporal_tables.md
+++ b/docs/dev/table/streaming/temporal_tables.md
@@ -178,7 +178,7 @@ ratesHistoryData.add(Tuple2.of("Euro", 119L));
 DataStream<Tuple2<String, Long>> ratesHistoryStream = env.fromCollection(ratesHistoryData);
 Table ratesHistory = tEnv.fromDataStream(ratesHistoryStream, "r_currency, r_rate, r_proctime.proctime");
 
-tEnv.registerTable("RatesHistory", ratesHistory);
+tEnv.createTemporaryView("RatesHistory", ratesHistory);
 
 // Create and register a temporal table function.
 // Define "r_proctime" as the time attribute and "r_currency" as the primary key.
@@ -206,7 +206,7 @@ val ratesHistory = env
   .fromCollection(ratesHistoryData)
   .toTable(tEnv, 'r_currency, 'r_rate, 'r_proctime.proctime)
 
-tEnv.registerTable("RatesHistory", ratesHistory)
+tEnv.createTemporaryView("RatesHistory", ratesHistory)
 
 // Create and register TemporalTableFunction.
 // Define "r_proctime" as the time attribute and "r_currency" as the primary key.

--- a/docs/dev/table/streaming/time_attributes.md
+++ b/docs/dev/table/streaming/time_attributes.md
@@ -151,7 +151,7 @@ public class UserActionSource implements StreamTableSource<Row>, DefinedProctime
 tEnv.registerTableSource("UserActions", new UserActionSource());
 
 WindowedTable windowedTable = tEnv
-	.scan("UserActions")
+	.from("UserActions")
 	.window(Tumble.over("10.minutes").on("UserActionTime").as("userActionWindow"));
 {% endhighlight %}
 </div>
@@ -182,7 +182,7 @@ class UserActionSource extends StreamTableSource[Row] with DefinedProctimeAttrib
 tEnv.registerTableSource("UserActions", new UserActionSource)
 
 val windowedTable = tEnv
-	.scan("UserActions")
+	.from("UserActions")
 	.window(Tumble over 10.minutes on 'UserActionTime as 'userActionWindow)
 {% endhighlight %}
 </div>
@@ -314,7 +314,7 @@ public class UserActionSource implements StreamTableSource<Row>, DefinedRowtimeA
 tEnv.registerTableSource("UserActions", new UserActionSource());
 
 WindowedTable windowedTable = tEnv
-	.scan("UserActions")
+	.from("UserActions")
 	.window(Tumble.over("10.minutes").on("UserActionTime").as("userActionWindow"));
 {% endhighlight %}
 </div>
@@ -353,7 +353,7 @@ class UserActionSource extends StreamTableSource[Row] with DefinedRowtimeAttribu
 tEnv.registerTableSource("UserActions", new UserActionSource)
 
 val windowedTable = tEnv
-	.scan("UserActions")
+	.from("UserActions")
 	.window(Tumble over 10.minutes on 'UserActionTime as 'userActionWindow)
 {% endhighlight %}
 </div>

--- a/docs/dev/table/streaming/time_attributes.zh.md
+++ b/docs/dev/table/streaming/time_attributes.zh.md
@@ -151,7 +151,7 @@ public class UserActionSource implements StreamTableSource<Row>, DefinedProctime
 tEnv.registerTableSource("UserActions", new UserActionSource());
 
 WindowedTable windowedTable = tEnv
-	.scan("UserActions")
+	.from("UserActions")
 	.window(Tumble.over("10.minutes").on("UserActionTime").as("userActionWindow"));
 {% endhighlight %}
 </div>
@@ -182,7 +182,7 @@ class UserActionSource extends StreamTableSource[Row] with DefinedProctimeAttrib
 tEnv.registerTableSource("UserActions", new UserActionSource)
 
 val windowedTable = tEnv
-	.scan("UserActions")
+	.from("UserActions")
 	.window(Tumble over 10.minutes on 'UserActionTime as 'userActionWindow)
 {% endhighlight %}
 </div>
@@ -314,7 +314,7 @@ public class UserActionSource implements StreamTableSource<Row>, DefinedRowtimeA
 tEnv.registerTableSource("UserActions", new UserActionSource());
 
 WindowedTable windowedTable = tEnv
-	.scan("UserActions")
+	.from("UserActions")
 	.window(Tumble.over("10.minutes").on("UserActionTime").as("userActionWindow"));
 {% endhighlight %}
 </div>
@@ -353,7 +353,7 @@ class UserActionSource extends StreamTableSource[Row] with DefinedRowtimeAttribu
 tEnv.registerTableSource("UserActions", new UserActionSource)
 
 val windowedTable = tEnv
-	.scan("UserActions")
+	.from("UserActions")
 	.window(Tumble over 10.minutes on 'UserActionTime as 'userActionWindow)
 {% endhighlight %}
 </div>

--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -55,7 +55,7 @@ BatchTableEnvironment tEnv = BatchTableEnvironment.create(env);
 // ...
 
 // specify table program
-Table orders = tEnv.scan("Orders"); // schema (a, b, c, rowtime)
+Table orders = tEnv.from("Orders"); // schema (a, b, c, rowtime)
 
 Table counts = orders
         .groupBy("a")
@@ -87,7 +87,7 @@ val tEnv = BatchTableEnvironment.create(env)
 // ...
 
 // specify table program
-val orders = tEnv.scan("Orders") // schema (a, b, c, rowtime)
+val orders = tEnv.from("Orders") // schema (a, b, c, rowtime)
 
 val result = orders
                .groupBy('a)
@@ -115,7 +115,7 @@ t_env = TableEnvironment.create(env, TableConfig())
 # ...
 
 # specify table program
-orders = t_env.scan("Orders")  # schema (a, b, c, rowtime)
+orders = t_env.from_path("Orders")  # schema (a, b, c, rowtime)
 
 orders.group_by("a").select("a, b.count as cnt").insert_into("result")
 
@@ -136,7 +136,7 @@ The next example shows a more complex Table API program. The program scans again
 // ...
 
 // specify table program
-Table orders = tEnv.scan("Orders"); // schema (a, b, c, rowtime)
+Table orders = tEnv.from("Orders"); // schema (a, b, c, rowtime)
 
 Table result = orders
         .filter("a.isNotNull && b.isNotNull && c.isNotNull")
@@ -155,7 +155,7 @@ Table result = orders
 // ...
 
 // specify table program
-val orders: Table = tEnv.scan("Orders") // schema (a, b, c, rowtime)
+val orders: Table = tEnv.from("Orders") // schema (a, b, c, rowtime)
 
 val result: Table = orders
         .filter('a.isNotNull && 'b.isNotNull && 'c.isNotNull)
@@ -174,7 +174,7 @@ val result: Table = orders
 # ...
 
 # specify table program
-orders = t_env.scan("Orders")  # schema (a, b, c, rowtime)
+orders = t_env.from_path("Orders")  # schema (a, b, c, rowtime)
 
 result = orders.filter("a.isNotNull && b.isNotNull && c.isNotNull") \
                .select("a.lowerCase() as a, b, rowtime") \
@@ -210,13 +210,13 @@ The Table API supports the following operations. Please note that not all operat
   <tbody>
   	<tr>
   		<td>
-        <strong>Scan</strong><br>
+        <strong>From</strong><br>
         <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
       </td>
   		<td>
         <p>Similar to the FROM clause in a SQL query. Performs a scan of a registered table.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 {% endhighlight %}
       </td>
   	</tr>
@@ -228,7 +228,7 @@ Table orders = tableEnv.scan("Orders");
       <td>
         <p>Similar to a SQL SELECT statement. Performs a select operation.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders.select("a, c as d");
 {% endhighlight %}
         <p>You can use star (<code>*</code>) to act as a wild card, selecting all of the columns in the table.</p>
@@ -245,7 +245,7 @@ Table result = orders.select("*");
       <td>
         <p>Renames fields.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders.as("x, y, z, t");
 {% endhighlight %}
       </td>
@@ -259,12 +259,12 @@ Table result = orders.as("x, y, z, t");
       <td>
         <p>Similar to a SQL WHERE clause. Filters out rows that do not pass the filter predicate.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders.where("b === 'red'");
 {% endhighlight %}
 or
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders.filter("a % 2 === 0");
 {% endhighlight %}
       </td>
@@ -285,13 +285,13 @@ Table result = orders.filter("a % 2 === 0");
   <tbody>
   	<tr>
   		<td>
-        <strong>Scan</strong><br>
+        <strong>From</strong><br>
         <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
       </td>
   		<td>
         <p>Similar to the FROM clause in a SQL query. Performs a scan of a registered table.</p>
 {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 {% endhighlight %}
       </td>
   	</tr>
@@ -303,12 +303,12 @@ val orders: Table = tableEnv.scan("Orders")
       <td>
         <p>Similar to a SQL SELECT statement. Performs a select operation.</p>
 {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 val result = orders.select('a, 'c as 'd)
 {% endhighlight %}
         <p>You can use star (<code>*</code>) to act as a wild card, selecting all of the columns in the table.</p>
 {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 val result = orders.select('*)
 {% endhighlight %}
       </td>
@@ -321,7 +321,7 @@ val result = orders.select('*)
       <td>
         <p>Renames fields.</p>
 {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders").as('x, 'y, 'z, 't)
+val orders: Table = tableEnv.from("Orders").as('x, 'y, 'z, 't)
 {% endhighlight %}
       </td>
     </tr>
@@ -334,12 +334,12 @@ val orders: Table = tableEnv.scan("Orders").as('x, 'y, 'z, 't)
       <td>
         <p>Similar to a SQL WHERE clause. Filters out rows that do not pass the filter predicate.</p>
 {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 val result = orders.filter('a % 2 === 0)
 {% endhighlight %}
 or
 {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 val result = orders.where('b === "red")
 {% endhighlight %}
       </td>
@@ -365,7 +365,7 @@ val result = orders.where('b === "red")
   		<td>
         <p>Similar to the FROM clause in a SQL query. Performs a scan of a registered table.</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 {% endhighlight %}
       </td>
   	</tr>
@@ -377,7 +377,7 @@ orders = table_env.scan("Orders")
       <td>
         <p>Similar to a SQL SELECT statement. Performs a select operation.</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.select("a, c as d")
 {% endhighlight %}
         <p>You can use star (<code>*</code>) to act as a wild card, selecting all of the columns in the table.</p>
@@ -394,7 +394,7 @@ result = orders.select("*")
       <td>
         <p>Renames fields.</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.alias("x, y, z, t")
 {% endhighlight %}
       </td>
@@ -408,12 +408,12 @@ result = orders.alias("x, y, z, t")
       <td>
         <p>Similar to a SQL WHERE clause. Filters out rows that do not pass the filter predicate.</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.where("b === 'red'")
 {% endhighlight %}
 or
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.filter("a % 2 === 0")
 {% endhighlight %}
       </td>
@@ -446,7 +446,7 @@ result = orders.filter("a % 2 === 0")
           <td>
           <p>Performs a field add operation. It will throw an exception if the added fields already exist.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders.addColumns("concat(c, 'sunny')");
 {% endhighlight %}
 </td>
@@ -460,7 +460,7 @@ Table result = orders.addColumns("concat(c, 'sunny')");
                   <td>
                   <p>Performs a field add operation. Existing fields will be replaced if add columns name is the same as the existing column name.  Moreover, if the added fields have duplicate field name, then the last one is used. </p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders.addOrReplaceColumns("concat(c, 'sunny') as desc");
 {% endhighlight %}
                   </td>
@@ -473,7 +473,7 @@ Table result = orders.addOrReplaceColumns("concat(c, 'sunny') as desc");
                   <td>
                   <p>Performs a field drop operation. The field expressions should be field reference expressions, and only existing fields can be dropped.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders.dropColumns("b, c");
 {% endhighlight %}
                   </td>
@@ -486,7 +486,7 @@ Table result = orders.dropColumns("b, c");
                   <td>
                   <p>Performs a field rename operation. The field expressions should be alias expressions, and only the existing fields can be renamed.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders.renameColumns("b as b2, c as c2");
 {% endhighlight %}
                   </td>
@@ -513,7 +513,7 @@ Table result = orders.renameColumns("b as b2, c as c2");
           <td>
             <p>Performs a field add operation. It will throw an exception if the added fields already exist.</p>
 {% highlight scala %}
-val orders = tableEnv.scan("Orders");
+val orders = tableEnv.from("Orders");
 val result = orders.addColumns(concat('c, "Sunny"))
 {% endhighlight %}
           </td>
@@ -526,7 +526,7 @@ val result = orders.addColumns(concat('c, "Sunny"))
                   <td>
                      <p>Performs a field add operation. Existing fields will be replaced if add columns name is the same as the existing column name.  Moreover, if the added fields have duplicate field name, then the last one is used. </p>
 {% highlight scala %}
-val orders = tableEnv.scan("Orders");
+val orders = tableEnv.from("Orders");
 val result = orders.addOrReplaceColumns(concat('c, "Sunny") as 'desc)
 {% endhighlight %}
                   </td>
@@ -539,7 +539,7 @@ val result = orders.addOrReplaceColumns(concat('c, "Sunny") as 'desc)
                   <td>
                     <p>Performs a field drop operation. The field expressions should be field reference expressions, and only existing fields can be dropped.</p>
 {% highlight scala %}
-val orders = tableEnv.scan("Orders");
+val orders = tableEnv.from("Orders");
 val result = orders.dropColumns('b, 'c)
 {% endhighlight %}
                   </td>
@@ -552,7 +552,7 @@ val result = orders.dropColumns('b, 'c)
                   <td>
                     <p>Performs a field rename operation. The field expressions should be alias expressions, and only the existing fields can be renamed.</p>
 {% highlight scala %}
-val orders = tableEnv.scan("Orders");
+val orders = tableEnv.from("Orders");
 val result = orders.renameColumns('b as 'b2, 'c as 'c2)
 {% endhighlight %}
                   </td>
@@ -578,7 +578,7 @@ val result = orders.renameColumns('b as 'b2, 'c as 'c2)
           <td>
           <p>Performs a field add operation. It will throw an exception if the added fields already exist.</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.add_columns("concat(c, 'sunny')")
 {% endhighlight %}
 </td>
@@ -592,7 +592,7 @@ result = orders.add_columns("concat(c, 'sunny')")
                   <td>
                   <p>Performs a field add operation. Existing fields will be replaced if add columns name is the same as the existing column name.  Moreover, if the added fields have duplicate field name, then the last one is used. </p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.add_or_replace_columns("concat(c, 'sunny') as desc")
 {% endhighlight %}
                   </td>
@@ -605,7 +605,7 @@ result = orders.add_or_replace_columns("concat(c, 'sunny') as desc")
                   <td>
                   <p>Performs a field drop operation. The field expressions should be field reference expressions, and only existing fields can be dropped.</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.drop_columns("b, c")
 {% endhighlight %}
                   </td>
@@ -618,7 +618,7 @@ result = orders.drop_columns("b, c")
                   <td>
                   <p>Performs a field rename operation. The field expressions should be alias expressions, and only the existing fields can be renamed.</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.rename_columns("b as b2, c as c2")
 {% endhighlight %}
                   </td>
@@ -653,7 +653,7 @@ result = orders.rename_columns("b as b2, c as c2")
       <td>
         <p>Similar to a SQL GROUP BY clause. Groups the rows on the grouping keys with a following running aggregation operator to aggregate rows group-wise.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders.groupBy("a").select("a, b.sum as d");
 {% endhighlight %}
         <p><b>Note:</b> For streaming queries the required state to compute the query result might grow infinitely depending on the type of aggregation and the number of distinct grouping keys. Please provide a query configuration with valid retention interval to prevent excessive state size. See <a href="streaming/query_configuration.html">Query Configuration</a> for details.</p>
@@ -667,7 +667,7 @@ Table result = orders.groupBy("a").select("a, b.sum as d");
     	<td>
         <p>Groups and aggregates a table on a <a href="#group-windows">group window</a> and possibly one or more grouping keys.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders
     .window(Tumble.over("5.minutes").on("rowtime").as("w")) // define window
     .groupBy("a, w") // group by key and window
@@ -683,7 +683,7 @@ Table result = orders
       <td>
        <p>Similar to a SQL OVER clause. Over window aggregates are computed for each row, based on a window (range) of preceding and succeeding rows. See the <a href="#over-windows">over windows section</a> for more details.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders
     // define window
     .window(Over  
@@ -706,7 +706,7 @@ Table result = orders
       <td>
         <p>Similar to a SQL DISTINCT aggregation clause such as COUNT(DISTINCT a). Distinct aggregation declares that an aggregation function (built-in or user-defined) is only applied on distinct input values. Distinct can be applied to <b>GroupBy Aggregation</b>, <b>GroupBy Window Aggregation</b> and <b>Over Window Aggregation</b>.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 // Distinct aggregation on group by
 Table groupByDistinctResult = orders
     .groupBy("a")
@@ -726,7 +726,7 @@ Table result = orders
 {% endhighlight %}
         <p>User-defined aggregation function can also be used with DISTINCT modifiers. To calculate the aggregate results only for distinct values, simply add the distinct modifier towards the aggregation function. </p>
 {% highlight java %}
-Table orders = tEnv.scan("Orders");
+Table orders = tEnv.from("Orders");
 
 // Use distinct aggregation for user-defined aggregate functions
 tEnv.registerFunction("myUdagg", new MyUdagg());
@@ -744,7 +744,7 @@ orders.groupBy("users").select("users, myUdagg.distinct(points) as myDistinctRes
       <td>
         <p>Similar to a SQL DISTINCT clause. Returns records with distinct value combinations.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders.distinct();
 {% endhighlight %}
         <p><b>Note:</b> For streaming queries the required state to compute the query result might grow infinitely depending on the number of distinct fields. Please provide a query configuration with valid retention interval to prevent excessive state size. If state cleaning is enabled, distinct have to emit messages to prevent too early state eviction of downstream operators which makes distinct contains result updating. See <a href="streaming/query_configuration.html">Query Configuration</a> for details.</p>
@@ -774,7 +774,7 @@ Table result = orders.distinct();
       <td>
         <p>Similar to a SQL GROUP BY clause. Groups the rows on the grouping keys with a following running aggregation operator to aggregate rows group-wise.</p>
 {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 val result = orders.groupBy('a).select('a, 'b.sum as 'd)
 {% endhighlight %}
         <p><b>Note:</b> For streaming queries the required state to compute the query result might grow infinitely depending on the type of aggregation and the number of distinct grouping keys. Please provide a query configuration with valid retention interval to prevent excessive state size. See <a href="streaming/query_configuration.html">Query Configuration</a> for details.</p>
@@ -788,7 +788,7 @@ val result = orders.groupBy('a).select('a, 'b.sum as 'd)
     	<td>
         <p>Groups and aggregates a table on a <a href="#group-windows">group window</a> and possibly one or more grouping keys.</p>
 {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 val result: Table = orders
     .window(Tumble over 5.minutes on 'rowtime as 'w) // define window
     .groupBy('a, 'w) // group by key and window
@@ -804,7 +804,7 @@ val result: Table = orders
     	<td>
        <p>Similar to a SQL OVER clause. Over window aggregates are computed for each row, based on a window (range) of preceding and succeeding rows. See the <a href="#over-windows">over windows section</a> for more details.</p>
        {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 val result: Table = orders
     // define window
     .window(Over  
@@ -827,7 +827,7 @@ val result: Table = orders
       <td>
         <p>Similar to a SQL DISTINCT AGGREGATION clause such as COUNT(DISTINCT a). Distinct aggregation declares that an aggregation function (built-in or user-defined) is only applied on distinct input values. Distinct can be applied to <b>GroupBy Aggregation</b>, <b>GroupBy Window Aggregation</b> and <b>Over Window Aggregation</b>.</p>
 {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders");
+val orders: Table = tableEnv.from("Orders");
 // Distinct aggregation on group by
 val groupByDistinctResult = orders
     .groupBy('a)
@@ -847,7 +847,7 @@ val result = orders
 {% endhighlight %}
         <p>User-defined aggregation function can also be used with DISTINCT modifiers. To calculate the aggregate results only for distinct values, simply add the distinct modifier towards the aggregation function. </p>
 {% highlight scala %}
-val orders: Table = tEnv.scan("Orders");
+val orders: Table = tEnv.from("Orders");
 
 // Use distinct aggregation for user-defined aggregate functions
 val myUdagg = new MyUdagg();
@@ -865,7 +865,7 @@ orders.groupBy('users).select('users, myUdagg.distinct('points) as 'myDistinctRe
       <td>
         <p>Similar to a SQL DISTINCT clause. Returns records with distinct value combinations.</p>
 {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 val result = orders.distinct()
 {% endhighlight %}
         <p><b>Note:</b> For streaming queries the required state to compute the query result might grow infinitely depending on the number of distinct fields. Please provide a query configuration with valid retention interval to prevent excessive state size. If state cleaning is enabled, distinct have to emit messages to prevent too early state eviction of downstream operators which makes distinct contains result updating. See <a href="streaming/query_configuration.html">Query Configuration</a> for details.</p>
@@ -893,7 +893,7 @@ val result = orders.distinct()
       <td>
         <p>Similar to a SQL GROUP BY clause. Groups the rows on the grouping keys with a following running aggregation operator to aggregate rows group-wise.</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.group_by("a").select("a, b.sum as d")
 {% endhighlight %}
         <p><b>Note:</b> For streaming queries the required state to compute the query result might grow infinitely depending on the type of aggregation and the number of distinct grouping keys. Please provide a query configuration with valid retention interval to prevent excessive state size. See <a href="streaming/query_configuration.html">Query Configuration</a> for details.</p>
@@ -907,7 +907,7 @@ result = orders.group_by("a").select("a, b.sum as d")
     	<td>
         <p>Groups and aggregates a table on a <a href="#group-windows">group window</a> and possibly one or more grouping keys.</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.window(Tumble.over("5.minutes").on("rowtime").alias("w")) \ 
                .group_by("a, w") \
                .select("a, w.start, w.end, w.rowtime, b.sum as d")
@@ -922,7 +922,7 @@ result = orders.window(Tumble.over("5.minutes").on("rowtime").alias("w")) \
       <td>
        <p>Similar to a SQL OVER clause. Over window aggregates are computed for each row, based on a window (range) of preceding and succeeding rows. See the <a href="#over-windows">over windows section</a> for more details.</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.over_window(Over.partition_by("a").order_by("rowtime")
                             .preceding("UNBOUNDED_RANGE").following("CURRENT_RANGE")
                             .alias("w")) \
@@ -940,7 +940,7 @@ result = orders.over_window(Over.partition_by("a").order_by("rowtime")
       <td>
         <p>Similar to a SQL DISTINCT aggregation clause such as COUNT(DISTINCT a). Distinct aggregation declares that an aggregation function (built-in or user-defined) is only applied on distinct input values. Distinct can be applied to <b>GroupBy Aggregation</b>, <b>GroupBy Window Aggregation</b> and <b>Over Window Aggregation</b>.</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 # Distinct aggregation on group by
 group_by_distinct_result = orders.group_by("a") \
                                  .select("a, b.sum.distinct as d")
@@ -969,7 +969,7 @@ result = orders.over_window(Over
       <td>
         <p>Similar to a SQL DISTINCT clause. Returns records with distinct value combinations.</p>
 {% highlight java %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.distinct()
 {% endhighlight %}
         <p><b>Note:</b> For streaming queries the required state to compute the query result might grow infinitely depending on the number of distinct fields. Please provide a query configuration with valid retention interval to prevent excessive state size. See <a href="streaming/query_configuration.html">Query Configuration</a> for details.</p>
@@ -1073,7 +1073,7 @@ TableFunction<String> split = new MySplitUDTF();
 tableEnv.registerFunction("split", split);
 
 // join
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders
     .joinLateral("split(c).as(s, t, v)")
     .select("a, b, s, t, v");
@@ -1094,7 +1094,7 @@ TableFunction<String> split = new MySplitUDTF();
 tableEnv.registerFunction("split", split);
 
 // join
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders
     .leftOuterJoinLateral("split(c).as(s, t, v)")
     .select("a, b, s, t, v");
@@ -1113,7 +1113,7 @@ Table result = orders
 
         <p>Currently only inner joins with temporal tables are supported.</p>
 {% highlight java %}
-Table ratesHistory = tableEnv.scan("RatesHistory");
+Table ratesHistory = tableEnv.from("RatesHistory");
 
 // register temporal table function with a time attribute and primary key
 TemporalTableFunction rates = ratesHistory.createTemporalTableFunction(
@@ -1122,7 +1122,7 @@ TemporalTableFunction rates = ratesHistory.createTemporalTableFunction(
 tableEnv.registerFunction("rates", rates);
 
 // join with "Orders" based on the time attribute and key
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders
     .joinLateral("rates(o_proctime)", "o_currency = r_currency")
 {% endhighlight %}
@@ -1257,13 +1257,13 @@ val result: Table = table
 
         <p>Currently only inner joins with temporal tables are supported.</p>
 {% highlight scala %}
-val ratesHistory = tableEnv.scan("RatesHistory")
+val ratesHistory = tableEnv.from("RatesHistory")
 
 // register temporal table function with a time attribute and primary key
 val rates = ratesHistory.createTemporalTableFunction('r_proctime, 'r_currency)
 
 // join with "Orders" based on the time attribute and key
-val orders = tableEnv.scan("Orders")
+val orders = tableEnv.from("Orders")
 val result = orders
     .joinLateral(rates('o_rowtime), 'r_currency === 'o_currency)
 {% endhighlight %}
@@ -1293,8 +1293,8 @@ val result = orders
       <td>
         <p>Similar to a SQL JOIN clause. Joins two tables. Both tables must have distinct field names and at least one equality join predicate must be defined through join operator or using a where or filter operator.</p>
 {% highlight python %}
-left = table_env.scan("Source1").select("a, b, c")
-right = table_env.scan("Source2").select("d, e, f")
+left = table_env.from_path("Source1").select("a, b, c")
+right = table_env.from_path("Source2").select("d, e, f")
 result = left.join(right).where("a = d").select("a, b, e")
 {% endhighlight %}
 <p><b>Note:</b> For streaming queries the required state to compute the query result might grow infinitely depending on the number of distinct input rows. Please provide a query configuration with valid retention interval to prevent excessive state size. See <a href="streaming/query_configuration.html">Query Configuration</a> for details.</p>
@@ -1311,8 +1311,8 @@ result = left.join(right).where("a = d").select("a, b, e")
       <td>
         <p>Similar to SQL LEFT/RIGHT/FULL OUTER JOIN clauses. Joins two tables. Both tables must have distinct field names and at least one equality join predicate must be defined.</p>
 {% highlight python %}
-left = table_env.scan("Source1").select("a, b, c")
-right = table_env.scan("Source2").select("d, e, f")
+left = table_env.from_path("Source1").select("a, b, c")
+right = table_env.from_path("Source2").select("d, e, f")
 
 left_outer_result = left.left_outer_join(right, "a = d").select("a, b, e")
 right_outer_result = left.right_outer_join(right, "a = d").select("a, b, e")
@@ -1343,7 +1343,7 @@ full_outer_result = left.full_outer_join(right, "a = d").select("a, b, e")
 table_env.register_java_function("split", "com.my.udf.MySplitUDTF")
 
 # join
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.join_lateral("split(c).as(s, t, v)").select("a, b, s, t, v")
 {% endhighlight %}
       </td>
@@ -1361,7 +1361,7 @@ result = orders.join_lateral("split(c).as(s, t, v)").select("a, b, s, t, v")
 table_env.register_java_function("split", "com.my.udf.MySplitUDTF")
 
 # join
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.left_outer_join_lateral("split(c).as(s, t, v)").select("a, b, s, t, v")
 {% endhighlight %}
       </td>
@@ -1502,7 +1502,7 @@ Table right = ds2.toTable(tableEnv, "a");
 Table result = left.select("a, b, c").where("a.in(" + right + ")");
 
 // using explicit registration
-tableEnv.registerTable("RightTable", right);
+tableEnv.createTemporaryView("RightTable", right);
 Table result = left.select("a, b, c").where("a.in(RightTable)");
 {% endhighlight %}
 
@@ -1651,8 +1651,8 @@ val result = left.select('a, 'b, 'c).where('a.in(right))
       <td>
         <p>Similar to a SQL UNION clause. Unions two tables with duplicate records removed. Both tables must have identical field types.</p>
 {% highlight python %}
-left = table_env.scan("Source1").select("a, b, c")
-right = table_env.scan("Source2").select("a, b, c")
+left = table_env.from_path("Source1").select("a, b, c")
+right = table_env.from_path("Source2").select("a, b, c")
 result = left.union(right)
 {% endhighlight %}
       </td>
@@ -1666,8 +1666,8 @@ result = left.union(right)
       <td>
         <p>Similar to a SQL UNION ALL clause. Unions two tables. Both tables must have identical field types.</p>
 {% highlight python %}
-left = table_env.scan("Source1").select("a, b, c")
-right = table_env.scan("Source2").select("a, b, c")
+left = table_env.from_path("Source1").select("a, b, c")
+right = table_env.from_path("Source2").select("a, b, c")
 result = left.union_all(right)
 {% endhighlight %}
       </td>
@@ -1681,8 +1681,8 @@ result = left.union_all(right)
       <td>
         <p>Similar to a SQL INTERSECT clause. Intersect returns records that exist in both tables. If a record is present one or both tables more than once, it is returned just once, i.e., the resulting table has no duplicate records. Both tables must have identical field types.</p>
 {% highlight python %}
-left = table_env.scan("Source1").select("a, b, c")
-right = table_env.scan("Source2").select("a, b, c")
+left = table_env.from_path("Source1").select("a, b, c")
+right = table_env.from_path("Source2").select("a, b, c")
 result = left.intersect(right)
 {% endhighlight %}
       </td>
@@ -1696,8 +1696,8 @@ result = left.intersect(right)
       <td>
         <p>Similar to a SQL INTERSECT ALL clause. IntersectAll returns records that exist in both tables. If a record is present in both tables more than once, it is returned as many times as it is present in both tables, i.e., the resulting table might have duplicate records. Both tables must have identical field types.</p>
 {% highlight python %}
-left = table_env.scan("Source1").select("a, b, c")
-right = table_env.scan("Source2").select("a, b, c")
+left = table_env.from_path("Source1").select("a, b, c")
+right = table_env.from_path("Source2").select("a, b, c")
 result = left.intersect_all(right)
 {% endhighlight %}
       </td>
@@ -1711,8 +1711,8 @@ result = left.intersect_all(right)
       <td>
         <p>Similar to a SQL EXCEPT clause. Minus returns records from the left table that do not exist in the right table. Duplicate records in the left table are returned exactly once, i.e., duplicates are removed. Both tables must have identical field types.</p>
 {% highlight python %}
-left = table_env.scan("Source1").select("a, b, c")
-right = table_env.scan("Source2").select("a, b, c")
+left = table_env.from_path("Source1").select("a, b, c")
+right = table_env.from_path("Source2").select("a, b, c")
 result = left.minus(right);
 {% endhighlight %}
       </td>
@@ -1726,8 +1726,8 @@ result = left.minus(right);
       <td>
         <p>Similar to a SQL EXCEPT ALL clause. MinusAll returns the records that do not exist in the right table. A record that is present n times in the left table and m times in the right table is returned (n - m) times, i.e., as many duplicates as are present in the right table are removed. Both tables must have identical field types.</p>
 {% highlight python %}
-left = table_env.scan("Source1").select("a, b, c")
-right = table_env.scan("Source2").select("a, b, c")
+left = table_env.from_path("Source1").select("a, b, c")
+right = table_env.from_path("Source2").select("a, b, c")
 result = left.minus_all(right)
 {% endhighlight %}
       </td>
@@ -1741,8 +1741,8 @@ result = left.minus_all(right)
       <td>
         <p>Similar to a SQL IN clause. In returns true if an expression exists in a given table sub-query. The sub-query table must consist of one column. This column must have the same data type as the expression.</p>
 {% highlight python %}
-left = table_env.scan("Source1").select("a, b, c")
-right = table_env.scan("Source2").select("a")
+left = table_env.from_path("Source1").select("a, b, c")
+right = table_env.from_path("Source2").select("a")
 
 # using implicit registration
 result = left.select("a, b, c").where("a.in(%s)" % right)
@@ -1880,7 +1880,7 @@ val result3: Table = in.orderBy('a.asc).offset(10).fetch(5)
       <td>
         <p>Similar to a SQL ORDER BY clause. Returns records globally sorted across all parallel partitions.</p>
 {% highlight python %}
-in = table_env.scan("Source1").select("a, b, c")
+in = table_env.from_path("Source1").select("a, b, c")
 result = in.order_by("a.asc")
 {% endhighlight %}
       </td>
@@ -1894,7 +1894,7 @@ result = in.order_by("a.asc")
       <td>
         <p>Similar to the SQL OFFSET and FETCH clauses. Offset and Fetch limit the number of records returned from a sorted result. Offset and Fetch are technically part of the Order By operator and thus must be preceded by it.</p>
 {% highlight python %}
-in = table_env.scan("Source1").select("a, b, c")
+in = table_env.from_path("Source1").select("a, b, c")
 
 # returns the first 5 records from the sorted result
 result1 = in.order_by("a.asc").fetch(5)
@@ -1934,10 +1934,10 @@ result3 = in.order_by("a.asc").offset(10).fetch(5)
       <td>
         <p>Similar to the INSERT INTO clause in a SQL query. Performs a insertion into a registered output table.</p>
 
-        <p>Output tables must be registered in the TableEnvironment (see <a href="common.html#register-a-tablesink">Register a TableSink</a>). Moreover, the schema of the registered table must match the schema of the query.</p>
+        <p>Output tables must be registered in the TableEnvironment (see <a href="common.html#connector-tables">Connector tables</a>). Moreover, the schema of the registered table must match the schema of the query.</p>
 
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 orders.insertInto("OutOrders");
 {% endhighlight %}
       </td>
@@ -1964,10 +1964,10 @@ orders.insertInto("OutOrders");
       <td>
         <p>Similar to the INSERT INTO clause in a SQL query. Performs a insertion into a registered output table.</p>
 
-        <p>Output tables must be registered in the TableEnvironment (see <a href="common.html#register-a-tablesink">Register a TableSink</a>). Moreover, the schema of the registered table must match the schema of the query.</p>
+        <p>Output tables must be registered in the TableEnvironment (see <a href="common.html#connector-tables">Connector tables</a>). Moreover, the schema of the registered table must match the schema of the query.</p>
 
 {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 orders.insertInto("OutOrders")
 {% endhighlight %}
       </td>
@@ -1997,7 +1997,7 @@ orders.insertInto("OutOrders")
         <p>Output tables must be registered in the TableEnvironment (see <a href="common.html#register-a-tablesink">Register a TableSink</a>). Moreover, the schema of the registered table must match the schema of the query.</p>
 
 {% highlight python %}
-orders = table_env.scan("Orders");
+orders = table_env.from_path("Orders");
 orders.insert_into("OutOrders");
 {% endhighlight %}
       </td>
@@ -2739,7 +2739,7 @@ public class Top2 extends TableAggregateFunction<Tuple2<Integer, Integer>, Top2A
 }
     
 tEnv.registerFunction("top2", new Top2());
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders
     .groupBy("key")
     .flatAggregate("top2(a) as (v, rank)")
@@ -2759,7 +2759,7 @@ Table result = orders
         <p>Groups and aggregates a table on a <a href="#group-windows">group window</a> and possibly one or more grouping keys. You have to close the "flatAggregate" with a select statement. And the select statement does not support aggregate functions.</p>
 {% highlight java %}
 tableEnv.registerFunction("top2", new Top2());
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders
     .window(Tumble.over("5.minutes").on("rowtime").as("w")) // define window
     .groupBy("a, w") // group by key and window
@@ -2967,7 +2967,7 @@ class Top2 extends TableAggregateFunction[JTuple2[JInteger, JInteger], Top2Accum
 }
 
 val top2 = new Top2
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 val result = orders
     .groupBy('key)
     .flatAggregate(top2('a) as ('v, 'rank))
@@ -2986,7 +2986,7 @@ val result = orders
         <p>Groups and aggregates a table on a <a href="#group-windows">group window</a> and possibly one or more grouping keys. You have to close the "flatAggregate" with a select statement. And the select statement does not support aggregate functions.</p>
 {% highlight scala %}
 val top2 = new Top2
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 val result = orders
     .window(Tumble over 5.minutes on 'rowtime as 'w) // define window
     .groupBy('a, 'w) // group by key and window

--- a/docs/dev/table/tableApi.zh.md
+++ b/docs/dev/table/tableApi.zh.md
@@ -55,7 +55,7 @@ BatchTableEnvironment tEnv = BatchTableEnvironment.create(env);
 // ...
 
 // specify table program
-Table orders = tEnv.scan("Orders"); // schema (a, b, c, rowtime)
+Table orders = tEnv.from("Orders"); // schema (a, b, c, rowtime)
 
 Table counts = orders
         .groupBy("a")
@@ -87,7 +87,7 @@ val tEnv = BatchTableEnvironment.create(env)
 // ...
 
 // specify table program
-val orders = tEnv.scan("Orders") // schema (a, b, c, rowtime)
+val orders = tEnv.from("Orders") // schema (a, b, c, rowtime)
 
 val result = orders
                .groupBy('a)
@@ -115,7 +115,7 @@ t_env = TableEnvironment.create(env, TableConfig())
 # ...
 
 # specify table program
-orders = t_env.scan("Orders")  # schema (a, b, c, rowtime)
+orders = t_env.from_path("Orders")  # schema (a, b, c, rowtime)
 
 orders.group_by("a").select("a, b.count as cnt").insert_into("result")
 
@@ -136,7 +136,7 @@ The next example shows a more complex Table API program. The program scans again
 // ...
 
 // specify table program
-Table orders = tEnv.scan("Orders"); // schema (a, b, c, rowtime)
+Table orders = tEnv.from("Orders"); // schema (a, b, c, rowtime)
 
 Table result = orders
         .filter("a.isNotNull && b.isNotNull && c.isNotNull")
@@ -155,7 +155,7 @@ Table result = orders
 // ...
 
 // specify table program
-val orders: Table = tEnv.scan("Orders") // schema (a, b, c, rowtime)
+val orders: Table = tEnv.from("Orders") // schema (a, b, c, rowtime)
 
 val result: Table = orders
         .filter('a.isNotNull && 'b.isNotNull && 'c.isNotNull)
@@ -174,7 +174,7 @@ val result: Table = orders
 # ...
 
 # specify table program
-orders = t_env.scan("Orders")  # schema (a, b, c, rowtime)
+orders = t_env.from_path("Orders")  # schema (a, b, c, rowtime)
 
 result = orders.filter("a.isNotNull && b.isNotNull && c.isNotNull") \
                .select("a.lowerCase() as a, b, rowtime") \
@@ -210,13 +210,13 @@ The Table API supports the following operations. Please note that not all operat
   <tbody>
   	<tr>
   		<td>
-        <strong>Scan</strong><br>
+        <strong>From</strong><br>
         <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
       </td>
   		<td>
         <p>Similar to the FROM clause in a SQL query. Performs a scan of a registered table.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 {% endhighlight %}
       </td>
   	</tr>
@@ -228,7 +228,7 @@ Table orders = tableEnv.scan("Orders");
       <td>
         <p>Similar to a SQL SELECT statement. Performs a select operation.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders.select("a, c as d");
 {% endhighlight %}
         <p>You can use star (<code>*</code>) to act as a wild card, selecting all of the columns in the table.</p>
@@ -245,7 +245,7 @@ Table result = orders.select("*");
       <td>
         <p>Renames fields.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders.as("x, y, z, t");
 {% endhighlight %}
       </td>
@@ -259,12 +259,12 @@ Table result = orders.as("x, y, z, t");
       <td>
         <p>Similar to a SQL WHERE clause. Filters out rows that do not pass the filter predicate.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders.where("b === 'red'");
 {% endhighlight %}
 or
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders.filter("a % 2 === 0");
 {% endhighlight %}
       </td>
@@ -285,13 +285,13 @@ Table result = orders.filter("a % 2 === 0");
   <tbody>
   	<tr>
   		<td>
-        <strong>Scan</strong><br>
+        <strong>From</strong><br>
         <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
       </td>
   		<td>
         <p>Similar to the FROM clause in a SQL query. Performs a scan of a registered table.</p>
 {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 {% endhighlight %}
       </td>
   	</tr>
@@ -303,12 +303,12 @@ val orders: Table = tableEnv.scan("Orders")
       <td>
         <p>Similar to a SQL SELECT statement. Performs a select operation.</p>
 {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 val result = orders.select('a, 'c as 'd)
 {% endhighlight %}
         <p>You can use star (<code>*</code>) to act as a wild card, selecting all of the columns in the table.</p>
 {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 val result = orders.select('*)
 {% endhighlight %}
       </td>
@@ -321,7 +321,7 @@ val result = orders.select('*)
       <td>
         <p>Renames fields.</p>
 {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders").as('x, 'y, 'z, 't)
+val orders: Table = tableEnv.from("Orders").as('x, 'y, 'z, 't)
 {% endhighlight %}
       </td>
     </tr>
@@ -334,12 +334,12 @@ val orders: Table = tableEnv.scan("Orders").as('x, 'y, 'z, 't)
       <td>
         <p>Similar to a SQL WHERE clause. Filters out rows that do not pass the filter predicate.</p>
 {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 val result = orders.filter('a % 2 === 0)
 {% endhighlight %}
 or
 {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 val result = orders.where('b === "red")
 {% endhighlight %}
       </td>
@@ -365,7 +365,7 @@ val result = orders.where('b === "red")
   		<td>
         <p>类似于SQL请求中的FROM子句，将一个环境中已注册的表转换成Table对象。</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 {% endhighlight %}
       </td>
   	</tr>
@@ -377,7 +377,7 @@ orders = table_env.scan("Orders")
       <td>
         <p>类似于SQL请求中的SELECT子句，执行一个select操作。</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.select("a, c as d")
 {% endhighlight %}
         <p>您可以使用星号 (<code>*</code>) 表示选择表中的所有列。</p>
@@ -394,7 +394,7 @@ result = orders.select("*")
       <td>
         <p>重命名字段。</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.alias("x, y, z, t")
 {% endhighlight %}
       </td>
@@ -408,12 +408,12 @@ result = orders.alias("x, y, z, t")
       <td>
         <p>类似于SQL请求中的WHERE子句，过滤掉表中不满足条件的行。</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.where("b === 'red'")
 {% endhighlight %}
 or
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.filter("a % 2 === 0")
 {% endhighlight %}
       </td>
@@ -446,7 +446,7 @@ result = orders.filter("a % 2 === 0")
           <td>
           <p>Performs a field add operation. It will throw an exception if the added fields already exist.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders.addColumns("concat(c, 'sunny')");
 {% endhighlight %}
 </td>
@@ -460,7 +460,7 @@ Table result = orders.addColumns("concat(c, 'sunny')");
                   <td>
                   <p>Performs a field add operation. Existing fields will be replaced if add columns name is the same as the existing column name.  Moreover, if the added fields have duplicate field name, then the last one is used. </p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders.addOrReplaceColumns("concat(c, 'sunny') as desc");
 {% endhighlight %}
                   </td>
@@ -473,7 +473,7 @@ Table result = orders.addOrReplaceColumns("concat(c, 'sunny') as desc");
                   <td>
                   <p>Performs a field drop operation. The field expressions should be field reference expressions, and only existing fields can be dropped.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders.dropColumns("b, c");
 {% endhighlight %}
                   </td>
@@ -486,7 +486,7 @@ Table result = orders.dropColumns("b, c");
                   <td>
                   <p>Performs a field rename operation. The field expressions should be alias expressions, and only the existing fields can be renamed.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders.renameColumns("b as b2, c as c2");
 {% endhighlight %}
                   </td>
@@ -513,7 +513,7 @@ Table result = orders.renameColumns("b as b2, c as c2");
           <td>
             <p>Performs a field add operation. It will throw an exception if the added fields already exist.</p>
 {% highlight scala %}
-val orders = tableEnv.scan("Orders");
+val orders = tableEnv.from("Orders");
 val result = orders.addColumns(concat('c, "Sunny"))
 {% endhighlight %}
           </td>
@@ -526,7 +526,7 @@ val result = orders.addColumns(concat('c, "Sunny"))
                   <td>
                      <p>Performs a field add operation. Existing fields will be replaced if add columns name is the same as the existing column name.  Moreover, if the added fields have duplicate field name, then the last one is used. </p>
 {% highlight scala %}
-val orders = tableEnv.scan("Orders");
+val orders = tableEnv.from("Orders");
 val result = orders.addOrReplaceColumns(concat('c, "Sunny") as 'desc)
 {% endhighlight %}
                   </td>
@@ -539,7 +539,7 @@ val result = orders.addOrReplaceColumns(concat('c, "Sunny") as 'desc)
                   <td>
                     <p>Performs a field drop operation. The field expressions should be field reference expressions, and only existing fields can be dropped.</p>
 {% highlight scala %}
-val orders = tableEnv.scan("Orders");
+val orders = tableEnv.from("Orders");
 val result = orders.dropColumns('b, 'c)
 {% endhighlight %}
                   </td>
@@ -552,7 +552,7 @@ val result = orders.dropColumns('b, 'c)
                   <td>
                     <p>Performs a field rename operation. The field expressions should be alias expressions, and only the existing fields can be renamed.</p>
 {% highlight scala %}
-val orders = tableEnv.scan("Orders");
+val orders = tableEnv.from("Orders");
 val result = orders.renameColumns('b as 'b2, 'c as 'c2)
 {% endhighlight %}
                   </td>
@@ -578,7 +578,7 @@ val result = orders.renameColumns('b as 'b2, 'c as 'c2)
           <td>
           <p>执行新增字段操作。如果欲添加字段已经存在，将会抛出异常。</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.add_columns("concat(c, 'sunny')")
 {% endhighlight %}
 </td>
@@ -592,7 +592,7 @@ result = orders.add_columns("concat(c, 'sunny')")
                   <td>
                   <p>执行新增字段操作。如果欲添加字段已经存在，将会替换该字段。如果新增字段列表中有同名字段，取最靠后的为有效字段。</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.add_or_replace_columns("concat(c, 'sunny') as desc")
 {% endhighlight %}
                   </td>
@@ -605,7 +605,7 @@ result = orders.add_or_replace_columns("concat(c, 'sunny') as desc")
                   <td>
                   <p>执行删除字段操作。参数必须是字段列表，并且必须是已经存在的字段才能被删除。</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.drop_columns("b, c")
 {% endhighlight %}
                   </td>
@@ -618,7 +618,7 @@ result = orders.drop_columns("b, c")
                   <td>
                   <p>执行重命名字段操作。参数必须是字段别名(例：b as b2)列表，并且必须是已经存在的字段才能被重命名。</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.rename_columns("b as b2, c as c2")
 {% endhighlight %}
                   </td>
@@ -653,7 +653,7 @@ result = orders.rename_columns("b as b2, c as c2")
       <td>
         <p>Similar to a SQL GROUP BY clause. Groups the rows on the grouping keys with a following running aggregation operator to aggregate rows group-wise.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders.groupBy("a").select("a, b.sum as d");
 {% endhighlight %}
         <p><b>Note:</b> For streaming queries the required state to compute the query result might grow infinitely depending on the type of aggregation and the number of distinct grouping keys. Please provide a query configuration with valid retention interval to prevent excessive state size. See <a href="streaming/query_configuration.html">Query Configuration</a> for details.</p>
@@ -667,7 +667,7 @@ Table result = orders.groupBy("a").select("a, b.sum as d");
     	<td>
         <p>Groups and aggregates a table on a <a href="#group-windows">group window</a> and possibly one or more grouping keys.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders
     .window(Tumble.over("5.minutes").on("rowtime").as("w")) // define window
     .groupBy("a, w") // group by key and window
@@ -683,7 +683,7 @@ Table result = orders
       <td>
        <p>Similar to a SQL OVER clause. Over window aggregates are computed for each row, based on a window (range) of preceding and succeeding rows. See the <a href="#over-windows">over windows section</a> for more details.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders
     // define window
     .window(Over
@@ -706,7 +706,7 @@ Table result = orders
       <td>
         <p>Similar to a SQL DISTINCT aggregation clause such as COUNT(DISTINCT a). Distinct aggregation declares that an aggregation function (built-in or user-defined) is only applied on distinct input values. Distinct can be applied to <b>GroupBy Aggregation</b>, <b>GroupBy Window Aggregation</b> and <b>Over Window Aggregation</b>.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 // Distinct aggregation on group by
 Table groupByDistinctResult = orders
     .groupBy("a")
@@ -726,7 +726,7 @@ Table result = orders
 {% endhighlight %}
         <p>User-defined aggregation function can also be used with DISTINCT modifiers. To calculate the aggregate results only for distinct values, simply add the distinct modifier towards the aggregation function. </p>
 {% highlight java %}
-Table orders = tEnv.scan("Orders");
+Table orders = tEnv.from("Orders");
 
 // Use distinct aggregation for user-defined aggregate functions
 tEnv.registerFunction("myUdagg", new MyUdagg());
@@ -744,7 +744,7 @@ orders.groupBy("users").select("users, myUdagg.distinct(points) as myDistinctRes
       <td>
         <p>Similar to a SQL DISTINCT clause. Returns records with distinct value combinations.</p>
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders.distinct();
 {% endhighlight %}
         <p><b>Note:</b> For streaming queries the required state to compute the query result might grow infinitely depending on the number of distinct fields. Please provide a query configuration with valid retention interval to prevent excessive state size. If state cleaning is enabled, distinct have to emit messages to prevent too early state eviction of downstream operators which makes distinct contains result updating. See <a href="streaming/query_configuration.html">Query Configuration</a> for details.</p>
@@ -774,7 +774,7 @@ Table result = orders.distinct();
       <td>
         <p>Similar to a SQL GROUP BY clause. Groups the rows on the grouping keys with a following running aggregation operator to aggregate rows group-wise.</p>
 {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 val result = orders.groupBy('a).select('a, 'b.sum as 'd)
 {% endhighlight %}
         <p><b>Note:</b> For streaming queries the required state to compute the query result might grow infinitely depending on the type of aggregation and the number of distinct grouping keys. Please provide a query configuration with valid retention interval to prevent excessive state size. See <a href="streaming/query_configuration.html">Query Configuration</a> for details.</p>
@@ -788,7 +788,7 @@ val result = orders.groupBy('a).select('a, 'b.sum as 'd)
     	<td>
         <p>Groups and aggregates a table on a <a href="#group-windows">group window</a> and possibly one or more grouping keys.</p>
 {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 val result: Table = orders
     .window(Tumble over 5.minutes on 'rowtime as 'w) // define window
     .groupBy('a, 'w) // group by key and window
@@ -804,7 +804,7 @@ val result: Table = orders
     	<td>
        <p>Similar to a SQL OVER clause. Over window aggregates are computed for each row, based on a window (range) of preceding and succeeding rows. See the <a href="#over-windows">over windows section</a> for more details.</p>
        {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 val result: Table = orders
     // define window
     .window(Over
@@ -827,7 +827,7 @@ val result: Table = orders
       <td>
         <p>Similar to a SQL DISTINCT AGGREGATION clause such as COUNT(DISTINCT a). Distinct aggregation declares that an aggregation function (built-in or user-defined) is only applied on distinct input values. Distinct can be applied to <b>GroupBy Aggregation</b>, <b>GroupBy Window Aggregation</b> and <b>Over Window Aggregation</b>.</p>
 {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders");
+val orders: Table = tableEnv.from("Orders");
 // Distinct aggregation on group by
 val groupByDistinctResult = orders
     .groupBy('a)
@@ -847,7 +847,7 @@ val result = orders
 {% endhighlight %}
         <p>User-defined aggregation function can also be used with DISTINCT modifiers. To calculate the aggregate results only for distinct values, simply add the distinct modifier towards the aggregation function. </p>
 {% highlight scala %}
-val orders: Table = tEnv.scan("Orders");
+val orders: Table = tEnv.from("Orders");
 
 // Use distinct aggregation for user-defined aggregate functions
 val myUdagg = new MyUdagg();
@@ -864,7 +864,7 @@ orders.groupBy('users).select('users, myUdagg.distinct('points) as 'myDistinctRe
       <td>
         <p>Similar to a SQL DISTINCT clause. Returns records with distinct value combinations.</p>
 {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 val result = orders.distinct()
 {% endhighlight %}
         <p><b>Note:</b> For streaming queries the required state to compute the query result might grow infinitely depending on the number of distinct fields. Please provide a query configuration with valid retention interval to prevent excessive state size. See <a href="streaming/query_configuration.html">Query Configuration</a> for details.</p>
@@ -892,7 +892,7 @@ val result = orders.distinct()
       <td>
         <p>类似于SQL的GROUP BY子句。将数据按照指定字段进行分组，之后对各组内数据执行聚合操作。</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.group_by("a").select("a, b.sum as d")
 {% endhighlight %}
         <p><b>注意：</b> 对于流式查询，计算查询结果所需的状态（state）可能会无限增长，具体情况取决于聚合操作的类型和分组的数量。您可能需要在查询配置中设置状态保留时间，以防止状态过大。详情请看<a href="streaming/query_configuration.html">查询配置</a>。</p>
@@ -906,7 +906,7 @@ result = orders.group_by("a").select("a, b.sum as d")
     	<td>
         <p>在一个窗口上分组和聚合数据，可包含其它分组字段。</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.window(Tumble.over("5.minutes").on("rowtime").alias("w")) \ 
                .group_by("a, w") \
                .select("a, w.start, w.end, w.rowtime, b.sum as d")
@@ -921,7 +921,7 @@ result = orders.window(Tumble.over("5.minutes").on("rowtime").alias("w")) \
       <td>
        <p>类似于SQL中的OVER开窗函数。Over窗口聚合对每一行都进行一次聚合计算，聚合的对象是以当前行的位置为基准，向前向后取一个区间范围内的所有数据。详情请见<a href="#over-windows">Over窗口</a>一节。</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.over_window(Over.partition_by("a").order_by("rowtime")
                             .preceding("UNBOUNDED_RANGE").following("CURRENT_RANGE")
                             .alias("w")) \
@@ -939,7 +939,7 @@ result = orders.over_window(Over.partition_by("a").order_by("rowtime")
       <td>
         <p>类似于SQL聚合函数中的的DISTINCT关键字比如COUNT(DISTINCT a)。带有distinct标记的聚合函数只会接受不重复的输入，重复输入将被丢弃。这个去重特性可以在<b>分组聚合（GroupBy Aggregation）</b>，<b>分组窗口聚合（GroupBy Window Aggregation）</b>以及<b>Over窗口聚合（Over Window Aggregation）</b>上使用。</p>
 {% highlight python %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 # Distinct aggregation on group by
 group_by_distinct_result = orders.group_by("a") \
                                  .select("a, b.sum.distinct as d")
@@ -968,7 +968,7 @@ result = orders.over_window(Over
       <td>
         <p>类似于SQL中的DISTINCT子句。返回去重后的数据。</p>
 {% highlight java %}
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.distinct()
 {% endhighlight %}
         <p><b>注意：</b> 对于流式查询，计算查询结果所需的状态（state）可能会无限增长，具体情况取决于执行去重判断时参与判断的字段的数量。您可能需要在查询配置中设置状态保留时间，以防止状态过大。详情请看<a href="streaming/query_configuration.html">查询配置</a>。</p>
@@ -1072,7 +1072,7 @@ TableFunction<String> split = new MySplitUDTF();
 tableEnv.registerFunction("split", split);
 
 // join
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders
     .joinLateral("split(c).as(s, t, v)")
     .select("a, b, s, t, v");
@@ -1093,7 +1093,7 @@ TableFunction<String> split = new MySplitUDTF();
 tableEnv.registerFunction("split", split);
 
 // join
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders
     .leftOuterJoinLateral("split(c).as(s, t, v)")
     .select("a, b, s, t, v");
@@ -1112,7 +1112,7 @@ Table result = orders
 
         <p>Currently only inner joins with temporal tables are supported.</p>
 {% highlight java %}
-Table ratesHistory = tableEnv.scan("RatesHistory");
+Table ratesHistory = tableEnv.from("RatesHistory");
 
 // register temporal table function with a time attribute and primary key
 TemporalTableFunction rates = ratesHistory.createTemporalTableFunction(
@@ -1121,7 +1121,7 @@ TemporalTableFunction rates = ratesHistory.createTemporalTableFunction(
 tableEnv.registerFunction("rates", rates);
 
 // join with "Orders" based on the time attribute and key
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders
     .joinLateral("rates(o_proctime)", "o_currency = r_currency")
 {% endhighlight %}
@@ -1256,13 +1256,13 @@ val result: Table = table
 
         <p>Currently only inner joins with temporal tables are supported.</p>
 {% highlight scala %}
-val ratesHistory = tableEnv.scan("RatesHistory")
+val ratesHistory = tableEnv.from("RatesHistory")
 
 // register temporal table function with a time attribute and primary key
 val rates = ratesHistory.createTemporalTableFunction('r_proctime, 'r_currency)
 
 // join with "Orders" based on the time attribute and key
-val orders = tableEnv.scan("Orders")
+val orders = tableEnv.from("Orders")
 val result = orders
     .joinLateral(rates('o_rowtime), 'r_currency === 'o_currency)
 {% endhighlight %}
@@ -1292,8 +1292,8 @@ val result = orders
       <td>
         <p>类似于SQL的JOIN子句。对两张表执行内连接操作。两张表必须具有不同的字段名称，并且必须在join方法或者随后的where或filter方法中定义至少一个等值连接条件。</p>
 {% highlight python %}
-left = table_env.scan("Source1").select("a, b, c")
-right = table_env.scan("Source2").select("d, e, f")
+left = table_env.from_path("Source1").select("a, b, c")
+right = table_env.from_path("Source2").select("d, e, f")
 result = left.join(right).where("a = d").select("a, b, e")
 {% endhighlight %}
 <p><b>注意：</b> 对于流式查询，计算查询结果所需的状态（state）可能会无限增长，具体取决于不重复的输入行的数量。您可能需要在查询配置中设置状态保留时间，以防止状态过大。详情请看<a href="streaming/query_configuration.html">查询配置</a>。</p>
@@ -1310,8 +1310,8 @@ result = left.join(right).where("a = d").select("a, b, e")
       <td>
         <p>类似于SQL的LEFT/RIGHT/FULL OUTER JOIN子句。对两张表执行外连接操作。两张表必须具有不同的字段名称，并且必须定义至少一个等值连接条件。</p>
 {% highlight python %}
-left = table_env.scan("Source1").select("a, b, c")
-right = table_env.scan("Source2").select("d, e, f")
+left = table_env.from_path("Source1").select("a, b, c")
+right = table_env.from_path("Source2").select("d, e, f")
 
 left_outer_result = left.left_outer_join(right, "a = d").select("a, b, e")
 right_outer_result = left.right_outer_join(right, "a = d").select("a, b, e")
@@ -1342,7 +1342,7 @@ full_outer_result = left.full_outer_join(right, "a = d").select("a, b, e")
 table_env.register_java_function("split", "com.my.udf.MySplitUDTF")
 
 # join
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.join_lateral("split(c).as(s, t, v)").select("a, b, s, t, v")
 {% endhighlight %}
       </td>
@@ -1360,7 +1360,7 @@ result = orders.join_lateral("split(c).as(s, t, v)").select("a, b, s, t, v")
 table_env.register_java_function("split", "com.my.udf.MySplitUDTF")
 
 # join
-orders = table_env.scan("Orders")
+orders = table_env.from_path("Orders")
 result = orders.left_outer_join_lateral("split(c).as(s, t, v)").select("a, b, s, t, v")
 {% endhighlight %}
       </td>
@@ -1501,7 +1501,7 @@ Table right = ds2.toTable(tableEnv, "a");
 Table result = left.select("a, b, c").where("a.in(" + right + ")");
 
 // using explicit registration
-tableEnv.registerTable("RightTable", right);
+tableEnv.createTemporaryView("RightTable", right);
 Table result = left.select("a, b, c").where("a.in(RightTable)");
 {% endhighlight %}
 
@@ -1650,8 +1650,8 @@ val result = left.select('a, 'b, 'c).where('a.in(right))
       <td>
         <p>类似于SQL的UNION子句。将两张表组合成一张表，这张表拥有二者去除重复后的全部数据。两张表的字段和类型必须完全一致。</p>
 {% highlight python %}
-left = table_env.scan("Source1").select("a, b, c")
-right = table_env.scan("Source2").select("a, b, c")
+left = table_env.from_path("Source1").select("a, b, c")
+right = table_env.from_path("Source2").select("a, b, c")
 result = left.union(right)
 {% endhighlight %}
       </td>
@@ -1665,8 +1665,8 @@ result = left.union(right)
       <td>
         <p>类似于SQL的UNION ALL子句。将两张表组合成一张表，这张表拥有二者的全部数据。两张表的字段和类型必须完全一致。</p>
 {% highlight python %}
-left = table_env.scan("Source1").select("a, b, c")
-right = table_env.scan("Source2").select("a, b, c")
+left = table_env.from_path("Source1").select("a, b, c")
+right = table_env.from_path("Source2").select("a, b, c")
 result = left.union_all(right)
 {% endhighlight %}
       </td>
@@ -1680,8 +1680,8 @@ result = left.union_all(right)
       <td>
         <p>类似于SQL的INTERSECT子句。Intersect返回在两张表中都存在的数据。如果一个记录在两张表中不止出现一次，则只返回一次，即结果表没有重复记录。两张表的字段和类型必须完全一致。</p>
 {% highlight python %}
-left = table_env.scan("Source1").select("a, b, c")
-right = table_env.scan("Source2").select("a, b, c")
+left = table_env.from_path("Source1").select("a, b, c")
+right = table_env.from_path("Source2").select("a, b, c")
 result = left.intersect(right)
 {% endhighlight %}
       </td>
@@ -1695,8 +1695,8 @@ result = left.intersect(right)
       <td>
         <p>类似于SQL的INTERSECT ALL子句。IntersectAll返回在两张表中都存在的数据。如果一个记录在两张表中不止出现一次，则按照它在两张表中都出现的次数返回，即结果表可能包含重复数据。两张表的字段和类型必须完全一致。</p>
 {% highlight python %}
-left = table_env.scan("Source1").select("a, b, c")
-right = table_env.scan("Source2").select("a, b, c")
+left = table_env.from_path("Source1").select("a, b, c")
+right = table_env.from_path("Source2").select("a, b, c")
 result = left.intersect_all(right)
 {% endhighlight %}
       </td>
@@ -1710,8 +1710,8 @@ result = left.intersect_all(right)
       <td>
         <p>类似于SQL的EXCEPT子句。Minus返回仅存在于左表，不存在于右表中的数据。左表中的相同数据只会返回一次，即数据会被去重。两张表的字段和类型必须完全一致。</p>
 {% highlight python %}
-left = table_env.scan("Source1").select("a, b, c")
-right = table_env.scan("Source2").select("a, b, c")
+left = table_env.from_path("Source1").select("a, b, c")
+right = table_env.from_path("Source2").select("a, b, c")
 result = left.minus(right);
 {% endhighlight %}
       </td>
@@ -1725,8 +1725,8 @@ result = left.minus(right);
       <td>
         <p>类似于SQL的EXCEPT ALL子句。MinusAll返回仅存在于左表，不存在于右表中的数据。如果一条数据在左表中出现了n次，在右表中出现了m次，最终这条数据将会被返回(n - m)次，即按右表中出现的次数来移除数据。两张表的字段和类型必须完全一致。</p>
 {% highlight python %}
-left = table_env.scan("Source1").select("a, b, c")
-right = table_env.scan("Source2").select("a, b, c")
+left = table_env.from_path("Source1").select("a, b, c")
+right = table_env.from_path("Source2").select("a, b, c")
 result = left.minus_all(right)
 {% endhighlight %}
       </td>
@@ -1740,8 +1740,8 @@ result = left.minus_all(right)
       <td>
         <p>类似于SQL的IN子句。如果In左边表达式的值在给定的子查询结果中则返回true。子查询的结果必须为单列。此列数据类型必须和表达式一致。</p>
 {% highlight python %}
-left = table_env.scan("Source1").select("a, b, c")
-right = table_env.scan("Source2").select("a")
+left = table_env.from_path("Source1").select("a, b, c")
+right = table_env.from_path("Source2").select("a")
 
 # using implicit registration
 result = left.select("a, b, c").where("a.in(%s)" % right)
@@ -1879,7 +1879,7 @@ val result3: Table = in.orderBy('a.asc).offset(10).fetch(5)
       <td>
         <p>类似于SQL的ORDER BY子句。返回包括所有子并发分区内所有数据的全局排序结果。</p>
 {% highlight python %}
-in = table_env.scan("Source1").select("a, b, c")
+in = table_env.from_path("Source1").select("a, b, c")
 result = in.order_by("a.asc")
 {% endhighlight %}
       </td>
@@ -1893,7 +1893,7 @@ result = in.order_by("a.asc")
       <td>
         <p>类似于SQL的OFFSET和FETCH子句。Offset和Fetch从已排序的结果中返回指定数量的数据。Offset和Fetch在技术上是Order By操作的一部分，因此必须紧跟其后出现。</p>
 {% highlight python %}
-in = table_env.scan("Source1").select("a, b, c")
+in = table_env.from_path("Source1").select("a, b, c")
 
 # returns the first 5 records from the sorted result
 result1 = in.order_by("a.asc").fetch(5)
@@ -1936,7 +1936,7 @@ result3 = in.order_by("a.asc").offset(10).fetch(5)
         <p>Output tables must be registered in the TableEnvironment (see <a href="common.html#register-a-tablesink">Register a TableSink</a>). Moreover, the schema of the registered table must match the schema of the query.</p>
 
 {% highlight java %}
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 orders.insertInto("OutOrders");
 {% endhighlight %}
       </td>
@@ -1963,10 +1963,10 @@ orders.insertInto("OutOrders");
       <td>
         <p>Similar to the INSERT INTO clause in a SQL query. Performs a insertion into a registered output table.</p>
 
-        <p>Output tables must be registered in the TableEnvironment (see <a href="common.html#register-a-tablesink">Register a TableSink</a>). Moreover, the schema of the registered table must match the schema of the query.</p>
+        <p>Output tables must be registered in the TableEnvironment (see <a href="common.html#connector-tables">Connector tables</a>). Moreover, the schema of the registered table must match the schema of the query.</p>
 
 {% highlight scala %}
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 orders.insertInto("OutOrders")
 {% endhighlight %}
       </td>
@@ -1996,7 +1996,7 @@ orders.insertInto("OutOrders")
         <p>输出表必须先在TableEnvironment中注册（详见<a href="common.html#register-a-tablesink">注册一个TableSink</a>）。此外，注册的表的模式（schema）必须和请求的结果的模式（schema）相匹配。</p>
 
 {% highlight python %}
-orders = table_env.scan("Orders");
+orders = table_env.from_path("Orders");
 orders.insert_into("OutOrders");
 {% endhighlight %}
       </td>
@@ -2738,7 +2738,7 @@ public class Top2 extends TableAggregateFunction<Tuple2<Integer, Integer>, Top2A
 }
 
 tEnv.registerFunction("top2", new Top2());
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders
     .groupBy("key")
     .flatAggregate("top2(a) as (v, rank)")
@@ -2758,7 +2758,7 @@ Table result = orders
         <p>Groups and aggregates a table on a <a href="#group-windows">group window</a> and possibly one or more grouping keys. You have to close the "flatAggregate" with a select statement. And the select statement does not support aggregate functions.</p>
 {% highlight java %}
 tableEnv.registerFunction("top2", new Top2());
-Table orders = tableEnv.scan("Orders");
+Table orders = tableEnv.from("Orders");
 Table result = orders
     .window(Tumble.over("5.minutes").on("rowtime").as("w")) // define window
     .groupBy("a, w") // group by key and window
@@ -2966,7 +2966,7 @@ class Top2 extends TableAggregateFunction[JTuple2[JInteger, JInteger], Top2Accum
 }
 
 val top2 = new Top2
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 val result = orders
     .groupBy('key)
     .flatAggregate(top2('a) as ('v, 'rank))
@@ -2985,7 +2985,7 @@ val result = orders
         <p>Groups and aggregates a table on a <a href="#group-windows">group window</a> and possibly one or more grouping keys. You have to close the "flatAggregate" with a select statement. And the select statement does not support aggregate functions.</p>
 {% highlight scala %}
 val top2 = new Top2
-val orders: Table = tableEnv.scan("Orders")
+val orders: Table = tableEnv.from("Orders")
 val result = orders
     .window(Tumble over 5.minutes on 'rowtime as 'w) // define window
     .groupBy('a, 'w) // group by key and window

--- a/docs/ops/scala_shell.md
+++ b/docs/ops/scala_shell.md
@@ -151,7 +151,7 @@ Scala-Flink> val textSource = stenv.fromDataStream(
     "The slings and arrows of outrageous fortune",
     "Or to take arms against a sea of troubles,"), 
   'text)
-Scala-Flink> stenv.registerTable("text_source", textSource)
+Scala-Flink> stenv.createTemporaryView("text_source", textSource)
 Scala-Flink> class $Split extends TableFunction[String] {
     def eval(s: String): Unit = {
       s.toLowerCase.split("\\W+").foreach(collect)
@@ -177,7 +177,7 @@ Scala-Flink> val textSource = btenv.fromDataSet(
     "The slings and arrows of outrageous fortune",
     "Or to take arms against a sea of troubles,"), 
   'text)
-Scala-Flink> btenv.registerTable("text_source", textSource)
+Scala-Flink> btenv.createTemporaryView("text_source", textSource)
 Scala-Flink> class $Split extends TableFunction[String] {
     def eval(s: String): Unit = {
       s.toLowerCase.split("\\W+").foreach(collect)

--- a/docs/ops/scala_shell.zh.md
+++ b/docs/ops/scala_shell.zh.md
@@ -151,7 +151,7 @@ Scala-Flink> val textSource = stenv.fromDataStream(
     "The slings and arrows of outrageous fortune",
     "Or to take arms against a sea of troubles,"), 
   'text)
-Scala-Flink> stenv.registerTable("text_source", textSource)
+Scala-Flink> stenv.createTemporaryView("text_source", textSource)
 Scala-Flink> class $Split extends TableFunction[String] {
     def eval(s: String): Unit = {
       s.toLowerCase.split("\\W+").foreach(collect)
@@ -177,7 +177,7 @@ Scala-Flink> val textSource = btenv.fromDataSet(
     "The slings and arrows of outrageous fortune",
     "Or to take arms against a sea of troubles,"), 
   'text)
-Scala-Flink> btenv.registerTable("text_source", textSource)
+Scala-Flink> btenv.createTemporaryView("text_source", textSource)
 Scala-Flink> class $Split extends TableFunction[String] {
     def eval(s: String): Unit = {
       s.toLowerCase.split("\\W+").foreach(collect)

--- a/docs/tutorials/python_table_api.md
+++ b/docs/tutorials/python_table_api.md
@@ -65,7 +65,7 @@ t_env.connect(FileSystem().path('/tmp/input')) \
                  .field('word', DataTypes.STRING())) \
     .with_schema(Schema()
                  .field('word', DataTypes.STRING())) \
-    .register_table_source('mySource')
+    .create_temporary_table('mySource')
 
 t_env.connect(FileSystem().path('/tmp/output')) \
     .with_format(OldCsv()
@@ -75,7 +75,7 @@ t_env.connect(FileSystem().path('/tmp/output')) \
     .with_schema(Schema()
                  .field('word', DataTypes.STRING())
                  .field('count', DataTypes.BIGINT())) \
-    .register_table_sink('mySink')
+    .create_temporary_table('mySink')
 {% endhighlight %}
 
 This registers a table named `mySource` and a table named `mySink` in the
@@ -87,7 +87,7 @@ Then we need to create a job which reads input from table `mySource`, preforms s
 operations and writes the results to table `mySink`.
 
 {% highlight python %}
-t_env.scan('mySource') \
+t_env.from_path('mySource') \
     .group_by('word') \
     .select('word, count(1)') \
     .insert_into('mySink')
@@ -120,7 +120,7 @@ t_env.connect(FileSystem().path('/tmp/input')) \
                  .field('word', DataTypes.STRING())) \
     .with_schema(Schema()
                  .field('word', DataTypes.STRING())) \
-    .register_table_source('mySource')
+    .create_temporary_table('mySource')
 
 t_env.connect(FileSystem().path('/tmp/output')) \
     .with_format(OldCsv()
@@ -130,9 +130,9 @@ t_env.connect(FileSystem().path('/tmp/output')) \
     .with_schema(Schema()
                  .field('word', DataTypes.STRING())
                  .field('count', DataTypes.BIGINT())) \
-    .register_table_sink('mySink')
+    .create_temporary_table('mySink')
 
-t_env.scan('mySource') \
+t_env.from_path('mySource') \
     .group_by('word') \
     .select('word, count(1)') \
     .insert_into('mySink')


### PR DESCRIPTION
## What is the purpose of the change

Update documentation with temporary objects. Changed references of `scan/registerTable/registerTableSource/registerTableSink` to `from/createTemporaryView/createTemporaryTable` wherever possible.

Added section describing differences between temporary tables and permanent tables.

Added description of what a virtual table (VIEW) and table(TABLE) are.

Added description of path expanding with catalog and database

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
