### PR TITLE
[FLINK-13095][state-processor-api] Provide an easy way to read / bootstrap window state using the State Processor API 

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/BootstrapTransformation.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/BootstrapTransformation.java
@@ -30,6 +30,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.checkpoint.OperatorState;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.state.api.functions.Timestamper;
 import org.apache.flink.state.api.output.BoundedOneInputStreamTaskRunner;
 import org.apache.flink.state.api.output.OperatorSubtaskStateReducer;
 import org.apache.flink.state.api.output.TaggedOperatorSubtaskState;
@@ -81,13 +82,18 @@ public class BootstrapTransformation<T> {
 	/** Local max parallelism for the bootstrapped operator. */
 	private final OptionalInt operatorMaxParallelism;
 
+	@Nullable
+	private final Timestamper<T> timestamper;
+
 	BootstrapTransformation(
 		DataSet<T> dataSet,
 		OptionalInt operatorMaxParallelism,
+		@Nullable Timestamper<T> timestamper,
 		SavepointWriterOperatorFactory factory) {
 		this.dataSet = dataSet;
 		this.operatorMaxParallelism = operatorMaxParallelism;
 		this.factory = factory;
+		this.timestamper = timestamper;
 		this.originalKeySelector = null;
 		this.hashKeySelector = null;
 		this.keyType = null;
@@ -96,12 +102,14 @@ public class BootstrapTransformation<T> {
 	<K> BootstrapTransformation(
 		DataSet<T> dataSet,
 		OptionalInt operatorMaxParallelism,
+		@Nullable Timestamper<T> timestamper,
 		SavepointWriterOperatorFactory factory,
 		@Nonnull KeySelector<T, K> keySelector,
 		@Nonnull TypeInformation<K> keyType) {
 		this.dataSet = dataSet;
 		this.operatorMaxParallelism = operatorMaxParallelism;
 		this.factory = factory;
+		this.timestamper = timestamper;
 		this.originalKeySelector = keySelector;
 		this.hashKeySelector = new HashSelector<>(keySelector);
 		this.keyType = keyType;
@@ -155,8 +163,8 @@ public class BootstrapTransformation<T> {
 
 		BoundedOneInputStreamTaskRunner<T> operatorRunner = new BoundedOneInputStreamTaskRunner<>(
 			config,
-			localMaxParallelism
-		);
+			localMaxParallelism,
+			timestamper);
 
 		MapPartitionOperator<T, TaggedOperatorSubtaskState> subtaskStates = input
 			.mapPartition(operatorRunner)

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/EvictingWindowReader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/EvictingWindowReader.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.state.api.functions.WindowReaderFunction;
+import org.apache.flink.state.api.input.KeyedStateInputFormat;
+import org.apache.flink.state.api.input.operator.WindowReaderOperator;
+import org.apache.flink.state.api.input.operator.window.AggregateEvictingWindowReaderFunction;
+import org.apache.flink.state.api.input.operator.window.PassThroughReader;
+import org.apache.flink.state.api.input.operator.window.ProcessEvictingWindowReader;
+import org.apache.flink.state.api.input.operator.window.ReduceEvictingWindowReaderFunction;
+import org.apache.flink.state.api.runtime.metadata.SavepointMetadata;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+
+/**
+ * This class provides entry points for reading keyed state
+ * written out using the {@code WindowOperator}.
+ *
+ * @param <W> The type of {@code Window}.
+ */
+@PublicEvolving
+public class EvictingWindowReader<W extends Window> {
+
+	/** The batch execution environment. Used for creating inputs for reading state. */
+	private final ExecutionEnvironment env;
+
+	/** The savepoint metadata, which maintains the current set of existing / newly added operator states. */
+	private final SavepointMetadata metadata;
+
+	/**
+	 * The state backend that was previously used to write existing operator states in this savepoint.
+	 * This is also the state backend that will be used when writing again this existing savepoint.
+	 */
+	private final StateBackend stateBackend;
+
+	/**
+	 * The window serializer used to write the window operator.
+	 */
+	private final TypeSerializer<W> windowSerializer;
+
+	EvictingWindowReader(ExecutionEnvironment env, SavepointMetadata metadata, StateBackend stateBackend, TypeSerializer<W> windowSerializer) {
+		Preconditions.checkNotNull(env, "The execution environment must not be null");
+		Preconditions.checkNotNull(metadata, "The savepoint metadata must not be null");
+		Preconditions.checkNotNull(stateBackend, "The state backend must not be null");
+		Preconditions.checkNotNull(windowSerializer, "The window serializer must not be null");
+
+		this.env = env;
+		this.metadata = metadata;
+		this.stateBackend = stateBackend;
+		this.windowSerializer = windowSerializer;
+	}
+
+	/**
+	 * Reads window state generated using a {@link ReduceFunction}.
+	 *
+	 * @param uid The uid of the operator.
+	 * @param function The reduce function used to create the window.
+	 * @param keyType The key type of the window.
+	 * @param reduceType The type information of the reduce function.
+	 * @param <T> The type of the reduce function.
+	 * @param <K> The key type of the operator.
+	 * @return A {@code DataSet} of objects read from keyed state.
+	 * @throws IOException If savepoint does not contain the specified uid.
+	 */
+	public <T, K> DataSet<T> reduce(
+		String uid,
+		ReduceFunction<T> function,
+		TypeInformation<K> keyType,
+		TypeInformation<T> reduceType) throws IOException {
+
+		return reduce(uid, function, new PassThroughReader<>(), keyType, reduceType, reduceType);
+	}
+
+	/**
+	 * Reads window state generated using a {@link ReduceFunction}.
+	 *
+	 * @param uid The uid of the operator.
+	 * @param function The reduce function used to create the window.
+	 * @param readerFunction The window reader function.
+	 * @param keyType The key type of the window.
+	 * @param reduceType The type information of the reduce function.
+	 * @param outputType The output type of the reader function.
+	 * @param <K> The type of the key.
+	 * @param <T> The type of the reduce function.
+	 * @param <OUT> The output type of the reduce function.
+	 * @return A {@code DataSet} of objects read from keyed state.
+	 * @throws IOException If savepoint does not contain the specified uid.
+	 */
+	public <K, T, OUT> DataSet<OUT> reduce(
+		String uid,
+		ReduceFunction<T> function,
+		WindowReaderFunction<T, OUT, K, W> readerFunction,
+		TypeInformation<K> keyType,
+		TypeInformation<T> reduceType,
+		TypeInformation<OUT> outputType) throws IOException {
+
+		WindowReaderOperator<?, K, StreamRecord<T>, W, OUT> operator = WindowReaderOperator.evictingWindow(
+			new ReduceEvictingWindowReaderFunction<>(readerFunction, function),
+			keyType,
+			windowSerializer,
+			reduceType,
+			env.getConfig()
+		);
+
+		return readWindowOperator(uid, outputType, operator);
+	}
+
+	/**
+	 * Reads window state generated using an {@link AggregateFunction}.
+	 *
+	 * @param uid The uid of the operator.
+	 * @param aggregateFunction The aggregate function used to create the window.
+	 * @param keyType The key type of the window.
+	 * @param inputType The type information of the accumulator function.
+	 * @param outputType The output type of the reader function.
+	 * @param <K> The type of the key.
+	 * @param <T> The type of the values that are aggregated.
+	 * @param <ACC> The type of the accumulator (intermediate aggregate state).
+	 * @param <R> The type of the aggregated result.
+	 * @return A {@code DataSet} of objects read from keyed state.
+	 * @throws IOException If savepoint does not contain the specified uid.
+	 */
+	public <K, T, ACC, R> DataSet<R> aggregate(
+		String uid,
+		AggregateFunction<T, ACC, R> aggregateFunction,
+		TypeInformation<K> keyType,
+		TypeInformation<T> inputType,
+		TypeInformation<R> outputType) throws IOException {
+
+		return aggregate(uid, aggregateFunction, new PassThroughReader<>(), keyType, inputType, outputType);
+	}
+
+	/**
+	 * Reads window state generated using an {@link AggregateFunction}.
+	 *
+	 * @param uid The uid of the operator.
+	 * @param aggregateFunction The aggregate function used to create the window.
+	 * @param readerFunction The window reader function.
+	 * @param keyType The key type of the window.
+	 * @param inputType The type information of the accumulator function.
+	 * @param outputType The output type of the reader function.
+	 * @param <K> The type of the key.
+	 * @param <T> The type of the values that are aggregated.
+	 * @param <ACC> The type of the accumulator (intermediate aggregate state).
+	 * @param <R> The type of the aggregated result.
+	 * @param <OUT> The output type of the reader function.
+	 * @return A {@code DataSet} of objects read from keyed state.
+	 * @throws IOException If savepoint does not contain the specified uid.
+	 */
+	public <K, T, ACC, R, OUT> DataSet<OUT> aggregate(
+		String uid,
+		AggregateFunction<T, ACC, R> aggregateFunction,
+		WindowReaderFunction<R, OUT, K, W> readerFunction,
+		TypeInformation<K> keyType,
+		TypeInformation<T> inputType,
+		TypeInformation<OUT> outputType) throws IOException {
+
+		WindowReaderOperator<?, K, StreamRecord<T>, W, OUT> operator = WindowReaderOperator.evictingWindow(
+			new AggregateEvictingWindowReaderFunction<>(readerFunction, aggregateFunction),
+			keyType,
+			windowSerializer,
+			inputType,
+			env.getConfig()
+		);
+
+		return readWindowOperator(uid, outputType, operator);
+	}
+
+	/**
+	 * Reads window state generated without any preaggregation such as {@code WindowedStream#apply}
+	 * and {@code WindowedStream#process}.
+	 *
+	 * @param uid The uid of the operator.
+	 * @param readerFunction The window reader function.
+	 * @param keyType The key type of the window.
+	 * @param stateType The type of records stored in state.
+	 * @param outputType The output type of the reader function.
+	 * @param <K> The type of the key.
+	 * @param <T> The type of the records stored in state.
+	 * @param <OUT> The output type of the reader function.
+	 * @return A {@code DataSet} of objects read from keyed state.
+	 * @throws IOException If the savepoint does not contain the specified uid.
+	 */
+	public <K, T, OUT> DataSet<OUT> process(
+		String uid,
+		WindowReaderFunction<T, OUT, K, W> readerFunction,
+		TypeInformation<K> keyType,
+		TypeInformation<T> stateType,
+		TypeInformation<OUT> outputType) throws IOException {
+
+		WindowReaderOperator<?, K, StreamRecord<T>, W, OUT> operator = WindowReaderOperator.evictingWindow(
+			new ProcessEvictingWindowReader<>(readerFunction),
+			keyType,
+			windowSerializer,
+			stateType,
+			env.getConfig());
+
+		return readWindowOperator(uid, outputType, operator);
+	}
+
+	private <K, T, OUT> DataSet<OUT> readWindowOperator(
+		String uid,
+		TypeInformation<OUT> outputType,
+		WindowReaderOperator<?, K, T, W, OUT> operator) throws IOException {
+		KeyedStateInputFormat<K, W, OUT> format = new KeyedStateInputFormat<>(
+			metadata.getOperatorState(uid),
+			stateBackend,
+			operator
+		);
+
+		return env.createInput(format, outputType);
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/ExistingSavepoint.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/ExistingSavepoint.java
@@ -40,6 +40,9 @@ import org.apache.flink.state.api.input.ListStateInputFormat;
 import org.apache.flink.state.api.input.UnionStateInputFormat;
 import org.apache.flink.state.api.input.operator.KeyedStateReaderOperator;
 import org.apache.flink.state.api.runtime.metadata.SavepointMetadata;
+import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.streaming.api.windowing.windows.Window;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
@@ -283,5 +286,28 @@ public class ExistingSavepoint extends WritableSavepoint<ExistingSavepoint> {
 			new KeyedStateReaderOperator<>(function, keyTypeInfo));
 
 		return env.createInput(inputFormat, outTypeInfo);
+	}
+
+	/**
+	 * Read window state from an operator in a {@code Savepoint}.
+	 * This method supports reading from any type of time based window, including but not limited to
+	 * Tumbling, Sliding, and Session windows for both event time and processing time.
+	 *
+	 * @return A {@link WindowReader}.
+	 */
+	public WindowReader<TimeWindow> timeWindow() {
+		return new WindowReader<>(env, metadata, stateBackend, new TimeWindow.Serializer());
+	}
+
+	/**
+	 * Read window state from an operator in a {@code Savepoint}.
+	 * This method supports reading from any type of window.
+	 *
+	 * @param assigner The {@link WindowAssigner} used to write out the operator.
+	 * @return A {@link WindowReader}.
+	 */
+	public <W extends Window> WindowReader<W> window(WindowAssigner<?, W> assigner) {
+		TypeSerializer<W> windowSerializer = assigner.getWindowSerializer(env.getConfig());
+		return new WindowReader<>(env, metadata, stateBackend, windowSerializer);
 	}
 }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WindowReader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WindowReader.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.state.api.functions.WindowReaderFunction;
+import org.apache.flink.state.api.input.KeyedStateInputFormat;
+import org.apache.flink.state.api.input.operator.WindowReaderOperator;
+import org.apache.flink.state.api.input.operator.window.PassThroughReader;
+import org.apache.flink.state.api.runtime.metadata.SavepointMetadata;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+
+/**
+ * This class provides entry points for reading keyed state
+ * written out using the {@code WindowOperator}.
+ *
+ * @param <W> The type of {@code Window}.
+ */
+@PublicEvolving
+public class WindowReader<W extends Window> {
+
+	/** The batch execution environment. Used for creating inputs for reading state. */
+	private final ExecutionEnvironment env;
+
+	/** The savepoint metadata, which maintains the current set of existing / newly added operator states. */
+	private final SavepointMetadata metadata;
+
+	/**
+	 * The state backend that was previously used to write existing operator states in this savepoint.
+	 * This is also the state backend that will be used when writing again this existing savepoint.
+	 */
+	private final StateBackend stateBackend;
+
+	/**
+	 * The window serializer used to write the window operator.
+	 */
+	private final TypeSerializer<W> windowSerializer;
+
+	WindowReader(ExecutionEnvironment env, SavepointMetadata metadata, StateBackend stateBackend, TypeSerializer<W> windowSerializer) {
+		Preconditions.checkNotNull(env, "The execution environment must not be null");
+		Preconditions.checkNotNull(metadata, "The savepoint metadata must not be null");
+		Preconditions.checkNotNull(stateBackend, "The state backend must not be null");
+		Preconditions.checkNotNull(windowSerializer, "The window serializer must not be null");
+
+		this.env = env;
+		this.metadata = metadata;
+		this.stateBackend = stateBackend;
+		this.windowSerializer = windowSerializer;
+	}
+
+	/**
+	 * Reads from a window that uses an evictor.
+	 */
+	public EvictingWindowReader<W> evictor() {
+		return new EvictingWindowReader<>(env, metadata, stateBackend, windowSerializer);
+	}
+
+	/**
+	 * Reads window state generated using a {@link ReduceFunction}.
+	 *
+	 * @param uid The uid of the operator.
+	 * @param function The reduce function used to create the window.
+	 * @param keyType The key type of the window.
+	 * @param reduceType The type information of the reduce function.
+	 * @param <T> The type of the reduce function.
+	 * @param <K> The key type of the operator.
+	 * @return A {@code DataSet} of objects read from keyed state.
+	 * @throws IOException If savepoint does not contain the specified uid.
+	 */
+	public <T, K> DataSet<T> reduce(
+		String uid,
+		ReduceFunction<T> function,
+		TypeInformation<K> keyType,
+		TypeInformation<T> reduceType) throws IOException {
+
+		return reduce(uid, function, new PassThroughReader<>(), keyType, reduceType, reduceType);
+	}
+
+	/**
+	 * Reads window state generated using a {@link ReduceFunction}.
+	 *
+	 * @param uid The uid of the operator.
+	 * @param function The reduce function used to create the window.
+	 * @param readerFunction The window reader function.
+	 * @param keyType The key type of the window.
+	 * @param reduceType The type information of the reduce function.
+	 * @param outputType The output type of the reader function.
+	 * @param <K> The type of the key.
+	 * @param <T> The type of the reduce function.
+	 * @param <OUT> The output type of the reduce function.
+	 * @return A {@code DataSet} of objects read from keyed state.
+	 * @throws IOException If savepoint does not contain the specified uid.
+	 */
+	public <K, T, OUT> DataSet<OUT> reduce(
+		String uid,
+		ReduceFunction<T> function,
+		WindowReaderFunction<T, OUT, K, W> readerFunction,
+		TypeInformation<K> keyType,
+		TypeInformation<T> reduceType,
+		TypeInformation<OUT> outputType) throws IOException {
+
+		WindowReaderOperator<?, K, T, W, OUT> operator = WindowReaderOperator.reduce(
+			function,
+			readerFunction,
+			keyType,
+			windowSerializer,
+			reduceType
+		);
+
+		return readWindowOperator(uid, outputType, operator);
+	}
+
+	/**
+	 * Reads window state generated using an {@link AggregateFunction}.
+	 *
+	 * @param uid The uid of the operator.
+	 * @param aggregateFunction The aggregate function used to create the window.
+	 * @param keyType The key type of the window.
+	 * @param accType The type information of the accumulator function.
+	 * @param outputType The output type of the reader function.
+	 * @param <K> The type of the key.
+	 * @param <T> The type of the values that are aggregated.
+	 * @param <ACC> The type of the accumulator (intermediate aggregate state).
+	 * @param <R> The type of the aggregated result.
+	 * @return A {@code DataSet} of objects read from keyed state.
+	 * @throws IOException If savepoint does not contain the specified uid.
+	 */
+	public <K, T, ACC, R> DataSet<R> aggregate(
+		String uid,
+		AggregateFunction<T, ACC, R> aggregateFunction,
+		TypeInformation<K> keyType,
+		TypeInformation<ACC> accType,
+		TypeInformation<R> outputType) throws IOException {
+
+		return aggregate(uid, aggregateFunction, new PassThroughReader<>(), keyType, accType, outputType);
+	}
+
+	/**
+	 * Reads window state generated using an {@link AggregateFunction}.
+	 *
+	 * @param uid The uid of the operator.
+	 * @param aggregateFunction The aggregate function used to create the window.
+	 * @param readerFunction The window reader function.
+	 * @param keyType The key type of the window.
+	 * @param accType The type information of the accumulator function.
+	 * @param outputType The output type of the reader function.
+	 * @param <K> The type of the key.
+	 * @param <T> The type of the values that are aggregated.
+	 * @param <ACC> The type of the accumulator (intermediate aggregate state).
+	 * @param <R> The type of the aggregated result.
+	 * @param <OUT> The output type of the reader function.
+	 * @return A {@code DataSet} of objects read from keyed state.
+	 * @throws IOException If savepoint does not contain the specified uid.
+	 */
+	public <K, T, ACC, R, OUT> DataSet<OUT> aggregate(
+		String uid,
+		AggregateFunction<T, ACC, R> aggregateFunction,
+		WindowReaderFunction<R, OUT, K, W> readerFunction,
+		TypeInformation<K> keyType,
+		TypeInformation<ACC> accType,
+		TypeInformation<OUT> outputType) throws IOException {
+
+		WindowReaderOperator<?, K, R, W, OUT> operator = WindowReaderOperator.aggregate(
+			aggregateFunction,
+			readerFunction,
+			keyType,
+			windowSerializer,
+			accType
+		);
+
+		return readWindowOperator(uid, outputType, operator);
+	}
+
+	/**
+	 * Reads window state generated without any preaggregation such as {@code WindowedStream#apply}
+	 * and {@code WindowedStream#process}.
+	 *
+	 * @param uid The uid of the operator.
+	 * @param readerFunction The window reader function.
+	 * @param keyType The key type of the window.
+	 * @param stateType The type of records stored in state.
+	 * @param outputType The output type of the reader function.
+	 * @param <K> The type of the key.
+	 * @param <T> The type of the records stored in state.
+	 * @param <OUT> The output type of the reader function.
+	 * @return A {@code DataSet} of objects read from keyed state.
+	 * @throws IOException If the savepoint does not contain the specified uid.
+	 */
+	public <K, T, OUT> DataSet<OUT> process(
+		String uid,
+		WindowReaderFunction<T, OUT, K, W> readerFunction,
+		TypeInformation<K> keyType,
+		TypeInformation<T> stateType,
+		TypeInformation<OUT> outputType) throws IOException {
+
+		WindowReaderOperator<?, K, T, W, OUT> operator = WindowReaderOperator.process(
+			readerFunction,
+			keyType,
+			windowSerializer,
+			stateType);
+
+		return readWindowOperator(uid, outputType, operator);
+	}
+
+	private <K, T, OUT> DataSet<OUT> readWindowOperator(
+		String uid,
+		TypeInformation<OUT> outputType,
+		WindowReaderOperator<?, K, T, W, OUT> operator) throws IOException {
+		KeyedStateInputFormat<K, W, OUT> format = new KeyedStateInputFormat<>(
+			metadata.getOperatorState(uid),
+			stateBackend,
+			operator
+		);
+
+		return env.createInput(format, outputType);
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WindowedOperatorTransformation.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WindowedOperatorTransformation.java
@@ -1,0 +1,664 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.state.api.functions.Timestamper;
+import org.apache.flink.state.api.output.operators.StateBootstrapWrapperOperator;
+import org.apache.flink.streaming.api.functions.aggregation.AggregationFunction;
+import org.apache.flink.streaming.api.functions.aggregation.ComparableAggregator;
+import org.apache.flink.streaming.api.functions.aggregation.SumAggregator;
+import org.apache.flink.streaming.api.functions.windowing.PassThroughWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.WindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
+import org.apache.flink.streaming.api.windowing.evictors.Evictor;
+import org.apache.flink.streaming.api.windowing.triggers.Trigger;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.operators.windowing.WindowOperator;
+import org.apache.flink.streaming.runtime.operators.windowing.WindowOperatorBuilder;
+
+import javax.annotation.Nullable;
+
+import java.util.OptionalInt;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link WindowedOperatorTransformation} represents a {@link OneInputOperatorTransformation} for bootstrapping
+ * window state.
+ *
+ * @param <K> The type of the key in the window.
+ * @param <T> The type of the elements in the window.
+ * @param <W> The type of the window.
+ */
+@PublicEvolving
+public class WindowedOperatorTransformation<T, K, W extends Window> {
+
+	private final DataSet<T> input;
+
+	private final WindowOperatorBuilder<T, K, W> builder;
+
+	private final OptionalInt operatorMaxParallelism;
+
+	@Nullable
+	private final Timestamper<T> timestamper;
+
+	private final KeySelector<T, K> keySelector;
+
+	private final TypeInformation<K> keyType;
+
+	WindowedOperatorTransformation(
+		DataSet<T> input,
+		OptionalInt operatorMaxParallelism,
+		@Nullable Timestamper<T> timestamper,
+		KeySelector<T, K> keySelector,
+		TypeInformation<K> keyType,
+		WindowAssigner<? super T, W> windowAssigner) {
+		this.input = input;
+		this.operatorMaxParallelism = operatorMaxParallelism;
+		this.timestamper = timestamper;
+		this.keySelector = keySelector;
+		this.keyType = keyType;
+
+		this.builder = new WindowOperatorBuilder<>(
+			windowAssigner,
+			windowAssigner.getDefaultTrigger(null),
+			input.getExecutionEnvironment().getConfig(),
+			input.getType(),
+			keySelector,
+			keyType
+		);
+	}
+
+	/**
+	 * Sets the {@code Trigger} that should be used to trigger window emission.
+	 */
+	@PublicEvolving
+	public WindowedOperatorTransformation<T, K, W> trigger(Trigger<? super T, ? super W> trigger) {
+		builder.trigger(trigger);
+		return this;
+	}
+
+	/**
+	 * Sets the {@code Evictor} that should be used to evict elements from a window before emission.
+	 *
+	 * <p>Note: When using an evictor window performance will degrade significantly, since
+	 * incremental aggregation of window results cannot be used.
+	 */
+	@PublicEvolving
+	public WindowedOperatorTransformation<T, K, W> evictor(Evictor<? super T, ? super W> evictor) {
+		builder.evictor(evictor);
+		return this;
+	}
+
+
+	// ------------------------------------------------------------------------
+	//  Operations on the keyed windows
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Applies a reduce function to the window. The window function is called for each evaluation
+	 * of the window for each key individually. The output of the reduce function is interpreted
+	 * as a regular non-windowed stream.
+	 *
+	 * <p>This window will try and incrementally aggregate data as much as the window policies
+	 * permit. For example, tumbling time windows can aggregate the data, meaning that only one
+	 * element per key is stored. Sliding time windows will aggregate on the granularity of the
+	 * slide interval, so a few elements are stored per key (one per slide interval).
+	 * Custom windows may not be able to incrementally aggregate, or may need to store extra values
+	 * in an aggregation tree.
+	 *
+	 * @param function The reduce function.
+	 * @return The data stream that is the result of applying the reduce function to the window.
+	 */
+	@SuppressWarnings("unchecked")
+	public BootstrapTransformation<T> reduce(ReduceFunction<T> function) {
+		if (function instanceof RichFunction) {
+			throw new UnsupportedOperationException("ReduceFunction of reduce can not be a RichFunction. " +
+				"Please use reduce(ReduceFunction, WindowFunction) instead.");
+		}
+
+		//clean the closure
+		function = input.clean(function);
+		return reduce(function, new PassThroughWindowFunction<>());
+	}
+
+	/**
+	 * Applies the given window function to each window. The window function is called for each
+	 * evaluation of the window for each key individually. The output of the window function is
+	 * interpreted as a regular non-windowed stream.
+	 *
+	 * <p>Arriving data is incrementally aggregated using the given reducer.
+	 *
+	 * @param reduceFunction The reduce function that is used for incremental aggregation.
+	 * @param function The window function.
+	 * @return The data stream that is the result of applying the window function to the window.
+	 */
+	public <R> BootstrapTransformation<T> reduce(
+		ReduceFunction<T> reduceFunction,
+		WindowFunction<T, R, K, W> function) {
+
+		//clean the closures
+		function = input.clean(function);
+		reduceFunction = input.clean(reduceFunction);
+
+		WindowOperator<K, T, ?, R, W> operator = builder.reduce(reduceFunction, function);
+
+		SavepointWriterOperatorFactory factory = (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+		return new BootstrapTransformation<>(input, operatorMaxParallelism, timestamper, factory, keySelector, keyType);
+	}
+
+
+	/**
+	 * Applies the given window function to each window. The window function is called for each
+	 * evaluation of the window for each key individually. The output of the window function is
+	 * interpreted as a regular non-windowed stream.
+	 *
+	 * <p>Arriving data is incrementally aggregated using the given reducer.
+	 *
+	 * @param reduceFunction The reduce function that is used for incremental aggregation.
+	 * @param function The window function.
+	 * @return The data stream that is the result of applying the window function to the window.
+	 */
+	@Internal
+	public <R> BootstrapTransformation<T> reduce(ReduceFunction<T> reduceFunction, ProcessWindowFunction<T, R, K, W> function) {
+		//clean the closures
+		function = input.clean(function);
+		reduceFunction = input.clean(reduceFunction);
+
+		WindowOperator<K, T, ?, R, W> operator = builder.reduce(reduceFunction, function);
+
+		SavepointWriterOperatorFactory factory = (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+		return new BootstrapTransformation<>(input, operatorMaxParallelism, timestamper, factory, keySelector, keyType);
+	}
+
+	// ------------------------------------------------------------------------
+	//  Aggregation Function
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Applies the given aggregation function to each window. The aggregation function is called for
+	 * each element, aggregating values incrementally and keeping the state to one accumulator
+	 * per key and window.
+	 *
+	 * @param function The aggregation function.
+	 * @return The data stream that is the result of applying the fold function to the window.
+	 *
+	 * @param <ACC> The type of the AggregateFunction's accumulator
+	 * @param <R> The type of the elements in the resulting stream, equal to the
+	 *            AggregateFunction's result type
+	 */
+	@PublicEvolving
+	public <ACC, R> BootstrapTransformation<T> aggregate(AggregateFunction<T, ACC, R> function) {
+		checkNotNull(function, "function");
+
+		if (function instanceof RichFunction) {
+			throw new UnsupportedOperationException("This aggregation function cannot be a RichFunction.");
+		}
+
+		TypeInformation<ACC> accumulatorType = TypeExtractor.getAggregateFunctionAccumulatorType(
+			function, input.getType(), null, false);
+
+		return aggregate(function, accumulatorType);
+	}
+
+	/**
+	 * Applies the given aggregation function to each window. The aggregation function is called for
+	 * each element, aggregating values incrementally and keeping the state to one accumulator
+	 * per key and window.
+	 *
+	 * @param function The aggregation function.
+	 * @return The data stream that is the result of applying the aggregation function to the window.
+	 *
+	 * @param <ACC> The type of the AggregateFunction's accumulator
+	 * @param <R> The type of the elements in the resulting stream, equal to the
+	 *            AggregateFunction's result type
+	 */
+	@PublicEvolving
+	public <ACC, R> BootstrapTransformation<T> aggregate(
+		AggregateFunction<T, ACC, R> function,
+		TypeInformation<ACC> accumulatorType) {
+
+		checkNotNull(function, "function");
+		checkNotNull(accumulatorType, "accumulatorType");
+
+		if (function instanceof RichFunction) {
+			throw new UnsupportedOperationException("This aggregation function cannot be a RichFunction.");
+		}
+
+		return aggregate(function, new PassThroughWindowFunction<>(), accumulatorType);
+	}
+
+	/**
+	 * Applies the given window function to each window. The window function is called for each
+	 * evaluation of the window for each key individually. The output of the window function is
+	 * interpreted as a regular non-windowed stream.
+	 *
+	 * <p>Arriving data is incrementally aggregated using the given aggregate function. This means
+	 * that the window function typically has only a single value to process when called.
+	 *
+	 * @param aggFunction The aggregate function that is used for incremental aggregation.
+	 * @param windowFunction The window function.
+	 *
+	 * @return The data stream that is the result of applying the window function to the window.
+	 *
+	 * @param <ACC> The type of the AggregateFunction's accumulator
+	 * @param <V> The type of AggregateFunction's result, and the WindowFunction's input
+	 * @param <R> The type of the elements in the resulting stream, equal to the
+	 *            WindowFunction's result type
+	 */
+	@PublicEvolving
+	public <ACC, V, R> BootstrapTransformation<T> aggregate(
+		AggregateFunction<T, ACC, V> aggFunction,
+		WindowFunction<V, R, K, W> windowFunction) {
+
+		checkNotNull(aggFunction, "aggFunction");
+		checkNotNull(windowFunction, "windowFunction");
+
+		TypeInformation<ACC> accumulatorType = TypeExtractor.getAggregateFunctionAccumulatorType(
+			aggFunction, input.getType(), null, false);
+
+		return aggregate(aggFunction, windowFunction, accumulatorType);
+	}
+
+	/**
+	 * Applies the given window function to each window. The window function is called for each
+	 * evaluation of the window for each key individually. The output of the window function is
+	 * interpreted as a regular non-windowed stream.
+	 *
+	 * <p>Arriving data is incrementally aggregated using the given aggregate function. This means
+	 * that the window function typically has only a single value to process when called.
+	 *
+	 * @param aggregateFunction The aggregation function that is used for incremental aggregation.
+	 * @param windowFunction The window function.
+	 * @param accumulatorType Type information for the internal accumulator type of the aggregation function
+	 *
+	 * @return The data stream that is the result of applying the window function to the window.
+	 *
+	 * @param <ACC> The type of the AggregateFunction's accumulator
+	 * @param <V> The type of AggregateFunction's result, and the WindowFunction's input
+	 * @param <R> The type of the elements in the resulting stream, equal to the
+	 *            WindowFunction's result type
+	 */
+	@PublicEvolving
+	public <ACC, V, R> BootstrapTransformation<T> aggregate(
+		AggregateFunction<T, ACC, V> aggregateFunction,
+		WindowFunction<V, R, K, W> windowFunction,
+		TypeInformation<ACC> accumulatorType) {
+
+		checkNotNull(aggregateFunction, "aggregateFunction");
+		checkNotNull(windowFunction, "windowFunction");
+		checkNotNull(accumulatorType, "accumulatorType");
+
+		if (aggregateFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("This aggregate function cannot be a RichFunction.");
+		}
+
+		//clean the closures
+		windowFunction = input.clean(windowFunction);
+		aggregateFunction = input.clean(aggregateFunction);
+
+		WindowOperator<K, T, ?, R, W> operator = builder.aggregate(aggregateFunction, windowFunction, accumulatorType);
+
+		SavepointWriterOperatorFactory factory = (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+		return new BootstrapTransformation<>(input, operatorMaxParallelism, timestamper, factory, keySelector, keyType);
+	}
+
+	/**
+	 * Applies the given window function to each window. The window function is called for each
+	 * evaluation of the window for each key individually. The output of the window function is
+	 * interpreted as a regular non-windowed stream.
+	 *
+	 * <p>Arriving data is incrementally aggregated using the given aggregate function. This means
+	 * that the window function typically has only a single value to process when called.
+	 *
+	 * @param aggFunction The aggregate function that is used for incremental aggregation.
+	 * @param windowFunction The window function.
+	 *
+	 * @return The data stream that is the result of applying the window function to the window.
+	 *
+	 * @param <ACC> The type of the AggregateFunction's accumulator
+	 * @param <V> The type of AggregateFunction's result, and the WindowFunction's input
+	 * @param <R> The type of the elements in the resulting stream, equal to the
+	 *            WindowFunction's result type
+	 */
+	@PublicEvolving
+	public <ACC, V, R> BootstrapTransformation<T> aggregate(
+		AggregateFunction<T, ACC, V> aggFunction,
+		ProcessWindowFunction<V, R, K, W> windowFunction) {
+
+		checkNotNull(aggFunction, "aggFunction");
+		checkNotNull(windowFunction, "windowFunction");
+
+		TypeInformation<ACC> accumulatorType = TypeExtractor.getAggregateFunctionAccumulatorType(
+			aggFunction, input.getType(), null, false);
+
+		return aggregate(aggFunction, windowFunction, accumulatorType);
+	}
+
+	/**
+	 * Applies the given window function to each window. The window function is called for each
+	 * evaluation of the window for each key individually. The output of the window function is
+	 * interpreted as a regular non-windowed stream.
+	 *
+	 * <p>Arriving data is incrementally aggregated using the given aggregate function. This means
+	 * that the window function typically has only a single value to process when called.
+	 *
+	 * @param aggregateFunction The aggregation function that is used for incremental aggregation.
+	 * @param windowFunction The window function.
+	 * @param accumulatorType Type information for the internal accumulator type of the aggregation function
+	 *
+	 * @return The data stream that is the result of applying the window function to the window.
+	 *
+	 * @param <ACC> The type of the AggregateFunction's accumulator
+	 * @param <V> The type of AggregateFunction's result, and the WindowFunction's input
+	 * @param <R> The type of the elements in the resulting stream, equal to the
+	 *            WindowFunction's result type
+	 */
+	@PublicEvolving
+	public <ACC, V, R> BootstrapTransformation<T> aggregate(
+		AggregateFunction<T, ACC, V> aggregateFunction,
+		ProcessWindowFunction<V, R, K, W> windowFunction,
+		TypeInformation<ACC> accumulatorType) {
+
+		checkNotNull(aggregateFunction, "aggregateFunction");
+		checkNotNull(windowFunction, "windowFunction");
+		checkNotNull(accumulatorType, "accumulatorType");
+
+		if (aggregateFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("This aggregate function cannot be a RichFunction.");
+		}
+
+		//clean the closures
+		windowFunction = input.clean(windowFunction);
+		aggregateFunction = input.clean(aggregateFunction);
+
+		WindowOperator<K, T, ?, R, W> operator = builder.aggregate(aggregateFunction, windowFunction, accumulatorType);
+
+		SavepointWriterOperatorFactory factory = (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+		return new BootstrapTransformation<>(input, operatorMaxParallelism, timestamper, factory, keySelector, keyType);
+	}
+
+	// ------------------------------------------------------------------------
+	//  Window Function (apply)
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Applies the given window function to each window. The window function is called for each
+	 * evaluation of the window for each key individually. The output of the window function is
+	 * interpreted as a regular non-windowed stream.
+	 *
+	 * <p>Note that this function requires that all data in the windows is buffered until the window
+	 * is evaluated, as the function provides no means of incremental aggregation.
+	 *
+	 * @param function The window function.
+	 * @return The data stream that is the result of applying the window function to the window.
+	 */
+	public <R> BootstrapTransformation<T> apply(WindowFunction<T, R, K, W> function) {
+		WindowOperator<K, T, ?, R, W> operator = builder.apply(function);
+
+		SavepointWriterOperatorFactory factory = (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+		return new BootstrapTransformation<>(input, operatorMaxParallelism, timestamper, factory, keySelector, keyType);
+	}
+
+	/**
+	 * Applies the given window function to each window. The window function is called for each
+	 * evaluation of the window for each key individually. The output of the window function is
+	 * interpreted as a regular non-windowed stream.
+	 *
+	 * <p>Note that this function requires that all data in the windows is buffered until the window
+	 * is evaluated, as the function provides no means of incremental aggregation.
+	 *
+	 * @param function The window function.
+	 * @param resultType Type information for the result type of the window function
+	 * @return The data stream that is the result of applying the window function to the window.
+	 */
+	public <R> BootstrapTransformation<T> apply(WindowFunction<T, R, K, W> function, TypeInformation<R> resultType) {
+		function = input.clean(function);
+
+		WindowOperator<K, T, ?, R, W> operator = builder.apply(function);
+
+		SavepointWriterOperatorFactory factory = (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+		return new BootstrapTransformation<>(input, operatorMaxParallelism, timestamper, factory, keySelector, keyType);
+	}
+
+	/**
+	 * Applies the given window function to each window. The window function is called for each
+	 * evaluation of the window for each key individually. The output of the window function is
+	 * interpreted as a regular non-windowed stream.
+	 *
+	 * <p>Note that this function requires that all data in the windows is buffered until the window
+	 * is evaluated, as the function provides no means of incremental aggregation.
+	 *
+	 * @param function The window function.
+	 * @return The data stream that is the result of applying the window function to the window.
+	 */
+	@PublicEvolving
+	public <R> BootstrapTransformation<T> process(ProcessWindowFunction<T, R, K, W> function) {
+		WindowOperator<K, T, ?, R, W> operator = builder.process(function);
+
+		SavepointWriterOperatorFactory factory = (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+		return new BootstrapTransformation<>(input, operatorMaxParallelism, timestamper, factory, keySelector, keyType);
+	}
+
+
+	// ------------------------------------------------------------------------
+	//  Pre-defined aggregations on the keyed windows
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Applies an aggregation that sums every window of the data stream at the
+	 * given position.
+	 *
+	 * @param positionToSum The position in the tuple/array to sum
+	 * @return The transformed DataStream.
+	 */
+	public BootstrapTransformation<T> sum(int positionToSum) {
+		return aggregate(new SumAggregator<>(positionToSum, input.getType(), input.getExecutionEnvironment().getConfig()));
+	}
+
+	/**
+	 * Applies an aggregation that sums every window of the pojo data stream at the given field for
+	 * every window.
+	 *
+	 * <p>A field expression is either the name of a public field or a getter method with
+	 * parentheses of the stream's underlying type. A dot can be used to drill down into objects,
+	 * as in {@code "field1.getInnerField2()" }.
+	 *
+	 * @param field The field to sum
+	 * @return The transformed DataStream.
+	 */
+	public BootstrapTransformation<T> sum(String field) {
+		return aggregate(new SumAggregator<>(field, input.getType(), input.getExecutionEnvironment().getConfig()));
+	}
+
+	/**
+	 * Applies an aggregation that that gives the minimum value of every window
+	 * of the data stream at the given position.
+	 *
+	 * @param positionToMin The position to minimize
+	 * @return The transformed DataStream.
+	 */
+	public BootstrapTransformation<T> min(int positionToMin) {
+		return aggregate(new ComparableAggregator<>(positionToMin, input.getType(), AggregationFunction.AggregationType.MIN, input.getExecutionEnvironment().getConfig()));
+	}
+
+	/**
+	 * Applies an aggregation that that gives the minimum value of the pojo data
+	 * stream at the given field expression for every window.
+	 *
+	 * <p>A field * expression is either the name of a public field or a getter method with
+	 * parentheses of the {@code DataStream}S underlying type. A dot can be used
+	 * to drill down into objects, as in {@code "field1.getInnerField2()" }.
+	 *
+	 * @param field The field expression based on which the aggregation will be applied.
+	 * @return The transformed DataStream.
+	 */
+	public BootstrapTransformation<T> min(String field) {
+		return aggregate(new ComparableAggregator<>(field, input.getType(), AggregationFunction.AggregationType.MIN, false, input.getExecutionEnvironment().getConfig()));
+	}
+
+	/**
+	 * Applies an aggregation that gives the minimum element of every window of
+	 * the data stream by the given position. If more elements have the same
+	 * minimum value the operator returns the first element by default.
+	 *
+	 * @param positionToMinBy
+	 *            The position to minimize by
+	 * @return The transformed DataStream.
+	 */
+	public BootstrapTransformation<T> minBy(int positionToMinBy) {
+		return this.minBy(positionToMinBy, true);
+	}
+
+	/**
+	 * Applies an aggregation that gives the minimum element of every window of
+	 * the data stream by the given field. If more elements have the same
+	 * minimum value the operator returns the first element by default.
+	 *
+	 * @param field The field to minimize by
+	 * @return The transformed DataStream.
+	 */
+	public BootstrapTransformation<T> minBy(String field) {
+		return this.minBy(field, true);
+	}
+
+	/**
+	 * Applies an aggregation that gives the minimum element of every window of
+	 * the data stream by the given position. If more elements have the same
+	 * minimum value the operator returns either the first or last one depending
+	 * on the parameter setting.
+	 *
+	 * @param positionToMinBy The position to minimize
+	 * @param first If true, then the operator return the first element with the minimum value, otherwise returns the last
+	 * @return The transformed DataStream.
+	 */
+	public BootstrapTransformation<T> minBy(int positionToMinBy, boolean first) {
+		return aggregate(new ComparableAggregator<>(positionToMinBy, input.getType(), AggregationFunction.AggregationType.MINBY, first, input.getExecutionEnvironment().getConfig()));
+	}
+
+	/**
+	 * Applies an aggregation that that gives the minimum element of the pojo
+	 * data stream by the given field expression for every window. A field
+	 * expression is either the name of a public field or a getter method with
+	 * parentheses of the {@code DataStreams} underlying type. A dot can be used
+	 * to drill down into objects, as in {@code "field1.getInnerField2()" }.
+	 *
+	 * @param field The field expression based on which the aggregation will be applied.
+	 * @param first If True then in case of field equality the first object will be returned
+	 * @return The transformed DataStream.
+	 */
+	public BootstrapTransformation<T> minBy(String field, boolean first) {
+		return aggregate(new ComparableAggregator<>(field, input.getType(), AggregationFunction.AggregationType.MINBY, first, input.getExecutionEnvironment().getConfig()));
+	}
+
+	/**
+	 * Applies an aggregation that gives the maximum value of every window of
+	 * the data stream at the given position.
+	 *
+	 * @param positionToMax The position to maximize
+	 * @return The transformed DataStream.
+	 */
+	public BootstrapTransformation<T> max(int positionToMax) {
+		return aggregate(new ComparableAggregator<>(positionToMax, input.getType(), AggregationFunction.AggregationType.MAX, input.getExecutionEnvironment().getConfig()));
+	}
+
+	/**
+	 * Applies an aggregation that that gives the maximum value of the pojo data
+	 * stream at the given field expression for every window. A field expression
+	 * is either the name of a public field or a getter method with parentheses
+	 * of the {@code DataStream DataStreams} underlying type. A dot can be used to drill
+	 * down into objects, as in {@code "field1.getInnerField2()" }.
+	 *
+	 * @param field The field expression based on which the aggregation will be applied.
+	 * @return The transformed DataStream.
+	 */
+	public BootstrapTransformation<T> max(String field) {
+		return aggregate(new ComparableAggregator<>(field, input.getType(), AggregationFunction.AggregationType.MAX, false, input.getExecutionEnvironment().getConfig()));
+	}
+
+	/**
+	 * Applies an aggregation that gives the maximum element of every window of
+	 * the data stream by the given position. If more elements have the same
+	 * maximum value the operator returns the first by default.
+	 *
+	 * @param positionToMaxBy
+	 *            The position to maximize by
+	 * @return The transformed DataStream.
+	 */
+	public BootstrapTransformation<T> maxBy(int positionToMaxBy) {
+		return this.maxBy(positionToMaxBy, true);
+	}
+
+	/**
+	 * Applies an aggregation that gives the maximum element of every window of
+	 * the data stream by the given field. If more elements have the same
+	 * maximum value the operator returns the first by default.
+	 *
+	 * @param field
+	 *            The field to maximize by
+	 * @return The transformed DataStream.
+	 */
+	public BootstrapTransformation<T> maxBy(String field) {
+		return this.maxBy(field, true);
+	}
+
+	/**
+	 * Applies an aggregation that gives the maximum element of every window of
+	 * the data stream by the given position. If more elements have the same
+	 * maximum value the operator returns either the first or last one depending
+	 * on the parameter setting.
+	 *
+	 * @param positionToMaxBy The position to maximize by
+	 * @param first If true, then the operator return the first element with the maximum value, otherwise returns the last
+	 * @return The transformed DataStream.
+	 */
+	public BootstrapTransformation<T> maxBy(int positionToMaxBy, boolean first) {
+		return aggregate(new ComparableAggregator<>(positionToMaxBy, input.getType(), AggregationFunction.AggregationType.MAXBY, first, input.getExecutionEnvironment().getConfig()));
+	}
+
+	/**
+	 * Applies an aggregation that that gives the maximum element of the pojo
+	 * data stream by the given field expression for every window. A field
+	 * expression is either the name of a public field or a getter method with
+	 * parentheses of the { DataStream}S underlying type. A dot can be used
+	 * to drill down into objects, as in {@code "field1.getInnerField2()" }.
+	 *
+	 * @param field The field expression based on which the aggregation will be applied.
+	 * @param first If True then in case of field equality the first object will be returned
+	 * @return The transformed DataStream.
+	 */
+	public BootstrapTransformation<T> maxBy(String field, boolean first) {
+		return aggregate(new ComparableAggregator<>(field, input.getType(), AggregationFunction.AggregationType.MAXBY, first, input.getExecutionEnvironment().getConfig()));
+	}
+
+	private BootstrapTransformation<T> aggregate(AggregationFunction<T> aggregator) {
+		return reduce(aggregator);
+	}
+
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/functions/Timestamper.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/functions/Timestamper.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.functions;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.functions.Function;
+
+/**
+ * Assigns an event time timestamp to the given record. This class
+ * does not create watermarks.
+ */
+@PublicEvolving
+@FunctionalInterface
+public interface Timestamper<T> extends Function {
+	long timestamp(T element);
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/functions/WindowReaderFunction.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/functions/WindowReaderFunction.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.functions;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.functions.AbstractRichFunction;
+import org.apache.flink.api.common.state.KeyedStateStore;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.util.Collector;
+
+import java.util.Set;
+
+/**
+ * Base abstract class for functions that are evaluated over keyed (grouped) windows using a context
+ * for retrieving extra information.
+ *
+ * @param <IN> The type of the input value.
+ * @param <OUT> The type of the output value.
+ * @param <KEY> The type of the key.
+ * @param <W> The type of {@code Window} that this window function can be applied on.
+ */
+@PublicEvolving
+public abstract class WindowReaderFunction<IN, OUT, KEY, W extends Window> extends AbstractRichFunction {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Evaluates the window and outputs none or several elements.
+	 *
+	 * @param key The key for which this window is evaluated.
+	 * @param context The context in which the window is being evaluated.
+	 * @param elements The elements in the window being evaluated.
+	 * @param out A collector for emitting elements.
+	 *
+	 * @throws Exception The function may throw exceptions to fail the program and trigger recovery.
+	 */
+	public abstract void readWindow(KEY key, Context<W> context, Iterable<IN> elements, Collector<OUT> out) throws Exception;
+
+	/**
+	 * The context holding window metadata.
+	 */
+	public interface Context<W extends Window> extends java.io.Serializable {
+		/**
+		 * Returns the window that is being evaluated.
+		 */
+		W window();
+
+		/**
+		 * State accessor for per-key and per-window state.
+		 */
+		KeyedStateStore windowState();
+
+		/**
+		 * State accessor for per-key global state.
+		 */
+		KeyedStateStore globalState();
+
+		/**
+		 * @return All registered event time timers for the current window.
+		 */
+		Set<Long> registeredEventTimeTimers() throws Exception;
+
+		/**
+		 * @return All registered processing time timers for the current window.
+		 */
+		Set<Long> registeredProcessingTimeTimers() throws Exception;
+
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/WindowReaderOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/WindowReaderOperator.java
@@ -1,0 +1,285 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.input.operator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.state.AggregatingState;
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.KeyedStateStore;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.DefaultKeyedStateStore;
+import org.apache.flink.runtime.state.KeyedStateBackend;
+import org.apache.flink.state.api.functions.WindowReaderFunction;
+import org.apache.flink.state.api.input.operator.window.WindowContents;
+import org.apache.flink.state.api.runtime.SavepointRuntimeContext;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * A {@link StateReaderOperator} for reading {@code WindowOperator} state.
+ *
+ * @param <S> The state type.
+ * @param <KEY> The key type.
+ * @param <IN> The type read from state.
+ * @param <W> The window type.
+ * @param <OUT> The output type of the reader.
+ */
+@Internal
+public class WindowReaderOperator<S extends State, KEY, IN, W extends Window, OUT>
+	extends StateReaderOperator<WindowReaderFunction<IN, OUT, KEY, W>, KEY, W, OUT> {
+
+	private static final String WINDOW_STATE_NAME = "window-contents";
+
+	private static final String WINDOW_TIMER_NAME = "window-timers";
+
+	private final WindowContents<S, IN> contents;
+
+	private final StateDescriptor<S, ?> descriptor;
+
+	private transient Context ctx;
+
+	public static <KEY, T, W extends Window, OUT> WindowReaderOperator<?, KEY, T, W, OUT> reduce(
+		ReduceFunction<T> function,
+		WindowReaderFunction<T, OUT, KEY, W> reader,
+		TypeInformation<KEY> keyType,
+		TypeSerializer<W> windowSerializer,
+		TypeInformation<T> inputType) {
+
+		StateDescriptor<ReducingState<T>, T> descriptor = new ReducingStateDescriptor<>(WINDOW_STATE_NAME, function, inputType);
+		return new WindowReaderOperator<>(reader, keyType, windowSerializer, WindowContents.reducingState(), descriptor);
+	}
+
+	public static <KEY, T, ACC, R, OUT, W extends Window> WindowReaderOperator<?, KEY, R, W, OUT> aggregate(
+		AggregateFunction<T, ACC, R> function,
+		WindowReaderFunction<R, OUT, KEY, W> readerFunction,
+		TypeInformation<KEY> keyType,
+		TypeSerializer<W> windowSerializer,
+		TypeInformation<ACC> accumulatorType) {
+
+		StateDescriptor<AggregatingState<T, R>, ACC> descriptor = new AggregatingStateDescriptor<>(WINDOW_STATE_NAME, function, accumulatorType);
+		return new WindowReaderOperator<>(readerFunction, keyType, windowSerializer, WindowContents.aggregatingState(), descriptor);
+	}
+
+	public static <KEY, T, W extends Window, OUT> WindowReaderOperator<?, KEY, T, W, OUT> process(
+		WindowReaderFunction<T, OUT, KEY, W> readerFunction,
+		TypeInformation<KEY> keyType,
+		TypeSerializer<W> windowSerializer,
+		TypeInformation<T> stateType) {
+
+		StateDescriptor<ListState<T>, List<T>> descriptor = new ListStateDescriptor<>(WINDOW_STATE_NAME, stateType);
+		return new WindowReaderOperator<>(readerFunction, keyType, windowSerializer, WindowContents.listState(), descriptor);
+	}
+
+	public static <KEY, T, W extends Window, OUT> WindowReaderOperator<?, KEY, StreamRecord<T>, W, OUT> evictingWindow(
+		WindowReaderFunction<StreamRecord<T>, OUT, KEY, W> readerFunction,
+		TypeInformation<KEY> keyType,
+		TypeSerializer<W> windowSerializer,
+		TypeInformation<T> stateType,
+		ExecutionConfig config) {
+
+		@SuppressWarnings({"unchecked", "rawtypes"})
+		TypeSerializer<StreamRecord<T>> streamRecordSerializer =
+			(TypeSerializer<StreamRecord<T>>) new StreamElementSerializer(stateType.createSerializer(config));
+
+		StateDescriptor<ListState<StreamRecord<T>>, List<StreamRecord<T>>> descriptor =
+			new ListStateDescriptor<>(WINDOW_STATE_NAME, streamRecordSerializer);
+
+		return new WindowReaderOperator<>(readerFunction, keyType, windowSerializer, WindowContents.listState(), descriptor);
+	}
+
+	private WindowReaderOperator(
+		WindowReaderFunction<IN, OUT, KEY, W> function,
+		TypeInformation<KEY> keyType,
+		TypeSerializer<W> namespaceSerializer,
+		WindowContents<S, IN> contents,
+		StateDescriptor<S, ?> descriptor) {
+		super(function, keyType, namespaceSerializer);
+
+		Preconditions.checkNotNull(contents, "WindowContents must not be null");
+		Preconditions.checkNotNull(descriptor, "The state descriptor must not be null");
+
+		this.contents = contents;
+		this.descriptor = descriptor;
+	}
+
+	@Override
+	public void open() throws Exception {
+		super.open();
+
+		ctx = new Context(getKeyedStateBackend(), getInternalTimerService(WINDOW_TIMER_NAME));
+	}
+
+	@Override
+	public void processElement(KEY key, W namespace, Collector<OUT> out) throws Exception {
+		ctx.window = namespace;
+		S state = getKeyedStateBackend().getPartitionedState(namespace, namespaceSerializer, descriptor);
+		function.readWindow(key, ctx, contents.contents(state), out);
+	}
+
+	@Override
+	public Iterator<Tuple2<KEY, W>> getKeysAndNamespaces(SavepointRuntimeContext ctx) throws Exception {
+		Iterator<Tuple2<KEY, W>> keysAndWindows = getKeyedStateBackend()
+			.<W>getKeysAndNamespaces(descriptor.getName()).iterator();
+
+		return new IteratorWithRemove<>(keysAndWindows);
+	}
+
+	private class Context implements WindowReaderFunction.Context<W> {
+
+		private static final String EVENT_TIMER_STATE = "event-time-timers";
+
+		private static final String PROC_TIMER_STATE = "proc-time-timers";
+
+		W window;
+
+		final PerWindowKeyedStateStore perWindowKeyedStateStore;
+
+		final DefaultKeyedStateStore keyedStateStore;
+
+		ListState<Long> eventTimers;
+
+		ListState<Long> procTimers;
+
+		private Context(KeyedStateBackend<KEY> keyedStateBackend, InternalTimerService<W> timerService) throws Exception {
+			keyedStateStore = new DefaultKeyedStateStore(keyedStateBackend, getExecutionConfig());
+			perWindowKeyedStateStore = new PerWindowKeyedStateStore(keyedStateBackend);
+
+			eventTimers = keyedStateBackend.getPartitionedState(
+				WINDOW_TIMER_NAME,
+				StringSerializer.INSTANCE,
+				new ListStateDescriptor<>(EVENT_TIMER_STATE, Types.LONG));
+
+			timerService.forEachEventTimeTimer((namespace, timer) -> {
+				eventTimers.add(timer);
+			});
+
+			procTimers = keyedStateBackend.getPartitionedState(
+				WINDOW_TIMER_NAME,
+				StringSerializer.INSTANCE,
+				new ListStateDescriptor<>(PROC_TIMER_STATE, Types.LONG));
+
+			timerService.forEachProcessingTimeTimer((namespace, timer) -> {
+				procTimers.add(timer);
+			});
+		}
+
+		@Override
+		public W window() {
+			return window;
+		}
+
+		@Override
+		public KeyedStateStore windowState() {
+			perWindowKeyedStateStore.window = window;
+			return perWindowKeyedStateStore;
+		}
+
+		@Override
+		public KeyedStateStore globalState() {
+			return keyedStateStore;
+		}
+
+		@Override
+		public Set<Long> registeredEventTimeTimers() throws Exception {
+			Iterable<Long> timers = eventTimers.get();
+			if (timers == null) {
+				return Collections.emptySet();
+			}
+
+			return StreamSupport
+				.stream(timers.spliterator(), false)
+				.collect(Collectors.toSet());
+		}
+
+		@Override
+		public Set<Long> registeredProcessingTimeTimers() throws Exception {
+			Iterable<Long> timers = procTimers.get();
+			if (timers == null) {
+				return Collections.emptySet();
+			}
+
+			return StreamSupport
+				.stream(timers.spliterator(), false)
+				.collect(Collectors.toSet());
+		}
+	}
+
+	private class PerWindowKeyedStateStore extends DefaultKeyedStateStore {
+
+		W window;
+
+		PerWindowKeyedStateStore(KeyedStateBackend<?> keyedStateBackend) {
+			super(keyedStateBackend, WindowReaderOperator.this.getExecutionConfig());
+		}
+
+		@Override
+		protected <SS extends State> SS getPartitionedState(StateDescriptor<SS, ?> stateDescriptor) throws Exception {
+			return keyedStateBackend.getPartitionedState(
+				window,
+				namespaceSerializer,
+				stateDescriptor);
+		}
+	}
+
+	private static class IteratorWithRemove<T> implements Iterator<T> {
+
+		private final Iterator<T> iterator;
+
+		private IteratorWithRemove(Iterator<T> iterator) {
+			this.iterator = iterator;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return iterator.hasNext();
+		}
+
+		@Override
+		public T next() {
+			return iterator.next();
+		}
+
+		@Override
+		public void remove() { }
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/AggregateEvictingWindowReaderFunction.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/AggregateEvictingWindowReaderFunction.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.input.operator.window;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.state.api.functions.WindowReaderFunction;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.Collections;
+
+/**
+ * A wrapper for reading an evicting window operator with an aggregate function.
+ */
+@Internal
+public class AggregateEvictingWindowReaderFunction<IN, ACC, R, OUT, KEY, W extends Window> extends EvictingWindowReaderFunction<IN, R, OUT, KEY, W> {
+
+	private final AggregateFunction<IN, ACC, R> aggFunction;
+
+	public AggregateEvictingWindowReaderFunction(WindowReaderFunction<R, OUT, KEY, W> wrappedFunction, AggregateFunction<IN, ACC, R> aggFunction) {
+		super(wrappedFunction);
+		this.aggFunction = aggFunction;
+	}
+
+	@Override
+	public Iterable<R> transform(Iterable<StreamRecord<IN>> elements) throws Exception {
+		ACC acc = aggFunction.createAccumulator();
+
+		for (StreamRecord<IN> element : elements) {
+			acc = aggFunction.add(element.getValue(), acc);
+		}
+
+		R result = aggFunction.getResult(acc);
+		return Collections.singletonList(result);
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/EvictingWindowReaderFunction.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/EvictingWindowReaderFunction.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.input.operator.window;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.functions.util.FunctionUtils;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.state.api.functions.WindowReaderFunction;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * Wrapper for reading state from an evicting window operator.
+ * @param <IN> The input type stored in state.
+ * @param <R> The aggregated type.
+ * @param <OUT> The output type of the reader function.
+ * @param <KEY> The key type.
+ * @param <W> The window type.
+ */
+@Internal
+public abstract class EvictingWindowReaderFunction<IN, R, OUT, KEY, W extends Window> extends WindowReaderFunction<StreamRecord<IN>, OUT, KEY, W> {
+
+	private final WindowReaderFunction<R, OUT, KEY, W> wrappedFunction;
+
+	protected EvictingWindowReaderFunction(WindowReaderFunction<R, OUT, KEY, W> wrappedFunction) {
+		this.wrappedFunction = Preconditions.checkNotNull(wrappedFunction, "Inner reader function cannot be null");
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		FunctionUtils.openFunction(wrappedFunction, parameters);
+	}
+
+	@Override
+	public void close() throws Exception {
+		FunctionUtils.closeFunction(wrappedFunction);
+	}
+
+	@Override
+	public void setRuntimeContext(RuntimeContext t) {
+		super.setRuntimeContext(t);
+		FunctionUtils.setFunctionRuntimeContext(wrappedFunction, t);
+	}
+
+	@Override
+	public void readWindow(KEY key, Context<W> context, Iterable<StreamRecord<IN>> elements, Collector<OUT> out) throws Exception {
+		Iterable<R> result = transform(elements);
+		wrappedFunction.readWindow(key, context, result, out);
+	}
+
+	public abstract Iterable<R> transform(Iterable<StreamRecord<IN>> elements) throws Exception;
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/PassThroughReader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/PassThroughReader.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.input.operator.window;
+
+import org.apache.flink.state.api.functions.WindowReaderFunction;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.util.Collector;
+
+/**
+ * A {@link WindowReaderFunction} that just emits each input element.
+ *
+ * @param <KEY> The key type.
+ * @param <W> The window type.
+ * @param <IN> The type stored in state.
+ */
+public class PassThroughReader<KEY, W extends Window, IN> extends WindowReaderFunction<IN, IN, KEY, W> {
+
+	@Override
+	public void readWindow(KEY key, Context<W> context, Iterable<IN> elements, Collector<IN> out) {
+		for (IN element : elements) {
+			out.collect(element);
+		}
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/ProcessEvictingWindowReader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/ProcessEvictingWindowReader.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.input.operator.window;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.state.api.functions.WindowReaderFunction;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.stream.StreamSupport;
+
+/**
+ * A wrapper function for reading an evicting window with no pre-aggregation.
+ */
+@Internal
+public class ProcessEvictingWindowReader<IN, OUT, KEY, W extends Window> extends EvictingWindowReaderFunction<IN, IN, OUT, KEY, W> {
+
+	public ProcessEvictingWindowReader(WindowReaderFunction<IN, OUT, KEY, W> wrappedFunction) {
+		super(wrappedFunction);
+	}
+
+	@Override
+	public Iterable<IN> transform(Iterable<StreamRecord<IN>> elements) throws Exception {
+		return () -> StreamSupport
+			.stream(elements.spliterator(), false)
+			.map(StreamRecord::getValue)
+			.iterator();
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/ReduceEvictingWindowReaderFunction.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/ReduceEvictingWindowReaderFunction.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.input.operator.window;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.state.api.functions.WindowReaderFunction;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.Collections;
+
+/**
+ * A wrapper function for reading state from an evicting window operator with a reduce function.
+ */
+@Internal
+public class ReduceEvictingWindowReaderFunction<IN, OUT, KEY, W extends Window> extends EvictingWindowReaderFunction<IN, IN, OUT, KEY, W> {
+
+	private final ReduceFunction<IN> reduceFunction;
+
+	public ReduceEvictingWindowReaderFunction(WindowReaderFunction<IN, OUT, KEY, W> wrappedFunction, ReduceFunction<IN> reduceFunction) {
+		super(wrappedFunction);
+		this.reduceFunction = reduceFunction;
+	}
+
+	@Override
+	public Iterable<IN> transform(Iterable<StreamRecord<IN>> elements) throws Exception {
+		IN curr = null;
+
+		for (StreamRecord<IN> element : elements) {
+			if (curr == null) {
+				curr = element.getValue();
+			} else {
+				curr = reduceFunction.reduce(curr, element.getValue());
+			}
+		}
+
+		return Collections.singletonList(curr);
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/WindowContents.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/WindowContents.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.input.operator.window;
+
+import org.apache.flink.api.common.state.AggregatingState;
+import org.apache.flink.api.common.state.AppendingState;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.State;
+
+import java.io.Serializable;
+import java.util.Collections;
+
+/**
+ * An abstraction for transforming any {@link State} type into an iterable over its contents.
+ *
+ * @param <S> The initial state type.
+ * @param <IN> The data in state.
+ */
+@FunctionalInterface
+public interface WindowContents<S extends State, IN> extends Serializable {
+
+	static <T> WindowContents<ReducingState<T>, T> reducingState() {
+		return (state) -> Collections.singletonList(state.get());
+	}
+
+	static <IN, OUT> WindowContents<AggregatingState<IN, OUT>, OUT> aggregatingState() {
+		return (state) -> Collections.singletonList(state.get());
+	}
+
+	static <T> WindowContents<ListState<T>, T> listState() {
+		return AppendingState::get;
+	}
+
+	Iterable<IN> contents(S state) throws Exception;
+}
+

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/BoundedOneInputStreamTaskRunner.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/BoundedOneInputStreamTaskRunner.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.functions.RichMapPartitionFunction;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.state.api.functions.Timestamper;
 import org.apache.flink.state.api.runtime.SavepointEnvironment;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.util.Collector;
@@ -45,6 +46,8 @@ public class BoundedOneInputStreamTaskRunner<IN> extends RichMapPartitionFunctio
 
 	private final int maxParallelism;
 
+	private final Timestamper<IN> timestamper;
+
 	private transient SavepointEnvironment env;
 
 	/**
@@ -55,10 +58,12 @@ public class BoundedOneInputStreamTaskRunner<IN> extends RichMapPartitionFunctio
 	 */
 	public BoundedOneInputStreamTaskRunner(
 		StreamConfig streamConfig,
-		int maxParallelism) {
+		int maxParallelism,
+		Timestamper<IN> timestamper) {
 
 		this.streamConfig = streamConfig;
 		this.maxParallelism = maxParallelism;
+		this.timestamper = timestamper;
 	}
 
 	@Override
@@ -73,7 +78,6 @@ public class BoundedOneInputStreamTaskRunner<IN> extends RichMapPartitionFunctio
 
 	@Override
 	public void mapPartition(Iterable<IN> values, Collector<TaggedOperatorSubtaskState> out) throws Exception {
-		new BoundedStreamTask<>(env, values, out).invoke();
+		new BoundedStreamTask<>(env, values, timestamper, out).invoke();
 	}
 }
-

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/TimestampAssignerWrapper.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/TimestampAssignerWrapper.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.output;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.state.api.functions.Timestamper;
+import org.apache.flink.streaming.api.functions.TimestampAssigner;
+
+/**
+ * Wraps an existing {@link TimestampAssigner} into a {@link Timestamper}.
+ */
+@Internal
+public class TimestampAssignerWrapper<T> implements Timestamper<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final TimestampAssigner<T> assigner;
+
+	public TimestampAssignerWrapper(TimestampAssigner<T> assigner) {
+		this.assigner = assigner;
+	}
+
+	@Override
+	public long timestamp(T element) {
+		return assigner.extractTimestamp(element, Long.MIN_VALUE);
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapWrapperOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapWrapperOperator.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.output.operators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.state.api.output.SnapshotUtils;
+import org.apache.flink.state.api.output.TaggedOperatorSubtaskState;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.SetupableStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.util.OutputTag;
+
+/**
+ * Wraps an existing operator so it can be bootstrapped.
+ */
+@Internal
+@SuppressWarnings({"unchecked", "deprecation"})
+public final class StateBootstrapWrapperOperator<IN, OUT, OP extends AbstractStreamOperator<OUT> & OneInputStreamOperator<IN, OUT>>
+	implements OneInputStreamOperator<IN, TaggedOperatorSubtaskState>,
+	SetupableStreamOperator<TaggedOperatorSubtaskState>,
+	BoundedOneInput {
+
+	private static final long serialVersionUID = 1L;
+
+	private final long timestamp;
+
+	private final Path savepointPath;
+
+	private Output<StreamRecord<TaggedOperatorSubtaskState>> output;
+
+	private final OP operator;
+
+	public StateBootstrapWrapperOperator(
+		long timestamp,
+		Path savepointPath,
+		OP operator) {
+
+		this.timestamp = timestamp;
+		this.savepointPath = savepointPath;
+		this.operator = operator;
+	}
+
+	@Override
+	public void setup(StreamTask<?, ?> containingTask, StreamConfig config, Output<StreamRecord<TaggedOperatorSubtaskState>> output) {
+		((SetupableStreamOperator) operator).setup(containingTask, config, new VoidOutput<>());
+
+		this.output = output;
+	}
+
+	@Override
+	public void processElement(StreamRecord<IN> element) throws Exception {
+		operator.processElement(element);
+	}
+
+	@Override
+	public void processWatermark(Watermark mark) throws Exception {
+		operator.processWatermark(mark);
+	}
+
+	@Override
+	public void processLatencyMarker(LatencyMarker latencyMarker) throws Exception {
+		operator.processLatencyMarker(latencyMarker);
+	}
+
+	@Override
+	public void open() throws Exception {
+		operator.open();
+	}
+
+	@Override
+	public void close() throws Exception {
+		operator.close();
+	}
+
+	@Override
+	public void dispose() throws Exception {
+		operator.dispose();
+	}
+
+	@Override
+	public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
+		operator.prepareSnapshotPreBarrier(checkpointId);
+	}
+
+	@Override
+	public OperatorSnapshotFutures snapshotState(long checkpointId, long timestamp, CheckpointOptions checkpointOptions, CheckpointStreamFactory storageLocation) throws Exception {
+		return operator.snapshotState(checkpointId, timestamp, checkpointOptions, storageLocation);
+	}
+
+	@Override
+	public void initializeState() throws Exception {
+		operator.initializeState();
+	}
+
+	@Override
+	public void setKeyContextElement1(StreamRecord<?> record) throws Exception {
+		operator.setKeyContextElement1(record);
+	}
+
+	@Override
+	public void setKeyContextElement2(StreamRecord<?> record) throws Exception {
+		operator.setKeyContextElement2(record);
+	}
+
+	@Override
+	public ChainingStrategy getChainingStrategy() {
+		return operator.getChainingStrategy();
+	}
+
+	@Override
+	public void setChainingStrategy(ChainingStrategy strategy) {
+		operator.setChainingStrategy(strategy);
+	}
+
+	@Override
+	public MetricGroup getMetricGroup() {
+		return operator.getMetricGroup();
+	}
+
+	@Override
+	public OperatorID getOperatorID() {
+		return operator.getOperatorID();
+	}
+
+	@Override
+	public void notifyCheckpointComplete(long checkpointId) throws Exception {
+		operator.notifyCheckpointComplete(checkpointId);
+	}
+
+	@Override
+	public void setCurrentKey(Object key) {
+		operator.setCurrentKey(key);
+	}
+
+	@Override
+	public Object getCurrentKey() {
+		return operator.getCurrentKey();
+	}
+
+	@Override
+	public void endInput() throws Exception {
+		TaggedOperatorSubtaskState state = SnapshotUtils.snapshot(
+			operator,
+			operator.getContainingTask().getEnvironment().getTaskInfo().getIndexOfThisSubtask(),
+			timestamp,
+			operator.getContainingTask().getCheckpointStorage(),
+			savepointPath);
+
+		output.collect(new StreamRecord<>(state));
+	}
+
+	private class VoidOutput<T> implements Output<T> {
+
+		@Override
+		public void emitWatermark(Watermark mark) {
+		}
+
+		@Override
+		public <X> void collect(OutputTag<X> outputTag, StreamRecord<X> record) {
+		}
+
+		@Override
+		public void emitLatencyMarker(LatencyMarker latencyMarker) {
+		}
+
+		@Override
+		public void collect(T record) {
+		}
+
+		@Override
+		public void close() {
+		}
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/MemoryStateBackendWindowITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/MemoryStateBackendWindowITCase.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api;
+
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+
+/**
+ * IT Case for reading window state with the memory state backend.
+ */
+public class MemoryStateBackendWindowITCase extends SavepointWindowReaderITCase<MemoryStateBackend> {
+
+	@Override
+	protected MemoryStateBackend getStateBackend() {
+		return new MemoryStateBackend();
+	}
+}
+
+

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/RocksDBStateBackendWindowITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/RocksDBStateBackendWindowITCase.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api;
+
+import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+
+/**
+ * IT Case for reading window state with the memory state backend.
+ */
+public class RocksDBStateBackendWindowITCase extends SavepointWindowReaderITCase<RocksDBStateBackend> {
+
+	@Override
+	protected RocksDBStateBackend getStateBackend() {
+		return new RocksDBStateBackend((StateBackend) new MemoryStateBackend());
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWindowReaderITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWindowReaderITCase.java
@@ -1,0 +1,370 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api;
+
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.state.api.functions.WindowReaderFunction;
+import org.apache.flink.state.api.utils.AggregateSum;
+import org.apache.flink.state.api.utils.ReduceSum;
+import org.apache.flink.state.api.utils.SavepointTestBase;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.WindowFunction;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.evictors.Evictor;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.operators.windowing.TimestampedValue;
+import org.apache.flink.util.Collector;
+
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+
+/**
+ * IT Case for reading window operator state.
+ */
+public abstract class SavepointWindowReaderITCase<B extends StateBackend> extends SavepointTestBase {
+	private static final String uid = "stateful-operator";
+
+	private static final Integer[] numbers = { 1, 2, 3 };
+
+	protected abstract B getStateBackend();
+
+	@Test
+	public void testReduceWindowStateReader() throws Exception {
+		String savepointPath = takeSavepoint(numbers, source -> {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+			env.setStateBackend(getStateBackend());
+			env.setParallelism(4);
+
+			env
+				.addSource(source)
+				.rebalance()
+				.assignTimestampsAndWatermarks(new ZeroTimestampAssigner<>())
+				.keyBy(id -> id)
+				.timeWindow(Time.milliseconds(10))
+				.reduce(new ReduceSum())
+				.uid(uid)
+				.addSink(new DiscardingSink<>());
+
+			return env;
+		});
+
+		ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
+		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
+
+		List<Integer> results = savepoint
+			.timeWindow()
+			.reduce(uid, new ReduceSum(), Types.INT, Types.INT)
+			.collect();
+
+		Assert.assertThat("Unexpected results from keyed state", results, Matchers.containsInAnyOrder(numbers));
+	}
+
+	@Test
+	public void testReduceEvictorWindowStateReader() throws Exception {
+		String savepointPath = takeSavepoint(numbers, source -> {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+			env.setStateBackend(getStateBackend());
+			env.setParallelism(4);
+
+			env
+				.addSource(source)
+				.rebalance()
+				.assignTimestampsAndWatermarks(new ZeroTimestampAssigner<>())
+				.keyBy(id -> id)
+				.timeWindow(Time.milliseconds(10))
+				.evictor(new NoOpEvictor<>())
+				.reduce(new ReduceSum())
+				.uid(uid)
+				.addSink(new DiscardingSink<>());
+
+			return env;
+		});
+
+		ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
+		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
+
+		List<Integer> results = savepoint
+			.timeWindow()
+			.evictor()
+			.reduce(uid, new ReduceSum(), Types.INT, Types.INT)
+			.collect();
+
+		Assert.assertThat("Unexpected results from keyed state", results, Matchers.containsInAnyOrder(numbers));
+	}
+
+	@Test
+	public void testAggregateWindowStateReader() throws Exception {
+		String savepointPath = takeSavepoint(numbers, source -> {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+			env.setStateBackend(getStateBackend());
+			env.setParallelism(4);
+
+			env
+				.addSource(source)
+				.rebalance()
+				.assignTimestampsAndWatermarks(new ZeroTimestampAssigner<>())
+				.keyBy(id -> id)
+				.timeWindow(Time.milliseconds(10))
+				.aggregate(new AggregateSum())
+				.uid(uid)
+				.addSink(new DiscardingSink<>());
+
+			return env;
+		});
+
+		ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
+		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
+
+		List<Integer> results = savepoint
+			.timeWindow()
+			.aggregate(uid, new AggregateSum(), Types.INT, Types.INT, Types.INT)
+			.collect();
+
+		Assert.assertThat("Unexpected results from keyed state", results, Matchers.containsInAnyOrder(numbers));
+	}
+
+	@Test
+	public void testAggregateEvictorWindowStateReader() throws Exception {
+		String savepointPath = takeSavepoint(numbers, source -> {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+			env.setStateBackend(getStateBackend());
+			env.setParallelism(4);
+
+			env
+				.addSource(source)
+				.rebalance()
+				.assignTimestampsAndWatermarks(new ZeroTimestampAssigner<>())
+				.keyBy(id -> id)
+				.timeWindow(Time.milliseconds(10))
+				.evictor(new NoOpEvictor<>())
+				.aggregate(new AggregateSum())
+				.uid(uid)
+				.addSink(new DiscardingSink<>());
+
+			return env;
+		});
+
+		ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
+		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
+
+		List<Integer> results = savepoint
+			.timeWindow()
+			.evictor()
+			.aggregate(uid, new AggregateSum(), Types.INT, Types.INT, Types.INT)
+			.collect();
+
+		Assert.assertThat("Unexpected results from keyed state", results, Matchers.containsInAnyOrder(numbers));
+	}
+
+	@Test
+	public void testProcessWindowStateReader() throws Exception {
+		String savepointPath = takeSavepoint(numbers, source -> {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+			env.setStateBackend(getStateBackend());
+			env.setParallelism(4);
+
+			env
+				.addSource(source)
+				.rebalance()
+				.assignTimestampsAndWatermarks(new ZeroTimestampAssigner<>())
+				.keyBy(id -> id)
+				.timeWindow(Time.milliseconds(10))
+				.process(new NoOpProcessWindowFunction())
+				.uid(uid)
+				.addSink(new DiscardingSink<>());
+
+			return env;
+		});
+
+		ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
+		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
+
+		List<Integer> results = savepoint
+			.timeWindow()
+			.process(uid, new BasicReaderFunction(), Types.INT, Types.INT, Types.INT)
+			.collect();
+
+		Assert.assertThat("Unexpected results from keyed state", results, Matchers.containsInAnyOrder(numbers));
+	}
+
+	@Test
+	public void testProcessEvictorWindowStateReader() throws Exception {
+		String savepointPath = takeSavepoint(numbers, source -> {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+			env.setStateBackend(getStateBackend());
+			env.setParallelism(4);
+
+			env
+				.addSource(source)
+				.rebalance()
+				.assignTimestampsAndWatermarks(new ZeroTimestampAssigner<>())
+				.keyBy(id -> id)
+				.timeWindow(Time.milliseconds(10))
+				.evictor(new NoOpEvictor<>())
+				.process(new NoOpProcessWindowFunction())
+				.uid(uid)
+				.addSink(new DiscardingSink<>());
+
+			return env;
+		});
+
+		ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
+		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
+
+		List<Integer> results = savepoint
+			.timeWindow()
+			.evictor()
+			.process(uid, new BasicReaderFunction(), Types.INT, Types.INT, Types.INT)
+			.collect();
+
+		Assert.assertThat("Unexpected results from keyed state", results, Matchers.containsInAnyOrder(numbers));
+	}
+
+	@Test
+	public void testApplyWindowStateReader() throws Exception {
+		String savepointPath = takeSavepoint(numbers, source -> {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+			env.setStateBackend(getStateBackend());
+			env.setParallelism(4);
+
+			env
+				.addSource(source)
+				.rebalance()
+				.assignTimestampsAndWatermarks(new ZeroTimestampAssigner<>())
+				.keyBy(id -> id)
+				.timeWindow(Time.milliseconds(10))
+				.apply(new NoOpWindowFunction())
+				.uid(uid)
+				.addSink(new DiscardingSink<>());
+
+			return env;
+		});
+
+		ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
+		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
+
+		List<Integer> results = savepoint
+			.timeWindow()
+			.process(uid, new BasicReaderFunction(), Types.INT, Types.INT, Types.INT)
+			.collect();
+
+		Assert.assertThat("Unexpected results from keyed state", results, Matchers.containsInAnyOrder(numbers));
+	}
+
+	@Test
+	public void testApplyEvictorWindowStateReader() throws Exception {
+		String savepointPath = takeSavepoint(numbers, source -> {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+			env.setStateBackend(getStateBackend());
+			env.setParallelism(4);
+
+			env
+				.addSource(source)
+				.rebalance()
+				.assignTimestampsAndWatermarks(new ZeroTimestampAssigner<>())
+				.keyBy(id -> id)
+				.timeWindow(Time.milliseconds(10))
+				.evictor(new NoOpEvictor<>())
+				.apply(new NoOpWindowFunction())
+				.uid(uid)
+				.addSink(new DiscardingSink<>());
+
+			return env;
+		});
+
+		ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
+		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
+
+		List<Integer> results = savepoint
+			.timeWindow()
+			.evictor()
+			.process(uid, new BasicReaderFunction(), Types.INT, Types.INT, Types.INT)
+			.collect();
+
+		Assert.assertThat("Unexpected results from keyed state", results, Matchers.containsInAnyOrder(numbers));
+	}
+
+	private static class ZeroTimestampAssigner<T> implements AssignerWithPunctuatedWatermarks<T> {
+		@Nullable
+		@Override
+		public Watermark checkAndGetNextWatermark(T lastElement, long extractedTimestamp) {
+			return null;
+		}
+
+		@Override
+		public long extractTimestamp(T element, long previousElementTimestamp) {
+			return 0;
+		}
+	}
+
+	private static class NoOpProcessWindowFunction extends ProcessWindowFunction<Integer, Integer, Integer, TimeWindow> {
+
+		@Override
+		public void process(Integer integer, Context context, Iterable<Integer> elements, Collector<Integer> out) { }
+	}
+
+	private static class NoOpWindowFunction implements WindowFunction<Integer, Integer, Integer, TimeWindow> {
+
+		@Override
+		public void apply(Integer integer, TimeWindow window, Iterable<Integer> input, Collector<Integer> out) { }
+	}
+
+	private static class BasicReaderFunction extends WindowReaderFunction<Integer, Integer, Integer, TimeWindow> {
+
+		@Override
+		public void readWindow(Integer key, Context<TimeWindow> context, Iterable<Integer> elements, Collector<Integer> out) throws Exception {
+			Assert.assertEquals("Unexpected window", new TimeWindow(0, 10), context.window());
+			Assert.assertThat("Unexpected registered timers", context.registeredEventTimeTimers(), Matchers.contains(9L));
+
+			out.collect(elements.iterator().next());
+		}
+	}
+
+	private static class NoOpEvictor<W extends Window> implements Evictor<Integer, W> {
+
+		@Override
+		public void evictBefore(Iterable<TimestampedValue<Integer>> elements, int size, W window, EvictorContext evictorContext) {
+		}
+
+		@Override
+		public void evictAfter(Iterable<TimestampedValue<Integer>> elements, int size, W window, EvictorContext evictorContext) {
+		}
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterITCase.java
@@ -28,9 +28,7 @@ import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
-import org.apache.flink.client.ClientUtils;
 import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -47,12 +45,13 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.co.BroadcastProcessFunction;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
-import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.util.StreamCollector;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.util.AbstractID;
 import org.apache.flink.util.Collector;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -64,7 +63,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * IT test for writing savepoints.
@@ -92,20 +91,21 @@ public class SavepointWriterITCase extends AbstractTestBase {
 		new CurrencyRate("EUR", 1.3)
 	);
 
-	public SavepointWriterITCase(StateBackend backend) throws Exception {
+	@SuppressWarnings("unused")
+	public SavepointWriterITCase(String ignore, StateBackend backend) {
 		this.backend = backend;
-
-		//reset the cluster so we can change the state backend
-		miniClusterResource.after();
-		miniClusterResource.before();
 	}
 
-	@Parameterized.Parameters(name = "Savepoint Writer: {0}")
-	public static Collection<StateBackend> data() {
-		return Arrays.asList(
-			new MemoryStateBackend(),
-			new RocksDBStateBackend((StateBackend) new MemoryStateBackend()));
+	@Parameterized.Parameters(name = "backend = {0}")
+	public static Object[] data() {
+		return new Object[][] {
+			{ "memory", new MemoryStateBackend() },
+			{ "rocksdb", new RocksDBStateBackend((StateBackend) new MemoryStateBackend())}
+		};
 	}
+
+	@Rule
+	public StreamCollector collector = new StreamCollector();
 
 	@Test
 	public void testStateBootstrapAndModification() throws Exception {
@@ -147,17 +147,16 @@ public class SavepointWriterITCase extends AbstractTestBase {
 		bEnv.execute("Bootstrap");
 	}
 
-	private void validateBootstrap(String savepointPath) throws ProgramInvocationException {
+	private void validateBootstrap(String savepointPath) throws Exception {
 		StreamExecutionEnvironment sEnv = StreamExecutionEnvironment.getExecutionEnvironment();
 		sEnv.setStateBackend(backend);
 
-		CollectSink.accountList.clear();
-
-		sEnv.fromCollection(accounts)
+		DataStream<Account> stream = sEnv.fromCollection(accounts)
 			.keyBy(acc -> acc.id)
 			.flatMap(new UpdateAndGetAccount())
-			.uid(ACCOUNT_UID)
-			.addSink(new CollectSink());
+			.uid(ACCOUNT_UID);
+
+		CompletableFuture<Collection<Account>> results = collector.collect(stream);
 
 		sEnv
 			.fromCollection(currencyRates)
@@ -170,9 +169,9 @@ public class SavepointWriterITCase extends AbstractTestBase {
 		jobGraph.setSavepointRestoreSettings(SavepointRestoreSettings.forPath(savepointPath, false));
 
 		ClusterClient<?> client = miniClusterResource.getClusterClient();
-		ClientUtils.submitJobAndWaitForResult(client, jobGraph, SavepointWriterITCase.class.getClassLoader());
+		client.submitJob(jobGraph);
 
-		Assert.assertEquals("Unexpected output", 3, CollectSink.accountList.size());
+		Assert.assertEquals("Unexpected output", 3, results.get().size());
 	}
 
 	private void modifySavepoint(String savepointPath, String modifyPath) throws Exception {
@@ -193,18 +192,16 @@ public class SavepointWriterITCase extends AbstractTestBase {
 		bEnv.execute("Modifying");
 	}
 
-	private void validateModification(String savepointPath) throws ProgramInvocationException {
+	private void validateModification(String savepointPath) throws Exception {
 		StreamExecutionEnvironment sEnv = StreamExecutionEnvironment.getExecutionEnvironment();
 		sEnv.setStateBackend(backend);
-
-		CollectSink.accountList.clear();
 
 		DataStream<Account> stream = sEnv.fromCollection(accounts)
 			.keyBy(acc -> acc.id)
 			.flatMap(new UpdateAndGetAccount())
 			.uid(ACCOUNT_UID);
 
-		stream.addSink(new CollectSink());
+		CompletableFuture<Collection<Account>> results = collector.collect(stream);
 
 		stream
 			.map(acc -> acc.id)
@@ -216,9 +213,9 @@ public class SavepointWriterITCase extends AbstractTestBase {
 		jobGraph.setSavepointRestoreSettings(SavepointRestoreSettings.forPath(savepointPath, false));
 
 		ClusterClient<?> client = miniClusterResource.getClusterClient();
-		ClientUtils.submitJobAndWaitForResult(client, jobGraph, SavepointWriterITCase.class.getClassLoader());
+		client.submitJob(jobGraph);
 
-		Assert.assertEquals("Unexpected output", 3, CollectSink.accountList.size());
+		Assert.assertEquals("Unexpected output", 3, results.get().size());
 	}
 
 	/**
@@ -426,18 +423,6 @@ public class SavepointWriterITCase extends AbstractTestBase {
 		@Override
 		public void processBroadcastElement(CurrencyRate value, Context ctx, Collector<Void> out) {
 			//ignore
-		}
-	}
-
-	/**
-	 * A simple collections sink.
-	 */
-	public static class CollectSink implements SinkFunction<Account> {
-		static Set<Integer> accountList = new ConcurrentSkipListSet<>();
-
-		@Override
-		public void invoke(Account value, Context context) {
-			accountList.add(value.id);
 		}
 	}
 }

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterWindowITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterWindowITCase.java
@@ -1,0 +1,417 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.state.api.utils.MaxWatermarkSource;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.datastream.WindowedStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.WindowFunction;
+import org.apache.flink.streaming.api.windowing.evictors.CountEvictor;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.streaming.util.StreamCollector;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.util.AbstractID;
+import org.apache.flink.util.Collector;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * IT Test for writing savepoints to the {@code WindowOperator}.
+ */
+@SuppressWarnings("unchecked")
+@RunWith(Parameterized.class)
+public class SavepointWriterWindowITCase extends AbstractTestBase {
+
+	private static final String UID = "uid";
+
+	private static final Collection<String> WORDS = Arrays.asList("hello", "world", "hello", "everyone");
+
+	private static final Matcher<Iterable<? extends Tuple2<String, Integer>>> STANDARD_MATCHER = Matchers.containsInAnyOrder(
+		Tuple2.of("hello", 2),
+		Tuple2.of("world", 1),
+		Tuple2.of("everyone", 1)
+	);
+
+	private static final Matcher<Iterable<? extends Tuple2<String, Integer>>> EVICTOR_MATCHER = Matchers.containsInAnyOrder(
+		Tuple2.of("hello", 1),
+		Tuple2.of("world", 1),
+		Tuple2.of("everyone", 1)
+	);
+
+	private static final TypeInformation<Tuple2<String, Integer>> TUPLE_TYPE_INFO = new TypeHint<Tuple2<String, Integer>>() {}.getTypeInfo();
+
+	private static final List<Tuple3<String, WindowBootstrap, WindowStream>> SETUP_FUNCTIONS = Arrays.asList(
+		Tuple3.of(
+			"reduce",
+			transformation -> transformation.reduce(new Reducer()),
+			stream -> stream.reduce(new Reducer())
+		),
+		Tuple3.of(
+			"aggregate",
+			transformation -> transformation.aggregate(new Aggregator()),
+			stream -> stream.aggregate(new Aggregator())
+		),
+		Tuple3.of(
+			"apply",
+			transformation -> transformation.apply(new CustomWindowFunction()),
+			stream -> stream.apply(new CustomWindowFunction())
+		),
+		Tuple3.of(
+			"process",
+			transformation -> transformation.process(new CustomProcessWindowFunction()),
+			stream -> stream.process(new CustomProcessWindowFunction())
+		)
+	);
+
+	private static final List<Tuple2<String, StateBackend>> STATE_BACKENDS = Arrays.asList(
+		Tuple2.of(
+			"MemoryStateBackend",
+			new MemoryStateBackend()
+		),
+		Tuple2.of(
+			"RocksDB",
+			new RocksDBStateBackend((StateBackend) new MemoryStateBackend())
+		)
+	);
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Collection<Object[]> data() {
+		List<Object[]> parameterList = new ArrayList<>();
+		for (Tuple2<String, StateBackend> stateBackend : STATE_BACKENDS) {
+			for (Tuple3<String, WindowBootstrap, WindowStream> setup : SETUP_FUNCTIONS) {
+				Object[] parameters = new Object[] {
+					stateBackend.f0 + ": " + setup.f0,
+					setup.f1,
+					setup.f2,
+					stateBackend.f1
+				};
+				parameterList.add(parameters);
+			}
+		}
+
+		return parameterList;
+	}
+
+	@Rule
+	public StreamCollector collector = new StreamCollector();
+
+	private final WindowBootstrap windowBootstrap;
+
+	private final WindowStream windowStream;
+
+	private final StateBackend stateBackend;
+
+	@SuppressWarnings("unused")
+	public SavepointWriterWindowITCase(String ignore, WindowBootstrap windowBootstrap, WindowStream windowStream, StateBackend stateBackend) {
+		this.windowBootstrap = windowBootstrap;
+		this.windowStream = windowStream;
+		this.stateBackend = stateBackend;
+	}
+
+	@Test
+	public void testTumbleWindow() throws Exception {
+		final String savepointPath = getTempDirPath(new AbstractID().toHexString());
+
+		ExecutionEnvironment bEnv = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple2<String, Integer>> bootstrapData = bEnv
+			.fromCollection(WORDS)
+			.map(word -> Tuple2.of(word, 1))
+			.returns(TUPLE_TYPE_INFO);
+
+		WindowedOperatorTransformation<Tuple2<String, Integer>, String, TimeWindow> transformation = OperatorTransformation
+			.bootstrapWith(bootstrapData)
+			.assignTimestamps(record -> 2L)
+			.keyBy(tuple -> tuple.f0, Types.STRING)
+			.timeWindow(Time.milliseconds(5));
+
+		Savepoint
+			.create(stateBackend, 128)
+			.withOperator(UID, windowBootstrap.bootstrap(transformation))
+			.write(savepointPath);
+
+		bEnv.execute("write state");
+
+		StreamExecutionEnvironment sEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+		sEnv.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		sEnv.setStateBackend(stateBackend);
+
+		WindowedStream<Tuple2<String, Integer>, String, TimeWindow> stream = sEnv
+			.addSource(new MaxWatermarkSource<Tuple2<String, Integer>>())
+			.returns(TUPLE_TYPE_INFO)
+			.keyBy(tuple -> tuple.f0)
+			.timeWindow(Time.milliseconds(5));
+
+		DataStream<Tuple2<String, Integer>> windowed = windowStream.window(stream).uid(UID);
+		CompletableFuture<Collection<Tuple2<String, Integer>>> future = collector.collect(windowed);
+
+		submitJob(savepointPath, sEnv);
+
+		Collection<Tuple2<String, Integer>> results = future.get();
+		Assert.assertThat("Incorrect results from bootstrapped windows", results, STANDARD_MATCHER);
+	}
+
+	@Test
+	public void testTumbleWindowWithEvictor() throws Exception {
+		final String savepointPath = getTempDirPath(new AbstractID().toHexString());
+
+		ExecutionEnvironment bEnv = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple2<String, Integer>> bootstrapData = bEnv
+			.fromCollection(WORDS)
+			.map(word -> Tuple2.of(word, 1))
+			.returns(TUPLE_TYPE_INFO);
+
+		WindowedOperatorTransformation<Tuple2<String, Integer>, String, TimeWindow> transformation = OperatorTransformation
+			.bootstrapWith(bootstrapData)
+			.assignTimestamps(record -> 2L)
+			.keyBy(tuple -> tuple.f0, Types.STRING)
+			.timeWindow(Time.milliseconds(5))
+			.evictor(CountEvictor.of(1));
+
+		Savepoint
+			.create(new MemoryStateBackend(), 128)
+			.withOperator(UID, windowBootstrap.bootstrap(transformation))
+			.write(savepointPath);
+
+		bEnv.execute("write state");
+
+		StreamExecutionEnvironment sEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+		sEnv.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+
+		WindowedStream<Tuple2<String, Integer>, String, TimeWindow> stream = sEnv
+			.addSource(new MaxWatermarkSource<>(), TUPLE_TYPE_INFO)
+			.keyBy(tuple -> tuple.f0)
+			.timeWindow(Time.milliseconds(5))
+			.evictor(CountEvictor.of(1));
+
+		DataStream<Tuple2<String, Integer>> windowed = windowStream.window(stream).uid(UID);
+		CompletableFuture<Collection<Tuple2<String, Integer>>> future = collector.collect(windowed);
+
+		submitJob(savepointPath, sEnv);
+
+		Collection<Tuple2<String, Integer>> results = future.get();
+		Assert.assertThat("Incorrect results from bootstrapped windows", results, EVICTOR_MATCHER);
+	}
+
+	@Test
+	public void testSlideWindow() throws Exception {
+		final String savepointPath = getTempDirPath(new AbstractID().toHexString());
+
+		ExecutionEnvironment bEnv = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple2<String, Integer>> bootstrapData = bEnv
+			.fromCollection(WORDS)
+			.map(word -> Tuple2.of(word, 1))
+			.returns(TUPLE_TYPE_INFO);
+
+		WindowedOperatorTransformation<Tuple2<String, Integer>, String, TimeWindow> transformation = OperatorTransformation
+			.bootstrapWith(bootstrapData)
+			.assignTimestamps(record -> 2L)
+			.keyBy(tuple -> tuple.f0, Types.STRING)
+			.timeWindow(Time.milliseconds(5), Time.milliseconds(1));
+
+		Savepoint
+			.create(new MemoryStateBackend(), 128)
+			.withOperator(UID, windowBootstrap.bootstrap(transformation))
+			.write(savepointPath);
+
+		bEnv.execute("write state");
+
+		StreamExecutionEnvironment sEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+		sEnv.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+
+		WindowedStream<Tuple2<String, Integer>, String, TimeWindow> stream = sEnv
+			.addSource(new MaxWatermarkSource<Tuple2<String, Integer>>())
+			.returns(TUPLE_TYPE_INFO)
+			.keyBy(tuple -> tuple.f0)
+			.timeWindow(Time.milliseconds(5), Time.milliseconds(1));
+
+		DataStream<Tuple2<String, Integer>> windowed = windowStream.window(stream).uid(UID);
+		CompletableFuture<Collection<Tuple2<String, Integer>>> future = collector.collect(windowed);
+
+		submitJob(savepointPath, sEnv);
+
+		Collection<Tuple2<String, Integer>> results = future.get();
+		Assert.assertEquals("Incorrect number of results", 15, results.size());
+		Assert.assertThat("Incorrect bootstrap state", new HashSet<>(results), STANDARD_MATCHER);
+	}
+
+	@Test
+	public void testSlideWindowWithEvictor() throws Exception {
+		final String savepointPath = getTempDirPath(new AbstractID().toHexString());
+
+		ExecutionEnvironment bEnv = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple2<String, Integer>> bootstrapData = bEnv
+			.fromCollection(WORDS)
+			.map(word -> Tuple2.of(word, 1))
+			.returns(TUPLE_TYPE_INFO);
+
+		WindowedOperatorTransformation<Tuple2<String, Integer>, String, TimeWindow> transformation = OperatorTransformation
+			.bootstrapWith(bootstrapData)
+			.assignTimestamps(record -> 2L)
+			.keyBy(tuple -> tuple.f0, Types.STRING)
+			.timeWindow(Time.milliseconds(5), Time.milliseconds(1))
+			.evictor(CountEvictor.of(1));
+
+		Savepoint
+			.create(new MemoryStateBackend(), 128)
+			.withOperator(UID, windowBootstrap.bootstrap(transformation))
+			.write(savepointPath);
+
+		bEnv.execute("write state");
+
+		StreamExecutionEnvironment sEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+		sEnv.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+
+		WindowedStream<Tuple2<String, Integer>, String, TimeWindow> stream = sEnv
+			.addSource(new MaxWatermarkSource<Tuple2<String, Integer>>())
+			.returns(TUPLE_TYPE_INFO)
+			.keyBy(tuple -> tuple.f0)
+			.timeWindow(Time.milliseconds(5), Time.milliseconds(1))
+			.evictor(CountEvictor.of(1));
+
+		DataStream<Tuple2<String, Integer>> windowed = windowStream.window(stream).uid(UID);
+		CompletableFuture<Collection<Tuple2<String, Integer>>> future = collector.collect(windowed);
+
+		submitJob(savepointPath, sEnv);
+
+		Collection<Tuple2<String, Integer>> results = future.get();
+		Assert.assertEquals("Incorrect number of results", 15, results.size());
+		Assert.assertThat("Incorrect bootstrap state", new HashSet<>(results), EVICTOR_MATCHER);
+	}
+
+	private void submitJob(String savepointPath, StreamExecutionEnvironment sEnv) {
+		JobGraph jobGraph = sEnv.getStreamGraph().getJobGraph();
+		jobGraph.setSavepointRestoreSettings(SavepointRestoreSettings.forPath(savepointPath, true));
+
+		ClusterClient<?> client = miniClusterResource.getClusterClient();
+		client.submitJob(jobGraph);
+	}
+
+	private static class Reducer implements ReduceFunction<Tuple2<String, Integer>> {
+
+		@Override
+		public Tuple2<String, Integer> reduce(Tuple2<String, Integer> value1, Tuple2<String, Integer> value2) {
+			return Tuple2.of(value1.f0, value1.f1 + value2.f1);
+		}
+	}
+
+	private static class Aggregator implements AggregateFunction<Tuple2<String, Integer>, Tuple2<String, Integer>, Tuple2<String, Integer>> {
+
+		@Override
+		public Tuple2<String, Integer> createAccumulator() {
+			return null;
+		}
+
+		@Override
+		public Tuple2<String, Integer> add(Tuple2<String, Integer> value, Tuple2<String, Integer> accumulator) {
+			if (accumulator == null) {
+				return Tuple2.of(value.f0, value.f1);
+			}
+
+			accumulator.f1 += value.f1;
+			return accumulator;
+		}
+
+		@Override
+		public Tuple2<String, Integer> getResult(Tuple2<String, Integer> accumulator) {
+			return accumulator;
+		}
+
+		@Override
+		public Tuple2<String, Integer> merge(Tuple2<String, Integer> a, Tuple2<String, Integer> b) {
+			a.f1 += b.f1;
+			return a;
+		}
+	}
+
+	private static class CustomWindowFunction implements WindowFunction<Tuple2<String, Integer>, Tuple2<String, Integer>, String, TimeWindow> {
+
+		@Override
+		public void apply(String s, TimeWindow window, Iterable<Tuple2<String, Integer>> input, Collector<Tuple2<String, Integer>> out) {
+			Iterator<Tuple2<String, Integer>> iterator = input.iterator();
+			Tuple2<String, Integer> acc = iterator.next();
+
+			while (iterator.hasNext()) {
+				Tuple2<String, Integer> next = iterator.next();
+				acc.f1 += next.f1;
+			}
+
+			out.collect(acc);
+		}
+	}
+
+	private static class CustomProcessWindowFunction extends ProcessWindowFunction<Tuple2<String, Integer>, Tuple2<String, Integer>, String, TimeWindow> {
+
+		@Override
+		public void process(String s, Context context, Iterable<Tuple2<String, Integer>> elements, Collector<Tuple2<String, Integer>> out) {
+			Iterator<Tuple2<String, Integer>> iterator = elements.iterator();
+			Tuple2<String, Integer> acc = iterator.next();
+
+			while (iterator.hasNext()) {
+				Tuple2<String, Integer> next = iterator.next();
+				acc.f1 += next.f1;
+			}
+
+			out.collect(acc);
+		}
+	}
+
+	@FunctionalInterface
+	private interface WindowBootstrap {
+		BootstrapTransformation<Tuple2<String, Integer>> bootstrap(WindowedOperatorTransformation<Tuple2<String, Integer>, String, TimeWindow> transformation);
+	}
+
+	@FunctionalInterface
+	private interface WindowStream {
+		SingleOutputStreamOperator<Tuple2<String, Integer>> window(WindowedStream<Tuple2<String, Integer>, String, TimeWindow> stream);
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/input/WindowReaderTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/input/WindowReaderTest.java
@@ -1,0 +1,331 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.input;
+
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.checkpoint.OperatorState;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.state.api.functions.WindowReaderFunction;
+import org.apache.flink.state.api.input.operator.WindowReaderOperator;
+import org.apache.flink.state.api.input.operator.window.PassThroughReader;
+import org.apache.flink.state.api.input.splits.KeyGroupRangeInputSplit;
+import org.apache.flink.state.api.runtime.OperatorIDGenerator;
+import org.apache.flink.state.api.utils.AggregateSum;
+import org.apache.flink.state.api.utils.ReduceSum;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.KeyedStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.transformations.OneInputTransformation;
+import org.apache.flink.streaming.api.windowing.assigners.EventTimeSessionWindows;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.triggers.Trigger;
+import org.apache.flink.streaming.api.windowing.triggers.TriggerResult;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.operators.windowing.WindowOperator;
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.MockStreamingRuntimeContext;
+import org.apache.flink.util.Collector;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests reading window state.
+ */
+@SuppressWarnings("unchecked")
+public class WindowReaderTest {
+
+	private static final int MAX_PARALLELISM = 128;
+
+	private static final String UID = "uid";
+
+	@Test
+	public void testReducingWindow() throws Exception {
+		WindowOperator<Integer, Integer, ?, Void, ?> operator = getWindowOperator(stream -> stream
+			.timeWindow(Time.milliseconds(1))
+			.reduce(new ReduceSum()));
+
+		OperatorState operatorState = getOperatorState(operator);
+
+		KeyedStateInputFormat<Integer, TimeWindow, Integer> format = new KeyedStateInputFormat<>(
+			operatorState,
+			new MemoryStateBackend(),
+			WindowReaderOperator.reduce(
+				new ReduceSum(),
+				new PassThroughReader<>(),
+				Types.INT,
+				new TimeWindow.Serializer(),
+				Types.INT));
+
+		List<Integer> list = readState(format);
+		Assert.assertEquals(Arrays.asList(1, 1), list);
+	}
+
+	@Test
+	public void testSessionWindow() throws Exception {
+		WindowOperator<Integer, Integer, ?, Void, ?> operator = getWindowOperator(stream -> stream
+			.window(EventTimeSessionWindows.withGap(Time.milliseconds(3)))
+			.reduce(new ReduceSum()));
+
+		OperatorState operatorState = getOperatorState(operator);
+
+		KeyedStateInputFormat<Integer, TimeWindow, Integer> format = new KeyedStateInputFormat<>(
+			operatorState,
+			new MemoryStateBackend(),
+			WindowReaderOperator.reduce(
+				new ReduceSum(),
+				new PassThroughReader<>(),
+				Types.INT,
+				new TimeWindow.Serializer(),
+				Types.INT));
+
+		List<Integer> list = readState(format);
+		Assert.assertEquals(Collections.singletonList(2), list);
+	}
+
+	@Test
+	public void testAggregateWindow() throws Exception {
+		WindowOperator<Integer, Integer, ?, Void, ?> operator = getWindowOperator(stream -> stream
+			.timeWindow(Time.milliseconds(1))
+			.aggregate(new AggregateSum()));
+
+		OperatorState operatorState = getOperatorState(operator);
+
+		KeyedStateInputFormat<Integer, TimeWindow, Integer> format = new KeyedStateInputFormat<>(
+			operatorState,
+			new MemoryStateBackend(),
+			WindowReaderOperator.aggregate(
+				new AggregateSum(),
+				new PassThroughReader<>(),
+				Types.INT,
+				new TimeWindow.Serializer(),
+				Types.INT));
+
+		List<Integer> list = readState(format);
+		Assert.assertEquals(Arrays.asList(1, 1), list);
+	}
+
+	@Test
+	public void testProcessReader() throws Exception {
+		WindowOperator<Integer, Integer, ?, Void, ?> operator = getWindowOperator(stream -> stream
+			.timeWindow(Time.milliseconds(1))
+			.process(mockProcessWindowFunction(), Types.INT));
+
+		OperatorState operatorState = getOperatorState(operator);
+
+		KeyedStateInputFormat<Integer, TimeWindow, Integer> format = new KeyedStateInputFormat<>(
+			operatorState,
+			new MemoryStateBackend(),
+			WindowReaderOperator.process(
+				new PassThroughReader<>(),
+				Types.INT,
+				new TimeWindow.Serializer(),
+				Types.INT));
+
+		List<Integer> list = readState(format);
+		Assert.assertEquals(Arrays.asList(1, 1), list);
+	}
+
+	@Test
+	public void testPerPaneAndPerKeyState() throws Exception {
+		WindowOperator<Integer, Integer, ?, Void, ?> operator = getWindowOperator(stream -> stream
+			.timeWindow(Time.milliseconds(1))
+			.trigger(new AlwaysFireTrigger<>())
+			.process(new MultiFireWindow(), Types.INT));
+
+		OperatorState operatorState = getOperatorState(operator);
+
+		KeyedStateInputFormat<Integer, TimeWindow, Tuple2<Integer, Integer>> format = new KeyedStateInputFormat<>(
+			operatorState,
+			new MemoryStateBackend(),
+			WindowReaderOperator.process(
+				new MultiFireReaderFunction(),
+				Types.INT,
+				new TimeWindow.Serializer(),
+				Types.INT));
+
+		List<Tuple2<Integer, Integer>> list = readState(format);
+		Assert.assertEquals(Arrays.asList(Tuple2.of(2, 1), Tuple2.of(2, 1)), list);
+	}
+
+	private static WindowOperator<Integer, Integer, ?, Void, ?> getWindowOperator(
+		Function<KeyedStream<Integer, Integer>, SingleOutputStreamOperator<Integer>> window) {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+
+		KeyedStream<Integer, Integer> keyedStream = env
+			.addSource(mockSourceFunction())
+			.returns(Integer.class)
+			.keyBy(new IdentityKeySelector());
+
+		DataStream<Integer> stream = window
+			.apply(keyedStream)
+			.uid(UID);
+
+		return getLastOperator(stream);
+	}
+
+	private static SourceFunction<Integer> mockSourceFunction() {
+		return (SourceFunction<Integer>) mock(SourceFunction.class);
+	}
+
+	private static <W extends Window> ProcessWindowFunction<Integer, Integer, Integer, W> mockProcessWindowFunction() {
+		return mock(ProcessWindowFunction.class);
+	}
+
+	private static OperatorState getOperatorState(WindowOperator<Integer, Integer, ?, Void, ?> operator) throws Exception {
+		KeyedOneInputStreamOperatorTestHarness<Integer, Integer, Void> harness = new KeyedOneInputStreamOperatorTestHarness<>(
+			operator,
+			new IdentityKeySelector<>(),
+			Types.INT,
+			MAX_PARALLELISM, 1, 0);
+
+		harness.open();
+		harness.processElement(1, 0);
+		harness.processElement(1, 1);
+		OperatorSubtaskState state = harness.snapshot(0, 0L);
+		harness.close();
+
+		OperatorID operatorID = OperatorIDGenerator.fromUid(UID);
+		OperatorState operatorState = new OperatorState(operatorID, 1, MAX_PARALLELISM);
+		operatorState.putState(0, state);
+		return operatorState;
+	}
+
+	private static <T> WindowOperator<Integer, Integer, ?, Void, ?> getLastOperator(DataStream<T> dataStream) {
+		Transformation<T> transformation = dataStream.getTransformation();
+		if (!(transformation instanceof OneInputTransformation)) {
+			Assert.fail("This test only supports window operators");
+		}
+
+		OneInputTransformation oneInput = (OneInputTransformation) transformation;
+		StreamOperator<?> operator = oneInput.getOperator();
+
+		if (!(operator instanceof WindowOperator)) {
+			Assert.fail("This test only supports window operators");
+		}
+
+		return (WindowOperator<Integer, Integer, ?, Void, ?>) operator;
+	}
+
+	@Nonnull
+	private <OUT> List<OUT> readState(KeyedStateInputFormat<Integer, TimeWindow, OUT> format) throws IOException {
+		KeyGroupRangeInputSplit split = format.createInputSplits(1)[0];
+		List<OUT> data = new ArrayList<>();
+
+		format.setRuntimeContext(new MockStreamingRuntimeContext(false, 1, 0));
+
+		format.openInputFormat();
+		format.open(split);
+
+		while (!format.reachedEnd()) {
+			data.add(format.nextRecord(null));
+		}
+
+		format.close();
+		format.closeInputFormat();
+
+		return data;
+	}
+
+	private static class IdentityKeySelector<T> implements KeySelector<T, T> {
+
+		@Override
+		public T getKey(T value) {
+			return value;
+		}
+	}
+
+	private static class MultiFireWindow extends ProcessWindowFunction<Integer, Integer, Integer, TimeWindow> {
+
+		@Override
+		public void process(Integer integer, Context context, Iterable<Integer> elements, Collector<Integer> out) throws Exception {
+			Integer element = elements.iterator().next();
+			context.globalState()
+				.getReducingState(new ReducingStateDescriptor<>("per-key", new ReduceSum(), Types.INT))
+				.add(element);
+
+			context.windowState()
+				.getReducingState(new ReducingStateDescriptor<>("per-pane", new ReduceSum(), Types.INT))
+				.add(element);
+		}
+	}
+
+	private static class MultiFireReaderFunction extends WindowReaderFunction<Integer, Tuple2<Integer, Integer>, Integer, TimeWindow> {
+
+		@Override
+		public void readWindow(Integer integer, Context<TimeWindow> context, Iterable<Integer> elements, Collector<Tuple2<Integer, Integer>> out) throws Exception {
+			Integer perKey = context.globalState()
+				.getReducingState(new ReducingStateDescriptor<>("per-key", new ReduceSum(), Types.INT))
+				.get();
+
+			Integer perPane = context.windowState()
+				.getReducingState(new ReducingStateDescriptor<>("per-pane", new ReduceSum(), Types.INT))
+				.get();
+
+			out.collect(Tuple2.of(perKey, perPane));
+		}
+	}
+
+	private static class AlwaysFireTrigger<W extends Window> extends Trigger<Object, W> {
+
+		@Override
+		public TriggerResult onElement(Object element, long timestamp, W window, TriggerContext ctx) throws Exception {
+			return TriggerResult.FIRE;
+		}
+
+		@Override
+		public TriggerResult onProcessingTime(long time, W window, TriggerContext ctx) throws Exception {
+			return TriggerResult.FIRE;
+		}
+
+		@Override
+		public TriggerResult onEventTime(long time, W window, TriggerContext ctx) throws Exception {
+			return TriggerResult.FIRE;
+		}
+
+		@Override
+		public void clear(W window, TriggerContext ctx) throws Exception {
+
+		}
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/utils/AggregateSum.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/utils/AggregateSum.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.utils;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+
+/**
+ * A simple sum aggregator.
+ */
+public class AggregateSum implements AggregateFunction<Integer, Integer, Integer> {
+
+	@Override
+	public Integer createAccumulator() {
+		return 0;
+	}
+
+	@Override
+	public Integer add(Integer value, Integer accumulator) {
+		return value + accumulator;
+	}
+
+	@Override
+	public Integer getResult(Integer accumulator) {
+		return accumulator;
+	}
+
+	@Override
+	public Integer merge(Integer a, Integer b) {
+		return a + b;
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/utils/MaxWatermarkSource.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/utils/MaxWatermarkSource.java
@@ -1,0 +1,42 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.utils;
+
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.watermark.Watermark;
+
+/**
+ * A simple source that emits a max watermark and then immediately returns.
+ * This provides an easy way to trigger all event time timers for a restored savepoint.
+ */
+public class MaxWatermarkSource<T> implements SourceFunction<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	@Override
+	public void run(SourceContext<T> ctx) {
+		ctx.emitWatermark(Watermark.MAX_WATERMARK);
+	}
+
+	@Override
+	public void cancel() {
+
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/utils/ReduceSum.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/utils/ReduceSum.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.utils;
+
+import org.apache.flink.api.common.functions.ReduceFunction;
+
+/**
+ * A simple sum reducer.
+ */
+public class ReduceSum implements ReduceFunction<Integer> {
+
+	@Override
+	public Integer reduce(Integer value1, Integer value2) {
+		return value1 + value2;
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/utils/SavepointTestBase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/utils/SavepointTestBase.java
@@ -33,6 +33,7 @@ import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.util.AbstractID;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -42,6 +43,10 @@ import java.util.function.Function;
  * A test base that includes utilities for taking a savepoint.
  */
 public abstract class SavepointTestBase extends AbstractTestBase {
+
+	public <T> String takeSavepoint(T[] data, Function<SourceFunction<T>, StreamExecutionEnvironment> jobGraphFactory) throws Exception {
+		return takeSavepoint(Arrays.asList(data), jobGraphFactory);
+	}
 
 	public <T> String takeSavepoint(Collection<T> data, Function<SourceFunction<T>, StreamExecutionEnvironment> jobGraphFactory) throws Exception {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Disposable;
 
 import java.util.stream.Stream;
@@ -74,6 +75,13 @@ public interface KeyedStateBackend<K>
 	 * @param namespace Namespace for which existing keys will be returned.
 	 */
 	<N> Stream<K> getKeys(String state, N namespace);
+
+	/**
+	 * @return A stream of all keys for the given state and namespace. Modifications to the state during iterating
+	 * 		   over it keys are not supported.
+	 * @param state State variable for which existing keys will be returned.
+	 */
+	<N> Stream<Tuple2<K, N>> getKeysAndNamespaces(String state);
 
 	/**
 	 * Creates or retrieves a keyed state backed by this state backend.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -258,6 +258,18 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		return table.getKeys(namespace);
 	}
 
+	@SuppressWarnings("unchecked")
+	@Override
+	public <N> Stream<Tuple2<K, N>> getKeysAndNamespaces(String state) {
+		if (!registeredKVStates.containsKey(state)) {
+			return Stream.empty();
+		}
+
+		final StateSnapshotRestore stateSnapshotRestore = registeredKVStates.get(state);
+		StateTable<K, N, ?> table = (StateTable<K, N, ?>) stateSnapshotRestore;
+		return table.getKeysAndNamespaces();
+	}
+
 	@Override
 	@Nonnull
 	public <N, SV, SEV, S extends State, IS extends S> IS createInternalState(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateTable.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.state.heap;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.StateEntry;
@@ -224,6 +225,12 @@ public abstract class StateTable<K, N, S>
 			.flatMap(stateMap -> StreamSupport.stream(Spliterators.spliteratorUnknownSize(stateMap.iterator(), 0), false))
 			.filter(entry -> entry.getNamespace().equals(namespace))
 			.map(StateEntry::getKey);
+	}
+
+	public Stream<Tuple2<K, N>> getKeysAndNamespaces() {
+		return Arrays.stream(keyGroupedStateMaps)
+			.flatMap(stateMap -> StreamSupport.stream(Spliterators.spliteratorUnknownSize(stateMap.iterator(), 0), false))
+			.map(entry -> Tuple2.of(entry.getKey(), entry.getNamespace()));
 	}
 
 	public StateIncrementalVisitor<K, N, S> getStateIncrementalVisitor(int recommendedMaxNumberOfReturnedRecords) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -48,6 +48,7 @@ import org.apache.flink.api.common.typeutils.base.FloatSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.GenericTypeInfo;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.api.java.typeutils.runtime.PojoSerializer;
@@ -93,11 +94,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.PrimitiveIterator;
 import java.util.Random;
+import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.CancellationException;
@@ -115,6 +118,10 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.isA;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.isOneOf;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.both;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -282,6 +289,49 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 				}
 
 				assertFalse(actualIterator.hasNext());
+			}
+		}
+		finally {
+			IOUtils.closeQuietly(backend);
+			backend.dispose();
+		}
+	}
+
+	@Test
+	public void testGetKeysAndNamespaces() throws Exception {
+		final int elementsNum = 1000;
+		String fieldName = "get-keys-test";
+		AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+		try {
+			final String ns1 = "ns1";
+			ValueState<Integer> keyedState1 = backend.getPartitionedState(
+				ns1,
+				StringSerializer.INSTANCE,
+				new ValueStateDescriptor<>(fieldName, IntSerializer.INSTANCE)
+			);
+
+			final String ns2 = "ns2";
+			ValueState<Integer> keyedState2 = backend.getPartitionedState(
+				ns2,
+				StringSerializer.INSTANCE,
+				new ValueStateDescriptor<>(fieldName, IntSerializer.INSTANCE)
+			);
+
+			for (int key = 0; key < elementsNum; key++) {
+				backend.setCurrentKey(key);
+				keyedState1.update(key * 2);
+				keyedState2.update(key * 2);
+			}
+
+			try (Stream<Tuple2<Integer, String>> stream = backend.getKeysAndNamespaces(fieldName)) {
+				final Map<String, Set<Integer>> keysByNamespace = new HashMap<>();
+				stream.forEach(entry -> {
+					assertThat("Unexpected namespace", entry.f1, isOneOf(ns1, ns2));
+					assertThat("Unexpected key", entry.f0, is(both(greaterThanOrEqualTo(0)).and(lessThan(elementsNum))));
+
+					Set<Integer> keys = keysByNamespace.computeIfAbsent(entry.f1, k -> new HashSet<>());
+					assertTrue("Duplicate key for namespace", keys.add(entry.f0));
+				});
 			}
 		}
 		finally {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
@@ -173,6 +173,16 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			.map(Map.Entry::getKey);
 	}
 
+	@Override
+	@SuppressWarnings("unchecked")
+	public <N> Stream<Tuple2<K, N>> getKeysAndNamespaces(String state) {
+		return stateValues.get(state).entrySet().stream()
+			.flatMap(entry ->
+				entry.getValue().entrySet().stream()
+					.map(namespace ->
+						Tuple2.of(entry.getKey(), (N) namespace.getKey())));
+	}
+
 	@Nonnull
 	@Override
 	public RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot(

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -33,6 +33,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.base.MapSerializer;
 import org.apache.flink.api.common.typeutils.base.MapSerializerSnapshot;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.contrib.streaming.state.iterator.RocksStateKeysAndNamespaceIterator;
 import org.apache.flink.contrib.streaming.state.iterator.RocksStateKeysIterator;
 import org.apache.flink.contrib.streaming.state.snapshot.RocksDBSnapshotStrategyBase;
 import org.apache.flink.contrib.streaming.state.ttl.RocksDbTtlCompactFiltersManager;
@@ -288,6 +289,29 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			ambiguousKeyPossible, nameSpaceBytes);
 
 		Stream<K> targetStream = StreamSupport.stream(Spliterators.spliteratorUnknownSize(iteratorWrapper, Spliterator.ORDERED), false);
+		return targetStream.onClose(iteratorWrapper::close);
+	}
+
+	@Override
+	public <N> Stream<Tuple2<K, N>> getKeysAndNamespaces(String state) {
+		RocksDbKvStateInfo columnInfo = kvStateInformation.get(state);
+		if (columnInfo == null || !(columnInfo.metaInfo instanceof RegisteredKeyValueStateBackendMetaInfo)) {
+			return Stream.empty();
+		}
+
+		RegisteredKeyValueStateBackendMetaInfo<N, ?> registeredKeyValueStateBackendMetaInfo =
+			(RegisteredKeyValueStateBackendMetaInfo<N, ?>) columnInfo.metaInfo;
+
+		final TypeSerializer<N> namespaceSerializer = registeredKeyValueStateBackendMetaInfo.getNamespaceSerializer();
+		boolean ambiguousKeyPossible = RocksDBKeySerializationUtils.isAmbiguousKeyPossible(getKeySerializer(), namespaceSerializer);
+
+		RocksIteratorWrapper iterator = RocksDBOperationUtils.getRocksIterator(db, columnInfo.columnFamilyHandle);
+		iterator.seekToFirst();
+
+		final RocksStateKeysAndNamespaceIterator<K, N> iteratorWrapper = new RocksStateKeysAndNamespaceIterator<>(
+			iterator, state, getKeySerializer(), namespaceSerializer, keyGroupPrefixBytes, ambiguousKeyPossible);
+
+		Stream<Tuple2<K, N>> targetStream = StreamSupport.stream(Spliterators.spliteratorUnknownSize(iteratorWrapper, Spliterator.ORDERED), false);
 		return targetStream.onClose(iteratorWrapper::close);
 	}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksStateKeysAndNamespaceIterator.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksStateKeysAndNamespaceIterator.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state.iterator;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.contrib.streaming.state.RocksDBKeySerializationUtils;
+import org.apache.flink.contrib.streaming.state.RocksIteratorWrapper;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Adapter class to bridge between {@link RocksIteratorWrapper} and {@link Iterator} to iterate over the keys
+ * and namespaces. This class is not thread safe.
+ *
+ * @param <K> the type of the iterated keys in RocksDB.
+ * @param <N> the type of the iterated namespaces in RocksDB.
+ */
+public class RocksStateKeysAndNamespaceIterator<K, N> implements Iterator<Tuple2<K, N>>, AutoCloseable {
+
+	@Nonnull
+	private final RocksIteratorWrapper iterator;
+
+	@Nonnull
+	private final String state;
+
+	@Nonnull
+	private final TypeSerializer<K> keySerializer;
+
+	@Nonnull
+	private final TypeSerializer<N> namespaceSerializer;
+
+	private final boolean ambiguousKeyPossible;
+	private final int keyGroupPrefixBytes;
+	private final DataInputDeserializer byteArrayDataInputView;
+	private Tuple2<K, N> nextKey;
+
+	public RocksStateKeysAndNamespaceIterator(
+		@Nonnull RocksIteratorWrapper iterator,
+		@Nonnull String state,
+		@Nonnull TypeSerializer<K> keySerializer,
+		@Nonnull TypeSerializer<N> namespaceSerializer, int keyGroupPrefixBytes,
+		boolean ambiguousKeyPossible) {
+		this.iterator = iterator;
+		this.state = state;
+		this.keySerializer = keySerializer;
+		this.namespaceSerializer = namespaceSerializer;
+		this.keyGroupPrefixBytes = keyGroupPrefixBytes;
+		this.nextKey = null;
+		this.ambiguousKeyPossible = ambiguousKeyPossible;
+		this.byteArrayDataInputView = new DataInputDeserializer();
+	}
+
+	@Override
+	public boolean hasNext() {
+		try {
+			while (nextKey == null && iterator.isValid()) {
+
+				final byte[] keyBytes = iterator.key();
+				final K currentKey = deserializeKey(keyBytes, byteArrayDataInputView);
+				final N currentNamespace = RocksDBKeySerializationUtils.readNamespace(
+					namespaceSerializer,
+					byteArrayDataInputView,
+					ambiguousKeyPossible
+				);
+				nextKey = Tuple2.of(currentKey, currentNamespace);
+				iterator.next();
+			}
+		} catch (Exception e) {
+			throw new FlinkRuntimeException("Failed to access state [" + state + "]", e);
+		}
+		return nextKey != null;
+	}
+
+	@Override
+	public Tuple2<K, N> next() {
+		if (!hasNext()) {
+			throw new NoSuchElementException("Failed to access state [" + state + "]");
+		}
+
+		Tuple2<K, N> tmpKey = nextKey;
+		nextKey = null;
+		return tmpKey;
+	}
+
+	private K deserializeKey(byte[] keyBytes, DataInputDeserializer readView) throws IOException {
+		readView.setBuffer(keyBytes, keyGroupPrefixBytes, keyBytes.length - keyGroupPrefixBytes);
+		return RocksDBKeySerializationUtils.readKey(
+			keySerializer,
+			byteArrayDataInputView,
+			ambiguousKeyPossible);
+	}
+
+	@Override
+	public void close() {
+		iterator.close();
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBRocksStateKeysAndNamespacesIteratorTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBRocksStateKeysAndNamespacesIteratorTest.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.contrib.streaming.state.iterator.RocksStateKeysAndNamespaceIterator;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.rocksdb.ColumnFamilyHandle;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for the RocksIteratorWrapper.
+ */
+public class RocksDBRocksStateKeysAndNamespacesIteratorTest {
+
+	@Rule
+	public final TemporaryFolder tmp = new TemporaryFolder();
+
+	@Test
+	public void testIterator() throws Exception {
+
+		// test for keyGroupPrefixBytes == 1 && ambiguousKeyPossible == false
+		testIteratorHelper(IntSerializer.INSTANCE, StringSerializer.INSTANCE, 128, i -> i);
+
+		// test for keyGroupPrefixBytes == 1 && ambiguousKeyPossible == true
+		testIteratorHelper(StringSerializer.INSTANCE, StringSerializer.INSTANCE, 128, i -> String.valueOf(i));
+
+		// test for keyGroupPrefixBytes == 2 && ambiguousKeyPossible == false
+		testIteratorHelper(IntSerializer.INSTANCE, StringSerializer.INSTANCE, 256, i -> i);
+
+		// test for keyGroupPrefixBytes == 2 && ambiguousKeyPossible == true
+		testIteratorHelper(StringSerializer.INSTANCE, StringSerializer.INSTANCE, 256, i -> String.valueOf(i));
+	}
+
+	@SuppressWarnings("unchecked")
+	<K> void testIteratorHelper(
+		TypeSerializer<K> keySerializer,
+		TypeSerializer namespaceSerializer,
+		int maxKeyGroupNumber,
+		Function<Integer, K> getKeyFunc) throws Exception {
+
+		String testStateName = "aha";
+		String namespace = "ns";
+
+		String dbPath = tmp.newFolder().getAbsolutePath();
+		String checkpointPath = tmp.newFolder().toURI().toString();
+		RocksDBStateBackend backend = new RocksDBStateBackend(new FsStateBackend(checkpointPath), true);
+		backend.setDbStoragePath(dbPath);
+
+		Environment env = new DummyEnvironment("TestTask", 1, 0);
+		RocksDBKeyedStateBackend<K> keyedStateBackend = (RocksDBKeyedStateBackend<K>) backend.createKeyedStateBackend(
+			env,
+			new JobID(),
+			"Test",
+			keySerializer,
+			maxKeyGroupNumber,
+			new KeyGroupRange(0, maxKeyGroupNumber - 1),
+			mock(TaskKvStateRegistry.class),
+			TtlTimeProvider.DEFAULT,
+			new UnregisteredMetricsGroup(),
+			Collections.emptyList(),
+			new CloseableRegistry());
+
+		try {
+			ValueState<String> testState = keyedStateBackend.getPartitionedState(
+				namespace,
+				namespaceSerializer,
+				new ValueStateDescriptor<>(testStateName, String.class));
+
+			// insert record
+			for (int i = 0; i < 1000; ++i) {
+				keyedStateBackend.setCurrentKey(getKeyFunc.apply(i));
+				testState.update(String.valueOf(i));
+			}
+
+			DataOutputSerializer outputStream = new DataOutputSerializer(8);
+			boolean ambiguousKeyPossible = RocksDBKeySerializationUtils.isAmbiguousKeyPossible(keySerializer, namespaceSerializer);
+			RocksDBKeySerializationUtils.writeNameSpace(
+				namespace,
+				namespaceSerializer,
+				outputStream,
+				ambiguousKeyPossible);
+
+			byte[] nameSpaceBytes = outputStream.getCopyOfBuffer();
+
+			// already created with the state, should be closed with the backend
+			ColumnFamilyHandle handle = keyedStateBackend.getColumnFamilyHandle(testStateName);
+
+			try (
+				RocksIteratorWrapper iterator = RocksDBOperationUtils.getRocksIterator(keyedStateBackend.db, handle);
+				RocksStateKeysAndNamespaceIterator<K, String> iteratorWrapper =
+					new RocksStateKeysAndNamespaceIterator<>(
+						iterator,
+						testStateName,
+						keySerializer,
+						namespaceSerializer,
+						keyedStateBackend.getKeyGroupPrefixBytes(),
+						ambiguousKeyPossible)) {
+
+				iterator.seekToFirst();
+
+				// valid record
+				List<Tuple2<Integer, String>> fetchedKeys = new ArrayList<>(1000);
+				while (iteratorWrapper.hasNext()) {
+					Tuple2 entry = iteratorWrapper.next();
+					entry.f0 = Integer.parseInt(entry.f0.toString());
+
+					fetchedKeys.add((Tuple2<Integer, String>) entry);
+				}
+
+				fetchedKeys.sort(Comparator.comparingInt(a -> a.f0));
+				Assert.assertEquals(1000, fetchedKeys.size());
+
+				for (int i = 0; i < 1000; ++i) {
+					Assert.assertEquals(i, fetchedKeys.get(i).f0.intValue());
+					Assert.assertEquals(namespace, fetchedKeys.get(i).f1);
+				}
+			}
+		} finally {
+			if (keyedStateBackend != null) {
+				keyedStateBackend.dispose();
+			}
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
@@ -24,56 +24,27 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.FoldFunction;
-import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.functions.RichFunction;
-import org.apache.flink.api.common.state.AggregatingStateDescriptor;
-import org.apache.flink.api.common.state.FoldingStateDescriptor;
-import org.apache.flink.api.common.state.ListStateDescriptor;
-import org.apache.flink.api.common.state.ReducingStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.Utils;
-import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.aggregation.AggregationFunction;
 import org.apache.flink.streaming.api.functions.aggregation.ComparableAggregator;
 import org.apache.flink.streaming.api.functions.aggregation.SumAggregator;
-import org.apache.flink.streaming.api.functions.windowing.AggregateApplyWindowFunction;
-import org.apache.flink.streaming.api.functions.windowing.FoldApplyProcessWindowFunction;
-import org.apache.flink.streaming.api.functions.windowing.FoldApplyWindowFunction;
 import org.apache.flink.streaming.api.functions.windowing.PassThroughWindowFunction;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
-import org.apache.flink.streaming.api.functions.windowing.ReduceApplyProcessWindowFunction;
-import org.apache.flink.streaming.api.functions.windowing.ReduceApplyWindowFunction;
 import org.apache.flink.streaming.api.functions.windowing.WindowFunction;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
-import org.apache.flink.streaming.api.windowing.assigners.BaseAlignedWindowAssigner;
-import org.apache.flink.streaming.api.windowing.assigners.MergingWindowAssigner;
 import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
 import org.apache.flink.streaming.api.windowing.evictors.Evictor;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.triggers.Trigger;
 import org.apache.flink.streaming.api.windowing.windows.Window;
-import org.apache.flink.streaming.runtime.operators.windowing.EvictingWindowOperator;
-import org.apache.flink.streaming.runtime.operators.windowing.WindowOperator;
-import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalAggregateProcessWindowFunction;
-import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalIterableProcessWindowFunction;
-import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalIterableWindowFunction;
-import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalSingleValueProcessWindowFunction;
-import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalSingleValueWindowFunction;
-import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalWindowFunction;
-import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
-import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.operators.windowing.WindowOperatorBuilder;
 import org.apache.flink.util.OutputTag;
-import org.apache.flink.util.Preconditions;
 
-import javax.annotation.Nullable;
-
-import java.lang.reflect.Type;
-
-import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -104,30 +75,23 @@ public class WindowedStream<T, K, W extends Window> {
 	/** The keyed data stream that is windowed by this stream. */
 	private final KeyedStream<T, K> input;
 
-	/** The window assigner. */
-	private final WindowAssigner<? super T, W> windowAssigner;
-
-	/** The trigger that is used for window evaluation/emission. */
-	private Trigger<? super T, ? super W> trigger;
-
-	/** The evictor that is used for evicting elements before window evaluation. */
-	private Evictor<? super T, ? super W> evictor;
-
-	/** The user-specified allowed lateness. */
-	private long allowedLateness = 0L;
-
-	/**
-	 * Side output {@code OutputTag} for late data. If no tag is set late data will simply be
-	 * dropped.
- 	 */
-	private OutputTag<T> lateDataOutputTag;
+	private final WindowOperatorBuilder<T, K, W> builder;
 
 	@PublicEvolving
-	public WindowedStream(KeyedStream<T, K> input,
-			WindowAssigner<? super T, W> windowAssigner) {
+	public WindowedStream(
+		KeyedStream<T, K> input,
+		WindowAssigner<? super T, W> windowAssigner) {
+
 		this.input = input;
-		this.windowAssigner = windowAssigner;
-		this.trigger = windowAssigner.getDefaultTrigger(input.getExecutionEnvironment());
+
+		this.builder = new WindowOperatorBuilder<>(
+			windowAssigner,
+			windowAssigner.getDefaultTrigger(input.getExecutionEnvironment()),
+			input.getExecutionConfig(),
+			input.getType(),
+			input.getKeySelector(),
+			input.getKeyType()
+		);
 	}
 
 	/**
@@ -135,15 +99,7 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@PublicEvolving
 	public WindowedStream<T, K, W> trigger(Trigger<? super T, ? super W> trigger) {
-		if (windowAssigner instanceof MergingWindowAssigner && !trigger.canMerge()) {
-			throw new UnsupportedOperationException("A merging window assigner cannot be used with a trigger that does not support merging.");
-		}
-
-		if (windowAssigner instanceof BaseAlignedWindowAssigner) {
-			throw new UnsupportedOperationException("Cannot use a " + windowAssigner.getClass().getSimpleName() + " with a custom trigger.");
-		}
-
-		this.trigger = trigger;
+		builder.trigger(trigger);
 		return this;
 	}
 
@@ -156,10 +112,7 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@PublicEvolving
 	public WindowedStream<T, K, W> allowedLateness(Time lateness) {
-		final long millis = lateness.toMilliseconds();
-		checkArgument(millis >= 0, "The allowed lateness cannot be negative.");
-
-		this.allowedLateness = millis;
+		builder.allowedLateness(lateness);
 		return this;
 	}
 
@@ -175,8 +128,8 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@PublicEvolving
 	public WindowedStream<T, K, W> sideOutputLateData(OutputTag<T> outputTag) {
-		Preconditions.checkNotNull(outputTag, "Side output tag must not be null.");
-		this.lateDataOutputTag = input.getExecutionEnvironment().clean(outputTag);
+		outputTag = input.getExecutionEnvironment().clean(outputTag);
+		builder.sideOutputLateData(outputTag);
 		return this;
 	}
 
@@ -188,10 +141,7 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@PublicEvolving
 	public WindowedStream<T, K, W> evictor(Evictor<? super T, ? super W> evictor) {
-		if (windowAssigner instanceof BaseAlignedWindowAssigner) {
-			throw new UnsupportedOperationException("Cannot use a " + windowAssigner.getClass().getSimpleName() + " with an Evictor.");
-		}
-		this.evictor = evictor;
+		builder.evictor(evictor);
 		return this;
 	}
 
@@ -224,7 +174,7 @@ public class WindowedStream<T, K, W extends Window> {
 
 		//clean the closure
 		function = input.getExecutionEnvironment().clean(function);
-		return reduce(function, new PassThroughWindowFunction<K, W, T>());
+		return reduce(function, new PassThroughWindowFunction<>());
 	}
 
 	/**
@@ -239,8 +189,8 @@ public class WindowedStream<T, K, W extends Window> {
 	 * @return The data stream that is the result of applying the window function to the window.
 	 */
 	public <R> SingleOutputStreamOperator<R> reduce(
-			ReduceFunction<T> reduceFunction,
-			WindowFunction<T, R, K, W> function) {
+		ReduceFunction<T> reduceFunction,
+		WindowFunction<T, R, K, W> function) {
 
 		TypeInformation<T> inType = input.getType();
 		TypeInformation<R> resultType = getWindowFunctionReturnType(function, inType);
@@ -260,60 +210,17 @@ public class WindowedStream<T, K, W extends Window> {
 	 * @return The data stream that is the result of applying the window function to the window.
 	 */
 	public <R> SingleOutputStreamOperator<R> reduce(
-			ReduceFunction<T> reduceFunction,
-			WindowFunction<T, R, K, W> function,
-			TypeInformation<R> resultType) {
-
-		if (reduceFunction instanceof RichFunction) {
-			throw new UnsupportedOperationException("ReduceFunction of reduce can not be a RichFunction.");
-		}
+		ReduceFunction<T> reduceFunction,
+		WindowFunction<T, R, K, W> function,
+		TypeInformation<R> resultType) {
 
 		//clean the closures
 		function = input.getExecutionEnvironment().clean(function);
 		reduceFunction = input.getExecutionEnvironment().clean(reduceFunction);
 
-		final String opName = generateOperatorName(windowAssigner, trigger, evictor, reduceFunction, function);
-		KeySelector<T, K> keySel = input.getKeySelector();
+		final String opName = builder.generateOperatorName(reduceFunction, function);
 
-		OneInputStreamOperator<T, R> operator;
-
-		if (evictor != null) {
-			@SuppressWarnings({"unchecked", "rawtypes"})
-			TypeSerializer<StreamRecord<T>> streamRecordSerializer =
-				(TypeSerializer<StreamRecord<T>>) new StreamElementSerializer(input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			ListStateDescriptor<StreamRecord<T>> stateDesc =
-				new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			operator =
-				new EvictingWindowOperator<>(windowAssigner,
-					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-					keySel,
-					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-					stateDesc,
-					new InternalIterableWindowFunction<>(new ReduceApplyWindowFunction<>(reduceFunction, function)),
-					trigger,
-					evictor,
-					allowedLateness,
-					lateDataOutputTag);
-
-		} else {
-			ReducingStateDescriptor<T> stateDesc = new ReducingStateDescriptor<>("window-contents",
-				reduceFunction,
-				input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			operator =
-				new WindowOperator<>(windowAssigner,
-					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-					keySel,
-					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-					stateDesc,
-					new InternalSingleValueWindowFunction<>(function),
-					trigger,
-					allowedLateness,
-					lateDataOutputTag);
-		}
-
+		OneInputStreamOperator<T, R> operator = builder.reduce(reduceFunction, function);
 		return input.transform(opName, resultType, operator);
 	}
 
@@ -351,54 +258,12 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@Internal
 	public <R> SingleOutputStreamOperator<R> reduce(ReduceFunction<T> reduceFunction, ProcessWindowFunction<T, R, K, W> function, TypeInformation<R> resultType) {
-		if (reduceFunction instanceof RichFunction) {
-			throw new UnsupportedOperationException("ReduceFunction of apply can not be a RichFunction.");
-		}
 		//clean the closures
 		function = input.getExecutionEnvironment().clean(function);
 		reduceFunction = input.getExecutionEnvironment().clean(reduceFunction);
 
-		final String opName = generateOperatorName(windowAssigner, trigger, evictor, reduceFunction, function);
-		KeySelector<T, K> keySel = input.getKeySelector();
-
-		OneInputStreamOperator<T, R> operator;
-
-		if (evictor != null) {
-			@SuppressWarnings({"unchecked", "rawtypes"})
-			TypeSerializer<StreamRecord<T>> streamRecordSerializer =
-					(TypeSerializer<StreamRecord<T>>) new StreamElementSerializer(input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			ListStateDescriptor<StreamRecord<T>> stateDesc =
-					new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			operator =
-					new EvictingWindowOperator<>(windowAssigner,
-							windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-							keySel,
-							input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-							stateDesc,
-							new InternalIterableProcessWindowFunction<>(new ReduceApplyProcessWindowFunction<>(reduceFunction, function)),
-							trigger,
-							evictor,
-							allowedLateness,
-							lateDataOutputTag);
-
-		} else {
-			ReducingStateDescriptor<T> stateDesc = new ReducingStateDescriptor<>("window-contents",
-					reduceFunction,
-					input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			operator =
-					new WindowOperator<>(windowAssigner,
-							windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-							keySel,
-							input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-							stateDesc,
-							new InternalSingleValueProcessWindowFunction<>(function),
-							trigger,
-							allowedLateness,
-							lateDataOutputTag);
-		}
+		final String opName = builder.generateOperatorName(reduceFunction, function);
+		OneInputStreamOperator<T, R> operator = builder.reduce(reduceFunction, function);
 
 		return input.transform(opName, resultType, operator);
 	}
@@ -425,7 +290,7 @@ public class WindowedStream<T, K, W extends Window> {
 		}
 
 		TypeInformation<R> resultType = TypeExtractor.getFoldReturnTypes(function, input.getType(),
-				Utils.getCallLocationName(), true);
+			Utils.getCallLocationName(), true);
 
 		return fold(initialValue, function, resultType);
 	}
@@ -447,7 +312,7 @@ public class WindowedStream<T, K, W extends Window> {
 				"Please use fold(FoldFunction, WindowFunction) instead.");
 		}
 
-		return fold(initialValue, function, new PassThroughWindowFunction<K, W, R>(), resultType, resultType);
+		return fold(initialValue, function, new PassThroughWindowFunction<>(), resultType, resultType);
 	}
 
 	/**
@@ -494,65 +359,20 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@PublicEvolving
 	@Deprecated
-	public <ACC, R> SingleOutputStreamOperator<R> fold(ACC initialValue,
-			FoldFunction<T, ACC> foldFunction,
-			WindowFunction<ACC, R, K, W> function,
-			TypeInformation<ACC> foldAccumulatorType,
-			TypeInformation<R> resultType) {
-		if (foldFunction instanceof RichFunction) {
-			throw new UnsupportedOperationException("FoldFunction of fold can not be a RichFunction.");
-		}
-		if (windowAssigner instanceof MergingWindowAssigner) {
-			throw new UnsupportedOperationException("Fold cannot be used with a merging WindowAssigner.");
-		}
-
-		if (windowAssigner instanceof BaseAlignedWindowAssigner) {
-			throw new UnsupportedOperationException("Fold cannot be used with a " +
-				windowAssigner.getClass().getSimpleName() + " assigner.");
-		}
+	public <ACC, R> SingleOutputStreamOperator<R> fold(
+		ACC initialValue,
+		FoldFunction<T, ACC> foldFunction,
+		WindowFunction<ACC, R, K, W> function,
+		TypeInformation<ACC> foldAccumulatorType,
+		TypeInformation<R> resultType) {
 
 		//clean the closures
 		function = input.getExecutionEnvironment().clean(function);
 		foldFunction = input.getExecutionEnvironment().clean(foldFunction);
 
-		final String opName = generateOperatorName(windowAssigner, trigger, evictor, foldFunction, function);
-		KeySelector<T, K> keySel = input.getKeySelector();
+		final String opName = builder.generateOperatorName(foldFunction, function);
 
-		OneInputStreamOperator<T, R> operator;
-
-		if (evictor != null) {
-			@SuppressWarnings({"unchecked", "rawtypes"})
-			TypeSerializer<StreamRecord<T>> streamRecordSerializer =
-				(TypeSerializer<StreamRecord<T>>) new StreamElementSerializer(input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			ListStateDescriptor<StreamRecord<T>> stateDesc =
-				new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			operator = new EvictingWindowOperator<>(windowAssigner,
-				windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-				keySel,
-				input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-				stateDesc,
-				new InternalIterableWindowFunction<>(new FoldApplyWindowFunction<>(initialValue, foldFunction, function, foldAccumulatorType)),
-				trigger,
-				evictor,
-				allowedLateness,
-				lateDataOutputTag);
-
-		} else {
-			FoldingStateDescriptor<T, ACC> stateDesc = new FoldingStateDescriptor<>("window-contents",
-				initialValue, foldFunction, foldAccumulatorType.createSerializer(getExecutionEnvironment().getConfig()));
-
-			operator = new WindowOperator<>(windowAssigner,
-				windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-				keySel,
-				input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-				stateDesc,
-				new InternalSingleValueWindowFunction<>(function),
-				trigger,
-				allowedLateness,
-				lateDataOutputTag);
-		}
+		OneInputStreamOperator<T, R> operator = builder.fold(initialValue, foldFunction, function, foldAccumulatorType);
 
 		return input.transform(opName, resultType, operator);
 	}
@@ -580,7 +400,7 @@ public class WindowedStream<T, K, W extends Window> {
 		}
 
 		TypeInformation<ACC> foldResultType = TypeExtractor.getFoldReturnTypes(foldFunction, input.getType(),
-				Utils.getCallLocationName(), true);
+			Utils.getCallLocationName(), true);
 
 		TypeInformation<R> windowResultType = getProcessWindowFunctionReturnType(windowFunction, foldResultType, Utils.getCallLocationName());
 
@@ -606,64 +426,18 @@ public class WindowedStream<T, K, W extends Window> {
 	@Deprecated
 	@Internal
 	public <R, ACC> SingleOutputStreamOperator<R> fold(
-			ACC initialValue,
-			FoldFunction<T, ACC> foldFunction,
-			ProcessWindowFunction<ACC, R, K, W> windowFunction,
-			TypeInformation<ACC> foldResultType,
-			TypeInformation<R> windowResultType) {
-		if (foldFunction instanceof RichFunction) {
-			throw new UnsupportedOperationException("FoldFunction can not be a RichFunction.");
-		}
-		if (windowAssigner instanceof MergingWindowAssigner) {
-			throw new UnsupportedOperationException("Fold cannot be used with a merging WindowAssigner.");
-		}
-
+		ACC initialValue,
+		FoldFunction<T, ACC> foldFunction,
+		ProcessWindowFunction<ACC, R, K, W> windowFunction,
+		TypeInformation<ACC> foldResultType,
+		TypeInformation<R> windowResultType) {
 		//clean the closures
 		windowFunction = input.getExecutionEnvironment().clean(windowFunction);
 		foldFunction = input.getExecutionEnvironment().clean(foldFunction);
 
-		final String opName = generateOperatorName(windowAssigner, trigger, evictor, foldFunction, windowFunction);
-		KeySelector<T, K> keySel = input.getKeySelector();
+		final String opName = builder.generateOperatorName(foldFunction, windowFunction);
 
-		OneInputStreamOperator<T, R> operator;
-
-		if (evictor != null) {
-			@SuppressWarnings({"unchecked", "rawtypes"})
-			TypeSerializer<StreamRecord<T>> streamRecordSerializer =
-					(TypeSerializer<StreamRecord<T>>) new StreamElementSerializer(input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			ListStateDescriptor<StreamRecord<T>> stateDesc =
-					new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			operator =
-					new EvictingWindowOperator<>(windowAssigner,
-							windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-							keySel,
-							input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-							stateDesc,
-							new InternalIterableProcessWindowFunction<>(new FoldApplyProcessWindowFunction<>(initialValue, foldFunction, windowFunction, foldResultType)),
-							trigger,
-							evictor,
-							allowedLateness,
-							lateDataOutputTag);
-
-		} else {
-			FoldingStateDescriptor<T, ACC> stateDesc = new FoldingStateDescriptor<>("window-contents",
-					initialValue,
-					foldFunction,
-					foldResultType.createSerializer(getExecutionEnvironment().getConfig()));
-
-			operator =
-					new WindowOperator<>(windowAssigner,
-							windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-							keySel,
-							input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-							stateDesc,
-							new InternalSingleValueProcessWindowFunction<>(windowFunction),
-							trigger,
-							allowedLateness,
-							lateDataOutputTag);
-		}
+		OneInputStreamOperator<T, R> operator = builder.fold(initialValue, foldFunction, windowFunction, foldResultType);
 
 		return input.transform(opName, windowResultType, operator);
 	}
@@ -693,10 +467,10 @@ public class WindowedStream<T, K, W extends Window> {
 		}
 
 		TypeInformation<ACC> accumulatorType = TypeExtractor.getAggregateFunctionAccumulatorType(
-				function, input.getType(), null, false);
+			function, input.getType(), null, false);
 
 		TypeInformation<R> resultType = TypeExtractor.getAggregateFunctionReturnType(
-				function, input.getType(), null, false);
+			function, input.getType(), null, false);
 
 		return aggregate(function, accumulatorType, resultType);
 	}
@@ -715,9 +489,9 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@PublicEvolving
 	public <ACC, R> SingleOutputStreamOperator<R> aggregate(
-			AggregateFunction<T, ACC, R> function,
-			TypeInformation<ACC> accumulatorType,
-			TypeInformation<R> resultType) {
+		AggregateFunction<T, ACC, R> function,
+		TypeInformation<ACC> accumulatorType,
+		TypeInformation<R> resultType) {
 
 		checkNotNull(function, "function");
 		checkNotNull(accumulatorType, "accumulatorType");
@@ -727,7 +501,7 @@ public class WindowedStream<T, K, W extends Window> {
 			throw new UnsupportedOperationException("This aggregation function cannot be a RichFunction.");
 		}
 
-		return aggregate(function, new PassThroughWindowFunction<K, W, R>(),
+		return aggregate(function, new PassThroughWindowFunction<>(),
 			accumulatorType, resultType);
 	}
 
@@ -751,17 +525,17 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@PublicEvolving
 	public <ACC, V, R> SingleOutputStreamOperator<R> aggregate(
-			AggregateFunction<T, ACC, V> aggFunction,
-			WindowFunction<V, R, K, W> windowFunction) {
+		AggregateFunction<T, ACC, V> aggFunction,
+		WindowFunction<V, R, K, W> windowFunction) {
 
 		checkNotNull(aggFunction, "aggFunction");
 		checkNotNull(windowFunction, "windowFunction");
 
 		TypeInformation<ACC> accumulatorType = TypeExtractor.getAggregateFunctionAccumulatorType(
-				aggFunction, input.getType(), null, false);
+			aggFunction, input.getType(), null, false);
 
 		TypeInformation<V> aggResultType = TypeExtractor.getAggregateFunctionReturnType(
-				aggFunction, input.getType(), null, false);
+			aggFunction, input.getType(), null, false);
 
 		TypeInformation<R> resultType = getWindowFunctionReturnType(windowFunction, aggResultType);
 
@@ -790,10 +564,10 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@PublicEvolving
 	public <ACC, V, R> SingleOutputStreamOperator<R> aggregate(
-			AggregateFunction<T, ACC, V> aggregateFunction,
-			WindowFunction<V, R, K, W> windowFunction,
-			TypeInformation<ACC> accumulatorType,
-			TypeInformation<R> resultType) {
+		AggregateFunction<T, ACC, V> aggregateFunction,
+		WindowFunction<V, R, K, W> windowFunction,
+		TypeInformation<ACC> accumulatorType,
+		TypeInformation<R> resultType) {
 
 		checkNotNull(aggregateFunction, "aggregateFunction");
 		checkNotNull(windowFunction, "windowFunction");
@@ -808,44 +582,9 @@ public class WindowedStream<T, K, W extends Window> {
 		windowFunction = input.getExecutionEnvironment().clean(windowFunction);
 		aggregateFunction = input.getExecutionEnvironment().clean(aggregateFunction);
 
-		final String opName = generateOperatorName(windowAssigner, trigger, evictor, aggregateFunction, windowFunction);
-		KeySelector<T, K> keySel = input.getKeySelector();
+		final String opName = builder.generateOperatorName(aggregateFunction, windowFunction);
 
-		OneInputStreamOperator<T, R> operator;
-
-		if (evictor != null) {
-			@SuppressWarnings({"unchecked", "rawtypes"})
-			TypeSerializer<StreamRecord<T>> streamRecordSerializer =
-					(TypeSerializer<StreamRecord<T>>) new StreamElementSerializer(input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			ListStateDescriptor<StreamRecord<T>> stateDesc =
-					new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			operator = new EvictingWindowOperator<>(windowAssigner,
-					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-					keySel,
-					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-					stateDesc,
-					new InternalIterableWindowFunction<>(new AggregateApplyWindowFunction<>(aggregateFunction, windowFunction)),
-					trigger,
-					evictor,
-					allowedLateness,
-					lateDataOutputTag);
-
-		} else {
-			AggregatingStateDescriptor<T, ACC, V> stateDesc = new AggregatingStateDescriptor<>("window-contents",
-					aggregateFunction, accumulatorType.createSerializer(getExecutionEnvironment().getConfig()));
-
-			operator = new WindowOperator<>(windowAssigner,
-					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-					keySel,
-					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-					stateDesc,
-					new InternalSingleValueWindowFunction<>(windowFunction),
-					trigger,
-					allowedLateness,
-					lateDataOutputTag);
-		}
+		OneInputStreamOperator<T, R> operator = builder.aggregate(aggregateFunction, windowFunction, accumulatorType);
 
 		return input.transform(opName, resultType, operator);
 	}
@@ -870,17 +609,17 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@PublicEvolving
 	public <ACC, V, R> SingleOutputStreamOperator<R> aggregate(
-			AggregateFunction<T, ACC, V> aggFunction,
-			ProcessWindowFunction<V, R, K, W> windowFunction) {
+		AggregateFunction<T, ACC, V> aggFunction,
+		ProcessWindowFunction<V, R, K, W> windowFunction) {
 
 		checkNotNull(aggFunction, "aggFunction");
 		checkNotNull(windowFunction, "windowFunction");
 
 		TypeInformation<ACC> accumulatorType = TypeExtractor.getAggregateFunctionAccumulatorType(
-				aggFunction, input.getType(), null, false);
+			aggFunction, input.getType(), null, false);
 
 		TypeInformation<V> aggResultType = TypeExtractor.getAggregateFunctionReturnType(
-				aggFunction, input.getType(), null, false);
+			aggFunction, input.getType(), null, false);
 
 		TypeInformation<R> resultType = getProcessWindowFunctionReturnType(windowFunction, aggResultType, null);
 
@@ -902,9 +641,9 @@ public class WindowedStream<T, K, W extends Window> {
 	}
 
 	private static <IN, OUT, KEY> TypeInformation<OUT> getProcessWindowFunctionReturnType(
-			ProcessWindowFunction<IN, OUT, KEY, ?> function,
-			TypeInformation<IN> inType,
-			String functionName) {
+		ProcessWindowFunction<IN, OUT, KEY, ?> function,
+		TypeInformation<IN> inType,
+		String functionName) {
 		return TypeExtractor.getUnaryOperatorReturnType(
 			function,
 			ProcessWindowFunction.class,
@@ -938,11 +677,11 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@PublicEvolving
 	public <ACC, V, R> SingleOutputStreamOperator<R> aggregate(
-			AggregateFunction<T, ACC, V> aggregateFunction,
-			ProcessWindowFunction<V, R, K, W> windowFunction,
-			TypeInformation<ACC> accumulatorType,
-			TypeInformation<V> aggregateResultType,
-			TypeInformation<R> resultType) {
+		AggregateFunction<T, ACC, V> aggregateFunction,
+		ProcessWindowFunction<V, R, K, W> windowFunction,
+		TypeInformation<ACC> accumulatorType,
+		TypeInformation<V> aggregateResultType,
+		TypeInformation<R> resultType) {
 
 		checkNotNull(aggregateFunction, "aggregateFunction");
 		checkNotNull(windowFunction, "windowFunction");
@@ -958,44 +697,9 @@ public class WindowedStream<T, K, W extends Window> {
 		windowFunction = input.getExecutionEnvironment().clean(windowFunction);
 		aggregateFunction = input.getExecutionEnvironment().clean(aggregateFunction);
 
-		final String opName = generateOperatorName(windowAssigner, trigger, evictor, aggregateFunction, windowFunction);
-		KeySelector<T, K> keySel = input.getKeySelector();
+		final String opName = builder.generateOperatorName(aggregateFunction, windowFunction);
 
-		OneInputStreamOperator<T, R> operator;
-
-		if (evictor != null) {
-			@SuppressWarnings({"unchecked", "rawtypes"})
-			TypeSerializer<StreamRecord<T>> streamRecordSerializer =
-					(TypeSerializer<StreamRecord<T>>) new StreamElementSerializer(input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			ListStateDescriptor<StreamRecord<T>> stateDesc =
-					new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			operator = new EvictingWindowOperator<>(windowAssigner,
-					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-					keySel,
-					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-					stateDesc,
-					new InternalAggregateProcessWindowFunction<>(aggregateFunction, windowFunction),
-					trigger,
-					evictor,
-					allowedLateness,
-					lateDataOutputTag);
-
-		} else {
-			AggregatingStateDescriptor<T, ACC, V> stateDesc = new AggregatingStateDescriptor<>("window-contents",
-					aggregateFunction, accumulatorType.createSerializer(getExecutionEnvironment().getConfig()));
-
-			operator = new WindowOperator<>(windowAssigner,
-					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-					keySel,
-					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-					stateDesc,
-					new InternalSingleValueProcessWindowFunction<>(windowFunction),
-					trigger,
-					allowedLateness,
-					lateDataOutputTag);
-		}
+		OneInputStreamOperator<T, R> operator = builder.aggregate(aggregateFunction, windowFunction, accumulatorType);
 
 		return input.transform(opName, resultType, operator);
 	}
@@ -1035,7 +739,11 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	public <R> SingleOutputStreamOperator<R> apply(WindowFunction<T, R, K, W> function, TypeInformation<R> resultType) {
 		function = input.getExecutionEnvironment().clean(function);
-		return apply(new InternalIterableWindowFunction<>(function), resultType, function);
+
+		final String opName = builder.generateOperatorName(function, null);
+		OneInputStreamOperator<T, R> operator = builder.apply(function);
+
+		return input.transform(opName, resultType, operator);
 	}
 
 	/**
@@ -1071,51 +779,10 @@ public class WindowedStream<T, K, W extends Window> {
 	@Internal
 	public <R> SingleOutputStreamOperator<R> process(ProcessWindowFunction<T, R, K, W> function, TypeInformation<R> resultType) {
 		function = input.getExecutionEnvironment().clean(function);
-		return apply(new InternalIterableProcessWindowFunction<>(function), resultType, function);
-	}
 
-	private <R> SingleOutputStreamOperator<R> apply(InternalWindowFunction<Iterable<T>, R, K, W> function, TypeInformation<R> resultType, Function originalFunction) {
+		final String opName = builder.generateOperatorName(function, null);
 
-		final String opName = generateOperatorName(windowAssigner, trigger, evictor, originalFunction, null);
-		KeySelector<T, K> keySel = input.getKeySelector();
-
-		WindowOperator<K, T, Iterable<T>, R, W> operator;
-
-		if (evictor != null) {
-			@SuppressWarnings({"unchecked", "rawtypes"})
-			TypeSerializer<StreamRecord<T>> streamRecordSerializer =
-					(TypeSerializer<StreamRecord<T>>) new StreamElementSerializer(input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			ListStateDescriptor<StreamRecord<T>> stateDesc =
-					new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			operator =
-				new EvictingWindowOperator<>(windowAssigner,
-					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-					keySel,
-					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-					stateDesc,
-					function,
-					trigger,
-					evictor,
-					allowedLateness,
-					lateDataOutputTag);
-
-		} else {
-			ListStateDescriptor<T> stateDesc = new ListStateDescriptor<>("window-contents",
-				input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			operator =
-				new WindowOperator<>(windowAssigner,
-					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-					keySel,
-					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-					stateDesc,
-					function,
-					trigger,
-					allowedLateness,
-					lateDataOutputTag);
-		}
+		OneInputStreamOperator<T, R> operator = builder.process(function);
 
 		return input.transform(opName, resultType, operator);
 	}
@@ -1157,55 +824,13 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@Deprecated
 	public <R> SingleOutputStreamOperator<R> apply(ReduceFunction<T> reduceFunction, WindowFunction<T, R, K, W> function, TypeInformation<R> resultType) {
-		if (reduceFunction instanceof RichFunction) {
-			throw new UnsupportedOperationException("ReduceFunction of apply can not be a RichFunction.");
-		}
-
 		//clean the closures
 		function = input.getExecutionEnvironment().clean(function);
 		reduceFunction = input.getExecutionEnvironment().clean(reduceFunction);
 
-		final String opName = generateOperatorName(windowAssigner, trigger, evictor, reduceFunction, function);
-		KeySelector<T, K> keySel = input.getKeySelector();
+		final String opName = builder.generateOperatorName(reduceFunction, function);
 
-		OneInputStreamOperator<T, R> operator;
-
-		if (evictor != null) {
-			@SuppressWarnings({"unchecked", "rawtypes"})
-			TypeSerializer<StreamRecord<T>> streamRecordSerializer =
-					(TypeSerializer<StreamRecord<T>>) new StreamElementSerializer(input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			ListStateDescriptor<StreamRecord<T>> stateDesc =
-					new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			operator =
-				new EvictingWindowOperator<>(windowAssigner,
-					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-					keySel,
-					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-					stateDesc,
-					new InternalIterableWindowFunction<>(new ReduceApplyWindowFunction<>(reduceFunction, function)),
-					trigger,
-					evictor,
-					allowedLateness,
-					lateDataOutputTag);
-
-		} else {
-			ReducingStateDescriptor<T> stateDesc = new ReducingStateDescriptor<>("window-contents",
-				reduceFunction,
-				input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			operator =
-				new WindowOperator<>(windowAssigner,
-					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-					keySel,
-					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-					stateDesc,
-					new InternalSingleValueWindowFunction<>(function),
-					trigger,
-					allowedLateness,
-					lateDataOutputTag);
-		}
+		OneInputStreamOperator<T, R> operator = builder.reduce(reduceFunction, function);
 
 		return input.transform(opName, resultType, operator);
 	}
@@ -1250,91 +875,15 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@Deprecated
 	public <R> SingleOutputStreamOperator<R> apply(R initialValue, FoldFunction<T, R> foldFunction, WindowFunction<R, R, K, W> function, TypeInformation<R> resultType) {
-		if (foldFunction instanceof RichFunction) {
-			throw new UnsupportedOperationException("FoldFunction of apply can not be a RichFunction.");
-		}
-		if (windowAssigner instanceof MergingWindowAssigner) {
-			throw new UnsupportedOperationException("Fold cannot be used with a merging WindowAssigner.");
-		}
-
 		//clean the closures
 		function = input.getExecutionEnvironment().clean(function);
 		foldFunction = input.getExecutionEnvironment().clean(foldFunction);
 
-		final String opName = generateOperatorName(windowAssigner, trigger, evictor, foldFunction, function);
-		KeySelector<T, K> keySel = input.getKeySelector();
+		final String opName = builder.generateOperatorName(foldFunction, function);
 
-		OneInputStreamOperator<T, R> operator;
-
-		if (evictor != null) {
-			@SuppressWarnings({"unchecked", "rawtypes"})
-			TypeSerializer<StreamRecord<T>> streamRecordSerializer =
-					(TypeSerializer<StreamRecord<T>>) new StreamElementSerializer(input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			ListStateDescriptor<StreamRecord<T>> stateDesc =
-					new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			operator = new EvictingWindowOperator<>(windowAssigner,
-				windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-				keySel,
-				input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-				stateDesc,
-				new InternalIterableWindowFunction<>(new FoldApplyWindowFunction<>(initialValue, foldFunction, function, resultType)),
-				trigger,
-				evictor,
-				allowedLateness,
-				lateDataOutputTag);
-
-		} else {
-			FoldingStateDescriptor<T, R> stateDesc = new FoldingStateDescriptor<>("window-contents",
-				initialValue, foldFunction, resultType.createSerializer(getExecutionEnvironment().getConfig()));
-
-			operator = new WindowOperator<>(windowAssigner,
-				windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-				keySel,
-				input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-				stateDesc,
-				new InternalSingleValueWindowFunction<>(function),
-				trigger,
-				allowedLateness,
-				lateDataOutputTag);
-		}
+		OneInputStreamOperator<T, R> operator = builder.fold(initialValue, foldFunction, function, resultType);
 
 		return input.transform(opName, resultType, operator);
-	}
-
-	private static String generateFunctionName(Function function) {
-		Class<? extends Function> functionClass = function.getClass();
-		if (functionClass.isAnonymousClass()) {
-			// getSimpleName returns an empty String for anonymous classes
-			Type[] interfaces = functionClass.getInterfaces();
-			if (interfaces.length == 0) {
-				// extends an existing class (like RichMapFunction)
-				Class<?> functionSuperClass = functionClass.getSuperclass();
-				return functionSuperClass.getSimpleName() + functionClass.getName().substring(functionClass.getEnclosingClass().getName().length());
-			} else {
-				// implements a Function interface
-				Class<?> functionInterface = functionClass.getInterfaces()[0];
-				return functionInterface.getSimpleName() + functionClass.getName().substring(functionClass.getEnclosingClass().getName().length());
-			}
-		} else {
-			return functionClass.getSimpleName();
-		}
-	}
-
-	private static String generateOperatorName(
-			WindowAssigner<?, ?> assigner,
-			Trigger<?, ?> trigger,
-			@Nullable Evictor<?, ?> evictor,
-			Function function1,
-			@Nullable Function function2) {
-		return "Window(" +
-			assigner + ", " +
-			trigger.getClass().getSimpleName() + ", " +
-			(evictor == null ? "" : (evictor.getClass().getSimpleName() + ", ")) +
-			generateFunctionName(function1) +
-			(function2 == null ? "" : (", " + generateFunctionName(function2))) +
-			")";
 	}
 
 	// ------------------------------------------------------------------------
@@ -1543,6 +1092,6 @@ public class WindowedStream<T, K, W extends Window> {
 
 	@VisibleForTesting
 	long getAllowedLateness() {
-		return allowedLateness;
+		return builder.getAllowedLateness();
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorBuilder.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorBuilder.java
@@ -1,0 +1,378 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.windowing;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.FoldFunction;
+import org.apache.flink.api.common.functions.Function;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.AppendingState;
+import org.apache.flink.api.common.state.FoldingStateDescriptor;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.functions.windowing.AggregateApplyWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.FoldApplyProcessWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.FoldApplyWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.ReduceApplyProcessWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.ReduceApplyWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.WindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.BaseAlignedWindowAssigner;
+import org.apache.flink.streaming.api.windowing.assigners.MergingWindowAssigner;
+import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
+import org.apache.flink.streaming.api.windowing.evictors.Evictor;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.triggers.Trigger;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalAggregateProcessWindowFunction;
+import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalIterableProcessWindowFunction;
+import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalIterableWindowFunction;
+import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalSingleValueProcessWindowFunction;
+import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalSingleValueWindowFunction;
+import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalWindowFunction;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.OutputTag;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.lang.reflect.Type;
+
+/**
+ * A builder for creating {@code WindowOperator}'s.
+ * @param <K> The type of key returned by the {@code KeySelector}.
+ * @param <T> The type of the incoming elements.
+ * @param <W> The type of {@code Window} that the {@code WindowAssigner} assigns.
+ */
+public class WindowOperatorBuilder<T, K, W extends Window> {
+
+	private static final String WINDOW_STATE_NAME = "window-contents";
+
+	private final ExecutionConfig config;
+
+	private final WindowAssigner<? super T, W> windowAssigner;
+
+	private final TypeInformation<T> inputType;
+
+	private final KeySelector<T, K> keySelector;
+
+	private final TypeInformation<K> keyType;
+
+	private Trigger<? super T, ? super W> trigger;
+
+	@Nullable
+	private Evictor<? super T, ? super W> evictor;
+
+	private long allowedLateness = 0L;
+
+	@Nullable
+	private OutputTag<T> lateDataOutputTag;
+
+	public WindowOperatorBuilder(
+		WindowAssigner<? super T, W> windowAssigner,
+		Trigger<? super T, ? super W> trigger,
+		ExecutionConfig config,
+		TypeInformation<T> inputType,
+		KeySelector<T, K> keySelector,
+		TypeInformation<K> keyType) {
+		this.windowAssigner = windowAssigner;
+		this.config = config;
+		this.inputType = inputType;
+		this.keySelector = keySelector;
+		this.keyType = keyType;
+		this.trigger = trigger;
+	}
+
+	public void trigger(Trigger<? super T, ? super W> trigger) {
+		Preconditions.checkNotNull(trigger, "Window triggers cannot be null");
+
+		if (windowAssigner instanceof MergingWindowAssigner && !trigger.canMerge()) {
+			throw new UnsupportedOperationException("A merging window assigner cannot be used with a trigger that does not support merging.");
+		}
+
+		if (windowAssigner instanceof BaseAlignedWindowAssigner) {
+			throw new UnsupportedOperationException("Cannot use a " + windowAssigner.getClass().getSimpleName() + " with a custom trigger.");
+		}
+
+		this.trigger = trigger;
+	}
+
+	public void allowedLateness(Time lateness) {
+		Preconditions.checkNotNull(lateness, "Allowed lateness cannot be null");
+
+		final long millis = lateness.toMilliseconds();
+		Preconditions.checkArgument(millis >= 0, "The allowed lateness cannot be negative.");
+
+		this.allowedLateness = millis;
+	}
+
+	public void sideOutputLateData(OutputTag<T> outputTag) {
+		Preconditions.checkNotNull(outputTag, "Side output tag must not be null.");
+		this.lateDataOutputTag = outputTag;
+	}
+
+	public void evictor(Evictor<? super T, ? super W> evictor) {
+		Preconditions.checkNotNull(evictor, "Evictor cannot be null");
+
+		if (windowAssigner instanceof BaseAlignedWindowAssigner) {
+			throw new UnsupportedOperationException("Cannot use a " + windowAssigner.getClass().getSimpleName() + " with an Evictor.");
+		}
+		this.evictor = evictor;
+	}
+
+	public <R> WindowOperator<K, T, ?, R, W> reduce(ReduceFunction<T> reduceFunction, WindowFunction<T, R, K, W> function) {
+		Preconditions.checkNotNull(reduceFunction, "ReduceFunction cannot be null");
+		Preconditions.checkNotNull(function, "WindowFunction cannot be null");
+
+		if (reduceFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("ReduceFunction of apply can not be a RichFunction.");
+		}
+
+		if (evictor != null) {
+			return buildEvictingWindowOperator(new InternalIterableWindowFunction<>(new ReduceApplyWindowFunction<>(reduceFunction, function)));
+		} else {
+			ReducingStateDescriptor<T> stateDesc = new ReducingStateDescriptor<>(WINDOW_STATE_NAME, reduceFunction, inputType.createSerializer(config));
+
+			return buildWindowOperator(stateDesc, new InternalSingleValueWindowFunction<>(function));
+		}
+	}
+
+	public <R> WindowOperator<K, T, ?, R, W> reduce(ReduceFunction<T> reduceFunction, ProcessWindowFunction<T, R, K, W> function) {
+		Preconditions.checkNotNull(reduceFunction, "ReduceFunction cannot be null");
+		Preconditions.checkNotNull(function, "ProcessWindowFunction cannot be null");
+
+		if (reduceFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("ReduceFunction of apply can not be a RichFunction.");
+		}
+
+		if (evictor != null) {
+			return buildEvictingWindowOperator(new InternalIterableProcessWindowFunction<>(new ReduceApplyProcessWindowFunction<>(reduceFunction, function)));
+		} else {
+			ReducingStateDescriptor<T> stateDesc = new ReducingStateDescriptor<>(WINDOW_STATE_NAME, reduceFunction, inputType.createSerializer(config));
+
+			return buildWindowOperator(stateDesc, new InternalSingleValueProcessWindowFunction<>(function));
+		}
+	}
+
+	@Deprecated
+	public <ACC, R> WindowOperator<K, T, ?, R, W> fold(
+		ACC initialValue,
+		FoldFunction<T, ACC> foldFunction,
+		WindowFunction<ACC, R, K, W> function,
+		TypeInformation<ACC> foldAccumulatorType) {
+
+		Preconditions.checkNotNull(foldAccumulatorType, "FoldFunction cannot be null");
+		Preconditions.checkNotNull(function, "WindowFunction cannot be null");
+
+		if (foldFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("FoldFunction of fold can not be a RichFunction.");
+		}
+		if (windowAssigner instanceof MergingWindowAssigner) {
+			throw new UnsupportedOperationException("Fold cannot be used with a merging WindowAssigner.");
+		}
+
+		if (windowAssigner instanceof BaseAlignedWindowAssigner) {
+			throw new UnsupportedOperationException("Fold cannot be used with a " +
+				windowAssigner.getClass().getSimpleName() + " assigner.");
+		}
+
+		if (evictor != null) {
+			return buildEvictingWindowOperator(new InternalIterableWindowFunction<>(new FoldApplyWindowFunction<>(initialValue, foldFunction, function, foldAccumulatorType)));
+		} else {
+			FoldingStateDescriptor<T, ACC> stateDesc = new FoldingStateDescriptor<>(WINDOW_STATE_NAME,
+				initialValue, foldFunction, foldAccumulatorType.createSerializer(config));
+			return buildWindowOperator(stateDesc, new InternalSingleValueWindowFunction<>(function));
+		}
+	}
+
+	@Deprecated
+	public <ACC, R> WindowOperator<K, T, ?, R, W> fold(
+		ACC initialValue,
+		FoldFunction<T, ACC> foldFunction,
+		ProcessWindowFunction<ACC, R, K, W> windowFunction,
+		TypeInformation<ACC> foldAccumulatorType) {
+
+		Preconditions.checkNotNull(foldAccumulatorType, "FoldFunction cannot be null");
+		Preconditions.checkNotNull(windowFunction, "ProcessWindowFunction cannot be null");
+
+		if (foldFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("FoldFunction of fold can not be a RichFunction.");
+		}
+		if (windowAssigner instanceof MergingWindowAssigner) {
+			throw new UnsupportedOperationException("Fold cannot be used with a merging WindowAssigner.");
+		}
+
+		if (windowAssigner instanceof BaseAlignedWindowAssigner) {
+			throw new UnsupportedOperationException("Fold cannot be used with a " +
+				windowAssigner.getClass().getSimpleName() + " assigner.");
+		}
+
+		if (evictor != null) {
+			InternalIterableProcessWindowFunction<T, R, K, W> internalFunction = new InternalIterableProcessWindowFunction<>(
+				new FoldApplyProcessWindowFunction<>(initialValue, foldFunction, windowFunction, foldAccumulatorType));
+			return buildEvictingWindowOperator(internalFunction);
+		} else {
+			FoldingStateDescriptor<T, ACC> stateDesc = new FoldingStateDescriptor<>(WINDOW_STATE_NAME,
+				initialValue, foldFunction, foldAccumulatorType.createSerializer(config));
+			return buildWindowOperator(stateDesc, new InternalSingleValueProcessWindowFunction<>(windowFunction));
+		}
+	}
+
+	public <ACC, V, R> WindowOperator<K, T, ?, R, W> aggregate(
+		AggregateFunction<T, ACC, V> aggregateFunction,
+		WindowFunction<V, R, K, W> windowFunction,
+		TypeInformation<ACC> accumulatorType) {
+
+		Preconditions.checkNotNull(aggregateFunction, "AggregateFunction cannot be null");
+		Preconditions.checkNotNull(windowFunction, "WindowFunction cannot be null");
+
+		if (aggregateFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("This aggregate function cannot be a RichFunction.");
+		}
+
+		if (evictor != null) {
+			return buildEvictingWindowOperator(new InternalIterableWindowFunction<>(new AggregateApplyWindowFunction<>(aggregateFunction, windowFunction)));
+		} else {
+			AggregatingStateDescriptor<T, ACC, V> stateDesc = new AggregatingStateDescriptor<>(WINDOW_STATE_NAME,
+				aggregateFunction, accumulatorType.createSerializer(config));
+
+			return buildWindowOperator(stateDesc, new InternalSingleValueWindowFunction<>(windowFunction));
+		}
+	}
+
+	public <ACC, V, R> WindowOperator<K, T, ?, R, W> aggregate(
+		AggregateFunction<T, ACC, V> aggregateFunction,
+		ProcessWindowFunction<V, R, K, W> windowFunction,
+		TypeInformation<ACC> accumulatorType) {
+
+		Preconditions.checkNotNull(aggregateFunction, "AggregateFunction cannot be null");
+		Preconditions.checkNotNull(windowFunction, "ProcessWindowFunction cannot be null");
+
+		if (aggregateFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("This aggregate function cannot be a RichFunction.");
+		}
+
+		if (evictor != null) {
+			return buildEvictingWindowOperator(new InternalAggregateProcessWindowFunction<>(aggregateFunction, windowFunction));
+		} else {
+			AggregatingStateDescriptor<T, ACC, V> stateDesc = new AggregatingStateDescriptor<>(WINDOW_STATE_NAME,
+				aggregateFunction, accumulatorType.createSerializer(config));
+
+			return buildWindowOperator(stateDesc, new InternalSingleValueProcessWindowFunction<>(windowFunction));
+		}
+	}
+
+	public <R> WindowOperator<K, T, ?, R, W> apply(WindowFunction<T, R, K, W> function) {
+		Preconditions.checkNotNull(function, "WindowFunction cannot be null");
+		return apply(new InternalIterableWindowFunction<>(function));
+	}
+
+	public <R> WindowOperator<K, T, ?, R, W> process(ProcessWindowFunction<T, R, K, W> function) {
+		Preconditions.checkNotNull(function, "ProcessWindowFunction cannot be null");
+		return apply(new InternalIterableProcessWindowFunction<>(function));
+	}
+
+	private  <R> WindowOperator<K, T, ?, R, W> apply(InternalWindowFunction<Iterable<T>, R, K, W> function) {
+		if (evictor != null) {
+			return buildEvictingWindowOperator(function);
+		} else {
+			ListStateDescriptor<T> stateDesc = new ListStateDescriptor<>(WINDOW_STATE_NAME, inputType.createSerializer(config));
+
+			return buildWindowOperator(stateDesc, function);
+		}
+	}
+
+	private <ACC, R> WindowOperator<K, T, ACC, R, W> buildWindowOperator(
+		StateDescriptor<? extends AppendingState<T, ACC>, ?> stateDesc,
+		InternalWindowFunction<ACC, R, K, W> function) {
+
+		return new WindowOperator<>(
+			windowAssigner,
+			windowAssigner.getWindowSerializer(config),
+			keySelector,
+			keyType.createSerializer(config),
+			stateDesc,
+			function,
+			trigger,
+			allowedLateness,
+			lateDataOutputTag);
+	}
+
+	private <R> WindowOperator<K, T, Iterable<T>, R, W> buildEvictingWindowOperator(InternalWindowFunction<Iterable<T>, R, K, W> function) {
+		@SuppressWarnings({"unchecked", "rawtypes"})
+		TypeSerializer<StreamRecord<T>> streamRecordSerializer =
+			(TypeSerializer<StreamRecord<T>>) new StreamElementSerializer(inputType.createSerializer(config));
+
+		ListStateDescriptor<StreamRecord<T>> stateDesc = new ListStateDescriptor<>(WINDOW_STATE_NAME, streamRecordSerializer);
+
+		return new EvictingWindowOperator<>(windowAssigner,
+			windowAssigner.getWindowSerializer(config),
+			keySelector,
+			keyType.createSerializer(config),
+			stateDesc,
+			function,
+			trigger,
+			evictor,
+			allowedLateness,
+			lateDataOutputTag);
+	}
+
+	private static String generateFunctionName(Function function) {
+		Class<? extends Function> functionClass = function.getClass();
+		if (functionClass.isAnonymousClass()) {
+			// getSimpleName returns an empty String for anonymous classes
+			Type[] interfaces = functionClass.getInterfaces();
+			if (interfaces.length == 0) {
+				// extends an existing class (like RichMapFunction)
+				Class<?> functionSuperClass = functionClass.getSuperclass();
+				return functionSuperClass.getSimpleName() + functionClass.getName().substring(functionClass.getEnclosingClass().getName().length());
+			} else {
+				// implements a Function interface
+				Class<?> functionInterface = functionClass.getInterfaces()[0];
+				return functionInterface.getSimpleName() + functionClass.getName().substring(functionClass.getEnclosingClass().getName().length());
+			}
+		} else {
+			return functionClass.getSimpleName();
+		}
+	}
+
+	public String generateOperatorName(Function function1, @Nullable Function function2) {
+		return "Window(" +
+			windowAssigner + ", " +
+			trigger.getClass().getSimpleName() + ", " +
+			(evictor == null ? "" : (evictor.getClass().getSimpleName() + ", ")) +
+			generateFunctionName(function1) +
+			(function2 == null ? "" : (", " + generateFunctionName(function2))) +
+			")";
+	}
+
+	@VisibleForTesting
+	public long getAllowedLateness() {
+		return allowedLateness;
+	}
+}

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/StreamCollector.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/StreamCollector.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+
+import org.junit.rules.ExternalResource;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A simple utility for collecting all the elements in a stream.
+ *
+ * <p><b>Note:</b> The stream collector assumes:
+ * 1) The stream is bounded.
+ * 2) All elements will fit in memory.
+ * 3) All tasks run within the same JVM.
+ */
+public class StreamCollector extends ExternalResource {
+
+	private static final AtomicLong counter = new AtomicLong();
+
+	private static final Map<Long, CountDownLatch> latches = new ConcurrentHashMap<>();
+
+	private static final Map<Long, Queue> resultQueues = new ConcurrentHashMap<>();
+
+	private List<Long> ids;
+
+	@Override
+	protected void before() {
+		ids = new ArrayList<>();
+	}
+
+	public <IN> CompletableFuture<Collection<IN>> collect(DataStream<IN> stream) {
+		final long id = counter.getAndIncrement();
+		ids.add(id);
+
+		int parallelism = stream.getParallelism();
+		if (parallelism == ExecutionConfig.PARALLELISM_DEFAULT) {
+			parallelism = stream.getExecutionEnvironment().getParallelism();
+		}
+
+		CountDownLatch latch = new CountDownLatch(parallelism);
+		latches.put(id, latch);
+
+		Queue<IN> results = new ConcurrentLinkedDeque<>();
+		resultQueues.put(id, results);
+
+		stream.addSink(new CollectingSink<>(id));
+
+		return CompletableFuture.runAsync(() -> {
+			try {
+				latch.await();
+			} catch (InterruptedException e) {
+				throw new RuntimeException("Failed to collect results");
+			}
+		}).thenApply(ignore -> results);
+	}
+
+	@Override
+	protected void after() {
+		for (Long id : ids) {
+			latches.remove(id);
+			resultQueues.remove(id);
+		}
+	}
+
+	private static class CollectingSink<IN> extends RichSinkFunction<IN> {
+
+		private final long id;
+
+		private transient CountDownLatch latch;
+
+		private transient Queue<IN> results;
+
+		private CollectingSink(long id) {
+			this.id = id;
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public void open(Configuration parameters) throws Exception {
+			latch   = StreamCollector.latches.get(id);
+			results = (Queue<IN>) StreamCollector.resultQueues.get(id);
+		}
+
+		@Override
+		public void invoke(IN value, Context context) throws Exception {
+			results.add(value);
+		}
+
+		@Override
+		public void close() throws Exception {
+			latch.countDown();
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Provide an easy way to read / bootstrap window state using the State Processor API.

## Brief changelog

129f26d  Adds support for listing namespaces for a state type from `KeyedStateBackend`. This is required as windows are encoded as namespaces in the state backend and up until now there has never been a way to query namespaces, all operations assume the calling code already knows what namespace they are interested in interacting with.

4c712cb   Adds support for reading window operator state by implementing a `WindowStateReaderOperator` and `WindowReaderFunction`. 

4cdc867   Extracts the logic from `WindowedStream` into a builder class so that there is one definitive way to create and configure the window operator. I ran all the end to end tests to ensure everything works as expected.

a6f4289 Cursory refactoring of some test utilities

c39bafc Adds support for bootstrapping window state. While this commit contains a lot of code it is all boilerplate due to the many ways users can configure the window operator. All user-facing changes simply sit on top of the `WindowOperatorBuilder`. 

## Verifying this change

Unit and IT tests cases

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDoc
