### PR TITLE
[FLINK-14580][hive] add HiveModuleFactory, HiveModuleDescriptor, and HiveModuleDescriptorValidator

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModuleDescriptor.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModuleDescriptor.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.module.hive;
+
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.descriptors.ModuleDescriptor;
+import org.apache.flink.util.StringUtils;
+
+import java.util.Map;
+
+import static org.apache.flink.table.module.hive.HiveModuleDescriptorValidator.MODULE_HIVE_VERSION;
+import static org.apache.flink.table.module.hive.HiveModuleDescriptorValidator.MODULE_TYPE_HIVE;
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * Module descriptor for {@link HiveModule}.
+ */
+public class HiveModuleDescriptor extends ModuleDescriptor {
+	private String hiveVersion;
+
+	public HiveModuleDescriptor() {
+		super(MODULE_TYPE_HIVE);
+	}
+
+	public HiveModuleDescriptor hiveVersion(String hiveVersion) {
+		checkArgument(!StringUtils.isNullOrWhitespaceOnly(hiveVersion));
+		this.hiveVersion = hiveVersion;
+		return this;
+	}
+
+	@Override
+	protected Map<String, String> toModuleProperties() {
+		final DescriptorProperties properties = new DescriptorProperties();
+
+		if (hiveVersion != null) {
+			properties.putString(MODULE_HIVE_VERSION, hiveVersion);
+		}
+
+		return properties.asMap();
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModuleDescriptorValidator.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModuleDescriptorValidator.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.module.hive;
+
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.descriptors.ModuleDescriptorValidator;
+
+/**
+ * Validator for {@link HiveModuleDescriptor}.
+ */
+public class HiveModuleDescriptorValidator extends ModuleDescriptorValidator {
+	public static final String MODULE_TYPE_HIVE = "hive";
+	public static final String MODULE_HIVE_VERSION = "hive-version";
+
+	@Override
+	public void validate(DescriptorProperties properties) {
+		super.validate(properties);
+		properties.validateValue(MODULE_TYPE, MODULE_TYPE_HIVE, false);
+		properties.validateString(MODULE_HIVE_VERSION, true, 1);
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModuleFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModuleFactory.java
@@ -19,10 +19,8 @@
 package org.apache.flink.table.module.hive;
 
 import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
-import org.apache.flink.table.catalog.hive.descriptors.HiveCatalogValidator;
 import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.factories.ModuleFactory;
-import org.apache.flink.table.module.CoreModule;
 import org.apache.flink.table.module.Module;
 
 import java.util.ArrayList;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModuleFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModuleFactory.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.module.hive;
+
+import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
+import org.apache.flink.table.catalog.hive.descriptors.HiveCatalogValidator;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.factories.ModuleFactory;
+import org.apache.flink.table.module.CoreModule;
+import org.apache.flink.table.module.Module;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.table.descriptors.ModuleDescriptorValidator.MODULE_TYPE;
+import static org.apache.flink.table.module.hive.HiveModuleDescriptorValidator.MODULE_HIVE_VERSION;
+import static org.apache.flink.table.module.hive.HiveModuleDescriptorValidator.MODULE_TYPE_HIVE;
+
+/**
+ * Factory for {@link HiveModule}.
+ */
+public class HiveModuleFactory implements ModuleFactory {
+
+	@Override
+	public Module createModule(Map<String, String> properties) {
+		final DescriptorProperties descProperties = getValidatedProperties(properties);
+
+		final String hiveVersion = descProperties.getOptionalString(MODULE_HIVE_VERSION)
+			.orElse(HiveShimLoader.getHiveVersion());
+
+		return new HiveModule(hiveVersion);
+	}
+
+	private static DescriptorProperties getValidatedProperties(Map<String, String> properties) {
+		final DescriptorProperties descriptorProperties = new DescriptorProperties(true);
+		descriptorProperties.putProperties(properties);
+
+		new HiveModuleDescriptorValidator().validate(descriptorProperties);
+
+		return descriptorProperties;
+	}
+
+	@Override
+	public Map<String, String> requiredContext() {
+		Map<String, String> context = new HashMap<>();
+		context.put(MODULE_TYPE, MODULE_TYPE_HIVE);
+
+		return context;
+	}
+
+	@Override
+	public List<String> supportedProperties() {
+		return new ArrayList<>();
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink-connectors/flink-connector-hive/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -14,3 +14,4 @@
 # limitations under the License.
 
 org.apache.flink.table.catalog.hive.factories.HiveCatalogFactory
+org.apache.flink.table.module.hive.HiveModuleFactory

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/module/hive/HiveModuleDescriptorTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/module/hive/HiveModuleDescriptorTest.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.table.module.hive;
 
-import org.apache.flink.table.catalog.hive.descriptors.HiveCatalogDescriptor;
-import org.apache.flink.table.catalog.hive.descriptors.HiveCatalogValidator;
 import org.apache.flink.table.descriptors.Descriptor;
 import org.apache.flink.table.descriptors.DescriptorTestBase;
 import org.apache.flink.table.descriptors.DescriptorValidator;

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/module/hive/HiveModuleDescriptorTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/module/hive/HiveModuleDescriptorTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.module.hive;
+
+import org.apache.flink.table.catalog.hive.descriptors.HiveCatalogDescriptor;
+import org.apache.flink.table.catalog.hive.descriptors.HiveCatalogValidator;
+import org.apache.flink.table.descriptors.Descriptor;
+import org.apache.flink.table.descriptors.DescriptorTestBase;
+import org.apache.flink.table.descriptors.DescriptorValidator;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for {@link HiveModuleDescriptor}.
+ */
+public class HiveModuleDescriptorTest extends DescriptorTestBase {
+
+	@Override
+	protected List<Descriptor> descriptors() {
+		final Descriptor descriptor = new HiveModuleDescriptor();
+
+		return Arrays.asList(descriptor);
+	}
+
+	@Override
+	protected List<Map<String, String>> properties() {
+		final Map<String, String> props1 = new HashMap<>();
+		props1.put("type", "hive");
+
+		return Arrays.asList(props1);
+	}
+
+	@Override
+	protected DescriptorValidator validator() {
+		return new HiveModuleDescriptorValidator();
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

add HiveModuleFactory, HiveModuleDescriptor, and HiveModuleDescriptorValidator for HiveModule.

## Brief change log

- add HiveModuleFactory, HiveModuleDescriptor, and HiveModuleDescriptorValidator for HiveModule.
- add UT

## Verifying this change

This change added tests and can be verified as `HiveModuleDescriptorTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs / JavaDocs)
