### PR TITLE
[FLINK-14589] [Runtime/Coordination] Redundant slot requests with the same AllocationID lead…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
@@ -193,7 +193,12 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 	public boolean allocateSlot(int index, JobID jobId, AllocationID allocationId, Time slotTimeout) {
 		checkInit();
 
-		TaskSlot taskSlot = taskSlots.get(index);
+		TaskSlot taskSlot = allocationIDTaskSlotMap.get(allocationId);
+		if (taskSlot != null) {
+			LOG.info("Allocation ID {} is already allocated in {}.", allocationId, taskSlot);
+			return false;
+		}
+		taskSlot = taskSlots.get(index);
 
 		boolean result = taskSlot.allocate(jobId, allocationId);
 


### PR DESCRIPTION
…s to inconsistent slot table

## What is the purpose of the change

When a slot request is redundantly made with the same AllocationID to a
slot index other than the already allocated one, slot table becomes
inconsistent having two slot indices allocated but one AllocationID
assigned to only the latest slot index. This can lead to slot leakage.
This patch prevents such redundent slot request from rendering
inconsistent slot allocation state by rejecting the request.

## Brief change log

  - Let `TaskSlotTable.allocateSlot` disallow slot allocation request if a requested allocation ID is already occupied by any slot.
  - Added a unit test to `TaskSlotTableTest`.

## Verifying this change
 - Existing tests should pass.
 - A newly added `testRedundantSlotAllocation` is succeeded with the fix.
 - Manually verified the change by running a constantly failing app (by throwing exception in UDF to trigger fail-over and swallowing interrupts on source to make cancellation stuck) with 64 parallelism with 8 slots per taskmanager and 600ms heartbeat timeout (100ms heartbeat interval) for both continuous fail-over and heartbeat timeout. Without fix, this stress test hits this bug and then keeps getting slot allocation failure exception. With the fix, it does survive without slot allocation failure for days (with log `Allocation ID {} is already allocated in {}.` printed, indicating it exercised the bug).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
