### PR TITLE
[FLINK-14637] Introduce framework off heap memory config

### DIFF
--- a/docs/_includes/generated/task_manager_memory_configuration.html
+++ b/docs/_includes/generated/task_manager_memory_configuration.html
@@ -13,6 +13,11 @@
             <td>Framework Heap Memory size for TaskExecutors. This is the size of JVM heap memory reserved for TaskExecutor framework, which will not be allocated to task slots.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.memory.framework.off-heap.size</h5></td>
+            <td style="word-wrap: break-word;">"64m"</td>
+            <td>Framework Off-Heap Memory size for TaskExecutors. This is the size of off-heap memory (JVM direct memory or native memory) reserved for TaskExecutor framework, which will not be allocated to task slots. It will be accounted as part of the JVM max direct memory size limit.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.memory.jvm-metaspace.size</h5></td>
             <td style="word-wrap: break-word;">"192m"</td>
             <td>JVM Metaspace Size for the TaskExecutors.</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -279,6 +279,16 @@ public class TaskManagerOptions {
 				+ " for TaskExecutor framework, which will not be allocated to task slots.");
 
 	/**
+	 * Framework Off-Heap Memory size for TaskExecutors.
+	 */
+	public static final ConfigOption<String> FRAMEWORK_OFF_HEAP_MEMORY =
+		key("taskmanager.memory.framework.off-heap.size")
+			.defaultValue("64m")
+			.withDescription("Framework Off-Heap Memory size for TaskExecutors. This is the size of off-heap memory"
+				+ " (JVM direct memory or native memory) reserved for TaskExecutor framework, which will not be"
+				+ " allocated to task slots. It will be accounted as part of the JVM max direct memory size limit.");
+
+	/**
 	 * Task Heap Memory size for TaskExecutors.
 	 */
 	public static final ConfigOption<String> TASK_HEAP_MEMORY =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceSpec.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceSpec.java
@@ -155,4 +155,26 @@ public class TaskExecutorResourceSpec {
 	public MemorySize getTotalProcessMemorySize() {
 		return getTotalFlinkMemorySize().add(jvmMetaspaceSize).add(jvmOverheadSize);
 	}
+
+	public MemorySize getJvmHeapMemorySize() {
+		return frameworkHeapSize.add(taskHeapSize).add(onHeapManagedMemorySize);
+	}
+
+	public MemorySize getJvmDirectMemorySize() {
+		return taskOffHeapSize.add(shuffleMemSize);
+	}
+
+	@Override
+	public String toString() {
+		return "TaskExecutorResourceSpec {"
+			+ "frameworkHeapSize=" + frameworkHeapSize.toString()
+			+ ", taskHeapSize=" + taskHeapSize.toString()
+			+ ", taskOffHeapSize=" + taskOffHeapSize.toString()
+			+ ", shuffleMemSize=" + shuffleMemSize.toString()
+			+ ", onHeapManagedMemorySize=" + onHeapManagedMemorySize.toString()
+			+ ", offHeapManagedMemorySize=" + offHeapManagedMemorySize.toString()
+			+ ", jvmMetaspaceSize=" + jvmMetaspaceSize.toString()
+			+ ", jvmOverheadSize=" + jvmOverheadSize.toString()
+			+ "}";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceSpec.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceSpec.java
@@ -78,6 +78,8 @@ public class TaskExecutorResourceSpec {
 
 	private final MemorySize frameworkHeapSize;
 
+	private final MemorySize frameworkOffHeapMemorySize;
+
 	private final MemorySize taskHeapSize;
 
 	private final MemorySize taskOffHeapSize;
@@ -94,6 +96,7 @@ public class TaskExecutorResourceSpec {
 
 	public TaskExecutorResourceSpec(
 		MemorySize frameworkHeapSize,
+		MemorySize frameworkOffHeapSize,
 		MemorySize taskHeapSize,
 		MemorySize taskOffHeapSize,
 		MemorySize shuffleMemSize,
@@ -103,6 +106,7 @@ public class TaskExecutorResourceSpec {
 		MemorySize jvmOverheadSize) {
 
 		this.frameworkHeapSize = frameworkHeapSize;
+		this.frameworkOffHeapMemorySize = frameworkOffHeapSize;
 		this.taskHeapSize = taskHeapSize;
 		this.taskOffHeapSize = taskOffHeapSize;
 		this.shuffleMemSize = shuffleMemSize;
@@ -114,6 +118,10 @@ public class TaskExecutorResourceSpec {
 
 	public MemorySize getFrameworkHeapSize() {
 		return frameworkHeapSize;
+	}
+
+	public MemorySize getFrameworkOffHeapMemorySize() {
+		return frameworkOffHeapMemorySize;
 	}
 
 	public MemorySize getTaskHeapSize() {
@@ -149,7 +157,7 @@ public class TaskExecutorResourceSpec {
 	}
 
 	public MemorySize getTotalFlinkMemorySize() {
-		return frameworkHeapSize.add(taskHeapSize).add(taskOffHeapSize).add(shuffleMemSize).add(getManagedMemorySize());
+		return frameworkHeapSize.add(frameworkOffHeapMemorySize).add(taskHeapSize).add(taskOffHeapSize).add(shuffleMemSize).add(getManagedMemorySize());
 	}
 
 	public MemorySize getTotalProcessMemorySize() {
@@ -161,13 +169,14 @@ public class TaskExecutorResourceSpec {
 	}
 
 	public MemorySize getJvmDirectMemorySize() {
-		return taskOffHeapSize.add(shuffleMemSize);
+		return frameworkOffHeapMemorySize.add(taskOffHeapSize).add(shuffleMemSize);
 	}
 
 	@Override
 	public String toString() {
 		return "TaskExecutorResourceSpec {"
 			+ "frameworkHeapSize=" + frameworkHeapSize.toString()
+			+ ", frameworkOffHeapSize=" + frameworkOffHeapMemorySize.toString()
 			+ ", taskHeapSize=" + taskHeapSize.toString()
 			+ ", taskOffHeapSize=" + taskOffHeapSize.toString()
 			+ ", shuffleMemSize=" + shuffleMemSize.toString()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
@@ -45,11 +45,8 @@ public class TaskExecutorResourceUtils {
 	// ------------------------------------------------------------------------
 
 	public static String generateJvmParametersStr(final TaskExecutorResourceSpec taskExecutorResourceSpec) {
-		final MemorySize jvmHeapSize = taskExecutorResourceSpec.getFrameworkHeapSize()
-			.add(taskExecutorResourceSpec.getTaskHeapSize())
-			.add(taskExecutorResourceSpec.getOnHeapManagedMemorySize());
-		final MemorySize jvmDirectSize = taskExecutorResourceSpec.getTaskOffHeapSize()
-			.add(taskExecutorResourceSpec.getShuffleMemSize());
+		final MemorySize jvmHeapSize = taskExecutorResourceSpec.getJvmHeapMemorySize();
+		final MemorySize jvmDirectSize = taskExecutorResourceSpec.getJvmDirectMemorySize();
 		final MemorySize jvmMetaspaceSize = taskExecutorResourceSpec.getJvmMetaspaceSize();
 
 		return "-Xmx" + jvmHeapSize.getBytes()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
@@ -62,6 +62,7 @@ public class TaskExecutorResourceUtils {
 	public static String generateDynamicConfigsStr(final TaskExecutorResourceSpec taskExecutorResourceSpec) {
 		final Map<String, String> configs = new HashMap<>();
 		configs.put(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY.key(), taskExecutorResourceSpec.getFrameworkHeapSize().getBytes() + "b");
+		configs.put(TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY.key(), taskExecutorResourceSpec.getFrameworkOffHeapMemorySize().getBytes() + "b");
 		configs.put(TaskManagerOptions.TASK_HEAP_MEMORY.key(), taskExecutorResourceSpec.getTaskHeapSize().getBytes() + "b");
 		configs.put(TaskManagerOptions.TASK_OFF_HEAP_MEMORY.key(), taskExecutorResourceSpec.getTaskOffHeapSize().getBytes() + "b");
 		configs.put(TaskManagerOptions.SHUFFLE_MEMORY_MIN.key(), taskExecutorResourceSpec.getShuffleMemSize().getBytes() + "b");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
@@ -525,6 +525,7 @@ public class TaskExecutorResourceUtils {
 		final FlinkInternalMemory flinkInternalMemory, final JvmMetaspaceAndOverhead jvmMetaspaceAndOverhead) {
 		return new TaskExecutorResourceSpec(
 			flinkInternalMemory.frameworkHeap,
+			new MemorySize(0), // TODO: replace with actual framework off-heap memory size
 			flinkInternalMemory.taskHeap,
 			flinkInternalMemory.taskOffHeap,
 			flinkInternalMemory.shuffle,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtilsTest.java
@@ -76,6 +76,7 @@ public class TaskExecutorResourceUtilsTest extends TestLogger {
 		}
 
 		assertThat(MemorySize.parse(configs.get(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY.key())), is(TM_RESOURCE_SPEC.getFrameworkHeapSize()));
+		assertThat(MemorySize.parse(configs.get(TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY.key())), is(TM_RESOURCE_SPEC.getFrameworkOffHeapMemorySize()));
 		assertThat(MemorySize.parse(configs.get(TaskManagerOptions.TASK_HEAP_MEMORY.key())), is(TM_RESOURCE_SPEC.getTaskHeapSize()));
 		assertThat(MemorySize.parse(configs.get(TaskManagerOptions.TASK_OFF_HEAP_MEMORY.key())), is(TM_RESOURCE_SPEC.getTaskOffHeapSize()));
 		assertThat(MemorySize.parse(configs.get(TaskManagerOptions.SHUFFLE_MEMORY_MAX.key())), is(TM_RESOURCE_SPEC.getShuffleMemSize()));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtilsTest.java
@@ -55,7 +55,8 @@ public class TaskExecutorResourceUtilsTest extends TestLogger {
 		MemorySize.parse("5m"),
 		MemorySize.parse("6m"),
 		MemorySize.parse("7m"),
-		MemorySize.parse("8m"));
+		MemorySize.parse("8m"),
+		MemorySize.parse("9m"));
 
 	@Test
 	public void testGenerateDynamicConfigurations() {
@@ -106,7 +107,7 @@ public class TaskExecutorResourceUtilsTest extends TestLogger {
 
 		assertThat(heapSizeMax, is(TM_RESOURCE_SPEC.getFrameworkHeapSize().add(TM_RESOURCE_SPEC.getTaskHeapSize()).add(TM_RESOURCE_SPEC.getOnHeapManagedMemorySize())));
 		assertThat(heapSizeMin, is(heapSizeMax));
-		assertThat(directSize, is(TM_RESOURCE_SPEC.getTaskOffHeapSize().add(TM_RESOURCE_SPEC.getShuffleMemSize())));
+		assertThat(directSize, is(TM_RESOURCE_SPEC.getFrameworkOffHeapMemorySize().add(TM_RESOURCE_SPEC.getTaskOffHeapSize()).add(TM_RESOURCE_SPEC.getShuffleMemSize())));
 		assertThat(metaspaceSize, is(TM_RESOURCE_SPEC.getJvmMetaspaceSize()));
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtilsTest.java
@@ -44,7 +44,7 @@ public class TaskExecutorResourceUtilsTest extends TestLogger {
 
 	private static final MemorySize TASK_HEAP_SIZE = MemorySize.parse("100m");
 	private static final MemorySize MANAGED_MEM_SIZE = MemorySize.parse("200m");
-	private static final MemorySize TOTAL_FLINK_MEM_SIZE = MemorySize.parse("800m");
+	private static final MemorySize TOTAL_FLINK_MEM_SIZE = MemorySize.parse("900m");
 	private static final MemorySize TOTAL_PROCESS_MEM_SIZE = MemorySize.parse("1g");
 
 	private static final TaskExecutorResourceSpec TM_RESOURCE_SPEC = new TaskExecutorResourceSpec(
@@ -118,6 +118,16 @@ public class TaskExecutorResourceUtilsTest extends TestLogger {
 		conf.setString(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY, frameworkHeapSize.getMebiBytes() + "m");
 
 		validateInAllConfigurations(conf, taskExecutorResourceSpec -> assertThat(taskExecutorResourceSpec.getFrameworkHeapSize(), is(frameworkHeapSize)));
+	}
+
+	@Test
+	public void testConfigFrameworkOffHeapMemory() {
+		final MemorySize frameworkOffHeapSize = MemorySize.parse("10m");
+
+		Configuration conf = new Configuration();
+		conf.setString(TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY, frameworkOffHeapSize.getMebiBytes() + "m");
+
+		validateInAllConfigurations(conf, taskExecutorResourceSpec -> assertThat(taskExecutorResourceSpec.getFrameworkOffHeapMemorySize(), is(frameworkOffHeapSize)));
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces a config option accounting for Flink framework off-heap memory usage (except for network buffers).

## Brief change log
- 402f7a39de80edadf7ad22d7fef5c9bd13f29386: Hotfix of adding shortcuts getting jvm heap/direct memory size in `TaskExecutorResourceSpec`.
- 05f8a709b0fbf7872aa11e33b8c7148c08ec36e6: Introduce config option for framework off-heap memory size.
- a862a0263ef349bf8df8a47242b1a768f0b10489: Introduce framework off-heap memory size in `TaskExecutorResourceSpec`
- f5fbfbd4f113563ea20ee6eed0b70905abcfa3fd: Update memory calculation logics to account for framework off-heap memory size.
- e9e139cea0b3d1ed18fd614c56563c6df036e30f: Generate dynamic configurations with respect to framework off-heap memory size.

## Verifying this change

- Add `TaskExecutorResourceUtilsTest#testConfigFrameworkOffHeapMemory`
- Update `TaskExecutorResourceUtilsTest#testGenerateDynamicConfigurations`
- Update `TaskExecutorResourceUtilsTest#testGenerateJvmParameters`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
