### PR TITLE
[FLINK-14646] Check non-null for key in KeyGroupStreamPartitioner

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupRangeAssignment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupRangeAssignment.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.util.MathUtils;
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nullable;
+
 public final class KeyGroupRangeAssignment {
 
 	/**
@@ -45,7 +47,8 @@ public final class KeyGroupRangeAssignment {
 	 * @param parallelism the current parallelism of the operator
 	 * @return the index of the parallel operator to which the given key should be routed.
 	 */
-	public static int assignKeyToParallelOperator(Object key, int maxParallelism, int parallelism) {
+	public static int assignKeyToParallelOperator(@Nullable Object key, int maxParallelism, int parallelism) {
+		Preconditions.checkNotNull(key, "Assigned key must not be null!");
 		return computeOperatorIndexForKeyGroup(maxParallelism, parallelism, assignToKeyGroup(key, maxParallelism));
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/KeyGroupStreamPartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/KeyGroupStreamPartitioner.java
@@ -55,7 +55,6 @@ public class KeyGroupStreamPartitioner<T, K> extends StreamPartitioner<T> implem
 		} catch (Exception e) {
 			throw new RuntimeException("Could not extract key from " + record.getInstance().getValue(), e);
 		}
-		Preconditions.checkNotNull(key, "HASH key must not be null!");
 		return KeyGroupRangeAssignment.assignKeyToParallelOperator(key, maxParallelism, numberOfChannels);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/KeyGroupStreamPartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/KeyGroupStreamPartitioner.java
@@ -55,6 +55,7 @@ public class KeyGroupStreamPartitioner<T, K> extends StreamPartitioner<T> implem
 		} catch (Exception e) {
 			throw new RuntimeException("Could not extract key from " + record.getInstance().getValue(), e);
 		}
+		Preconditions.checkNotNull(key, "HASH key must not be null!");
 		return KeyGroupRangeAssignment.assignKeyToParallelOperator(key, maxParallelism, numberOfChannels);
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Add non-null check for key in KeyGroupStreamPartitioner because the NPE message thrown is not friendly to users.

## Brief change log

Add Preconditions to check null.
