### PR TITLE
[FLINK-14693][hotfix][python] Python tox checks fails on travis

### DIFF
--- a/flink-python/dev/lint-python.sh
+++ b/flink-python/dev/lint-python.sh
@@ -204,20 +204,21 @@ function install_py_env() {
 # In some situations,you need to run the script with "sudo". e.g. sudo ./lint-python.sh
 function install_tox() {
     if [ -f "$TOX_PATH" ]; then
-        $CONDA_PATH remove -p $CONDA_HOME tox -y -q 2>&1 >/dev/null
+        $PIP_PATH uninstall tox -y -q 2>&1 >/dev/null
         if [ $? -ne 0 ]; then
-            echo "conda remove tox failed \
+            echo "pip uninstall tox failed \
             please try to exec the script again.\
             if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
             exit 1
         fi
     fi
 
-    # virtualenv 16.6.2 released in 2019-07-14 is incompatible with py27 and py34,
-    # force install an older version(16.0.0) to avoid this problem.
-    $CONDA_PATH install -p $CONDA_HOME -c conda-forge virtualenv=16.0.0 tox -y -q 2>&1 >/dev/null
+    # tox 3.14.0 depends on both 0.19 and 0.23 of importlib_metadata at the same time and
+    # conda will try to install both these two versions and it will cause problems occasionally.
+    # Using pip as the package manager could avoid this problem.
+    $PIP_PATH install -q virtualenv==16.0.0 tox==3.14.0 2>&1 >/dev/null
     if [ $? -ne 0 ]; then
-        echo "conda install tox failed \
+        echo "pip install tox failed \
         please try to exec the script again.\
         if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
         exit 1
@@ -536,6 +537,9 @@ CONDA_HOME=$CURRENT_DIR/.conda
 
 # conda path
 CONDA_PATH=$CONDA_HOME/bin/conda
+
+# pip path
+PIP_PATH=$CONDA_HOME/bin/pip
 
 # tox path
 TOX_PATH=$CONDA_HOME/bin/tox


### PR DESCRIPTION
## What is the purpose of the change

*This pr fix the tox wrong installation*


## Brief change log

  - *replace conda install tox with pip install*


## Verifying this change

This change added tests and can be verified as follows:

  - *fix installing error without test*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
