### PR TITLE
[FLINK-13969] Resuming Externalized Checkpoint (rocks, incremental, scale down) end-to-end test fails on Travis

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -504,30 +504,7 @@ public class CheckpointCoordinator {
 
 		// make some eager pre-checks
 		synchronized (lock) {
-			// abort if the coordinator has been shutdown in the meantime
-			if (shutdown) {
-				throw new CheckpointException(CheckpointFailureReason.CHECKPOINT_COORDINATOR_SHUTDOWN);
-			}
-
-			// Don't allow periodic checkpoint if scheduling has been disabled
-			if (isPeriodic && !periodicScheduling) {
-				throw new CheckpointException(CheckpointFailureReason.PERIODIC_SCHEDULER_SHUTDOWN);
-			}
-
-			// validate whether the checkpoint can be triggered, with respect to the limit of
-			// concurrent checkpoints, and the minimum time between checkpoints.
-			// these checks are not relevant for savepoints
-			if (!props.forceCheckpoint()) {
-				// sanity check: there should never be more than one trigger request queued
-				if (triggerRequestQueued) {
-					LOG.warn("Trying to trigger another checkpoint for job {} while one was queued already.", job);
-					throw new CheckpointException(CheckpointFailureReason.ALREADY_QUEUED);
-				}
-
-				checkConcurrentCheckpoints();
-
-				checkMinPauseBetweenCheckpoints();
-			}
+			preCheckBeforeTriggeringCheckpoint(isPeriodic, props.forceCheckpoint());
 		}
 
 		// check if all tasks that we need to trigger are running.
@@ -629,21 +606,7 @@ public class CheckpointCoordinator {
 		try {
 			// re-acquire the coordinator-wide lock
 			synchronized (lock) {
-				// since we released the lock in the meantime, we need to re-check
-				// that the conditions still hold.
-				if (shutdown) {
-					throw new CheckpointException(CheckpointFailureReason.CHECKPOINT_COORDINATOR_SHUTDOWN);
-				}
-				else if (!props.forceCheckpoint()) {
-					if (triggerRequestQueued) {
-						LOG.warn("Trying to trigger another checkpoint for job {} while one was queued already.", job);
-						throw new CheckpointException(CheckpointFailureReason.ALREADY_QUEUED);
-					}
-
-					checkConcurrentCheckpoints();
-
-					checkMinPauseBetweenCheckpoints();
-				}
+				preCheckBeforeTriggeringCheckpoint(isPeriodic, props.forceCheckpoint());
 
 				LOG.info("Triggering checkpoint {} @ {} for job {}.", checkpointID, timestamp, job);
 
@@ -704,6 +667,10 @@ public class CheckpointCoordinator {
 				LOG.warn("Cannot dispose failed checkpoint storage location {}", checkpointStorageLocation, t2);
 			}
 
+			// rethrow the CheckpointException directly.
+			if (t instanceof CheckpointException) {
+				throw (CheckpointException) t;
+			}
 			throw new CheckpointException(CheckpointFailureReason.EXCEPTION, t);
 		}
 	}
@@ -1514,5 +1481,28 @@ public class CheckpointCoordinator {
 
 	private boolean allPendingCheckpointsDiscarded() {
 		return pendingCheckpoints.values().stream().allMatch(PendingCheckpoint::isDiscarded);
+	}
+
+	private void preCheckBeforeTriggeringCheckpoint(boolean isPeriodic, boolean forceCheckpoint) throws CheckpointException {
+		// abort if the coordinator has been shutdown in the meantime
+		if (shutdown) {
+			throw new CheckpointException(CheckpointFailureReason.CHECKPOINT_COORDINATOR_SHUTDOWN);
+		}
+
+		// Don't allow periodic checkpoint if scheduling has been disabled
+		if (isPeriodic && !periodicScheduling) {
+			throw new CheckpointException(CheckpointFailureReason.PERIODIC_SCHEDULER_SHUTDOWN);
+		}
+
+		if (!forceCheckpoint) {
+			if (triggerRequestQueued) {
+				LOG.warn("Trying to trigger another checkpoint for job {} while one was queued already.", job);
+				throw new CheckpointException(CheckpointFailureReason.ALREADY_QUEUED);
+			}
+
+			checkConcurrentCheckpoints();
+
+			checkMinPauseBetweenCheckpoints();
+		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Prevent triggering new checkpoints after the coordinator has been stopped.

Currently, we only check whether the coordinator has been stopped, but only check in actual triggering checkpoint, in this pr we want to fix this.

The event order will lead to this problem is 
- triggerCheckpoint  eager pre-checks
- job cancel
- triggerCheckpoint actual trigger checkpoint

all the three steps are guarded by lock, will release the lock after step 1 and require the lock in step 3.

we checked whether the coordinator has been stopped in eager pre-checks, but not in actual trigger checkpoint.

## Brief change log

  - *Add a check whether the coordinator has been stopped when actual trigger checkpoint*

## Verifying this change

This change added tests and can be verified as follows:
  - *Added test to verify this change in `CheckpointCoordinatorTest#testTriggerCheckpointAfterCancel`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
