### PR TITLE
[FLINK-14601] [client] CLI documentation for list is missing '-a'

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -284,7 +284,9 @@ public class CliFrontendParser {
 
 	private static Options getListOptionsWithoutDeprecatedOptions(Options options) {
 		options.addOption(RUNNING_OPTION);
-		return options.addOption(SCHEDULED_OPTION);
+		options.addOption(ALL_OPTION);
+		options.addOption(SCHEDULED_OPTION);
+		return options;
 	}
 
 	private static Options getCancelOptionsWithoutDeprecatedOptions(Options options) {


### PR DESCRIPTION
## What is the purpose of the change

resolve the issue CLI documentation for list is missing '-a'
  described in [FLINK-14601](https://issues.apache.org/jira/browse/FLINK-14601)


## Brief change log
  - add ALL_OPTION to the options of CliFrontend list

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
