### PR TITLE
[FLINK-14635][e2e tests] Use non-relocated imports for AWS SDK Kinesis classes in tests.

### DIFF
--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -169,6 +169,11 @@ under the License.
 						<goals>
 							<goal>test-jar</goal>
 						</goals>
+						<configuration>
+							<includes>
+								<include>org.apache.flink.streaming.connectors.kinesis.testutils.*</include>
+							</includes>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -76,9 +76,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * and runs a single fetcher throughout the subtask's lifetime. The fetcher accomplishes the following:
  * <ul>
  *     <li>1. continuously poll Kinesis to discover shards that the subtask should subscribe to. The subscribed subset
- *     		  of shards, including future new shards, is non-overlapping across subtasks (no two subtasks will be
- *     		  subscribed to the same shard) and determinate across subtask restores (the subtask will always subscribe
- *     		  to the same subset of shards even after restoring)</li>
+ *            of shards, including future new shards, is non-overlapping across subtasks (no two subtasks will be
+ *            subscribed to the same shard) and determinate across subtask restores (the subtask will always subscribe
+ *            to the same subset of shards even after restoring)</li>
  *     <li>2. decide where in each discovered shard should the fetcher start subscribing to</li>
  *     <li>3. subscribe to shards by creating a single thread for each shard</li>
  * </ul>
@@ -87,6 +87,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * and 2) last processed sequence numbers of each subscribed shard. Since operations on the second state will be performed
  * by multiple threads, these operations should only be done using the handler methods provided in this class.
  */
+@SuppressWarnings("unchecked")
 @Internal
 public class KinesisDataFetcher<T> {
 
@@ -195,8 +196,8 @@ public class KinesisDataFetcher<T> {
 
 	private final AssignerWithPeriodicWatermarks<T> periodicWatermarkAssigner;
 	private final WatermarkTracker watermarkTracker;
-	private final transient RecordEmitter recordEmitter;
-	private transient boolean isIdle;
+	private final RecordEmitter recordEmitter;
+	private boolean isIdle;
 
 	/**
 	 * The watermark related state for each shard consumer. Entries in this map will be created when shards
@@ -280,8 +281,8 @@ public class KinesisDataFetcher<T> {
 
 		@Override
 		public RecordQueue<RecordWrapper<T>> getQueue(int producerIndex) {
-			return queues.computeIfAbsent(producerIndex, (key) -> {
-				return new RecordQueue<RecordWrapper<T>>() {
+			return queues.computeIfAbsent(producerIndex, (key) ->
+				new RecordQueue<RecordWrapper<T>>() {
 					@Override
 					public void put(RecordWrapper<T> record) {
 						emit(record, this);
@@ -296,8 +297,6 @@ public class KinesisDataFetcher<T> {
 					public RecordWrapper<T> peek() {
 						return null;
 					}
-
-				};
 			});
 		}
 	}
@@ -621,6 +620,7 @@ public class KinesisDataFetcher<T> {
 	}
 
 	/** After calling {@link KinesisDataFetcher#shutdownFetcher()}, this can be called to await the fetcher shutdown. */
+	@SuppressWarnings("StatementWithEmptyBody")
 	public void awaitTermination() throws InterruptedException {
 		while (!shardConsumersExecutor.awaitTermination(1, TimeUnit.MINUTES)) {
 			// Keep waiting.
@@ -757,8 +757,6 @@ public class KinesisDataFetcher<T> {
 	 *
 	 * <p>Responsible for tracking per shard watermarks and emit timestamps extracted from
 	 * the record, when a watermark assigner was configured.
-	 *
-	 * @param rw
 	 */
 	private void emitRecordAndUpdateState(RecordWrapper<T> rw) {
 		synchronized (checkpointLock) {
@@ -952,22 +950,22 @@ public class KinesisDataFetcher<T> {
 	/** Timer task to update shared watermark state. */
 	private class WatermarkSyncCallback implements ProcessingTimeCallback {
 
+		private static final long LOG_INTERVAL_MILLIS = 60_000;
+
 		private final ProcessingTimeService timerService;
 		private final long interval;
-		private final MetricGroup shardMetricsGroup;
 		private long lastGlobalWatermark = Long.MIN_VALUE;
 		private long propagatedLocalWatermark = Long.MIN_VALUE;
-		private long logIntervalMillis = 60_000;
 		private int stalledWatermarkIntervalCount = 0;
 		private long lastLogged;
 
 		WatermarkSyncCallback(ProcessingTimeService timerService, long interval) {
 			this.timerService = checkNotNull(timerService);
 			this.interval = interval;
-			this.shardMetricsGroup = consumerMetricGroup.addGroup("subtaskId",
+			MetricGroup shardMetricsGroup = consumerMetricGroup.addGroup("subtaskId",
 				String.valueOf(indexOfThisConsumerSubtask));
-			this.shardMetricsGroup.gauge("localWatermark", () -> nextWatermark);
-			this.shardMetricsGroup.gauge("globalWatermark", () -> lastGlobalWatermark);
+			shardMetricsGroup.gauge("localWatermark", () -> nextWatermark);
+			shardMetricsGroup.gauge("globalWatermark", () -> lastGlobalWatermark);
 		}
 
 		public void start() {
@@ -987,7 +985,7 @@ public class KinesisDataFetcher<T> {
 					LOG.info("WatermarkSyncCallback subtask: {} is idle", indexOfThisConsumerSubtask);
 				}
 
-				if (timestamp - lastLogged > logIntervalMillis) {
+				if (timestamp - lastLogged > LOG_INTERVAL_MILLIS) {
 					lastLogged = System.currentTimeMillis();
 					LOG.info("WatermarkSyncCallback subtask: {} local watermark: {}"
 							+ ", global watermark: {}, delta: {} timeouts: {}, emitter: {}",

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
@@ -52,7 +52,6 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -213,8 +212,6 @@ public class KinesisProxy implements KinesisProxyInterface {
 	/**
 	 * Create the Kinesis client, using the provided configuration properties and default {@link ClientConfiguration}.
 	 * Derived classes can override this method to customize the client configuration.
-	 * @param configProps
-	 * @return
 	 */
 	protected AmazonKinesis createKinesisClient(Properties configProps) {
 
@@ -483,12 +480,7 @@ public class KinesisProxy implements KinesisProxyInterface {
 		// 	https://github.com/lyft/kinesalite/pull/4
 		if (startShardId != null && listShardsResults != null) {
 			List<Shard> shards = listShardsResults.getShards();
-			Iterator<Shard> shardItr = shards.iterator();
-			while (shardItr.hasNext()) {
-				if (StreamShardHandle.compareShardIds(shardItr.next().getShardId(), startShardId) <= 0) {
-					shardItr.remove();
-				}
-			}
+			shards.removeIf(shard -> StreamShardHandle.compareShardIds(shard.getShardId(), startShardId) <= 0);
 		}
 
 		return listShardsResults;

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
@@ -28,8 +28,6 @@ import org.apache.flink.streaming.connectors.kinesis.config.ProducerConfigConsta
 
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -77,8 +75,6 @@ public class KinesisConfigUtil {
 	/** Default values for ThreadPoolSize. **/
 	protected static final int DEFAULT_THREAD_POOL_SIZE = 10;
 
-	private static final Logger LOG = LoggerFactory.getLogger(KinesisConfigUtil.class);
-
 	/**
 	 * Validate configuration properties for {@link FlinkKinesisConsumer}.
 	 */
@@ -87,6 +83,7 @@ public class KinesisConfigUtil {
 
 		validateAwsConfiguration(config);
 
+		//noinspection SimplifiableBooleanExpression - the current logic expression is actually easier to understand
 		if (!(config.containsKey(AWSConfigConstants.AWS_REGION) ^ config.containsKey(ConsumerConfigConstants.AWS_ENDPOINT))) {
 			// per validation in AwsClientBuilder
 			throw new IllegalArgumentException(String.format("For FlinkKinesisConsumer either AWS region ('%s') or AWS endpoint ('%s') must be set in the config.",
@@ -177,6 +174,7 @@ public class KinesisConfigUtil {
 	 * Replace deprecated configuration properties for {@link FlinkKinesisProducer}.
 	 * This should be remove along with deprecated keys
 	 */
+	@SuppressWarnings("deprecation")
 	public static Properties replaceDeprecatedProducerKeys(Properties configProps) {
 		// Replace deprecated key
 		if (configProps.containsKey(ProducerConfigConstants.COLLECTION_MAX_COUNT)) {
@@ -207,6 +205,7 @@ public class KinesisConfigUtil {
 	 * @param configProps original config properties.
 	 * @return backfilled config properties.
 	 */
+	@SuppressWarnings("UnusedReturnValue")
 	public static Properties backfillConsumerKeys(Properties configProps) {
 		HashMap<String, String> oldKeyToNewKeys = new HashMap<>();
 		oldKeyToNewKeys.put(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_BASE, ConsumerConfigConstants.LIST_SHARDS_BACKOFF_BASE);

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/KinesisPubsubClient.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/KinesisPubsubClient.java
@@ -15,26 +15,26 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.kinesis.test;
+package org.apache.flink.streaming.connectors.kinesis.testutils;
 
 import org.apache.flink.api.common.time.Deadline;
-import org.apache.flink.kinesis.shaded.com.amazonaws.AmazonClientException;
-import org.apache.flink.kinesis.shaded.com.amazonaws.auth.AWSCredentialsProvider;
-import org.apache.flink.kinesis.shaded.com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
-import org.apache.flink.kinesis.shaded.com.amazonaws.client.builder.AwsClientBuilder;
-import org.apache.flink.kinesis.shaded.com.amazonaws.services.kinesis.AmazonKinesis;
-import org.apache.flink.kinesis.shaded.com.amazonaws.services.kinesis.AmazonKinesisClientBuilder;
-import org.apache.flink.kinesis.shaded.com.amazonaws.services.kinesis.model.GetRecordsResult;
-import org.apache.flink.kinesis.shaded.com.amazonaws.services.kinesis.model.PutRecordRequest;
-import org.apache.flink.kinesis.shaded.com.amazonaws.services.kinesis.model.PutRecordResult;
-import org.apache.flink.kinesis.shaded.com.amazonaws.services.kinesis.model.Record;
-import org.apache.flink.kinesis.shaded.com.amazonaws.services.kinesis.model.ResourceNotFoundException;
 import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants;
 import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
 import org.apache.flink.streaming.connectors.kinesis.proxy.GetShardListResult;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxy;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
 
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.kinesis.AmazonKinesis;
+import com.amazonaws.services.kinesis.AmazonKinesisClientBuilder;
+import com.amazonaws.services.kinesis.model.GetRecordsResult;
+import com.amazonaws.services.kinesis.model.PutRecordRequest;
+import com.amazonaws.services.kinesis.model.PutRecordResult;
+import com.amazonaws.services.kinesis.model.Record;
+import com.amazonaws.services.kinesis.model.ResourceNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,13 +46,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-class KinesisPubsubClient implements KinesisExampleTest.PubsubClient {
+public class KinesisPubsubClient implements PubsubClient {
 	private static final Logger LOG = LoggerFactory.getLogger(KinesisPubsubClient.class);
 
 	private final AmazonKinesis kinesisClient;
 	private final Properties properties;
 
-	KinesisPubsubClient(Properties properties) {
+	public KinesisPubsubClient(Properties properties) {
 		this.kinesisClient = createClientWithCredentials(properties);
 		this.properties = properties;
 	}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/PubsubClient.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/PubsubClient.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.testutils;
+
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Simple client to publish and retrieve messages.
+ */
+public interface PubsubClient {
+
+	void createTopic(String topic, int partitions, Properties props) throws Exception;
+
+	void sendMessage(String topic, String msg);
+
+	List<String> readAllMessages(String streamName) throws Exception;
+}

--- a/flink-end-to-end-tests/flink-streaming-kinesis-test/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-kinesis-test/pom.xml
@@ -52,6 +52,14 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-kinesis_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>${junit.version}</version>

--- a/flink-end-to-end-tests/flink-streaming-kinesis-test/src/main/java/org/apache/flink/streaming/kinesis/test/KinesisExampleTest.java
+++ b/flink-end-to-end-tests/flink-streaming-kinesis-test/src/main/java/org/apache/flink/streaming/kinesis/test/KinesisExampleTest.java
@@ -19,6 +19,8 @@ package org.apache.flink.streaming.kinesis.test;
 
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.streaming.connectors.kinesis.testutils.KinesisPubsubClient;
+import org.apache.flink.streaming.connectors.kinesis.testutils.PubsubClient;
 
 import org.junit.Assert;
 import org.slf4j.Logger;
@@ -26,7 +28,6 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -34,17 +35,6 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class KinesisExampleTest {
 	private static final Logger LOG = LoggerFactory.getLogger(KinesisExampleTest.class);
-
-	/**
-	 * Interface to the pubsub system for this test.
-	 */
-	interface PubsubClient {
-		void createTopic(String topic, int partitions, Properties props) throws Exception;
-
-		void sendMessage(String topic, String msg);
-
-		List<String> readAllMessages(String streamName) throws Exception;
-	}
 
 	public static void main(String[] args) throws Exception {
 		LOG.info("System properties: {}", System.getProperties());


### PR DESCRIPTION
## What is the purpose of the change

This allows compiling the code base fully in the IDE again by changing the way that the AWS SDK classes are used in the `KinesisPubsubClient` in the Kineses end-2-end test.

Some imports were referring to relocated classes from the connector, which cannot be resolved in the IDE because no shading happens during compilation.

## Brief change log

  - Instead of using relocated imports, use vanilla imports in `KinesisPubsubClient`.
  - We add a provided AWS SDK dependency for the non-relocated classes. This follows the pattern to not directly reference transitive dependencies, especially shaded ones. That way, we supports IDE and unit test compilation / execution.
  - For end-2-end test execution, we relocate the AWS SDK classes in the shade phase following the exact same pattern as the original relocation in the Kinesis connector.
  - We need to make sure we don't operate directly on relocated classes when simultaneously using non relocated classes (class cast exceptions). We use a utility in the Kinesis module to directly obtain stringified or byte[]-ified versions of the records, rather than objects backed by relocated classes.

## Verifying this change

This changes a test which still runs and works.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **yes** (in a test)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
