### PR TITLE
[FLINK-14689]Add catalog related commands support in SQL Parser

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -35,6 +35,7 @@
     "org.apache.flink.sql.parser.dml.RichSqlInsert",
     "org.apache.flink.sql.parser.dml.RichSqlInsertKeyword",
     "org.apache.flink.sql.parser.dql.SqlShowCatalogs",
+    "org.apache.flink.sql.parser.dql.SqlDescribeCatalog",
     "org.apache.flink.sql.parser.type.ExtendedSqlBasicTypeNameSpec",
     "org.apache.flink.sql.parser.type.ExtendedSqlCollectionTypeNameSpec",
     "org.apache.flink.sql.parser.utils.SqlTimeUnit",
@@ -377,7 +378,8 @@
   # Example: SqlShowDatabases(), SqlShowTables().
   statementParserMethods: [
     "RichSqlInsert()",
-    "SqlShowCatalogs()"
+    "SqlShowCatalogs()",
+    "SqlDescribeCatalog()"
   ]
 
   # List of methods for parsing custom literals.

--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -32,6 +32,7 @@
     "org.apache.flink.sql.parser.ddl.SqlTableColumn",
     "org.apache.flink.sql.parser.ddl.SqlTableOption",
     "org.apache.flink.sql.parser.ddl.SqlWatermark",
+    "org.apache.flink.sql.parser.ddl.SqlUseCatalog",
     "org.apache.flink.sql.parser.dml.RichSqlInsert",
     "org.apache.flink.sql.parser.dml.RichSqlInsertKeyword",
     "org.apache.flink.sql.parser.dql.SqlShowCatalogs",
@@ -58,7 +59,8 @@
     "OVERWRITE",
     "STRING",
     "BYTES",
-    "CATALOGS"
+    "CATALOGS",
+    "USE"
   ]
 
   # List of keywords from "keywords" section that are not reserved.
@@ -351,6 +353,7 @@
     "UNDER"
     "UNNAMED"
     "USAGE"
+    "USE"
     "USER_DEFINED_TYPE_CATALOG"
     "USER_DEFINED_TYPE_CODE"
     "USER_DEFINED_TYPE_NAME"
@@ -379,7 +382,8 @@
   statementParserMethods: [
     "RichSqlInsert()",
     "SqlShowCatalogs()",
-    "SqlDescribeCatalog()"
+    "SqlDescribeCatalog()",
+    "SqlUseCatalog()"
   ]
 
   # List of methods for parsing custom literals.

--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -34,6 +34,7 @@
     "org.apache.flink.sql.parser.ddl.SqlWatermark",
     "org.apache.flink.sql.parser.dml.RichSqlInsert",
     "org.apache.flink.sql.parser.dml.RichSqlInsertKeyword",
+    "org.apache.flink.sql.parser.dql.SqlShowCatalogs",
     "org.apache.flink.sql.parser.type.ExtendedSqlBasicTypeNameSpec",
     "org.apache.flink.sql.parser.type.ExtendedSqlCollectionTypeNameSpec",
     "org.apache.flink.sql.parser.utils.SqlTimeUnit",
@@ -55,7 +56,8 @@
     "WATERMARK",
     "OVERWRITE",
     "STRING",
-    "BYTES"
+    "BYTES",
+    "CATALOGS"
   ]
 
   # List of keywords from "keywords" section that are not reserved.
@@ -81,6 +83,7 @@
     "C"
     "CASCADE"
     "CATALOG"
+    "CATALOGS"
     "CATALOG_NAME"
     "CENTURY"
     "CHAIN"
@@ -373,7 +376,8 @@
   # Return type of method implementation should be 'SqlNode'.
   # Example: SqlShowDatabases(), SqlShowTables().
   statementParserMethods: [
-    "RichSqlInsert()"
+    "RichSqlInsert()",
+    "SqlShowCatalogs()"
   ]
 
   # List of methods for parsing custom literals.

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -41,6 +41,20 @@ SqlDescribeCatalog SqlDescribeCatalog() :
     }
 
 }
+
+SqlUseCatalog SqlUseCatalog() :
+{
+SqlIdentifier catalogName;
+SqlParserPos pos;
+}
+{
+<USE> <CATALOG> { pos = getPos();}
+    catalogName = SimpleIdentifier()
+    {
+        return new SqlUseCatalog(pos, catalogName);
+    }
+}
+
 void TableColumn(TableCreationContext context) :
 {
 }

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -28,6 +28,19 @@ SqlShowCatalogs SqlShowCatalogs() :
     }
 }
 
+SqlDescribeCatalog SqlDescribeCatalog() :
+{
+    SqlIdentifier catalogName;
+    SqlParserPos pos;
+}
+{
+    <DESCRIBE> <CATALOG> { pos = getPos();}
+    catalogName = SimpleIdentifier()
+    {
+        return new SqlDescribeCatalog(pos, catalogName);
+    }
+
+}
 void TableColumn(TableCreationContext context) :
 {
 }

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -15,6 +15,19 @@
 // limitations under the License.
 -->
 
+/**
+* Parse a "Show Catalogs" metadata query command.
+*/
+SqlShowCatalogs SqlShowCatalogs() :
+{
+}
+{
+    <SHOW> <CATALOGS>
+    {
+        return new SqlShowCatalogs(getPos());
+    }
+}
+
 void TableColumn(TableCreationContext context) :
 {
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlUseCatalog.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlUseCatalog.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * USE CATALOG sql call.
+ */
+public class SqlUseCatalog extends SqlCall {
+
+	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("USE CATALOG", SqlKind.OTHER);
+	private final SqlIdentifier catalogName;
+
+	public SqlUseCatalog(SqlParserPos pos, SqlIdentifier catalogName) {
+		super(pos);
+		this.catalogName = catalogName;
+	}
+
+	@Override
+	public SqlOperator getOperator() {
+		return OPERATOR;
+	}
+
+	@Override
+	public List<SqlNode> getOperandList() {
+		return Collections.singletonList(catalogName);
+	}
+
+	public String getCatalogName() {
+		return catalogName.getSimple();
+	}
+
+	@Override
+	public void unparse(
+			SqlWriter writer,
+			int leftPrec,
+			int rightPrec) {
+		writer.keyword("USE CATALOG");
+		catalogName.unparse(writer, leftPrec, rightPrec);
+	}
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlDescribeCatalog.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlDescribeCatalog.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.dql;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * DESCRIBE CATALOG sql call.
+ */
+public class SqlDescribeCatalog extends SqlCall {
+
+	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("DESCRIBE CATALOG", SqlKind.OTHER);
+	private final SqlIdentifier catalogName;
+
+	public SqlDescribeCatalog(SqlParserPos pos, SqlIdentifier catalogName) {
+		super(pos);
+		this.catalogName = catalogName;
+	}
+
+	@Override
+	public SqlOperator getOperator() {
+		return OPERATOR;
+	}
+
+	@Override
+	public List<SqlNode> getOperandList() {
+		return Collections.singletonList(catalogName);
+	}
+
+	public String getCatalogName() {
+		return catalogName.getSimple();
+	}
+
+	@Override
+	public void unparse(
+			SqlWriter writer,
+			int leftPrec,
+			int rightPrec) {
+		writer.keyword("DESCRIBE CATALOG");
+		catalogName.unparse(writer, leftPrec, rightPrec);
+	}
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCatalogs.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCatalogs.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.dql;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * SHOW CATALOGS sql call.
+ */
+public class SqlShowCatalogs extends SqlCall {
+
+	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("SHOW CATALOGS", SqlKind.OTHER);
+
+	public SqlShowCatalogs(SqlParserPos pos) {
+		super(pos);
+	}
+
+	@Override
+	public SqlOperator getOperator() {
+		return OPERATOR;
+	}
+
+	@Override
+	public List<SqlNode> getOperandList() {
+		return Collections.EMPTY_LIST;
+	}
+
+	@Override
+	public void unparse(
+			SqlWriter writer,
+			int leftPrec,
+			int rightPrec) {
+		writer.keyword("SHOW CATALOGS");
+	}
+}

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -79,6 +79,18 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	}
 
 	@Test
+	public void testDescribeCatalog() {
+		check("describe catalog a", "DESCRIBE CATALOG `A`");
+	}
+
+	/**
+	 * Here we override the super method to avoid test error from `describe schema` supported in original calcite.
+	 */
+	@Override
+	public void testDescribeSchema() {
+	}
+
+	@Test
 	public void testCreateTable() {
 		check("CREATE TABLE tbl1 (\n" +
 				"  a bigint,\n" +

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -91,6 +91,11 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	}
 
 	@Test
+	public void testUseCatalog() {
+		check("use catalog a", "USE CATALOG `A`");
+	}
+
+	@Test
 	public void testCreateTable() {
 		check("CREATE TABLE tbl1 (\n" +
 				"  a bigint,\n" +

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -74,6 +74,11 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	}
 
 	@Test
+	public void testShowCatalogs() {
+		check("show catalogs", "SHOW CATALOGS");
+	}
+
+	@Test
 	public void testCreateTable() {
 		check("CREATE TABLE tbl1 (\n" +
 				"  a bigint,\n" +


### PR DESCRIPTION
## What is the purpose of the change
Add catalog related commands support in SQL Parser :

- SHOW CATALOGS
- DESCRIBE CATALOG catalogName
- USE CATALOG catalogName
The PR is only about parser related changes to support catalog related commands and Hooking up with table env will come later.

## Brief change log
  - [aacc11](https://github.com/apache/flink/pull/10149/commits/aacc11c30aa8cae9389ebf2a43782fa7cb149158)Add show catalogs support in SQL Parser

  - [2b472b](https://github.com/apache/flink/pull/10149/commits/2b472bee6a0a8677ca30cd82c753ba9d0b80411e)Add describe catalog syntax in SQL Parser
  - [a746f79](https://github.com/apache/flink/pull/10149/commits/a746f791dab3a4d7cfda8de3d4ad5a62fd45a44d)Add use catalog syntax in Sql Parser


## Verifying this change

This change added tests and can be verified as follows:
  - *FlinkSqlParserImplTest#testShowCatalogs*
  - *FlinkSqlParserImplTest#testDescribeCatalog*
  - *FlinkSqlParserImplTest#testUseCatalog*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
