### PR TITLE
[FLINK-14420][doc] Add documentation for pluggable module

### DIFF
--- a/docs/dev/table/hive/hive_functions.md
+++ b/docs/dev/table/hive/hive_functions.md
@@ -169,7 +169,7 @@ Please reference to [Hive]({{ site.baseurl }}/dev/table/hive/index.html) for dat
 
 ## Use Hive Built-in Functions via HiveModule
 
-HiveModule provides Hive built-in functions as Flink system (built-in) functions to Flink SQL and Table API users.
+The `HiveModule` provides Hive built-in functions as Flink system (built-in) functions to Flink SQL and Table API users.
 
 <div class="codetabs" markdown="1">
 <div data-lang="Java" markdown="1">

--- a/docs/dev/table/hive/hive_functions.md
+++ b/docs/dev/table/hive/hive_functions.md
@@ -165,3 +165,39 @@ Support for Hive functions has only been tested for Flink batch in Blink planner
 Hive functions currently cannot be used across catalogs in Flink.
 
 Please reference to [Hive]({{ site.baseurl }}/dev/table/hive/index.html) for data type limitations.
+
+
+## Use Hive Built-in Functions via HiveModule
+
+HiveModule provides Hive built-in functions as Flink system (built-in) functions to Flink SQL and Table API users.
+
+<div class="codetabs" markdown="1">
+<div data-lang="Java" markdown="1">
+{% highlight java %}
+
+String name            = "myhive";
+String version         = "2.3.4";
+
+tableEnv.loadModue(name, new HiveModule(version));
+{% endhighlight %}
+</div>
+<div data-lang="Scala" markdown="1">
+{% highlight scala %}
+
+val name            = "myhive"
+val version         = "2.3.4"
+
+tableEnv.loadModue(name, new HiveModule(version));
+{% endhighlight %}
+</div>
+<div data-lang="YAML" markdown="1">
+{% highlight yaml %}
+modules:
+   - name: core
+     type: core
+   - name: myhive
+     type: hive
+     hive-version: 2.3.4
+{% endhighlight %}
+</div>
+</div>

--- a/docs/dev/table/hive/hive_functions.zh.md
+++ b/docs/dev/table/hive/hive_functions.zh.md
@@ -169,7 +169,7 @@ Please reference to [Hive]({{ site.baseurl }}/dev/table/hive/index.html) for dat
 
 ## Use Hive Built-in Functions via HiveModule
 
-HiveModule provides Hive built-in functions as Flink system (built-in) functions to Flink SQL and Table API users.
+The `HiveModule` provides Hive built-in functions as Flink system (built-in) functions to Flink SQL and Table API users.
 
 <div class="codetabs" markdown="1">
 <div data-lang="Java" markdown="1">

--- a/docs/dev/table/hive/hive_functions.zh.md
+++ b/docs/dev/table/hive/hive_functions.zh.md
@@ -165,3 +165,39 @@ Support for Hive functions has only been tested for Flink batch in Blink planner
 Hive functions currently cannot be used across catalogs in Flink.
 
 Please reference to [Hive]({{ site.baseurl }}/dev/table/hive/index.html) for data type limitations.
+
+
+## Use Hive Built-in Functions via HiveModule
+
+HiveModule provides Hive built-in functions as Flink system (built-in) functions to Flink SQL and Table API users.
+
+<div class="codetabs" markdown="1">
+<div data-lang="Java" markdown="1">
+{% highlight java %}
+
+String name            = "myhive";
+String version         = "2.3.4";
+
+tableEnv.loadModue(name, new HiveModule(version));
+{% endhighlight %}
+</div>
+<div data-lang="Scala" markdown="1">
+{% highlight scala %}
+
+val name            = "myhive"
+val version         = "2.3.4"
+
+tableEnv.loadModue(name, new HiveModule(version));
+{% endhighlight %}
+</div>
+<div data-lang="YAML" markdown="1">
+{% highlight yaml %}
+modules:
+   - name: core
+     type: core
+   - name: myhive
+     type: hive
+     hive-version: 2.3.4
+{% endhighlight %}
+</div>
+</div>

--- a/docs/dev/table/modules.md
+++ b/docs/dev/table/modules.md
@@ -1,0 +1,128 @@
+---
+title: "Modules"
+is_beta: true
+nav-parent_id: tableapi
+nav-pos: 90
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+Modules can extend Flink's built-in objects by defining a set of metadata, for example, functions.
+
+Modules are pluggable. Flink provides a few pre-built modules. Users can write their own too.
+
+For example, users can define their own geo functions and plug them into Flink as built-in functions to be used in 
+Flink SQL and Table APIs. Another example is users can load an out-of-shelf Hive module to use Hive built-in 
+functions as part of Flink built-in functions.
+
+* This will be replaced by the TOC
+{:toc}
+
+## Module Types
+
+### CoreModule
+
+`CoreModule` currently contains all system (built-in) functions. It's loaded by default.
+
+### HiveModule
+
+The `HiveModule` provides Hive built-in functions as Flink's system functions to SQL and Table API users.
+Flink's [Hive documentation]({{ site.baseurl }}/dev/table/hive/index.html) provides full details on setting up the module.
+
+### User-Defined Module
+
+Users can develop custom modules by implementing the `Module` interface.
+To use custom modules in SQL CLI, users should develop both a module and its corresponding module factory by implementing 
+the `ModuleFactory` interface.
+
+Module factory defines a set of properties for configuring the module when the SQL CLI bootstraps.
+The set of properties will be passed to a discovery service where the service tries to match the properties to
+ a `ModuleFactory` and initiate a corresponding module instance.
+ 
+
+## Namespace and Resolution Order
+
+Objects provided by modules are taken as part of Flink's system (built-in) objects, thus they don't have any namespaces.
+
+The order to load modules matter for resolution purpose. When there are two objects of the same name residing in two modules,
+Flink always resolve the object reference to the one in the 1st loaded module. 
+
+
+## Module API
+
+### Loading and unloading a Module
+
+Users can load and unload modules in an existing Flink session.
+
+<div class="codetabs" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+tableEnv.loadModule("myModule", new CustomModule());
+tableEnv.unloadModule("myModule");
+{% endhighlight %}
+</div>
+<div data-lang="YAML" markdown="1">
+
+All modules defined using YAML must provide a `type` property that specifies the type. 
+The following types are supported out of the box.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-center" style="width: 25%">Catalog</th>
+      <th class="text-center">Type Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+        <td class="text-center">CoreModule</td>
+        <td class="text-center">core</td>
+    </tr>
+    <tr>
+        <td class="text-center">HiveModule</td>
+        <td class="text-center">hive</td>
+    </tr>
+  </tbody>
+</table>
+
+{% highlight yaml %}
+modules:
+   - name: core
+     type: core
+   - name: myhive
+     type: hive
+     hive-version: 1.2.1
+{% endhighlight %}
+</div>
+</div>
+
+### List Available Catalogs
+
+<div class="codetabs" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+tableEnv.listModules();
+{% endhighlight %}
+</div>
+<div data-lang="SQL" markdown="1">
+{% highlight sql %}
+Flink SQL> SHOW MODULES;
+{% endhighlight %}
+</div>
+</div>

--- a/docs/dev/table/modules.md
+++ b/docs/dev/table/modules.md
@@ -23,13 +23,13 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-Modules can extend Flink's built-in objects by defining a set of metadata, for example, functions.
-
-Modules are pluggable. Flink provides a few pre-built modules. Users can write their own too.
+Modules allow users to extend Flink's built-in objects, such as defining functions that behave like Flink 
+built-in functions. They are pluggable, and while Flink provides a few pre-built modules, users can write 
+their own.
 
 For example, users can define their own geo functions and plug them into Flink as built-in functions to be used in 
 Flink SQL and Table APIs. Another example is users can load an out-of-shelf Hive module to use Hive built-in 
-functions as part of Flink built-in functions.
+functions as Flink built-in functions.
 
 * This will be replaced by the TOC
 {:toc}
@@ -38,7 +38,7 @@ functions as part of Flink built-in functions.
 
 ### CoreModule
 
-`CoreModule` currently contains all system (built-in) functions. It's loaded by default.
+`CoreModule` contains all of Flink's system (built-in) functions and is loaded by default.
 
 ### HiveModule
 
@@ -51,18 +51,16 @@ Users can develop custom modules by implementing the `Module` interface.
 To use custom modules in SQL CLI, users should develop both a module and its corresponding module factory by implementing 
 the `ModuleFactory` interface.
 
-Module factory defines a set of properties for configuring the module when the SQL CLI bootstraps.
-The set of properties will be passed to a discovery service where the service tries to match the properties to
- a `ModuleFactory` and initiate a corresponding module instance.
+A module factory defines a set of properties for configuring the module when the SQL CLI bootstraps.
+Properties are passed to a discovery service where the service tries to match the properties to
+ a `ModuleFactory` and instantiate a corresponding module instance.
  
 
 ## Namespace and Resolution Order
 
-Objects provided by modules are taken as part of Flink's system (built-in) objects, thus they don't have any namespaces.
+Objects provided by modules are considered part of Flink's system (built-in) objects; thus, they don't have any namespaces.
 
-The order to load modules matter for resolution purpose. When there are two objects of the same name residing in two modules,
-Flink always resolve the object reference to the one in the 1st loaded module. 
-
+When there are two objects of the same name residing in two modules, Flink always resolves the object reference to the one in the 1st loaded module.
 
 ## Module API
 

--- a/docs/dev/table/modules.md
+++ b/docs/dev/table/modules.md
@@ -43,7 +43,7 @@ functions as part of Flink built-in functions.
 ### HiveModule
 
 The `HiveModule` provides Hive built-in functions as Flink's system functions to SQL and Table API users.
-Flink's [Hive documentation]({{ site.baseurl }}/dev/table/hive/index.html) provides full details on setting up the module.
+Flink's [Hive documentation]({{ site.baseurl }}/dev/table/hive/hive_functions.html) provides full details on setting up the module.
 
 ### User-Defined Module
 

--- a/docs/dev/table/modules.zh.md
+++ b/docs/dev/table/modules.zh.md
@@ -23,13 +23,13 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-Modules can extend Flink's built-in objects by defining a set of metadata, for example, functions.
-
-Modules are pluggable. Flink provides a few pre-built modules. Users can write their own too.
+Modules allow users to extend Flink's built-in objects, such as defining functions that behave like Flink 
+built-in functions. They are pluggable, and while Flink provides a few pre-built modules, users can write 
+their own.
 
 For example, users can define their own geo functions and plug them into Flink as built-in functions to be used in 
 Flink SQL and Table APIs. Another example is users can load an out-of-shelf Hive module to use Hive built-in 
-functions as part of Flink built-in functions.
+functions as Flink built-in functions.
 
 * This will be replaced by the TOC
 {:toc}
@@ -38,7 +38,7 @@ functions as part of Flink built-in functions.
 
 ### CoreModule
 
-`CoreModule` currently contains all system (built-in) functions. It's loaded by default.
+`CoreModule` contains all of Flink's system (built-in) functions and is loaded by default.
 
 ### HiveModule
 
@@ -51,18 +51,16 @@ Users can develop custom modules by implementing the `Module` interface.
 To use custom modules in SQL CLI, users should develop both a module and its corresponding module factory by implementing 
 the `ModuleFactory` interface.
 
-Module factory defines a set of properties for configuring the module when the SQL CLI bootstraps.
-The set of properties will be passed to a discovery service where the service tries to match the properties to
- a `ModuleFactory` and initiate a corresponding module instance.
+A module factory defines a set of properties for configuring the module when the SQL CLI bootstraps.
+Properties are passed to a discovery service where the service tries to match the properties to
+ a `ModuleFactory` and instantiate a corresponding module instance.
  
 
 ## Namespace and Resolution Order
 
-Objects provided by modules are taken as part of Flink's system (built-in) objects, thus they don't have any namespaces.
+Objects provided by modules are considered part of Flink's system (built-in) objects; thus, they don't have any namespaces.
 
-The order to load modules matter for resolution purpose. When there are two objects of the same name residing in two modules,
-Flink always resolve the object reference to the one in the 1st loaded module. 
-
+When there are two objects of the same name residing in two modules, Flink always resolves the object reference to the one in the 1st loaded module.
 
 ## Module API
 

--- a/docs/dev/table/modules.zh.md
+++ b/docs/dev/table/modules.zh.md
@@ -43,7 +43,7 @@ functions as part of Flink built-in functions.
 ### HiveModule
 
 The `HiveModule` provides Hive built-in functions as Flink's system functions to SQL and Table API users.
-Flink's [Hive documentation]({{ site.baseurl }}/dev/table/hive/index.html) provides full details on setting up the module.
+Flink's [Hive documentation]({{ site.baseurl }}/dev/table/hive/hive_functions.html) provides full details on setting up the module.
 
 ### User-Defined Module
 

--- a/docs/dev/table/modules.zh.md
+++ b/docs/dev/table/modules.zh.md
@@ -1,0 +1,128 @@
+---
+title: "模块"
+is_beta: true
+nav-parent_id: tableapi
+nav-pos: 90
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+Modules can extend Flink's built-in objects by defining a set of metadata, for example, functions.
+
+Modules are pluggable. Flink provides a few pre-built modules. Users can write their own too.
+
+For example, users can define their own geo functions and plug them into Flink as built-in functions to be used in 
+Flink SQL and Table APIs. Another example is users can load an out-of-shelf Hive module to use Hive built-in 
+functions as part of Flink built-in functions.
+
+* This will be replaced by the TOC
+{:toc}
+
+## Module Types
+
+### CoreModule
+
+`CoreModule` currently contains all system (built-in) functions. It's loaded by default.
+
+### HiveModule
+
+The `HiveModule` provides Hive built-in functions as Flink's system functions to SQL and Table API users.
+Flink's [Hive documentation]({{ site.baseurl }}/dev/table/hive/index.html) provides full details on setting up the module.
+
+### User-Defined Module
+
+Users can develop custom modules by implementing the `Module` interface.
+To use custom modules in SQL CLI, users should develop both a module and its corresponding module factory by implementing 
+the `ModuleFactory` interface.
+
+Module factory defines a set of properties for configuring the module when the SQL CLI bootstraps.
+The set of properties will be passed to a discovery service where the service tries to match the properties to
+ a `ModuleFactory` and initiate a corresponding module instance.
+ 
+
+## Namespace and Resolution Order
+
+Objects provided by modules are taken as part of Flink's system (built-in) objects, thus they don't have any namespaces.
+
+The order to load modules matter for resolution purpose. When there are two objects of the same name residing in two modules,
+Flink always resolve the object reference to the one in the 1st loaded module. 
+
+
+## Module API
+
+### Loading and unloading a Module
+
+Users can load and unload modules in an existing Flink session.
+
+<div class="codetabs" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+tableEnv.loadModule("myModule", new CustomModule());
+tableEnv.unloadModule("myModule");
+{% endhighlight %}
+</div>
+<div data-lang="YAML" markdown="1">
+
+All modules defined using YAML must provide a `type` property that specifies the type. 
+The following types are supported out of the box.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-center" style="width: 25%">Catalog</th>
+      <th class="text-center">Type Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+        <td class="text-center">CoreModule</td>
+        <td class="text-center">core</td>
+    </tr>
+    <tr>
+        <td class="text-center">HiveModule</td>
+        <td class="text-center">hive</td>
+    </tr>
+  </tbody>
+</table>
+
+{% highlight yaml %}
+modules:
+   - name: core
+     type: core
+   - name: myhive
+     type: hive
+     hive-version: 1.2.1
+{% endhighlight %}
+</div>
+</div>
+
+### List Available Catalogs
+
+<div class="codetabs" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
+{% highlight java %}
+tableEnv.listModules();
+{% endhighlight %}
+</div>
+<div data-lang="SQL" markdown="1">
+{% highlight sql %}
+Flink SQL> SHOW MODULES;
+{% endhighlight %}
+</div>
+</div>


### PR DESCRIPTION
### What is the purpose of the change

Add doc for pluggable module

## Brief change log

Add doc for pluggable module

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper:(no)
  - The S3 file system connector: (no)
## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
