### PR TITLE
[FLINK-14641][docs] Fix description of metric `fullRestarts`

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -1276,7 +1276,10 @@ Metrics related to data exchange between task executors using netty network comm
     </tr>
     <tr>
       <td>fullRestarts</td>
-      <td>The total number of full restarts since this job was submitted.</td>
+      <td>
+        The total number of full restarts since this job was submitted.
+        <span class="label label-danger">Attention:</span> Since 1.9.2, this metric also includes fine-grained restarts.
+      </td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/docs/monitoring/metrics.zh.md
+++ b/docs/monitoring/metrics.zh.md
@@ -1276,7 +1276,10 @@ Metrics related to data exchange between task executors using netty network comm
     </tr>
     <tr>
       <td>fullRestarts</td>
-      <td>The total number of full restarts since this job was submitted.</td>
+      <td>
+        The total number of full restarts since this job was submitted.
+        <span class="label label-danger">Attention:</span> Since 1.9.2, this metric also includes fine-grained restarts.
+      </td>
       <td>Gauge</td>
     </tr>
     <tr>


### PR DESCRIPTION

## What is the purpose of the change

The metric `fullRestarts` counts both full restarts and fine grained restarts since 1.9.2.
This PR is to update the metric description doc accordingly.

## Brief change log

  - *Fixed descriptions doc of metric `fullRestarts`*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
