### PR TITLE
[FLINK-14640] Change Type of Field currentExecutions from ConcurrentHashMap to HashMap

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -202,7 +202,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	private final ConcurrentHashMap<IntermediateDataSetID, IntermediateResult> intermediateResults;
 
 	/** The currently executed tasks, for callbacks. */
-	private final ConcurrentHashMap<ExecutionAttemptID, Execution> currentExecutions;
+	private final Map<ExecutionAttemptID, Execution> currentExecutions;
 
 	/** Listeners that receive messages when the entire job switches it status
 	 * (such as from RUNNING to FINISHED). */
@@ -465,7 +465,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 		this.tasks = new ConcurrentHashMap<>(16);
 		this.intermediateResults = new ConcurrentHashMap<>(16);
 		this.verticesInCreationOrder = new ArrayList<>(16);
-		this.currentExecutions = new ConcurrentHashMap<>(16);
+		this.currentExecutions = new HashMap<>(16);
 
 		this.jobStatusListeners  = new CopyOnWriteArrayList<>();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -246,13 +246,15 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 			JobVertex v1 = new JobVertex("v1", jid1);
 			JobVertex v2 = new JobVertex("v2", jid2);
 
-			Map<ExecutionAttemptID, Execution> executions = setupExecution(v1, 7650, v2, 2350).f1;
+			Tuple2<ExecutionGraph, Map<ExecutionAttemptID, Execution>> graphExecutionsTuple = setupExecution(v1, 7650, v2, 2350);
+			ExecutionGraph testExecutionGraph = graphExecutionsTuple.f0;
+			Collection<Execution> executions = new ArrayList<>(graphExecutionsTuple.f1.values());
 
-			for (Execution e : executions.values()) {
+			for (Execution e : executions) {
 				e.markFinished();
 			}
 
-			assertEquals(0, executions.size());
+			assertEquals(0, testExecutionGraph.getRegisteredExecutions().size());
 		}
 		catch (Exception e) {
 			e.printStackTrace();
@@ -270,13 +272,15 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 			JobVertex v1 = new JobVertex("v1", jid1);
 			JobVertex v2 = new JobVertex("v2", jid2);
 
-			Map<ExecutionAttemptID, Execution> executions = setupExecution(v1, 7, v2, 6).f1;
+			Tuple2<ExecutionGraph, Map<ExecutionAttemptID, Execution>> graphExecutionsTuple = setupExecution(v1, 7, v2, 6);
+			ExecutionGraph testExecutionGraph = graphExecutionsTuple.f0;
+			Collection<Execution> executions = new ArrayList<>(graphExecutionsTuple.f1.values());
 
-			for (Execution e : executions.values()) {
+			for (Execution e : executions) {
 				e.markFailed(null);
 			}
 
-			assertEquals(0, executions.size());
+			assertEquals(0, testExecutionGraph.getRegisteredExecutions().size());
 		}
 		catch (Exception e) {
 			e.printStackTrace();
@@ -294,13 +298,15 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 			JobVertex v1 = new JobVertex("v1", jid1);
 			JobVertex v2 = new JobVertex("v2", jid2);
 
-			Map<ExecutionAttemptID, Execution> executions = setupExecution(v1, 7, v2, 6).f1;
+			Tuple2<ExecutionGraph, Map<ExecutionAttemptID, Execution>> graphExecutionsTuple = setupExecution(v1, 7, v2, 6);
+			ExecutionGraph testExecutionGraph = graphExecutionsTuple.f0;
+			Collection<Execution> executions = new ArrayList<>(graphExecutionsTuple.f1.values());
 
-			for (Execution e : executions.values()) {
+			for (Execution e : executions) {
 				e.fail(null);
 			}
 
-			assertEquals(0, executions.size());
+			assertEquals(0, testExecutionGraph.getRegisteredExecutions().size());
 		}
 		catch (Exception e) {
 			e.printStackTrace();
@@ -397,14 +403,16 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 			JobVertex v1 = new JobVertex("v1", jid1);
 			JobVertex v2 = new JobVertex("v2", jid2);
 
-			Map<ExecutionAttemptID, Execution> executions = setupExecution(v1, 19, v2, 37).f1;
+			Tuple2<ExecutionGraph, Map<ExecutionAttemptID, Execution>> graphExecutionsTuple = setupExecution(v1, 19, v2, 37);
+			ExecutionGraph testExecutionGraph = graphExecutionsTuple.f0;
+			Collection<Execution> executions = new ArrayList<>(graphExecutionsTuple.f1.values());
 
-			for (Execution e : executions.values()) {
+			for (Execution e : executions) {
 				e.cancel();
 				e.completeCancelling();
 			}
 
-			assertEquals(0, executions.size());
+			assertEquals(0, testExecutionGraph.getRegisteredExecutions().size());
 		}
 		catch (Exception e) {
 			e.printStackTrace();


### PR DESCRIPTION


## What is the purpose of the change

*This pull request changes Type of Field currentExecutions from ConcurrentHashMap to HashMap*


## Brief change log

  - *Change Type of Field currentExecutions from ConcurrentHashMap to HashMap*


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
