### PR TITLE
[FLINK-14326][FLINK-14324][table] Support to apply watermark assigner in planner

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/WatermarkSpec.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/WatermarkSpec.java
@@ -89,4 +89,10 @@ public class WatermarkSpec {
 	public int hashCode() {
 		return Objects.hash(rowtimeAttribute, watermarkExpressionString, watermarkExprOutputType);
 	}
+
+	@Override
+	public String toString() {
+		return "rowtime: '" + rowtimeAttribute + '\'' +
+			", watermark: '" + watermarkExpressionString + '\'';
+	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/calcite/sql/validate/ParameterScope.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/calcite/sql/validate/ParameterScope.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.validate;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
+
+import java.util.Map;
+
+// This class is copied from Calcite's org.apache.calcite.sql.validate.ParameterScope,
+// can be removed after https://issues.apache.org/jira/browse/CALCITE-3476 is fixed.
+//
+// Modification:
+// - L66~L69: override resolveColumn method
+
+/**
+ * A scope which contains nothing besides a few parameters. Like
+ * {@link EmptyScope} (which is its base class), it has no parent scope.
+ *
+ * @see ParameterNamespace
+ */
+public class ParameterScope extends EmptyScope {
+	//~ Instance fields --------------------------------------------------------
+
+	/**
+	 * Map from the simple names of the parameters to types of the parameters
+	 * ({@link RelDataType}).
+	 */
+	private final Map<String, RelDataType> nameToTypeMap;
+
+	//~ Constructors -----------------------------------------------------------
+
+	public ParameterScope(
+		SqlValidatorImpl validator,
+		Map<String, RelDataType> nameToTypeMap) {
+		super(validator);
+		this.nameToTypeMap = nameToTypeMap;
+	}
+
+	//~ Methods ----------------------------------------------------------------
+
+	public SqlQualified fullyQualify(SqlIdentifier identifier) {
+		return SqlQualified.create(this, 1, null, identifier);
+	}
+
+	public SqlValidatorScope getOperandScope(SqlCall call) {
+		return this;
+	}
+
+	@Override
+	public RelDataType resolveColumn(String name, SqlNode ctx) {
+		return nameToTypeMap.get(name);
+	}
+}
+
+// End ParameterScope.java

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/SqlExprToRexConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/SqlExprToRexConverter.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.calcite;
+
+import org.apache.calcite.rex.RexNode;
+
+/**
+ * Converts SQL expressions to {@link RexNode}.
+ */
+public interface SqlExprToRexConverter {
+
+	/**
+	 * Converts a SQL expression to a {@link RexNode} expression.
+	 */
+	RexNode convertToRexNode(String expr);
+
+	/**
+	 * Converts an array of SQL expressions to an array of {@link RexNode} expressions.
+	 */
+	RexNode[] convertToRexNodes(String[] exprs);
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/SqlExprToRexConverterImpl.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/SqlExprToRexConverterImpl.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.calcite;
+
+import org.apache.flink.table.planner.plan.FlinkCalciteCatalogReader;
+
+import org.apache.calcite.config.CalciteConnectionConfig;
+import org.apache.calcite.config.CalciteConnectionConfigImpl;
+import org.apache.calcite.config.CalciteConnectionProperty;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.jdbc.CalciteSchemaBuilder;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.prepare.CalciteCatalogReader;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.impl.AbstractSchema;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.tools.FrameworkConfig;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+
+/**
+ * Standard implementation of {@link SqlExprToRexConverter}.
+ */
+public class SqlExprToRexConverterImpl implements SqlExprToRexConverter {
+
+	private static final String TEMPORARY_TABLE_NAME = "__temp_table__";
+	private static final String QUERY_FORMAT = "SELECT %s FROM " + TEMPORARY_TABLE_NAME;
+
+	private final FlinkPlannerImpl planner;
+
+	public SqlExprToRexConverterImpl(
+			FrameworkConfig config,
+			FlinkTypeFactory typeFactory,
+			RelOptCluster cluster,
+			RelDataType tableRowType) {
+		this.planner = new FlinkPlannerImpl(
+			config,
+			(isLenient) -> createSingleTableCatalogReader(isLenient, config, typeFactory, tableRowType),
+			typeFactory,
+			cluster
+		);
+	}
+
+	@Override
+	public RexNode convertToRexNode(String expr) {
+		return convertToRexNodes(new String[]{expr})[0];
+	}
+
+	@Override
+	public RexNode[] convertToRexNodes(String[] exprs) {
+		String query = String.format(QUERY_FORMAT, String.join(",", exprs));
+		SqlNode parsed = planner.parser().parse(query);
+		SqlNode validated = planner.validate(parsed);
+		RelNode rel = planner.rel(validated).rel;
+		// The plan should in the following tree
+		// LogicalProject
+		// +- TableScan
+		if (rel instanceof LogicalProject
+			&& rel.getInput(0) != null
+			&& rel.getInput(0) instanceof TableScan) {
+			return ((LogicalProject) rel).getProjects().toArray(new RexNode[0]);
+		} else {
+			throw new IllegalStateException("The root RelNode should be LogicalProject, but is " + rel.toString());
+		}
+	}
+
+	// ------------------------------------------------------------------------------------------
+	// Utilities
+	// ------------------------------------------------------------------------------------------
+
+	/**
+	 * Creates a catalog reader that contains a single {@link Table} with temporary table name
+	 * and specified {@code rowType}.
+	 *
+	 * @param rowType     table row type
+	 * @return the {@link CalciteCatalogReader} instance
+	 */
+	private static CalciteCatalogReader createSingleTableCatalogReader(
+			boolean lenientCaseSensitivity,
+			FrameworkConfig config,
+			FlinkTypeFactory typeFactory,
+			RelDataType rowType) {
+
+		// connection properties
+		boolean caseSensitive = !lenientCaseSensitivity && config.getParserConfig().caseSensitive();
+		Properties properties = new Properties();
+		properties.put(
+			CalciteConnectionProperty.CASE_SENSITIVE.camelName(),
+			String.valueOf(caseSensitive));
+		CalciteConnectionConfig connectionConfig = new CalciteConnectionConfigImpl(properties);
+
+		// prepare root schema
+		final RowTypeSpecifiedTable table = new RowTypeSpecifiedTable(rowType);
+		final Map<String, Table> tableMap = Collections.singletonMap(TEMPORARY_TABLE_NAME, table);
+		CalciteSchema schema = CalciteSchemaBuilder.asRootSchema(new TableSpecifiedSchema(tableMap));
+
+		return new FlinkCalciteCatalogReader(
+			schema,
+			new ArrayList<>(new ArrayList<>()),
+			typeFactory,
+			connectionConfig);
+	}
+
+	// ------------------------------------------------------------------------------------------
+	// Inner Class
+	// ------------------------------------------------------------------------------------------
+
+	/**
+	 * A {@link AbstractTable} that can specify the row type explicitly.
+	 */
+	private static class RowTypeSpecifiedTable extends AbstractTable {
+		private final RelDataType rowType;
+
+		RowTypeSpecifiedTable(RelDataType rowType) {
+			this.rowType = Objects.requireNonNull(rowType);
+		}
+
+		@Override
+		public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+			return this.rowType;
+		}
+	}
+
+	/**
+	 * A {@link AbstractSchema} that can specify the table map explicitly.
+	 */
+	private static class TableSpecifiedSchema extends AbstractSchema {
+		private final Map<String, Table> tableMap;
+
+		TableSpecifiedSchema(Map<String, Table> tableMap) {
+			this.tableMap = Objects.requireNonNull(tableMap);
+		}
+
+		@Override
+		protected Map<String, Table> getTableMap() {
+			return tableMap;
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/DatabaseCalciteSchema.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/DatabaseCalciteSchema.java
@@ -185,7 +185,7 @@ class DatabaseCalciteSchema extends FlinkSchema {
 			tableSource,
 			isStreamingMode,
 			FlinkStatistic.builder().tableStats(tableStats).build(),
-			null);
+			table);
 	}
 
 	private TableStats extractTableStats(ConnectorCatalogTable<?, ?> table, ObjectPath tablePath) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/QueryOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/QueryOperationConverter.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.ConnectorCatalogTable;
 import org.apache.flink.table.catalog.FunctionLookup;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.expressions.CallExpression;
@@ -356,7 +357,7 @@ public class QueryOperationConverter extends QueryOperationDefaultVisitor<RelNod
 			}
 
 			TableSourceTable<?> tableSourceTable = new TableSourceTable<>(
-					tableSource, !isBatch, statistic, null);
+					tableSource, !isBatch, statistic, ConnectorCatalogTable.source(tableSource, isBatch));
 			FlinkRelOptTable table = FlinkRelOptTable.create(
 				relBuilder.getRelOptSchema(),
 				tableSourceTable.getRowType(relBuilder.getTypeFactory()),

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
@@ -28,7 +28,6 @@ import org.apache.calcite.prepare.CalciteCatalogReader
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.{RelFieldCollation, RelRoot}
 import org.apache.calcite.sql.advise.{SqlAdvisor, SqlAdvisorValidator}
-import org.apache.calcite.sql.validate.SqlValidator
 import org.apache.calcite.sql.{SqlKind, SqlNode, SqlOperatorTable}
 import org.apache.calcite.sql2rel.{RelDecorrelator, SqlRexConvertletTable, SqlToRelConverter}
 import org.apache.calcite.tools.{FrameworkConfig, RelConversionException}
@@ -144,6 +143,14 @@ class FlinkPlannerImpl(
     }
   }
 
+  /**
+    * Creates a new instance of [[SqlExprToRexConverter]] to convert SQL expression
+    * to RexNode.
+    */
+  def createSqlExprToRexConverter(tableRowType: RelDataType): SqlExprToRexConverter = {
+    new SqlExprToRexConverterImpl(config, typeFactory, cluster, tableRowType)
+  }
+
   /** Implements [[org.apache.calcite.plan.RelOptTable.ViewExpander]]
     * interface for [[org.apache.calcite.tools.Planner]]. */
   class ViewExpanderImpl extends ViewExpander {
@@ -154,14 +161,14 @@ class FlinkPlannerImpl(
         schemaPath: util.List[String],
         viewPath: util.List[String]): RelRoot = {
 
-      val sqlNode: SqlNode = parser.parse(queryString)
-      val catalogReader: CalciteCatalogReader = catalogReaderSupplier.apply(false)
+      val sqlNode = parser.parse(queryString)
+      val catalogReader = catalogReaderSupplier.apply(false)
         .withSchemaPath(schemaPath)
-      val validator: SqlValidator =
+      val validator =
         new FlinkCalciteSqlValidator(operatorTable, catalogReader, typeFactory)
       validator.setIdentifierExpansion(true)
-      val validatedSqlNode: SqlNode = validator.validate(sqlNode)
-      val sqlToRelConverter: SqlToRelConverter = new SqlToRelConverter(
+      val validatedSqlNode = validator.validate(sqlNode)
+      val sqlToRelConverter = new SqlToRelConverter(
         new ViewExpanderImpl,
         validator,
         catalogReader,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/WatermarkGeneratorCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/WatermarkGeneratorCodeGenerator.scala
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.codegen
+
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.table.api.TableConfig
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
+import org.apache.flink.table.planner.codegen.CodeGenUtils.{BASE_ROW, newName}
+import org.apache.flink.table.planner.codegen.Indenter.toISC
+import org.apache.flink.table.runtime.generated.{GeneratedWatermarkGenerator, WatermarkGenerator}
+import org.apache.flink.table.types.logical.{LogicalTypeRoot, RowType}
+import org.apache.calcite.rex.RexNode
+
+/**
+  * A code generator for generating [[WatermarkGenerator]]s.
+  */
+object WatermarkGeneratorCodeGenerator {
+
+  def generateWatermarkGenerator(
+      config: TableConfig,
+      inputType: RowType,
+      watermarkExpr: RexNode): GeneratedWatermarkGenerator = {
+    // validation
+    val watermarkOutputType = FlinkTypeFactory.toLogicalType(watermarkExpr.getType)
+    if (watermarkOutputType.getTypeRoot != LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) {
+      throw new CodeGenException(
+        "WatermarkGenerator only accepts output data type of TIMESTAMP," +
+          " but is " + watermarkOutputType)
+    }
+    val funcName = newName("WatermarkGenerator")
+    val ctx = CodeGeneratorContext(config)
+    val generator = new ExprCodeGenerator(ctx, false)
+      .bindInput(inputType, inputTerm = "row")
+    val generatedExpr = generator.generateExpression(watermarkExpr)
+
+    val funcCode =
+      j"""
+      public final class $funcName
+          extends ${classOf[WatermarkGenerator].getCanonicalName} {
+
+        ${ctx.reuseMemberCode()}
+
+        public $funcName(Object[] references) throws Exception {
+          ${ctx.reuseInitCode()}
+        }
+
+        @Override
+        public void open(${classOf[Configuration].getCanonicalName} parameters) throws Exception {
+          ${ctx.reuseOpenCode()}
+        }
+
+        @Override
+        public Long currentWatermark($BASE_ROW row) throws Exception {
+          ${ctx.reusePerRecordCode()}
+          ${ctx.reuseLocalVariableCode()}
+          ${ctx.reuseInputUnboxingCode()}
+          ${generatedExpr.code}
+          if (${generatedExpr.nullTerm}) {
+            return null;
+          } else {
+            return ${generatedExpr.resultTerm};
+          }
+        }
+
+        @Override
+        public void close() throws Exception {
+          ${ctx.reuseCloseCode()}
+        }
+      }
+    """.stripMargin
+    new GeneratedWatermarkGenerator(funcName, funcCode, ctx.references.toArray)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/PhysicalTableSourceScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/PhysicalTableSourceScan.scala
@@ -58,7 +58,13 @@ abstract class PhysicalTableSourceScan(
   }
 
   override def explainTerms(pw: RelWriter): RelWriter = {
-    super.explainTerms(pw).item("fields", getRowType.getFieldNames.asScala.mkString(", "))
+    val hasWatermark = tableSourceTable.watermarkSpec.isDefined && tableSourceTable.isStreamingMode
+    val rowtime = tableSourceTable.watermarkSpec.map(_.getRowtimeAttribute).orNull
+    val watermark = tableSourceTable.watermarkSpec.map(_.getWatermarkExpressionString).orNull
+    super.explainTerms(pw)
+      .item("fields", getRowType.getFieldNames.asScala.mkString(", "))
+      .itemIf("rowtime", rowtime, hasWatermark)
+      .itemIf("watermark", watermark, hasWatermark)
   }
 
   def createInput[IN](

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecTableSourceScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecTableSourceScan.scala
@@ -26,10 +26,10 @@ import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.functions.{AssignerWithPeriodicWatermarks, AssignerWithPunctuatedWatermarks}
 import org.apache.flink.streaming.api.watermark.Watermark
-import org.apache.flink.table.api.{DataTypes, TableException}
+import org.apache.flink.table.api.{DataTypes, TableConfig, TableException, WatermarkSpec}
 import org.apache.flink.table.dataformat.DataFormatConverters.DataFormatConverter
 import org.apache.flink.table.dataformat.{BaseRow, DataFormatConverters}
-import org.apache.flink.table.planner.codegen.CodeGeneratorContext
+import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, WatermarkGeneratorCodeGenerator}
 import org.apache.flink.table.planner.codegen.OperatorCodeGenerator._
 import org.apache.flink.table.planner.delegation.StreamPlanner
 import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, StreamExecNode}
@@ -43,11 +43,14 @@ import org.apache.flink.table.sources.wmstrategies.{PeriodicWatermarkAssigner, P
 import org.apache.flink.table.sources.{RowtimeAttributeDescriptor, StreamTableSource}
 import org.apache.flink.table.types.{DataType, FieldsDataType}
 import org.apache.flink.types.Row
-
 import org.apache.calcite.plan._
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.metadata.RelMetadataQuery
 import org.apache.calcite.rex.RexNode
+import org.apache.flink.table.planner.calcite.{FlinkTypeFactory, SqlExprToRexConverter}
+import org.apache.flink.table.runtime.operators.wmassigners.WatermarkAssignerOperatorFactory
+import org.apache.flink.table.types.logical.RowType
+import org.apache.flink.table.types.utils.TypeConversions
 
 import java.util
 
@@ -153,33 +156,91 @@ class StreamExecTableSourceScan(
 
     val ingestedTable = new DataStream(planner.getExecEnv, streamTransformation)
 
-    // generate watermarks for rowtime indicator
-    val rowtimeDesc: Option[RowtimeAttributeDescriptor] =
-      TableSourceUtil.getRowtimeAttributeDescriptor(tableSource, tableSourceTable.selectedFields)
-
-    val withWatermarks = if (rowtimeDesc.isDefined) {
-      val rowtimeFieldIdx = getRowType.getFieldNames.indexOf(rowtimeDesc.get.getAttributeName)
-      val watermarkStrategy = rowtimeDesc.get.getWatermarkStrategy
-      watermarkStrategy match {
-        case p: PeriodicWatermarkAssigner =>
-          val watermarkGenerator = new PeriodicWatermarkAssignerWrapper(rowtimeFieldIdx, p)
-          ingestedTable.assignTimestampsAndWatermarks(watermarkGenerator)
-        case p: PunctuatedWatermarkAssigner =>
-          val watermarkGenerator =
-            new PunctuatedWatermarkAssignerWrapper(rowtimeFieldIdx, p, producedDataType)
-          ingestedTable.assignTimestampsAndWatermarks(watermarkGenerator)
-        case _: PreserveWatermarks =>
-          // The watermarks have already been provided by the underlying DataStream.
-          ingestedTable
-      }
+    val withWatermarks = if (tableSourceTable.watermarkSpec.isDefined) {
+      // generate watermarks for rowtime indicator from WatermarkSpec
+      val rowType = tableSourceTable.getRowType(planner.getTypeFactory)
+      val converter = planner.createFlinkPlanner.createSqlExprToRexConverter(rowType)
+      applyWatermarkByWatermarkSpec(
+        config,
+        ingestedTable,
+        FlinkTypeFactory.toLogicalRowType(rowType),
+        tableSourceTable.watermarkSpec.get,
+        converter)
     } else {
-      // No need to generate watermarks if no rowtime attribute is specified.
-      ingestedTable
+      val rowtimeDesc: Option[RowtimeAttributeDescriptor] =
+        TableSourceUtil.getRowtimeAttributeDescriptor(tableSource, tableSourceTable.selectedFields)
+
+      // generate watermarks for rowtime indicator from DefinedRowtimeAttributes
+      if (rowtimeDesc.isDefined) {
+        applyWatermarkByRowtimeAttributeDescriptor(
+          ingestedTable,
+          rowtimeDesc.get,
+          producedDataType)
+      } else {
+        // No need to generate watermarks if no rowtime attribute is specified.
+        ingestedTable
+      }
     }
+
     withWatermarks.getTransformation
   }
 
-  def needInternalConversion: Boolean = {
+  private def applyWatermarkByWatermarkSpec(
+      config: TableConfig,
+      input: DataStream[BaseRow],
+      inputType: RowType,
+      watermarkSpec: WatermarkSpec,
+      converter: SqlExprToRexConverter): DataStream[BaseRow] = {
+    // TODO: [FLINK-14473] support nested field as the rowtime attribute in the future
+    val rowtime = watermarkSpec.getRowtimeAttribute
+    if (rowtime.contains(".")) {
+      throw new TableException(
+        s"Nested field '$rowtime' as rowtime attribute is not supported right now.")
+    }
+    val rowtimeFieldIndex = getRowType.getFieldNames.indexOf(rowtime)
+    val watermarkExpr = converter.convertToRexNode(watermarkSpec.getWatermarkExpressionString)
+    val watermarkResultType = TypeConversions.fromLogicalToDataType(
+      FlinkTypeFactory.toLogicalType(watermarkExpr.getType))
+    // check the derived datatype equals to the datatype in WatermarkSpec in TableSchema.
+    if (!watermarkResultType.equals(watermarkSpec.getWatermarkExprOutputType)) {
+      throw new TableException(
+        s"The derived data type '$watermarkResultType' of watermark expression doesn't equal to " +
+          s"the data type '${watermarkSpec.getWatermarkExprOutputType}' in WatermarkSpec. " +
+          "Please pass in correct result type of watermark expression when constructing " +
+          "TableSchema.")
+    }
+    val watermarkGenerator = WatermarkGeneratorCodeGenerator.generateWatermarkGenerator(
+      config,
+      inputType,
+      watermarkExpr)
+    val operatorFactory = new WatermarkAssignerOperatorFactory(
+      rowtimeFieldIndex,
+      0L,
+      watermarkGenerator)
+    input.transform(s"WatermarkAssigner($watermarkSpec)", input.getType, operatorFactory)
+  }
+
+  private def applyWatermarkByRowtimeAttributeDescriptor(
+      input: DataStream[BaseRow],
+      rowtimeDesc: RowtimeAttributeDescriptor,
+      producedDataType: DataType): DataStream[BaseRow] = {
+    val rowtimeFieldIdx = getRowType.getFieldNames.indexOf(rowtimeDesc.getAttributeName)
+    val watermarkStrategy = rowtimeDesc.getWatermarkStrategy
+    watermarkStrategy match {
+      case p: PeriodicWatermarkAssigner =>
+        val watermarkGenerator = new PeriodicWatermarkAssignerWrapper(rowtimeFieldIdx, p)
+        input.assignTimestampsAndWatermarks(watermarkGenerator)
+      case p: PunctuatedWatermarkAssigner =>
+        val watermarkGenerator =
+          new PunctuatedWatermarkAssignerWrapper(rowtimeFieldIdx, p, producedDataType)
+        input.assignTimestampsAndWatermarks(watermarkGenerator)
+      case _: PreserveWatermarks =>
+        // The watermarks have already been provided by the underlying DataStream.
+        input
+    }
+  }
+
+  private def needInternalConversion: Boolean = {
     val fieldIndexes = TableSourceUtil.computeIndexMapping(
       tableSource,
       isStreamTable = true,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoTableSourceScanRule.scala
@@ -50,8 +50,8 @@ class PushPartitionIntoTableSourceScanRule extends RelOptRule(
 
     val scan: LogicalTableScan = call.rel(1)
     scan.getTable.unwrap(classOf[TableSourceTable[_]]) match {
-      case table: TableSourceTable[_] => table.catalogTable != null &&
-          table.catalogTable.isPartitioned &&
+      case table: TableSourceTable[_] =>
+        table.catalogTable.isPartitioned &&
           table.tableSource.isInstanceOf[PartitionableTableSource]
       case _ => false
     }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/TableSourceTable.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/TableSourceTable.scala
@@ -22,9 +22,13 @@ import org.apache.flink.table.catalog.CatalogTable
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
 import org.apache.flink.table.planner.sources.TableSourceUtil
-import org.apache.flink.table.sources.TableSource
+import org.apache.flink.table.sources.{TableSource, TableSourceValidation}
 import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeFactory}
 import org.apache.flink.shaded.guava18.com.google.common.base.Preconditions
+import org.apache.flink.table.api.{TableException, WatermarkSpec}
+import org.apache.flink.table.types.logical.{TimestampKind, TimestampType}
+
+import scala.collection.JavaConverters._
 
 /**
   * Abstract class which define the interfaces required to convert a [[TableSource]] to
@@ -54,15 +58,46 @@ class TableSourceTable[T](
   Preconditions.checkNotNull(statistic)
   Preconditions.checkNotNull(catalogTable)
 
+  val watermarkSpec: Option[WatermarkSpec] = catalogTable
+    .getSchema
+    // we only support single watermark currently
+    .getWatermarkSpecs.asScala.headOption
+
+  if (TableSourceValidation.hasRowtimeAttribute(tableSource) && watermarkSpec.isDefined) {
+    throw new TableException(
+        "If watermark is specified in DDL, the underlying TableSource of connector shouldn't" +
+          " return an non-empty list of RowtimeAttributeDescriptor" +
+          " via DefinedRowtimeAttributes interface.")
+  }
+
   // TODO implements this
   // TableSourceUtil.validateTableSource(tableSource)
 
   override def getRowType(typeFactory: RelDataTypeFactory): RelDataType = {
-    TableSourceUtil.getRelDataType(
+    val factory = typeFactory.asInstanceOf[FlinkTypeFactory]
+    val (fieldNames, fieldTypes) = TableSourceUtil.getFieldNamesTypes(
       tableSource,
       selectedFields,
-      streaming = isStreamingMode,
-      typeFactory.asInstanceOf[FlinkTypeFactory])
+      streaming = isStreamingMode)
+    // patch rowtime field according to WatermarkSpec
+    val patchedTypes = if (isStreamingMode && watermarkSpec.isDefined) {
+      // TODO: [FLINK-14473] we only support top-level rowtime attribute right now
+      val rowtime = watermarkSpec.get.getRowtimeAttribute
+      if (rowtime.contains(".")) {
+        throw new TableException(
+          s"Nested field '$rowtime' as rowtime attribute is not supported right now.")
+      }
+      val idx = fieldNames.indexOf(rowtime)
+      val originalType = fieldTypes(idx).asInstanceOf[TimestampType]
+      val rowtimeType = new TimestampType(
+        originalType.isNullable,
+        TimestampKind.ROWTIME,
+        originalType.getPrecision)
+      fieldTypes.patch(idx, Seq(rowtimeType), 1)
+    } else {
+      fieldTypes
+    }
+    factory.buildRelNodeRowType(fieldNames, patchedTypes)
   }
 
   /**

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/TableSourceTable.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/TableSourceTable.scala
@@ -23,8 +23,8 @@ import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
 import org.apache.flink.table.planner.sources.TableSourceUtil
 import org.apache.flink.table.sources.TableSource
-
 import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeFactory}
+import org.apache.flink.shaded.guava18.com.google.common.base.Preconditions
 
 /**
   * Abstract class which define the interfaces required to convert a [[TableSource]] to
@@ -49,6 +49,10 @@ class TableSourceTable[T](
       catalogTable: CatalogTable) {
     this(tableSource, isStreamingMode, statistic, None, catalogTable)
   }
+
+  Preconditions.checkNotNull(tableSource)
+  Preconditions.checkNotNull(statistic)
+  Preconditions.checkNotNull(catalogTable)
 
   // TODO implements this
   // TableSourceUtil.validateTableSource(tableSource)

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.sqlexec;
+package org.apache.flink.table.planner.operations;
 
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
 import org.apache.flink.table.api.DataTypes;
@@ -44,8 +44,6 @@ import org.apache.flink.table.planner.calcite.CalciteParser;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.planner.catalog.CatalogManagerCalciteSchema;
 import org.apache.flink.table.planner.delegation.PlannerContext;
-import org.apache.flink.table.planner.operations.SqlConversionException;
-import org.apache.flink.table.planner.operations.SqlToOperationConverter;
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions;
 import org.apache.flink.table.types.DataType;
 
@@ -70,7 +68,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Test cases for {@link org.apache.flink.table.planner.operations.SqlToOperationConverter}.
+ * Test cases for {@link SqlToOperationConverter}.
  */
 public class SqlToOperationConverterTest {
 	private final TableConfig tableConfig = new TableConfig();

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableScanTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableScanTest.xml
@@ -19,17 +19,41 @@ limitations under the License.
   <TestCase name="testTableSourceScan">
     <Resource name="sql">
       <![CDATA[SELECT * FROM MyTable]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testDDLTableScan">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM src WHERE a > 1]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(ts=[$0], a=[$1], b=[$2])
++- LogicalFilter(condition=[>($1, 1)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, src, source: [CollectionTableSource(ts, a, b)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[ts, a, b], where=[>(a, 1)])
++- TableSourceScan(table=[[default_catalog, default_database, src, source: [CollectionTableSource(ts, a, b)]]], fields=[ts, a, b])
+]]>
+
     </Resource>
   </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
@@ -16,36 +16,63 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
-  <TestCase name="testTableSourceScan">
-    <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testDataStreamScan">
     <Resource name="sql">
       <![CDATA[SELECT * FROM DataStreamTable]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalTableScan(table=[[default_catalog, default_database, DataStreamTable]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 DataStreamScan(table=[[default_catalog, default_database, DataStreamTable]], fields=[a, b, c])
 ]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testTableSourceScan">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testDDLTableScan">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM src WHERE a > 1]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(ts=[$0], a=[$1], b=[$2])
++- LogicalFilter(condition=[>($1, 1)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, src, source: [CollectionTableSource(ts, a, b)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[ts, a, b], where=[>(a, 1)])
++- TableSourceScan(table=[[default_catalog, default_database, src, source: [CollectionTableSource(ts, a, b)]]], fields=[ts, a, b], rowtime=[ts], watermark=[`ts` - INTERVAL '0.001' SECOND])
+]]>
+
     </Resource>
   </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/WatermarkGeneratorCodeGenTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/WatermarkGeneratorCodeGenTest.scala
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.codegen
+
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.util.MockStreamingRuntimeContext
+import org.apache.flink.table.api.TableConfig
+import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog, GenericInMemoryCatalog, ObjectIdentifier}
+import org.apache.flink.table.dataformat.GenericRow
+import org.apache.flink.table.module.ModuleManager
+import org.apache.flink.table.planner.calcite.{FlinkPlannerImpl, FlinkTypeFactory}
+import org.apache.flink.table.planner.catalog.CatalogManagerCalciteSchema
+import org.apache.flink.table.planner.delegation.PlannerContext
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.JavaFunc5
+import org.apache.flink.table.runtime.generated.WatermarkGenerator
+import org.apache.flink.table.types.logical.{IntType, TimestampType}
+import org.apache.calcite.jdbc.CalciteSchemaBuilder.asRootSchema
+
+import org.junit.Assert.{assertEquals, assertTrue}
+import org.junit.Test
+
+import java.lang.{Integer => JInt, Long => JLong}
+import java.util.Collections
+
+/**
+  * Tests the generated [[WatermarkGenerator]] from [[WatermarkGeneratorCodeGenerator]].
+  */
+class WatermarkGeneratorCodeGenTest {
+
+  // mock FlinkPlannerImpl to avoid discovering TableEnvironment and Executor.
+  val catalog = new GenericInMemoryCatalog("MockCatalog", "default")
+  val catalogManager = new CatalogManager("builtin", catalog)
+  val functionCatalog = new FunctionCatalog(catalogManager, new ModuleManager)
+  val plannerContext = new PlannerContext(
+    new TableConfig,
+    functionCatalog,
+    catalogManager,
+    asRootSchema(new CatalogManagerCalciteSchema(catalogManager, false)),
+    Collections.emptyList())
+  val planner: FlinkPlannerImpl = plannerContext.createFlinkPlanner(
+    catalogManager.getCurrentCatalog,
+    catalogManager.getCurrentDatabase)
+
+  val data = List(
+    GenericRow.of(JLong.valueOf(1000L), JInt.valueOf(5)),
+    GenericRow.of(null, JInt.valueOf(4)),
+    GenericRow.of(JLong.valueOf(3000L), null),
+    GenericRow.of(JLong.valueOf(5000L), JInt.valueOf(3)),
+    GenericRow.of(JLong.valueOf(4000L), JInt.valueOf(10)),
+    GenericRow.of(JLong.valueOf(6000L), JInt.valueOf(8))
+  )
+
+  @Test
+  def testAscendingWatermark(): Unit = {
+    val generator = generateWatermarkGenerator("ts - INTERVAL '0.001' SECOND")
+    val results = data.map(d => generator.currentWatermark(d))
+    val expected = List(
+      JLong.valueOf(999L),
+      null,
+      JLong.valueOf(2999),
+      JLong.valueOf(4999),
+      JLong.valueOf(3999),
+      JLong.valueOf(5999))
+    assertEquals(expected, results)
+  }
+
+  @Test
+  def testBoundedOutOfOrderWatermark(): Unit = {
+    val generator = generateWatermarkGenerator("ts - INTERVAL '5' SECOND")
+    val results = data.map(d => generator.currentWatermark(d))
+    val expected = List(
+      JLong.valueOf(-4000L),
+      null,
+      JLong.valueOf(-2000L),
+      JLong.valueOf(0L),
+      JLong.valueOf(-1000L),
+      JLong.valueOf(1000L))
+    assertEquals(expected, results)
+  }
+
+  @Test
+  def testCustomizedWatermark(): Unit = {
+    JavaFunc5.openCalled = false
+    JavaFunc5.closeCalled = false
+    functionCatalog.registerTempCatalogScalarFunction(
+      ObjectIdentifier.of("builtin", "default", "myFunc"),
+      new JavaFunc5
+    )
+    val generator = generateWatermarkGenerator("myFunc(ts, `offset`)")
+    // mock open and close invoking
+    generator.setRuntimeContext(new MockStreamingRuntimeContext(false, 1, 1))
+    generator.open(new Configuration())
+    val results = data.map(d => generator.currentWatermark(d))
+    generator.close()
+    val expected = List(
+      JLong.valueOf(995L),
+      null,
+      null,
+      JLong.valueOf(4997L),
+      JLong.valueOf(3990L),
+      JLong.valueOf(5992L))
+    assertEquals(expected, results)
+    assertTrue(JavaFunc5.openCalled)
+    assertTrue(JavaFunc5.closeCalled)
+  }
+
+  private def generateWatermarkGenerator(expr: String): WatermarkGenerator = {
+    val tableRowType = plannerContext.getTypeFactory.buildRelNodeRowType(
+      Seq("ts", "offset"),
+      Seq(
+        new TimestampType(3),
+        new IntType()
+      ))
+    val rowType = FlinkTypeFactory.toLogicalRowType(tableRowType)
+    val converter = planner.createSqlExprToRexConverter(tableRowType)
+    val rexNode = converter.convertToRexNode(expr)
+    val generated = WatermarkGeneratorCodeGenerator
+      .generateWatermarkGenerator(new TableConfig(), rowType, rexNode)
+    generated.newInstance(Thread.currentThread().getContextClassLoader)
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/TableScanTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/TableScanTest.scala
@@ -20,8 +20,8 @@ package org.apache.flink.table.planner.plan.batch.sql
 
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.scala._
+import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory
 import org.apache.flink.table.planner.utils.TableTestBase
-
 import org.junit.Test
 
 class TableScanTest extends TableTestBase {
@@ -32,6 +32,24 @@ class TableScanTest extends TableTestBase {
   def testTableSourceScan(): Unit = {
     util.addTableSource[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
     util.verifyPlan("SELECT * FROM MyTable")
+  }
+
+
+  @Test
+  def testDDLTableScan(): Unit = {
+    TestCollectionTableFactory.isStreaming = false
+    util.addTable(
+      """
+        |CREATE TABLE src (
+        |  ts TIMESTAMP(3),
+        |  a INT,
+        |  b DOUBLE,
+        |  WATERMARK FOR ts AS ts - INTERVAL '0.001' SECOND
+        |) WITH (
+        |  'connector' = 'COLLECTION'
+        |)
+      """.stripMargin)
+    util.verifyPlan("SELECT * FROM src WHERE a > 1")
   }
 
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TimeAttributeITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TimeAttributeITCase.scala
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.sql
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.ValidationException
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.JavaFunc5
+import org.apache.flink.table.planner.runtime.utils.{StreamingTestBase, TestingAppendSink}
+import org.apache.flink.types.Row
+import org.junit.Assert.{assertEquals, assertTrue}
+import org.junit.Test
+
+import java.sql.Timestamp
+import java.util.TimeZone
+
+import scala.collection.JavaConverters._
+
+/**
+  * Integration tests for time attributes defined in DDL.
+  */
+class TimeAttributeITCase extends StreamingTestBase {
+
+  val data = List(
+    row(utcTimestamp(1L), 1, 1d),
+    row(utcTimestamp(2L), 1, 2d),
+    row(utcTimestamp(3L), 1, 2d),
+    row(utcTimestamp(4L), 1, 5d),
+    row(utcTimestamp(7L), 1, 3d),
+    row(utcTimestamp(8L), 1, 3d),
+    row(utcTimestamp(16L), 1, 4d))
+  TestCollectionTableFactory.reset()
+  TestCollectionTableFactory.initData(data.asJava)
+  TestCollectionTableFactory.isStreaming = true
+
+  @Test
+  def testWindowAggregateOnWatermark(): Unit = {
+    val ddl =
+      """
+        |CREATE TABLE src (
+        |  ts TIMESTAMP(3),
+        |  a INT,
+        |  b DOUBLE,
+        |  WATERMARK FOR ts AS ts - INTERVAL '0.001' SECOND
+        |) WITH (
+        |  'connector' = 'COLLECTION'
+        |)
+      """.stripMargin
+    val query =
+      """
+        |SELECT TUMBLE_END(ts, INTERVAL '0.003' SECOND), COUNT(ts), SUM(b)
+        |FROM src
+        |GROUP BY TUMBLE(ts, INTERVAL '0.003' SECOND)
+      """.stripMargin
+    tEnv.sqlUpdate(ddl)
+    val sink = new TestingAppendSink()
+    tEnv.sqlQuery(query).toAppendStream[Row].addSink(sink)
+    tEnv.execute("SQL JOB")
+
+    val expected = Seq(
+      "1970-01-01T00:00:00.003,2,3.0",
+      "1970-01-01T00:00:00.006,2,7.0",
+      "1970-01-01T00:00:00.009,2,6.0",
+      "1970-01-01T00:00:00.018,1,4.0")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  @Test
+  def testWindowAggregateOnCustomizedWatermark(): Unit = {
+    JavaFunc5.openCalled = false
+    JavaFunc5.closeCalled = false
+    tEnv.registerFunction("myFunc", new JavaFunc5)
+    val ddl =
+      """
+        |CREATE TABLE src (
+        |  ts TIMESTAMP(3),
+        |  a INT,
+        |  b DOUBLE,
+        |  WATERMARK FOR ts AS myFunc(ts, a)
+        |) WITH (
+        |  'connector' = 'COLLECTION'
+        |)
+      """.stripMargin
+    val query =
+      """
+        |SELECT TUMBLE_END(ts, INTERVAL '0.003' SECOND), COUNT(ts), SUM(b)
+        |FROM src
+        |GROUP BY TUMBLE(ts, INTERVAL '0.003' SECOND)
+      """.stripMargin
+    tEnv.sqlUpdate(ddl)
+    val sink = new TestingAppendSink()
+    tEnv.sqlQuery(query).toAppendStream[Row].addSink(sink)
+    tEnv.execute("SQL JOB")
+
+    val expected = Seq(
+      "1970-01-01T00:00:00.003,2,3.0",
+      "1970-01-01T00:00:00.006,2,7.0",
+      "1970-01-01T00:00:00.009,2,6.0",
+      "1970-01-01T00:00:00.018,1,4.0")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+    assertTrue(JavaFunc5.openCalled)
+    assertTrue(JavaFunc5.closeCalled)
+  }
+
+  @Test
+  def testWindowAggregateOnNestedRowtime(): Unit = {
+    val ddl =
+      """
+        |CREATE TABLE src (
+        |  col ROW<
+        |    ts TIMESTAMP(3),
+        |    a INT,
+        |    b DOUBLE>,
+        |  WATERMARK FOR col.ts AS col.ts - INTERVAL '0.001' SECOND
+        |) WITH (
+        |  'connector' = 'COLLECTION'
+        |)
+      """.stripMargin
+    val query =
+      """
+        |SELECT TUMBLE_END(col.ts, INTERVAL '0.003' SECOND), COUNT(*)
+        |FROM src
+        |GROUP BY TUMBLE(col.ts, INTERVAL '0.003' SECOND)
+      """.stripMargin
+    tEnv.sqlUpdate(ddl)
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage(
+      "Nested field 'col.ts' as rowtime attribute is not supported right now.")
+    tEnv.sqlQuery(query)
+  }
+
+  // ------------------------------------------------------------------------------------------
+
+  private def utcTimestamp(ts: Long): Timestamp = {
+    new Timestamp(ts - TimeZone.getDefault.getOffset(ts))
+  }
+
+  private def row(args: Any*):Row = {
+    val row = new Row(args.length)
+    0 until args.length foreach {
+      i => row.setField(i, args(i))
+    }
+    row
+  }
+
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/generated/GeneratedWatermarkGenerator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/generated/GeneratedWatermarkGenerator.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.generated;
+
+/**
+ * Describes a generated {@link WatermarkGenerator}.
+ */
+public class GeneratedWatermarkGenerator extends GeneratedClass<WatermarkGenerator> {
+
+	private static final long serialVersionUID = 1L;
+
+	public GeneratedWatermarkGenerator(String className, String code, Object[] references) {
+		super(className, code, references);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/generated/WatermarkGenerator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/generated/WatermarkGenerator.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.generated;
+
+import org.apache.flink.api.common.functions.AbstractRichFunction;
+import org.apache.flink.table.dataformat.BaseRow;
+
+import javax.annotation.Nullable;
+
+/**
+ * The {@link WatermarkGenerator} is used to generate watermark based the input elements.
+ */
+public abstract class WatermarkGenerator extends AbstractRichFunction {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Returns the watermark for the current row or null if no watermark should be generated.
+	 *
+	 * @param row The current row.
+	 * @return The watermark for this row or null if no watermark should be generated.
+	 */
+	@Nullable
+	public abstract Long currentWatermark(BaseRow row) throws Exception;
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/wmassigners/BoundedOutOfOrderWatermarkGenerator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/wmassigners/BoundedOutOfOrderWatermarkGenerator.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.wmassigners;
+
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.runtime.generated.WatermarkGenerator;
+
+import javax.annotation.Nullable;
+
+/**
+ * A watermark generator for rowtime attributes which are out-of-order by a bounded time interval.
+ *
+ * <p>Emits watermarks which are the observed timestamp minus the specified delay.
+ */
+public class BoundedOutOfOrderWatermarkGenerator extends WatermarkGenerator {
+
+	private static final long serialVersionUID = 1L;
+	private final long delay;
+	private final int rowtimeIndex;
+
+	/**
+	 * @param rowtimeIndex the field index of rowtime attribute, the value of rowtime should never be null.
+	 * @param delay The delay by which watermarks are behind the observed timestamp.
+	 */
+	public BoundedOutOfOrderWatermarkGenerator(int rowtimeIndex, long delay) {
+		this.delay = delay;
+		this.rowtimeIndex = rowtimeIndex;
+	}
+
+	@Nullable
+	@Override
+	public Long currentWatermark(BaseRow row) {
+		return row.getLong(rowtimeIndex) - delay;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/wmassigners/WatermarkAssignerOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/wmassigners/WatermarkAssignerOperator.java
@@ -18,7 +18,8 @@
 
 package org.apache.flink.table.runtime.operators.wmassigners;
 
-import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
+import org.apache.flink.api.common.functions.util.FunctionUtils;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
@@ -28,6 +29,7 @@ import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeCallback;
 import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.runtime.generated.WatermarkGenerator;
 
 /**
  * A stream operator that extracts timestamps from stream elements and
@@ -41,29 +43,32 @@ public class WatermarkAssignerOperator
 
 	private final int rowtimeFieldIndex;
 
-	private final long watermarkDelay;
-
 	private final long idleTimeout;
+
+	private final WatermarkGenerator watermarkGenerator;
+
+	private transient long lastWatermark;
 
 	private transient long watermarkInterval;
 
 	private transient long currentWatermark;
 
-	private transient long currentMaxTimestamp;
-
 	private transient long lastRecordTime;
 
 	private transient StreamStatusMaintainer streamStatusMaintainer;
 
+	/** Flag to prevent duplicate function.close() calls in close() and dispose(). */
+	private transient boolean functionsClosed = false;
+
 	/**
 	 * Create a watermark assigner operator.
 	 * @param rowtimeFieldIndex  the field index to extract event timestamp
-	 * @param watermarkDelay    the delay by which watermarks are behind the maximum observed timestamp.
+	 * @param watermarkGenerator	the watermark generator
 	 * @param idleTimeout   (idleness checking timeout)
 	 */
-	public WatermarkAssignerOperator(int rowtimeFieldIndex, long watermarkDelay, long idleTimeout) {
+	public WatermarkAssignerOperator(int rowtimeFieldIndex, WatermarkGenerator watermarkGenerator, long idleTimeout) {
 		this.rowtimeFieldIndex = rowtimeFieldIndex;
-		this.watermarkDelay = watermarkDelay;
+		this.watermarkGenerator = watermarkGenerator;
 
 		this.idleTimeout = idleTimeout;
 		this.chainingStrategy = ChainingStrategy.ALWAYS;
@@ -75,7 +80,6 @@ public class WatermarkAssignerOperator
 
 		// watermark and timestamp should start from 0
 		this.currentWatermark = 0;
-		this.currentMaxTimestamp = 0;
 		this.watermarkInterval = getExecutionConfig().getAutoWatermarkInterval();
 		this.lastRecordTime = getProcessingTimeService().getCurrentProcessingTime();
 		this.streamStatusMaintainer = getContainingTask().getStreamStatusMaintainer();
@@ -84,6 +88,9 @@ public class WatermarkAssignerOperator
 			long now = getProcessingTimeService().getCurrentProcessingTime();
 			getProcessingTimeService().registerTimer(now + watermarkInterval, this);
 		}
+
+		FunctionUtils.setFunctionRuntimeContext(watermarkGenerator, getRuntimeContext());
+		FunctionUtils.openFunction(watermarkGenerator, new Configuration());
 	}
 
 	@Override
@@ -98,24 +105,25 @@ public class WatermarkAssignerOperator
 			throw new RuntimeException("RowTime field should not be null," +
 					" please convert it to a non-null long value.");
 		}
-		long ts = row.getLong(rowtimeFieldIndex);
-		currentMaxTimestamp = Math.max(currentMaxTimestamp, ts);
+		Long watermark = watermarkGenerator.currentWatermark(row);
+		if (watermark != null) {
+			currentWatermark = Math.max(currentWatermark, watermark);
+		}
 		// forward element
 		output.collect(element);
 
-		// eagerly emit watermark to avoid period timer not called
-		// current_ts - last_ts > interval
-		if (currentMaxTimestamp - (currentWatermark + watermarkDelay) > watermarkInterval) {
+		// eagerly emit watermark to avoid period timer not called (this often happens when cpu load is high)
+		// current_wm - last_wm > interval
+		if (currentWatermark - lastWatermark > watermarkInterval) {
 			advanceWatermark();
 		}
 	}
 
 	private void advanceWatermark() {
-		long newWatermark = currentMaxTimestamp - watermarkDelay;
-		if (newWatermark > currentWatermark) {
-			currentWatermark = newWatermark;
+		if (currentWatermark > lastWatermark) {
+			lastWatermark = currentWatermark;
 			// emit watermark
-			output.emitWatermark(new Watermark(newWatermark));
+			output.emitWatermark(new Watermark(currentWatermark));
 		}
 	}
 
@@ -138,8 +146,7 @@ public class WatermarkAssignerOperator
 
 	/**
 	 * Override the base implementation to completely ignore watermarks propagated from
-	 * upstream (we rely only on the {@link AssignerWithPeriodicWatermarks} to emit
-	 * watermarks from here).
+	 * upstream (we rely only on the {@link WatermarkGenerator} to emit watermarks from here).
 	 */
 	@Override
 	public void processWatermark(Watermark mark) throws Exception {
@@ -155,16 +162,23 @@ public class WatermarkAssignerOperator
 		}
 	}
 
-	public void endInput() throws Exception {
-		processWatermark(Watermark.MAX_WATERMARK);
-	}
-
 	@Override
 	public void close() throws Exception {
-		endInput(); // TODO after introduce endInput
 		super.close();
 
 		// emit a final watermark
 		advanceWatermark();
+
+		functionsClosed = true;
+		FunctionUtils.closeFunction(watermarkGenerator);
+	}
+
+	@Override
+	public void dispose() throws Exception {
+		super.dispose();
+		if (!functionsClosed) {
+			functionsClosed = true;
+			FunctionUtils.closeFunction(watermarkGenerator);
+		}
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/wmassigners/WatermarkAssignerOperatorFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/wmassigners/WatermarkAssignerOperatorFactory.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.wmassigners;
+
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.runtime.generated.GeneratedWatermarkGenerator;
+import org.apache.flink.table.runtime.generated.WatermarkGenerator;
+
+/**
+ * The factory of {@link WatermarkAssignerOperator}.
+ */
+public class WatermarkAssignerOperatorFactory implements OneInputStreamOperatorFactory<BaseRow, BaseRow> {
+	private static final long serialVersionUID = 1L;
+
+	private final int rowtimeFieldIndex;
+
+	private final long idleTimeout;
+
+	private final GeneratedWatermarkGenerator generatedWatermarkGenerator;
+
+	private ChainingStrategy strategy = ChainingStrategy.HEAD;
+
+	public WatermarkAssignerOperatorFactory(
+			int rowtimeFieldIndex,
+			long idleTimeout,
+			GeneratedWatermarkGenerator generatedWatermarkGenerator) {
+		this.rowtimeFieldIndex = rowtimeFieldIndex;
+		this.idleTimeout = idleTimeout;
+		this.generatedWatermarkGenerator = generatedWatermarkGenerator;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public StreamOperator createStreamOperator(StreamTask containingTask, StreamConfig config, Output output) {
+		WatermarkGenerator watermarkGenerator = generatedWatermarkGenerator.newInstance(containingTask.getUserCodeClassLoader());
+		WatermarkAssignerOperator operator = new WatermarkAssignerOperator(rowtimeFieldIndex, watermarkGenerator, idleTimeout);
+		operator.setup(containingTask, config, output);
+		return operator;
+	}
+
+	@Override
+	public void setChainingStrategy(ChainingStrategy strategy) {
+		this.strategy = strategy;
+	}
+
+	@Override
+	public ChainingStrategy getChainingStrategy() {
+		return strategy;
+	}
+
+	@Override
+	public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+		return WatermarkAssignerOperator.class;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/wmassigners/WatermarkAssignerOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/wmassigners/WatermarkAssignerOperatorTest.java
@@ -19,31 +19,39 @@
 package org.apache.flink.table.runtime.operators.wmassigners;
 
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.GenericRow;
+import org.apache.flink.table.runtime.generated.WatermarkGenerator;
 
 import org.junit.Test;
 
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 /**
  * Tests of {@link WatermarkAssignerOperator}.
  */
 public class WatermarkAssignerOperatorTest extends WatermarkAssignerOperatorTestBase {
 
+	private static final WatermarkGenerator WATERMARK_GENERATOR = new BoundedOutOfOrderWatermarkGenerator(0, 1);
+
 	@Test
 	public void testWatermarkAssignerWithIdleSource() throws Exception {
 		// with timeout 1000 ms
-		final WatermarkAssignerOperator operator = new WatermarkAssignerOperator(0, 1, 1000);
+		final WatermarkAssignerOperator operator = new WatermarkAssignerOperator(0, WATERMARK_GENERATOR, 1000);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness =
 			new OneInputStreamOperatorTestHarness<>(operator);
 		testHarness.getExecutionConfig().setAutoWatermarkInterval(50);
@@ -83,7 +91,7 @@ public class WatermarkAssignerOperatorTest extends WatermarkAssignerOperatorTest
 
 	@Test
 	public void testWatermarkAssignerOperator() throws Exception {
-		final WatermarkAssignerOperator operator = new WatermarkAssignerOperator(0, 1, -1);
+		final WatermarkAssignerOperator operator = new WatermarkAssignerOperator(0, WATERMARK_GENERATOR, -1);
 
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness =
 			new OneInputStreamOperatorTestHarness<>(operator);
@@ -162,4 +170,105 @@ public class WatermarkAssignerOperatorTest extends WatermarkAssignerOperatorTest
 		assertEquals(Long.MAX_VALUE, ((Watermark) testHarness.getOutput().poll()).getTimestamp());
 	}
 
+	@Test
+	public void testCustomizedWatermarkGenerator() throws Exception {
+		MyWatermarkGenerator.openCalled = false;
+		MyWatermarkGenerator.closeCalled = false;
+		WatermarkGenerator generator = new MyWatermarkGenerator(1);
+		WatermarkAssignerOperator operator = new WatermarkAssignerOperator(0, generator, -1);
+
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness =
+			new OneInputStreamOperatorTestHarness<>(operator);
+
+		testHarness.getExecutionConfig().setAutoWatermarkInterval(5);
+
+		long currentTime = 0;
+		List<Watermark> expected = new ArrayList<>();
+
+		testHarness.open();
+
+		testHarness.processElement(new StreamRecord<>(GenericRow.of(1L, 0L)));
+		testHarness.processElement(new StreamRecord<>(GenericRow.of(2L, 1L)));
+		testHarness.processWatermark(new Watermark(2)); // this watermark should be ignored
+		testHarness.processElement(new StreamRecord<>(GenericRow.of(3L, 1L)));
+		currentTime = currentTime + 5;
+		testHarness.setProcessingTime(currentTime);
+		expected.add(new Watermark(1L));
+
+		testHarness.processElement(new StreamRecord<>(GenericRow.of(4L, 2L)));
+		testHarness.processElement(new StreamRecord<>(GenericRow.of(2L, 1L)));
+		testHarness.processElement(new StreamRecord<>(GenericRow.of(1L, 0L)));
+		testHarness.processElement(new StreamRecord<>(GenericRow.of(6L, null)));
+		currentTime = currentTime + 5;
+		testHarness.setProcessingTime(currentTime);
+		expected.add(new Watermark(2L));
+
+		testHarness.processElement(new StreamRecord<>(GenericRow.of(9L, 8L)));
+		expected.add(new Watermark(8L));
+
+		// no watermark output
+		testHarness.processElement(new StreamRecord<>(GenericRow.of(8L, 7L)));
+		testHarness.processElement(new StreamRecord<>(GenericRow.of(10L, null)));
+		testHarness.processElement(new StreamRecord<>(GenericRow.of(11L, 10L)));
+		currentTime = currentTime + 5;
+		testHarness.setProcessingTime(currentTime);
+		expected.add(new Watermark(10L));
+
+		testHarness.close();
+
+		// num_watermark + num_records
+		assertEquals(expected.size() + 11, testHarness.getOutput().size());
+		List<Watermark> results = extractWatermarks(testHarness.getOutput());
+		assertEquals(expected, results);
+		assertTrue(MyWatermarkGenerator.openCalled);
+		assertTrue(MyWatermarkGenerator.closeCalled);
+	}
+
+	/**
+	 * The special watermark generator will generate null watermarks and
+	 * also checks open&close are called.
+	 */
+	private static final class MyWatermarkGenerator extends WatermarkGenerator {
+
+		private static final long serialVersionUID = 1L;
+		private static boolean openCalled = false;
+		private static boolean closeCalled = false;
+
+		private final int watermarkFieldIndex;
+
+		private MyWatermarkGenerator(int watermarkFieldIndex) {
+			this.watermarkFieldIndex = watermarkFieldIndex;
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			super.open(parameters);
+			if (closeCalled) {
+				fail("Close called before open.");
+			}
+			openCalled = true;
+		}
+
+		@Nullable
+		@Override
+		public Long currentWatermark(BaseRow row) throws Exception {
+			if (!openCalled) {
+				fail("Open was not called before run.");
+			}
+			if (row.isNullAt(watermarkFieldIndex)) {
+				return null;
+			} else {
+				return row.getLong(watermarkFieldIndex);
+			}
+		}
+
+		@Override
+		public void close() throws Exception {
+			super.close();
+			if (!openCalled) {
+				fail("Open was not called before close.");
+			}
+			closeCalled = true;
+		}
+	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/wmassigners/WatermarkAssignerOperatorTestBase.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/wmassigners/WatermarkAssignerOperatorTestBase.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Base class for watermark assigner operator test.
  */
-public class WatermarkAssignerOperatorTestBase {
+public abstract class WatermarkAssignerOperatorTestBase {
 
 	protected Tuple2<Long, Long> validateElement(Object element, long nextElementValue, long currentWatermark) {
 		if (element instanceof StreamRecord) {


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This support DDL watermark end-to-end in blink planner. 

## Brief change log

- 0c0342c380002db8e05bb51d2e56af4fcbe5165b: Support referencing function with fully/partially qualified names in SQL
   - this is the same to #10039, you can skip to review this commit.
- 35761fd70e6b2069541273beb62ae1c55e5baddd: Make sure TableSourceTable.catalogTable is not null
- 3e89f491d29a11ba4c4bf25ac372051a5e29d45e: Convert SqlCreateTable with SqlWatermark to CatalogTable
- 8990d4686b38627c99d5cd53f667afea9cdd7de5: Introduce WatermarkGenerator interface to generate watermark from current row
- cdb56e005a9c6bfde47f88f189f806a90ac7457f: Support code generation a WatermarkGenerator from RexNode
  - this introduced `SqlToRexConverter` interface to convert a SQL string to `RexNode`. 
- a3db95a7340322421d1fa826dcac850116011687: Support to generate and apply watermark assigner in translateToPlan

## Verifying this change

This change added tests:
 - `SqlToOperationConverterTest#testCreateTableWithWatermark`: makes sure the watermark information is converted into `CatalogTable` from `SqlCreateTable` correctly.
 - `WatermarkAssignerOperatorTest#testCustomizedWatermarkGenerator`: makes sure the `WatermarkGenerator` interface works correctly.
 - `WatermarkGeneratorCodeGenTest`: makes sure the generated `WatermarkGenerator` is as expected.
 - `TableScanTest#testDDLTableScan`: makes sure the watermark information is in the plan in streaming mode, but not in the plan in batch mode. 
 - `TimeAttributeITCase`: makes sure the DDL watermark works end-to-end. 

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
