### PR TITLE
[FLINK-14676][table-planner-blink] Introduce parallelism inference for InputFormatTableSource

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -88,6 +88,14 @@ public class ExecutionConfigOptions {
 	// ------------------------------------------------------------------------
 	//  Resource Options
 	// ------------------------------------------------------------------------
+	@Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
+	public static final ConfigOption<String> TABLE_EXEC_RESOURCE_INFER_MODE =
+		key("table.exec.resource.infer.mode")
+			.defaultValue("NONE")
+			.withDescription("Sets infer resource mode according to statics. Only NONE, or ONLY_SOURCE can be set.\n" +
+					"If set NONE, parallelism and memory of all node are set by config.\n" +
+					"If set ONLY_SOURCE, only source parallelism is inferred according to statics.\n");
+
 	@Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
 	public static final ConfigOption<Integer> TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM =
 		key("table.exec.resource.default-parallelism")
@@ -123,6 +131,19 @@ public class ExecutionConfigOptions {
 		key("table.exec.resource.sort.memory")
 			.defaultValue("128 mb")
 			.withDescription("Sets the managed buffer memory size for sort operator.");
+
+	@Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
+	public static final ConfigOption<Integer> TABLE_EXEC_RESOURCE_INFER_SOURCE_PARALLELISM_MAX =
+		key("table.exec.resource.infer.source.parallelism.max")
+			.defaultValue(1000)
+			.withDescription("Sets max infer parallelism for source operator.");
+
+	@Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
+	public static final ConfigOption<Long> TABLE_EXEC_RESOURCE_INFER_ROWS_PER_PARTITION =
+		key("table.exec.resource.infer.rows-per-partition")
+			.defaultValue(1000000L)
+			.withDescription("Sets how many rows one partition processes. We will infer parallelism according " +
+					"to input row count.");
 
 	// ------------------------------------------------------------------------
 	//  Agg Options

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/TableConfigUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/TableConfigUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.utils;
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.planner.calcite.CalciteConfig;
 import org.apache.flink.table.planner.calcite.CalciteConfig$;
 import org.apache.flink.table.planner.plan.utils.OperatorType;
@@ -111,6 +112,46 @@ public class TableConfigUtils {
 	public static CalciteConfig getCalciteConfig(TableConfig tableConfig) {
 		return tableConfig.getPlannerConfig().unwrap(CalciteConfig.class).orElse(
 				CalciteConfig$.MODULE$.DEFAULT());
+	}
+
+	/**
+	 * Infer resource mode.
+	 */
+	public enum InferMode {
+		NONE, ONLY_SOURCE
+	}
+
+	/**
+	 * Gets the resource infer mode.
+	 */
+	public static InferMode getInferMode(TableConfig tableConf) {
+		String config = tableConf.getConfiguration().getString(
+				ExecutionConfigOptions.TABLE_EXEC_RESOURCE_INFER_MODE);
+		try {
+			return InferMode.valueOf(config);
+		} catch (IllegalArgumentException ex) {
+			throw new IllegalArgumentException("Infer mode can only be set: NONE or ONLY_SOURCE.");
+		}
+	}
+
+	/**
+	 * Gets the config row count that one partition processes.
+	 * @param tableConf Configuration.
+	 * @return the config row count that one partition processes.
+	 */
+	public static long getInferRowCountPerPartition(TableConfig tableConf) {
+		return tableConf.getConfiguration().getLong(
+				ExecutionConfigOptions.TABLE_EXEC_RESOURCE_INFER_ROWS_PER_PARTITION);
+	}
+
+	/**
+	 * Gets the config max num of source parallelism.
+	 * @param tableConf Configuration.
+	 * @return the config max num of source parallelism.
+	 */
+	public static int getSourceMaxParallelism(TableConfig tableConf) {
+		return tableConf.getConfiguration().getInteger(
+				ExecutionConfigOptions.TABLE_EXEC_RESOURCE_INFER_SOURCE_PARALLELISM_MAX);
 	}
 
 	// Make sure that we cannot instantiate this class

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/PhysicalTableSourceScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/PhysicalTableSourceScan.scala
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.core.io.InputSplit
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.schema.{FlinkRelOptTable, TableSourceTable}
 import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter.fromDataTypeToTypeInfo
@@ -68,11 +69,14 @@ abstract class PhysicalTableSourceScan(
   }
 
   def createInput[IN](
+      conf: TableConfig,
       env: StreamExecutionEnvironment,
       format: InputFormat[IN, _ <: InputSplit],
       t: TypeInformation[IN]): Transformation[IN]
 
-  def getSourceTransformation(env: StreamExecutionEnvironment): Transformation[_] = {
+  def getSourceTransformation(
+      conf: TableConfig,
+      env: StreamExecutionEnvironment): Transformation[_] = {
     if (sourceTransform == null) {
       sourceTransform = tableSource match {
         case format: InputFormatTableSource[_] =>
@@ -81,6 +85,7 @@ abstract class PhysicalTableSourceScan(
           val typeInfo = fromDataTypeToTypeInfo(format.getProducedDataType)
               .asInstanceOf[TypeInformation[Any]]
           createInput(
+            conf,
             env,
             format.getInputFormat.asInstanceOf[InputFormat[Any, _ <: InputSplit]],
             typeInfo.asInstanceOf[TypeInformation[Any]])

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecTableSourceScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecTableSourceScan.scala
@@ -154,8 +154,6 @@ class BatchExecTableSourceScan(
     // We can use InputFormatSourceFunction directly to support InputFormat.
     val func = new InputFormatSourceFunction[IN](format, t)
     val transformation = env.addSource(func, tableSource.explainSource(), t).getTransformation
-    println(env.getParallelism)
-    println(transformation.getParallelism)
 
     // only infer parallelism for InputFormatTableSource. InputFormat source is safe
     // and important.

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecTableSourceScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecTableSourceScan.scala
@@ -102,7 +102,7 @@ class StreamExecTableSourceScan(
   override protected def translateToPlanInternal(
       planner: StreamPlanner): Transformation[BaseRow] = {
     val config = planner.getTableConfig
-    val inputTransform = getSourceTransformation(planner.getExecEnv)
+    val inputTransform = getSourceTransformation(config, planner.getExecEnv)
 
     val fieldIndexes = TableSourceUtil.computeIndexMapping(
       tableSource,
@@ -250,6 +250,7 @@ class StreamExecTableSourceScan(
   }
 
   override def createInput[IN](
+      conf: TableConfig,
       env: StreamExecutionEnvironment,
       format: InputFormat[IN, _ <: InputSplit],
       t: TypeInformation[IN]): Transformation[IN] = {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/BatchExecResourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/BatchExecResourceTest.scala
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.batch.sql
+
+import org.apache.flink.api.common.typeinfo.{TypeInformation, Types}
+import org.apache.flink.table.api.TableConfig
+import org.apache.flink.table.api.config.ExecutionConfigOptions
+import org.apache.flink.table.delegation.Planner
+import org.apache.flink.table.plan.stats.TableStats
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode
+import org.apache.flink.table.planner.plan.stats.FlinkStatistic
+import org.apache.flink.table.planner.utils.{TableConfigUtils, TableTestBase, TableTestUtil}
+
+import org.junit.{Assert, Before, Test}
+
+class BatchExecResourceTest extends TableTestBase {
+
+  private val util = batchTestUtil()
+
+  @Before
+  def before(): Unit = {
+    val table3Stats = new TableStats(5000000)
+    util.addInputFormatTableSource("table3",
+      Array[TypeInformation[_]](Types.INT, Types.LONG, Types.STRING),
+      Array("a", "b", "c"), FlinkStatistic.builder().tableStats(table3Stats).build())
+    BatchExecResourceTest.setResourceConfig(util.getTableEnv.getConfig)
+  }
+
+  @Test
+  def testSourceParallelismNoneInfer(): Unit = {
+    util.getPlanner.getExecEnv.setParallelism(17)
+    util.getTableEnv.getConfig.getConfiguration.setString(
+      ExecutionConfigOptions.TABLE_EXEC_RESOURCE_INFER_MODE,
+      TableConfigUtils.InferMode.NONE.toString
+    )
+    val sql = "SELECT * FROM table3"
+    assertSourceParallelism(sql, 17)
+  }
+
+  @Test
+  def testSourceParallelism(): Unit = {
+    util.getTableEnv.getConfig.getConfiguration.setString(
+      ExecutionConfigOptions.TABLE_EXEC_RESOURCE_INFER_MODE,
+      TableConfigUtils.InferMode.ONLY_SOURCE.toString
+    )
+    val sql = "SELECT * FROM table3"
+    assertSourceParallelism(sql, 5)
+  }
+
+  @Test
+  def testSourceParallelismMaxNum(): Unit = {
+    util.getTableEnv.getConfig.getConfiguration.setString(
+      ExecutionConfigOptions.TABLE_EXEC_RESOURCE_INFER_MODE,
+      TableConfigUtils.InferMode.ONLY_SOURCE.toString
+    )
+    util.getTableEnv.getConfig.getConfiguration.setInteger(
+      ExecutionConfigOptions.TABLE_EXEC_RESOURCE_INFER_SOURCE_PARALLELISM_MAX,
+      2
+    )
+    val sql = "SELECT * FROM table3"
+    assertSourceParallelism(sql, 2)
+  }
+
+  private def assertSourceParallelism(sql: String, parallelism: Int): Unit = {
+    val table = util.tableEnv.sqlQuery(sql)
+    val relNode = util.getPlanner.optimize(TableTestUtil.toRelNode(table))
+    val execNode = util.getPlanner.translateToExecNodePlan(Seq(relNode)).get(0)
+    val transform = execNode.asInstanceOf[ExecNode[Planner, _]].translateToPlan(util.getPlanner)
+    Assert.assertEquals(parallelism, transform.getParallelism)
+  }
+}
+
+object BatchExecResourceTest {
+
+  def setResourceConfig(tableConfig: TableConfig): Unit = {
+    tableConfig.getConfiguration.setInteger(
+      ExecutionConfigOptions.TABLE_EXEC_RESOURCE_INFER_SOURCE_PARALLELISM_MAX,
+      1000)
+    tableConfig.getConfiguration.setLong(
+      ExecutionConfigOptions.TABLE_EXEC_RESOURCE_INFER_ROWS_PER_PARTITION,
+      1000000
+    )
+  }
+}


### PR DESCRIPTION

## What is the purpose of the change

FLINK-12801 has introduce parallelism setting for table, but because TableSource generate DataStream, maybe DataStream is not a real source, that will lead to some shuffle errors. So FLINK-13494 remove these implementations.

In this ticket, I would like to introduce parallelism inference only for InputFormatTableSource, the RowCount of InputFormatTableSource is more accurate than downstream stages. It is worth to automatically generate its parallelism.

## Brief change log

Add infer related config options.
inferParallelism when is batch mode and InputFormatTableSource

## Verifying this change

BatchExecResourceTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
