### PR TITLE
[FLINK-14630] Re-enable logging for Yarn tests

### DIFF
--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -88,11 +88,6 @@
             <td>Time between heartbeats with the ResourceManager in seconds.</td>
         </tr>
         <tr>
-            <td><h5>yarn.log-config-file</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>The location of the log config file, e.g. the path to your log4j.properties for log4j.</td>
-        </tr>
-        <tr>
             <td><h5>yarn.maximum-failed-containers</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Maximum number of containers the system is going to reallocate in case of a failure.</td>

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.AkkaOptions;
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.JobResult;
@@ -68,11 +69,12 @@ public class YARNITCase extends YarnTestBase {
 			configuration.setString(AkkaOptions.ASK_TIMEOUT, "30 s");
 			final YarnClient yarnClient = getYarnClient();
 
-			try (final YarnClusterDescriptor yarnClusterDescriptor = new YarnClusterDescriptor(
-				configuration,
-				getYarnConfiguration(),
-				yarnClient,
-				true)) {
+			try (final YarnClusterDescriptor yarnClusterDescriptor = org.apache.flink.yarn.YarnTestUtils.createClusterDescriptorWithLogging(
+					System.getenv(ConfigConstants.ENV_FLINK_CONF_DIR),
+					configuration,
+					getYarnConfiguration(),
+					yarnClient,
+					true)) {
 
 				yarnClusterDescriptor.setLocalJarPath(new Path(flinkUberjar.getAbsolutePath()));
 				yarnClusterDescriptor.addShipFiles(Arrays.asList(flinkLibFolder.listFiles()));

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.yarn;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.client.cli.CliFrontend;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.PackagedProgram;
@@ -94,11 +95,12 @@ public class YarnConfigurationITCase extends YarnTestBase {
 			configuration.setString(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MAX, String.valueOf(4L << 20));
 
 			final YarnConfiguration yarnConfiguration = getYarnConfiguration();
-			final YarnClusterDescriptor clusterDescriptor = new YarnClusterDescriptor(
-				configuration,
-				yarnConfiguration,
-				yarnClient,
-				true);
+			final YarnClusterDescriptor clusterDescriptor = YarnTestUtils.createClusterDescriptorWithLogging(
+					CliFrontend.getConfigurationDirectoryFromEnv(),
+					configuration,
+					yarnConfiguration,
+					yarnClient,
+					true);
 
 			clusterDescriptor.setLocalJarPath(new Path(flinkUberjar.getAbsolutePath()));
 			clusterDescriptor.addShipFiles(Arrays.asList(flinkLibFolder.listFiles()));

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -305,7 +305,7 @@ public abstract class YarnTestBase extends TestLogger {
 	@Nonnull
 	YarnClusterDescriptor createYarnClusterDescriptor(org.apache.flink.configuration.Configuration flinkConfiguration) {
 		final YarnClusterDescriptor yarnClusterDescriptor = YarnTestUtils.createClusterDescriptorWithLogging(
-				CliFrontend.getConfigurationDirectoryFromEnv(),
+				tempConfPathForSecureRun.getAbsolutePath(),
 				flinkConfiguration,
 				YARN_CONFIGURATION,
 				yarnClient,

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -304,11 +304,12 @@ public abstract class YarnTestBase extends TestLogger {
 
 	@Nonnull
 	YarnClusterDescriptor createYarnClusterDescriptor(org.apache.flink.configuration.Configuration flinkConfiguration) {
-		final YarnClusterDescriptor yarnClusterDescriptor = new YarnClusterDescriptor(
-			flinkConfiguration,
-			YARN_CONFIGURATION,
-			yarnClient,
-			true);
+		final YarnClusterDescriptor yarnClusterDescriptor = YarnTestUtils.createClusterDescriptorWithLogging(
+				CliFrontend.getConfigurationDirectoryFromEnv(),
+				flinkConfiguration,
+				YARN_CONFIGURATION,
+				yarnClient,
+				true);
 		yarnClusterDescriptor.setLocalJarPath(new Path(flinkUberjar.toURI()));
 		yarnClusterDescriptor.addShipFiles(Collections.singletonList(flinkLibFolder));
 		return yarnClusterDescriptor;

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -730,7 +730,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			systemShipFiles.add(file.getAbsoluteFile());
 		}
 
-		final String logConfigFilePath = configuration.getString(YarnConfigOptions.APPLICATION_LOG_CONFIG_FILE);
+		final String logConfigFilePath = configuration.getString(YarnConfigOptionsInternal.APPLICATION_LOG_CONFIG_FILE);
 		if (logConfigFilePath != null) {
 			systemShipFiles.add(new File(logConfigFilePath));
 		}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -950,10 +950,13 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 					"");
 		}
 
+		final boolean hasLogback = logConfigFilePath != null && logConfigFilePath.endsWith(CONFIG_FILE_LOGBACK_NAME);
+		final boolean hasLog4j = logConfigFilePath != null && logConfigFilePath.endsWith(CONFIG_FILE_LOG4J_NAME);
+
 		final ContainerLaunchContext amContainer = setupApplicationMasterContainer(
 				yarnClusterEntrypoint,
-				logConfigFilePath != null && logConfigFilePath.endsWith(CONFIG_FILE_LOGBACK_NAME),
-				logConfigFilePath != null && logConfigFilePath.endsWith(CONFIG_FILE_LOG4J_NAME),
+				hasLogback,
+				hasLog4j,
 				hasKrb5,
 				clusterSpecification.getMasterMemoryMB());
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -443,7 +443,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 		}
 
 		discoverLogConfigFile().ifPresent(
-				file -> configuration.setString(YarnConfigOptions.APPLICATION_LOG_CONFIG_FILE, file.getPath())
+				file -> configuration.setString(YarnConfigOptionsInternal.APPLICATION_LOG_CONFIG_FILE, file.getPath())
 		);
 	}
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.yarn.cli;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.client.cli.AbstractCustomCommandLine;
 import org.apache.flink.client.cli.CliArgsException;
 import org.apache.flink.client.cli.CliFrontend;
@@ -442,12 +443,13 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 			configuration.setString(YarnConfigOptions.NODE_LABEL, nodeLabelValue);
 		}
 
-		discoverLogConfigFile().ifPresent(
+		discoverLogConfigFile(configurationDirectory).ifPresent(
 				file -> configuration.setString(YarnConfigOptionsInternal.APPLICATION_LOG_CONFIG_FILE, file.getPath())
 		);
 	}
 
-	private Optional<File> discoverLogConfigFile() {
+	@VisibleForTesting
+	public static Optional<File> discoverLogConfigFile(final String configurationDirectory) {
 		Optional<File> logConfigFile = Optional.empty();
 
 		final File log4jFile = new File(configurationDirectory + File.separator + CONFIG_FILE_LOG4J_NAME);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -443,13 +443,21 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 			configuration.setString(YarnConfigOptions.NODE_LABEL, nodeLabelValue);
 		}
 
-		discoverLogConfigFile(configurationDirectory).ifPresent(
-				file -> configuration.setString(YarnConfigOptionsInternal.APPLICATION_LOG_CONFIG_FILE, file.getPath())
-		);
+		setLogConfigFileInConfig(configuration, configurationDirectory);
 	}
 
 	@VisibleForTesting
-	public static Optional<File> discoverLogConfigFile(final String configurationDirectory) {
+	public static Configuration setLogConfigFileInConfig(final Configuration configuration, final String configurationDirectory) {
+		if (configuration.getString(YarnConfigOptionsInternal.APPLICATION_LOG_CONFIG_FILE) != null) {
+			return configuration;
+		}
+
+		FlinkYarnSessionCli.discoverLogConfigFile(configurationDirectory).ifPresent(file ->
+				configuration.setString(YarnConfigOptionsInternal.APPLICATION_LOG_CONFIG_FILE, file.getPath()));
+		return configuration;
+	}
+
+	private static Optional<File> discoverLogConfigFile(final String configurationDirectory) {
 		Optional<File> logConfigFile = Optional.empty();
 
 		final File log4jFile = new File(configurationDirectory + File.separator + CONFIG_FILE_LOG4J_NAME);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/YarnConfigUtils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/YarnConfigUtils.java
@@ -22,7 +22,6 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -36,14 +35,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * Utilities for parsing {@link org.apache.flink.configuration.ConfigOption configuration options}.
  */
 public class YarnConfigUtils {
-
-	public static <T> void encodeListToConfig(
-			final Configuration configuration,
-			final ConfigOption<List<String>> key,
-			final Collection<T> value,
-			final Function<T, String> mapper) {
-		encodeListToConfig(configuration, key, value.stream(), mapper);
-	}
 
 	public static <T> void encodeListToConfig(
 			final Configuration configuration,

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -208,12 +208,6 @@ public class YarnConfigOptions {
 
 	// ----------------------- YARN CLI OPTIONS ------------------------------------
 
-	public static final ConfigOption<String> APPLICATION_LOG_CONFIG_FILE =
-			key("yarn.log-config-file")
-				.stringType()
-				.noDefaultValue()
-				.withDescription("The location of the log config file, e.g. the path to your log4j.properties for log4j.");
-
 	public static final ConfigOption<List<String>> SHIP_DIRECTORIES =
 			key("yarn.ship-directories")
 				.stringType()

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptionsInternal.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptionsInternal.java
@@ -35,4 +35,9 @@ public class YarnConfigOptionsInternal {
 					.noDefaultValue()
 					.withDescription("**DO NOT USE** Specify YARN dynamic properties.");
 
+	public static final ConfigOption<String> APPLICATION_LOG_CONFIG_FILE =
+			key("$internal.yarn.log-config-file")
+					.stringType()
+					.noDefaultValue()
+					.withDescription("**DO NOT USE** The location of the log config file, e.g. the path to your log4j.properties for log4j.");
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptionsInternal.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptionsInternal.java
@@ -31,6 +31,7 @@ public class YarnConfigOptionsInternal {
 
 	public static final ConfigOption<String> DYNAMIC_PROPERTIES =
 			key("$internal.yarn.dynamic-properties")
+					.stringType()
 					.noDefaultValue()
 					.withDescription("**DO NOT USE** Specify YARN dynamic properties.");
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/AbstractYarnClusterTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/AbstractYarnClusterTest.java
@@ -64,11 +64,12 @@ public class AbstractYarnClusterTest extends TestLogger {
 		yarnClient.init(yarnConfiguration);
 		yarnClient.start();
 
-		final YarnClusterDescriptor clusterDescriptor = new YarnClusterDescriptor(
-			new Configuration(),
-			yarnConfiguration,
-			yarnClient,
-			false);
+		final YarnClusterDescriptor clusterDescriptor = YarnTestUtils.createClusterDescriptorWithLogging(
+				temporaryFolder.newFolder().getAbsolutePath(),
+				new Configuration(),
+				yarnConfiguration,
+				yarnClient,
+				false);
 
 		try {
 			clusterDescriptor.retrieve(applicationId);

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -522,11 +522,12 @@ public class YarnClusterDescriptorTest extends TestLogger {
 		closableYarnClient.init(yarnConfiguration);
 		closableYarnClient.start();
 
-		yarnClusterDescriptor = new YarnClusterDescriptor(
-			new Configuration(),
-			yarnConfiguration,
-			closableYarnClient,
-			false);
+		yarnClusterDescriptor = YarnTestUtils.createClusterDescriptorWithLogging(
+				temporaryFolder.getRoot().getAbsolutePath(),
+				new Configuration(),
+				yarnConfiguration,
+				closableYarnClient,
+				false);
 
 		yarnClusterDescriptor.close();
 
@@ -538,10 +539,11 @@ public class YarnClusterDescriptorTest extends TestLogger {
 	}
 
 	private YarnClusterDescriptor createYarnClusterDescriptor(Configuration configuration) {
-		return new YarnClusterDescriptor(
-			configuration,
-			yarnConfiguration,
-			yarnClient,
-			true);
+		return YarnTestUtils.createClusterDescriptorWithLogging(
+				temporaryFolder.getRoot().getAbsolutePath(),
+				configuration,
+				yarnConfiguration,
+				yarnClient,
+				true);
 	}
 }

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTestUtils.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTestUtils.java
@@ -20,7 +20,6 @@ package org.apache.flink.yarn;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
-import org.apache.flink.yarn.configuration.YarnConfigOptionsInternal;
 
 import org.apache.hadoop.util.VersionInfo;
 import org.apache.hadoop.yarn.client.api.YarnClient;
@@ -49,17 +48,7 @@ public class YarnTestUtils {
 			final YarnConfiguration yarnConfiguration,
 			final YarnClient yarnClient,
 			final boolean sharedYarnClient) {
-		final Configuration effectiveConfiguration = addLogDirToConfiguration(flinkConfiguration, flinkConfDir);
+		final Configuration effectiveConfiguration = FlinkYarnSessionCli.setLogConfigFileInConfig(flinkConfiguration, flinkConfDir);
 		return new YarnClusterDescriptor(effectiveConfiguration, yarnConfiguration, yarnClient, sharedYarnClient);
-	}
-
-	private static Configuration addLogDirToConfiguration(final Configuration flinkConfiguration, final String flinkConfDir) {
-		if (flinkConfiguration.getString(YarnConfigOptionsInternal.APPLICATION_LOG_CONFIG_FILE) != null) {
-			return flinkConfiguration;
-		}
-
-		FlinkYarnSessionCli.discoverLogConfigFile(flinkConfDir).ifPresent(file ->
-				flinkConfiguration.setString(YarnConfigOptionsInternal.APPLICATION_LOG_CONFIG_FILE, file.getAbsolutePath()));
-		return flinkConfiguration;
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

With [FLINK-14502](https://issues.apache.org/jira/browse/FLINK-14502) we changed how log property files are being discovered by the `YarnClusterDescriptor` and this resulted in Yarn tests not writing their job manager log files anymore. This made debugging a lot harder and next to impossible. 

This commit fixes this by introducing and exposing the utility method `Configuration setLogConfigFileInConfig(...)` in the `FlinkYarnSessionCli` which is responsible for discovering the log config file. This method is now used directly by the tests to simulate what the CLI does based on user-provided input.

## Verifying this change

Running a test like the `YarnITCase` and seeing the log files being created in the `target` dir is sufficient to verify the validity of the change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
