### PR TITLE
[FLINK-14594] Fix matching logics of ResourceSpec/ResourceProfile/Resource considering double values

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
@@ -64,8 +64,6 @@ public final class ResourceSpec implements Serializable {
 	 */
 	public static final ResourceSpec DEFAULT = UNKNOWN;
 
-	public static final String GPU_NAME = "GPU";
-
 	/** How many cpu cores are needed, use double so we can specify cpu like 0.1. */
 	private final double cpuCores;
 
@@ -172,7 +170,7 @@ public final class ResourceSpec implements Serializable {
 
 	public double getGPUResource() {
 		throwUnsupportedOperationExceptionIfUnknown();
-		Resource gpuResource = extendedResources.get(GPU_NAME);
+		Resource gpuResource = extendedResources.get(GPUResource.NAME);
 		if (gpuResource != null) {
 			return gpuResource.getValue();
 		}

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
@@ -168,14 +168,9 @@ public final class ResourceSpec implements Serializable {
 		return offHeapManagedMemory;
 	}
 
-	public double getGPUResource() {
+	public Resource getGPUResource() {
 		throwUnsupportedOperationExceptionIfUnknown();
-		Resource gpuResource = extendedResources.get(GPUResource.NAME);
-		if (gpuResource != null) {
-			return gpuResource.getValue();
-		}
-
-		return 0.0;
+		return extendedResources.get(GPUResource.NAME);
 	}
 
 	public Map<String, Resource> getExtendedResources() {
@@ -213,7 +208,7 @@ public final class ResourceSpec implements Serializable {
 		if (cmp1 <= 0 && cmp2 <= 0 && cmp3 <= 0 && cmp4 <= 0 && cmp5 <= 0) {
 			for (Resource resource : extendedResources.values()) {
 				if (!other.extendedResources.containsKey(resource.getName()) ||
-					other.extendedResources.get(resource.getName()).getValue() < resource.getValue()) {
+					other.extendedResources.get(resource.getName()).getValue().compareTo(resource.getValue()) < 0) {
 					return false;
 				}
 			}

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
@@ -215,8 +215,7 @@ public final class ResourceSpec implements Serializable {
 		if (cmp1 <= 0 && cmp2 <= 0 && cmp3 <= 0 && cmp4 <= 0 && cmp5 <= 0) {
 			for (Resource resource : extendedResources.values()) {
 				if (!other.extendedResources.containsKey(resource.getName()) ||
-					other.extendedResources.get(resource.getName()).getResourceAggregateType() != resource.getResourceAggregateType() ||
-						other.extendedResources.get(resource.getName()).getValue() < resource.getValue()) {
+					other.extendedResources.get(resource.getName()).getValue() < resource.getValue()) {
 					return false;
 				}
 			}

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.common.operators;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.api.common.resources.GPUResource;
 import org.apache.flink.api.common.resources.Resource;
 import org.apache.flink.configuration.MemorySize;
@@ -64,8 +65,9 @@ public final class ResourceSpec implements Serializable {
 	 */
 	public static final ResourceSpec DEFAULT = UNKNOWN;
 
-	/** How many cpu cores are needed, use double so we can specify cpu like 0.1. */
-	private final double cpuCores;
+	/** How many cpu cores are needed. Can be null only if it is unknown. */
+	@Nullable
+	private final Resource cpuCores;
 
 	/** How much task heap memory is needed. */
 	@Nullable // can be null only for UNKNOWN
@@ -86,20 +88,22 @@ public final class ResourceSpec implements Serializable {
 	private final Map<String, Resource> extendedResources = new HashMap<>(1);
 
 	private ResourceSpec(
-		double cpuCores,
-		MemorySize taskHeapMemory,
-		MemorySize taskOffHeapMemory,
-		MemorySize onHeapManagedMemory,
-		MemorySize offHeapManagedMemory,
-		Resource... extendedResources) {
+			final Resource cpuCores,
+			final MemorySize taskHeapMemory,
+			final MemorySize taskOffHeapMemory,
+			final MemorySize onHeapManagedMemory,
+			final MemorySize offHeapManagedMemory,
+			final Resource... extendedResources) {
 
-		checkArgument(cpuCores >= 0, "The cpu cores of the resource spec should not be negative.");
+		checkNotNull(cpuCores);
+		checkArgument(cpuCores instanceof CPUResource, "cpuCores must be CPUResource");
 
 		this.cpuCores = cpuCores;
 		this.taskHeapMemory = checkNotNull(taskHeapMemory);
 		this.taskOffHeapMemory = checkNotNull(taskOffHeapMemory);
 		this.onHeapManagedMemory = checkNotNull(onHeapManagedMemory);
 		this.offHeapManagedMemory = checkNotNull(offHeapManagedMemory);
+
 		for (Resource resource : extendedResources) {
 			if (resource != null) {
 				this.extendedResources.put(resource.getName(), resource);
@@ -111,7 +115,7 @@ public final class ResourceSpec implements Serializable {
 	 * Creates a new ResourceSpec with all fields unknown.
 	 */
 	private ResourceSpec() {
-		this.cpuCores = -1;
+		this.cpuCores = null;
 		this.taskHeapMemory = null;
 		this.taskOffHeapMemory = null;
 		this.onHeapManagedMemory = null;
@@ -125,13 +129,15 @@ public final class ResourceSpec implements Serializable {
 	 * @param other Reference to resource to merge in.
 	 * @return The new resource with merged values.
 	 */
-	public ResourceSpec merge(ResourceSpec other) {
+	public ResourceSpec merge(final ResourceSpec other) {
+		checkNotNull(other, "Cannot merge with null resources");
+
 		if (this.equals(UNKNOWN) || other.equals(UNKNOWN)) {
 			return UNKNOWN;
 		}
 
 		ResourceSpec target = new ResourceSpec(
-			this.cpuCores + other.cpuCores,
+			this.cpuCores.merge(other.cpuCores),
 			this.taskHeapMemory.add(other.taskHeapMemory),
 			this.taskOffHeapMemory.add(other.taskOffHeapMemory),
 			this.onHeapManagedMemory.add(other.onHeapManagedMemory),
@@ -143,7 +149,7 @@ public final class ResourceSpec implements Serializable {
 		return target;
 	}
 
-	public double getCpuCores() {
+	public Resource getCpuCores() {
 		throwUnsupportedOperationExceptionIfUnknown();
 		return this.cpuCores;
 	}
@@ -200,7 +206,7 @@ public final class ResourceSpec implements Serializable {
 			throw new IllegalArgumentException("Cannot compare specified resources with UNKNOWN resources.");
 		}
 
-		int cmp1 = Double.compare(this.cpuCores, other.cpuCores);
+		int cmp1 = this.cpuCores.getValue().compareTo(other.getCpuCores().getValue());
 		int cmp2 = this.taskHeapMemory.compareTo(other.taskHeapMemory);
 		int cmp3 = this.taskOffHeapMemory.compareTo(other.taskOffHeapMemory);
 		int cmp4 = this.onHeapManagedMemory.compareTo(other.onHeapManagedMemory);
@@ -223,7 +229,7 @@ public final class ResourceSpec implements Serializable {
 			return true;
 		} else if (obj != null && obj.getClass() == ResourceSpec.class) {
 			ResourceSpec that = (ResourceSpec) obj;
-			return this.cpuCores == that.cpuCores &&
+			return Objects.equals(this.cpuCores, that.cpuCores) &&
 				Objects.equals(this.taskHeapMemory, that.taskHeapMemory) &&
 				Objects.equals(this.taskOffHeapMemory, that.taskOffHeapMemory) &&
 				Objects.equals(this.onHeapManagedMemory, that.onHeapManagedMemory) &&
@@ -236,8 +242,7 @@ public final class ResourceSpec implements Serializable {
 
 	@Override
 	public int hashCode() {
-		final long cpuBits =  Double.doubleToLongBits(cpuCores);
-		int result = (int) (cpuBits ^ (cpuBits >>> 32));
+		int result = Objects.hashCode(cpuCores);
 		result = 31 * result + Objects.hashCode(taskHeapMemory);
 		result = 31 * result + Objects.hashCode(taskOffHeapMemory);
 		result = 31 * result + Objects.hashCode(onHeapManagedMemory);
@@ -252,16 +257,16 @@ public final class ResourceSpec implements Serializable {
 			return "ResourceSpec{UNKNOWN}";
 		}
 
-		StringBuilder extend = new StringBuilder();
-		for (Resource resource : extendedResources.values()) {
-			extend.append(", ").append(resource.getName()).append("=").append(resource.getValue());
+		final StringBuilder extResources = new StringBuilder(extendedResources.size() * 10);
+		for (Map.Entry<String, Resource> resource : extendedResources.entrySet()) {
+			extResources.append(", ").append(resource.getKey()).append('=').append(resource.getValue().getValue());
 		}
 		return "ResourceSpec{" +
-			"cpuCores=" + cpuCores +
+			"cpuCores=" + cpuCores.getValue() +
 			", taskHeapMemory=" + taskHeapMemory +
 			", taskOffHeapMemory=" + taskOffHeapMemory +
 			", onHeapManagedMemory=" + onHeapManagedMemory +
-			", offHeapManagedMemory=" + offHeapManagedMemory +
+			", offHeapManagedMemory=" + offHeapManagedMemory + extResources +
 			'}';
 	}
 
@@ -278,12 +283,8 @@ public final class ResourceSpec implements Serializable {
 	//  builder
 	// ------------------------------------------------------------------------
 
-	public static Builder newBuilder(double cpuCores, MemorySize taskHeapMemory) {
-		return new Builder(cpuCores, taskHeapMemory);
-	}
-
 	public static Builder newBuilder(double cpuCores, int taskHeapMemoryMB) {
-		return newBuilder(cpuCores, MemorySize.parse(taskHeapMemoryMB + "m"));
+		return new Builder(new CPUResource(cpuCores), MemorySize.parse(taskHeapMemoryMB + "m"));
 	}
 
 	/**
@@ -291,20 +292,20 @@ public final class ResourceSpec implements Serializable {
 	 */
 	public static class Builder {
 
-		private double cpuCores;
+		private Resource cpuCores;
 		private MemorySize taskHeapMemory;
 		private MemorySize taskOffHeapMemory = MemorySize.ZERO;
 		private MemorySize onHeapManagedMemory = MemorySize.ZERO;
 		private MemorySize offHeapManagedMemory = MemorySize.ZERO;
 		private GPUResource gpuResource;
 
-		private Builder(double cpuCores, MemorySize taskHeapMemory) {
+		private Builder(CPUResource cpuCores, MemorySize taskHeapMemory) {
 			this.cpuCores = cpuCores;
 			this.taskHeapMemory = taskHeapMemory;
 		}
 
 		public Builder setCpuCores(double cpuCores) {
-			this.cpuCores = cpuCores;
+			this.cpuCores = new CPUResource(cpuCores);
 			return this;
 		}
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
@@ -193,26 +193,6 @@ public final class ResourceSpec implements Serializable {
 	}
 
 	/**
-	 * Check whether all the field values are valid.
-	 *
-	 * @return True if all the values are equal or greater than 0, otherwise false.
-	 */
-	public boolean isValid() {
-		if (this.equals(UNKNOWN)) {
-			return true;
-		}
-		if (this.cpuCores < 0) {
-			return false;
-		}
-		for (Resource resource : extendedResources.values()) {
-			if (resource.getValue() < 0) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	/**
 	 * Checks the current resource less than or equal with the other resource by comparing
 	 * all the fields in the resource.
 	 *

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.resources.GPUResource;
 import org.apache.flink.api.common.resources.Resource;
 import org.apache.flink.configuration.MemorySize;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
@@ -199,10 +198,15 @@ public final class ResourceSpec implements Serializable {
 	 * @param other The resource to compare
 	 * @return True if current resource is less than or equal with the other resource, otherwise return false.
 	 */
-	public boolean lessThanOrEqual(@Nonnull ResourceSpec other) {
-		if (this.equals(UNKNOWN) || other.equals(UNKNOWN)) {
-			throw new IllegalArgumentException("UNKNOWN ResourceSpecs cannot be numerically compared.");
+	public boolean lessThanOrEqual(final ResourceSpec other) {
+		checkNotNull(other, "Cannot compare with null resources");
+
+		if (this.equals(UNKNOWN) && other.equals(UNKNOWN)) {
+			return true;
+		} else if (this.equals(UNKNOWN) || other.equals(UNKNOWN)) {
+			throw new IllegalArgumentException("Cannot compare specified resources with UNKNOWN resources.");
 		}
+
 		int cmp1 = Double.compare(this.cpuCores, other.cpuCores);
 		int cmp2 = this.taskHeapMemory.compareTo(other.taskHeapMemory);
 		int cmp3 = this.taskOffHeapMemory.compareTo(other.taskOffHeapMemory);

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/util/OperatorValidationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/util/OperatorValidationUtils.java
@@ -63,14 +63,11 @@ public class OperatorValidationUtils {
 
 	public static void validateResources(ResourceSpec resources) {
 		Preconditions.checkNotNull(resources, "The resources must be not null.");
-		Preconditions.checkArgument(resources.isValid(), "The values in resources must be not less than 0.");
 	}
 
 	public static void validateMinAndPreferredResources(ResourceSpec minResources, ResourceSpec preferredResources) {
 		Preconditions.checkNotNull(minResources, "The min resources must be not null.");
 		Preconditions.checkNotNull(preferredResources, "The preferred resources must be not null.");
-		Preconditions.checkArgument(minResources.isValid() && preferredResources.isValid(),
-			"The resources must either be UNKNOWN or all the fields are no less than 0.");
 		Preconditions.checkArgument((minResources == ResourceSpec.UNKNOWN && preferredResources == ResourceSpec.UNKNOWN) ||
 				(minResources != ResourceSpec.UNKNOWN && preferredResources != ResourceSpec.UNKNOWN && minResources.lessThanOrEqual(preferredResources)),
 			"The resources must be either both UNKNOWN or both not UNKNOWN. If not UNKNOWN,"

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/util/OperatorValidationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/util/OperatorValidationUtils.java
@@ -68,8 +68,7 @@ public class OperatorValidationUtils {
 	public static void validateMinAndPreferredResources(ResourceSpec minResources, ResourceSpec preferredResources) {
 		Preconditions.checkNotNull(minResources, "The min resources must be not null.");
 		Preconditions.checkNotNull(preferredResources, "The preferred resources must be not null.");
-		Preconditions.checkArgument((minResources == ResourceSpec.UNKNOWN && preferredResources == ResourceSpec.UNKNOWN) ||
-				(minResources != ResourceSpec.UNKNOWN && preferredResources != ResourceSpec.UNKNOWN && minResources.lessThanOrEqual(preferredResources)),
+		Preconditions.checkArgument(minResources.lessThanOrEqual(preferredResources),
 			"The resources must be either both UNKNOWN or both not UNKNOWN. If not UNKNOWN,"
 				+ " the preferred resources must be greater than or equal to the min resources.");
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/resources/CPUResource.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/resources/CPUResource.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.resources;
+
+import org.apache.flink.annotation.Internal;
+
+import java.math.BigDecimal;
+
+/**
+ * Represents CPU resource.
+ */
+@Internal
+public class CPUResource extends Resource {
+
+	private static final long serialVersionUID = 7228645888210984393L;
+
+	public static final String NAME = "CPU";
+
+	public CPUResource(double value) {
+		super(NAME, value);
+	}
+
+	private CPUResource(BigDecimal value) {
+		super(NAME, value);
+	}
+
+	@Override
+	public Resource create(BigDecimal value) {
+		return new CPUResource(value);
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/resources/GPUResource.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/resources/GPUResource.java
@@ -19,7 +19,6 @@
 package org.apache.flink.api.common.resources;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.operators.ResourceSpec;
 
 /**
  * The GPU resource.
@@ -29,8 +28,10 @@ public class GPUResource extends Resource {
 
 	private static final long serialVersionUID = -2276080061777135142L;
 
+	public static final String NAME = "GPU";
+
 	public GPUResource(double value) {
-		super(ResourceSpec.GPU_NAME, value);
+		super(NAME, value);
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/resources/GPUResource.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/resources/GPUResource.java
@@ -30,15 +30,11 @@ public class GPUResource extends Resource {
 	private static final long serialVersionUID = -2276080061777135142L;
 
 	public GPUResource(double value) {
-		this(value, ResourceAggregateType.AGGREGATE_TYPE_SUM);
-	}
-
-	private GPUResource(double value, ResourceAggregateType type) {
-		super(ResourceSpec.GPU_NAME, value, type);
+		super(ResourceSpec.GPU_NAME, value);
 	}
 
 	@Override
-	public Resource create(double value, ResourceAggregateType type) {
-		return new GPUResource(value, type);
+	public Resource create(double value) {
+		return new GPUResource(value);
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/operators/ResourceSpecTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/operators/ResourceSpecTest.java
@@ -35,22 +35,6 @@ import static org.junit.Assert.assertTrue;
 public class ResourceSpecTest extends TestLogger {
 
 	@Test
-	public void testIsValid() throws Exception {
-		ResourceSpec rs = ResourceSpec.newBuilder(1.0, 100).build();
-		assertTrue(rs.isValid());
-
-		rs = ResourceSpec.newBuilder(1.0, 100).
-				setGPUResource(1).
-				build();
-		assertTrue(rs.isValid());
-
-		rs = ResourceSpec.newBuilder(1.0, 100).
-				setGPUResource(-1).
-				build();
-		assertFalse(rs.isValid());
-	}
-
-	@Test
 	public void testLessThanOrEqual() throws Exception {
 		ResourceSpec rs1 = ResourceSpec.newBuilder(1.0, 100).build();
 		ResourceSpec rs2 = ResourceSpec.newBuilder(1.0, 100).build();

--- a/flink-core/src/test/java/org/apache/flink/api/common/operators/ResourceSpecTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/operators/ResourceSpecTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.operators;
 
+import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.api.common.resources.GPUResource;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.util.TestLogger;
@@ -121,7 +122,7 @@ public class ResourceSpecTest extends TestLogger {
 		ResourceSpec rs2 = ResourceSpec.newBuilder(1.0, 100).build();
 
 		ResourceSpec rs3 = rs1.merge(rs2);
-		assertEquals(2.0, rs3.getCpuCores(), 0.000001);
+		assertEquals(new CPUResource(2.0), rs3.getCpuCores());
 		assertEquals(200, rs3.getTaskHeapMemory().getMebiBytes());
 		assertEquals(new GPUResource(1.1), rs3.getGPUResource());
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/operators/ResourceSpecTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/operators/ResourceSpecTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.operators;
 
+import org.apache.flink.api.common.resources.GPUResource;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.util.TestLogger;
 
@@ -122,10 +123,10 @@ public class ResourceSpecTest extends TestLogger {
 		ResourceSpec rs3 = rs1.merge(rs2);
 		assertEquals(2.0, rs3.getCpuCores(), 0.000001);
 		assertEquals(200, rs3.getTaskHeapMemory().getMebiBytes());
-		assertEquals(1.1, rs3.getGPUResource(), 0.000001);
+		assertEquals(new GPUResource(1.1), rs3.getGPUResource());
 
 		ResourceSpec rs4 = rs1.merge(rs3);
-		assertEquals(2.2, rs4.getGPUResource(), 0.000001);
+		assertEquals(new GPUResource(2.2), rs4.getGPUResource());
 	}
 
 	@Test

--- a/flink-core/src/test/java/org/apache/flink/api/common/operators/ResourceSpecTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/operators/ResourceSpecTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue;
 public class ResourceSpecTest extends TestLogger {
 
 	@Test
-	public void testLessThanOrEqual() throws Exception {
+	public void testLessThanOrEqualWhenBothSpecified() {
 		ResourceSpec rs1 = ResourceSpec.newBuilder(1.0, 100).build();
 		ResourceSpec rs2 = ResourceSpec.newBuilder(1.0, 100).build();
 		assertTrue(rs1.lessThanOrEqual(rs2));
@@ -52,6 +52,23 @@ public class ResourceSpecTest extends TestLogger {
 				build();
 		assertFalse(rs4.lessThanOrEqual(rs3));
 		assertTrue(rs3.lessThanOrEqual(rs4));
+	}
+
+	@Test
+	public void testLessThanOrEqualWhenBothUnknown(){
+		assertTrue(ResourceSpec.UNKNOWN.lessThanOrEqual(ResourceSpec.UNKNOWN));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testLessThanOrEqualWhenUnknownWithSpecified(){
+		final ResourceSpec rs1 = ResourceSpec.newBuilder(1.0, 100).build();
+		assertTrue(ResourceSpec.UNKNOWN.lessThanOrEqual(rs1));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testLessThanOrEqualWhenSpecifiedWithUnknown(){
+		final ResourceSpec rs1 = ResourceSpec.newBuilder(1.0, 100).build();
+		assertTrue(rs1.lessThanOrEqual(ResourceSpec.UNKNOWN));
 	}
 
 	@Test

--- a/flink-core/src/test/java/org/apache/flink/api/common/resources/ResourceTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/resources/ResourceTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.resources;
+
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link Resource}.
+ */
+public class ResourceTest extends TestLogger {
+
+	@Test
+	public void testConstructorValid() {
+		final Resource v1 = new TestResource(0.1);
+		assertTestResourceValueEquals(0.1, v1);
+
+		final Resource v2 = new TestResource(BigDecimal.valueOf(0.1));
+		assertTestResourceValueEquals(0.1, v2);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testConstructorInvalidValue() {
+		new TestResource(-0.1);
+	}
+
+	@Test
+	public void testEquals() {
+		final Resource v1 = new TestResource(0.1);
+		final Resource v2 = new TestResource(0.1);
+		final Resource v3 = new TestResource(0.2);
+		assertTrue(v1.equals(v2));
+		assertFalse(v1.equals(v3));
+	}
+
+	@Test
+	public void testEqualsIgnoringScale() {
+		final Resource v1 = new TestResource(new BigDecimal("0.1"));
+		final Resource v2 = new TestResource(new BigDecimal("0.10"));
+		assertTrue(v1.equals(v2));
+	}
+
+	@Test
+	public void testMerge() {
+		final Resource v1 = new TestResource(0.1);
+		final Resource v2 = new TestResource(0.2);
+		assertTestResourceValueEquals(0.3, v1.merge(v2));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testMergeErrorOnDifferentTypes() {
+		final Resource v1 = new TestResource(0.1);
+		final Resource v2 = new GPUResource(0.1);
+		v1.merge(v2);
+	}
+
+	@Test
+	public void testSubtract() {
+		final Resource v1 = new TestResource(0.2);
+		final Resource v2 = new TestResource(0.1);
+		assertTestResourceValueEquals(0.1, v1.subtract(v2));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testSubtractLargerValue() {
+		final Resource v1 = new TestResource(0.1);
+		final Resource v2 = new TestResource(0.2);
+		v1.subtract(v2);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testSubtractErrorOnDifferentTypes() {
+		final Resource v1 = new TestResource(0.1);
+		final Resource v2 = new GPUResource(0.1);
+		v1.subtract(v2);
+	}
+
+	private static void assertTestResourceValueEquals(final double value, final Resource resource) {
+		assertEquals(new TestResource(value), resource);
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/resources/TestResource.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/resources/TestResource.java
@@ -18,30 +18,25 @@
 
 package org.apache.flink.api.common.resources;
 
-import org.apache.flink.annotation.Internal;
-
 import java.math.BigDecimal;
 
 /**
- * The GPU resource.
+ * Test implementation for {@link Resource}.
  */
-@Internal
-public class GPUResource extends Resource {
+public class TestResource extends Resource {
 
-	private static final long serialVersionUID = -2276080061777135142L;
+	public static final String NAME = "TestResource";
 
-	public static final String NAME = "GPU";
-
-	public GPUResource(double value) {
+	public TestResource(final double value) {
 		super(NAME, value);
 	}
 
-	private GPUResource(BigDecimal value) {
+	public TestResource(final BigDecimal value) {
 		super(NAME, value);
 	}
 
 	@Override
 	public Resource create(BigDecimal value) {
-		return new GPUResource(value);
+		return new TestResource(value);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -492,7 +492,7 @@ public class ResourceProfile implements Serializable {
 		Map<String, Resource> copiedExtendedResources = new HashMap<>(resourceSpec.getExtendedResources());
 
 		return new ResourceProfile(
-			resourceSpec.getCpuCores(),
+			resourceSpec.getCpuCores().getValue().doubleValue(),
 			resourceSpec.getTaskHeapMemory(),
 			resourceSpec.getTaskOffHeapMemory(),
 			resourceSpec.getOnHeapManagedMemory(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -27,6 +27,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -301,7 +302,7 @@ public class ResourceProfile implements Serializable {
 			shuffleMemory.getBytes() >= required.shuffleMemory.getBytes()) {
 			for (Map.Entry<String, Resource> resource : required.extendedResources.entrySet()) {
 				if (!extendedResources.containsKey(resource.getKey()) ||
-					extendedResources.get(resource.getKey()).getValue() < resource.getValue().getValue()) {
+					extendedResources.get(resource.getKey()).getValue().compareTo(resource.getValue().getValue()) < 0) {
 					return false;
 				}
 			}
@@ -397,7 +398,7 @@ public class ResourceProfile implements Serializable {
 		other.extendedResources.forEach((String name, Resource resource) -> {
 			resultExtendedResource.compute(name, (ignored, oldResource) -> {
 				Resource resultResource = oldResource.subtract(resource);
-				return resultResource.getValue() == 0 ? null : resultResource;
+				return resultResource.getValue().compareTo(BigDecimal.ZERO) == 0 ? null : resultResource;
 			});
 		});
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -29,7 +29,6 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 
@@ -49,7 +48,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  * </ol>
  * The extended resources are compared ordered by the resource names.
  */
-public class ResourceProfile implements Serializable, Comparable<ResourceProfile> {
+public class ResourceProfile implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
@@ -310,46 +309,6 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 			return true;
 		}
 		return false;
-	}
-
-	@Override
-	public int compareTo(@Nonnull ResourceProfile other) {
-		if (this == other) {
-			return 0;
-		} else if (this.equals(UNKNOWN)) {
-			return -1;
-		} else if (other.equals(UNKNOWN)) {
-			return 1;
-		}
-
-		int cmp = this.getTotalMemory().compareTo(other.getTotalMemory());
-		if (cmp == 0) {
-			cmp = Double.compare(this.cpuCores, other.cpuCores);
-		}
-		if (cmp == 0) {
-			Iterator<Map.Entry<String, Resource>> thisIterator = extendedResources.entrySet().iterator();
-			Iterator<Map.Entry<String, Resource>> otherIterator = other.extendedResources.entrySet().iterator();
-			while (thisIterator.hasNext() && otherIterator.hasNext()) {
-				Map.Entry<String, Resource> thisResource = thisIterator.next();
-				Map.Entry<String, Resource> otherResource = otherIterator.next();
-				if ((cmp = otherResource.getKey().compareTo(thisResource.getKey())) != 0) {
-					return cmp;
-				}
-				if (!otherResource.getValue().getResourceAggregateType().equals(thisResource.getValue().getResourceAggregateType())) {
-					return 1;
-				}
-				if ((cmp = Double.compare(thisResource.getValue().getValue(), otherResource.getValue().getValue())) != 0) {
-					return cmp;
-				}
-			}
-			if (thisIterator.hasNext()) {
-				return 1;
-			}
-			if (otherIterator.hasNext()) {
-				return -1;
-			}
-		}
-		return cmp;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -301,8 +301,7 @@ public class ResourceProfile implements Serializable {
 			shuffleMemory.getBytes() >= required.shuffleMemory.getBytes()) {
 			for (Map.Entry<String, Resource> resource : required.extendedResources.entrySet()) {
 				if (!extendedResources.containsKey(resource.getKey()) ||
-						!extendedResources.get(resource.getKey()).getResourceAggregateType().equals(resource.getValue().getResourceAggregateType()) ||
-						extendedResources.get(resource.getKey()).getValue() < resource.getValue().getValue()) {
+					extendedResources.get(resource.getKey()).getValue() < resource.getValue().getValue()) {
 					return false;
 				}
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.MemorySize;
@@ -492,7 +493,7 @@ public class TaskManagerServices {
 	public static ResourceProfile computeSlotResourceProfile(int numOfSlots, long managedMemorySize) {
 		int managedMemoryPerSlotMB = (int) bytesToMegabytes(managedMemorySize / numOfSlots);
 		return new ResourceProfile(
-			Double.MAX_VALUE,
+			new CPUResource(Double.MAX_VALUE),
 			MemorySize.MAX_VALUE,
 			MemorySize.MAX_VALUE,
 			// TODO: before operators separate on-heap/off-heap managed memory, we use on-heap managed memory to denote total managed memory

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/LocationPreferenceSlotSelectionStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/LocationPreferenceSlotSelectionStrategyTest.java
@@ -30,6 +30,9 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+/**
+ * Tests for {@link LocationPreferenceSlotSelectionStrategy}.
+ */
 public class LocationPreferenceSlotSelectionStrategyTest extends SlotSelectionStrategyTestBase {
 
 	public LocationPreferenceSlotSelectionStrategyTest() {
@@ -48,8 +51,9 @@ public class LocationPreferenceSlotSelectionStrategyTest extends SlotSelectionSt
 		Optional<SlotSelectionStrategy.SlotInfoAndLocality> match = runMatching(slotProfile);
 		Assert.assertTrue(match.get().getSlotInfo().getResourceProfile().isMatching(slotProfile.getResourceProfile()));
 
-		ResourceProfile evenBiggerResourceProfile =
-			new ResourceProfile(biggerResourceProfile.getCpuCores() + 1, resourceProfile.getTaskHeapMemory());
+		ResourceProfile evenBiggerResourceProfile = new ResourceProfile(
+			biggerResourceProfile.getCpuCores().getValue().doubleValue() + 1.0,
+			resourceProfile.getTaskHeapMemory().getMebiBytes());
 		slotProfile = new SlotProfile(evenBiggerResourceProfile, Collections.emptyList(), Collections.emptySet());
 
 		match = runMatching(slotProfile);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
@@ -121,30 +121,6 @@ public class ResourceProfileTest {
 	}
 
 	@Test
-	public void testCompareTo() {
-		ResourceSpec rs1 = ResourceSpec.newBuilder(1.0, 100).build();
-		ResourceSpec rs2 = ResourceSpec.newBuilder(1.0, 100).build();
-		assertEquals(0, ResourceProfile.fromResourceSpec(rs1).compareTo(ResourceProfile.fromResourceSpec(rs2)));
-
-		ResourceSpec rs3 = ResourceSpec.newBuilder(1.0, 100).
-				setGPUResource(2.2).
-				build();
-		assertEquals(-1, ResourceProfile.fromResourceSpec(rs1).compareTo(ResourceProfile.fromResourceSpec(rs3)));
-		assertEquals(1, ResourceProfile.fromResourceSpec(rs3).compareTo(ResourceProfile.fromResourceSpec(rs1)));
-
-		ResourceSpec rs4 = ResourceSpec.newBuilder(1.0, 100).
-				setGPUResource(1.1).
-				build();
-		assertEquals(1, ResourceProfile.fromResourceSpec(rs3).compareTo(ResourceProfile.fromResourceSpec(rs4)));
-		assertEquals(-1, ResourceProfile.fromResourceSpec(rs4).compareTo(ResourceProfile.fromResourceSpec(rs3)));
-
-		ResourceSpec rs5 = ResourceSpec.newBuilder(1.0, 100).
-				setGPUResource(2.2).
-				build();
-		assertEquals(0, ResourceProfile.fromResourceSpec(rs3).compareTo(ResourceProfile.fromResourceSpec(rs5)));
-	}
-
-	@Test
 	public void testGet() {
 		ResourceSpec rs = ResourceSpec.newBuilder(1.0, 100).
 				setGPUResource(1.6).

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
@@ -130,7 +130,7 @@ public class ResourceProfileTest {
 		assertEquals(1.0, rp.getCpuCores(), 0.000001);
 		assertEquals(150, rp.getTotalMemory().getMebiBytes());
 		assertEquals(100, rp.getOperatorsMemory().getMebiBytes());
-		assertEquals(1.6, rp.getExtendedResources().get(GPUResource.NAME).getValue(), 0.000001);
+		assertEquals(new GPUResource(1.6), rp.getExtendedResources().get(GPUResource.NAME));
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
@@ -130,7 +130,7 @@ public class ResourceProfileTest {
 		assertEquals(1.0, rp.getCpuCores(), 0.000001);
 		assertEquals(150, rp.getTotalMemory().getMebiBytes());
 		assertEquals(100, rp.getOperatorsMemory().getMebiBytes());
-		assertEquals(1.6, rp.getExtendedResources().get(ResourceSpec.GPU_NAME).getValue(), 0.000001);
+		assertEquals(1.6, rp.getExtendedResources().get(GPUResource.NAME).getValue(), 0.000001);
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.clusterframework.types;
 
 import org.apache.flink.api.common.operators.ResourceSpec;
+import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.api.common.resources.GPUResource;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.core.testutils.CommonTestUtils;
@@ -127,7 +128,7 @@ public class ResourceProfileTest {
 				build();
 		ResourceProfile rp = ResourceProfile.fromResourceSpec(rs, MemorySize.parse(50 + "m"));
 
-		assertEquals(1.0, rp.getCpuCores(), 0.000001);
+		assertEquals(new CPUResource(1.0), rp.getCpuCores());
 		assertEquals(150, rp.getTotalMemory().getMebiBytes());
 		assertEquals(100, rp.getOperatorsMemory().getMebiBytes());
 		assertEquals(new GPUResource(1.6), rp.getExtendedResources().get(GPUResource.NAME));
@@ -161,7 +162,7 @@ public class ResourceProfileTest {
 
 	@Test
 	public void testMergeWithOverflow() {
-		final double largeDouble = Double.MAX_VALUE - 1.0;
+		final CPUResource largeDouble = new CPUResource(Double.MAX_VALUE - 1.0);
 		final MemorySize largeMemory = MemorySize.MAX_VALUE.subtract(MemorySize.parse("100m"));
 
 		ResourceProfile rp1 = new ResourceProfile(3.0, 300, 300, 300, 300, 300, Collections.emptyMap());


### PR DESCRIPTION

## What is the purpose of the change

This PR is to fix the matching logics of ResourceSpec/ResourceProfile/Resource.

There are resources of double type values, like cpuCores or all extended resources. These values can be generated via a merge or subtract, so that there can be small deltas.

Currently, in resource matching, these resources are matched without considering the deltas, which may result in issues. More details see FLINK-14594.


## Brief change log

- Introduce a ResourceValue which stores a double value and its acceptable precision (the same kind of resource should use the same precision). It provides compareTo method, in which two ResourceValues are considered equal if the subtracted abs does not exceed the precision. It also provides merge/subtract/validation operations.
- Change Resource to use ResourceValue to store its value.
- Change ResourceSpec to use ResourceValue for cpuCores. 
- Replace the usages of equals with another method hasSameResources which considers the precision.
- Change ResourceProfile to use ResourceValue for cpuCores. 
- Replace the usages of equals with another method hasSameResources which considers the precision.


## Verifying this change

 - *Added tests for ResourceValue/AdditiveResourceValue*
 - Changes to ResourceSpec/ResourceProfile are already covered by their existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
