### PR TITLE
[hotfix][table] Fix the comments of Operation

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/Operation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/Operation.java
@@ -19,12 +19,13 @@
 package org.apache.flink.table.operations;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.table.delegation.Planner;
 
 /**
  * Covers all sort of Table operations such as queries(DQL), modifications(DML), definitions(DDL),
  * or control actions(DCL). This is the output of
- * {@link Planner#parse(String)}.
+ * {@link Planner#getParser()} and {@link Parser#parse(String)}.
  *
  * @see QueryOperation
  * @see ModifyOperation


### PR DESCRIPTION

## What is the purpose of the change

We have Parser to parse instead of parsing in Planner.

## Brief change log

Fix the comments of Operation to refer Parser.

## Verifying this change

no

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no