### PR TITLE
[FLINK-14642] [types] Add support for copying null values to the TupleSeriali…

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializer.java
@@ -106,6 +106,10 @@ public class TupleSerializer<T extends Tuple> extends TupleSerializerBase<T> imp
 
 	@Override
 	public T copy(T from) {
+		if (from == null) {
+			return null;
+		}
+
 		T target = instantiateRaw();
 		for (int i = 0; i < arity; i++) {
 			Object copy = fieldSerializers[i].copy(from.getField(i));
@@ -116,6 +120,10 @@ public class TupleSerializer<T extends Tuple> extends TupleSerializerBase<T> imp
 	
 	@Override
 	public T copy(T from, T reuse) {
+		if (from == null) {
+			return null;
+		}
+
 		for (int i = 0; i < arity; i++) {
 			Object copy = fieldSerializers[i].copy((Object)from.getField(i), reuse.getField(i));
 			reuse.setField(copy, i);

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/CaseClassSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/CaseClassSerializer.scala
@@ -86,13 +86,18 @@ abstract class CaseClassSerializer[T <: Product](
   }
 
   def copy(from: T): T = {
-    initArray()
-    var i = 0
-    while (i < arity) {
-      fields(i) = fieldSerializers(i).copy(from.productElement(i).asInstanceOf[AnyRef])
-      i += 1
+    if (from == null) {
+      null.asInstanceOf[T]
     }
-    createInstance(fields)
+    else {
+      initArray()
+      var i = 0
+      while (i < arity) {
+        fields(i) = fieldSerializers(i).copy(from.productElement(i).asInstanceOf[AnyRef])
+        i += 1
+      }
+      createInstance(fields)
+    }
   }
 
   def serialize(value: T, target: DataOutputView) {


### PR DESCRIPTION
…zer and CaseClassSerializer

## What is the purpose of the change

This PR makes the `copy` method of the TupleSerializer and CaseClassSerializer to handle NULL values properly, so elements of these types can be passed between chained operators.   
Without this PR, the following code may throw NPE in case of `map` function returns null, which may confuse the user.

```
stream.map(xxx).filter(_ != null).xxx //the return type of the map function is Tuple and it may return null
```

## Brief change log

  - return **null** if the element itself is null.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (**yes**)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
