### PR TITLE
[FLINK-14627][tests] Refactor ExecutionGraph creation in tests as TestingExecutionGraphBuilder

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -26,7 +26,6 @@ import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.accumulators.AccumulatorHelper;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.JobException;
@@ -34,7 +33,6 @@ import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
-import org.apache.flink.runtime.blob.VoidBlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureManager;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
@@ -49,16 +47,13 @@ import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.SuppressRestartsException;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy;
-import org.apache.flink.runtime.executiongraph.failover.RestartAllStrategy;
 import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverTopology;
 import org.apache.flink.runtime.executiongraph.failover.flip1.ResultPartitionAvailabilityChecker;
-import org.apache.flink.runtime.executiongraph.failover.flip1.partitionrelease.NotReleasingPartitionReleaseStrategy;
 import org.apache.flink.runtime.executiongraph.failover.flip1.partitionrelease.PartitionReleaseStrategy;
 import org.apache.flink.runtime.executiongraph.restart.ExecutionGraphRestartCallback;
 import org.apache.flink.runtime.executiongraph.restart.RestartCallback;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
-import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTrackerImpl;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
@@ -76,7 +71,6 @@ import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingExecutionVertex;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
-import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.StateBackend;
@@ -108,7 +102,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -322,112 +315,6 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	// --------------------------------------------------------------------------------------------
 	//   Constructors
 	// --------------------------------------------------------------------------------------------
-
-	/**
-	 * This constructor is for tests only, because it sets default values for many fields.
-	 */
-	@VisibleForTesting
-	ExecutionGraph(
-			ScheduledExecutorService futureExecutor,
-			Executor ioExecutor,
-			JobID jobId,
-			String jobName,
-			Configuration jobConfig,
-			SerializedValue<ExecutionConfig> serializedConfig,
-			Time timeout,
-			RestartStrategy restartStrategy,
-			SlotProvider slotProvider) throws IOException {
-
-		this(
-			new JobInformation(
-				jobId,
-				jobName,
-				serializedConfig,
-				jobConfig,
-				Collections.emptyList(),
-				Collections.emptyList()),
-			futureExecutor,
-			ioExecutor,
-			timeout,
-			restartStrategy,
-			slotProvider);
-	}
-
-	/**
-	 * This constructor is for tests only, because it does not include class loading information.
-	 */
-	@VisibleForTesting
-	ExecutionGraph(
-			JobInformation jobInformation,
-			ScheduledExecutorService futureExecutor,
-			Executor ioExecutor,
-			Time timeout,
-			RestartStrategy restartStrategy,
-			SlotProvider slotProvider) throws IOException {
-		this(
-			jobInformation,
-			futureExecutor,
-			ioExecutor,
-			timeout,
-			restartStrategy,
-			new RestartAllStrategy.Factory(),
-			slotProvider);
-	}
-
-	@VisibleForTesting
-	ExecutionGraph(
-			JobInformation jobInformation,
-			ScheduledExecutorService futureExecutor,
-			Executor ioExecutor,
-			Time timeout,
-			RestartStrategy restartStrategy,
-			FailoverStrategy.Factory failoverStrategy,
-			SlotProvider slotProvider) throws IOException {
-		this(
-			jobInformation,
-			futureExecutor,
-			ioExecutor,
-			timeout,
-			restartStrategy,
-			failoverStrategy,
-			slotProvider,
-			ExecutionGraph.class.getClassLoader(),
-			VoidBlobWriter.getInstance(),
-			timeout);
-	}
-
-	@VisibleForTesting
-	public ExecutionGraph(
-			JobInformation jobInformation,
-			ScheduledExecutorService futureExecutor,
-			Executor ioExecutor,
-			Time timeout,
-			RestartStrategy restartStrategy,
-			FailoverStrategy.Factory failoverStrategy,
-			SlotProvider slotProvider,
-			ClassLoader userClassLoader,
-			BlobWriter blobWriter,
-			Time allocationTimeout) throws IOException {
-		this(
-			jobInformation,
-			futureExecutor,
-			ioExecutor,
-			timeout,
-			restartStrategy,
-			JobManagerOptions.MAX_ATTEMPTS_HISTORY_SIZE.defaultValue(),
-			failoverStrategy,
-			slotProvider,
-			userClassLoader,
-			blobWriter,
-			allocationTimeout,
-			new NotReleasingPartitionReleaseStrategy.Factory(),
-			NettyShuffleMaster.INSTANCE,
-			new JobMasterPartitionTrackerImpl(
-				jobInformation.getJobId(),
-				NettyShuffleMaster.INSTANCE,
-				ignored -> Optional.empty()),
-			ScheduleMode.LAZY_FROM_SOURCES);
-	}
 
 	public ExecutionGraph(
 			JobInformation jobInformation,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
@@ -23,8 +23,9 @@ import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAda
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
-import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.TestingExecutionGraphBuilder;
+import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
@@ -138,7 +139,9 @@ public class ExecutionGraphCheckpointCoordinatorTest extends TestLogger {
 		JobVertex jobVertex = new JobVertex("MockVertex");
 		jobVertex.setInvokableClass(AbstractInvokable.class);
 
-		final ExecutionGraph executionGraph = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(jobVertex)
+		final ExecutionGraph executionGraph = TestingExecutionGraphBuilder
+			.newBuilder()
+			.setJobGraph(new JobGraph(jobVertex))
 			.setRpcTimeout(timeout)
 			.setAllocationTimeout(timeout)
 			.build();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest.java
@@ -132,7 +132,9 @@ public class AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest 
 	}
 
 	private ExecutionGraph createExecutionGraph(final JobGraph jobGraph) throws Exception {
-		final ExecutionGraph executionGraph = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(jobGraph)
+		final ExecutionGraph executionGraph = TestingExecutionGraphBuilder
+			.newBuilder()
+			.setJobGraph(jobGraph)
 			.setRestartStrategy(new FixedDelayRestartStrategy(10, 0))
 			.setFailoverStrategyFactory(AdaptedRestartPipelinedRegionStrategyNG::new)
 			.setSlotProvider(new SimpleSlotProvider(jobGraph.getJobID(), 2))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGConcurrentFailoverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGConcurrentFailoverTest.java
@@ -270,7 +270,9 @@ public class AdaptedRestartPipelinedRegionStrategyNGConcurrentFailoverTest exten
 			NettyShuffleMaster.INSTANCE,
 			ignored -> Optional.empty());
 
-		final ExecutionGraph graph = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(jg)
+		final ExecutionGraph graph = TestingExecutionGraphBuilder
+			.newBuilder()
+			.setJobGraph(jg)
 			.setRestartStrategy(manuallyTriggeredRestartStrategy)
 			.setFailoverStrategyFactory(TestAdaptedRestartPipelinedRegionStrategyNG::new)
 			.setSlotProvider(slotProvider)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGFailoverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGFailoverTest.java
@@ -390,7 +390,9 @@ public class AdaptedRestartPipelinedRegionStrategyNGFailoverTest extends TestLog
 			NettyShuffleMaster.INSTANCE,
 			ignored -> Optional.empty());
 
-		final ExecutionGraph eg = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(jobGraph)
+		final ExecutionGraph eg = TestingExecutionGraphBuilder
+			.newBuilder()
+			.setJobGraph(jobGraph)
 			.setRestartStrategy(restartStrategy)
 			.setFailoverStrategyFactory(TestAdaptedRestartPipelinedRegionStrategyNG::new)
 			.setPartitionTracker(partitionTracker)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -21,13 +21,10 @@ package org.apache.flink.runtime.executiongraph;
 import org.apache.flink.api.common.ArchivedExecutionConfig;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.ExecutionMode;
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
-import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsTracker;
@@ -36,15 +33,13 @@ import org.apache.flink.runtime.checkpoint.StandaloneCheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.StandaloneCompletedCheckpointStore;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.execution.ExecutionState;
-import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
+import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
-import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.OptionalFailure;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
@@ -54,7 +49,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -93,8 +87,7 @@ public class ArchivedExecutionGraphTest extends TestLogger {
 		v1.setInvokableClass(AbstractInvokable.class);
 		v2.setInvokableClass(AbstractInvokable.class);
 
-		List<JobVertex> vertices = new ArrayList<>(Arrays.asList(v1, v2));
-
+		JobGraph jobGraph = new JobGraph(v1, v2);
 		ExecutionConfig config = new ExecutionConfig();
 
 		config.setExecutionMode(ExecutionMode.BATCH_FORCED);
@@ -103,20 +96,14 @@ public class ArchivedExecutionGraphTest extends TestLogger {
 		config.enableObjectReuse();
 		config.setGlobalJobParameters(new TestJobParameters());
 
-		runtimeGraph = new ExecutionGraph(
-			TestingUtils.defaultExecutor(),
-			TestingUtils.defaultExecutor(),
-			new JobID(),
-			"test job",
-			new Configuration(),
-			new SerializedValue<>(config),
-			AkkaUtils.getDefaultTimeout(),
-			new NoRestartStrategy(),
-			mock(SlotProvider.class));
+		jobGraph.setExecutionConfig(config);
+
+		runtimeGraph = TestingExecutionGraphBuilder
+			.newBuilder()
+			.setJobGraph(jobGraph)
+			.build();
 
 		runtimeGraph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
-
-		runtimeGraph.attachJobGraph(vertices);
 
 		List<ExecutionJobVertex> jobVertices = new ArrayList<>();
 		jobVertices.add(runtimeGraph.getJobVertex(v1ID));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphCoLocationRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphCoLocationRestartTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.executiongraph;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationConstraint;
@@ -69,12 +70,11 @@ public class ExecutionGraphCoLocationRestartTest extends SchedulerTestBase {
 		groupVertex.setStrictlyCoLocatedWith(groupVertex2);
 
 		//initiate and schedule job
-		final ExecutionGraph eg = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(groupVertex, groupVertex2)
+		final ExecutionGraph eg = TestingExecutionGraphBuilder
+			.newBuilder()
+			.setJobGraph(new JobGraph(groupVertex, groupVertex2))
 			.setSlotProvider(testingSlotProvider)
-			.setRestartStrategy(
-				new TestRestartStrategy(
-					1,
-					false))
+			.setRestartStrategy(new TestRestartStrategy(1, false))
 			.build();
 
 		// enable the queued scheduling for the slot pool

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -166,7 +166,9 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 			v4.connectNewDataSetAsInput(v2, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
 
 			DirectScheduledExecutorService executor = new DirectScheduledExecutorService();
-			ExecutionGraph eg = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(jobId)
+			ExecutionGraph eg = TestingExecutionGraphBuilder
+				.newBuilder()
+				.setJobGraph(new JobGraph(jobId, "Test Job"))
 				.setFutureExecutor(executor)
 				.setIoExecutor(executor)
 				.setSlotProvider(new TestingSlotProvider(ignore -> new CompletableFuture<>()))
@@ -444,9 +446,10 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 		DirectScheduledExecutorService directExecutor = new DirectScheduledExecutorService();
 
 		// execution graph that executes actions synchronously
-		ExecutionGraph eg = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(jobId)
+		ExecutionGraph eg = TestingExecutionGraphBuilder
+			.newBuilder()
+			.setJobGraph(new JobGraph(jobId, "Test Job"))
 			.setFutureExecutor(directExecutor)
-			.setIoExecutor(TestingUtils.defaultExecutor())
 			.setSlotProvider(slotProvider)
 			.setBlobWriter(blobWriter)
 			.build();
@@ -513,9 +516,9 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 		DirectScheduledExecutorService executorService = new DirectScheduledExecutorService();
 
 		// execution graph that executes actions synchronously
-		ExecutionGraph eg = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(new JobID())
+		ExecutionGraph eg = TestingExecutionGraphBuilder
+			.newBuilder()
 			.setFutureExecutor(executorService)
-			.setIoExecutor(TestingUtils.defaultExecutor())
 			.setSlotProvider(slotProvider)
 			.setBlobWriter(blobWriter)
 			.build();
@@ -591,13 +594,17 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 
 		final ScheduledExecutorService scheduledExecutorService = new ScheduledThreadPoolExecutor(3);
 
-		final ExecutionGraph executionGraph = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(sourceVertex, sinkVertex)
+		final JobGraph jobGraph = new JobGraph(sourceVertex, sinkVertex);
+		jobGraph.setScheduleMode(ScheduleMode.EAGER);
+
+		final ExecutionGraph executionGraph = TestingExecutionGraphBuilder
+			.newBuilder()
+			.setJobGraph(jobGraph)
 			.setSlotProvider(slotProvider)
 			.setIoExecutor(scheduledExecutorService)
 			.setFutureExecutor(scheduledExecutorService)
 			.setAllocationTimeout(timeout)
 			.setRpcTimeout(timeout)
-			.setScheduleMode(ScheduleMode.EAGER)
 			.build();
 
 		executionGraph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
@@ -677,10 +684,14 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 
 		final SlotProvider slotProvider = new IteratorTestingSlotProvider(slotFutures.iterator());
 
-		final ExecutionGraph executionGraph = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(jobId, sourceVertex, sinkVertex)
+		final JobGraph jobGraph = new JobGraph(jobId, "Test Job", sourceVertex, sinkVertex);
+		jobGraph.setScheduleMode(ScheduleMode.EAGER);
+
+		final ExecutionGraph executionGraph = TestingExecutionGraphBuilder
+			.newBuilder()
+			.setJobGraph(jobGraph)
 			.setSlotProvider(slotProvider)
 			.setFutureExecutor(new DirectScheduledExecutorService())
-			.setScheduleMode(ScheduleMode.EAGER)
 			.build();
 
 		executionGraph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphMetricsTest.java
@@ -18,9 +18,6 @@
 
 package org.apache.flink.runtime.executiongraph;
 
-import org.apache.flink.api.common.time.Time;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.execution.ExecutionState;
@@ -33,12 +30,10 @@ import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
-import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
@@ -57,7 +52,7 @@ public class ExecutionGraphMetricsTest extends TestLogger {
 	 * This test tests that the restarting time metric correctly displays restarting times.
 	 */
 	@Test
-	public void testExecutionGraphRestartTimeMetric() throws JobException, IOException, InterruptedException {
+	public void testExecutionGraphRestartTimeMetric() throws Exception {
 		final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
 		try {
 			// setup execution graph with mocked scheduling logic
@@ -68,9 +63,6 @@ public class ExecutionGraphMetricsTest extends TestLogger {
 			jobVertex.setInvokableClass(NoOpInvokable.class);
 			JobGraph jobGraph = new JobGraph("Test Job", jobVertex);
 
-			Configuration jobConfig = new Configuration();
-			Time timeout = Time.seconds(10L);
-
 			CompletableFuture<LogicalSlot> slotFuture1 = CompletableFuture.completedFuture(new TestingLogicalSlotBuilder().createTestingLogicalSlot());
 			CompletableFuture<LogicalSlot> slotFuture2 = CompletableFuture.completedFuture(new TestingLogicalSlotBuilder().createTestingLogicalSlot());
 			ArrayDeque<CompletableFuture<LogicalSlot>> slotFutures = new ArrayDeque<>();
@@ -79,16 +71,14 @@ public class ExecutionGraphMetricsTest extends TestLogger {
 
 			TestRestartStrategy testingRestartStrategy = TestRestartStrategy.manuallyTriggered();
 
-			ExecutionGraph executionGraph = new ExecutionGraph(
-				executor,
-				executor,
-				jobGraph.getJobID(),
-				jobGraph.getName(),
-				jobConfig,
-				new SerializedValue<>(null),
-				timeout,
-				testingRestartStrategy,
-				new TestingSlotProvider(ignore -> slotFutures.removeFirst()));
+			ExecutionGraph executionGraph = TestingExecutionGraphBuilder
+				.newBuilder()
+				.setJobGraph(jobGraph)
+				.setFutureExecutor(executor)
+				.setIoExecutor(executor)
+				.setRestartStrategy(testingRestartStrategy)
+				.setSlotProvider(new TestingSlotProvider(ignore -> slotFutures.removeFirst()))
+				.build();
 
 			executionGraph.start(mainThreadExecutor);
 
@@ -96,8 +86,6 @@ public class ExecutionGraphMetricsTest extends TestLogger {
 
 			// check that the restarting time is 0 since it's the initial start
 			assertEquals(0L, restartingTime.getValue().longValue());
-
-			executionGraph.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
 
 			// start execution
 			executionGraph.scheduleForExecution();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphNotEnoughResourceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphNotEnoughResourceTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.ScheduleMode;
@@ -109,13 +110,16 @@ public class ExecutionGraphNotEnoughResourceTest extends TestLogger {
 			sink.setSlotSharingGroup(sharingGroup);
 			sink.connectNewDataSetAsInput(source, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED_BOUNDED);
 
-			TestRestartStrategy restartStrategy =
-				new TestRestartStrategy(numRestarts, false);
+			final JobGraph jobGraph = new JobGraph(TEST_JOB_ID, "Test Job", source, sink);
+			jobGraph.setScheduleMode(ScheduleMode.EAGER);
 
-			final ExecutionGraph eg = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(TEST_JOB_ID, source, sink)
+			TestRestartStrategy restartStrategy = new TestRestartStrategy(numRestarts, false);
+
+			final ExecutionGraph eg = TestingExecutionGraphBuilder
+				.newBuilder()
+				.setJobGraph(jobGraph)
 				.setSlotProvider(scheduler)
 				.setRestartStrategy(restartStrategy)
-				.setScheduleMode(ScheduleMode.EAGER)
 				.setAllocationTimeout(Time.milliseconds(1L))
 				.build();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -22,9 +22,6 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.JobException;
-import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
@@ -32,10 +29,8 @@ import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAda
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.SuppressRestartsException;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy;
-import org.apache.flink.runtime.executiongraph.failover.RestartAllStrategy;
 import org.apache.flink.runtime.executiongraph.restart.FixedDelayRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.InfiniteDelayRestartStrategy;
-import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
 import org.apache.flink.runtime.executiongraph.utils.NotCancelAckingTaskGateway;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
@@ -61,10 +56,8 @@ import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGate
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
-import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.util.FlinkException;
-import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
@@ -73,7 +66,6 @@ import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -107,9 +99,13 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
 	@Test
 	public void testNoManualRestart() throws Exception {
-		NoRestartStrategy restartStrategy = new NoRestartStrategy();
-		ExecutionGraph eg = createSimpleExecutionGraph(
-			restartStrategy, new SimpleSlotProvider(TEST_JOB_ID, NUM_TASKS), createJobGraph());
+		ExecutionGraph eg = TestingExecutionGraphBuilder
+			.newBuilder()
+			.setSlotProvider(new SimpleSlotProvider(TEST_JOB_ID, NUM_TASKS))
+			.setJobGraph(createJobGraph())
+			.build();
+
+		startAndScheduleExecutionGraph(eg);
 
 		eg.getAllExecutionVertices().iterator().next().fail(new Exception("Test Exception"));
 
@@ -136,9 +132,26 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	@Test
 	public void testRestartAutomatically() throws Exception {
 		try (SlotPool slotPool = createSlotPoolImpl()) {
-			restartAfterFailure(TestingExecutionGraphBuilder.newBuilder()
+			ExecutionGraph executionGraph = TestingExecutionGraphBuilder
+				.newBuilder()
+				.setJobGraph(createJobGraph())
 				.setRestartStrategy(TestRestartStrategy.directExecuting())
-				.buildAndScheduleForExecution(slotPool));
+				.setSlotProvider(createSchedulerWithSlots(slotPool))
+				.build();
+
+			startAndScheduleExecutionGraph(executionGraph);
+
+			executionGraph.getAllExecutionVertices().iterator().next().fail(new Exception("Test Exception"));
+
+			assertEquals(JobStatus.FAILING, executionGraph.getState());
+
+			for (ExecutionVertex vertex : executionGraph.getAllExecutionVertices()) {
+				vertex.getCurrentExecutionAttempt().completeCancelling();
+			}
+
+			assertEquals(JobStatus.RUNNING, executionGraph.getState());
+			finishAllVertices(executionGraph);
+			assertEquals(JobStatus.FINISHED, executionGraph.getState());
 		}
 
 	}
@@ -153,10 +166,14 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		// We want to manually control the restart and delay
 		try (SlotPool slotPool = createSlotPoolImpl()) {
 			TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
-			final ExecutionGraph executionGraph = TestingExecutionGraphBuilder.newBuilder()
+			final ExecutionGraph executionGraph = TestingExecutionGraphBuilder
+				.newBuilder()
+				.setJobGraph(createJobGraph())
 				.setRestartStrategy(new InfiniteDelayRestartStrategy())
-				.setTaskManagerLocation(taskManagerLocation)
-				.buildAndScheduleForExecution(slotPool);
+				.setSlotProvider(createSchedulerWithSlots(slotPool, taskManagerLocation))
+				.build();
+
+			startAndScheduleExecutionGraph(executionGraph);
 
 			// Release the TaskManager and wait for the job to restart
 			slotPool.releaseTaskManager(taskManagerLocation.getResourceID(), new Exception("Test Exception"));
@@ -179,10 +196,14 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	public void testFailWhileRestarting() throws Exception {
 		try (SlotPool slotPool = createSlotPoolImpl()) {
 			TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
-			final ExecutionGraph executionGraph = TestingExecutionGraphBuilder.newBuilder()
+			final ExecutionGraph executionGraph = TestingExecutionGraphBuilder
+				.newBuilder()
+				.setJobGraph(createJobGraph())
 				.setRestartStrategy(new InfiniteDelayRestartStrategy())
-				.setTaskManagerLocation(taskManagerLocation)
-				.buildAndScheduleForExecution(slotPool);
+				.setSlotProvider(createSchedulerWithSlots(slotPool, taskManagerLocation))
+				.build();
+
+			startAndScheduleExecutionGraph(executionGraph);
 
 			// Release the TaskManager and wait for the job to restart
 			slotPool.releaseTaskManager(taskManagerLocation.getResourceID(), new Exception("Test Exception"));
@@ -213,9 +234,14 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	@Test
 	public void testCancelWhileFailing() throws Exception {
 		try (SlotPool slotPool = createSlotPoolImpl()) {
-			final ExecutionGraph graph = TestingExecutionGraphBuilder.newBuilder()
+			final ExecutionGraph graph = TestingExecutionGraphBuilder
+				.newBuilder()
+				.setJobGraph(createJobGraph())
 				.setRestartStrategy(new InfiniteDelayRestartStrategy())
-				.buildAndScheduleForExecution(slotPool);
+				.setSlotProvider(createSchedulerWithSlots(slotPool))
+				.build();
+
+			startAndScheduleExecutionGraph(graph);
 
 			assertEquals(JobStatus.RUNNING, graph.getState());
 
@@ -243,7 +269,13 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	@Test
 	public void testFailWhileCanceling() throws Exception {
 		try (SlotPool slotPool = createSlotPoolImpl()) {
-			final ExecutionGraph graph = TestingExecutionGraphBuilder.newBuilder().buildAndScheduleForExecution(slotPool);
+			final ExecutionGraph graph = TestingExecutionGraphBuilder
+				.newBuilder()
+				.setJobGraph(createJobGraph())
+				.setSlotProvider(createSchedulerWithSlots(slotPool))
+				.build();
+
+			startAndScheduleExecutionGraph(graph);
 
 			assertEquals(JobStatus.RUNNING, graph.getState());
 			switchAllTasksToRunning(graph);
@@ -267,10 +299,16 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	@Test
 	public void testTaskFailingWhileGlobalFailing() throws Exception {
 		try (SlotPool slotPool = createSlotPoolImpl()) {
-			final ExecutionGraph graph = TestingExecutionGraphBuilder.newBuilder()
+			final ExecutionGraph graph = TestingExecutionGraphBuilder
+				.newBuilder()
 				.setRestartStrategy(new InfiniteDelayRestartStrategy())
 				.setFailoverStrategyFactory(new TestFailoverStrategy.Factory())
-				.buildAndScheduleForExecution(slotPool);
+				.setJobGraph(createJobGraph())
+				.setSlotProvider(createSchedulerWithSlots(slotPool))
+				.build();
+
+			startAndScheduleExecutionGraph(graph);
+
 			final TestFailoverStrategy failoverStrategy = (TestFailoverStrategy) graph.getFailoverStrategy();
 
 			// switch all tasks to running
@@ -295,9 +333,14 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	@Test
 	public void testNoRestartOnSuppressException() throws Exception {
 		try (SlotPool slotPool = createSlotPoolImpl()) {
-			ExecutionGraph eg = TestingExecutionGraphBuilder.newBuilder()
+			ExecutionGraph eg = TestingExecutionGraphBuilder
+				.newBuilder()
+				.setJobGraph(createJobGraph())
 				.setRestartStrategy(new FixedDelayRestartStrategy(Integer.MAX_VALUE, 0))
-				.buildAndScheduleForExecution(slotPool);
+				.setSlotProvider(createSchedulerWithSlots(slotPool))
+				.build();
+
+			startAndScheduleExecutionGraph(eg);
 
 			// Fail with unrecoverable Exception
 			eg.getAllExecutionVertices().iterator().next().fail(
@@ -330,11 +373,14 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		JobGraph jobGraph = new JobGraph("Pointwise job", sender, receiver);
 
 		try (SlotPool slotPool = createSlotPoolImpl()) {
-			ExecutionGraph eg = TestingExecutionGraphBuilder.newBuilder()
+			ExecutionGraph eg = TestingExecutionGraphBuilder
+				.newBuilder()
 				.setRestartStrategy(TestRestartStrategy.directExecuting())
 				.setJobGraph(jobGraph)
-				.setNumberOfTasks(2)
-				.buildAndScheduleForExecution(slotPool);
+				.setSlotProvider(createSchedulerWithSlots(slotPool, new LocalTaskManagerLocation(), 2))
+				.build();
+
+			startAndScheduleExecutionGraph(eg);
 
 			Iterator<ExecutionVertex> executionVertices = eg.getAllExecutionVertices().iterator();
 
@@ -379,8 +425,10 @@ public class ExecutionGraphRestartTest extends TestLogger {
 			ExecutionGraph eg = TestingExecutionGraphBuilder.newBuilder()
 				.setRestartStrategy(new InfiniteDelayRestartStrategy())
 				.setJobGraph(createJobGraphToCancel())
-				.setNumberOfTasks(2)
-				.buildAndScheduleForExecution(slotPool);
+				.setSlotProvider(createSchedulerWithSlots(slotPool, new LocalTaskManagerLocation(), 2))
+				.build();
+
+			startAndScheduleExecutionGraph(eg);
 
 			// Fail right after cancel (for example with concurrent slot release)
 			eg.cancel();
@@ -405,11 +453,14 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	@Test
 	public void testFailExecutionGraphAfterCancel() throws Exception {
 		try (SlotPool slotPool = createSlotPoolImpl()) {
-			ExecutionGraph eg = TestingExecutionGraphBuilder.newBuilder()
+			ExecutionGraph eg = TestingExecutionGraphBuilder
+				.newBuilder()
 				.setRestartStrategy(new InfiniteDelayRestartStrategy())
 				.setJobGraph(createJobGraphToCancel())
-				.setNumberOfTasks(2)
-				.buildAndScheduleForExecution(slotPool);
+				.setSlotProvider(createSchedulerWithSlots(slotPool, new LocalTaskManagerLocation(), 2))
+				.build();
+
+			startAndScheduleExecutionGraph(eg);
 
 			// Fail right after cancel (for example with concurrent slot release)
 			eg.cancel();
@@ -433,10 +484,14 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		TestRestartStrategy controllableRestartStrategy = TestRestartStrategy.manuallyTriggered();
 		try (SlotPool slotPool = createSlotPoolImpl()) {
 			TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
-			ExecutionGraph eg = TestingExecutionGraphBuilder.newBuilder()
+			ExecutionGraph eg = TestingExecutionGraphBuilder
+				.newBuilder()
+				.setJobGraph(createJobGraph())
 				.setRestartStrategy(controllableRestartStrategy)
-				.setTaskManagerLocation(taskManagerLocation)
-				.buildAndScheduleForExecution(slotPool);
+				.setSlotProvider(createSchedulerWithSlots(slotPool, taskManagerLocation))
+				.build();
+
+			startAndScheduleExecutionGraph(eg);
 
 			// Release the TaskManager and wait for the job to restart
 			slotPool.releaseTaskManager(taskManagerLocation.getResourceID(), new Exception("Test Exception"));
@@ -460,13 +515,16 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		final int parallelism = 10;
 		final TestRestartStrategy triggeredRestartStrategy = TestRestartStrategy.manuallyTriggered();
 
-		final ExecutionGraph eg = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(TEST_JOB_ID, createNoOpVertex(parallelism))
-			.setScheduleMode(ScheduleMode.EAGER)
+		final JobGraph jobGraph = new JobGraph(TEST_JOB_ID, "Test Job", createNoOpVertex(parallelism));
+		jobGraph.setScheduleMode(ScheduleMode.EAGER);
+
+		final ExecutionGraph eg = TestingExecutionGraphBuilder
+			.newBuilder()
+			.setJobGraph(jobGraph)
 			.setRestartStrategy(triggeredRestartStrategy)
 			.build();
 
-		eg.start(mainThreadExecutor);
-		eg.scheduleForExecution();
+		startAndScheduleExecutionGraph(eg);
 
 		switchToRunning(eg);
 
@@ -503,15 +561,16 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		final SlotProvider slots = new SimpleSlotProvider(TEST_JOB_ID, parallelism, taskManagerGateway);
 		final TestRestartStrategy restartStrategy = TestRestartStrategy.manuallyTriggered();
 
-		final ExecutionGraph eg = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(TEST_JOB_ID, vertex)
+		final JobGraph jobGraph = new JobGraph(TEST_JOB_ID, "Test Job", vertex);
+		jobGraph.setScheduleMode(ScheduleMode.EAGER);
+		final ExecutionGraph eg = TestingExecutionGraphBuilder
+			.newBuilder()
+			.setJobGraph(jobGraph)
 			.setSlotProvider(slots)
 			.setRestartStrategy(restartStrategy)
-			.setScheduleMode(ScheduleMode.EAGER)
 			.build();
 
-		eg.start(mainThreadExecutor);
-
-		eg.scheduleForExecution();
+		startAndScheduleExecutionGraph(eg);
 
 		switchToRunning(eg);
 
@@ -555,19 +614,20 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		vertex3.connectNewDataSetAsInput(vertex2, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
 
 		try (SlotPool slotPool = createSlotPoolImpl()) {
-			final SlotProvider slots = createSchedulerWithSlots(2, slotPool, new LocalTaskManagerLocation());
+			final SlotProvider slots = createSchedulerWithSlots(slotPool, new LocalTaskManagerLocation(), 2);
 
 			final AllocationID allocationId = slotPool.getAvailableSlotsInformation().iterator().next().getAllocationId();
 
-			final ExecutionGraph eg = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(TEST_JOB_ID, vertex1, vertex2, vertex3)
+			final JobGraph jobGraph = new JobGraph(TEST_JOB_ID, "Test Job", vertex1, vertex2, vertex3);
+			jobGraph.setScheduleMode(ScheduleMode.EAGER);
+			final ExecutionGraph eg = TestingExecutionGraphBuilder
+				.newBuilder()
+				.setJobGraph(jobGraph)
 				.setSlotProvider(slots)
 				.setAllocationTimeout(Time.minutes(60))
-				.setScheduleMode(ScheduleMode.EAGER)
 				.build();
 
-			eg.start(mainThreadExecutor);
-
-			eg.scheduleForExecution();
+			startAndScheduleExecutionGraph(eg);
 
 			slotPool.failAllocation(
 				allocationId,
@@ -582,7 +642,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		final int parallelism = 20;
 
 		try (SlotPool slotPool = createSlotPoolImpl()) {
-			final Scheduler scheduler = createSchedulerWithSlots(parallelism, slotPool, new LocalTaskManagerLocation());
+			final Scheduler scheduler = createSchedulerWithSlots(slotPool, new LocalTaskManagerLocation(), parallelism);
 
 			final SlotSharingGroup sharingGroup = new SlotSharingGroup();
 
@@ -599,15 +659,16 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
 			TestRestartStrategy restartStrategy = TestRestartStrategy.directExecuting();
 
-			final ExecutionGraph eg = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(TEST_JOB_ID, source, sink)
+			final JobGraph jobGraph = new JobGraph(TEST_JOB_ID, "Test Job", source, sink);
+			jobGraph.setScheduleMode(ScheduleMode.EAGER);
+			final ExecutionGraph eg = TestingExecutionGraphBuilder
+				.newBuilder()
+				.setJobGraph(jobGraph)
 				.setSlotProvider(scheduler)
 				.setRestartStrategy(restartStrategy)
-				.setScheduleMode(ScheduleMode.EAGER)
 				.build();
 
-			eg.start(mainThreadExecutor);
-
-			eg.scheduleForExecution();
+			startAndScheduleExecutionGraph(eg);
 
 			switchToRunning(eg);
 
@@ -637,13 +698,13 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	public void testFailureWhileRestarting() throws Exception {
 
 		final TestRestartStrategy restartStrategy = TestRestartStrategy.manuallyTriggered();
-		final ExecutionGraph executionGraph = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(createJobGraph())
+		final ExecutionGraph executionGraph = TestingExecutionGraphBuilder.newBuilder()
+			.setJobGraph(createJobGraph())
 			.setRestartStrategy(restartStrategy)
 			.setSlotProvider(new TestingSlotProvider(ignored -> new CompletableFuture<>()))
 			.build();
 
-		executionGraph.start(mainThreadExecutor);
-		executionGraph.scheduleForExecution();
+		startAndScheduleExecutionGraph(executionGraph);
 
 		assertThat(executionGraph.getState(), is(JobStatus.RUNNING));
 
@@ -665,11 +726,14 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		JobGraph jobGraph = new JobGraph("Pointwise job", sender, receiver);
 
 		try (SlotPool slotPool = createSlotPoolImpl()) {
-			ExecutionGraph eg = TestingExecutionGraphBuilder.newBuilder()
+			ExecutionGraph eg = TestingExecutionGraphBuilder
+				.newBuilder()
 				.setRestartStrategy(new TestRestartStrategy(1, false))
 				.setJobGraph(jobGraph)
-				.setNumberOfTasks(2)
-				.buildAndScheduleForExecution(slotPool);
+				.setSlotProvider(createSchedulerWithSlots(slotPool, new LocalTaskManagerLocation(), 2))
+				.build();
+
+			startAndScheduleExecutionGraph(eg);
 
 			Iterator<ExecutionVertex> executionVertices = eg.getAllExecutionVertices().iterator();
 
@@ -703,62 +767,22 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	//  Utilities
 	// ------------------------------------------------------------------------
 
-	private static class TestingExecutionGraphBuilder {
-		private RestartStrategy restartStrategy = new NoRestartStrategy();
-		private FailoverStrategy.Factory failoverStrategyFactory = new RestartAllStrategy.Factory();
-		private JobGraph jobGraph = createJobGraph();
-		private int tasksNum = NUM_TASKS;
-		private TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
-
-		private TestingExecutionGraphBuilder setRestartStrategy(RestartStrategy restartStrategy) {
-			this.restartStrategy = restartStrategy;
-			return this;
-		}
-
-		private TestingExecutionGraphBuilder setFailoverStrategyFactory(FailoverStrategy.Factory failoverStrategyFactory) {
-			this.failoverStrategyFactory = failoverStrategyFactory;
-			return this;
-		}
-
-		private TestingExecutionGraphBuilder setJobGraph(JobGraph jobGraph) {
-			this.jobGraph = jobGraph;
-			return this;
-		}
-
-		TestingExecutionGraphBuilder setNumberOfTasks(@SuppressWarnings("SameParameterValue") int tasksNum) {
-			this.tasksNum = tasksNum;
-			return this;
-		}
-
-		private TestingExecutionGraphBuilder setTaskManagerLocation(TaskManagerLocation taskManagerLocation) {
-			this.taskManagerLocation = taskManagerLocation;
-			return this;
-		}
-
-		private static TestingExecutionGraphBuilder newBuilder() {
-			return new TestingExecutionGraphBuilder();
-		}
-
-		private ExecutionGraph buildAndScheduleForExecution(SlotPool slotPool) throws Exception {
-			final Scheduler scheduler = createSchedulerWithSlots(tasksNum, slotPool, taskManagerLocation);
-			final ExecutionGraph eg = createSimpleExecutionGraph(
-				restartStrategy,
-				failoverStrategyFactory,
-				scheduler,
-				jobGraph);
-
-			assertEquals(JobStatus.CREATED, eg.getState());
-
-			eg.scheduleForExecution();
-			assertEquals(JobStatus.RUNNING, eg.getState());
-
-			return eg;
-		}
+	private static void startAndScheduleExecutionGraph(ExecutionGraph executionGraph) throws Exception {
+		executionGraph.start(mainThreadExecutor);
+		assertThat(executionGraph.getState(), is(JobStatus.CREATED));
+		executionGraph.scheduleForExecution();
+		assertThat(executionGraph.getState(), is(JobStatus.RUNNING));
 	}
 
-	private static Scheduler createSchedulerWithSlots(
-		int numSlots, SlotPool slotPool, TaskManagerLocation taskManagerLocation) throws Exception {
+	private static Scheduler createSchedulerWithSlots(SlotPool slotPool) throws Exception {
+		return createSchedulerWithSlots(slotPool, new LocalTaskManagerLocation());
+	}
 
+	private static Scheduler createSchedulerWithSlots(SlotPool slotPool, TaskManagerLocation taskManagerLocation) throws Exception {
+		return createSchedulerWithSlots(slotPool, taskManagerLocation, NUM_TASKS);
+	}
+
+	private static Scheduler createSchedulerWithSlots(SlotPool slotPool, TaskManagerLocation taskManagerLocation, int numSlots) throws Exception {
 		final TaskManagerGateway taskManagerGateway = new SimpleAckingTaskManagerGateway();
 		setupSlotPool(slotPool);
 		Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.INSTANCE, slotPool);
@@ -797,57 +821,6 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		JobGraph jobGraph = new JobGraph("Test Job", vertex);
 		jobGraph.setExecutionConfig(executionConfig);
 		return jobGraph;
-	}
-
-	private static ExecutionGraph createSimpleExecutionGraph(
-		final RestartStrategy restartStrategy,
-		final SlotProvider slotProvider,
-		final JobGraph jobGraph) throws IOException, JobException {
-
-		return createSimpleExecutionGraph(restartStrategy, new RestartAllStrategy.Factory(), slotProvider, jobGraph);
-	}
-
-	private static ExecutionGraph createSimpleExecutionGraph(
-		final RestartStrategy restartStrategy,
-		final FailoverStrategy.Factory failoverStrategyFactory,
-		final SlotProvider slotProvider,
-		final JobGraph jobGraph) throws IOException, JobException {
-
-		final ExecutionGraph executionGraph = new ExecutionGraph(
-			new JobInformation(
-				TEST_JOB_ID,
-				"Test job",
-				new SerializedValue<>(new ExecutionConfig()),
-				new Configuration(),
-				Collections.emptyList(),
-				Collections.emptyList()),
-			TestingUtils.defaultExecutor(),
-			TestingUtils.defaultExecutor(),
-			AkkaUtils.getDefaultTimeout(),
-			restartStrategy,
-			failoverStrategyFactory,
-			slotProvider);
-
-		executionGraph.start(mainThreadExecutor);
-		executionGraph.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
-
-		return executionGraph;
-	}
-
-	private void restartAfterFailure(ExecutionGraph eg) {
-		eg.start(mainThreadExecutor);
-		eg.getAllExecutionVertices().iterator().next().fail(new Exception("Test Exception"));
-
-		assertEquals(JobStatus.FAILING, eg.getState());
-
-		for (ExecutionVertex vertex : eg.getAllExecutionVertices()) {
-			vertex.getCurrentExecutionAttempt().completeCancelling();
-		}
-
-		assertEquals(JobStatus.RUNNING, eg.getState());
-
-		finishAllVertices(eg);
-		assertEquals(JobStatus.FINISHED, eg.getState());
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -21,26 +21,13 @@ package org.apache.flink.runtime.executiongraph;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.metrics.MetricGroup;
-import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
-import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.blob.BlobWriter;
-import org.apache.flink.runtime.blob.VoidBlobWriter;
-import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
-import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
-import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.execution.ExecutionState;
-import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy;
-import org.apache.flink.runtime.executiongraph.failover.RestartAllStrategy;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
-import org.apache.flink.runtime.io.network.partition.NoOpJobMasterPartitionTracker;
-import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -49,24 +36,16 @@ import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
-import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
-import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
-import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.testutils.DirectScheduledExecutorService;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
 import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
@@ -80,8 +59,6 @@ import static org.junit.Assert.assertNotNull;
  * A collection of utility methods for testing the ExecutionGraph and its related classes.
  */
 public class ExecutionGraphTestUtils {
-
-	private static final Logger TEST_LOGGER = LoggerFactory.getLogger(ExecutionGraphTestUtils.class);
 
 	// ------------------------------------------------------------------------
 	//  reaching states
@@ -387,7 +364,9 @@ public class ExecutionGraphTestUtils {
 		checkNotNull(vertices);
 		checkNotNull(timeout);
 
-		return new TestingExecutionGraphBuilder(vertices)
+		return TestingExecutionGraphBuilder
+			.newBuilder()
+			.setJobGraph(new JobGraph(vertices))
 			.setFutureExecutor(executor)
 			.setIoExecutor(executor)
 			.setSlotProvider(slotProvider)
@@ -433,10 +412,14 @@ public class ExecutionGraphTestUtils {
 		JobVertex ajv = new JobVertex("TestVertex", id);
 		ajv.setInvokableClass(AbstractInvokable.class);
 
-		ExecutionGraph graph = new TestingExecutionGraphBuilder(ajv)
+		JobGraph jobGraph = new JobGraph(ajv);
+		jobGraph.setScheduleMode(scheduleMode);
+
+		ExecutionGraph graph = TestingExecutionGraphBuilder
+			.newBuilder()
+			.setJobGraph(jobGraph)
 			.setIoExecutor(executor)
 			.setFutureExecutor(executor)
-			.setScheduleMode(scheduleMode)
 			.build();
 
 		graph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
@@ -518,144 +501,6 @@ public class ExecutionGraphTestUtils {
 			}
 
 			subtaskIndex++;
-		}
-	}
-
-	/**
-	 * Builder for {@link ExecutionGraph}.
-	 */
-	public static class TestingExecutionGraphBuilder {
-
-		private ShuffleMaster<?> shuffleMaster = NettyShuffleMaster.INSTANCE;
-		private Time allocationTimeout = Time.seconds(10L);
-		private BlobWriter blobWriter = VoidBlobWriter.getInstance();
-		private MetricGroup metricGroup = new UnregisteredMetricsGroup();
-		private RestartStrategy restartStrategy = new NoRestartStrategy();
-		private Time rpcTimeout = AkkaUtils.getDefaultTimeout();
-		private CheckpointRecoveryFactory checkpointRecoveryFactory = new StandaloneCheckpointRecoveryFactory();
-		private ClassLoader classLoader = getClass().getClassLoader();
-		private SlotProvider slotProvider = new TestingSlotProvider(slotRequestId -> CompletableFuture.completedFuture(new TestingLogicalSlotBuilder().createTestingLogicalSlot()));
-		private Executor ioExecutor = TestingUtils.defaultExecutor();
-		private ScheduledExecutorService futureExecutor = TestingUtils.defaultExecutor();
-		private Configuration jobMasterConfig = new Configuration();
-		private JobGraph jobGraph;
-		private JobMasterPartitionTracker partitionTracker = NoOpJobMasterPartitionTracker.INSTANCE;
-		private FailoverStrategy.Factory failoverStrategyFactory = new RestartAllStrategy.Factory();
-
-		public TestingExecutionGraphBuilder(final JobVertex ... jobVertices) {
-			this(new JobID(), "test job", jobVertices);
-		}
-
-		public TestingExecutionGraphBuilder(final JobID jobId, final JobVertex ... jobVertices) {
-			this(jobId, "test job", jobVertices);
-		}
-
-		public TestingExecutionGraphBuilder(final String jobName, final JobVertex ... jobVertices) {
-			this(new JobID(), jobName, jobVertices);
-		}
-
-		public TestingExecutionGraphBuilder(final JobID jobId, final String jobName, final JobVertex ... jobVertices) {
-			this(new JobGraph(jobId, jobName, jobVertices));
-		}
-
-		public TestingExecutionGraphBuilder(final JobGraph jobGraph) {
-			this.jobGraph = jobGraph;
-		}
-
-		public TestingExecutionGraphBuilder setJobMasterConfig(final Configuration jobMasterConfig) {
-			this.jobMasterConfig = jobMasterConfig;
-			return this;
-		}
-
-		public TestingExecutionGraphBuilder setFutureExecutor(final ScheduledExecutorService futureExecutor) {
-			this.futureExecutor = futureExecutor;
-			return this;
-		}
-
-		public TestingExecutionGraphBuilder setIoExecutor(final Executor ioExecutor) {
-			this.ioExecutor = ioExecutor;
-			return this;
-		}
-
-		public TestingExecutionGraphBuilder setSlotProvider(final SlotProvider slotProvider) {
-			this.slotProvider = slotProvider;
-			return this;
-		}
-
-		public TestingExecutionGraphBuilder setClassLoader(final ClassLoader classLoader) {
-			this.classLoader = classLoader;
-			return this;
-		}
-
-		public TestingExecutionGraphBuilder setCheckpointRecoveryFactory(final CheckpointRecoveryFactory checkpointRecoveryFactory) {
-			this.checkpointRecoveryFactory = checkpointRecoveryFactory;
-			return this;
-		}
-
-		public TestingExecutionGraphBuilder setRpcTimeout(final Time rpcTimeout) {
-			this.rpcTimeout = rpcTimeout;
-			return this;
-		}
-
-		public TestingExecutionGraphBuilder setRestartStrategy(final RestartStrategy restartStrategy) {
-			this.restartStrategy = restartStrategy;
-			return this;
-		}
-
-		public TestingExecutionGraphBuilder setMetricGroup(final MetricGroup metricGroup) {
-			this.metricGroup = metricGroup;
-			return this;
-		}
-
-		public TestingExecutionGraphBuilder setBlobWriter(final BlobWriter blobWriter) {
-			this.blobWriter = blobWriter;
-			return this;
-		}
-
-		public TestingExecutionGraphBuilder setAllocationTimeout(final Time allocationTimeout) {
-			this.allocationTimeout = allocationTimeout;
-			return this;
-		}
-
-		public TestingExecutionGraphBuilder setShuffleMaster(final ShuffleMaster<?> shuffleMaster) {
-			this.shuffleMaster = shuffleMaster;
-			return this;
-		}
-
-		public TestingExecutionGraphBuilder setPartitionTracker(final JobMasterPartitionTracker partitionTracker) {
-			this.partitionTracker = partitionTracker;
-			return this;
-		}
-
-		public TestingExecutionGraphBuilder setScheduleMode(ScheduleMode scheduleMode) {
-			jobGraph.setScheduleMode(scheduleMode);
-			return this;
-		}
-
-		public TestingExecutionGraphBuilder setFailoverStrategyFactory(FailoverStrategy.Factory failoverStrategyFactory) {
-			this.failoverStrategyFactory = failoverStrategyFactory;
-			return this;
-		}
-
-		public ExecutionGraph build() throws JobException, JobExecutionException {
-			return ExecutionGraphBuilder.buildGraph(
-				null,
-				jobGraph,
-				jobMasterConfig,
-				futureExecutor,
-				ioExecutor,
-				slotProvider,
-				classLoader,
-				checkpointRecoveryFactory,
-				rpcTimeout,
-				restartStrategy,
-				metricGroup,
-				blobWriter,
-				allocationTimeout,
-				TEST_LOGGER,
-				shuffleMaster,
-				partitionTracker,
-				failoverStrategyFactory);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.io.network.partition.TestingJobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.util.TestLogger;
 
@@ -51,7 +52,9 @@ public class ExecutionVertexTest extends TestLogger {
 		final TestingJobMasterPartitionTracker partitionTracker = new TestingJobMasterPartitionTracker();
 		partitionTracker.setStopTrackingAndReleasePartitionsConsumer(releasePartitionsFuture::complete);
 
-		final ExecutionGraph executionGraph = new ExecutionGraphTestUtils.TestingExecutionGraphBuilder(producerJobVertex, consumerJobVertex)
+		final ExecutionGraph executionGraph = TestingExecutionGraphBuilder
+			.newBuilder()
+			.setJobGraph(new JobGraph(producerJobVertex, consumerJobVertex))
 			.setPartitionTracker(partitionTracker)
 			.build();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/GlobalModVersionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/GlobalModVersionTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy;
@@ -29,7 +28,6 @@ import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
-import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.util.TestLogger;
 
@@ -154,32 +152,27 @@ public class GlobalModVersionTest extends TestLogger {
 	// ------------------------------------------------------------------------
 
 	private ExecutionGraph createSampleGraph(FailoverStrategy failoverStrategy) throws Exception {
-
 		final JobID jid = new JobID();
 		final int parallelism = new Random().nextInt(10) + 1;
-
-		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(jid, parallelism);
-
-		// build a simple execution graph with on job vertex, parallelism 2
-		final ExecutionGraph graph = new ExecutionGraph(
-			new DummyJobInformation(
-				jid,
-				"test job"),
-			TestingUtils.defaultExecutor(),
-			TestingUtils.defaultExecutor(),
-			Time.seconds(10),
-			new InfiniteDelayRestartStrategy(),
-			new CustomStrategy(failoverStrategy),
-			slotProvider);
-
-		graph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
 
 		JobVertex jv = new JobVertex("test vertex");
 		jv.setInvokableClass(NoOpInvokable.class);
 		jv.setParallelism(parallelism);
 
 		JobGraph jg = new JobGraph(jid, "testjob", jv);
-		graph.attachJobGraph(jg.getVerticesSortedTopologicallyFromSources());
+
+		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(jid, parallelism);
+
+		// build a simple execution graph with on job vertex, parallelism 2
+		final ExecutionGraph graph = TestingExecutionGraphBuilder
+			.newBuilder()
+			.setJobGraph(jg)
+			.setRestartStrategy(new InfiniteDelayRestartStrategy())
+			.setFailoverStrategyFactory(new CustomStrategy(failoverStrategy))
+			.setSlotProvider(slotProvider)
+			.build();
+
+		graph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
 
 		return graph;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/LegacyJobVertexIdTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/LegacyJobVertexIdTest.java
@@ -18,16 +18,11 @@
 
 package org.apache.flink.runtime.executiongraph;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.util.SerializedValue;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -35,10 +30,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ScheduledExecutorService;
-
-import static org.mockito.Mockito.mock;
 
 public class LegacyJobVertexIdTest {
 
@@ -48,19 +39,10 @@ public class LegacyJobVertexIdTest {
 		JobVertexID legacyId1 = new JobVertexID();
 		JobVertexID legacyId2 = new JobVertexID();
 
-		JobVertex jobVertex = new JobVertex("test", defaultId, Arrays.asList(legacyId1, legacyId2), new ArrayList<OperatorID>(), new ArrayList<OperatorID>());
+		JobVertex jobVertex = new JobVertex("test", defaultId, Arrays.asList(legacyId1, legacyId2), new ArrayList<>(), new ArrayList<>());
 		jobVertex.setInvokableClass(AbstractInvokable.class);
 
-		ExecutionGraph executionGraph = new ExecutionGraph(
-			mock(ScheduledExecutorService.class),
-			mock(Executor.class),
-			new JobID(),
-			"test",
-			mock(Configuration.class),
-			mock(SerializedValue.class),
-			Time.seconds(1),
-			mock(RestartStrategy.class),
-			mock(SlotProvider.class));
+		ExecutionGraph executionGraph = TestingExecutionGraphBuilder.newBuilder().build();
 
 		ExecutionJobVertex executionJobVertex =
 				new ExecutionJobVertex(executionGraph, jobVertex, 1, Time.seconds(1));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
@@ -18,30 +18,21 @@
 
 package org.apache.flink.runtime.executiongraph;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
+import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.testingUtils.TestingUtils;
-import org.apache.flink.util.SerializedValue;
 
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.JobException;
-import org.apache.flink.runtime.jobgraph.JobVertex;
-import org.apache.flink.runtime.jobgraph.DistributionPattern;
-import org.apache.flink.api.common.JobID;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 
 public class PointwisePatternTest {
@@ -256,18 +247,9 @@ public class PointwisePatternTest {
 	}
 
 	private ExecutionGraph getDummyExecutionGraph() throws Exception {
-		return new ExecutionGraph(
-			TestingUtils.defaultExecutor(),
-			TestingUtils.defaultExecutor(),
-			new JobID(),
-			"Test Job Sample Name",
-			new Configuration(),
-			new SerializedValue<>(new ExecutionConfig()),
-			AkkaUtils.getDefaultTimeout(),
-			new NoRestartStrategy(),
-			new TestingSlotProvider(ignored -> new CompletableFuture<>()));
+		return TestingExecutionGraphBuilder.newBuilder().build();
 	}
-	
+
 	private void testLowToHigh(int lowDop, int highDop) throws Exception {
 		if (highDop < lowDop) {
 			throw new IllegalArgumentException();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingExecutionGraphBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingExecutionGraphBuilder.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.runtime.JobException;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.blob.BlobWriter;
+import org.apache.flink.runtime.blob.VoidBlobWriter;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
+import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy;
+import org.apache.flink.runtime.executiongraph.failover.RestartAllStrategy;
+import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
+import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
+import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
+import org.apache.flink.runtime.io.network.partition.NoOpJobMasterPartitionTracker;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
+import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
+import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Builder of {@link ExecutionGraph} used in testing.
+ */
+public class TestingExecutionGraphBuilder {
+
+	private static final Logger LOG = LoggerFactory.getLogger(TestingExecutionGraphBuilder.class);
+
+	public static TestingExecutionGraphBuilder newBuilder() {
+		return new TestingExecutionGraphBuilder();
+	}
+
+	private ScheduledExecutorService futureExecutor = TestingUtils.defaultExecutor();
+	private Executor ioExecutor = TestingUtils.defaultExecutor();
+	private Time rpcTimeout = AkkaUtils.getDefaultTimeout();
+	private RestartStrategy restartStrategy = new NoRestartStrategy();
+	private FailoverStrategy.Factory failoverStrategyFactory = new RestartAllStrategy.Factory();
+	private SlotProvider slotProvider = new TestingSlotProvider(slotRequestId -> CompletableFuture.completedFuture(new TestingLogicalSlotBuilder().createTestingLogicalSlot()));
+	private ClassLoader userClassLoader = ExecutionGraph.class.getClassLoader();
+	private BlobWriter blobWriter = VoidBlobWriter.getInstance();
+	private Time allocationTimeout = AkkaUtils.getDefaultTimeout();
+	private ShuffleMaster<?> shuffleMaster = NettyShuffleMaster.INSTANCE;
+	private JobMasterPartitionTracker partitionTracker = NoOpJobMasterPartitionTracker.INSTANCE;
+	private Configuration jobMasterConfig = new Configuration();
+	private JobGraph jobGraph = new JobGraph();
+	private MetricGroup metricGroup = new UnregisteredMetricsGroup();
+	private CheckpointRecoveryFactory checkpointRecoveryFactory = new StandaloneCheckpointRecoveryFactory();
+
+	private TestingExecutionGraphBuilder() {
+
+	}
+
+	public TestingExecutionGraphBuilder setJobMasterConfig(Configuration jobMasterConfig) {
+		this.jobMasterConfig = jobMasterConfig;
+		return this;
+	}
+
+	public TestingExecutionGraphBuilder setJobGraph(JobGraph jobGraph) {
+		this.jobGraph = jobGraph;
+		return this;
+	}
+
+	public TestingExecutionGraphBuilder setFutureExecutor(ScheduledExecutorService futureExecutor) {
+		this.futureExecutor = futureExecutor;
+		return this;
+	}
+
+	public TestingExecutionGraphBuilder setIoExecutor(Executor ioExecutor) {
+		this.ioExecutor = ioExecutor;
+		return this;
+	}
+
+	public TestingExecutionGraphBuilder setRpcTimeout(Time rpcTimeout) {
+		this.rpcTimeout = rpcTimeout;
+		return this;
+	}
+
+	public TestingExecutionGraphBuilder setRestartStrategy(RestartStrategy restartStrategy) {
+		this.restartStrategy = restartStrategy;
+		return this;
+	}
+
+	public TestingExecutionGraphBuilder setFailoverStrategyFactory(FailoverStrategy.Factory failoverStrategyFactory) {
+		this.failoverStrategyFactory = failoverStrategyFactory;
+		return this;
+	}
+
+	public TestingExecutionGraphBuilder setSlotProvider(SlotProvider slotProvider) {
+		this.slotProvider = slotProvider;
+		return this;
+	}
+
+	public TestingExecutionGraphBuilder setUserClassLoader(ClassLoader userClassLoader) {
+		this.userClassLoader = userClassLoader;
+		return this;
+	}
+
+	public TestingExecutionGraphBuilder setBlobWriter(BlobWriter blobWriter) {
+		this.blobWriter = blobWriter;
+		return this;
+	}
+
+	public TestingExecutionGraphBuilder setAllocationTimeout(Time allocationTimeout) {
+		this.allocationTimeout = allocationTimeout;
+		return this;
+	}
+
+	public TestingExecutionGraphBuilder setShuffleMaster(ShuffleMaster<?> shuffleMaster) {
+		this.shuffleMaster = shuffleMaster;
+		return this;
+	}
+
+	public TestingExecutionGraphBuilder setPartitionTracker(JobMasterPartitionTracker partitionTracker) {
+		this.partitionTracker = partitionTracker;
+		return this;
+	}
+
+	public TestingExecutionGraphBuilder setMetricGroup(MetricGroup metricGroup) {
+		this.metricGroup = metricGroup;
+		return this;
+	}
+
+	public TestingExecutionGraphBuilder setCheckpointRecoveryFactory(CheckpointRecoveryFactory checkpointRecoveryFactory) {
+		this.checkpointRecoveryFactory = checkpointRecoveryFactory;
+		return this;
+	}
+
+	public ExecutionGraph build() throws JobException, JobExecutionException {
+		return ExecutionGraphBuilder.buildGraph(
+			null,
+			jobGraph,
+			jobMasterConfig,
+			futureExecutor,
+			ioExecutor,
+			slotProvider,
+			userClassLoader,
+			checkpointRecoveryFactory,
+			rpcTimeout,
+			restartStrategy,
+			metricGroup,
+			blobWriter,
+			allocationTimeout,
+			LOG,
+			shuffleMaster,
+			partitionTracker,
+			failoverStrategyFactory);
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
@@ -18,26 +18,23 @@
 
 package org.apache.flink.runtime.executiongraph;
 
-import static org.junit.Assert.*;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
-import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
-import org.apache.flink.runtime.jobgraph.JobVertex;
-import org.apache.flink.runtime.jobgraph.DistributionPattern;
-import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
-import org.apache.flink.runtime.testingUtils.TestingUtils;
-import org.apache.flink.util.SerializedValue;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class VertexSlotSharingTest {
 
@@ -79,23 +76,14 @@ public class VertexSlotSharingTest {
 			v4.setSlotSharingGroup(jg2);
 			v5.setSlotSharingGroup(jg2);
 			
-			List<JobVertex> vertices = new ArrayList<JobVertex>(Arrays.asList(v1, v2, v3, v4, v5));
-			
-			ExecutionGraph eg = new ExecutionGraph(
-				TestingUtils.defaultExecutor(),
-				TestingUtils.defaultExecutor(),
-				new JobID(),
-				"test job",
-				new Configuration(),
-				new SerializedValue<>(new ExecutionConfig()),
-				AkkaUtils.getDefaultTimeout(),
-				new NoRestartStrategy(),
-				new TestingSlotProvider(ignored -> new CompletableFuture<>()));
+			List<JobVertex> vertices = new ArrayList<>(Arrays.asList(v1, v2, v3, v4, v5));
+
+			ExecutionGraph eg = TestingExecutionGraphBuilder.newBuilder().build();
 			eg.attachJobGraph(vertices);
 			
 			// verify that the vertices are all in the same slot sharing group
-			SlotSharingGroup group1 = null;
-			SlotSharingGroup group2 = null;
+			SlotSharingGroup group1;
+			SlotSharingGroup group2;
 			
 			// verify that v1 tasks have no slot sharing group
 			assertNull(eg.getJobVertex(v1.getID()).getSlotSharingGroup());


### PR DESCRIPTION
## What is the purpose of the change

Refactor ExecutionGraph creation in tests as TestingExecutionGraphBuilder

## Brief change log

- Introduce `o.a.f.runtime.executiongraph.TestingExecutionGraphBuilder`, mainly based on `ExecutionGraphUtils.TestingExecutionGraphBuilder`
- Replace `@VisibleForTesting` constructors with `TestingExecutionGraphBuilder` and then remove those constructors
- Replace `ExecutionGraphUtils.TestingExecutionGraphBuilder` constructors with `TestingExecutionGraphBuilder` and then remove it
- Refactor `ExecutionGraphRestartTest` for removing the internal class `TestingExecutionGraphBuilder`

## Verifying this change

This change is a code refactor without functionality changes so that covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

CC @tillrohrmann @zentol 
