### PR TITLE
[FLINK-14611][runtime] Move allVerticesInSameSlotSharingGroupByDefault setting from ExecutionConfig to StreamGraph

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -160,9 +160,6 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	/** The default input dependency constraint to schedule tasks. */
 	private InputDependencyConstraint defaultInputDependencyConstraint = InputDependencyConstraint.ANY;
 
-	/** Flag to indicate whether to put all vertices into the same slot sharing group by default. */
-	private boolean allVerticesInSameSlotSharingGroupByDefault = true;
-
 	// ------------------------------- User code values --------------------------------------------
 
 	private GlobalJobParameters globalJobParameters = new GlobalJobParameters();
@@ -569,32 +566,6 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	@PublicEvolving
 	public InputDependencyConstraint getDefaultInputDependencyConstraint() {
 		return defaultInputDependencyConstraint;
-	}
-
-	/**
-	 * Enables to put all vertices into the same slot sharing group by default.
-	 */
-	@Internal
-	public void enableAllVerticesInSameSlotSharingGroupByDefault() {
-		this.allVerticesInSameSlotSharingGroupByDefault = true;
-	}
-
-	/**
-	 * Disables to put all vertices into the same slot sharing group by default.
-	 */
-	@Internal
-	public void disableAllVerticesInSameSlotSharingGroupByDefault() {
-		this.allVerticesInSameSlotSharingGroupByDefault = false;
-	}
-
-	/**
-	 * Gets whether to put all vertices into the same slot sharing group by default.
-	 *
-	 * @return whether to put all vertices into the same slot sharing group by default.
-	 */
-	@Internal
-	public boolean isAllVerticesInSameSlotSharingGroupByDefault() {
-		return allVerticesInSameSlotSharingGroupByDefault;
 	}
 
 	/**
@@ -1025,8 +996,7 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 				registeredPojoTypes.equals(other.registeredPojoTypes) &&
 				taskCancellationIntervalMillis == other.taskCancellationIntervalMillis &&
 				useSnapshotCompression == other.useSnapshotCompression &&
-				defaultInputDependencyConstraint == other.defaultInputDependencyConstraint &&
-				allVerticesInSameSlotSharingGroupByDefault == other.allVerticesInSameSlotSharingGroupByDefault;
+				defaultInputDependencyConstraint == other.defaultInputDependencyConstraint;
 
 		} else {
 			return false;
@@ -1054,8 +1024,7 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 			registeredPojoTypes,
 			taskCancellationIntervalMillis,
 			useSnapshotCompression,
-			defaultInputDependencyConstraint,
-			allVerticesInSameSlotSharingGroupByDefault);
+			defaultInputDependencyConstraint);
 	}
 
 	public boolean canEqual(Object obj) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -100,6 +100,9 @@ public class StreamGraph implements Pipeline {
 	 */
 	private boolean blockingConnectionsBetweenChains;
 
+	/** Flag to indicate whether to put all vertices into the same slot sharing group by default. */
+	private boolean allVerticesInSameSlotSharingGroupByDefault = true;
+
 	private Map<Integer, StreamNode> streamNodes;
 	private Set<Integer> sources;
 	private Set<Integer> sinks;
@@ -210,6 +213,25 @@ public class StreamGraph implements Pipeline {
 	 */
 	public void setBlockingConnectionsBetweenChains(boolean blockingConnectionsBetweenChains) {
 		this.blockingConnectionsBetweenChains = blockingConnectionsBetweenChains;
+	}
+
+	/**
+	 * Set whether to put all vertices into the same slot sharing group by default.
+	 *
+	 * @param allVerticesInSameSlotSharingGroupByDefault indicates whether to put all vertices
+	 *                                                   into the same slot sharing group by default.
+	 */
+	public void setAllVerticesInSameSlotSharingGroupByDefault(boolean allVerticesInSameSlotSharingGroupByDefault) {
+		this.allVerticesInSameSlotSharingGroupByDefault = allVerticesInSameSlotSharingGroupByDefault;
+	}
+
+	/**
+	 * Gets whether to put all vertices into the same slot sharing group by default.
+	 *
+	 * @return whether to put all vertices into the same slot sharing group by default.
+	 */
+	public boolean isAllVerticesInSameSlotSharingGroupByDefault() {
+		return allVerticesInSameSlotSharingGroupByDefault;
 	}
 
 	// Checkpointing

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -18,7 +18,6 @@
 package org.apache.flink.streaming.api.graph;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.api.common.operators.ResourceSpec;
@@ -630,15 +629,14 @@ public class StreamingJobGraphGenerator {
 
 	/**
 	 * Maps a vertex to its region slot sharing group.
-	 * If {@link ExecutionConfig#isAllVerticesInSameSlotSharingGroupByDefault()}
+	 * If {@link StreamGraph#isAllVerticesInSameSlotSharingGroupByDefault()}
 	 * returns true, all regions will be in the same slot sharing group.
 	 */
 	private Map<JobVertexID, SlotSharingGroup> buildVertexRegionSlotSharingGroups() {
 		final Map<JobVertexID, SlotSharingGroup> vertexRegionSlotSharingGroups = new HashMap<>();
 		final SlotSharingGroup defaultSlotSharingGroup = new SlotSharingGroup();
 
-		final boolean allRegionsInSameSlotSharingGroup = streamGraph.getExecutionConfig()
-			.isAllVerticesInSameSlotSharingGroupByDefault();
+		final boolean allRegionsInSameSlotSharingGroup = streamGraph.isAllVerticesInSameSlotSharingGroupByDefault();
 
 		final Set<LogicalPipelinedRegion> regions = new DefaultLogicalTopology(jobGraph).getLogicalPipelinedRegions();
 		for (LogicalPipelinedRegion region : regions) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -666,7 +666,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 			.findFirst()
 			.get()
 			.setSlotSharingGroup("testSlotSharingGroup");
-		streamGraph.getExecutionConfig().enableAllVerticesInSameSlotSharingGroupByDefault();
+		streamGraph.setAllVerticesInSameSlotSharingGroupByDefault(true);
 		final JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);
 
 		final List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();
@@ -686,7 +686,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 	@Test
 	public void testSlotSharingOnAllVerticesInSameSlotSharingGroupByDefaultDisabled() {
 		final StreamGraph streamGraph = createStreamGraphForSlotSharingTest();
-		streamGraph.getExecutionConfig().disableAllVerticesInSameSlotSharingGroupByDefault();
+		streamGraph.setAllVerticesInSameSlotSharingGroupByDefault(false);
 		final JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);
 
 		final List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/BatchExecutor.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/BatchExecutor.java
@@ -67,7 +67,6 @@ public class BatchExecutor extends ExecutorBase {
 		if (isShuffleModeAllBatch()) {
 			executionConfig.setDefaultInputDependencyConstraint(InputDependencyConstraint.ALL);
 		}
-		executionConfig.disableAllVerticesInSameSlotSharingGroupByDefault();
 	}
 
 	@Override
@@ -85,6 +84,7 @@ public class BatchExecutor extends ExecutorBase {
 			}
 		});
 		streamGraph.setChaining(true);
+		streamGraph.setAllVerticesInSameSlotSharingGroupByDefault(false);
 		streamGraph.setScheduleMode(ScheduleMode.LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST);
 		streamGraph.setStateBackend(null);
 		if (streamGraph.getCheckpointConfig().isCheckpointingEnabled()) {

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/delegation/BatchExecutorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/delegation/BatchExecutorTest.java
@@ -66,6 +66,6 @@ public class BatchExecutorTest extends TestLogger {
 
 	@Test
 	public void testAllVerticesInSameSlotSharingGroupByDefaultIsDisabled() {
-		assertFalse(streamGraph.getExecutionConfig().isAllVerticesInSameSlotSharingGroupByDefault());
+		assertFalse(streamGraph.isAllVerticesInSameSlotSharingGroupByDefault());
 	}
 }


### PR DESCRIPTION

## What is the purpose of the change

allVerticesInSameSlotSharingGroupByDefault is currently for internal use only.
It's better to not add it in ExecutionConfig which is for user configurations.
This PR is to move it from ExecutionConfig to StreamGraph.


## Brief change log

  - *Moved allVerticesInSameSlotSharingGroupByDefault from ExecutionConfig to StreamGraph*
  - *Adjusted its usages*


## Verifying this change

This change is already covered by existing tests, such as BatchExecutorTest and StreamingJobGraphGeneratorTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
