### PR TITLE
[FLINK-14679][shuffle] Store number of partitions in PartitionDescriptor

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptor.java
@@ -72,6 +72,10 @@ public class ResultPartitionDeploymentDescriptor implements Serializable {
 		return partitionDescriptor.getPartitionType();
 	}
 
+	public int getTotalNumberOfPartitions() {
+		return partitionDescriptor.getTotalNumberOfPartitions();
+	}
+
 	public int getNumberOfSubpartitions() {
 		return partitionDescriptor.getNumberOfSubpartitions();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/PartitionDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/PartitionDescriptor.java
@@ -42,6 +42,9 @@ public class PartitionDescriptor implements Serializable {
 	/** The ID of the result this partition belongs to. */
 	private final IntermediateDataSetID resultId;
 
+	/** The total number of partitions for the result. */
+	private final int totalNumberOfPartitions;
+
 	/** The ID of the partition. */
 	private final IntermediateResultPartitionID partitionId;
 
@@ -57,11 +60,14 @@ public class PartitionDescriptor implements Serializable {
 	@VisibleForTesting
 	public PartitionDescriptor(
 			IntermediateDataSetID resultId,
+			int totalNumberOfPartitions,
 			IntermediateResultPartitionID partitionId,
 			ResultPartitionType partitionType,
 			int numberOfSubpartitions,
 			int connectionIndex) {
 		this.resultId = checkNotNull(resultId);
+		checkArgument(totalNumberOfPartitions >= 1);
+		this.totalNumberOfPartitions = totalNumberOfPartitions;
 		this.partitionId = checkNotNull(partitionId);
 		this.partitionType = checkNotNull(partitionType);
 		checkArgument(numberOfSubpartitions >= 1);
@@ -71,6 +77,10 @@ public class PartitionDescriptor implements Serializable {
 
 	public IntermediateDataSetID getResultId() {
 		return resultId;
+	}
+
+	public int getTotalNumberOfPartitions() {
+		return totalNumberOfPartitions;
 	}
 
 	public IntermediateResultPartitionID getPartitionId() {
@@ -119,6 +129,7 @@ public class PartitionDescriptor implements Serializable {
 		IntermediateResult result = partition.getIntermediateResult();
 		return new PartitionDescriptor(
 			result.getId(),
+			partition.getIntermediateResult().getNumberOfAssignedPartitions(),
 			partition.getPartitionId(),
 			result.getResultType(),
 			numberOfSubpartitions,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptorTest.java
@@ -47,6 +47,7 @@ import static org.junit.Assert.assertThat;
  */
 public class ResultPartitionDeploymentDescriptorTest extends TestLogger {
 	private static final IntermediateDataSetID resultId = new IntermediateDataSetID();
+	private static final int numberOfPartitions = 5;
 
 	private static final IntermediateResultPartitionID partitionId = new IntermediateResultPartitionID();
 	private static final ExecutionAttemptID producerExecutionId = new ExecutionAttemptID();
@@ -57,6 +58,7 @@ public class ResultPartitionDeploymentDescriptorTest extends TestLogger {
 
 	private static final PartitionDescriptor partitionDescriptor = new PartitionDescriptor(
 		resultId,
+		numberOfPartitions,
 		partitionId,
 		partitionType,
 		numberOfSubpartitions,
@@ -115,6 +117,7 @@ public class ResultPartitionDeploymentDescriptorTest extends TestLogger {
 
 	private static void verifyResultPartitionDeploymentDescriptorCopy(ResultPartitionDeploymentDescriptor copy) {
 		assertThat(copy.getResultId(), is(resultId));
+		assertThat(copy.getTotalNumberOfPartitions(), is(numberOfPartitions));
 		assertThat(copy.getPartitionId(), is(partitionId));
 		assertThat(copy.getPartitionType(), is(partitionType));
 		assertThat(copy.getNumberOfSubpartitions(), is(numberOfSubpartitions));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ShuffleDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ShuffleDescriptorTest.java
@@ -22,10 +22,10 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
-import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.shuffle.PartitionDescriptor;
+import org.apache.flink.runtime.shuffle.PartitionDescriptorBuilder;
 import org.apache.flink.runtime.shuffle.ProducerDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.UnknownShuffleDescriptor;
@@ -166,12 +166,10 @@ public class ShuffleDescriptorTest extends TestLogger {
 			id.getProducerId(),
 			STUB_CONNECTION_ID.getAddress().getAddress(),
 			STUB_CONNECTION_ID.getAddress().getPort());
-		PartitionDescriptor partitionDescriptor = new PartitionDescriptor(
-			new IntermediateDataSetID(),
-			id.getPartitionId(),
-			ResultPartitionType.PIPELINED,
-			1,
-			0);
+		PartitionDescriptor partitionDescriptor = PartitionDescriptorBuilder
+			.newBuilder()
+			.setPartitionId(id.getPartitionId())
+			.build();
 		ShuffleDescriptor shuffleDescriptor =
 			NettyShuffleMaster.INSTANCE.registerPartitionWithProducer(
 				partitionDescriptor,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/AbstractPartitionTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/AbstractPartitionTrackerTest.java
@@ -19,8 +19,7 @@ package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
-import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
-import org.apache.flink.runtime.shuffle.PartitionDescriptor;
+import org.apache.flink.runtime.shuffle.PartitionDescriptorBuilder;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.util.TestLogger;
 
@@ -69,12 +68,11 @@ public class AbstractPartitionTrackerTest extends TestLogger {
 		boolean hasLocalResources) {
 
 		return new ResultPartitionDeploymentDescriptor(
-			new PartitionDescriptor(
-				new IntermediateDataSetID(),
-				resultPartitionId.getPartitionId(),
-				type,
-				1,
-				0),
+			PartitionDescriptorBuilder
+				.newBuilder()
+				.setPartitionId(resultPartitionId.getPartitionId())
+				.setPartitionType(type)
+				.build(),
 			new ShuffleDescriptor() {
 				@Override
 				public ResultPartitionID getResultPartitionID() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
@@ -22,8 +22,8 @@ import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.io.disk.FileChannelManager;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
-import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.shuffle.PartitionDescriptor;
+import org.apache.flink.runtime.shuffle.PartitionDescriptorBuilder;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
 
@@ -99,12 +99,11 @@ public enum PartitionTestUtils {
 	public static ResultPartitionDeploymentDescriptor createPartitionDeploymentDescriptor(
 		ResultPartitionType partitionType) {
 		ShuffleDescriptor shuffleDescriptor = NettyShuffleDescriptorBuilder.newBuilder().buildLocal();
-		PartitionDescriptor partitionDescriptor = new PartitionDescriptor(
-			new IntermediateDataSetID(),
-			shuffleDescriptor.getResultPartitionID().getPartitionId(),
-			partitionType,
-			1,
-			0);
+		PartitionDescriptor partitionDescriptor = PartitionDescriptorBuilder
+			.newBuilder()
+			.setPartitionId(shuffleDescriptor.getResultPartitionID().getPartitionId())
+			.setPartitionType(partitionType)
+			.build();
 		return new ResultPartitionDeploymentDescriptor(
 			partitionDescriptor,
 			shuffleDescriptor,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -21,9 +21,7 @@ import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.io.disk.FileChannelManager;
 import org.apache.flink.runtime.io.disk.FileChannelManagerImpl;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
-import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
-import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
-import org.apache.flink.runtime.shuffle.PartitionDescriptor;
+import org.apache.flink.runtime.shuffle.PartitionDescriptorBuilder;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
 import org.apache.flink.util.TestLogger;
@@ -103,12 +101,10 @@ public class ResultPartitionFactoryTest extends TestLogger {
 			releasePartitionOnConsumption);
 
 		final ResultPartitionDeploymentDescriptor descriptor = new ResultPartitionDeploymentDescriptor(
-			new PartitionDescriptor(
-				new IntermediateDataSetID(),
-				new IntermediateResultPartitionID(),
-				partitionType,
-				1,
-				0),
+			PartitionDescriptorBuilder
+				.newBuilder()
+				.setPartitionType(partitionType)
+				.build(),
 			NettyShuffleDescriptorBuilder.newBuilder().buildLocal(),
 			1,
 			true

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/PartitionDescriptorBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/PartitionDescriptorBuilder.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.shuffle;
+
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+
+/**
+ * Builder for {@link PartitionDescriptor} in tests.
+ */
+public class PartitionDescriptorBuilder {
+	private IntermediateResultPartitionID partitionId;
+	private ResultPartitionType partitionType;
+
+	private PartitionDescriptorBuilder() {
+		this.partitionId = new IntermediateResultPartitionID();
+		this.partitionType = ResultPartitionType.PIPELINED;
+	}
+
+	public PartitionDescriptorBuilder setPartitionId(IntermediateResultPartitionID partitionId) {
+		this.partitionId = partitionId;
+		return this;
+	}
+
+	public PartitionDescriptorBuilder setPartitionType(ResultPartitionType partitionType) {
+		this.partitionType = partitionType;
+		return this;
+	}
+
+	public PartitionDescriptor build() {
+		return new PartitionDescriptor(new IntermediateDataSetID(), partitionId, partitionType, 1, 0);
+	}
+
+	public static PartitionDescriptorBuilder newBuilder() {
+		return new PartitionDescriptorBuilder();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/PartitionDescriptorBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/PartitionDescriptorBuilder.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 public class PartitionDescriptorBuilder {
 	private IntermediateResultPartitionID partitionId;
 	private ResultPartitionType partitionType;
+	private int totalNumberOfPartitions = 1;
 
 	private PartitionDescriptorBuilder() {
 		this.partitionId = new IntermediateResultPartitionID();
@@ -44,8 +45,13 @@ public class PartitionDescriptorBuilder {
 		return this;
 	}
 
+	public PartitionDescriptorBuilder setTotalNumberOfPartitions(int totalNumberOfPartitions) {
+		this.totalNumberOfPartitions = totalNumberOfPartitions;
+		return this;
+	}
+
 	public PartitionDescriptor build() {
-		return new PartitionDescriptor(new IntermediateDataSetID(), partitionId, partitionType, 1, 0);
+		return new PartitionDescriptor(new IntermediateDataSetID(), totalNumberOfPartitions, partitionId, partitionType, 1, 0);
 	}
 
 	public static PartitionDescriptorBuilder newBuilder() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSubmissionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSubmissionTest.java
@@ -55,6 +55,7 @@ import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.StackTraceSampleResponse;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.PartitionDescriptor;
+import org.apache.flink.runtime.shuffle.PartitionDescriptorBuilder;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.runtime.taskmanager.Task;
@@ -740,12 +741,10 @@ public class TaskExecutorSubmissionTest extends TestLogger {
 	private TaskDeploymentDescriptor createSender(
 			NettyShuffleDescriptor shuffleDescriptor,
 			Class<? extends AbstractInvokable> abstractInvokable) throws IOException {
-		PartitionDescriptor partitionDescriptor = new PartitionDescriptor(
-			new IntermediateDataSetID(),
-			shuffleDescriptor.getResultPartitionID().getPartitionId(),
-			ResultPartitionType.PIPELINED,
-			1,
-			0);
+		PartitionDescriptor partitionDescriptor = PartitionDescriptorBuilder
+			.newBuilder()
+			.setPartitionId(shuffleDescriptor.getResultPartitionID().getPartitionId())
+			.build();
 		ResultPartitionDeploymentDescriptor resultPartitionDeploymentDescriptor = new ResultPartitionDeploymentDescriptor(
 			partitionDescriptor,
 			shuffleDescriptor,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -43,10 +43,10 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.io.network.partition.consumer.RemoteChannelStateChecker;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
-import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmanager.PartitionProducerDisposedException;
 import org.apache.flink.runtime.shuffle.PartitionDescriptor;
+import org.apache.flink.runtime.shuffle.PartitionDescriptorBuilder;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.taskexecutor.PartitionProducerStateChecker;
@@ -245,12 +245,7 @@ public class TaskTest extends TestLogger {
 
 	@Test
 	public void testExecutionFailsInNetworkRegistrationForPartitions() throws Exception {
-		final PartitionDescriptor partitionDescriptor = new PartitionDescriptor(
-			new IntermediateDataSetID(),
-			new IntermediateResultPartitionID(),
-			ResultPartitionType.PIPELINED,
-			1,
-			1);
+		final PartitionDescriptor partitionDescriptor = PartitionDescriptorBuilder.newBuilder().build();
 		final ShuffleDescriptor shuffleDescriptor = NettyShuffleDescriptorBuilder.newBuilder().buildLocal();
 		final ResultPartitionDeploymentDescriptor dummyPartition = new ResultPartitionDeploymentDescriptor(
 			partitionDescriptor,


### PR DESCRIPTION
With this PR the `PartitionDescriptor` also contains the total number of partitions for the corresponding dataset. This is useful for the ResourceManager and external shuffle services in general, as it allows them to judge whether they have received all partitions for the given dataset.