### PR TITLE
[FLINK-14494][docs] Add ConfigOption type to the documentation generator

### DIFF
--- a/docs/_includes/generated/akka_configuration.html
+++ b/docs/_includes/generated/akka_configuration.html
@@ -3,123 +3,147 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>akka.ask.timeout</h5></td>
             <td style="word-wrap: break-word;">"10 s"</td>
+            <td>String</td>
             <td>Timeout used for all futures and blocking Akka calls. If Flink fails due to timeouts then you should try to increase this value. Timeouts can be caused by slow machines or a congested network. The timeout value requires a time-unit specifier (ms/s/min/h/d).</td>
         </tr>
         <tr>
             <td><h5>akka.client-socket-worker-pool.pool-size-factor</h5></td>
             <td style="word-wrap: break-word;">1.0</td>
+            <td>Double</td>
             <td>The pool size factor is used to determine thread pool size using the following formula: ceil(available processors * factor). Resulting size is then bounded by the pool-size-min and pool-size-max values.</td>
         </tr>
         <tr>
             <td><h5>akka.client-socket-worker-pool.pool-size-max</h5></td>
             <td style="word-wrap: break-word;">2</td>
+            <td>Integer</td>
             <td>Max number of threads to cap factor-based number to.</td>
         </tr>
         <tr>
             <td><h5>akka.client-socket-worker-pool.pool-size-min</h5></td>
             <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
             <td>Min number of threads to cap factor-based number to.</td>
         </tr>
         <tr>
             <td><h5>akka.client.timeout</h5></td>
             <td style="word-wrap: break-word;">"60 s"</td>
+            <td>String</td>
             <td>Timeout for all blocking calls on the client side.</td>
         </tr>
         <tr>
             <td><h5>akka.fork-join-executor.parallelism-factor</h5></td>
             <td style="word-wrap: break-word;">2.0</td>
+            <td>Double</td>
             <td>The parallelism factor is used to determine thread pool size using the following formula: ceil(available processors * factor). Resulting size is then bounded by the parallelism-min and parallelism-max values.</td>
         </tr>
         <tr>
             <td><h5>akka.fork-join-executor.parallelism-max</h5></td>
             <td style="word-wrap: break-word;">64</td>
+            <td>Integer</td>
             <td>Max number of threads to cap factor-based parallelism number to.</td>
         </tr>
         <tr>
             <td><h5>akka.fork-join-executor.parallelism-min</h5></td>
             <td style="word-wrap: break-word;">8</td>
+            <td>Integer</td>
             <td>Min number of threads to cap factor-based parallelism number to.</td>
         </tr>
         <tr>
             <td><h5>akka.framesize</h5></td>
             <td style="word-wrap: break-word;">"10485760b"</td>
+            <td>String</td>
             <td>Maximum size of messages which are sent between the JobManager and the TaskManagers. If Flink fails because messages exceed this limit, then you should increase it. The message size requires a size-unit specifier.</td>
         </tr>
         <tr>
             <td><h5>akka.jvm-exit-on-fatal-error</h5></td>
             <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
             <td>Exit JVM on fatal Akka errors.</td>
         </tr>
         <tr>
             <td><h5>akka.log.lifecycle.events</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Turns on the Akka’s remote logging of events. Set this value to 'true' in case of debugging.</td>
         </tr>
         <tr>
             <td><h5>akka.lookup.timeout</h5></td>
             <td style="word-wrap: break-word;">"10 s"</td>
+            <td>String</td>
             <td>Timeout used for the lookup of the JobManager. The timeout value has to contain a time-unit specifier (ms/s/min/h/d).</td>
         </tr>
         <tr>
             <td><h5>akka.retry-gate-closed-for</h5></td>
             <td style="word-wrap: break-word;">50</td>
+            <td>Long</td>
             <td>Milliseconds a gate should be closed for after a remote connection was disconnected.</td>
         </tr>
         <tr>
             <td><h5>akka.server-socket-worker-pool.pool-size-factor</h5></td>
             <td style="word-wrap: break-word;">1.0</td>
+            <td>Double</td>
             <td>The pool size factor is used to determine thread pool size using the following formula: ceil(available processors * factor). Resulting size is then bounded by the pool-size-min and pool-size-max values.</td>
         </tr>
         <tr>
             <td><h5>akka.server-socket-worker-pool.pool-size-max</h5></td>
             <td style="word-wrap: break-word;">2</td>
+            <td>Integer</td>
             <td>Max number of threads to cap factor-based number to.</td>
         </tr>
         <tr>
             <td><h5>akka.server-socket-worker-pool.pool-size-min</h5></td>
             <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
             <td>Min number of threads to cap factor-based number to.</td>
         </tr>
         <tr>
             <td><h5>akka.ssl.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
             <td>Turns on SSL for Akka’s remote communication. This is applicable only when the global ssl flag security.ssl.enabled is set to true.</td>
         </tr>
         <tr>
             <td><h5>akka.startup-timeout</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Timeout after which the startup of a remote component is considered being failed.</td>
         </tr>
         <tr>
             <td><h5>akka.tcp.timeout</h5></td>
             <td style="word-wrap: break-word;">"20 s"</td>
+            <td>String</td>
             <td>Timeout for all outbound connections. If you should experience problems with connecting to a TaskManager due to a slow network, you should increase this value.</td>
         </tr>
         <tr>
             <td><h5>akka.throughput</h5></td>
             <td style="word-wrap: break-word;">15</td>
+            <td>Integer</td>
             <td>Number of messages that are processed in a batch before returning the thread to the pool. Low values denote a fair scheduling whereas high values can increase the performance at the cost of unfairness.</td>
         </tr>
         <tr>
             <td><h5>akka.transport.heartbeat.interval</h5></td>
             <td style="word-wrap: break-word;">"1000 s"</td>
+            <td>String</td>
             <td>Heartbeat interval for Akka’s transport failure detector. Since Flink uses TCP, the detector is not necessary. Therefore, the detector is disabled by setting the interval to a very high value. In case you should need the transport failure detector, set the interval to some reasonable value. The interval value requires a time-unit specifier (ms/s/min/h/d).</td>
         </tr>
         <tr>
             <td><h5>akka.transport.heartbeat.pause</h5></td>
             <td style="word-wrap: break-word;">"6000 s"</td>
+            <td>String</td>
             <td>Acceptable heartbeat pause for Akka’s transport failure detector. Since Flink uses TCP, the detector is not necessary. Therefore, the detector is disabled by setting the pause to a very high value. In case you should need the transport failure detector, set the pause to some reasonable value. The pause value requires a time-unit specifier (ms/s/min/h/d).</td>
         </tr>
         <tr>
             <td><h5>akka.transport.threshold</h5></td>
             <td style="word-wrap: break-word;">300.0</td>
+            <td>Double</td>
             <td>Threshold for the transport failure detector. Since Flink uses TCP, the detector is not necessary and, thus, the threshold is set to a high value.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/algorithm_configuration.html
+++ b/docs/_includes/generated/algorithm_configuration.html
@@ -3,23 +3,27 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>taskmanager.runtime.hashjoin-bloom-filters</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Flag to activate/deactivate bloom filters in the hybrid hash join implementation. In cases where the hash join needs to spill to disk (datasets larger than the reserved fraction of memory), these bloom filters can greatly reduce the number of spilled records, at the cost some CPU cycles.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.runtime.max-fan</h5></td>
             <td style="word-wrap: break-word;">128</td>
+            <td>Integer</td>
             <td>The maximal fan-in for external merge joins and fan-out for spilling hash tables. Limits the number of file handles per operator, but may cause intermediate merging/partitioning, if set too small.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.runtime.sort-spilling-threshold</h5></td>
             <td style="word-wrap: break-word;">0.8</td>
+            <td>Float</td>
             <td>A sort operation starts spilling when this fraction of its memory budget is full.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/blob_server_configuration.html
+++ b/docs/_includes/generated/blob_server_configuration.html
@@ -3,58 +3,69 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>blob.client.connect.timeout</h5></td>
             <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
             <td>The connection timeout in milliseconds for the blob client.</td>
         </tr>
         <tr>
             <td><h5>blob.client.socket.timeout</h5></td>
             <td style="word-wrap: break-word;">300000</td>
+            <td>Integer</td>
             <td>The socket timeout in milliseconds for the blob client.</td>
         </tr>
         <tr>
             <td><h5>blob.fetch.backlog</h5></td>
             <td style="word-wrap: break-word;">1000</td>
+            <td>Integer</td>
             <td>The config parameter defining the backlog of BLOB fetches on the JobManager.</td>
         </tr>
         <tr>
             <td><h5>blob.fetch.num-concurrent</h5></td>
             <td style="word-wrap: break-word;">50</td>
+            <td>Integer</td>
             <td>The config parameter defining the maximum number of concurrent BLOB fetches that the JobManager serves.</td>
         </tr>
         <tr>
             <td><h5>blob.fetch.retries</h5></td>
             <td style="word-wrap: break-word;">5</td>
+            <td>Integer</td>
             <td>The config parameter defining number of retires for failed BLOB fetches.</td>
         </tr>
         <tr>
             <td><h5>blob.offload.minsize</h5></td>
             <td style="word-wrap: break-word;">1048576</td>
+            <td>Integer</td>
             <td>The minimum size for messages to be offloaded to the BlobServer.</td>
         </tr>
         <tr>
             <td><h5>blob.server.port</h5></td>
             <td style="word-wrap: break-word;">"0"</td>
+            <td>String</td>
             <td>The config parameter defining the server port of the blob service.</td>
         </tr>
         <tr>
             <td><h5>blob.service.cleanup.interval</h5></td>
             <td style="word-wrap: break-word;">3600</td>
+            <td>Long</td>
             <td>Cleanup interval of the blob caches at the task managers (in seconds).</td>
         </tr>
         <tr>
             <td><h5>blob.service.ssl.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
             <td>Flag to override ssl support for the blob service transport.</td>
         </tr>
         <tr>
             <td><h5>blob.storage.directory</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The config parameter defining the storage directory to be used by the blob server.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/checkpointing_configuration.html
+++ b/docs/_includes/generated/checkpointing_configuration.html
@@ -3,58 +3,69 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>state.backend</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The state backend to be used to store and checkpoint state.</td>
         </tr>
         <tr>
             <td><h5>state.backend.async</h5></td>
             <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
             <td>Option whether the state backend should use an asynchronous snapshot method where possible and configurable. Some state backends may not support asynchronous snapshots, or only support asynchronous snapshots, and ignore this option.</td>
         </tr>
         <tr>
             <td><h5>state.backend.fs.memory-threshold</h5></td>
             <td style="word-wrap: break-word;">1024</td>
+            <td>Integer</td>
             <td>The minimum size of state data files. All state chunks smaller than that are stored inline in the root checkpoint metadata file.</td>
         </tr>
         <tr>
             <td><h5>state.backend.fs.write-buffer-size</h5></td>
             <td style="word-wrap: break-word;">4096</td>
+            <td>Integer</td>
             <td>The default size of the write buffer for the checkpoint streams that write to file systems. The actual write buffer size is determined to be the maximum of the value of this option and option 'state.backend.fs.memory-threshold'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.incremental</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Option whether the state backend should create incremental checkpoints, if possible. For an incremental checkpoint, only a diff from the previous checkpoint is stored, rather than the complete checkpoint state. Some state backends may not support incremental checkpoints and ignore this option.</td>
         </tr>
         <tr>
             <td><h5>state.backend.local-recovery</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>This option configures local recovery for this state backend. By default, local recovery is deactivated. Local recovery currently only covers keyed state backends. Currently, MemoryStateBackend does not support local recovery and ignore this option.</td>
         </tr>
         <tr>
             <td><h5>state.checkpoints.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The default directory used for storing the data files and meta data of checkpoints in a Flink supported filesystem. The storage path must be accessible from all participating processes/nodes(i.e. all TaskManagers and JobManagers).</td>
         </tr>
         <tr>
             <td><h5>state.checkpoints.num-retained</h5></td>
             <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
             <td>The maximum number of completed checkpoints to retain.</td>
         </tr>
         <tr>
             <td><h5>state.savepoints.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The default directory for savepoints. Used by the state backends that write savepoints to file systems (MemoryStateBackend, FsStateBackend, RocksDBStateBackend).</td>
         </tr>
         <tr>
             <td><h5>taskmanager.state.local.root-dirs</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The config parameter defining the root directories for storing file-based state for local recovery. Local recovery currently only covers keyed state backends. Currently, MemoryStateBackend does not support local recovery and ignore this option</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/cluster_configuration.html
+++ b/docs/_includes/generated/cluster_configuration.html
@@ -3,38 +3,45 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>cluster.evenly-spread-out-slots</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Enable the slot spread out allocation strategy. This strategy tries to spread out the slots evenly across all available <span markdown="span">`TaskExecutors`</span>.</td>
         </tr>
         <tr>
             <td><h5>cluster.registration.error-delay</h5></td>
             <td style="word-wrap: break-word;">10000</td>
+            <td>Long</td>
             <td>The pause made after an registration attempt caused an exception (other than timeout) in milliseconds.</td>
         </tr>
         <tr>
             <td><h5>cluster.registration.initial-timeout</h5></td>
             <td style="word-wrap: break-word;">100</td>
+            <td>Long</td>
             <td>Initial registration timeout between cluster components in milliseconds.</td>
         </tr>
         <tr>
             <td><h5>cluster.registration.max-timeout</h5></td>
             <td style="word-wrap: break-word;">30000</td>
+            <td>Long</td>
             <td>Maximum registration timeout between cluster components in milliseconds.</td>
         </tr>
         <tr>
             <td><h5>cluster.registration.refused-registration-delay</h5></td>
             <td style="word-wrap: break-word;">30000</td>
+            <td>Long</td>
             <td>The pause made after the registration attempt was refused in milliseconds.</td>
         </tr>
         <tr>
             <td><h5>cluster.services.shutdown-timeout</h5></td>
             <td style="word-wrap: break-word;">30000</td>
+            <td>Long</td>
             <td>The shutdown timeout for cluster services like executors in milliseconds.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/common_section.html
+++ b/docs/_includes/generated/common_section.html
@@ -3,63 +3,75 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>jobmanager.heap.size</h5></td>
             <td style="word-wrap: break-word;">"1024m"</td>
+            <td>String</td>
             <td>JVM heap size for the JobManager.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.total-flink.size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Total Flink Memory size for the TaskExecutors. This includes all the memory that a TaskExecutor consumes, except for JVM Metaspace and JVM Overhead. It consists of Framework Heap Memory, Task Heap Memory, Task Off-Heap Memory, Managed Memory, and Shuffle Memory.</td>
         </tr>
         <tr>
             <td><h5>parallelism.default</h5></td>
             <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
             <td>Default parallelism for jobs.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.numberOfTaskSlots</h5></td>
             <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
             <td>The number of parallel operator or user function instances that a single TaskManager can run. If this value is larger than 1, a single TaskManager takes multiple instances of a function or operator. That way, the TaskManager can utilize multiple CPU cores, but at the same time, the available memory is divided between the different operator or function instances. This value is typically proportional to the number of physical CPU cores that the TaskManager's machine has (e.g., equal to the number of cores, or half the number of cores).</td>
         </tr>
         <tr>
             <td><h5>state.backend</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The state backend to be used to store and checkpoint state.</td>
         </tr>
         <tr>
             <td><h5>state.checkpoints.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The default directory used for storing the data files and meta data of checkpoints in a Flink supported filesystem. The storage path must be accessible from all participating processes/nodes(i.e. all TaskManagers and JobManagers).</td>
         </tr>
         <tr>
             <td><h5>state.savepoints.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The default directory for savepoints. Used by the state backends that write savepoints to file systems (MemoryStateBackend, FsStateBackend, RocksDBStateBackend).</td>
         </tr>
         <tr>
             <td><h5>high-availability</h5></td>
             <td style="word-wrap: break-word;">"NONE"</td>
+            <td>String</td>
             <td>Defines high-availability mode used for the cluster execution. To enable high-availability, set this mode to "ZOOKEEPER" or specify FQN of factory class.</td>
         </tr>
         <tr>
             <td><h5>high-availability.storageDir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>File system path (URI) where Flink persists metadata in high-availability setups.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.internal.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Turns on SSL for internal network communication. Optionally, specific components may override this through their own settings (rpc, data transport, REST, etc).</td>
         </tr>
         <tr>
             <td><h5>security.ssl.rest.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Turns on SSL for external communication via the REST endpoints.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/core_configuration.html
+++ b/docs/_includes/generated/core_configuration.html
@@ -3,33 +3,39 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>classloader.parent-first-patterns.additional</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>A (semicolon-separated) list of patterns that specifies which classes should always be resolved through the parent ClassLoader first. A pattern is a simple prefix that is checked against the fully qualified class name. These patterns are appended to "classloader.parent-first-patterns.default".</td>
         </tr>
         <tr>
             <td><h5>classloader.parent-first-patterns.default</h5></td>
             <td style="word-wrap: break-word;">"java.;<wbr>scala.;<wbr>org.apache.flink.;<wbr>com.esotericsoftware.kryo;<wbr>org.apache.hadoop.;<wbr>javax.annotation.;<wbr>org.slf4j;<wbr>org.apache.log4j;<wbr>org.apache.logging;<wbr>org.apache.commons.logging;<wbr>ch.qos.logback"</td>
+            <td>String</td>
             <td>A (semicolon-separated) list of patterns that specifies which classes should always be resolved through the parent ClassLoader first. A pattern is a simple prefix that is checked against the fully qualified class name. This setting should generally not be modified. To add another pattern we recommend to use "classloader.parent-first-patterns.additional" instead.</td>
         </tr>
         <tr>
             <td><h5>classloader.resolve-order</h5></td>
             <td style="word-wrap: break-word;">"child-first"</td>
+            <td>String</td>
             <td>Defines the class resolution strategy when loading classes from user code, meaning whether to first check the user code jar ("child-first") or the application classpath ("parent-first"). The default settings indicate to load classes first from the user code jar, which means that user code jars can include and load different dependencies than Flink uses (transitively).</td>
         </tr>
         <tr>
             <td><h5>io.tmp.dirs</h5></td>
             <td style="word-wrap: break-word;">'LOCAL_DIRS' on Yarn. '_FLINK_TMP_DIR' on Mesos. System.getProperty("java.io.tmpdir") in standalone.</td>
+            <td>String</td>
             <td>Directories for temporary files, separated by",", "|", or the system's java.io.File.pathSeparator.</td>
         </tr>
         <tr>
             <td><h5>parallelism.default</h5></td>
             <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
             <td>Default parallelism for jobs.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/deployment_configuration.html
+++ b/docs/_includes/generated/deployment_configuration.html
@@ -3,23 +3,27 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>execution.attached</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Specifies if the pipeline is submitted in attached or detached mode.</td>
         </tr>
         <tr>
             <td><h5>execution.shutdown-on-attached-exit</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>If the job is submitted in attached mode, perform a best-effort cluster shutdown when the CLI is terminated abruptly, e.g., in response to a user interrupt, such as typing Ctrl + C.</td>
         </tr>
         <tr>
             <td><h5>execution.target</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The deployment target for the execution, e.g. "local" for local execution.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/environment_configuration.html
+++ b/docs/_includes/generated/environment_configuration.html
@@ -3,53 +3,63 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>env.hadoop.conf.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Path to hadoop configuration directory. It is required to read HDFS and/or YARN configuration. You can also set it via environment variable.</td>
         </tr>
         <tr>
             <td><h5>env.java.opts</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Java options to start the JVM of all Flink processes with.</td>
         </tr>
         <tr>
             <td><h5>env.java.opts.historyserver</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Java options to start the JVM of the HistoryServer with.</td>
         </tr>
         <tr>
             <td><h5>env.java.opts.jobmanager</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Java options to start the JVM of the JobManager with.</td>
         </tr>
         <tr>
             <td><h5>env.java.opts.taskmanager</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Java options to start the JVM of the TaskManager with.</td>
         </tr>
         <tr>
             <td><h5>env.log.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Defines the directory where the Flink logs are saved. It has to be an absolute path. (Defaults to the log directory under Flink’s home)</td>
         </tr>
         <tr>
             <td><h5>env.log.max</h5></td>
             <td style="word-wrap: break-word;">5</td>
+            <td>Integer</td>
             <td>The maximum number of old log files to keep.</td>
         </tr>
         <tr>
             <td><h5>env.ssh.opts</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Additional command line options passed to SSH clients when starting or stopping JobManager, TaskManager, and Zookeeper services (start-cluster.sh, stop-cluster.sh, start-zookeeper-quorum.sh, stop-zookeeper-quorum.sh).</td>
         </tr>
         <tr>
             <td><h5>env.yarn.conf.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Path to yarn configuration directory. It is required to run flink on YARN. You can also set it via environment variable.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/execution_config_configuration.html
+++ b/docs/_includes/generated/execution_config_configuration.html
@@ -3,23 +3,27 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>table.exec.async-lookup.buffer-capacity</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">100</td>
+            <td>Integer</td>
             <td>The max number of async i/o operation that the async lookup join can trigger.</td>
         </tr>
         <tr>
             <td><h5>table.exec.async-lookup.timeout</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">"3 min"</td>
+            <td>String</td>
             <td>The async timeout for the asynchronous operation to complete.</td>
         </tr>
         <tr>
             <td><h5>table.exec.disabled-operators</h5><br> <span class="label label-primary">Batch</span></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Mainly for testing. A comma-separated list of operator names, each name represents a kind of disabled operator.
 Operators that can be disabled include "NestedLoopJoin", "ShuffleHashJoin", "BroadcastHashJoin", "SortMergeJoin", "HashAgg", "SortAgg".
 By default no operator is disabled.</td>
@@ -27,46 +31,55 @@ By default no operator is disabled.</td>
         <tr>
             <td><h5>table.exec.mini-batch.allow-latency</h5><br> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">"-1 ms"</td>
+            <td>String</td>
             <td>The maximum latency can be used for MiniBatch to buffer input records. MiniBatch is an optimization to buffer input records to reduce state access. MiniBatch is triggered with the allowed latency interval and when the maximum number of buffered records reached. NOTE: If table.exec.mini-batch.enabled is set true, its value must be greater than zero.</td>
         </tr>
         <tr>
             <td><h5>table.exec.mini-batch.enabled</h5><br> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Specifies whether to enable MiniBatch optimization. MiniBatch is an optimization to buffer input records to reduce state access. This is disabled by default. To enable this, users should set this config to true. NOTE: If mini-batch is enabled, 'table.exec.mini-batch.allow-latency' and 'table.exec.mini-batch.size' must be set.</td>
         </tr>
         <tr>
             <td><h5>table.exec.mini-batch.size</h5><br> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">-1</td>
+            <td>Long</td>
             <td>The maximum number of input records can be buffered for MiniBatch. MiniBatch is an optimization to buffer input records to reduce state access. MiniBatch is triggered with the allowed latency interval and when the maximum number of buffered records reached. NOTE: MiniBatch only works for non-windowed aggregations currently. If table.exec.mini-batch.enabled is set true, its value must be positive.</td>
         </tr>
         <tr>
             <td><h5>table.exec.resource.default-parallelism</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">-1</td>
+            <td>Integer</td>
             <td>Sets default parallelism for all operators (such as aggregate, join, filter) to run with parallel instances. This config has a higher priority than parallelism of StreamExecutionEnvironment (actually, this config overrides the parallelism of StreamExecutionEnvironment). A value of -1 indicates that no default parallelism is set, then it will fallback to use the parallelism of StreamExecutionEnvironment.</td>
         </tr>
         <tr>
             <td><h5>table.exec.resource.external-buffer-memory</h5><br> <span class="label label-primary">Batch</span></td>
             <td style="word-wrap: break-word;">"10 mb"</td>
+            <td>String</td>
             <td>Sets the external buffer memory size that is used in sort merge join and nested join and over window.</td>
         </tr>
         <tr>
             <td><h5>table.exec.resource.hash-agg.memory</h5><br> <span class="label label-primary">Batch</span></td>
             <td style="word-wrap: break-word;">"128 mb"</td>
+            <td>String</td>
             <td>Sets the managed memory size of hash aggregate operator.</td>
         </tr>
         <tr>
             <td><h5>table.exec.resource.hash-join.memory</h5><br> <span class="label label-primary">Batch</span></td>
             <td style="word-wrap: break-word;">"128 mb"</td>
+            <td>String</td>
             <td>Sets the managed memory for hash join operator. It defines the lower limit.</td>
         </tr>
         <tr>
             <td><h5>table.exec.resource.sort.memory</h5><br> <span class="label label-primary">Batch</span></td>
             <td style="word-wrap: break-word;">"128 mb"</td>
+            <td>String</td>
             <td>Sets the managed buffer memory size for sort operator.</td>
         </tr>
         <tr>
             <td><h5>table.exec.shuffle-mode</h5><br> <span class="label label-primary">Batch</span></td>
             <td style="word-wrap: break-word;">"batch"</td>
+            <td>String</td>
             <td>Sets exec shuffle mode. Only batch or pipeline can be set.
 batch: the job will run stage by stage. 
 pipeline: the job will run in streaming mode, but it may cause resource deadlock that receiver waits for resource to start when the sender holds resource to wait to send data to the receiver.</td>
@@ -74,36 +87,43 @@ pipeline: the job will run in streaming mode, but it may cause resource deadlock
         <tr>
             <td><h5>table.exec.sort.async-merge-enabled</h5><br> <span class="label label-primary">Batch</span></td>
             <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
             <td>Whether to asynchronously merge sorted spill files.</td>
         </tr>
         <tr>
             <td><h5>table.exec.sort.default-limit</h5><br> <span class="label label-primary">Batch</span></td>
             <td style="word-wrap: break-word;">-1</td>
+            <td>Integer</td>
             <td>Default limit when user don't set a limit after order by. -1 indicates that this configuration is ignored.</td>
         </tr>
         <tr>
             <td><h5>table.exec.sort.max-num-file-handles</h5><br> <span class="label label-primary">Batch</span></td>
             <td style="word-wrap: break-word;">128</td>
+            <td>Integer</td>
             <td>The maximal fan-in for external merge sort. It limits the number of file handles per operator. If it is too small, may cause intermediate merging. But if it is too large, it will cause too many files opened at the same time, consume memory and lead to random reading.</td>
         </tr>
         <tr>
             <td><h5>table.exec.source.idle-timeout</h5><br> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">"-1 ms"</td>
+            <td>String</td>
             <td>When a source do not receive any elements for the timeout time, it will be marked as temporarily idle. This allows downstream tasks to advance their watermarks without the need to wait for watermarks from this source while it is idle.</td>
         </tr>
         <tr>
             <td><h5>table.exec.spill-compression.block-size</h5><br> <span class="label label-primary">Batch</span></td>
             <td style="word-wrap: break-word;">"64 kb"</td>
+            <td>String</td>
             <td>The memory size used to do compress when spilling data. The larger the memory, the higher the compression ratio, but more memory resource will be consumed by the job.</td>
         </tr>
         <tr>
             <td><h5>table.exec.spill-compression.enabled</h5><br> <span class="label label-primary">Batch</span></td>
             <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
             <td>Whether to compress spilled data. Currently we only support compress spilled data for sort and hash-agg and hash-join operators.</td>
         </tr>
         <tr>
             <td><h5>table.exec.window-agg.buffer-size-limit</h5><br> <span class="label label-primary">Batch</span></td>
             <td style="word-wrap: break-word;">100000</td>
+            <td>Integer</td>
             <td>Sets the window elements buffer size limit used in group window agg operator.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/failure_rate_restart_strategy_configuration.html
+++ b/docs/_includes/generated/failure_rate_restart_strategy_configuration.html
@@ -3,23 +3,27 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>restart-strategy.failure-rate.delay</h5></td>
             <td style="word-wrap: break-word;">"1 s"</td>
+            <td>String</td>
             <td>Delay between two consecutive restart attempts if <span markdown="span">`restart-strategy`</span> has been set to <span markdown="span">`failure-rate`</span>. It can be specified using notation: "1 min", "20 s"</td>
         </tr>
         <tr>
             <td><h5>restart-strategy.failure-rate.failure-rate-interval</h5></td>
             <td style="word-wrap: break-word;">"1 min"</td>
+            <td>String</td>
             <td>Time interval for measuring failure rate if <span markdown="span">`restart-strategy`</span> has been set to <span markdown="span">`failure-rate`</span>. It can be specified using notation: "1 min", "20 s"</td>
         </tr>
         <tr>
             <td><h5>restart-strategy.failure-rate.max-failures-per-interval</h5></td>
             <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
             <td>Maximum number of restarts in given time interval before failing a job if <span markdown="span">`restart-strategy`</span> has been set to <span markdown="span">`failure-rate`</span>.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/file_system_configuration.html
+++ b/docs/_includes/generated/file_system_configuration.html
@@ -3,23 +3,27 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>fs.default-scheme</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The default filesystem scheme, used for paths that do not declare a scheme explicitly. May contain an authority, e.g. host:port in case of an HDFS NameNode.</td>
         </tr>
         <tr>
             <td><h5>fs.output.always-create-directory</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>File writers running with a parallelism larger than one create a directory for the output file path and put the different result files (one per parallel writer task) into that directory. If this option is set to "true", writers with a parallelism of 1 will also create a directory and place a single result file into it. If the option is set to "false", the writer will directly create the file directly at the output path, without creating a containing directory.</td>
         </tr>
         <tr>
             <td><h5>fs.overwrite-files</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Specifies whether file output writers should overwrite existing files by default. Set to "true" to overwrite by default,"false" otherwise.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/fixed_delay_restart_strategy_configuration.html
+++ b/docs/_includes/generated/fixed_delay_restart_strategy_configuration.html
@@ -3,18 +3,21 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>restart-strategy.fixed-delay.attempts</h5></td>
             <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
             <td>The number of times that Flink retries the execution before the job is declared as failed if <span markdown="span">`restart-strategy`</span> has been set to <span markdown="span">`fixed-delay`</span>.</td>
         </tr>
         <tr>
             <td><h5>restart-strategy.fixed-delay.delay</h5></td>
             <td style="word-wrap: break-word;">"1 s"</td>
+            <td>String</td>
             <td>Delay between two consecutive restart attempts if <span markdown="span">`restart-strategy`</span> has been set to <span markdown="span">`fixed-delay`</span>. Delaying the retries can be helpful when the program interacts with external systems where for example connections or pending transactions should reach a timeout before re-execution is attempted. It can be specified using notation: "1 min", "20 s"</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/heartbeat_manager_configuration.html
+++ b/docs/_includes/generated/heartbeat_manager_configuration.html
@@ -3,18 +3,21 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>heartbeat.interval</h5></td>
             <td style="word-wrap: break-word;">10000</td>
+            <td>Long</td>
             <td>Time interval for requesting heartbeat from sender side.</td>
         </tr>
         <tr>
             <td><h5>heartbeat.timeout</h5></td>
             <td style="word-wrap: break-word;">50000</td>
+            <td>Long</td>
             <td>Timeout for requesting and receiving heartbeat for both sender and receiver sides.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/high_availability_configuration.html
+++ b/docs/_includes/generated/high_availability_configuration.html
@@ -3,28 +3,33 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>high-availability</h5></td>
             <td style="word-wrap: break-word;">"NONE"</td>
+            <td>String</td>
             <td>Defines high-availability mode used for the cluster execution. To enable high-availability, set this mode to "ZOOKEEPER" or specify FQN of factory class.</td>
         </tr>
         <tr>
             <td><h5>high-availability.cluster-id</h5></td>
             <td style="word-wrap: break-word;">"/default"</td>
+            <td>String</td>
             <td>The ID of the Flink cluster, used to separate multiple Flink clusters from each other. Needs to be set for standalone clusters but is automatically inferred in YARN and Mesos.</td>
         </tr>
         <tr>
             <td><h5>high-availability.jobmanager.port</h5></td>
             <td style="word-wrap: break-word;">"0"</td>
+            <td>String</td>
             <td>Optional port (range) used by the job manager in high-availability mode.</td>
         </tr>
         <tr>
             <td><h5>high-availability.storageDir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>File system path (URI) where Flink persists metadata in high-availability setups.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/high_availability_zookeeper_configuration.html
+++ b/docs/_includes/generated/high_availability_zookeeper_configuration.html
@@ -3,78 +3,93 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>high-availability.zookeeper.client.acl</h5></td>
             <td style="word-wrap: break-word;">"open"</td>
+            <td>String</td>
             <td>Defines the ACL (open|creator) to be configured on ZK node. The configuration value can be set to “creator” if the ZooKeeper server configuration has the “authProvider” property mapped to use SASLAuthenticationProvider and the cluster is configured to run in secure mode (Kerberos).</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.client.connection-timeout</h5></td>
             <td style="word-wrap: break-word;">15000</td>
+            <td>Integer</td>
             <td>Defines the connection timeout for ZooKeeper in ms.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.client.max-retry-attempts</h5></td>
             <td style="word-wrap: break-word;">3</td>
+            <td>Integer</td>
             <td>Defines the number of connection retries before the client gives up.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.client.retry-wait</h5></td>
             <td style="word-wrap: break-word;">5000</td>
+            <td>Integer</td>
             <td>Defines the pause between consecutive retries in ms.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.client.session-timeout</h5></td>
             <td style="word-wrap: break-word;">60000</td>
+            <td>Integer</td>
             <td>Defines the session timeout for the ZooKeeper session in ms.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.path.checkpoint-counter</h5></td>
             <td style="word-wrap: break-word;">"/checkpoint-counter"</td>
+            <td>String</td>
             <td>ZooKeeper root path (ZNode) for checkpoint counters.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.path.checkpoints</h5></td>
             <td style="word-wrap: break-word;">"/checkpoints"</td>
+            <td>String</td>
             <td>ZooKeeper root path (ZNode) for completed checkpoints.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.path.jobgraphs</h5></td>
             <td style="word-wrap: break-word;">"/jobgraphs"</td>
+            <td>String</td>
             <td>ZooKeeper root path (ZNode) for job graphs</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.path.latch</h5></td>
             <td style="word-wrap: break-word;">"/leaderlatch"</td>
+            <td>String</td>
             <td>Defines the znode of the leader latch which is used to elect the leader.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.path.leader</h5></td>
             <td style="word-wrap: break-word;">"/leader"</td>
+            <td>String</td>
             <td>Defines the znode of the leader which contains the URL to the leader and the current leader session ID.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.path.mesos-workers</h5></td>
             <td style="word-wrap: break-word;">"/mesos-workers"</td>
+            <td>String</td>
             <td>The ZooKeeper root path for persisting the Mesos worker information.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.path.root</h5></td>
             <td style="word-wrap: break-word;">"/flink"</td>
+            <td>String</td>
             <td>The root path under which Flink stores its entries in ZooKeeper.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.path.running-registry</h5></td>
             <td style="word-wrap: break-word;">"/running_job_registry/"</td>
+            <td>String</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.quorum</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The ZooKeeper quorum to use, when running Flink in a high-availability mode with ZooKeeper.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/history_server_configuration.html
+++ b/docs/_includes/generated/history_server_configuration.html
@@ -3,48 +3,57 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>historyserver.archive.clean-expired-jobs</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Whether HistoryServer should cleanup jobs that are no longer present `historyserver.archive.fs.dir`.</td>
         </tr>
         <tr>
             <td><h5>historyserver.archive.fs.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Comma separated list of directories to fetch archived jobs from. The history server will monitor these directories for archived jobs. You can configure the JobManager to archive jobs to a directory via `jobmanager.archive.fs.dir`.</td>
         </tr>
         <tr>
             <td><h5>historyserver.archive.fs.refresh-interval</h5></td>
             <td style="word-wrap: break-word;">10000</td>
+            <td>Long</td>
             <td>Interval in milliseconds for refreshing the archived job directories.</td>
         </tr>
         <tr>
             <td><h5>historyserver.web.address</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Address of the HistoryServer's web interface.</td>
         </tr>
         <tr>
             <td><h5>historyserver.web.port</h5></td>
             <td style="word-wrap: break-word;">8082</td>
+            <td>Integer</td>
             <td>Port of the HistoryServers's web interface.</td>
         </tr>
         <tr>
             <td><h5>historyserver.web.refresh-interval</h5></td>
             <td style="word-wrap: break-word;">10000</td>
+            <td>Long</td>
             <td>The refresh interval for the HistoryServer web-frontend in milliseconds.</td>
         </tr>
         <tr>
             <td><h5>historyserver.web.ssl.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Enable HTTPs access to the HistoryServer web frontend. This is applicable only when the global SSL flag security.ssl.enabled is set to true.</td>
         </tr>
         <tr>
             <td><h5>historyserver.web.tmpdir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>This configuration parameter allows defining the Flink web directory to be used by the history server web interface. The web interface will copy its static files into the directory.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/job_manager_configuration.html
+++ b/docs/_includes/generated/job_manager_configuration.html
@@ -3,63 +3,75 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>jobmanager.archive.fs.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Dictionary for JobManager to store the archives of completed jobs.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.execution.attempts-history-size</h5></td>
             <td style="word-wrap: break-word;">16</td>
+            <td>Integer</td>
             <td>The maximum number of prior execution attempts kept in history.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.execution.failover-strategy</h5></td>
             <td style="word-wrap: break-word;">"full"</td>
+            <td>String</td>
             <td>This option specifies how the job computation recovers from task failures. Accepted values are:<ul><li>'full': Restarts all tasks to recover the job.</li><li>'region': Restarts all tasks that could be affected by the task failure. More details can be found <a href="../dev/task_failure_recovery.html#restart-pipelined-region-failover-strategy">here</a>.</li></ul></td>
         </tr>
         <tr>
             <td><h5>jobmanager.heap.size</h5></td>
             <td style="word-wrap: break-word;">"1024m"</td>
+            <td>String</td>
             <td>JVM heap size for the JobManager.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.rpc.address</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The config parameter defining the network address to connect to for communication with the job manager. This value is only interpreted in setups where a single JobManager with static name or address exists (simple standalone setups, or container setups with dynamic service name resolution). It is not used in many high-availability setups, when a leader-election service (like ZooKeeper) is used to elect and discover the JobManager leader from potentially multiple standby JobManagers.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.rpc.port</h5></td>
             <td style="word-wrap: break-word;">6123</td>
+            <td>Integer</td>
             <td>The config parameter defining the network port to connect to for communication with the job manager. Like jobmanager.rpc.address, this value is only interpreted in setups where a single JobManager with static name/address and port exists (simple standalone setups, or container setups with dynamic service name resolution). This config option is not used in many high-availability setups, when a leader-election service (like ZooKeeper) is used to elect and discover the JobManager leader from potentially multiple standby JobManagers.</td>
         </tr>
         <tr>
             <td><h5>jobstore.cache-size</h5></td>
             <td style="word-wrap: break-word;">52428800</td>
+            <td>Long</td>
             <td>The job store cache size in bytes which is used to keep completed jobs in memory.</td>
         </tr>
         <tr>
             <td><h5>jobstore.expiration-time</h5></td>
             <td style="word-wrap: break-word;">3600</td>
+            <td>Long</td>
             <td>The time in seconds after which a completed job expires and is purged from the job store.</td>
         </tr>
         <tr>
             <td><h5>jobstore.max-capacity</h5></td>
             <td style="word-wrap: break-word;">2147483647</td>
+            <td>Integer</td>
             <td>The max number of completed jobs that can be kept in the job store.</td>
         </tr>
         <tr>
             <td><h5>slot.idle.timeout</h5></td>
             <td style="word-wrap: break-word;">50000</td>
+            <td>Long</td>
             <td>The timeout in milliseconds for a idle slot in Slot Pool.</td>
         </tr>
         <tr>
             <td><h5>slot.request.timeout</h5></td>
             <td style="word-wrap: break-word;">300000</td>
+            <td>Long</td>
             <td>The timeout in milliseconds for requesting a slot from Slot Pool.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/kerberos_configuration.html
+++ b/docs/_includes/generated/kerberos_configuration.html
@@ -3,28 +3,33 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>security.kerberos.login.contexts</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>A comma-separated list of login contexts to provide the Kerberos credentials to (for example, `Client,KafkaClient` to use the credentials for ZooKeeper authentication and for Kafka authentication)</td>
         </tr>
         <tr>
             <td><h5>security.kerberos.login.keytab</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Absolute path to a Kerberos keytab file that contains the user credentials.</td>
         </tr>
         <tr>
             <td><h5>security.kerberos.login.principal</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Kerberos principal name associated with the keytab.</td>
         </tr>
         <tr>
             <td><h5>security.kerberos.login.use-ticket-cache</h5></td>
             <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
             <td>Indicates whether to read from your Kerberos ticket cache.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/mesos_configuration.html
+++ b/docs/_includes/generated/mesos_configuration.html
@@ -3,68 +3,81 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>mesos.failover-timeout</h5></td>
             <td style="word-wrap: break-word;">604800</td>
+            <td>Integer</td>
             <td>The failover timeout in seconds for the Mesos scheduler, after which running tasks are automatically shut down.</td>
         </tr>
         <tr>
             <td><h5>mesos.master</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The Mesos master URL. The value should be in one of the following forms: <ul><li>host:port</li><li>zk://host1:port1,host2:port2,.../path</li><li>zk://username:password@host1:port1,host2:port2,.../path</li><li>file:///path/to/file</li></ul></td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.artifactserver.port</h5></td>
             <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
             <td>The config parameter defining the Mesos artifact server port to use. Setting the port to 0 will let the OS choose an available port.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.artifactserver.ssl.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
             <td>Enables SSL for the Flink artifact server. Note that security.ssl.enabled also needs to be set to true encryption to enable encryption.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.declined-offer-refuse-duration</h5></td>
             <td style="word-wrap: break-word;">5000</td>
+            <td>Long</td>
             <td>Amount of time to ask the Mesos master to not resend a declined resource offer again. This ensures a declined resource offer isn't resent immediately after being declined</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.framework.name</h5></td>
             <td style="word-wrap: break-word;">"Flink"</td>
+            <td>String</td>
             <td>Mesos framework name</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.framework.principal</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Mesos framework principal</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.framework.role</h5></td>
             <td style="word-wrap: break-word;">"*"</td>
+            <td>String</td>
             <td>Mesos framework role definition</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.framework.secret</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Mesos framework secret</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.framework.user</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Mesos framework user</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.port-assignments</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Comma-separated list of configuration keys which represent a configurable port. All port keys will dynamically get a port assigned through Mesos.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.unused-offer-expiration</h5></td>
             <td style="word-wrap: break-word;">120000</td>
+            <td>Long</td>
             <td>Amount of time to wait for unused expired offers before declining them. This ensures your scheduler will not hoard unuseful offers.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/mesos_task_manager_configuration.html
+++ b/docs/_includes/generated/mesos_task_manager_configuration.html
@@ -3,83 +3,99 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>mesos.constraints.hard.hostattribute</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Constraints for task placement on Mesos based on agent attributes. Takes a comma-separated list of key:value pairs corresponding to the attributes exposed by the target mesos agents. Example: az:eu-west-1a,series:t2</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.bootstrap-cmd</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>A command which is executed before the TaskManager is started.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.container.docker.force-pull-image</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Instruct the docker containerizer to forcefully pull the image rather than reuse a cached version.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.container.docker.parameters</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Custom parameters to be passed into docker run command when using the docker containerizer. Comma separated list of "key=value" pairs. The "value" may contain '='.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.container.image.name</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Image name to use for the container.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.container.type</h5></td>
             <td style="word-wrap: break-word;">"mesos"</td>
+            <td>String</td>
             <td>Type of the containerization used: “mesos” or “docker”.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.container.volumes</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>A comma separated list of [host_path:]container_path[:RO|RW]. This allows for mounting additional volumes into your container.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.cpus</h5></td>
             <td style="word-wrap: break-word;">0.0</td>
+            <td>Double</td>
             <td>CPUs to assign to the Mesos workers.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.disk</h5></td>
             <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
             <td>Disk space to assign to the Mesos workers in MB.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.gpus</h5></td>
             <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
             <td>GPUs to assign to the Mesos workers.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.hostname</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Optional value to define the TaskManager’s hostname. The pattern _TASK_ is replaced by the actual id of the Mesos task. This can be used to configure the TaskManager to use Mesos DNS (e.g. _TASK_.flink-service.mesos) for name lookups.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.mem</h5></td>
             <td style="word-wrap: break-word;">1024</td>
+            <td>Integer</td>
             <td>Memory to assign to the Mesos workers in MB.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.taskmanager-cmd</h5></td>
             <td style="word-wrap: break-word;">"$FLINK_HOME/bin/mesos-taskmanager.sh"</td>
+            <td>String</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.uris</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>A comma separated list of URIs of custom artifacts to be downloaded into the sandbox of Mesos workers.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.numberOfTaskSlots</h5></td>
             <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
             <td>The number of parallel operator or user function instances that a single TaskManager can run. If this value is larger than 1, a single TaskManager takes multiple instances of a function or operator. That way, the TaskManager can utilize multiple CPU cores, but at the same time, the available memory is divided between the different operator or function instances. This value is typically proportional to the number of physical CPU cores that the TaskManager's machine has (e.g., equal to the number of cores, or half the number of cores).</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/metric_configuration.html
+++ b/docs/_includes/generated/metric_configuration.html
@@ -3,103 +3,123 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>metrics.fetcher.update-interval</h5></td>
             <td style="word-wrap: break-word;">10000</td>
+            <td>Long</td>
             <td>Update interval for the metric fetcher used by the web UI in milliseconds. Decrease this value for faster updating metrics. Increase this value if the metric fetcher causes too much load. Setting this value to 0 disables the metric fetching completely.</td>
         </tr>
         <tr>
             <td><h5>metrics.internal.query-service.port</h5></td>
             <td style="word-wrap: break-word;">"0"</td>
+            <td>String</td>
             <td>The port range used for Flink's internal metric query service. Accepts a list of ports (“50100,50101”), ranges(“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple Flink components are running on the same machine. Per default Flink will pick a random port.</td>
         </tr>
         <tr>
             <td><h5>metrics.internal.query-service.thread-priority</h5></td>
             <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
             <td>The thread priority used for Flink's internal metric query service. The thread is created by Akka's thread pool executor. The range of the priority is from 1 (MIN_PRIORITY) to 10 (MAX_PRIORITY). Warning, increasing this value may bring the main Flink components down.</td>
         </tr>
         <tr>
             <td><h5>metrics.latency.granularity</h5></td>
             <td style="word-wrap: break-word;">"operator"</td>
+            <td>String</td>
             <td>Defines the granularity of latency metrics. Accepted values are:<ul><li>single - Track latency without differentiating between sources and subtasks.</li><li>operator - Track latency while differentiating between sources, but not subtasks.</li><li>subtask - Track latency while differentiating between sources and subtasks.</li></ul></td>
         </tr>
         <tr>
             <td><h5>metrics.latency.history-size</h5></td>
             <td style="word-wrap: break-word;">128</td>
+            <td>Integer</td>
             <td>Defines the number of measured latencies to maintain at each operator.</td>
         </tr>
         <tr>
             <td><h5>metrics.latency.interval</h5></td>
             <td style="word-wrap: break-word;">0</td>
+            <td>Long</td>
             <td>Defines the interval at which latency tracking marks are emitted from the sources. Disables latency tracking if set to 0 or a negative value. Enabling this feature can significantly impact the performance of the cluster.</td>
         </tr>
         <tr>
             <td><h5>metrics.reporter.&lt;name&gt;.&lt;parameter&gt;</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Configures the parameter &lt;parameter&gt; for the reporter named &lt;name&gt;.</td>
         </tr>
         <tr>
             <td><h5>metrics.reporter.&lt;name&gt;.class</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The reporter class to use for the reporter named &lt;name&gt;.</td>
         </tr>
         <tr>
             <td><h5>metrics.reporter.&lt;name&gt;.interval</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The reporter interval to use for the reporter named &lt;name&gt;.</td>
         </tr>
         <tr>
             <td><h5>metrics.reporters</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>An optional list of reporter names. If configured, only reporters whose name matches any of the names in the list will be started. Otherwise, all reporters that could be found in the configuration will be started.</td>
         </tr>
         <tr>
             <td><h5>metrics.scope.delimiter</h5></td>
             <td style="word-wrap: break-word;">"."</td>
+            <td>String</td>
             <td>Delimiter used to assemble the metric identifier.</td>
         </tr>
         <tr>
             <td><h5>metrics.scope.jm</h5></td>
             <td style="word-wrap: break-word;">"&lt;host&gt;.jobmanager"</td>
+            <td>String</td>
             <td>Defines the scope format string that is applied to all metrics scoped to a JobManager.</td>
         </tr>
         <tr>
             <td><h5>metrics.scope.jm.job</h5></td>
             <td style="word-wrap: break-word;">"&lt;host&gt;.jobmanager.&lt;job_name&gt;"</td>
+            <td>String</td>
             <td>Defines the scope format string that is applied to all metrics scoped to a job on a JobManager.</td>
         </tr>
         <tr>
             <td><h5>metrics.scope.operator</h5></td>
             <td style="word-wrap: break-word;">"&lt;host&gt;.taskmanager.&lt;tm_id&gt;.&lt;job_name&gt;.&lt;operator_name&gt;.&lt;subtask_index&gt;"</td>
+            <td>String</td>
             <td>Defines the scope format string that is applied to all metrics scoped to an operator.</td>
         </tr>
         <tr>
             <td><h5>metrics.scope.task</h5></td>
             <td style="word-wrap: break-word;">"&lt;host&gt;.taskmanager.&lt;tm_id&gt;.&lt;job_name&gt;.&lt;task_name&gt;.&lt;subtask_index&gt;"</td>
+            <td>String</td>
             <td>Defines the scope format string that is applied to all metrics scoped to a task.</td>
         </tr>
         <tr>
             <td><h5>metrics.scope.tm</h5></td>
             <td style="word-wrap: break-word;">"&lt;host&gt;.taskmanager.&lt;tm_id&gt;"</td>
+            <td>String</td>
             <td>Defines the scope format string that is applied to all metrics scoped to a TaskManager.</td>
         </tr>
         <tr>
             <td><h5>metrics.scope.tm.job</h5></td>
             <td style="word-wrap: break-word;">"&lt;host&gt;.taskmanager.&lt;tm_id&gt;.&lt;job_name&gt;"</td>
+            <td>String</td>
             <td>Defines the scope format string that is applied to all metrics scoped to a job on a TaskManager.</td>
         </tr>
         <tr>
             <td><h5>metrics.system-resource</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Flag indicating whether Flink should report system resource metrics such as machine's CPU, memory or network usage.</td>
         </tr>
         <tr>
             <td><h5>metrics.system-resource-probing-interval</h5></td>
             <td style="word-wrap: break-word;">5000</td>
+            <td>Long</td>
             <td>Interval between probing of system resource metrics specified in milliseconds. Has an effect only when 'metrics.system-resource' is enabled.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/_includes/generated/netty_shuffle_environment_configuration.html
@@ -3,43 +3,51 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>taskmanager.data.port</h5></td>
             <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
             <td>The task manager’s port used for data exchange operations.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.data.ssl.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
             <td>Enable SSL support for the taskmanager data transport. This is applicable only when the global flag for internal SSL (security.ssl.internal.enabled) is set to true</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.detailed-metrics</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Boolean flag to enable/disable more detailed metrics about inbound/outbound network queue lengths.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.memory.buffers-per-channel</h5></td>
             <td style="word-wrap: break-word;">2</td>
+            <td>Integer</td>
             <td>Maximum number of network buffers to use for each outgoing/incoming channel (subpartition/input channel).In credit-based flow control mode, this indicates how many credits are exclusive in each input channel. It should be configured at least 2 for good performance. 1 buffer is for receiving in-flight data in the subpartition and 1 buffer is for parallel serialization.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.memory.floating-buffers-per-gate</h5></td>
             <td style="word-wrap: break-word;">8</td>
+            <td>Integer</td>
             <td>Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate). In credit-based flow control mode, this indicates how many floating credits are shared among all the input channels. The floating buffers are distributed based on backlog (real-time output buffers in the subpartition) feedback, and can help relieve back-pressure caused by unbalanced data distribution among the subpartitions. This value should be increased in case of higher round trip times between nodes and/or larger number of machines in the cluster.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.request-backoff.initial</h5></td>
             <td style="word-wrap: break-word;">100</td>
+            <td>Integer</td>
             <td>Minimum backoff in milliseconds for partition requests of input channels.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.request-backoff.max</h5></td>
             <td style="word-wrap: break-word;">10000</td>
+            <td>Integer</td>
             <td>Maximum backoff in milliseconds for partition requests of input channels.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/network_netty_configuration.html
+++ b/docs/_includes/generated/network_netty_configuration.html
@@ -3,43 +3,51 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>taskmanager.network.netty.client.connectTimeoutSec</h5></td>
             <td style="word-wrap: break-word;">120</td>
+            <td>Integer</td>
             <td>The Netty client connection timeout.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.netty.client.numThreads</h5></td>
             <td style="word-wrap: break-word;">-1</td>
+            <td>Integer</td>
             <td>The number of Netty client threads.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.netty.num-arenas</h5></td>
             <td style="word-wrap: break-word;">-1</td>
+            <td>Integer</td>
             <td>The number of Netty arenas.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.netty.sendReceiveBufferSize</h5></td>
             <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
             <td>The Netty send and receive buffer size. This defaults to the system buffer size (cat /proc/sys/net/ipv4/tcp_[rw]mem) and is 4 MiB in modern Linux.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.netty.server.backlog</h5></td>
             <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
             <td>The netty server connection backlog.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.netty.server.numThreads</h5></td>
             <td style="word-wrap: break-word;">-1</td>
+            <td>Integer</td>
             <td>The number of Netty server threads.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.netty.transport</h5></td>
             <td style="word-wrap: break-word;">"nio"</td>
+            <td>String</td>
             <td>The Netty transport type, either "nio" or "epoll"</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/optimizer_config_configuration.html
+++ b/docs/_includes/generated/optimizer_config_configuration.html
@@ -3,13 +3,15 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>table.optimizer.agg-phase-strategy</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">"AUTO"</td>
+            <td>String</td>
             <td>Strategy for aggregate phase. Only AUTO, TWO_PHASE or ONE_PHASE can be set.
 AUTO: No special enforcer for aggregate stage. Whether to choose two stage aggregate or one stage aggregate depends on cost. 
 TWO_PHASE: Enforce to use two stage aggregate which has localAggregate and globalAggregate. Note that if aggregate call does not support optimize into two phase, we will still use one stage aggregate.
@@ -18,36 +20,43 @@ ONE_PHASE: Enforce to use one stage aggregate which only has CompleteGlobalAggre
         <tr>
             <td><h5>table.optimizer.distinct-agg.split.bucket-num</h5><br> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">1024</td>
+            <td>Integer</td>
             <td>Configure the number of buckets when splitting distinct aggregation. The number is used in the first level aggregation to calculate a bucket key 'hash_code(distinct_key) % BUCKET_NUM' which is used as an additional group key after splitting.</td>
         </tr>
         <tr>
             <td><h5>table.optimizer.distinct-agg.split.enabled</h5><br> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Tells the optimizer whether to split distinct aggregation (e.g. COUNT(DISTINCT col), SUM(DISTINCT col)) into two level. The first aggregation is shuffled by an additional key which is calculated using the hashcode of distinct_key and number of buckets. This optimization is very useful when there is data skew in distinct aggregation and gives the ability to scale-up the job. Default is false.</td>
         </tr>
         <tr>
             <td><h5>table.optimizer.join-reorder-enabled</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Enables join reorder in optimizer. Default is disabled.</td>
         </tr>
         <tr>
             <td><h5>table.optimizer.join.broadcast-threshold</h5><br> <span class="label label-primary">Batch</span></td>
             <td style="word-wrap: break-word;">1048576</td>
+            <td>Long</td>
             <td>Configures the maximum size in bytes for a table that will be broadcast to all worker nodes when performing a join. By setting this value to -1 to disable broadcasting.</td>
         </tr>
         <tr>
             <td><h5>table.optimizer.reuse-source-enabled</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
             <td>When it is true, the optimizer will try to find out duplicated table sources and reuse them. This works only when table.optimizer.reuse-sub-plan-enabled is true.</td>
         </tr>
         <tr>
             <td><h5>table.optimizer.reuse-sub-plan-enabled</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
             <td>When it is true, the optimizer will try to find out duplicated sub-plans and reuse them.</td>
         </tr>
         <tr>
             <td><h5>table.optimizer.source.predicate-pushdown-enabled</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
             <td>When it is true, the optimizer will push down predicates into the FilterableTableSource. Default value is true.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/optimizer_configuration.html
+++ b/docs/_includes/generated/optimizer_configuration.html
@@ -3,23 +3,27 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>compiler.delimited-informat.max-line-samples</h5></td>
             <td style="word-wrap: break-word;">10</td>
+            <td>Integer</td>
             <td>he maximum number of line samples taken by the compiler for delimited inputs. The samples are used to estimate the number of records. This value can be overridden for a specific input with the input format’s parameters.</td>
         </tr>
         <tr>
             <td><h5>compiler.delimited-informat.max-sample-len</h5></td>
             <td style="word-wrap: break-word;">2097152</td>
+            <td>Integer</td>
             <td>The maximal length of a line sample that the compiler takes for delimited inputs. If the length of a single sample exceeds this value (possible because of misconfiguration of the parser), the sampling aborts. This value can be overridden for a specific input with the input format’s parameters.</td>
         </tr>
         <tr>
             <td><h5>compiler.delimited-informat.min-line-samples</h5></td>
             <td style="word-wrap: break-word;">2</td>
+            <td>Integer</td>
             <td>The minimum number of line samples taken by the compiler for delimited inputs. The samples are used to estimate the number of records. This value can be overridden for a specific input with the input format’s parameters</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/pipeline_configuration.html
+++ b/docs/_includes/generated/pipeline_configuration.html
@@ -3,18 +3,21 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>pipeline.classpaths</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>List&lt;String&gt;</td>
             <td>A semicolon-separated list of the classpaths to package with the job jars to be sent to the cluster. These have to be valid URLs.</td>
         </tr>
         <tr>
             <td><h5>pipeline.jars</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>List&lt;String&gt;</td>
             <td>A semicolon-separated list of the jars to package with the job jars to be sent to the cluster. These have to be valid paths.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/prometheus_push_gateway_reporter_configuration.html
+++ b/docs/_includes/generated/prometheus_push_gateway_reporter_configuration.html
@@ -3,43 +3,51 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>deleteOnShutdown</h5></td>
             <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
             <td>Specifies whether to delete metrics from the PushGateway on shutdown.</td>
         </tr>
         <tr>
             <td><h5>filterLabelValueCharacters</h5></td>
             <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
             <td>Specifies whether to filter label value characters. If enabled, all characters not matching [a-zA-Z0-9:_] will be removed, otherwise no characters will be removed. Before disabling this option please ensure that your label values meet the <a href="https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels">Prometheus requirements</a>.</td>
         </tr>
         <tr>
             <td><h5>groupingKey</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Specifies the grouping key which is the group and global labels of all metrics. The label name and value are separated by '=', and labels are separated by ';', e.g., <span markdown="span">`k1=v1;k2=v2`</span>. Please ensure that your grouping key meets the <a href="https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels">Prometheus requirements</a>.</td>
         </tr>
         <tr>
             <td><h5>host</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The PushGateway server host.</td>
         </tr>
         <tr>
             <td><h5>jobName</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The job name under which metrics will be pushed</td>
         </tr>
         <tr>
             <td><h5>port</h5></td>
             <td style="word-wrap: break-word;">-1</td>
+            <td>Integer</td>
             <td>The PushGateway server port.</td>
         </tr>
         <tr>
             <td><h5>randomJobNameSuffix</h5></td>
             <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
             <td>Specifies whether a random suffix should be appended to the job name.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/python_configuration.html
+++ b/docs/_includes/generated/python_configuration.html
@@ -3,18 +3,21 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>python.fn-execution.bundle.size</h5></td>
             <td style="word-wrap: break-word;">1000</td>
+            <td>Integer</td>
             <td>The maximum number of elements to include in a bundle for Python user-defined function execution. The elements are processed asynchronously. One bundle of elements are processed before processing the next bundle of elements. A larger value can improve the throughput, but at the cost of more memory usage and higher latency.</td>
         </tr>
         <tr>
             <td><h5>python.fn-execution.bundle.time</h5></td>
             <td style="word-wrap: break-word;">1000</td>
+            <td>Long</td>
             <td>Sets the waiting timeout(in milliseconds) before processing a bundle for Python user-defined function execution. The timeout defines how long the elements of a bundle will be buffered before being processed. Lower timeouts lead to lower tail latencies, but may affect throughput.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/queryable_state_configuration.html
+++ b/docs/_includes/generated/queryable_state_configuration.html
@@ -3,48 +3,57 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>queryable-state.client.network-threads</h5></td>
             <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
             <td>Number of network (Netty's event loop) Threads for queryable state client.</td>
         </tr>
         <tr>
             <td><h5>queryable-state.enable</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Option whether the queryable state proxy and server should be enabled where possible and configurable.</td>
         </tr>
         <tr>
             <td><h5>queryable-state.proxy.network-threads</h5></td>
             <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
             <td>Number of network (Netty's event loop) Threads for queryable state proxy.</td>
         </tr>
         <tr>
             <td><h5>queryable-state.proxy.ports</h5></td>
             <td style="word-wrap: break-word;">"9069"</td>
+            <td>String</td>
             <td>The port range of the queryable state proxy. The specified range can be a single port: "9123", a range of ports: "50100-50200", or a list of ranges and ports: "50100-50200,50300-50400,51234".</td>
         </tr>
         <tr>
             <td><h5>queryable-state.proxy.query-threads</h5></td>
             <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
             <td>Number of query Threads for queryable state proxy. Uses the number of slots if set to 0.</td>
         </tr>
         <tr>
             <td><h5>queryable-state.server.network-threads</h5></td>
             <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
             <td>Number of network (Netty's event loop) Threads for queryable state server.</td>
         </tr>
         <tr>
             <td><h5>queryable-state.server.ports</h5></td>
             <td style="word-wrap: break-word;">"9067"</td>
+            <td>String</td>
             <td>The port range of the queryable state server. The specified range can be a single port: "9123", a range of ports: "50100-50200", or a list of ranges and ports: "50100-50200,50300-50400,51234".</td>
         </tr>
         <tr>
             <td><h5>queryable-state.server.query-threads</h5></td>
             <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
             <td>Number of query Threads for queryable state server. Uses the number of slots if set to 0.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/resource_manager_configuration.html
+++ b/docs/_includes/generated/resource_manager_configuration.html
@@ -3,43 +3,51 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>containerized.heap-cutoff-min</h5></td>
             <td style="word-wrap: break-word;">600</td>
+            <td>Integer</td>
             <td>Minimum amount of heap memory to remove in containers, as a safety margin.</td>
         </tr>
         <tr>
             <td><h5>containerized.heap-cutoff-ratio</h5></td>
             <td style="word-wrap: break-word;">0.25</td>
+            <td>Float</td>
             <td>Percentage of heap space to remove from containers (YARN / Mesos), to compensate for other JVM memory usage.</td>
         </tr>
         <tr>
             <td><h5>local.number-resourcemanager</h5></td>
             <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
             <td>The number of resource managers start.</td>
         </tr>
         <tr>
             <td><h5>resourcemanager.job.timeout</h5></td>
             <td style="word-wrap: break-word;">"5 minutes"</td>
+            <td>String</td>
             <td>Timeout for jobs which don't have a job manager as leader assigned.</td>
         </tr>
         <tr>
             <td><h5>resourcemanager.rpc.port</h5></td>
             <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
             <td>Defines the network port to connect to for communication with the resource manager. By default, the port of the JobManager, because the same ActorSystem is used. Its not possible to use this configuration key to define port ranges.</td>
         </tr>
         <tr>
             <td><h5>resourcemanager.standalone.start-up-time</h5></td>
             <td style="word-wrap: break-word;">-1</td>
+            <td>Long</td>
             <td>Time in milliseconds of the start-up period of a standalone cluster. During this time, resource manager of the standalone cluster expects new task executors to be registered, and will not fail slot requests that can not be satisfied by any current registered slots. After this time, it will fail pending and new coming requests immediately that can not be satisfied by registered slots. If not set, 'slotmanager.request-timeout' will be used by default.</td>
         </tr>
         <tr>
             <td><h5>resourcemanager.taskmanager-timeout</h5></td>
             <td style="word-wrap: break-word;">30000</td>
+            <td>Long</td>
             <td>The timeout for an idle task manager to be released.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/rest_configuration.html
+++ b/docs/_includes/generated/rest_configuration.html
@@ -3,73 +3,87 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>rest.address</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The address that should be used by clients to connect to the server.</td>
         </tr>
         <tr>
             <td><h5>rest.await-leader-timeout</h5></td>
             <td style="word-wrap: break-word;">30000</td>
+            <td>Long</td>
             <td>The time in ms that the client waits for the leader address, e.g., Dispatcher or WebMonitorEndpoint</td>
         </tr>
         <tr>
             <td><h5>rest.bind-address</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The address that the server binds itself.</td>
         </tr>
         <tr>
             <td><h5>rest.bind-port</h5></td>
             <td style="word-wrap: break-word;">"8081"</td>
+            <td>String</td>
             <td>The port that the server binds itself. Accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple Rest servers are running on the same machine.</td>
         </tr>
         <tr>
             <td><h5>rest.client.max-content-length</h5></td>
             <td style="word-wrap: break-word;">104857600</td>
+            <td>Integer</td>
             <td>The maximum content length in bytes that the client will handle.</td>
         </tr>
         <tr>
             <td><h5>rest.connection-timeout</h5></td>
             <td style="word-wrap: break-word;">15000</td>
+            <td>Long</td>
             <td>The maximum time in ms for the client to establish a TCP connection.</td>
         </tr>
         <tr>
             <td><h5>rest.idleness-timeout</h5></td>
             <td style="word-wrap: break-word;">300000</td>
+            <td>Long</td>
             <td>The maximum time in ms for a connection to stay idle before failing.</td>
         </tr>
         <tr>
             <td><h5>rest.port</h5></td>
             <td style="word-wrap: break-word;">8081</td>
+            <td>Integer</td>
             <td>The port that the client connects to. If rest.bind-port has not been specified, then the REST server will bind to this port.</td>
         </tr>
         <tr>
             <td><h5>rest.retry.delay</h5></td>
             <td style="word-wrap: break-word;">3000</td>
+            <td>Long</td>
             <td>The time in ms that the client waits between retries (See also `rest.retry.max-attempts`).</td>
         </tr>
         <tr>
             <td><h5>rest.retry.max-attempts</h5></td>
             <td style="word-wrap: break-word;">20</td>
+            <td>Integer</td>
             <td>The number of retries the client will attempt if a retryable operations fails.</td>
         </tr>
         <tr>
             <td><h5>rest.server.max-content-length</h5></td>
             <td style="word-wrap: break-word;">104857600</td>
+            <td>Integer</td>
             <td>The maximum content length in bytes that the server will handle.</td>
         </tr>
         <tr>
             <td><h5>rest.server.numThreads</h5></td>
             <td style="word-wrap: break-word;">4</td>
+            <td>Integer</td>
             <td>The number of threads for the asynchronous processing of requests.</td>
         </tr>
         <tr>
             <td><h5>rest.server.thread-priority</h5></td>
             <td style="word-wrap: break-word;">5</td>
+            <td>Integer</td>
             <td>Thread priority of the REST server's executor for processing asynchronous requests. Lowering the thread priority will give Flink's main components more CPU time whereas increasing will allocate more time for the REST server's processing.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/restart_strategy_configuration.html
+++ b/docs/_includes/generated/restart_strategy_configuration.html
@@ -3,13 +3,15 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>restart-strategy</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Defines the restart strategy to use in case of job failures.<br />Accepted values are:<ul><li><span markdown="span">`none`</span>, <span markdown="span">`off`</span>, <span markdown="span">`disable`</span>: No restart strategy.</li><li><span markdown="span">`fixeddelay`</span>, <span markdown="span">`fixed-delay`</span>: Fixed delay restart strategy. More details can be found <a href="../dev/task_failure_recovery.html#fixed-delay-restart-strategy">here</a>.</li><li><span markdown="span">`failurerate`</span>, <span markdown="span">`failure-rate`</span>: Failure rate restart strategy. More details can be found <a href="../dev/task_failure_recovery.html#failure-rate-restart-strategy">here</a>.</li></ul>If checkpointing is disabled, the default value is <span markdown="span">`none`</span>. If checkpointing is enabled, the default value is <span markdown="span">`fixed-delay`</span> with <span markdown="span">`Integer.MAX_VALUE`</span> restart attempts and '<span markdown="span">`1 s`</span>' delay.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/rocks_db_configurable_configuration.html
+++ b/docs/_includes/generated/rocks_db_configurable_configuration.html
@@ -3,63 +3,75 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>state.backend.rocksdb.block.blocksize</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The approximate size (in bytes) of user data packed per block. RocksDB has default blocksize as '4KB'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.block.cache-size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The amount of the cache for data blocks in RocksDB. RocksDB has default block-cache size as '8MB'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.compaction.level.max-size-level-base</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The upper-bound of the total size of level base files in bytes. RocksDB has default configuration as '10MB'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.compaction.level.target-file-size-base</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The target file size for compaction, which determines a level-1 file size. RocksDB has default configuration as '2MB'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.compaction.level.use-dynamic-size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>If true, RocksDB will pick target size of each level dynamically. From an empty DB, RocksDB would make last level the base level, which means merging L0 data into the last level, until it exceeds max_bytes_for_level_base. And then repeat this process for second last level and so on. RocksDB has default configuration as 'false'. For more information, please refer to <a href="https://github.com/facebook/rocksdb/wiki/Leveled-Compaction#level_compaction_dynamic_level_bytes-is-true">RocksDB's doc.</a></td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.compaction.style</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The specified compaction style for DB. Candidate compaction style is LEVEL, FIFO or UNIVERSAL, and RocksDB choose 'LEVEL' as default style.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.files.open</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The maximum number of open files (per TaskManager) that can be used by the DB, '-1' means no limit. RocksDB has default configuration as '5000'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.thread.num</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The maximum number of concurrent background flush and compaction jobs (per TaskManager). RocksDB has default configuration as '1'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.writebuffer.count</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Tne maximum number of write buffers that are built up in memory. RocksDB has default configuration as '2'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.writebuffer.number-to-merge</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The minimum number of write buffers that will be merged together before writing to storage. RocksDB has default configuration as '1'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.writebuffer.size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The amount of data built up in memory (backed by an unsorted log on disk) before converting to a sorted on-disk files. RocksDB has default writebuffer size as '4MB'.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/rocks_db_configuration.html
+++ b/docs/_includes/generated/rocks_db_configuration.html
@@ -3,38 +3,45 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>state.backend.rocksdb.checkpoint.transfer.thread.num</h5></td>
             <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
             <td>The number of threads (per stateful operator) used to transfer (download and upload) files in RocksDBStateBackend.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.localdir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The local directory (on the TaskManager) where RocksDB puts its files.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.options-factory</h5></td>
             <td style="word-wrap: break-word;">"org.apache.flink.contrib.streaming.state.DefaultConfigurableOptionsFactory"</td>
+            <td>String</td>
             <td>The options factory class for RocksDB to create DBOptions and ColumnFamilyOptions. The default options factory is org.apache.flink.contrib.streaming.state.DefaultConfigurableOptionsFactory, and it would read the configured options which provided in 'RocksDBConfigurableOptions'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.predefined-options</h5></td>
             <td style="word-wrap: break-word;">"DEFAULT"</td>
+            <td>String</td>
             <td>The predefined settings for RocksDB DBOptions and ColumnFamilyOptions by Flink community. Current supported candidate predefined-options are DEFAULT, SPINNING_DISK_OPTIMIZED, SPINNING_DISK_OPTIMIZED_HIGH_MEM or FLASH_SSD_OPTIMIZED. Note that user customized options and options from the OptionsFactory are applied on top of these predefined ones.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.timer-service.factory</h5></td>
             <td style="word-wrap: break-word;">"HEAP"</td>
+            <td>String</td>
             <td>This determines the factory for timer service state implementation. Options are either HEAP (heap-based, default) or ROCKSDB for an implementation based on RocksDB .</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.ttl.compaction.filter.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>This determines if compaction filter to cleanup state with TTL is enabled for backend.Note: User can still decide in state TTL configuration in state descriptor whether the filter is active for particular state or not.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/rocks_db_native_metric_configuration.html
+++ b/docs/_includes/generated/rocks_db_native_metric_configuration.html
@@ -3,118 +3,141 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.actual-delayed-write-rate</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Monitor the current actual delayed write rate. 0 means no delay.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.background-errors</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Monitor the number of background errors in RocksDB.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.column-family-as-variable</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Whether to expose the column family as a variable.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.compaction-pending</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Track pending compactions in RocksDB. Returns 1 if a compaction is pending, 0 otherwise.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.cur-size-active-mem-table</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Monitor the approximate size of the active memtable in bytes.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.cur-size-all-mem-tables</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Monitor the approximate size of the active and unflushed immutable memtables in bytes.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.estimate-live-data-size</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Estimate of the amount of live data in bytes.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.estimate-num-keys</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Estimate the number of keys in RocksDB.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.estimate-pending-compaction-bytes</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Estimated total number of bytes compaction needs to rewrite to get all levels down to under target size. Not valid for other compactions than level-based.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.estimate-table-readers-mem</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Estimate the memory used for reading SST tables, excluding memory used in block cache (e.g.,filter and index blocks) in bytes.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.mem-table-flush-pending</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Monitor the number of pending memtable flushes in RocksDB.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.num-deletes-active-mem-table</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Monitor the total number of delete entries in the active memtable.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.num-deletes-imm-mem-tables</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Monitor the total number of delete entries in the unflushed immutable memtables.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.num-entries-active-mem-table</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Monitor the total number of entries in the active memtable.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.num-entries-imm-mem-tables</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Monitor the total number of entries in the unflushed immutable memtables.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.num-immutable-mem-table</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Monitor the number of immutable memtables in RocksDB.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.num-live-versions</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Monitor number of live versions. Version is an internal data structure. See RocksDB file version_set.h for details. More live versions often mean more SST files are held from being deleted, by iterators or unfinished compactions.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.num-running-compactions</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Monitor the number of currently running compactions.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.num-running-flushes</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Monitor the number of currently running flushes.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.num-snapshots</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Monitor the number of unreleased snapshots of the database.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.size-all-mem-tables</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Monitor the approximate size of the active, unflushed immutable, and pinned immutable memtables in bytes.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.total-sst-files-size</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Monitor the total size (bytes) of all SST files.WARNING: may slow down online queries if there are too many files.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/savepoint_config_configuration.html
+++ b/docs/_includes/generated/savepoint_config_configuration.html
@@ -3,18 +3,21 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>execution.savepoint.ignore-unclaimed-state</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Allow to skip savepoint state that cannot be restored. Allow this if you removed an operator from your pipeline after the savepoint was triggered.</td>
         </tr>
         <tr>
             <td><h5>execution.savepoint.path</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Path to a savepoint to restore the job from (for example hdfs:///flink/savepoint-1537).</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/security_configuration.html
+++ b/docs/_includes/generated/security_configuration.html
@@ -3,138 +3,165 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>security.ssl.algorithms</h5></td>
             <td style="word-wrap: break-word;">"TLS_RSA_WITH_AES_128_CBC_SHA"</td>
+            <td>String</td>
             <td>The comma separated list of standard SSL algorithms to be supported. Read more <a href="http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#ciphersuites">here</a></td>
         </tr>
         <tr>
             <td><h5>security.ssl.internal.close-notify-flush-timeout</h5></td>
             <td style="word-wrap: break-word;">-1</td>
+            <td>Integer</td>
             <td>The timeout (in ms) for flushing the `close_notify` that was triggered by closing a channel. If the `close_notify` was not flushed in the given timeout the channel will be closed forcibly. (-1 = use system default)</td>
         </tr>
         <tr>
             <td><h5>security.ssl.internal.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Turns on SSL for internal network communication. Optionally, specific components may override this through their own settings (rpc, data transport, REST, etc).</td>
         </tr>
         <tr>
             <td><h5>security.ssl.internal.handshake-timeout</h5></td>
             <td style="word-wrap: break-word;">-1</td>
+            <td>Integer</td>
             <td>The timeout (in ms) during SSL handshake. (-1 = use system default)</td>
         </tr>
         <tr>
             <td><h5>security.ssl.internal.key-password</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The secret to decrypt the key in the keystore for Flink's internal endpoints (rpc, data transport, blob server).</td>
         </tr>
         <tr>
             <td><h5>security.ssl.internal.keystore</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The Java keystore file with SSL Key and Certificate, to be used Flink's internal endpoints (rpc, data transport, blob server).</td>
         </tr>
         <tr>
             <td><h5>security.ssl.internal.keystore-password</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The secret to decrypt the keystore file for Flink's for Flink's internal endpoints (rpc, data transport, blob server).</td>
         </tr>
         <tr>
             <td><h5>security.ssl.internal.session-cache-size</h5></td>
             <td style="word-wrap: break-word;">-1</td>
+            <td>Integer</td>
             <td>The size of the cache used for storing SSL session objects. According to https://github.com/netty/netty/issues/832, you should always set this to an appropriate number to not run into a bug with stalling IO threads during garbage collection. (-1 = use system default).</td>
         </tr>
         <tr>
             <td><h5>security.ssl.internal.session-timeout</h5></td>
             <td style="word-wrap: break-word;">-1</td>
+            <td>Integer</td>
             <td>The timeout (in ms) for the cached SSL session objects. (-1 = use system default)</td>
         </tr>
         <tr>
             <td><h5>security.ssl.internal.truststore</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The truststore file containing the public CA certificates to verify the peer for Flink's internal endpoints (rpc, data transport, blob server).</td>
         </tr>
         <tr>
             <td><h5>security.ssl.internal.truststore-password</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The password to decrypt the truststore for Flink's internal endpoints (rpc, data transport, blob server).</td>
         </tr>
         <tr>
             <td><h5>security.ssl.key-password</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The secret to decrypt the server key in the keystore.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.keystore</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The Java keystore file to be used by the flink endpoint for its SSL Key and Certificate.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.keystore-password</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The secret to decrypt the keystore file.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.protocol</h5></td>
             <td style="word-wrap: break-word;">"TLSv1.2"</td>
+            <td>String</td>
             <td>The SSL protocol version to be supported for the ssl transport. Note that it doesn’t support comma separated list.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.provider</h5></td>
             <td style="word-wrap: break-word;">"JDK"</td>
+            <td>String</td>
             <td>The SSL engine provider to use for the ssl transport:<ul><li><span markdown="span">`JDK`</span>: default Java-based SSL engine</li><li><span markdown="span">`OPENSSL`</span>: openSSL-based SSL engine using system libraries</li></ul><span markdown="span">`OPENSSL`</span> is based on <a href="http://netty.io/wiki/forked-tomcat-native.html#wiki-h2-4">netty-tcnative</a> and comes in two flavours:<ul><li>dynamically linked: This will use your system's openSSL libraries (if compatible) and requires <span markdown="span">`opt/flink-shaded-netty-tcnative-dynamic-*.jar`</span> to be copied to <span markdown="span">`lib/`</span></li><li>statically linked: Due to potential licensing issues with openSSL (see <a href="https://issues.apache.org/jira/browse/LEGAL-393">LEGAL-393</a>), we cannot ship pre-built libraries. However, you can build the required library yourself and put it into <span markdown="span">`lib/`</span>:<br /><span markdown="span">`git clone https://github.com/apache/flink-shaded.git &amp;&amp; cd flink-shaded &amp;&amp; mvn clean package -Pinclude-netty-tcnative-static -pl flink-shaded-netty-tcnative-static`</span></li></ul></td>
         </tr>
         <tr>
             <td><h5>security.ssl.rest.authentication-enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Turns on mutual SSL authentication for external communication via the REST endpoints.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.rest.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Turns on SSL for external communication via the REST endpoints.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.rest.key-password</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The secret to decrypt the key in the keystore for Flink's external REST endpoints.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.rest.keystore</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The Java keystore file with SSL Key and Certificate, to be used Flink's external REST endpoints.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.rest.keystore-password</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The secret to decrypt the keystore file for Flink's for Flink's external REST endpoints.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.rest.truststore</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The truststore file containing the public CA certificates to verify the peer for Flink's external REST endpoints.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.rest.truststore-password</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The password to decrypt the truststore for Flink's external REST endpoints.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.truststore</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The truststore file containing the public CA certificates to be used by flink endpoints to verify the peer’s certificate.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.truststore-password</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The secret to decrypt the truststore.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.verify-hostname</h5></td>
             <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
             <td>Flag to enable peer’s hostname verification during ssl handshake.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/shuffle_service_configuration.html
+++ b/docs/_includes/generated/shuffle_service_configuration.html
@@ -3,13 +3,15 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>shuffle-service-factory.class</h5></td>
             <td style="word-wrap: break-word;">"org.apache.flink.runtime.io.network.NettyShuffleServiceFactory"</td>
+            <td>String</td>
             <td>The full class name of the shuffle service factory implementation to be used by the cluster. The default implementation uses Netty for network communication and local memory as well disk space to store results on a TaskExecutor.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -3,89 +3,106 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>task.cancellation.interval</h5></td>
             <td style="word-wrap: break-word;">30000</td>
+            <td>Long</td>
             <td>Time interval between two successive task cancellation attempts in milliseconds.</td>
         </tr>
         <tr>
             <td><h5>task.cancellation.timeout</h5></td>
             <td style="word-wrap: break-word;">180000</td>
+            <td>Long</td>
             <td>Timeout in milliseconds after which a task cancellation times out and leads to a fatal TaskManager error. A value of 0 deactivates the watch dog.</td>
         </tr>
         <tr>
             <td><h5>task.cancellation.timers.timeout</h5></td>
             <td style="word-wrap: break-word;">7500</td>
+            <td>Long</td>
             <td>Time we wait for the timers in milliseconds to finish all pending timer threads when the stream task is cancelled.</td>
         </tr>
         <tr>
             <td><h5>task.checkpoint.alignment.max-size</h5></td>
             <td style="word-wrap: break-word;">-1</td>
+            <td>Long</td>
             <td>The maximum number of bytes that a checkpoint alignment may buffer. If the checkpoint alignment buffers more than the configured amount of data, the checkpoint is aborted (skipped). A value of -1 indicates that there is no limit.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.debug.memory.log</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Flag indicating whether to start a thread, which repeatedly logs the memory usage of the JVM.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.debug.memory.log-interval</h5></td>
             <td style="word-wrap: break-word;">5000</td>
+            <td>Long</td>
             <td>The interval (in ms) for the log thread to log the current memory usage.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.exit-on-fatal-akka-error</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Whether the quarantine monitor for task managers shall be started. The quarantine monitor shuts down the actor system if it detects that it has quarantined another actor system or if it has been quarantined by another actor system.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.host</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The address of the network interface that the TaskManager binds to. This option can be used to define explicitly a binding address. Because different TaskManagers need different values for this option, usually it is specified in an additional non-shared TaskManager-specific config file.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.jvm-exit-on-oom</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td>Whether to kill the TaskManager when the task thread throws an OutOfMemoryError.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.bind-policy</h5></td>
             <td style="word-wrap: break-word;">"ip"</td>
+            <td>String</td>
             <td>The automatic address binding policy used by the TaskManager if "taskmanager.host" is not set. The value should be one of the following:
 <ul><li>"name" - uses hostname as binding address</li><li>"ip" - uses host's ip address as binding address</li></ul></td>
         </tr>
         <tr>
             <td><h5>taskmanager.numberOfTaskSlots</h5></td>
             <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
             <td>The number of parallel operator or user function instances that a single TaskManager can run. If this value is larger than 1, a single TaskManager takes multiple instances of a function or operator. That way, the TaskManager can utilize multiple CPU cores, but at the same time, the available memory is divided between the different operator or function instances. This value is typically proportional to the number of physical CPU cores that the TaskManager's machine has (e.g., equal to the number of cores, or half the number of cores).</td>
         </tr>
         <tr>
             <td><h5>taskmanager.registration.initial-backoff</h5></td>
             <td style="word-wrap: break-word;">"500 ms"</td>
+            <td>String</td>
             <td>The initial registration backoff between two consecutive registration attempts. The backoff is doubled for each new registration attempt until it reaches the maximum registration backoff.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.registration.max-backoff</h5></td>
             <td style="word-wrap: break-word;">"30 s"</td>
+            <td>String</td>
             <td>The maximum registration backoff between two consecutive registration attempts. The max registration backoff requires a time unit specifier (ms/s/min/h/d).</td>
         </tr>
         <tr>
             <td><h5>taskmanager.registration.refused-backoff</h5></td>
             <td style="word-wrap: break-word;">"10 s"</td>
+            <td>String</td>
             <td>The backoff after a registration has been refused by the job manager before retrying to connect.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.registration.timeout</h5></td>
             <td style="word-wrap: break-word;">"5 min"</td>
+            <td>String</td>
             <td>Defines the timeout for the TaskManager registration. If the duration is exceeded without a successful registration, then the TaskManager terminates.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.rpc.port</h5></td>
             <td style="word-wrap: break-word;">"0"</td>
+            <td>String</td>
             <td>The task manager’s IPC port. Accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple TaskManagers are running on the same machine.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/task_manager_memory_configuration.html
+++ b/docs/_includes/generated/task_manager_memory_configuration.html
@@ -3,93 +3,111 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>taskmanager.memory.framework.heap.size</h5></td>
             <td style="word-wrap: break-word;">"128m"</td>
+            <td>String</td>
             <td>Framework Heap Memory size for TaskExecutors. This is the size of JVM heap memory reserved for TaskExecutor framework, which will not be allocated to task slots.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.jvm-metaspace.size</h5></td>
             <td style="word-wrap: break-word;">"192m"</td>
+            <td>String</td>
             <td>JVM Metaspace Size for the TaskExecutors.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.jvm-overhead.fraction</h5></td>
             <td style="word-wrap: break-word;">0.1</td>
+            <td>Float</td>
             <td>Fraction of Total Process Memory to be reserved for JVM Overhead. This is off-heap memory reserved for JVM overhead, such as thread stack space, I/O direct memory, compile cache, etc. The size of JVM Overhead is derived to make up the configured fraction of the Total Process Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of JVM Overhead can be explicitly specified by setting the min/max size to the same value.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.jvm-overhead.max</h5></td>
             <td style="word-wrap: break-word;">"1g"</td>
+            <td>String</td>
             <td>Max JVM Overhead size for the TaskExecutors. This is off-heap memory reserved for JVM overhead, such as thread stack space, I/O direct memory, compile cache, etc. The size of JVM Overhead is derived to make up the configured fraction of the Total Process Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of JVM Overhead can be explicitly specified by setting the min/max size to the same value.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.jvm-overhead.min</h5></td>
             <td style="word-wrap: break-word;">"128m"</td>
+            <td>String</td>
             <td>Min JVM Overhead size for the TaskExecutors. This is off-heap memory reserved for JVM overhead, such as thread stack space, I/O direct memory, compile cache, etc. The size of JVM Overhead is derived to make up the configured fraction of the Total Process Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of JVM Overhead can be explicitly specified by setting the min/max size to the same value.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.managed.fraction</h5></td>
             <td style="word-wrap: break-word;">0.5</td>
+            <td>Float</td>
             <td>Fraction of Total Flink Memory to be used as Managed Memory, if Managed Memory size is not explicitly specified.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.managed.off-heap.fraction</h5></td>
             <td style="word-wrap: break-word;">-1.0</td>
+            <td>Float</td>
             <td>Fraction of Managed Memory that Off-Heap Managed Memory takes, if Off-Heap Managed Memory size is not explicitly specified. If the fraction is not explicitly specified (or configured with negative values), it will be derived from the legacy config option 'taskmanager.memory.off-heap', to use either all on-heap memory or all off-heap memory for Managed Memory.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.managed.off-heap.size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Off-Heap Managed Memory size for TaskExecutors. This is the part of Managed Memory that is off-heap, while the remaining is on-heap. If unspecified, it will be derived to make up the configured fraction of the Managed Memory size.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.managed.size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Managed Memory size for TaskExecutors. This is the size of memory managed by the memory manager, including both On-Heap Managed Memory and Off-Heap Managed Memory, reserved for sorting, hash tables, caching of intermediate results and state backends. Memory consumers can either allocate memory from the memory manager in the form of MemorySegments, or reserve bytes from the memory manager and keep their memory usage within that boundary. If unspecified, it will be derived to make up the configured fraction of the Total Flink Memory.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.segment-size</h5></td>
             <td style="word-wrap: break-word;">"32kb"</td>
+            <td>String</td>
             <td>Size of memory buffers used by the network stack and the memory manager.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.shuffle.fraction</h5></td>
             <td style="word-wrap: break-word;">0.1</td>
+            <td>Float</td>
             <td>Fraction of Total Flink Memory to be used as Shuffle Memory. Shuffle Memory is off-heap memory reserved for ShuffleEnvironment (e.g., network buffers). Shuffle Memory size is derived to make up the configured fraction of the Total Flink Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of Shuffle Memory can be explicitly specified by setting the min/max size to the same value.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.shuffle.max</h5></td>
             <td style="word-wrap: break-word;">"1g"</td>
+            <td>String</td>
             <td>Max Shuffle Memory size for TaskExecutors. Shuffle Memory is off-heap memory reserved for ShuffleEnvironment (e.g., network buffers). Shuffle Memory size is derived to make up the configured fraction of the Total Flink Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of Shuffle Memory can be explicitly specified by setting the min/max to the same value.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.shuffle.min</h5></td>
             <td style="word-wrap: break-word;">"64m"</td>
+            <td>String</td>
             <td>Min Shuffle Memory size for TaskExecutors. Shuffle Memory is off-heap memory reserved for ShuffleEnvironment (e.g., network buffers). Shuffle Memory size is derived to make up the configured fraction of the Total Flink Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of Shuffle Memory can be explicitly specified by setting the min/max to the same value.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.task.heap.size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Task Heap Memory size for TaskExecutors. This is the size of JVM heap memory reserved for user code. If not specified, it will be derived as Total Flink Memory minus Framework Heap Memory, Task Off-Heap Memory, (On-Heap and Off-Heap) Managed Memory and Shuffle Memory.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.task.off-heap.size</h5></td>
             <td style="word-wrap: break-word;">"0b"</td>
+            <td>String</td>
             <td>Task Heap Memory size for TaskExecutors. This is the size of off heap memory (JVM direct memory or native memory) reserved for user code.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.total-flink.size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Total Flink Memory size for the TaskExecutors. This includes all the memory that a TaskExecutor consumes, except for JVM Metaspace and JVM Overhead. It consists of Framework Heap Memory, Task Heap Memory, Task Off-Heap Memory, Managed Memory, and Shuffle Memory.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.total-process.size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Total Process Memory size for the TaskExecutors. This includes all the memory that a TaskExecutor consumes, consisting of Total Flink Memory, JVM Metaspace, and JVM Overhead. On containerized setups, this should be set to the container memory.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/web_configuration.html
+++ b/docs/_includes/generated/web_configuration.html
@@ -3,83 +3,99 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>web.access-control-allow-origin</h5></td>
             <td style="word-wrap: break-word;">"*"</td>
+            <td>String</td>
             <td>Access-Control-Allow-Origin header for all responses from the web-frontend.</td>
         </tr>
         <tr>
             <td><h5>web.address</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Address for runtime monitor web-frontend server.</td>
         </tr>
         <tr>
             <td><h5>web.backpressure.cleanup-interval</h5></td>
             <td style="word-wrap: break-word;">600000</td>
+            <td>Integer</td>
             <td>Time, in milliseconds, after which cached stats are cleaned up if not accessed.</td>
         </tr>
         <tr>
             <td><h5>web.backpressure.delay-between-samples</h5></td>
             <td style="word-wrap: break-word;">50</td>
+            <td>Integer</td>
             <td>Delay between stack trace samples to determine back pressure in milliseconds.</td>
         </tr>
         <tr>
             <td><h5>web.backpressure.num-samples</h5></td>
             <td style="word-wrap: break-word;">100</td>
+            <td>Integer</td>
             <td>Number of stack trace samples to take to determine back pressure.</td>
         </tr>
         <tr>
             <td><h5>web.backpressure.refresh-interval</h5></td>
             <td style="word-wrap: break-word;">60000</td>
+            <td>Integer</td>
             <td>Time, in milliseconds, after which available stats are deprecated and need to be refreshed (by resampling).</td>
         </tr>
         <tr>
             <td><h5>web.checkpoints.history</h5></td>
             <td style="word-wrap: break-word;">10</td>
+            <td>Integer</td>
             <td>Number of checkpoints to remember for recent history.</td>
         </tr>
         <tr>
             <td><h5>web.history</h5></td>
             <td style="word-wrap: break-word;">5</td>
+            <td>Integer</td>
             <td>Number of archived jobs for the JobManager.</td>
         </tr>
         <tr>
             <td><h5>web.log.path</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Path to the log file (may be in /log for standalone but under log directory when using YARN).</td>
         </tr>
         <tr>
             <td><h5>web.refresh-interval</h5></td>
             <td style="word-wrap: break-word;">3000</td>
+            <td>Long</td>
             <td>Refresh interval for the web-frontend in milliseconds.</td>
         </tr>
         <tr>
             <td><h5>web.ssl.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
             <td>Flag indicating whether to override SSL support for the JobManager Web UI.</td>
         </tr>
         <tr>
             <td><h5>web.submit.enable</h5></td>
             <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
             <td>Flag indicating whether jobs can be uploaded and run from the web-frontend.</td>
         </tr>
         <tr>
             <td><h5>web.timeout</h5></td>
             <td style="word-wrap: break-word;">10000</td>
+            <td>Long</td>
             <td>Timeout for asynchronous operations by the web monitor in milliseconds.</td>
         </tr>
         <tr>
             <td><h5>web.tmpdir</h5></td>
             <td style="word-wrap: break-word;">System.getProperty("java.io.tmpdir")</td>
+            <td>String</td>
             <td>Flink web directory which is used by the webmonitor.</td>
         </tr>
         <tr>
             <td><h5>web.upload.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Directory for uploading the job jars. If not specified a dynamic directory will be used under the directory specified by JOB_MANAGER_WEB_TMPDIR_KEY.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -3,113 +3,135 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>yarn.application-attempt-failures-validity-interval</h5></td>
             <td style="word-wrap: break-word;">10000</td>
+            <td>Long</td>
             <td>Time window in milliseconds which defines the number of application attempt failures when restarting the AM. Failures which fall outside of this window are not being considered. Set this value to -1 in order to count globally. See <a href="https://hortonworks.com/blog/apache-hadoop-yarn-hdp-2-2-fault-tolerance-features-long-running-services/">here</a> for more information.</td>
         </tr>
         <tr>
             <td><h5>yarn.application-attempts</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Number of ApplicationMaster restarts. Note that that the entire Flink cluster will restart and the YARN Client will loose the connection. Also, the JobManager address will change and you’ll need to set the JM host:port manually. It is recommended to leave this option at 1.</td>
         </tr>
         <tr>
             <td><h5>yarn.application-master.port</h5></td>
             <td style="word-wrap: break-word;">"0"</td>
+            <td>String</td>
             <td>With this configuration option, users can specify a port, a range of ports or a list of ports for the Application Master (and JobManager) RPC port. By default we recommend using the default value (0) to let the operating system choose an appropriate port. In particular when multiple AMs are running on the same physical host, fixed port assignments prevent the AM from starting. For example when running Flink on YARN on an environment with a restrictive firewall, this option allows specifying a range of allowed ports.</td>
         </tr>
         <tr>
             <td><h5>yarn.application.id</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The YARN application id of the running yarn cluster. This is the YARN cluster where the pipeline is going to be executed.</td>
         </tr>
         <tr>
             <td><h5>yarn.application.name</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>A custom name for your YARN application.</td>
         </tr>
         <tr>
             <td><h5>yarn.application.node-label</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Specify YARN node label for the YARN application.</td>
         </tr>
         <tr>
             <td><h5>yarn.application.priority</h5></td>
             <td style="word-wrap: break-word;">-1</td>
+            <td>Integer</td>
             <td>A non-negative integer indicating the priority for submitting a Flink YARN application. It will only take effect if YARN priority scheduling setting is enabled. Larger integer corresponds with higher priority. If priority is negative or set to '-1'(default), Flink will unset yarn priority setting and use cluster default priority. Please refer to YARN's official documentation for specific settings required to enable priority scheduling for the targeted YARN version.</td>
         </tr>
         <tr>
             <td><h5>yarn.application.queue</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The YARN queue on which to put the current pipeline.</td>
         </tr>
         <tr>
             <td><h5>yarn.application.type</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>A custom type for your YARN application..</td>
         </tr>
         <tr>
             <td><h5>yarn.appmaster.rpc.address</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The hostname or address where the application master RPC system is listening.</td>
         </tr>
         <tr>
             <td><h5>yarn.appmaster.rpc.port</h5></td>
             <td style="word-wrap: break-word;">-1</td>
+            <td>Integer</td>
             <td>The port where the application master RPC system is listening.</td>
         </tr>
         <tr>
             <td><h5>yarn.appmaster.vcores</h5></td>
             <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
             <td>The number of virtual cores (vcores) used by YARN application master.</td>
         </tr>
         <tr>
             <td><h5>yarn.containers.vcores</h5></td>
             <td style="word-wrap: break-word;">-1</td>
+            <td>Integer</td>
             <td>The number of virtual cores (vcores) per YARN container. By default, the number of vcores is set to the number of slots per TaskManager, if set, or to 1, otherwise. In order for this parameter to be used your cluster must have CPU scheduling enabled. You can do this by setting the <span markdown="span">`org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler`</span>.</td>
         </tr>
         <tr>
             <td><h5>yarn.flink-dist-jar</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>The location of the Flink dist jar.</td>
         </tr>
         <tr>
             <td><h5>yarn.heartbeat.container-request-interval</h5></td>
             <td style="word-wrap: break-word;">500</td>
+            <td>Integer</td>
             <td>Time between heartbeats with the ResourceManager in milliseconds if Flink requests containers:<ul><li>The lower this value is, the faster Flink will get notified about container allocations since requests and allocations are transmitted via heartbeats.</li><li>The lower this value is, the more excessive containers might get allocated which will eventually be released but put pressure on Yarn.</li></ul>If you observe too many container allocations on the ResourceManager, then it is recommended to increase this value. See <a href="https://issues.apache.org/jira/browse/YARN-1902">this link</a> for more information.</td>
         </tr>
         <tr>
             <td><h5>yarn.heartbeat.interval</h5></td>
             <td style="word-wrap: break-word;">5</td>
+            <td>Integer</td>
             <td>Time between heartbeats with the ResourceManager in seconds.</td>
         </tr>
         <tr>
             <td><h5>yarn.maximum-failed-containers</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>Maximum number of containers the system is going to reallocate in case of a failure.</td>
         </tr>
         <tr>
             <td><h5>yarn.per-job-cluster.include-user-jar</h5></td>
             <td style="word-wrap: break-word;">"ORDER"</td>
+            <td>String</td>
             <td>Defines whether user-jars are included in the system class path for per-job-clusters as well as their positioning in the path. They can be positioned at the beginning ("FIRST"), at the end ("LAST"), or be positioned based on their name ("ORDER").</td>
         </tr>
         <tr>
             <td><h5>yarn.properties-file.location</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>When a Flink job is submitted to YARN, the JobManager’s host and the number of available processing slots is written into a properties file, so that the Flink client is able to pick those details up. This configuration parameter allows changing the default location of that file (for example for environments sharing a Flink installation between users).</td>
         </tr>
         <tr>
             <td><h5>yarn.ship-directories</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>List&lt;String&gt;</td>
             <td>A semicolon-separated list of directories to be shipped to the YARN cluster.</td>
         </tr>
         <tr>
             <td><h5>yarn.tags</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
             <td>A comma-separated list of tags to apply to the Flink YARN application.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/zoo_keeper_configuration.html
+++ b/docs/_includes/generated/zoo_keeper_configuration.html
@@ -3,23 +3,27 @@
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
             <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 65%">Description</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><h5>zookeeper.sasl.disable</h5></td>
             <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>zookeeper.sasl.login-context-name</h5></td>
             <td style="word-wrap: break-word;">"Client"</td>
+            <td>String</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>zookeeper.sasl.service-name</h5></td>
             <td style="word-wrap: break-word;">"zookeeper"</td>
+            <td>String</td>
             <td></td>
         </tr>
     </tbody>

--- a/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
@@ -26,15 +26,18 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.description.Formatter;
 import org.apache.flink.configuration.description.HtmlFormatter;
+import org.apache.flink.util.TimeUtils;
 import org.apache.flink.util.function.ThrowingConsumer;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -47,6 +50,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.docs.util.Utils.escapeCharacters;
 
@@ -158,6 +162,7 @@ public class ConfigOptionsDocGenerator {
 		});
 	}
 
+	@VisibleForTesting
 	static void processConfigOptions(String rootDir, String module, String packageName, String pathPrefix, ThrowingConsumer<Class<?>, IOException> classConsumer) throws IOException, ClassNotFoundException {
 		Path configDir = Paths.get(rootDir, module, pathPrefix, packageName.replaceAll("\\.", "/"));
 
@@ -202,6 +207,7 @@ public class ConfigOptionsDocGenerator {
 		return tables;
 	}
 
+	@VisibleForTesting
 	static List<OptionWithMetaInfo> extractConfigOptions(Class<?> clazz) {
 		try {
 			List<OptionWithMetaInfo> configOptions = new ArrayList<>(8);
@@ -241,7 +247,8 @@ public class ConfigOptionsDocGenerator {
 		htmlTable.append("        <tr>\n");
 		htmlTable.append("            <th class=\"text-left\" style=\"width: 20%\">Key</th>\n");
 		htmlTable.append("            <th class=\"text-left\" style=\"width: 15%\">Default</th>\n");
-		htmlTable.append("            <th class=\"text-left\" style=\"width: 65%\">Description</th>\n");
+		htmlTable.append("            <th class=\"text-left\" style=\"width: 10%\">Type</th>\n");
+		htmlTable.append("            <th class=\"text-left\" style=\"width: 55%\">Description</th>\n");
 		htmlTable.append("        </tr>\n");
 		htmlTable.append("    </thead>\n");
 		htmlTable.append("    <tbody>\n");
@@ -265,6 +272,7 @@ public class ConfigOptionsDocGenerator {
 	private static String toHtmlString(final OptionWithMetaInfo optionWithMetaInfo) {
 		ConfigOption<?> option = optionWithMetaInfo.option;
 		String defaultValue = stringifyDefault(optionWithMetaInfo);
+		String type = typeToHtml(optionWithMetaInfo);
 		Documentation.TableOption tableOption = optionWithMetaInfo.field.getAnnotation(Documentation.TableOption.class);
 		StringBuilder execModeStringBuilder = new StringBuilder();
 		if (tableOption != null) {
@@ -286,10 +294,76 @@ public class ConfigOptionsDocGenerator {
 			"        <tr>\n" +
 			"            <td><h5>" + escapeCharacters(option.key()) + "</h5>" + execModeStringBuilder.toString() + "</td>\n" +
 			"            <td style=\"word-wrap: break-word;\">" + escapeCharacters(addWordBreakOpportunities(defaultValue)) + "</td>\n" +
+			"            <td>" + type + "</td>\n" +
 			"            <td>" + formatter.format(option.description()) + "</td>\n" +
 			"        </tr>\n";
 	}
 
+	private static Class<?> getClazz(ConfigOption<?> option) {
+		try {
+			Method getClazzMethod = ConfigOption.class.getDeclaredMethod("getClazz");
+			getClazzMethod.setAccessible(true);
+			Class clazz = (Class) getClazzMethod.invoke(option);
+			getClazzMethod.setAccessible(false);
+			return clazz;
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private static boolean isList(ConfigOption<?> option) {
+		try {
+			Method getClazzMethod = ConfigOption.class.getDeclaredMethod("isList");
+			getClazzMethod.setAccessible(true);
+			boolean isList = (boolean) getClazzMethod.invoke(option);
+			getClazzMethod.setAccessible(false);
+			return isList;
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@VisibleForTesting
+	static String typeToHtml(OptionWithMetaInfo optionWithMetaInfo) {
+		ConfigOption<?> option = optionWithMetaInfo.option;
+		Class<?> clazz = getClazz(option);
+		boolean isList = isList(option);
+
+		if (clazz.isEnum()) {
+			return enumTypeToHtml(clazz, isList);
+		}
+
+		return atomicTypeToHtml(clazz, isList);
+	}
+
+	private static String atomicTypeToHtml(Class<?> clazz, boolean isList) {
+		String typeName = clazz.getSimpleName();
+
+		final String type;
+		if (isList) {
+			type = String.format("List<%s>", typeName);
+		} else {
+			type = typeName;
+		}
+
+		return escapeCharacters(type);
+	}
+
+	private static String enumTypeToHtml(Class<?> enumClazz, boolean isList) {
+		final String type;
+		if (isList) {
+			type = "List<Enum>";
+		} else {
+			type = "Enum";
+		}
+
+		return String.format(
+			"<p>%s</p>Possible values: %s",
+			escapeCharacters(type),
+			escapeCharacters(Arrays.toString(enumClazz.getEnumConstants())));
+	}
+
+	@VisibleForTesting
 	static String stringifyDefault(OptionWithMetaInfo optionWithMetaInfo) {
 		ConfigOption<?> option = optionWithMetaInfo.option;
 		Documentation.OverrideDefault overrideDocumentedDefault = optionWithMetaInfo.field.getAnnotation(Documentation.OverrideDefault.class);
@@ -297,14 +371,31 @@ public class ConfigOptionsDocGenerator {
 			return overrideDocumentedDefault.value();
 		} else {
 			Object value = option.defaultValue();
-			if (value instanceof String) {
-				if (((String) value).isEmpty()) {
-					return "(none)";
-				}
-				return "\"" + value + "\"";
-			}
-			return value == null ? "(none)" : value.toString();
+			return stringifyObject(value);
 		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static String stringifyObject(Object value) {
+		if (value instanceof String) {
+			if (((String) value).isEmpty()) {
+				return "(none)";
+			}
+			return "\"" + value + "\"";
+		} else if (value instanceof Duration) {
+			return TimeUtils.getStringInMillis((Duration) value);
+		} else if (value instanceof List) {
+			return ((List<Object>) value).stream()
+				.map(ConfigOptionsDocGenerator::stringifyObject)
+				.collect(Collectors.joining(";"));
+		} else if (value instanceof Map) {
+			return ((Map<String, String>) value)
+				.entrySet()
+				.stream()
+				.map(e -> String.format("%s:%s", e.getKey(), e.getValue()))
+				.collect(Collectors.joining(","));
+		}
+		return value == null ? "(none)" : value.toString();
 	}
 
 	private static String addWordBreakOpportunities(String value) {

--- a/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
@@ -69,6 +69,8 @@ public class ConfigOptionsDocGenerator {
 	};
 
 	static final Set<String> EXCLUSIONS = new HashSet<>(Arrays.asList(
+		"org.apache.flink.configuration.ReadableConfig",
+		"org.apache.flink.configuration.WritableConfig",
 		"org.apache.flink.configuration.ConfigOptions",
 		"org.apache.flink.contrib.streaming.state.PredefinedOptions"));
 

--- a/flink-docs/src/test/java/org/apache/flink/docs/configuration/ConfigOptionsDocGeneratorTest.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/configuration/ConfigOptionsDocGeneratorTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.description.Formatter;
 import org.apache.flink.configuration.description.HtmlFormatter;
 import org.apache.flink.docs.configuration.data.TestCommonOptions;
@@ -36,11 +37,14 @@ import org.junit.rules.TemporaryFolder;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
@@ -64,6 +68,108 @@ public class ConfigOptionsDocGeneratorTest {
 			.withDescription("This is long example description for the second option.");
 	}
 
+	private enum TestEnum {
+		VALUE_1,
+		VALUE_2,
+		VALUE_3;
+	}
+
+	static class TypeTestConfigGroup {
+		public static ConfigOption<TestEnum> enumOption = ConfigOptions
+			.key("option.enum")
+			.enumType(TestEnum.class)
+			.defaultValue(TestEnum.VALUE_1)
+			.withDescription("Description");
+
+		public static ConfigOption<List<TestEnum>> enumListOption = ConfigOptions
+			.key("option.enum.list")
+			.enumType(TestEnum.class)
+			.asList()
+			.defaultValues(TestEnum.VALUE_1, TestEnum.VALUE_2)
+			.withDescription("Description");
+
+		public static ConfigOption<MemorySize> memoryOption = ConfigOptions
+			.key("option.memory")
+			.memoryType()
+			.defaultValue(new MemorySize(1024))
+			.withDescription("Description");
+
+		public static ConfigOption<Map<String, String>> mapOption = ConfigOptions
+			.key("option.map")
+			.mapType()
+			.defaultValue(Collections.singletonMap("key1", "value1"))
+			.withDescription("Description");
+
+		public static ConfigOption<List<Map<String, String>>> mapListOption = ConfigOptions
+			.key("option.map.list")
+			.mapType()
+			.asList()
+			.defaultValues(Collections.singletonMap("key1", "value1"), Collections.singletonMap("key2", "value2"))
+			.withDescription("Description");
+
+		public static ConfigOption<Duration> durationOption = ConfigOptions
+			.key("option.duration")
+			.durationType()
+			.defaultValue(Duration.ofMinutes(1))
+			.withDescription("Description");
+	}
+
+	@Test
+	public void testCreatingTypes() {
+		final String expectedTable =
+			"<table class=\"table table-bordered\">\n" +
+				"    <thead>\n" +
+				"        <tr>\n" +
+				"            <th class=\"text-left\" style=\"width: 20%\">Key</th>\n" +
+				"            <th class=\"text-left\" style=\"width: 15%\">Default</th>\n" +
+				"            <th class=\"text-left\" style=\"width: 10%\">Type</th>\n" +
+				"            <th class=\"text-left\" style=\"width: 55%\">Description</th>\n" +
+				"        </tr>\n" +
+				"    </thead>\n" +
+				"    <tbody>\n" +
+				"        <tr>\n" +
+				"            <td><h5>option.duration</h5></td>\n" +
+				"            <td style=\"word-wrap: break-word;\">60000ms</td>\n" +
+				"            <td>Duration</td>\n" +
+				"            <td>Description</td>\n" +
+				"        </tr>\n" +
+				"        <tr>\n" +
+				"            <td><h5>option.enum</h5></td>\n" +
+				"            <td style=\"word-wrap: break-word;\">VALUE_1</td>\n" +
+				"            <td><p>Enum</p>Possible values: [VALUE_1, VALUE_2, VALUE_3]</td>\n" +
+				"            <td>Description</td>\n" +
+				"        </tr>\n" +
+				"        <tr>\n" +
+				"            <td><h5>option.enum.list</h5></td>\n" +
+				"            <td style=\"word-wrap: break-word;\">VALUE_1;<wbr>VALUE_2</td>\n" +
+				"            <td><p>List&lt;Enum&gt;</p>Possible values: [VALUE_1, VALUE_2, VALUE_3]</td>\n" +
+				"            <td>Description</td>\n" +
+				"        </tr>\n" +
+				"        <tr>\n" +
+				"            <td><h5>option.map</h5></td>\n" +
+				"            <td style=\"word-wrap: break-word;\">key1:value1</td>\n" +
+				"            <td>Map</td>\n" +
+				"            <td>Description</td>\n" +
+				"        </tr>\n" +
+				"        <tr>\n" +
+				"            <td><h5>option.map.list</h5></td>\n" +
+				"            <td style=\"word-wrap: break-word;\">key1:value1;<wbr>key2:value2</td>\n" +
+				"            <td>List&lt;Map&gt;</td>\n" +
+				"            <td>Description</td>\n" +
+				"        </tr>\n" +
+				"        <tr>\n" +
+				"            <td><h5>option.memory</h5></td>\n" +
+				"            <td style=\"word-wrap: break-word;\">1024 bytes</td>\n" +
+				"            <td>MemorySize</td>\n" +
+				"            <td>Description</td>\n" +
+				"        </tr>\n" +
+				"    </tbody>\n" +
+				"</table>\n";
+		final String htmlTable = ConfigOptionsDocGenerator.generateTablesForClass(TypeTestConfigGroup.class).get(0).f1;
+
+		assertEquals(expectedTable, htmlTable);
+	}
+
 	@Test
 	public void testCreatingDescription() {
 		final String expectedTable =
@@ -72,18 +178,21 @@ public class ConfigOptionsDocGeneratorTest {
 			"        <tr>\n" +
 			"            <th class=\"text-left\" style=\"width: 20%\">Key</th>\n" +
 			"            <th class=\"text-left\" style=\"width: 15%\">Default</th>\n" +
-			"            <th class=\"text-left\" style=\"width: 65%\">Description</th>\n" +
+			"            <th class=\"text-left\" style=\"width: 10%\">Type</th>\n" +
+			"            <th class=\"text-left\" style=\"width: 55%\">Description</th>\n" +
 			"        </tr>\n" +
 			"    </thead>\n" +
 			"    <tbody>\n" +
 			"        <tr>\n" +
 			"            <td><h5>first.option.a</h5></td>\n" +
 			"            <td style=\"word-wrap: break-word;\">2</td>\n" +
+			"            <td>Integer</td>\n" +
 			"            <td>This is example description for the first option.</td>\n" +
 			"        </tr>\n" +
 			"        <tr>\n" +
 			"            <td><h5>second.option.a</h5></td>\n" +
 			"            <td style=\"word-wrap: break-word;\">(none)</td>\n" +
+			"            <td>String</td>\n" +
 			"            <td>This is long example description for the second option.</td>\n" +
 			"        </tr>\n" +
 			"    </tbody>\n" +
@@ -123,6 +232,12 @@ public class ConfigOptionsDocGeneratorTest {
 		public static ConfigOption<String> option5 = ConfigOptions
 			.key("a.c.b.option")
 			.noDefaultValue();
+
+		// should end up in group2, full key-prefix match for group 2
+		// checks that the longest matching group is assigned
+		public static ConfigOption<Integer> option6 = ConfigOptions
+			.key("a.b.c.d.option")
+			.defaultValue(2);
 	}
 
 	@Test
@@ -139,6 +254,8 @@ public class ConfigOptionsDocGeneratorTest {
 		assertThat(tablesConverted.get("group1"), containsString("a.b.option"));
 		assertThat(tablesConverted.get("group1"), containsString("a.b.c.option"));
 		assertThat(tablesConverted.get("group1"), containsString("a.b.c.e.option"));
+		assertThat(tablesConverted.get("group2"), containsString("a.b.c.d.option"));
+		assertThat(tablesConverted.get("group1"), not(containsString("a.b.c.d.option")));
 		assertThat(tablesConverted.get("default"), containsString("a.option"));
 		assertThat(tablesConverted.get("default"), containsString("a.c.b.option"));
 	}
@@ -185,13 +302,15 @@ public class ConfigOptionsDocGeneratorTest {
 			"        <tr>\n" +
 			"            <th class=\"text-left\" style=\"width: 20%\">Key</th>\n" +
 			"            <th class=\"text-left\" style=\"width: 15%\">Default</th>\n" +
-			"            <th class=\"text-left\" style=\"width: 65%\">Description</th>\n" +
+			"            <th class=\"text-left\" style=\"width: 10%\">Type</th>\n" +
+			"            <th class=\"text-left\" style=\"width: 55%\">Description</th>\n" +
 			"        </tr>\n" +
 			"    </thead>\n" +
 			"    <tbody>\n" +
 			"        <tr>\n" +
 			"            <td><h5>first.option.a</h5></td>\n" +
 			"            <td style=\"word-wrap: break-word;\">2</td>\n" +
+			"            <td>Integer</td>\n" +
 			"            <td>This is example description for the first option.</td>\n" +
 			"        </tr>\n" +
 			"    </tbody>\n" +
@@ -202,13 +321,15 @@ public class ConfigOptionsDocGeneratorTest {
 			"        <tr>\n" +
 			"            <th class=\"text-left\" style=\"width: 20%\">Key</th>\n" +
 			"            <th class=\"text-left\" style=\"width: 15%\">Default</th>\n" +
-			"            <th class=\"text-left\" style=\"width: 65%\">Description</th>\n" +
+			"            <th class=\"text-left\" style=\"width: 10%\">Type</th>\n" +
+			"            <th class=\"text-left\" style=\"width: 55%\">Description</th>\n" +
 			"        </tr>\n" +
 			"    </thead>\n" +
 			"    <tbody>\n" +
 			"        <tr>\n" +
 			"            <td><h5>second.option.a</h5></td>\n" +
 			"            <td style=\"word-wrap: break-word;\">(none)</td>\n" +
+			"            <td>String</td>\n" +
 			"            <td>This is long example description for the second option.</td>\n" +
 			"        </tr>\n" +
 			"    </tbody>\n" +
@@ -219,18 +340,21 @@ public class ConfigOptionsDocGeneratorTest {
 			"        <tr>\n" +
 			"            <th class=\"text-left\" style=\"width: 20%\">Key</th>\n" +
 			"            <th class=\"text-left\" style=\"width: 15%\">Default</th>\n" +
-			"            <th class=\"text-left\" style=\"width: 65%\">Description</th>\n" +
+			"            <th class=\"text-left\" style=\"width: 10%\">Type</th>\n" +
+			"            <th class=\"text-left\" style=\"width: 55%\">Description</th>\n" +
 			"        </tr>\n" +
 			"    </thead>\n" +
 			"    <tbody>\n" +
 			"        <tr>\n" +
 			"            <td><h5>fourth.option.a</h5></td>\n" +
 			"            <td style=\"word-wrap: break-word;\">(none)</td>\n" +
+			"            <td>String</td>\n" +
 			"            <td>This is long example description for the fourth option.</td>\n" +
 			"        </tr>\n" +
 			"        <tr>\n" +
 			"            <td><h5>third.option.a</h5></td>\n" +
 			"            <td style=\"word-wrap: break-word;\">2</td>\n" +
+			"            <td>Integer</td>\n" +
 			"            <td>This is example description for the third option.</td>\n" +
 			"        </tr>\n" +
 			"    </tbody>\n" +
@@ -259,18 +383,21 @@ public class ConfigOptionsDocGeneratorTest {
 				"        <tr>\n" +
 				"            <th class=\"text-left\" style=\"width: 20%\">Key</th>\n" +
 				"            <th class=\"text-left\" style=\"width: 15%\">Default</th>\n" +
-				"            <th class=\"text-left\" style=\"width: 65%\">Description</th>\n" +
+				"            <th class=\"text-left\" style=\"width: 10%\">Type</th>\n" +
+				"            <th class=\"text-left\" style=\"width: 55%\">Description</th>\n" +
 				"        </tr>\n" +
 				"    </thead>\n" +
 				"    <tbody>\n" +
 				"        <tr>\n" +
 				"            <td><h5>first.option.a</h5></td>\n" +
 				"            <td style=\"word-wrap: break-word;\">default_1</td>\n" +
+				"            <td>Integer</td>\n" +
 				"            <td>This is example description for the first option.</td>\n" +
 				"        </tr>\n" +
 				"        <tr>\n" +
 				"            <td><h5>second.option.a</h5></td>\n" +
 				"            <td style=\"word-wrap: break-word;\">default_2</td>\n" +
+				"            <td>String</td>\n" +
 				"            <td>This is long example description for the second option.</td>\n" +
 				"        </tr>\n" +
 				"    </tbody>\n" +
@@ -298,18 +425,21 @@ public class ConfigOptionsDocGeneratorTest {
 			"        <tr>\n" +
 			"            <th class=\"text-left\" style=\"width: 20%\">Key</th>\n" +
 			"            <th class=\"text-left\" style=\"width: 15%\">Default</th>\n" +
-			"            <th class=\"text-left\" style=\"width: 65%\">Description</th>\n" +
+			"            <th class=\"text-left\" style=\"width: 10%\">Type</th>\n" +
+			"            <th class=\"text-left\" style=\"width: 55%\">Description</th>\n" +
 			"        </tr>\n" +
 			"    </thead>\n" +
 			"    <tbody>\n" +
 			"        <tr>\n" +
 			"            <td><h5>" + TestCommonOptions.COMMON_POSITIONED_OPTION.key() + "</h5></td>\n" +
 			"            <td style=\"word-wrap: break-word;\">" + TestCommonOptions.COMMON_POSITIONED_OPTION.defaultValue() + "</td>\n" +
+			"            <td>Integer</td>\n" +
 			"            <td>" + formatter.format(TestCommonOptions.COMMON_POSITIONED_OPTION.description()) + "</td>\n" +
 			"        </tr>\n" +
 			"        <tr>\n" +
 			"            <td><h5>" + TestCommonOptions.COMMON_OPTION.key() + "</h5></td>\n" +
 			"            <td style=\"word-wrap: break-word;\">" + TestCommonOptions.COMMON_OPTION.defaultValue() + "</td>\n" +
+			"            <td>Integer</td>\n" +
 			"            <td>" + formatter.format(TestCommonOptions.COMMON_OPTION.description()) + "</td>\n" +
 			"        </tr>\n" +
 			"    </tbody>\n" +
@@ -345,13 +475,15 @@ public class ConfigOptionsDocGeneratorTest {
 				"        <tr>\n" +
 				"            <th class=\"text-left\" style=\"width: 20%\">Key</th>\n" +
 				"            <th class=\"text-left\" style=\"width: 15%\">Default</th>\n" +
-				"            <th class=\"text-left\" style=\"width: 65%\">Description</th>\n" +
+				"            <th class=\"text-left\" style=\"width: 10%\">Type</th>\n" +
+				"            <th class=\"text-left\" style=\"width: 55%\">Description</th>\n" +
 				"        </tr>\n" +
 				"    </thead>\n" +
 				"    <tbody>\n" +
 				"        <tr>\n" +
 				"            <td><h5>first.option.a</h5></td>\n" +
 				"            <td style=\"word-wrap: break-word;\">2</td>\n" +
+				"            <td>Integer</td>\n" +
 				"            <td>This is example description for the first option.</td>\n" +
 				"        </tr>\n" +
 				"    </tbody>\n" +


### PR DESCRIPTION
## What is the purpose of the change

It adds generating type column to `ConfigOptionsDocGenerator`

## Verifying this change

* Added `org.apache.flink.docs.configuration.ConfigOptionsDocGeneratorTest#testCreatingTypes`
* All previous tests should run

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
