### PR TITLE
[FLINK-14636][runtime] Enable scheduling for ScheduleMode.LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -112,6 +112,7 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
 		switch (scheduleMode) {
 			case EAGER:
 				return new EagerSchedulingStrategy.Factory();
+			case LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST:
 			case LAZY_FROM_SOURCES:
 				return new LazyFromSourcesSchedulingStrategy.Factory();
 			default:


### PR DESCRIPTION
## What is the purpose of the change

*This enables scheduling of jobs with ScheduleMode.LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST with DefaultScheduler.*


## Brief change log

  - *See commit*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage (_will be covered later_).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
