### PR TITLE
[FLINK-14374][runtime,tests] Run RegionFailoverITCase also with DefaultScheduler enabled

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SchedulerNGFactoryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SchedulerNGFactoryFactory.java
@@ -26,7 +26,14 @@ import org.apache.flink.runtime.scheduler.DefaultSchedulerFactory;
 import org.apache.flink.runtime.scheduler.LegacySchedulerFactory;
 import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
 
-final class SchedulerNGFactoryFactory {
+/**
+ * Factory for {@link SchedulerNGFactory}.
+ */
+public final class SchedulerNGFactoryFactory {
+
+	public static final String SCHEDULER_TYPE_LEGACY = "legacy";
+
+	public static final String SCHEDULER_TYPE_NG = "ng";
 
 	private SchedulerNGFactoryFactory() {}
 
@@ -36,10 +43,10 @@ final class SchedulerNGFactoryFactory {
 
 		final String schedulerName = configuration.getString(JobManagerOptions.SCHEDULER);
 		switch (schedulerName) {
-			case "legacy":
+			case SCHEDULER_TYPE_LEGACY:
 				return new LegacySchedulerFactory(restartStrategyFactory);
 
-			case "ng":
+			case SCHEDULER_TYPE_NG:
 				return new DefaultSchedulerFactory();
 
 			default:

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
@@ -69,7 +69,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -123,9 +122,9 @@ public class RegionFailoverITCase extends TestLogger {
 		this.schedulerType = checkNotNull(schedulerType);
 	}
 
-	@Parameterized.Parameters
-	public static Iterable<Object[]> testParameters() {
-		return Arrays.asList(new Object[][]{{SCHEDULER_TYPE_NG}, {SCHEDULER_TYPE_LEGACY}});
+	@Parameterized.Parameters(name = "scheduler = {0}")
+	public static Object[] testParameters() {
+		return new Object[]{SCHEDULER_TYPE_NG, SCHEDULER_TYPE_LEGACY};
 	}
 
 	@Before

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
@@ -65,8 +65,11 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -79,11 +82,15 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
 
+import static org.apache.flink.runtime.dispatcher.SchedulerNGFactoryFactory.SCHEDULER_TYPE_LEGACY;
+import static org.apache.flink.runtime.dispatcher.SchedulerNGFactoryFactory.SCHEDULER_TYPE_NG;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for region failover with multi regions.
  */
+@RunWith(Parameterized.class)
 public class RegionFailoverITCase extends TestLogger {
 
 	private static final int FAIL_BASE = 1000;
@@ -110,15 +117,33 @@ public class RegionFailoverITCase extends TestLogger {
 	@ClassRule
 	public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
 
+	private final String schedulerType;
+
+	public RegionFailoverITCase(final String schedulerType) {
+		this.schedulerType = checkNotNull(schedulerType);
+	}
+
+	@Parameterized.Parameters
+	public static Iterable<Object[]> testParameters() {
+		return Arrays.asList(new Object[][]{{SCHEDULER_TYPE_NG}, {SCHEDULER_TYPE_LEGACY}});
+	}
+
 	@Before
 	public void setup() throws Exception {
 		Configuration configuration = new Configuration();
 		configuration.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "region");
 		configuration.setString(HighAvailabilityOptions.HA_MODE, TestingHAFactory.class.getName());
 
-		// global failover times: 3, region failover times: NUM_OF_RESTARTS
-		configuration.setInteger(FailingRestartStrategy.NUM_FAILURES_CONFIG_OPTION, 3);
-		configuration.setString(RestartStrategyOptions.RESTART_STRATEGY, FailingRestartStrategy.class.getName());
+		configuration.setString(JobManagerOptions.SCHEDULER, schedulerType);
+
+		// If the LegacyScheduler is configured, we will use a custom RestartStrategy
+		// (FailingRestartStrategy). This is done to test FLINK-13452. DefaultScheduler takes a
+		// different code path, and also cannot be configured with custom RestartStrategies.
+		if (SCHEDULER_TYPE_LEGACY.equals(schedulerType)) {
+			// global failover times: 3, region failover times: NUM_OF_RESTARTS
+			configuration.setInteger(FailingRestartStrategy.NUM_FAILURES_CONFIG_OPTION, 3);
+			configuration.setString(RestartStrategyOptions.RESTART_STRATEGY, FailingRestartStrategy.class.getName());
+		}
 
 		cluster = new MiniClusterWithClientResource(
 			new MiniClusterResourceConfiguration.Builder()


### PR DESCRIPTION
## What is the purpose of the change

*This enables `RegionFailoverITCase` to run with LegacyScheduler and DefaultScheduler.*

## Brief change log

  - *See commits*

## Verifying this change


This change is already covered by existing tests, such as *RegionFailoverITCase*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
