### PR TITLE
[FLINK-14613][table-planner-blink] Fix temporal table join when containing multiple keyfields with UDF

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.xml
@@ -296,7 +296,7 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, n
 ]]>
 	</Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithMulUDFANDConstantCondition">
+  <TestCase name="testJoinTemporalTableWithMultiUDFANDConstantCondition">
 	<Resource name="sql">
 	  <![CDATA[
 SELECT * FROM MyTable AS T

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.xml
@@ -271,15 +271,15 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, n
     </Resource>
   </TestCase>
   <TestCase name="testJoinTemporalTableWithUDFANDConstantCondition">
-	<Resource name="sql">
-	  <![CDATA[
+    <Resource name="sql">
+      <![CDATA[
 SELECT * FROM MyTable AS T
 JOIN temporalTest FOR SYSTEM_TIME AS OF T.proctime AS D
 ON T.b = concat(D.name, '!') AND D.age = 11
-]]>
-	</Resource>
-	<Resource name="planBefore">
-	  <![CDATA[
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
 LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 3}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
@@ -287,25 +287,25 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
       +- LogicalSnapshot(period=[$cor0.proctime])
          +- LogicalTableScan(table=[[default_catalog, default_database, temporalTest, source: [TestTemporalTable(id, name, age)]]])
 ]]>
-	</Resource>
-	<Resource name="planAfter">
-	  <![CDATA[
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(11) AS age])
 +- LookupJoin(table=[TestTemporalTable(id, name, age)], joinType=[InnerJoin], async=[false], on=[b=$f3], where=[=(age, 11)], select=[a, b, c, proctime, rowtime, id, name, age, $f3])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
-	</Resource>
+    </Resource>
   </TestCase>
   <TestCase name="testJoinTemporalTableWithMultiUDFANDConstantCondition">
-	<Resource name="sql">
-	  <![CDATA[
+    <Resource name="sql">
+      <![CDATA[
 SELECT * FROM MyTable AS T
 JOIN temporalTest FOR SYSTEM_TIME AS OF T.proctime AS D
 ON T.a = D.id + 1 AND T.b = concat(D.name, '!') AND D.age = 11
- ]]>
-	</Resource>
-	<Resource name="planBefore">
-	  <![CDATA[
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
 LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1, 3}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
@@ -313,25 +313,25 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
       +- LogicalSnapshot(period=[$cor0.proctime])
          +- LogicalTableScan(table=[[default_catalog, default_database, temporalTest, source: [TestTemporalTable(id, name, age)]]])
 ]]>
-	</Resource>
-	<Resource name="planAfter">
-	  <![CDATA[
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(11) AS age])
 +- LookupJoin(table=[TestTemporalTable(id, name, age)], joinType=[InnerJoin], async=[false], on=[a=$f3, b=$f4], where=[=(age, 11)], select=[a, b, c, proctime, rowtime, id, name, age, $f3, $f4])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
-	</Resource>
-	</TestCase>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinTemporalTableWithUDFANDRReferenceCondition">
-	<Resource name="sql">
-	  <![CDATA[
+    <Resource name="sql">
+      <![CDATA[
 SELECT * FROM MyTable AS T
 JOIN temporalTest FOR SYSTEM_TIME AS OF T.proctime AS D
 ON T.a = D.id AND T.b = concat(D.name, '!')
-]]>
-	</Resource>
-	<Resource name="planBefore">
-	  <![CDATA[
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
 LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1, 3}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
@@ -339,14 +339,13 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
       +- LogicalSnapshot(period=[$cor0.proctime])
          +- LogicalTableScan(table=[[default_catalog, default_database, temporalTest, source: [TestTemporalTable(id, name, age)]]])
 ]]>
-	</Resource>
-	<Resource name="planAfter">
-	  <![CDATA[
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
 +- LookupJoin(table=[TestTemporalTable(id, name, age)], joinType=[InnerJoin], async=[false], on=[a=id, b=$f3], where=[], select=[a, b, c, proctime, rowtime, id, name, age, $f3])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
-	</Resource>
+    </Resource>
   </TestCase>
-
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.xml
@@ -270,4 +270,83 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, n
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinTemporalTableWithUDFANDConstantCondition">
+	<Resource name="sql">
+	  <![CDATA[
+SELECT * FROM MyTable AS T
+JOIN temporalTest FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.b = concat(D.name, '!') AND D.age = 11
+]]>
+	</Resource>
+	<Resource name="planBefore">
+	  <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[AND(=($cor0.b, CONCAT($1, _UTF-16LE'!')), =($2, 11))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, temporalTest, source: [TestTemporalTable(id, name, age)]]])
+]]>
+	</Resource>
+	<Resource name="planAfter">
+	  <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(11) AS age])
++- LookupJoin(table=[TestTemporalTable(id, name, age)], joinType=[InnerJoin], async=[false], on=[b=$f3], where=[=(age, 11)], select=[a, b, c, proctime, rowtime, id, name, age, $f3])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithMulUDFANDConstantCondition">
+	<Resource name="sql">
+	  <![CDATA[
+SELECT * FROM MyTable AS T
+JOIN temporalTest FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id + 1 AND T.b = concat(D.name, '!') AND D.age = 11
+ ]]>
+	</Resource>
+	<Resource name="planBefore">
+	  <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[AND(=($cor0.a, +($0, 1)), =($cor0.b, CONCAT($1, _UTF-16LE'!')), =($2, 11))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, temporalTest, source: [TestTemporalTable(id, name, age)]]])
+]]>
+	</Resource>
+	<Resource name="planAfter">
+	  <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(11) AS age])
++- LookupJoin(table=[TestTemporalTable(id, name, age)], joinType=[InnerJoin], async=[false], on=[a=$f3, b=$f4], where=[=(age, 11)], select=[a, b, c, proctime, rowtime, id, name, age, $f3, $f4])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+	</Resource>
+	</TestCase>
+  <TestCase name="testJoinTemporalTableWithUDFANDRReferenceCondition">
+	<Resource name="sql">
+	  <![CDATA[
+SELECT * FROM MyTable AS T
+JOIN temporalTest FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id AND T.b = concat(D.name, '!')
+]]>
+	</Resource>
+	<Resource name="planBefore">
+	  <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($cor0.b, CONCAT($1, _UTF-16LE'!')))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, temporalTest, source: [TestTemporalTable(id, name, age)]]])
+]]>
+	</Resource>
+	<Resource name="planAfter">
+	  <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
++- LookupJoin(table=[TestTemporalTable(id, name, age)], joinType=[InnerJoin], async=[false], on=[a=id, b=$f3], where=[], select=[a, b, c, proctime, rowtime, id, name, age, $f3])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+	</Resource>
+  </TestCase>
+
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
@@ -352,6 +352,45 @@ class LookupJoinTest extends TableTestBase with Serializable {
     streamUtil.verifyPlan(sql)
   }
 
+  @Test
+  def testJoinTemporalTableWithUDFANDConstantCondition(): Unit = {
+
+    val sql =
+      """
+        |SELECT * FROM MyTable AS T
+        |JOIN temporalTest FOR SYSTEM_TIME AS OF T.proctime AS D
+        |ON T.b = concat(D.name, '!') AND D.age = 11
+      """.stripMargin
+
+    streamUtil.verifyPlan(sql)
+  }
+
+  @Test
+  def testJoinTemporalTableWithMultiUDFANDConstantCondition(): Unit = {
+
+    val sql =
+      """
+        |SELECT * FROM MyTable AS T
+        |JOIN temporalTest FOR SYSTEM_TIME AS OF T.proctime AS D
+        |ON T.a = D.id + 1 AND T.b = concat(D.name, '!') AND D.age = 11
+      """.stripMargin
+
+    streamUtil.verifyPlan(sql)
+  }
+
+
+  @Test
+  def testJoinTemporalTableWithUDFANDRReferenceCondition(): Unit = {
+    val sql =
+      """
+        |SELECT * FROM MyTable AS T
+        |JOIN temporalTest FOR SYSTEM_TIME AS OF T.proctime AS D
+        |ON T.a = D.id AND T.b = concat(D.name, '!')
+      """.stripMargin
+
+    streamUtil.verifyPlan(sql)
+  }
+
   // ==========================================================================================
 
   private def expectExceptionThrown(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
@@ -54,7 +54,9 @@ class LookupJoinITCase extends StreamingTestBase {
   val userData = List(
     (11, 1L, "Julian"),
     (22, 2L, "Jark"),
-    (33, 3L, "Fabian"))
+    (33, 3L, "Fabian"),
+    (11, 4L, "Hello world"),
+    (11, 5L, "Hello world"))
 
   val userTableSource = InMemoryLookupableTableSource.builder()
     .data(userData)
@@ -535,19 +537,20 @@ class LookupJoinITCase extends StreamingTestBase {
       .toTable(tEnv, 'id, 'len, 'content, 'proctime.proctime)
     tEnv.registerTable("T", streamTable)
 
-    tEnv.registerTableSource("userTable", userWithSameAgeTableSourceWith2Keys)
+    tEnv.registerTableSource("userTable", userTableSource)
 
-    val sql = "SELECT T.id, T.content, D.name, D.age  FROM T JOIN userTable " +
-      "for system_time as of T.proctime AS D ON T.content = concat(D.name, '!') AND D.age = 11"
+    val sql = "SELECT T.id, T.content, D.age, D.id FROM T JOIN userTable " +
+      "for system_time as of T.proctime AS D " +
+      "ON T.id = D.id + 4 AND T.content = concat(D.name, '!') AND D.age = 11"
 
     val sink = new TestingAppendSink
     tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
     env.execute()
 
     val expected = Seq(
-      "9,Hello world!,Hello world,11")
+      "9,Hello world!,11,5")
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
-    assertEquals(0, userWithSameAgeTableSourceWith2Keys.getResourceCounter)
+    assertEquals(0, userTableSource.getResourceCounter)
   }
 
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
@@ -86,20 +86,6 @@ class LookupJoinITCase extends StreamingTestBase {
     .field("name", Types.STRING)
     .build()
 
-  val userDataWithSameAge = List(
-    (11, 1L, "Julian"),
-    (22, 2L, "Jark"),
-    (33, 3L, "Fabian"),
-    (11, 4L, "Hello world")
-  )
-
-  val userWithSameAgeTableSourceWith2Keys = InMemoryLookupableTableSource.builder()
-    .data(userDataWithSameAge)
-    .field("age", Types.INT)
-    .field("id", Types.LONG)
-    .field("name", Types.STRING)
-    .build()
-
   @Test
   def testJoinTemporalTable(): Unit = {
     val streamTable = env.fromCollection(data)


### PR DESCRIPTION

## What is the purpose of the change

Fix temporal table join when containing multiple keyfields with UDF.
The issue link is https://issues.apache.org/jira/browse/FLINK-14613


## Brief change log

Add  keyfields with UDF condition to remainingJoinCondition in CommonLookupJoin.


## Verifying this change
This change added tests and can be verified as follows:

(1) LookupJoinITCase#testJoinTemporalTableOnMultiKeyFieldsWithUDF

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
