### PR TITLE
[FLINK-14373][tests] Fix ZooKeeperHighAvailabilityITCase to pass with NG scheduler

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -1279,6 +1279,11 @@ Metrics related to data exchange between task executors using netty network comm
       <td>The total number of full restarts since this job was submitted.</td>
       <td>Gauge</td>
     </tr>
+    <tr>
+      <td>numberOfRestarts</td>
+      <td>The total number of restarts since this job was submitted, including full restarts and fine grained restarts.</td>
+      <td>Gauge</td>
+    </tr>
   </tbody>
 </table>
 

--- a/docs/monitoring/metrics.zh.md
+++ b/docs/monitoring/metrics.zh.md
@@ -1279,6 +1279,11 @@ Metrics related to data exchange between task executors using netty network comm
       <td>The total number of full restarts since this job was submitted.</td>
       <td>Gauge</td>
     </tr>
+    <tr>
+      <td>numberOfRestarts</td>
+      <td>The total number of restarts since this job was submitted, including full restarts and fine grained restarts.</td>
+      <td>Gauge</td>
+    </tr>
   </tbody>
 </table>
 

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/MeterView.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/MeterView.java
@@ -33,6 +33,9 @@ package org.apache.flink.metrics;
  * <p>The events are counted by a {@link Counter}.
  */
 public class MeterView implements Meter, View {
+
+	private static final int DEFAULT_TIME_SPAN_IN_SECONDS = 60;
+
 	/** The underlying counter maintaining the count. */
 	private final Counter counter;
 	/** The time-span over which the average is calculated. */
@@ -46,6 +49,10 @@ public class MeterView implements Meter, View {
 
 	public MeterView(int timeSpanInSeconds) {
 		this(new SimpleCounter(), timeSpanInSeconds);
+	}
+
+	public MeterView(Counter counter) {
+		this(counter, DEFAULT_TIME_SPAN_IN_SECONDS);
 	}
 
 	public MeterView(Counter counter, int timeSpanInSeconds) {

--- a/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/MeterViewTest.java
+++ b/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/MeterViewTest.java
@@ -33,7 +33,7 @@ public class MeterViewTest extends TestLogger {
 	public void testGetCount() {
 		Counter c = new SimpleCounter();
 		c.inc(5);
-		Meter m = new MeterView(c, 60);
+		Meter m = new MeterView(c);
 
 		assertEquals(5, m.getCount());
 	}
@@ -41,7 +41,7 @@ public class MeterViewTest extends TestLogger {
 	@Test
 	public void testMarkEvent() {
 		Counter c = new SimpleCounter();
-		Meter m = new MeterView(c, 60);
+		Meter m = new MeterView(c);
 
 		assertEquals(0, m.getCount());
 		m.markEvent();
@@ -53,7 +53,7 @@ public class MeterViewTest extends TestLogger {
 	@Test
 	public void testGetRate() {
 		Counter c = new SimpleCounter();
-		MeterView m = new MeterView(c, 60);
+		MeterView m = new MeterView(c);
 
 		// values = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 		for (int x = 0; x < 12; x++) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/ExecutionFailureHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/ExecutionFailureHandler.java
@@ -44,6 +44,9 @@ public class ExecutionFailureHandler {
 	/** Strategy to judge whether and when a restarting should be done. */
 	private final RestartBackoffTimeStrategy restartBackoffTimeStrategy;
 
+	/** Number of all restarts happened since this job is submitted. */
+	private long numberOfRestarts;
+
 	/**
 	 * Creates the handler to deal with task failures.
 	 *
@@ -52,9 +55,9 @@ public class ExecutionFailureHandler {
 	 * @param restartBackoffTimeStrategy helps to decide whether to restart failed tasks and the restarting delay
 	 */
 	public ExecutionFailureHandler(
-		FailoverTopology<?, ?> failoverTopology,
-		FailoverStrategy failoverStrategy,
-		RestartBackoffTimeStrategy restartBackoffTimeStrategy) {
+			final FailoverTopology<?, ?> failoverTopology,
+			final FailoverStrategy failoverStrategy,
+			final RestartBackoffTimeStrategy restartBackoffTimeStrategy) {
 
 		this.failoverTopology = checkNotNull(failoverTopology);
 		this.failoverStrategy = checkNotNull(failoverStrategy);
@@ -98,6 +101,8 @@ public class ExecutionFailureHandler {
 
 		restartBackoffTimeStrategy.notifyFailure(cause);
 		if (restartBackoffTimeStrategy.canRestart()) {
+			numberOfRestarts++;
+
 			return FailureHandlingResult.restartable(
 				verticesToRestart,
 				restartBackoffTimeStrategy.getBackoffTime());
@@ -112,5 +117,9 @@ public class ExecutionFailureHandler {
 		Optional<Throwable> unrecoverableError = ThrowableClassifier.findThrowableOfThrowableType(
 			cause, ThrowableType.NonRecoverableError);
 		return unrecoverableError.isPresent();
+	}
+
+	public long getNumberOfRestarts() {
+		return numberOfRestarts;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/InputChannelMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/InputChannelMetrics.java
@@ -52,7 +52,7 @@ public class InputChannelMetrics {
 		Counter[] counters = new Counter[parents.length];
 		for (int i = 0; i < parents.length; i++) {
 			counters[i] = parents[i].counter(name);
-			parents[i].meter(name + MetricNames.SUFFIX_RATE, new MeterView(counters[i], 60));
+			parents[i].meter(name + MetricNames.SUFFIX_RATE, new MeterView(counters[i]));
 		}
 		return new MultiCounterWrapper(counters);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -51,6 +51,8 @@ public class MetricNames {
 	public static final String TASK_SLOTS_TOTAL = "taskSlotsTotal";
 	public static final String NUM_REGISTERED_TASK_MANAGERS = "numRegisteredTaskManagers";
 
+	public static final String NUMBER_OF_RESTARTS = "numberOfRestarts";
+
 	public static final String MEMORY_USED = "Used";
 	public static final String MEMORY_COMMITTED = "Committed";
 	public static final String MEMORY_MAX = "Max";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/OperatorIOMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/OperatorIOMetricGroup.java
@@ -39,8 +39,8 @@ public class OperatorIOMetricGroup extends ProxyMetricGroup<OperatorMetricGroup>
 		super(parentMetricGroup);
 		numRecordsIn = parentMetricGroup.counter(MetricNames.IO_NUM_RECORDS_IN);
 		numRecordsOut = parentMetricGroup.counter(MetricNames.IO_NUM_RECORDS_OUT);
-		numRecordsInRate = parentMetricGroup.meter(MetricNames.IO_NUM_RECORDS_IN_RATE, new MeterView(numRecordsIn, 60));
-		numRecordsOutRate = parentMetricGroup.meter(MetricNames.IO_NUM_RECORDS_OUT_RATE, new MeterView(numRecordsOut, 60));
+		numRecordsInRate = parentMetricGroup.meter(MetricNames.IO_NUM_RECORDS_IN_RATE, new MeterView(numRecordsIn));
+		numRecordsOutRate = parentMetricGroup.meter(MetricNames.IO_NUM_RECORDS_OUT_RATE, new MeterView(numRecordsOut));
 	}
 
 	public Counter getNumRecordsInCounter() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
@@ -51,16 +51,16 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 
 		this.numBytesIn = counter(MetricNames.IO_NUM_BYTES_IN);
 		this.numBytesOut = counter(MetricNames.IO_NUM_BYTES_OUT);
-		this.numBytesInRate = meter(MetricNames.IO_NUM_BYTES_IN_RATE, new MeterView(numBytesIn, 60));
-		this.numBytesOutRate = meter(MetricNames.IO_NUM_BYTES_OUT_RATE, new MeterView(numBytesOut, 60));
+		this.numBytesInRate = meter(MetricNames.IO_NUM_BYTES_IN_RATE, new MeterView(numBytesIn));
+		this.numBytesOutRate = meter(MetricNames.IO_NUM_BYTES_OUT_RATE, new MeterView(numBytesOut));
 
 		this.numRecordsIn = counter(MetricNames.IO_NUM_RECORDS_IN, new SumCounter());
 		this.numRecordsOut = counter(MetricNames.IO_NUM_RECORDS_OUT, new SumCounter());
-		this.numRecordsInRate = meter(MetricNames.IO_NUM_RECORDS_IN_RATE, new MeterView(numRecordsIn, 60));
-		this.numRecordsOutRate = meter(MetricNames.IO_NUM_RECORDS_OUT_RATE, new MeterView(numRecordsOut, 60));
+		this.numRecordsInRate = meter(MetricNames.IO_NUM_RECORDS_IN_RATE, new MeterView(numRecordsIn));
+		this.numRecordsOutRate = meter(MetricNames.IO_NUM_RECORDS_OUT_RATE, new MeterView(numRecordsOut));
 
 		this.numBuffersOut = counter(MetricNames.IO_NUM_BUFFERS_OUT);
-		this.numBuffersOutRate = meter(MetricNames.IO_NUM_BUFFERS_OUT_RATE, new MeterView(numBuffersOut, 60));
+		this.numBuffersOutRate = meter(MetricNames.IO_NUM_BUFFERS_OUT_RATE, new MeterView(numBuffersOut));
 	}
 
 	public IOMetrics createSnapshot() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -152,6 +152,11 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 	// ------------------------------------------------------------------------
 
 	@Override
+	protected long getNumberOfRestarts() {
+		return executionFailureHandler.getNumberOfRestarts();
+	}
+
+	@Override
 	protected void startSchedulingInternal() {
 		log.debug("Starting scheduling with scheduling strategy [{}]", schedulingStrategy.getClass().getName());
 		prepareExecutionGraphForNgScheduling();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
@@ -82,6 +82,11 @@ public class LegacyScheduler extends SchedulerBase {
 	}
 
 	@Override
+	protected long getNumberOfRestarts() {
+		return getExecutionGraph().getNumberOfRestarts();
+	}
+
+	@Override
 	protected void startSchedulingInternal() {
 		final ExecutionGraph executionGraph = getExecutionGraph();
 		try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -413,9 +413,6 @@ public abstract class SchedulerBase implements SchedulerNG {
 	}
 
 	@Override
-	public abstract void handleGlobalFailure(final Throwable cause);
-
-	@Override
 	public final boolean updateTaskExecutionState(final TaskExecutionState taskExecutionState) {
 		final Optional<ExecutionVertexID> executionVertexId = getExecutionVertexId(taskExecutionState.getID());
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -99,6 +99,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
+import static org.apache.flink.runtime.metrics.MetricNames.NUMBER_OF_RESTARTS;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -194,6 +195,8 @@ public abstract class SchedulerBase implements SchedulerNG {
 		this.failoverTopology = executionGraph.getFailoverTopology();
 
 		this.inputsLocationsRetriever = new ExecutionGraphToInputsLocationsRetrieverAdapter(executionGraph);
+
+		jobManagerJobMetricGroup.gauge(NUMBER_OF_RESTARTS, this::getNumberOfRestarts);
 	}
 
 	private ExecutionGraph createAndRestoreExecutionGraph(
@@ -371,6 +374,8 @@ public abstract class SchedulerBase implements SchedulerNG {
 	protected JobGraph getJobGraph() {
 		return jobGraph;
 	}
+
+	protected abstract long getNumberOfRestarts();
 
 	// ------------------------------------------------------------------------
 	// SchedulerNG

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/ExecutionFailureHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/ExecutionFailureHandlerTest.java
@@ -87,6 +87,7 @@ public class ExecutionFailureHandlerTest extends TestLogger {
 		} catch (IllegalStateException ex) {
 			// expected
 		}
+		assertEquals(1, executionFailureHandler.getNumberOfRestarts());
 	}
 
 	/**
@@ -118,6 +119,7 @@ public class ExecutionFailureHandlerTest extends TestLogger {
 		} catch (IllegalStateException ex) {
 			// expected
 		}
+		assertEquals(0, executionFailureHandler.getNumberOfRestarts());
 	}
 
 	/**
@@ -146,6 +148,7 @@ public class ExecutionFailureHandlerTest extends TestLogger {
 		} catch (IllegalStateException ex) {
 			// expected
 		}
+		assertEquals(0, executionFailureHandler.getNumberOfRestarts());
 	}
 
 	/**

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/WindowOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/WindowOperator.java
@@ -286,7 +286,7 @@ public abstract class WindowOperator<K, W extends Window>
 		this.numLateRecordsDropped = metrics.counter(LATE_ELEMENTS_DROPPED_METRIC_NAME);
 		this.lateRecordsDroppedRate = metrics.meter(
 				LATE_ELEMENTS_DROPPED_RATE_METRIC_NAME,
-				new MeterView(numLateRecordsDropped, 60));
+				new MeterView(numLateRecordsDropped));
 		this.watermarkLatency = metrics.gauge(WATERMARK_LATENCY_METRIC_NAME, () -> {
 			long watermark = internalTimerService.currentWatermark();
 			if (watermark < 0) {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ZooKeeperHighAvailabilityITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ZooKeeperHighAvailabilityITCase.java
@@ -32,14 +32,15 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.runtime.concurrent.FutureUtils;
-import org.apache.flink.runtime.executiongraph.metrics.NumberOfFullRestartsGauge;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.state.CheckpointListener;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
@@ -53,6 +54,7 @@ import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.testutils.junit.category.AlsoRunWithSchedulerNG;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
@@ -62,6 +64,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
@@ -93,6 +96,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Integration tests for {@link org.apache.flink.runtime.checkpoint.ZooKeeperCompletedCheckpointStore}.
  */
+@Category(AlsoRunWithSchedulerNG.class)
 public class ZooKeeperHighAvailabilityITCase extends TestLogger {
 
 	private static final Duration TEST_TIMEOUT = Duration.ofSeconds(10000L);
@@ -424,10 +428,10 @@ public class ZooKeeperHighAvailabilityITCase extends TestLogger {
 	}
 
 	/**
-	 * Reporter that exposes the {@link NumberOfFullRestartsGauge} metric.
+	 * Reporter that exposes the {@code numberOfRestarts} metric.
 	 */
 	public static class RestartReporter implements MetricReporter {
-		static volatile NumberOfFullRestartsGauge numRestarts = null;
+		static volatile Gauge<Long> numRestarts = null;
 
 		@Override
 		public void open(MetricConfig metricConfig) {
@@ -438,9 +442,9 @@ public class ZooKeeperHighAvailabilityITCase extends TestLogger {
 		}
 
 		@Override
-		public void notifyOfAddedMetric(Metric metric, String s, MetricGroup metricGroup) {
-			if (metric instanceof NumberOfFullRestartsGauge) {
-				numRestarts = (NumberOfFullRestartsGauge) metric;
+		public void notifyOfAddedMetric(Metric metric, String name, MetricGroup metricGroup) {
+			if (name.equals(MetricNames.NUMBER_OF_RESTARTS)) {
+				numRestarts = (Gauge<Long>) metric;
 			}
 		}
 


### PR DESCRIPTION

## What is the purpose of the change

This PR is to fix ZooKeeperHighAvailabilityITCase to pass with NG scheduler. And then annotate it with category AlsoRunWithSchedulerNG.

## Brief change log

  - *Fix ZooKeeperHighAvailabilityITCase to pass with NG scheduler*
  - *Annotate ZooKeeperHighAvailabilityITCase with category AlsoRunWithSchedulerNG*


## Verifying this change

This change is already covered by the changed IT case itself.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
