### PR TITLE
[FLINK-14603][runtime]Notify the potential buffer consumers if the size of LocalBufferPool has been expanded.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/AvailabilityProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/AvailabilityProvider.java
@@ -90,6 +90,16 @@ public interface AvailabilityProvider {
 		}
 
 		/**
+		 *  Creates a new uncompleted future as the current state and returns the
+		 *  previous uncompleted one.
+		 */
+		public CompletableFuture<?> getUnavailableToResetUnavailable() {
+			CompletableFuture<?> toNotify = isAvailable;
+			isAvailable = new CompletableFuture<>();
+			return toNotify;
+		}
+
+		/**
 		 * @return a future that is completed if the respective provider is available.
 		 */
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -229,14 +229,14 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 	}
 
 	private void recycleMemorySegments(Collection<MemorySegment> segments, int size) throws IOException {
+		internalRecycleMemorySegments(segments);
+
 		synchronized (factoryLock) {
 			numTotalRequiredBuffers -= size;
 
 			// note: if this fails, we're fine for the buffer pool since we already recycled the segments
 			redistributeBuffers();
 		}
-
-		internalRecycleMemorySegments(segments);
 	}
 
 	private void internalRecycleMemorySegments(Collection<MemorySegment> segments) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
@@ -414,10 +414,12 @@ public class LocalBufferPoolTest extends TestLogger {
 
 		// request one buffer
 		final BufferBuilder bufferBuilder = checkNotNull(localBufferPool.requestBufferBuilderBlocking());
-		assertFalse(localBufferPool.isAvailable().isDone());
+		CompletableFuture<?> availableFuture = localBufferPool.isAvailable();
+		assertFalse(availableFuture.isDone());
 
 		// set the pool size
 		localBufferPool.setNumBuffers(2);
+		assertTrue(availableFuture.isDone());
 		assertTrue(localBufferPool.isAvailable().isDone());
 
 		// drain the global buffer pool
@@ -435,7 +437,7 @@ public class LocalBufferPoolTest extends TestLogger {
 
 		// reset the pool size
 		localBufferPool.setNumBuffers(1);
-		final CompletableFuture<?> availableFuture = localBufferPool.isAvailable();
+		availableFuture = localBufferPool.isAvailable();
 		assertFalse(availableFuture.isDone());
 
 		// recycle the requested buffer


### PR DESCRIPTION
## What is the purpose of the change
Currently, when the size of ```LocalBufferPool``` is expended by ```LocalBufferPool#setNumBuffers``` and there are segments available in the global ```NetworkBufferPool```, we may failed to notify the potential buffer consumers which are waiting for the ``LocalBufferPool`` to be available. This is a potential regression compared to the previous implementation in which the blocking request thread will wake itself up actively and request available buffers form the global pool.

The purpose of this PR is to fix the regression by notify the potential buffer consumers when the size of ```LocalBufferPool``` is expended.

## Brief change log

  - The potential buffer consumers are notified when the size of ```LocalBufferPool``` is expended.
  - Test case ```LocalBufferPoolTest#testIsAvailableOrNot``` is enhanced to cover the scenario.


## Verifying this change

This change is verified by enhancing the existing test case ```LocalBufferPoolTest#testIsAvailableOrNot```.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
