### PR TITLE
[FLINK-14600][runtime] Change Type of Field verticesFinished from AtomicInteger to int

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -117,7 +117,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -268,7 +267,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 
 	// ------ Execution status and progress. These values are volatile, and accessed under the lock -------
 
-	private final AtomicInteger verticesFinished;
+	private int verticesFinished;
 
 	/** Current status of the job execution. */
 	private volatile JobStatus state = JobStatus.CREATED;
@@ -480,8 +479,6 @@ public class ExecutionGraph implements AccessExecutionGraph {
 
 		this.restartStrategy = restartStrategy;
 		this.kvStateLocationRegistry = new KvStateLocationRegistry(jobInformation.getJobId(), getAllVertices());
-
-		this.verticesFinished = new AtomicInteger();
 
 		this.globalModVersion = 1L;
 
@@ -1381,7 +1378,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	 */
 	void vertexFinished() {
 		assertRunningInJobMasterMainThread();
-		final int numFinished = verticesFinished.incrementAndGet();
+		final int numFinished = ++verticesFinished;
 		if (numFinished == numVerticesTotal) {
 			// done :-)
 
@@ -1412,7 +1409,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 
 	void vertexUnFinished() {
 		assertRunningInJobMasterMainThread();
-		verticesFinished.getAndDecrement();
+		verticesFinished--;
 	}
 
 	/**


### PR DESCRIPTION

## What is the purpose of the change

*This pull request degenerates the current AtomicInteger type of verticesFinished to a normal int type*


## Brief change log

  - *Degenerate the current AtomicInteger type of verticesFinished to a normal int type*

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
