### PR TITLE
[FLINK-14590][python] Unify the working directory of Java process and Python process when submitting python jobs via "flink run -py"

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonDriver.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonDriver.java
@@ -25,9 +25,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import py4j.GatewayServer;
 
+import java.io.File;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * A main class used to launch Python applications. It executes python as a
@@ -65,8 +67,10 @@ public final class PythonDriver {
 		final List<String> commands = constructPythonCommands(pythonDriverOptions);
 		try {
 			// prepare the exec environment of python progress.
+			String tmpDir = System.getProperty("java.io.tmpdir") +
+				File.separator + "pyflink" + File.separator + UUID.randomUUID();
 			PythonDriverEnvUtils.PythonEnvironment pythonEnv = PythonDriverEnvUtils.preparePythonEnvironment(
-				pythonDriverOptions.getPythonLibFiles());
+				pythonDriverOptions.getPythonLibFiles(), tmpDir);
 			// set env variable PYFLINK_GATEWAY_PORT for connecting of python gateway in python progress.
 			pythonEnv.systemEnv.put("PYFLINK_GATEWAY_PORT", String.valueOf(gatewayServer.getListeningPort()));
 			// start the python process.

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonDriverEnvUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonDriverEnvUtils.java
@@ -21,7 +21,6 @@ package org.apache.flink.client.python;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.FileUtils;
-import org.apache.flink.util.StringUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,11 +29,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static org.apache.flink.python.util.ResourceUtil.extractBasicDependenciesFromResource;
 
@@ -48,7 +47,7 @@ public final class PythonDriverEnvUtils {
 	 * Wraps Python exec environment.
 	 */
 	public static class PythonEnvironment {
-		public String workingDirectory;
+		public String storageDirectory;
 
 		public String pythonExec = "python";
 
@@ -85,28 +84,24 @@ public final class PythonDriverEnvUtils {
 	 * Prepares PythonEnvironment to start python process.
 	 *
 	 * @param pythonLibFiles The dependent Python files.
+	 * @param tmpDir The temporary directory files copied to.
 	 * @return PythonEnvironment the Python environment which will be executed in Python process.
 	 */
-	public static PythonEnvironment preparePythonEnvironment(List<Path> pythonLibFiles)
-		throws IOException, InterruptedException {
+	public static PythonEnvironment preparePythonEnvironment(
+				List<Path> pythonLibFiles,
+				String tmpDir) throws IOException, InterruptedException {
 		PythonEnvironment env = new PythonEnvironment();
 
-		// 1. setup temporary local directory for the user files
-		String tmpDir = System.getProperty("java.io.tmpdir") +
-			File.separator + "pyflink" + File.separator + UUID.randomUUID();
+		tmpDir = new File(tmpDir).getAbsolutePath();
 
+		// 1. setup temporary local directory for the user files
 		Path tmpDirPath = new Path(tmpDir);
 		FileSystem fs = tmpDirPath.getFileSystem();
-		if (fs.exists(tmpDirPath)) {
-			fs.delete(tmpDirPath, true);
-		}
 		fs.mkdirs(tmpDirPath);
 
-		env.workingDirectory = tmpDirPath.toString();
+		env.storageDirectory = tmpDir;
 
-		StringBuilder pythonPathEnv = new StringBuilder();
-
-		pythonPathEnv.append(env.workingDirectory);
+		List<String> pythonPathList = new ArrayList<>();
 
 		List<File> internalLibs = extractBasicDependenciesFromResource(
 			tmpDir,
@@ -115,39 +110,54 @@ public final class PythonDriverEnvUtils {
 
 		// 2. append the internal lib files to PYTHONPATH.
 		for (File file: internalLibs) {
-			pythonPathEnv.append(File.pathSeparator);
-			pythonPathEnv.append(file.getAbsolutePath());
+			pythonPathList.add(file.getAbsolutePath());
 			file.deleteOnExit();
 		}
 
 		// 3. copy relevant python files to tmp dir and set them in PYTHONPATH.
 		for (Path pythonFile : pythonLibFiles) {
 			String sourceFileName = pythonFile.getName();
-			Path targetPath = new Path(tmpDirPath, sourceFileName);
-			FileUtils.copy(pythonFile, targetPath, true);
-			String targetFileNames = Files.walk(Paths.get(targetPath.toString()))
-				.filter(Files::isRegularFile)
-				.filter(f -> !f.toString().endsWith(".py"))
-				.map(java.nio.file.Path::toString)
-				.collect(Collectors.joining(File.pathSeparator));
-			pythonPathEnv.append(File.pathSeparator);
-			pythonPathEnv.append(targetFileNames);
+			// add random UUID parent directory to avoid name conflict.
+			Path targetPath = new Path(
+				tmpDirPath,
+				String.join(File.separator, UUID.randomUUID().toString(), sourceFileName));
+			if (!pythonFile.getFileSystem().isDistributedFS()) {
+				// if the path is local file, try to create symbolic link.
+				createSymbolicLinkForPyflinkLib(
+					Paths.get(new File(pythonFile.getPath()).getAbsolutePath()),
+					Paths.get(targetPath.toString()));
+			} else {
+				FileUtils.copy(pythonFile, targetPath, true);
+			}
+			if (Paths.get(targetPath.toString()).toRealPath().toFile().isFile() &&
+				sourceFileName.endsWith(".py")) {
+				// add the parent directory of .py file itself to PYTHONPATH
+				pythonPathList.add(targetPath.getParent().toString());
+			} else {
+				pythonPathList.add(targetPath.toString());
+			}
 		}
 
-		// 4. add the parent directory to PYTHONPATH for files suffixed with .py
-		String pyFileParents = Files.walk(Paths.get(tmpDirPath.toString()))
-			.filter(file -> file.toString().endsWith(".py"))
-			.map(java.nio.file.Path::getParent)
-			.distinct()
-			.map(java.nio.file.Path::toString)
-			.collect(Collectors.joining(File.pathSeparator));
-		if (!StringUtils.isNullOrWhitespaceOnly(pyFileParents)) {
-			pythonPathEnv.append(File.pathSeparator);
-			pythonPathEnv.append(pyFileParents);
-		}
-
-		env.pythonPath = pythonPathEnv.toString();
+		env.pythonPath = String.join(File.pathSeparator, pythonPathList);
 		return env;
+	}
+
+	/**
+	 * Creates symbolLink in working directory for pyflink lib.
+	 *
+	 * @param libPath          the pyflink lib file path.
+	 * @param symbolicLinkPath the symbolic link to pyflink lib.
+	 */
+	public static void createSymbolicLinkForPyflinkLib(java.nio.file.Path libPath, java.nio.file.Path symbolicLinkPath)
+			throws IOException {
+		symbolicLinkPath.getParent().toFile().mkdirs();
+		try {
+			Files.createSymbolicLink(symbolicLinkPath, libPath);
+		} catch (IOException e) {
+			LOG.error("Create symbol link for pyflink lib failed.", e);
+			LOG.info("Try to copy pyflink lib to working directory");
+			Files.copy(libPath, symbolicLinkPath);
+		}
 	}
 
 	/**
@@ -165,8 +175,6 @@ public final class PythonDriverEnvUtils {
 		pythonEnv.systemEnv.forEach(env::put);
 		commands.add(0, pythonEnv.pythonExec);
 		pythonProcessBuilder.command(commands);
-		// set the working directory.
-		pythonProcessBuilder.directory(new File(pythonEnv.workingDirectory));
 		// redirect the stderr to stdout
 		pythonProcessBuilder.redirectErrorStream(true);
 		// set the child process the output same as the parent process.
@@ -177,7 +185,7 @@ public final class PythonDriverEnvUtils {
 		}
 
 		// Make sure that the python sub process will be killed when JVM exit
-		ShutDownPythonHook hook = new ShutDownPythonHook(process, pythonEnv.workingDirectory);
+		ShutDownPythonHook hook = new ShutDownPythonHook(process, pythonEnv.storageDirectory);
 		Runtime.getRuntime().addShutdownHook(hook);
 
 		return process;

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonDriverEnvUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonDriverEnvUtils.java
@@ -84,7 +84,7 @@ public final class PythonDriverEnvUtils {
 	 * Prepares PythonEnvironment to start python process.
 	 *
 	 * @param pythonLibFiles The dependent Python files.
-	 * @param tmpDir The temporary directory files copied to.
+	 * @param tmpDir The temporary directory which files will be copied to.
 	 * @return PythonEnvironment the Python environment which will be executed in Python process.
 	 */
 	public static PythonEnvironment preparePythonEnvironment(
@@ -123,14 +123,14 @@ public final class PythonDriverEnvUtils {
 				String.join(File.separator, UUID.randomUUID().toString(), sourceFileName));
 			if (!pythonFile.getFileSystem().isDistributedFS()) {
 				// if the path is local file, try to create symbolic link.
+				new File(targetPath.getParent().toString()).mkdir();
 				createSymbolicLinkForPyflinkLib(
 					Paths.get(new File(pythonFile.getPath()).getAbsolutePath()),
 					Paths.get(targetPath.toString()));
 			} else {
 				FileUtils.copy(pythonFile, targetPath, true);
 			}
-			if (Paths.get(targetPath.toString()).toRealPath().toFile().isFile() &&
-				sourceFileName.endsWith(".py")) {
+			if (Files.isRegularFile(Paths.get(targetPath.toString()).toRealPath()) && sourceFileName.endsWith(".py")) {
 				// add the parent directory of .py file itself to PYTHONPATH
 				pythonPathList.add(targetPath.getParent().toString());
 			} else {
@@ -150,7 +150,6 @@ public final class PythonDriverEnvUtils {
 	 */
 	public static void createSymbolicLinkForPyflinkLib(java.nio.file.Path libPath, java.nio.file.Path symbolicLinkPath)
 			throws IOException {
-		symbolicLinkPath.getParent().toFile().mkdirs();
 		try {
 			Files.createSymbolicLink(symbolicLinkPath, libPath);
 		} catch (IOException e) {

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonDriverEnvUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonDriverEnvUtils.java
@@ -47,7 +47,7 @@ public final class PythonDriverEnvUtils {
 	 * Wraps Python exec environment.
 	 */
 	public static class PythonEnvironment {
-		public String storageDirectory;
+		public String tempDirectory;
 
 		public String pythonExec = "python";
 
@@ -79,7 +79,6 @@ public final class PythonDriverEnvUtils {
 		}
 	}
 
-
 	/**
 	 * Prepares PythonEnvironment to start python process.
 	 *
@@ -88,8 +87,8 @@ public final class PythonDriverEnvUtils {
 	 * @return PythonEnvironment the Python environment which will be executed in Python process.
 	 */
 	public static PythonEnvironment preparePythonEnvironment(
-				List<Path> pythonLibFiles,
-				String tmpDir) throws IOException, InterruptedException {
+			List<Path> pythonLibFiles,
+			String tmpDir) throws IOException, InterruptedException {
 		PythonEnvironment env = new PythonEnvironment();
 
 		tmpDir = new File(tmpDir).getAbsolutePath();
@@ -99,8 +98,9 @@ public final class PythonDriverEnvUtils {
 		FileSystem fs = tmpDirPath.getFileSystem();
 		fs.mkdirs(tmpDirPath);
 
-		env.storageDirectory = tmpDir;
+		env.tempDirectory = tmpDir;
 
+		// 2. append the internal lib files to PYTHONPATH.
 		List<String> pythonPathList = new ArrayList<>();
 
 		List<File> internalLibs = extractBasicDependenciesFromResource(
@@ -108,7 +108,6 @@ public final class PythonDriverEnvUtils {
 			UUID.randomUUID().toString(),
 			true);
 
-		// 2. append the internal lib files to PYTHONPATH.
 		for (File file: internalLibs) {
 			pythonPathList.add(file.getAbsolutePath());
 			file.deleteOnExit();
@@ -184,7 +183,7 @@ public final class PythonDriverEnvUtils {
 		}
 
 		// Make sure that the python sub process will be killed when JVM exit
-		ShutDownPythonHook hook = new ShutDownPythonHook(process, pythonEnv.storageDirectory);
+		ShutDownPythonHook hook = new ShutDownPythonHook(process, pythonEnv.tempDirectory);
 		Runtime.getRuntime().addShutdownHook(hook);
 
 		return process;

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverEnvUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverEnvUtilsTest.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.client.python;
 
-import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.util.FileUtils;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -29,6 +29,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,100 +47,104 @@ import java.util.stream.Collectors;
 public class PythonDriverEnvUtilsTest {
 	private static final String UUID_PATTERN = "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}";
 
-	private Path tmpDirPath;
-	private FileSystem tmpDirFs;
+	private String tmpDirPath;
 
 	@Before
 	public void prepareTestEnvironment() {
-		String tmpDir = System.getProperty("java.io.tmpdir") +
-			File.separator + "pyflink" + File.separator + UUID.randomUUID();
-
-		tmpDirPath = new Path(tmpDir);
-		try {
-			tmpDirFs = tmpDirPath.getFileSystem();
-			if (tmpDirFs.exists(tmpDirPath)) {
-				tmpDirFs.delete(tmpDirPath, true);
-			}
-			tmpDirFs.mkdirs(tmpDirPath);
-		} catch (IOException e) {
-			throw new RuntimeException("initial PythonUtil test environment failed");
-		}
+		tmpDirPath = System.getProperty("java.io.tmpdir") +
+			File.separator + "pyflink_" + UUID.randomUUID();
+		new File(tmpDirPath).mkdirs();
 	}
 
 	@Test
 	public void testPreparePythonEnvironment() throws IOException, InterruptedException {
 		// xxx/a.zip, xxx/subdir/b.py, xxx/subdir/c.zip
-		File a = new File(tmpDirPath.toString() + File.separator + "a.zip");
+		File a = new File(tmpDirPath + File.separator + "a.zip");
 		a.createNewFile();
-		File subdir = new File(tmpDirPath.toString() + File.separator + "subdir");
+		File moduleDir = new File(tmpDirPath + File.separator + "module_dir");
+		moduleDir.mkdir();
+		File subdir = new File(tmpDirPath + File.separator + "subdir");
 		subdir.mkdir();
-		File b = new File(tmpDirPath.toString() + File.separator + "subdir" + File.separator + "b.py");
+		File b = new File(tmpDirPath + File.separator + "subdir" + File.separator + "b.py");
 		b.createNewFile();
-		File c = new File(tmpDirPath.toString() + File.separator + "subdir" + File.separator + "c.zip");
+		File c = new File(tmpDirPath + File.separator + "subdir" + File.separator + "c.zip");
 		c.createNewFile();
 
 		List<Path> pyFilesList = new ArrayList<>();
-		pyFilesList.add(tmpDirPath);
+		pyFilesList.add(new Path(a.getAbsolutePath()));
+		pyFilesList.add(new Path(moduleDir.getAbsolutePath()));
+		// test relative path
+		String relativePath = Paths.get(new File("").getAbsolutePath())
+			.relativize(Paths.get(b.getAbsolutePath())).toString();
+		pyFilesList.add(new Path(relativePath));
+		// test path with schema
+		pyFilesList.add(new Path("file://" + c.getAbsolutePath()));
 
-		PythonDriverEnvUtils.PythonEnvironment env = PythonDriverEnvUtils.preparePythonEnvironment(pyFilesList);
+		PythonDriverEnvUtils.PythonEnvironment env = PythonDriverEnvUtils.preparePythonEnvironment(
+			pyFilesList,
+			tmpDirPath);
+		String base = replaceUUID(env.storageDirectory);
 		Set<String> expectedPythonPaths = new HashSet<>();
-		expectedPythonPaths.add(env.workingDirectory);
-
-		String targetDir = env.workingDirectory + File.separator + tmpDirPath.getName();
-		expectedPythonPaths.add(targetDir + File.separator + a.getName());
-		expectedPythonPaths.add(targetDir + File.separator + "subdir" + File.separator + c.getName());
-
-		// the parent dir for files suffixed with .py should also be added to PYTHONPATH
-		expectedPythonPaths.add(targetDir + File.separator + "subdir");
+		expectedPythonPaths.add(String.join(File.separator, base, "{uuid}", "a.zip"));
+		expectedPythonPaths.add(String.join(File.separator, base, "{uuid}", "module_dir"));
+		expectedPythonPaths.add(String.join(File.separator, base, "{uuid}"));
+		expectedPythonPaths.add(String.join(File.separator, base, "{uuid}", "c.zip"));
 
 		Set<String> expectedInteralLibPatterns = new HashSet<>();
 		expectedInteralLibPatterns.add(
-			Pattern.quote(env.workingDirectory + File.separator) + UUID_PATTERN + "pyflink\\.zip");
+			Pattern.quote(env.storageDirectory + File.separator) + UUID_PATTERN + "pyflink\\.zip");
 		expectedInteralLibPatterns.add(
-			Pattern.quote(env.workingDirectory + File.separator) + UUID_PATTERN + "py4j-0\\.10\\.8\\.1-src\\.zip");
+			Pattern.quote(env.storageDirectory + File.separator) + UUID_PATTERN + "py4j-0\\.10\\.8\\.1-src\\.zip");
 		expectedInteralLibPatterns.add(
-			Pattern.quote(env.workingDirectory + File.separator) + UUID_PATTERN + "cloudpickle-1\\.2\\.2-src\\.zip");
+			Pattern.quote(env.storageDirectory + File.separator) + UUID_PATTERN + "cloudpickle-1\\.2\\.2-src\\.zip");
+
 		List<String> actualPaths = Arrays.asList(env.pythonPath.split(File.pathSeparator));
-		expectedPythonPaths.addAll(
-			getMatchedPaths(
-				expectedInteralLibPatterns,
-				actualPaths));
-		Assert.assertEquals(expectedPythonPaths, new HashSet<>(actualPaths));
+		List<String> internalLibPaths = getMatchedPaths(expectedInteralLibPatterns, actualPaths)
+			.stream()
+			.map(PythonDriverEnvUtilsTest::replaceUUID)
+			.collect(Collectors.toList());
+		expectedPythonPaths.addAll(internalLibPaths);
+		Assert.assertEquals(
+			expectedPythonPaths,
+			actualPaths.stream().map(PythonDriverEnvUtilsTest::replaceUUID).collect(Collectors.toSet()));
 	}
 
 	@Test
 	public void testStartPythonProcess() {
 		PythonDriverEnvUtils.PythonEnvironment pythonEnv = new PythonDriverEnvUtils.PythonEnvironment();
-		pythonEnv.workingDirectory = tmpDirPath.toString();
+		pythonEnv.storageDirectory = tmpDirPath.toString();
 		pythonEnv.pythonPath = tmpDirPath.toString();
 		List<String> commands = new ArrayList<>();
-		Path pyPath = new Path(tmpDirPath, "word_count.py");
+		String pyPath = String.join(File.separator, tmpDirPath, "verifier.py");
 		try {
-			tmpDirFs.create(pyPath, FileSystem.WriteMode.OVERWRITE);
-			File pyFile = new File(pyPath.toString());
+			File pyFile = new File(pyPath);
+			pyFile.createNewFile();
+			pyFile.setExecutable(true);
 			String pyProgram = "#!/usr/bin/python\n" +
 				"# -*- coding: UTF-8 -*-\n" +
+				"import os\n" +
 				"import sys\n" +
 				"\n" +
 				"if __name__=='__main__':\n" +
 				"\tfilename = sys.argv[1]\n" +
 				"\tfo = open(filename, \"w\")\n" +
-				"\tfo.write( \"hello world\")\n" +
+				"\tfo.write(os.getcwd())\n" +
 				"\tfo.close()";
 			Files.write(pyFile.toPath(), pyProgram.getBytes(), StandardOpenOption.WRITE);
-			Path result = new Path(tmpDirPath, "word_count_result.txt");
-			commands.add(pyFile.getName());
-			commands.add(result.getName());
+			String result = String.join(File.separator, tmpDirPath, "python_working_directory.txt");
+			commands.add(pyPath);
+			commands.add(result);
 			Process pythonProcess = PythonDriverEnvUtils.startPythonProcess(pythonEnv, commands);
 			int exitCode = pythonProcess.waitFor();
 			if (exitCode != 0) {
 				throw new RuntimeException("Python process exits with code: " + exitCode);
 			}
 			String cmdResult = new String(Files.readAllBytes(new File(result.toString()).toPath()));
-			Assert.assertEquals(cmdResult, "hello world");
+			// Check if the working directory of python process is the same as java process.
+			Assert.assertEquals(cmdResult, System.getProperty("user.dir"));
 			pythonProcess.destroyForcibly();
-			tmpDirFs.delete(pyPath, true);
-			tmpDirFs.delete(result, true);
+			new File(pyPath).delete();
+			new File(result).delete();
 		} catch (IOException | InterruptedException e) {
 			throw new RuntimeException("test start Python process failed " + e.getMessage());
 		}
@@ -147,11 +152,13 @@ public class PythonDriverEnvUtilsTest {
 
 	@After
 	public void cleanEnvironment() {
-		try {
-			tmpDirFs.delete(tmpDirPath, true);
-		} catch (IOException e) {
-			throw new RuntimeException("delete tmp dir failed " + e.getMessage());
-		}
+		FileUtils.deleteDirectoryQuietly(new File(tmpDirPath));
+	}
+
+	private static String replaceUUID(String originPath) {
+		return originPath.replaceAll(
+			"[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}",
+			"{uuid}");
 	}
 
 	private static Set<String> getMatchedPaths(Collection<String> patterns, Collection<String> paths) {

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverEnvUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverEnvUtilsTest.java
@@ -83,7 +83,7 @@ public class PythonDriverEnvUtilsTest {
 		PythonDriverEnvUtils.PythonEnvironment env = PythonDriverEnvUtils.preparePythonEnvironment(
 			pyFilesList,
 			tmpDirPath);
-		String base = replaceUUID(env.storageDirectory);
+		String base = replaceUUID(env.tempDirectory);
 		Set<String> expectedPythonPaths = new HashSet<>();
 		expectedPythonPaths.add(String.join(File.separator, base, "{uuid}", "a.zip"));
 		expectedPythonPaths.add(String.join(File.separator, base, "{uuid}", "module_dir"));
@@ -92,11 +92,11 @@ public class PythonDriverEnvUtilsTest {
 
 		Set<String> expectedInteralLibPatterns = new HashSet<>();
 		expectedInteralLibPatterns.add(
-			Pattern.quote(env.storageDirectory + File.separator) + UUID_PATTERN + "pyflink\\.zip");
+			Pattern.quote(env.tempDirectory + File.separator) + UUID_PATTERN + "pyflink\\.zip");
 		expectedInteralLibPatterns.add(
-			Pattern.quote(env.storageDirectory + File.separator) + UUID_PATTERN + "py4j-0\\.10\\.8\\.1-src\\.zip");
+			Pattern.quote(env.tempDirectory + File.separator) + UUID_PATTERN + "py4j-0\\.10\\.8\\.1-src\\.zip");
 		expectedInteralLibPatterns.add(
-			Pattern.quote(env.storageDirectory + File.separator) + UUID_PATTERN + "cloudpickle-1\\.2\\.2-src\\.zip");
+			Pattern.quote(env.tempDirectory + File.separator) + UUID_PATTERN + "cloudpickle-1\\.2\\.2-src\\.zip");
 
 		List<String> actualPaths = Arrays.asList(env.pythonPath.split(File.pathSeparator));
 		List<String> internalLibPaths = getMatchedPaths(expectedInteralLibPatterns, actualPaths)
@@ -112,7 +112,7 @@ public class PythonDriverEnvUtilsTest {
 	@Test
 	public void testStartPythonProcess() {
 		PythonDriverEnvUtils.PythonEnvironment pythonEnv = new PythonDriverEnvUtils.PythonEnvironment();
-		pythonEnv.storageDirectory = tmpDirPath;
+		pythonEnv.tempDirectory = tmpDirPath;
 		pythonEnv.pythonPath = tmpDirPath;
 		List<String> commands = new ArrayList<>();
 		String pyPath = String.join(File.separator, tmpDirPath, "verifier.py");

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverEnvUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverEnvUtilsTest.java
@@ -112,8 +112,8 @@ public class PythonDriverEnvUtilsTest {
 	@Test
 	public void testStartPythonProcess() {
 		PythonDriverEnvUtils.PythonEnvironment pythonEnv = new PythonDriverEnvUtils.PythonEnvironment();
-		pythonEnv.storageDirectory = tmpDirPath.toString();
-		pythonEnv.pythonPath = tmpDirPath.toString();
+		pythonEnv.storageDirectory = tmpDirPath;
+		pythonEnv.pythonPath = tmpDirPath;
 		List<String> commands = new ArrayList<>();
 		String pyPath = String.join(File.separator, tmpDirPath, "verifier.py");
 		try {
@@ -139,11 +139,11 @@ public class PythonDriverEnvUtilsTest {
 			if (exitCode != 0) {
 				throw new RuntimeException("Python process exits with code: " + exitCode);
 			}
-			String cmdResult = new String(Files.readAllBytes(new File(result.toString()).toPath()));
+			String cmdResult = new String(Files.readAllBytes(new File(result).toPath()));
 			// Check if the working directory of python process is the same as java process.
 			Assert.assertEquals(cmdResult, System.getProperty("user.dir"));
 			pythonProcess.destroyForcibly();
-			new File(pyPath).delete();
+			pyFile.delete();
 			new File(result).delete();
 		} catch (IOException | InterruptedException e) {
 			throw new RuntimeException("test start Python process failed " + e.getMessage());


### PR DESCRIPTION
## What is the purpose of the change

*This pull request unifies the working directory of Java process and Python process when submitting python jobs via "flink run -py".*


## Brief change log

  - *Remove working directory setting when creating python process.*
  - *Adapt PYTHONPATH creation to support run python process in java working directory.*


## Verifying this change

This change is already covered by existing tests, such as *PythonEnvUtilsTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
