### PR TITLE
[FLINK-14642][runtime] Deprecate metric `fullRestarts`

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -1278,10 +1278,7 @@ Metrics related to data exchange between task executors using netty network comm
     </tr>
     <tr>
       <td>fullRestarts</td>
-      <td>
-        The total number of full restarts since this job was submitted.
-        <span class="label label-danger">Attention:</span> Since 1.9.2, this metric also includes fine-grained restarts.
-      </td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <b>numRestarts</b>.</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/docs/monitoring/metrics.zh.md
+++ b/docs/monitoring/metrics.zh.md
@@ -1278,10 +1278,7 @@ Metrics related to data exchange between task executors using netty network comm
     </tr>
     <tr>
       <td>fullRestarts</td>
-      <td>
-        The total number of full restarts since this job was submitted.
-        <span class="label label-danger">Attention:</span> Since 1.9.2, this metric also includes fine-grained restarts.
-      </td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <b>numRestarts</b>.</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -52,6 +52,8 @@ public class MetricNames {
 	public static final String NUM_REGISTERED_TASK_MANAGERS = "numRegisteredTaskManagers";
 
 	public static final String NUM_RESTARTS = "numRestarts";
+
+	@Deprecated
 	public static final String FULL_RESTARTS = "fullRestarts";
 
 	public static final String MEMORY_USED = "Used";


### PR DESCRIPTION
## What is the purpose of the change

FLINK-14164 introduces a metric 'numberOfRestarts' that counts all kinds of restarts.
The metric 'fullRestarts' is superseded and this PR is to deprecate it for future removal.

This change is based on #10128 and #10150.

## Brief change log

  - *Marked NumberOfFullRestartsGauge as deprecated*
  - *Adjust description doc of 'numberOfRestarts'*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
Manually verified locally.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
