### PR TITLE
[FLINK-12342][yarn] Remove container requests in order to reduce excess containers

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -370,46 +370,21 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 	@Override
 	public void onContainersAllocated(List<Container> containers) {
 		runAsync(() -> {
+			log.info("Received {} containers with {} pending container requests.", containers.size(), numPendingContainerRequests);
 			final Collection<AMRMClient.ContainerRequest> pendingRequests = getPendingRequests();
 			final Iterator<AMRMClient.ContainerRequest> pendingRequestsIterator = pendingRequests.iterator();
 
-			for (Container container : containers) {
-				log.info(
-					"Received new container: {} - Remaining pending container requests: {}",
-					container.getId(),
-					numPendingContainerRequests);
+			// number of allocated containers can be larger than the number of pending container requests
+			final int numAcceptedContainers = Math.min(containers.size(), numPendingContainerRequests);
+			final List<Container> requiredContainers = containers.subList(0, numAcceptedContainers);
+			final List<Container> excessContainers = containers.subList(numAcceptedContainers, containers.size());
 
-				if (numPendingContainerRequests > 0) {
-					removeContainerRequest(pendingRequestsIterator.next());
-
-					final String containerIdStr = container.getId().toString();
-					final ResourceID resourceId = new ResourceID(containerIdStr);
-
-					workerNodeMap.put(resourceId, new YarnWorkerNode(container));
-
-					try {
-						// Context information used to start a TaskExecutor Java process
-						ContainerLaunchContext taskExecutorLaunchContext = createTaskExecutorLaunchContext(
-							container.getResource(),
-							containerIdStr,
-							container.getNodeId().getHost());
-
-						nodeManagerClient.startContainer(container, taskExecutorLaunchContext);
-					} catch (Throwable t) {
-						log.error("Could not start TaskManager in container {}.", container.getId(), t);
-
-						// release the failed container
-						workerNodeMap.remove(resourceId);
-						resourceManagerClient.releaseAssignedContainer(container.getId());
-						// and ask for a new one
-						requestYarnContainerIfRequired();
-					}
-				} else {
-					// return the excessive containers
-					log.info("Returning excess container {}.", container.getId());
-					resourceManagerClient.releaseAssignedContainer(container.getId());
-				}
+			for (int i = 0; i < requiredContainers.size(); i++) {
+				removeContainerRequest(pendingRequestsIterator.next());
 			}
+
+			excessContainers.forEach(this::returnExcessContainer);
+			requiredContainers.forEach(this::startTaskExecutorInContainer);
 
 			// if we are waiting for no further containers, we can go to the
 			// regular heartbeat interval
@@ -417,6 +392,36 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 				resourceManagerClient.setHeartbeatInterval(yarnHeartbeatIntervalMillis);
 			}
 		});
+	}
+
+	private void startTaskExecutorInContainer(Container container) {
+		final String containerIdStr = container.getId().toString();
+		final ResourceID resourceId = new ResourceID(containerIdStr);
+
+		workerNodeMap.put(resourceId, new YarnWorkerNode(container));
+
+		try {
+			// Context information used to start a TaskExecutor Java process
+			ContainerLaunchContext taskExecutorLaunchContext = createTaskExecutorLaunchContext(
+				container.getResource(),
+				containerIdStr,
+				container.getNodeId().getHost());
+
+			nodeManagerClient.startContainer(container, taskExecutorLaunchContext);
+		} catch (Throwable t) {
+			log.error("Could not start TaskManager in container {}.", container.getId(), t);
+
+			// release the failed container
+			workerNodeMap.remove(resourceId);
+			resourceManagerClient.releaseAssignedContainer(container.getId());
+			// and ask for a new one
+			requestYarnContainerIfRequired();
+		}
+	}
+
+	private void returnExcessContainer(Container excessContainer) {
+		log.info("Returning excess container {}.", excessContainer.getId());
+		resourceManagerClient.releaseAssignedContainer(excessContainer.getId());
 	}
 
 	private void removeContainerRequest(AMRMClient.ContainerRequest pendingContainerRequest) {


### PR DESCRIPTION
## What is the purpose of the change

This commit changes the order in which the container requests are removed when
onContainersAllocated is being called. The idea is to remove the container requests
as fast as possible in order to avoid allocating excess containers as described in
YARN-1902.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
