### PR TITLE
[FLINK-14660][sql cli] add 'SHOW MODULES' to SQL CLI

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -276,6 +276,9 @@ public class CliClient {
 			case SHOW_FUNCTIONS:
 				callShowFunctions();
 				break;
+			case SHOW_MODULES:
+				callShowModules();
+				break;
 			case USE_CATALOG:
 				callUseCatalog(cmdCall);
 				break;
@@ -417,6 +420,23 @@ public class CliClient {
 		} else {
 			Collections.sort(functions);
 			functions.forEach((v) -> terminal.writer().println(v));
+		}
+		terminal.flush();
+	}
+
+	private void callShowModules() {
+		final List<String> modules;
+		try {
+			modules = executor.listModules(context);
+		} catch (SqlExecutionException e) {
+			printExecutionException(e);
+			return;
+		}
+		if (modules.isEmpty()) {
+			terminal.writer().println(CliStrings.messageInfo(CliStrings.MESSAGE_EMPTY).toAnsi());
+		} else {
+			// modules are already in the loaded order
+			modules.forEach((v) -> terminal.writer().println(v));
 		}
 		terminal.flush();
 	}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
@@ -99,6 +99,10 @@ public final class SqlCommandParser {
 			"SHOW\\s+FUNCTIONS",
 			NO_OPERANDS),
 
+		SHOW_MODULES(
+			"SHOW\\s+MODULES",
+			NO_OPERANDS),
+
 		USE_CATALOG(
 			"USE\\s+CATALOG\\s+(.*)",
 			SINGLE_OPERAND),

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -66,6 +66,11 @@ public interface Executor {
 	List<String> listFunctions(SessionContext session) throws SqlExecutionException;
 
 	/**
+	 * Lists all modules known to the executor in their loaded order.
+	 */
+	List<String> listModules(SessionContext session) throws SqlExecutionException;
+
+	/**
 	 * Sets a catalog with given name as the current catalog.
 	 */
 	void useCatalog(SessionContext session, String catalogName) throws SqlExecutionException;

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -249,6 +249,15 @@ public class LocalExecutor implements Executor {
 	}
 
 	@Override
+	public List<String> listModules(SessionContext session) throws SqlExecutionException {
+		final ExecutionContext<?> context = getOrCreateExecutionContext(session);
+		final TableEnvironment tableEnv = context
+			.createEnvironmentInstance()
+			.getTableEnvironment();
+		return context.wrapClassLoader(() -> Arrays.asList(tableEnv.listModules()));
+	}
+
+	@Override
 	public void useCatalog(SessionContext session, String catalogName) throws SqlExecutionException {
 		final ExecutionContext<?> context = getOrCreateExecutionContext(session);
 		final TableEnvironment tableEnv = context

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -238,6 +238,11 @@ public class CliClientTest extends TestLogger {
 		}
 
 		@Override
+		public List<String> listModules(SessionContext session) throws SqlExecutionException {
+			return null;
+		}
+
+		@Override
 		public void useCatalog(SessionContext session, String catalogName) throws SqlExecutionException {
 
 		}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
@@ -151,6 +151,11 @@ public class CliResultViewTest {
 		}
 
 		@Override
+		public List<String> listModules(SessionContext session) throws SqlExecutionException {
+			return null;
+		}
+
+		@Override
 		public void useCatalog(SessionContext session, String catalogName) throws SqlExecutionException {
 
 		}


### PR DESCRIPTION
### What is the purpose of the change

Add 'show modules' to sql client. 

Since all the 'show xxx' are in sql client and not in sql parser, we add 'show modules' to sql cli for now. All the 'show xxx' commands should be moved parser together all at once

## Brief change log

- add 'show modules' to sql cli
- add `listModules` API to executor

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? ( docs later)
