### PR TITLE
[FLINK-14231] Handle the pending processing-time timers to make endInput semantics on the operator chain strict

### DIFF
--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingTest.java
@@ -165,7 +165,6 @@ public class ContinuousFileProcessingTest {
 		}
 
 		TextInputFormat format = new TextInputFormat(new Path(testBasePath));
-		TypeInformation<String> typeInfo = TypeExtractor.getInputFormatTypes(format);
 
 		final long watermarkInterval = 10;
 

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/Utils.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/Utils.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.hdfstests;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.io.FileInputFormat;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.streaming.api.functions.source.ContinuousFileReaderOperatorFactory;
+import org.apache.flink.streaming.api.functions.source.TimestampedFileInputSplit;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+
+/**
+ * Utility class that contains common methods for testing.
+ */
+public class Utils {
+
+	public static <OUT> OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, OUT> createContinuousFileProcessingTestHarness(
+		FileInputFormat<OUT> inputFormat) throws Exception {
+
+		return createContinuousFileProcessingTestHarness(inputFormat, TypeExtractor.getInputFormatTypes(inputFormat), null);
+	}
+
+	public static <OUT> OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, OUT> createContinuousFileProcessingTestHarness(
+		FileInputFormat<OUT> inputFormat,
+		TypeInformation<OUT> outTypeInfo,
+		ExecutionConfig executionConfig) throws Exception {
+
+		OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, OUT> testHarness =
+			new OneInputStreamOperatorTestHarness<>(new ContinuousFileReaderOperatorFactory<>(inputFormat));
+		testHarness.getOperatorFactory().setOutputType(
+			outTypeInfo,
+			executionConfig == null ? testHarness.getExecutionConfig() : executionConfig);
+
+		return testHarness;
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/NeverFireProcessingTimeService.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/NeverFireProcessingTimeService.java
@@ -22,6 +22,7 @@ import org.apache.flink.streaming.runtime.tasks.ProcessingTimeCallback;
 import org.apache.flink.streaming.runtime.tasks.TimerService;
 import org.apache.flink.util.concurrent.NeverCompleteFuture;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -56,13 +57,9 @@ public final class NeverFireProcessingTimeService implements TimerService {
 	}
 
 	@Override
-	public void quiesce() throws InterruptedException {
+	public CompletableFuture<Void> quiesce() {
 		shutdown.set(true);
-	}
-
-	@Override
-	public void awaitPendingAfterQuiesce() throws InterruptedException {
-		shutdown.set(true);
+		return CompletableFuture.completedFuture(null);
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
@@ -35,6 +35,7 @@ import org.apache.flink.streaming.api.operators.OutputTypeConfigurable;
 import org.apache.flink.streaming.api.operators.StreamSourceContexts;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
@@ -215,8 +216,13 @@ class ContinuousFileReaderOperator<OUT> extends AbstractStreamOperator<OUT>
 		}
 	};
 
-	ContinuousFileReaderOperator(FileInputFormat<OUT> format, MailboxExecutor mailboxExecutor) {
+	ContinuousFileReaderOperator(
+		FileInputFormat<OUT> format,
+		ProcessingTimeService processingTimeService,
+		MailboxExecutor mailboxExecutor) {
+
 		this.format = checkNotNull(format);
+		this.processingTimeService = checkNotNull(processingTimeService);
 		this.executor = checkNotNull(mailboxExecutor);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -155,7 +155,7 @@ public abstract class AbstractStreamOperator<OUT>
 
 	// ---------------- time handler ------------------
 
-	private transient ProcessingTimeService processingTimeService;
+	protected transient ProcessingTimeService processingTimeService;
 	protected transient InternalTimeServiceManager<?> timeServiceManager;
 
 	// ---------------- two-input operator watermarks ------------------
@@ -174,7 +174,6 @@ public abstract class AbstractStreamOperator<OUT>
 	public void setup(StreamTask<?, ?> containingTask, StreamConfig config, Output<StreamRecord<OUT>> output) {
 		final Environment environment = containingTask.getEnvironment();
 		this.container = containingTask;
-		this.processingTimeService = containingTask.getProcessingTimeService(config.getChainIndex());
 		this.config = config;
 		try {
 			OperatorMetricGroup operatorMetricGroup = environment.getMetricGroup().getOrAddOperator(config.getOperatorID(), config.getOperatorName());
@@ -232,6 +231,15 @@ public abstract class AbstractStreamOperator<OUT>
 
 		stateKeySelector1 = config.getStatePartitioner(0, getUserCodeClassloader());
 		stateKeySelector2 = config.getStatePartitioner(1, getUserCodeClassloader());
+	}
+
+	/**
+	 * @deprecated The {@link ProcessingTimeService} instance should be passed by the operator
+	 * constructor and this method will be removed along with {@link SetupableStreamOperator}.
+	 */
+	@Deprecated
+	public void setProcessingTimeService(ProcessingTimeService processingTimeService) {
+		this.processingTimeService = Preconditions.checkNotNull(processingTimeService);
 	}
 
 	@Override
@@ -558,7 +566,7 @@ public abstract class AbstractStreamOperator<OUT>
 	 * Returns the {@link ProcessingTimeService} responsible for getting the current
 	 * processing time and registering timers.
 	 */
-	protected ProcessingTimeService getProcessingTimeService() {
+	public ProcessingTimeService getProcessingTimeService() {
 		return processingTimeService;
 	}
 
@@ -672,7 +680,6 @@ public abstract class AbstractStreamOperator<OUT>
 	public final ChainingStrategy getChainingStrategy() {
 		return chainingStrategy;
 	}
-
 
 	// ------------------------------------------------------------------------
 	//  Metrics

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeServiceAware;
+
+/**
+ * Base class for all stream operator factories. It implements some common methods and the
+ * {@link ProcessingTimeServiceAware} interface which enables stream operators to access
+ * {@link ProcessingTimeService}.
+ */
+public abstract class AbstractStreamOperatorFactory<OUT> implements StreamOperatorFactory<OUT>, ProcessingTimeServiceAware {
+
+	protected ChainingStrategy chainingStrategy = ChainingStrategy.ALWAYS;
+
+	protected transient ProcessingTimeService processingTimeService;
+
+	@Override
+	public void setChainingStrategy(ChainingStrategy strategy) {
+		this.chainingStrategy = strategy;
+	}
+
+	@Override
+	public ChainingStrategy getChainingStrategy() {
+		return chainingStrategy;
+	}
+
+	@Override
+	public void setProcessingTimeService(ProcessingTimeService processingTimeService) {
+		this.processingTimeService = processingTimeService;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorFactoryUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorFactoryUtil.java
@@ -17,11 +17,14 @@
 
 package org.apache.flink.streaming.api.operators;
 
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeServiceAware;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
+
+import java.util.Optional;
 
 /**
  * A utility to instantiate new operators with a given factory.
@@ -34,9 +37,9 @@ public class StreamOperatorFactoryUtil {
 	 * @param containingTask the containing task.
 	 * @param configuration the configuration of the operator.
 	 * @param output the output of the operator.
-	 * @return a newly created and configured operator.
+	 * @return a newly created and configured operator, and the {@link ProcessingTimeService} instance it can access.
 	 */
-	public static <OUT, OP extends StreamOperator<OUT>> OP createOperator(
+	public static <OUT, OP extends StreamOperator<OUT>> Tuple2<OP, Optional<ProcessingTimeService>> createOperator(
 			StreamOperatorFactory<OUT> operatorFactory,
 			StreamTask<OUT, ?> containingTask,
 			StreamConfig configuration,
@@ -48,11 +51,13 @@ public class StreamOperatorFactoryUtil {
 			((YieldingOperatorFactory) operatorFactory).setMailboxExecutor(mailboxExecutor);
 		}
 
+		ProcessingTimeService processingTimeService = null;
 		if (operatorFactory instanceof ProcessingTimeServiceAware) {
-			ProcessingTimeService processingTimeService = containingTask.getProcessingTimeServiceFactory().createProcessingTimeService(mailboxExecutor);
+			processingTimeService = containingTask.getProcessingTimeServiceFactory().createProcessingTimeService(mailboxExecutor);
 			((ProcessingTimeServiceAware) operatorFactory).setProcessingTimeService(processingTimeService);
 		}
 
-		return operatorFactory.createStreamOperator(containingTask, configuration, output);
+		OP op = operatorFactory.createStreamOperator(containingTask, configuration, output);
+		return new Tuple2<>(op, Optional.ofNullable(processingTimeService));
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
@@ -30,6 +30,7 @@ import org.apache.flink.streaming.api.functions.async.AsyncFunction;
 import org.apache.flink.streaming.api.functions.async.ResultFuture;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.MailboxExecutor;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
@@ -76,7 +77,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @Internal
 public class AsyncWaitOperator<IN, OUT>
 		extends AbstractUdfStreamOperator<OUT, AsyncFunction<IN, OUT>>
-		implements OneInputStreamOperator<IN, OUT> {
+		implements OneInputStreamOperator<IN, OUT>, BoundedOneInput {
 	private static final long serialVersionUID = 1L;
 
 	private static final String STATE_NAME = "_async_wait_operator_state_";
@@ -234,13 +235,11 @@ public class AsyncWaitOperator<IN, OUT>
 	}
 
 	@Override
-	public void close() throws Exception {
-		try {
-			waitInFlightInputsFinished();
-		}
-		finally {
-			super.close();
-		}
+	public void endInput() throws Exception {
+		// we should wait here for the data in flight to be finished. the reason is that the
+		// timer not in running will be forbidden to fire after this, so that when the async
+		// operation is stuck, it results in deadlock due to what the timeout timer is not fired
+		waitInFlightInputsFinished();
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
@@ -42,6 +42,7 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.util.Preconditions;
 
@@ -108,6 +109,7 @@ public class AsyncWaitOperator<IN, OUT>
 			long timeout,
 			int capacity,
 			@Nonnull AsyncDataStream.OutputMode outputMode,
+			@Nonnull ProcessingTimeService processingTimeService,
 			@Nonnull MailboxExecutor mailboxExecutor) {
 		super(asyncFunction);
 
@@ -121,6 +123,8 @@ public class AsyncWaitOperator<IN, OUT>
 		this.outputMode = Preconditions.checkNotNull(outputMode, "outputMode");
 
 		this.timeout = timeout;
+
+		this.processingTimeService = Preconditions.checkNotNull(processingTimeService);
 
 		this.mailboxExecutor = mailboxExecutor;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.operators.async;
 import org.apache.flink.streaming.api.datastream.AsyncDataStream;
 import org.apache.flink.streaming.api.functions.async.AsyncFunction;
 import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.MailboxExecutor;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
@@ -33,13 +34,14 @@ import org.apache.flink.streaming.runtime.tasks.StreamTask;
  *
  * @param <OUT> The output type of the operator
  */
-public class AsyncWaitOperatorFactory<IN, OUT> implements OneInputStreamOperatorFactory<IN, OUT>, YieldingOperatorFactory<OUT> {
+public class AsyncWaitOperatorFactory<IN, OUT> extends AbstractStreamOperatorFactory<OUT>
+	implements OneInputStreamOperatorFactory<IN, OUT>, YieldingOperatorFactory<OUT> {
+
 	private final AsyncFunction<IN, OUT> asyncFunction;
 	private final long timeout;
 	private final int capacity;
 	private final AsyncDataStream.OutputMode outputMode;
 	private MailboxExecutor mailboxExecutor;
-	private ChainingStrategy strategy = ChainingStrategy.HEAD;
 
 	public AsyncWaitOperatorFactory(
 			AsyncFunction<IN, OUT> asyncFunction,
@@ -50,6 +52,7 @@ public class AsyncWaitOperatorFactory<IN, OUT> implements OneInputStreamOperator
 		this.timeout = timeout;
 		this.capacity = capacity;
 		this.outputMode = outputMode;
+		this.chainingStrategy = ChainingStrategy.HEAD;
 	}
 
 	@Override
@@ -64,19 +67,10 @@ public class AsyncWaitOperatorFactory<IN, OUT> implements OneInputStreamOperator
 				timeout,
 				capacity,
 				outputMode,
+				processingTimeService,
 				mailboxExecutor);
 		asyncWaitOperator.setup(containingTask, config, output);
 		return asyncWaitOperator;
-	}
-
-	@Override
-	public void setChainingStrategy(ChainingStrategy strategy) {
-		this.strategy = strategy;
-	}
-
-	@Override
-	public ChainingStrategy getChainingStrategy() {
-		return strategy;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeService.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 
 /**
@@ -53,4 +54,16 @@ public interface ProcessingTimeService {
 	 * @return Scheduled future representing the task to be executed repeatedly
 	 */
 	ScheduledFuture<?> scheduleAtFixedRate(ProcessingTimeCallback callback, long initialDelay, long period);
+
+	/**
+	 * This method puts the service into a state where it does not register new timers, but
+	 * returns for each call to {@link #registerTimer} or {@link #scheduleAtFixedRate} a "mock"
+	 * future and the "mock" future will be never completed. Furthermore, the timers registered
+	 * before are prevented from firing, but the timers in running are allowed to finish.
+	 *
+	 * <p>If no timer is running, the quiesce-completed future is immediately completed and
+	 * returned. Otherwise, the future returned will be completed when all running timers have
+	 * finished.
+	 */
+	CompletableFuture<Void> quiesce();
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeServiceAware.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeServiceAware.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * Interface for {@link org.apache.flink.streaming.api.operators.StreamOperatorFactory},
+ * which enables stream operators to access {@link ProcessingTimeService}.
+ *
+ * <p>For an stream operator, if it needs to access the {@link ProcessingTimeService}, it
+ * must be created through a operator factory that implements {@link ProcessingTimeServiceAware},
+ * and the operator factory should set the {@link ProcessingTimeService} instance into the
+ * stream operator.
+ */
+@PublicEvolving
+public interface ProcessingTimeServiceAware {
+
+	void setProcessingTimeService(ProcessingTimeService processingTimeService);
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeServiceFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeServiceFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.api.operators.MailboxExecutor;
+
+/**
+ * A factory for creating processing time services with a given {@link MailboxExecutor}.
+ * The factory is usually bound to a specific task.
+ */
+@FunctionalInterface
+@Internal
+public interface ProcessingTimeServiceFactory {
+
+	/**
+	 * Creates a new processing time service with the mailbox executor. The mailbox executor
+	 * is used to defer the {@link ProcessingTimeCallback} of the timer registered with the
+	 * {@link ProcessingTimeService} to mailbox for execution.
+	 */
+	ProcessingTimeService createProcessingTimeService(MailboxExecutor mailboxExecutor);
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeServiceImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeServiceImpl.java
@@ -18,18 +18,36 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.concurrent.NeverCompleteFuture;
+
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
+@Internal
 class ProcessingTimeServiceImpl implements ProcessingTimeService {
+
 	private final TimerService timerService;
+
 	private final Function<ProcessingTimeCallback, ProcessingTimeCallback> processingTimeCallbackWrapper;
+
+	private final AtomicInteger numRunningTimers;
+
+	private final CompletableFuture<Void> quiesceCompletedFuture;
+
+	private volatile boolean quiesced;
 
 	ProcessingTimeServiceImpl(
 			TimerService timerService,
 			Function<ProcessingTimeCallback, ProcessingTimeCallback> processingTimeCallbackWrapper) {
 		this.timerService = timerService;
 		this.processingTimeCallbackWrapper = processingTimeCallbackWrapper;
+
+		this.numRunningTimers = new AtomicInteger(0);
+		this.quiesceCompletedFuture = new CompletableFuture<>();
+		this.quiesced = false;
 	}
 
 	@Override
@@ -39,11 +57,63 @@ class ProcessingTimeServiceImpl implements ProcessingTimeService {
 
 	@Override
 	public ScheduledFuture<?> registerTimer(long timestamp, ProcessingTimeCallback target) {
-		return timerService.registerTimer(timestamp, processingTimeCallbackWrapper.apply(target));
+		if (isQuiesced()) {
+			return new NeverCompleteFuture(
+				ProcessingTimeServiceUtil.getProcessingTimeDelay(timestamp, getCurrentProcessingTime()));
+		}
+
+		return timerService.registerTimer(
+			timestamp, addQuiesceProcessingToCallback(processingTimeCallbackWrapper.apply(target)));
 	}
 
 	@Override
 	public ScheduledFuture<?> scheduleAtFixedRate(ProcessingTimeCallback callback, long initialDelay, long period) {
-		return timerService.scheduleAtFixedRate(processingTimeCallbackWrapper.apply(callback), initialDelay, period);
+		if (isQuiesced()) {
+			return new NeverCompleteFuture(initialDelay);
+		}
+
+		return timerService.scheduleAtFixedRate(
+			addQuiesceProcessingToCallback(processingTimeCallbackWrapper.apply(callback)), initialDelay, period);
+	}
+
+	@Override
+	public CompletableFuture<Void> quiesce() {
+		if (!quiesced) {
+			quiesced = true;
+
+			if (numRunningTimers.get() == 0) {
+				quiesceCompletedFuture.complete(null);
+			}
+		}
+
+		return quiesceCompletedFuture;
+	}
+
+	private boolean isQuiesced() {
+		return quiesced;
+	}
+
+	private ProcessingTimeCallback addQuiesceProcessingToCallback(ProcessingTimeCallback callback) {
+
+		return timestamp -> {
+			if (isQuiesced()) {
+				return;
+			}
+
+			numRunningTimers.incrementAndGet();
+			try {
+				// double check to deal with the race condition:
+				// before executing the previous line to increase the number of running timers,
+				// the quiesce-completed future is already completed as the number of running
+				// timers is 0 and "quiesced" is true
+				if (!isQuiesced()) {
+					callback.onProcessingTime(timestamp);
+				}
+			} finally {
+				if (numRunningTimers.decrementAndGet() == 0 && isQuiesced()) {
+					quiesceCompletedFuture.complete(null);
+				}
+			}
+		};
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeServiceUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeServiceUtil.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * Utility for classes that implements the {@link ProcessingTimeService} interface.
+ */
+@Internal
+public class ProcessingTimeServiceUtil {
+
+	/**
+	 * Returns the remaining delay of the processing time specified by {@code processingTimestamp}.
+	 *
+	 * @param processingTimestamp the processing time in milliseconds
+	 * @param currentTimestamp the current processing timestamp; it usually uses
+	 *        {@link ProcessingTimeService#getCurrentProcessingTime()} to get
+	 * @return the remaining delay of the processing time
+	 */
+	public static long getProcessingTimeDelay(long processingTimestamp, long currentTimestamp) {
+
+		// delay the firing of the timer by 1 ms to align the semantics with watermark. A watermark
+		// T says we won't see elements in the future with a timestamp smaller or equal to T.
+		// With processing time, we therefore need to delay firing the timer by one ms.
+		return Math.max(processingTimestamp - currentTimestamp, 0) + 1;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamOperatorWrapper.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamOperatorWrapper.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.MailboxExecutor;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+
+import javax.annotation.Nonnull;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * This class handles the close, endInput and other related logic of a {@link StreamOperator}.
+ * It also automatically propagates the close operation to the next wrapper that the {@link #next}
+ * points to, so we can use {@link #next} to link all operator wrappers in the operator chain and
+ * close all operators only by calling the {@link #close(StreamTaskActionExecutor)} method of the
+ * header operator wrapper.
+ */
+@Internal
+public class StreamOperatorWrapper<OUT, OP extends StreamOperator<OUT>> {
+
+	private final OP wrapped;
+
+	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+	private final Optional<ProcessingTimeService> processingTimeService;
+
+	private final MailboxExecutor mailboxExecutor;
+
+	private StreamOperatorWrapper<?, ?> previous;
+
+	private StreamOperatorWrapper<?, ?> next;
+
+	StreamOperatorWrapper(
+		OP wrapped,
+		Optional<ProcessingTimeService> processingTimeService,
+		MailboxExecutor mailboxExecutor) {
+
+		this.wrapped = checkNotNull(wrapped);
+		this.processingTimeService = checkNotNull(processingTimeService);
+		this.mailboxExecutor = checkNotNull(mailboxExecutor);
+	}
+
+	/**
+	 * Closes the wrapped operator and propagates the close operation to the next wrapper that the
+	 * {@link #next} points to.
+	 *
+	 * <p>Note that this method must be called in the task thread, because we need to call
+	 * {@link MailboxExecutor#yield()} to take the mails of closing operator and running timers and
+	 * run them.
+	 */
+	public void close(StreamTaskActionExecutor actionExecutor) throws Exception {
+		close(actionExecutor, false);
+	}
+
+	/**
+	 * Ends an input of the operator contained by this wrapper.
+	 *
+	 * @param inputId the input ID starts from 1 which indicates the first input.
+	 */
+	public void endOperatorInput(int inputId) throws Exception {
+		if (wrapped instanceof BoundedOneInput) {
+			((BoundedOneInput) wrapped).endInput();
+		} else if (wrapped instanceof BoundedMultiInput) {
+			((BoundedMultiInput) wrapped).endInput(inputId);
+		}
+	}
+
+	public OP getStreamOperator() {
+		return wrapped;
+	}
+
+	void setPrevious(StreamOperatorWrapper previous) {
+		this.previous = previous;
+	}
+
+	void setNext(StreamOperatorWrapper next) {
+		this.next = next;
+	}
+
+	private void close(StreamTaskActionExecutor actionExecutor, boolean invokingEndInput) throws Exception {
+		if (invokingEndInput) {
+			// NOTE: This only do for the case where the operator is one-input operator. At present,
+			// any non-head operator on the operator chain is one-input operator.
+			actionExecutor.runThrowing(() -> endOperatorInput(1));
+		}
+
+		quiesceTimeServiceAndCloseOperator(actionExecutor);
+
+		// propagate the close operation to the next wrapper
+		if (next != null) {
+			next.close(actionExecutor, true);
+		}
+	}
+
+	private void quiesceTimeServiceAndCloseOperator(StreamTaskActionExecutor actionExecutor)
+		throws InterruptedException, ExecutionException {
+
+		// step 1. to ensure that there is no longer output triggered by the timers before invoking the "close()"
+		//         method of the operator, we quiesce the processing time service to prevent the pending timers
+		//         from firing, but wait the timers in running to finish
+		// step 2. invoke the "close()" method of the operator. executing the close operation must be deferred
+		//         to the mailbox to ensure that mails already in the mailbox are finished before closing the
+		//         operator
+		// step 3. send a closed mail to ensure that the mails that are from the operator and still in the mailbox
+		//         are completed before exiting the following mailbox processing loop
+		CompletableFuture<Void> closedFuture = quiesceProcessingTimeService()
+			.thenCompose(unused  -> deferCloseOperatorToMailbox(actionExecutor))
+			.thenCompose(unused -> sendClosedMail());
+
+		// run the mailbox processing loop until all operations are finished
+		while (!closedFuture.isDone()) {
+			while (mailboxExecutor.tryYield()) {}
+
+			// we wait a little bit to avoid unnecessary CPU occupation due to empty loops,
+			// such as when all mails of the operator have been processed but the closed future
+			// has not been set to completed state
+			try {
+				closedFuture.get(1, TimeUnit.MILLISECONDS);
+			} catch (TimeoutException ex) {
+				// do nothing
+			}
+		}
+
+		// expose the exception thrown when closing
+		closedFuture.get();
+	}
+
+	private CompletableFuture<Void> deferCloseOperatorToMailbox(StreamTaskActionExecutor actionExecutor) {
+		final CompletableFuture<Void> closeOperatorFuture = new CompletableFuture<>();
+
+		mailboxExecutor.execute(
+			() -> {
+				try {
+					closeOperator(actionExecutor);
+					closeOperatorFuture.complete(null);
+				} catch (Throwable t) {
+					closeOperatorFuture.completeExceptionally(t);
+				}
+			},
+			"StreamOperatorWrapper#closeOperator for " + wrapped
+		);
+		return closeOperatorFuture;
+	}
+
+	private CompletableFuture<Void> quiesceProcessingTimeService() {
+		return processingTimeService
+			.map(ProcessingTimeService::quiesce)
+			.orElse(CompletableFuture.completedFuture(null));
+	}
+
+	private CompletableFuture<Void> sendClosedMail() {
+		final CompletableFuture<Void> future = new CompletableFuture<>();
+
+		mailboxExecutor.execute(() ->
+			future.complete(null), "StreamOperatorWrapper#sendClosedMail for " + wrapped);
+		return future;
+	}
+
+	private void closeOperator(StreamTaskActionExecutor actionExecutor) throws Exception {
+		actionExecutor.runThrowing(wrapped::close);
+	}
+
+	static class ReadIterator implements Iterator<StreamOperatorWrapper<?, ?>>, Iterable<StreamOperatorWrapper<?, ?>> {
+
+		private final boolean reverse;
+
+		private StreamOperatorWrapper<?, ?> current;
+
+		ReadIterator(StreamOperatorWrapper<?, ?> first, boolean reverse) {
+			this.current = first;
+			this.reverse = reverse;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return this.current != null;
+		}
+
+		@Override
+		public StreamOperatorWrapper<?, ?> next() {
+			if (hasNext()) {
+				StreamOperatorWrapper<?, ?> next = current;
+				current = reverse ? current.previous : current.next;
+				return next;
+			}
+
+			throw new NoSuchElementException();
+		}
+
+		@Nonnull
+		@Override
+		public Iterator<StreamOperatorWrapper<?, ?>> iterator() {
+			return this;
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -1027,10 +1027,16 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		return timerService;
 	}
 
-	public ProcessingTimeService getProcessingTimeService(int operatorIndex) {
-		Preconditions.checkState(timerService != null, "The timer service has not been initialized.");
-		MailboxExecutor mailboxExecutor = mailboxProcessor.getMailboxExecutor(operatorIndex);
-		return new ProcessingTimeServiceImpl(timerService, callback -> deferCallbackToMailbox(mailboxExecutor, callback));
+	@VisibleForTesting
+	OP getHeadOperator() {
+		return this.headOperator;
+	}
+
+	public ProcessingTimeServiceFactory getProcessingTimeServiceFactory() {
+		return mailboxExecutor -> {
+			Preconditions.checkState(timerService != null, "The timer service has not been initialized.");
+			return new ProcessingTimeServiceImpl(timerService, callback -> deferCallbackToMailbox(mailboxExecutor, callback));
+		};
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeService.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Deadline;
-import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.NeverCompleteFuture;
 
 import org.slf4j.Logger;
@@ -28,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -58,6 +58,8 @@ public class SystemProcessingTimeService implements TimerService {
 	private final ExceptionHandler exceptionHandler;
 	private final AtomicInteger status;
 
+	private final CompletableFuture<Void> quiesceCompletedFuture;
+
 	@VisibleForTesting
 	SystemProcessingTimeService(ExceptionHandler exceptionHandler) {
 		this(exceptionHandler, null);
@@ -67,11 +69,12 @@ public class SystemProcessingTimeService implements TimerService {
 
 		this.exceptionHandler = checkNotNull(exceptionHandler);
 		this.status = new AtomicInteger(STATUS_ALIVE);
+		this.quiesceCompletedFuture = new CompletableFuture<>();
 
 		if (threadFactory == null) {
-			this.timerService = new ScheduledThreadPoolExecutor(1);
+			this.timerService = new ScheduledTaskExecutor(1);
 		} else {
-			this.timerService = new ScheduledThreadPoolExecutor(1, threadFactory);
+			this.timerService = new ScheduledTaskExecutor(1, threadFactory);
 		}
 
 		// tasks should be removed if the future is canceled
@@ -99,10 +102,7 @@ public class SystemProcessingTimeService implements TimerService {
 	@Override
 	public ScheduledFuture<?> registerTimer(long timestamp, ProcessingTimeCallback callback) {
 
-		// delay the firing of the timer by 1 ms to align the semantics with watermark. A watermark
-		// T says we won't see elements in the future with a timestamp smaller or equal to T.
-		// With processing time, we therefore need to delay firing the timer by one ms.
-		long delay = Math.max(timestamp - getCurrentProcessingTime(), 0) + 1;
+		long delay = ProcessingTimeServiceUtil.getProcessingTimeDelay(timestamp, getCurrentProcessingTime());
 
 		// we directly try to register the timer and only react to the status on exception
 		// that way we save unnecessary volatile accesses for each timer
@@ -166,20 +166,12 @@ public class SystemProcessingTimeService implements TimerService {
 	}
 
 	@Override
-	public void quiesce() throws InterruptedException {
+	public CompletableFuture<Void> quiesce() {
 		if (status.compareAndSet(STATUS_ALIVE, STATUS_QUIESCED)) {
 			timerService.shutdown();
 		}
-	}
 
-	@Override
-	public void awaitPendingAfterQuiesce() throws InterruptedException {
-		if (!timerService.isTerminated()) {
-			Preconditions.checkState(timerService.isTerminating() || timerService.isShutdown());
-
-			// await forever (almost)
-			timerService.awaitTermination(365L, TimeUnit.DAYS);
-		}
+		return quiesceCompletedFuture;
 	}
 
 	@Override
@@ -248,6 +240,23 @@ public class SystemProcessingTimeService implements TimerService {
 	}
 
 	// ------------------------------------------------------------------------
+
+	private class ScheduledTaskExecutor extends ScheduledThreadPoolExecutor {
+
+		public ScheduledTaskExecutor(int corePoolSize) {
+			super(corePoolSize);
+		}
+
+		public ScheduledTaskExecutor(int corePoolSize, ThreadFactory threadFactory) {
+			super(corePoolSize, threadFactory);
+		}
+
+		@Override
+		protected void terminated() {
+			super.terminated();
+			quiesceCompletedFuture.complete(null);
+		}
+	}
 
 	/**
 	 * An exception handler, called when {@link ProcessingTimeCallback} throws an exception.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TestProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TestProcessingTimeService.java
@@ -24,6 +24,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.PriorityQueue;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Delayed;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
@@ -117,16 +118,12 @@ public class TestProcessingTimeService implements TimerService {
 	}
 
 	@Override
-	public void quiesce() {
+	public CompletableFuture<Void> quiesce() {
 		if (!isTerminated) {
 			isQuiesced = true;
 			priorityQueue.clear();
 		}
-	}
-
-	@Override
-	public void awaitPendingAfterQuiesce() throws InterruptedException {
-		// do nothing.
+		return CompletableFuture.completedFuture(null);
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TimerService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TimerService.java
@@ -42,23 +42,6 @@ public interface TimerService extends ProcessingTimeService {
 	boolean isTerminated();
 
 	/**
-	 * This method puts the service into a state where it does not register new timers, but
-	 * returns for each call to {@link #registerTimer(long, ProcessingTimeCallback)} only a "mock" future.
-	 * Furthermore, the method clears all not yet started timers.
-	 *
-	 * <p>This method can be used to cleanly shut down the timer service. The using components
-	 * will not notice that the service is shut down (as for example via exceptions when registering
-	 * a new timer), but the service will simply not fire any timer any more.
-	 */
-	void quiesce() throws InterruptedException;
-
-	/**
-	 * This method can be used after calling {@link #quiesce()}, and awaits the completion
-	 * of currently executing timers.
-	 */
-	void awaitPendingAfterQuiesce() throws InterruptedException;
-
-	/**
 	 * Shuts down and clean up the timer service provider hard and immediately. This does not wait
 	 * for any timer to complete. Any further call to {@link #registerTimer(long, ProcessingTimeCallback)}
 	 * will result in a hard exception.

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -276,6 +276,7 @@ public class AsyncWaitOperatorTest extends TestLogger {
 
 		// wait until all async collectors in the buffer have been emitted out.
 		synchronized (testHarness.getCheckpointLock()) {
+			testHarness.endInput();
 			testHarness.close();
 		}
 
@@ -347,6 +348,7 @@ public class AsyncWaitOperatorTest extends TestLogger {
 		expectedOutput.add(new StreamRecord<>(16, initialTime + 8));
 
 		synchronized (testHarness.getCheckpointLock()) {
+			testHarness.endInput();
 			testHarness.close();
 		}
 
@@ -665,6 +667,7 @@ public class AsyncWaitOperatorTest extends TestLogger {
 
 		// wait until all async collectors in the buffer have been emitted out.
 		synchronized (testHarness.getCheckpointLock()) {
+			testHarness.endInput();
 			testHarness.close();
 		}
 
@@ -698,6 +701,7 @@ public class AsyncWaitOperatorTest extends TestLogger {
 		}
 
 		synchronized (harness.getCheckpointLock()) {
+			harness.endInput();
 			harness.close();
 		}
 
@@ -861,6 +865,7 @@ public class AsyncWaitOperatorTest extends TestLogger {
 		}
 
 		synchronized (recoverHarness.getCheckpointLock()) {
+			recoverHarness.endInput();
 			recoverHarness.close();
 		}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/MailboxOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/MailboxOperatorTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.MailboxExecutor;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
@@ -80,8 +81,9 @@ public class MailboxOperatorTest extends TestLogger {
 		assertThat(numMailsProcessed, is(Arrays.asList(0, 2, 4)));
 	}
 
-	private static class ReplicatingMailOperatorFactory implements OneInputStreamOperatorFactory<Integer, Integer>,
-			YieldingOperatorFactory<Integer> {
+	private static class ReplicatingMailOperatorFactory extends AbstractStreamOperatorFactory<Integer>
+		implements OneInputStreamOperatorFactory<Integer, Integer>,	YieldingOperatorFactory<Integer> {
+
 		private MailboxExecutor mailboxExecutor;
 
 		@Override
@@ -95,17 +97,13 @@ public class MailboxOperatorTest extends TestLogger {
 				StreamConfig config,
 				Output<StreamRecord<Integer>> output) {
 			ReplicatingMailOperator operator = new ReplicatingMailOperator(mailboxExecutor);
+			operator.setProcessingTimeService(processingTimeService);
 			operator.setup(containingTask, config, output);
 			return (Operator) operator;
 		}
 
 		@Override
 		public void setChainingStrategy(ChainingStrategy strategy) {
-		}
-
-		@Override
-		public ChainingStrategy getChainingStrategy() {
-			return ChainingStrategy.ALWAYS;
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/MailboxOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/MailboxOperatorTest.java
@@ -39,7 +39,7 @@ import org.apache.flink.util.function.RunnableWithException;
 
 import org.junit.Test;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.stream.Collectors;
@@ -60,31 +60,43 @@ public class MailboxOperatorTest extends TestLogger {
 			BasicTypeInfo.INT_TYPE_INFO,
 			BasicTypeInfo.INT_TYPE_INFO);
 
-		testHarness.setupOperatorChain(new OperatorID(), new ReplicatingMailOperatorFactory())
-			.chain(new OperatorID(), new ReplicatingMailOperatorFactory(), IntSerializer.INSTANCE)
+		final int maxProcessingElements = 3;
+
+		testHarness.setupOperatorChain(new OperatorID(), new ReplicatingMailOperatorFactory(maxProcessingElements))
+			.chain(new OperatorID(), new ReplicatingMailOperatorFactory(maxProcessingElements), IntSerializer.INSTANCE)
 			.finish();
 
 		testHarness.invoke();
 		testHarness.waitForTaskRunning();
 
-		testHarness.processElement(new StreamRecord<>(0));
-		testHarness.processElement(new StreamRecord<>(0));
-		testHarness.processElement(new StreamRecord<>(0));
+		for (int i = 0; i < maxProcessingElements; i++) {
+			testHarness.processElement(new StreamRecord<>(0));
+		}
 
 		testHarness.endInput();
 		testHarness.waitForTaskCompletion();
 
 		// with each input two mails should be processed, one of each operator in the chain
+		List<Integer> expected = new ArrayList<>();
+		for (int i = 0; i < maxProcessingElements; i++) {
+			expected.add(i * 2);
+		}
 		List<Integer> numMailsProcessed = testHarness.getOutput().stream()
 			.map(element -> ((StreamRecord<Integer>) element).getValue())
 			.collect(Collectors.toList());
-		assertThat(numMailsProcessed, is(Arrays.asList(0, 2, 4)));
+		assertThat(numMailsProcessed, is(expected));
 	}
 
 	private static class ReplicatingMailOperatorFactory extends AbstractStreamOperatorFactory<Integer>
 		implements OneInputStreamOperatorFactory<Integer, Integer>,	YieldingOperatorFactory<Integer> {
 
+		private final int maxProcessingElements;
+
 		private MailboxExecutor mailboxExecutor;
+
+		ReplicatingMailOperatorFactory(final int maxProcessingElements) {
+			this.maxProcessingElements = maxProcessingElements;
+		}
 
 		@Override
 		public void setMailboxExecutor(MailboxExecutor mailboxExecutor) {
@@ -96,7 +108,7 @@ public class MailboxOperatorTest extends TestLogger {
 				StreamTask<?, ?> containingTask,
 				StreamConfig config,
 				Output<StreamRecord<Integer>> output) {
-			ReplicatingMailOperator operator = new ReplicatingMailOperator(mailboxExecutor);
+			ReplicatingMailOperator operator = new ReplicatingMailOperator(maxProcessingElements, mailboxExecutor);
 			operator.setProcessingTimeService(processingTimeService);
 			operator.setup(containingTask, config, output);
 			return (Operator) operator;
@@ -114,25 +126,42 @@ public class MailboxOperatorTest extends TestLogger {
 
 	private static class ReplicatingMailOperator extends AbstractStreamOperator<Integer>
 			implements OneInputStreamOperator<Integer, Integer> {
+
+		private final int maxProcessingElements;
+
 		private final ReplicatingMail replicatingMail;
 
-		ReplicatingMailOperator(final MailboxExecutor mailboxExecutor) {
-			replicatingMail = new ReplicatingMail(mailboxExecutor);
+		private long numProcessedElements = 0;
+
+		ReplicatingMailOperator(final int maxProcessingElements, final MailboxExecutor mailboxExecutor) {
+			this.maxProcessingElements = maxProcessingElements;
+			this.replicatingMail = new ReplicatingMail(mailboxExecutor);
 		}
 
 		@Override
 		public void processElement(StreamRecord<Integer> upstreamMailCount) throws Exception {
+			if (numProcessedElements >= maxProcessingElements) {
+				return;
+			}
+
 			// for the very first element, enqueue one mail that replicates itself
 			if (!replicatingMail.hasBeenEnqueued()) {
 				replicatingMail.run();
 			}
 			// output how many mails have been processed so far (from upstream and this operator)
 			output.collect(new StreamRecord<>(replicatingMail.getMailCount() + upstreamMailCount.getValue()));
+
+			if (++numProcessedElements == maxProcessingElements) {
+				replicatingMail.stop();
+			}
 		}
 	}
 
 	private static class ReplicatingMail implements RunnableWithException {
 		private int mailCount = -1;
+
+		private boolean stopped = false;
+
 		private final MailboxExecutor mailboxExecutor;
 
 		ReplicatingMail(final MailboxExecutor mailboxExecutor) {
@@ -142,7 +171,9 @@ public class MailboxOperatorTest extends TestLogger {
 		@Override
 		public void run() {
 			try {
-				mailboxExecutor.execute(this, "Blocking mail" + ++mailCount);
+				if (!stopped) {
+					mailboxExecutor.execute(this, "Blocking mail" + ++mailCount);
+				}
 			} catch (RejectedExecutionException e) {
 				// during shutdown the executor will reject new mails, which is fine for us.
 			}
@@ -154,6 +185,10 @@ public class MailboxOperatorTest extends TestLogger {
 
 		int getMailCount() {
 			return mailCount;
+		}
+
+		void stop() {
+			stopped = true;
 		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamOperatorChainingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamOperatorChainingTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.streaming.api.operators.StreamMap;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.OperatorChain;
+import org.apache.flink.streaming.runtime.tasks.StreamOperatorWrapper;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.util.MockStreamTaskBuilder;
 
@@ -133,10 +134,8 @@ public class StreamOperatorChainingTest {
 
 			headOperator.setup(mockTask, streamConfig, operatorChain.getChainEntryPoint());
 
-			for (StreamOperator<?> operator : operatorChain.getAllOperators()) {
-				if (operator != null) {
-					operator.open();
-				}
+			for (StreamOperatorWrapper<?, ?> operatorWrapper : operatorChain.getAllOperators(true)) {
+				operatorWrapper.getStreamOperator().open();
 			}
 
 			headOperator.processElement(new StreamRecord<>(1));
@@ -254,10 +253,8 @@ public class StreamOperatorChainingTest {
 
 			headOperator.setup(mockTask, streamConfig, operatorChain.getChainEntryPoint());
 
-			for (StreamOperator<?> operator : operatorChain.getAllOperators()) {
-				if (operator != null) {
-					operator.open();
-				}
+			for (StreamOperatorWrapper<?, ?> operatorWrapper : operatorChain.getAllOperators(true)) {
+				operatorWrapper.getStreamOperator().open();
 			}
 
 			headOperator.processElement(new StreamRecord<>(1));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
@@ -226,6 +226,7 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
 				.setTimerService(timerService)
 				.build();
 
+			operator.setProcessingTimeService(mockTask.getProcessingTimeServiceFactory().createProcessingTimeService(null));
 			operator.setup(mockTask, cfg, (Output<StreamRecord<T>>) mock(Output.class));
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamTaskTimerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamTaskTimerTest.java
@@ -70,11 +70,7 @@ public class StreamTaskTimerTest extends TestLogger {
 	@Test
 	public void testOpenCloseAndTimestamps() {
 		// first one spawns thread
-		timeService.registerTimer(System.currentTimeMillis(), new ProcessingTimeCallback() {
-			@Override
-			public void onProcessingTime(long timestamp) {
-			}
-		});
+		timeService.registerTimer(System.currentTimeMillis(), timestamp -> {});
 
 		assertEquals(1, StreamTask.TRIGGER_THREAD_GROUP.activeCount());
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamTaskTimerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamTaskTimerTest.java
@@ -56,7 +56,10 @@ public class StreamTaskTimerTest extends TestLogger {
 	@Before
 	public void setup() throws Exception {
 		testHarness = startTestHarness();
-		timeService = testHarness.getTask().getProcessingTimeService(0);
+
+		StreamTask<?, ?> task = testHarness.getTask();
+		timeService = task.getProcessingTimeServiceFactory().createProcessingTimeService(
+			task.getMailboxExecutorFactory().createExecutor(testHarness.getStreamConfig().getChainIndex()));
 	}
 
 	@After
@@ -175,6 +178,7 @@ public class StreamTaskTimerTest extends TestLogger {
 		testHarness.setupOutputForSingletonOperatorChain();
 
 		StreamConfig streamConfig = testHarness.getStreamConfig();
+		streamConfig.setChainIndex(0);
 		streamConfig.setStreamOperator(new StreamMap<String, String>(new DummyMapFunction<>()));
 
 		testHarness.invoke();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TestProcessingTimeServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TestProcessingTimeServiceTest.java
@@ -56,7 +56,7 @@ public class TestProcessingTimeServiceTest {
 
 		testHarness.invoke();
 
-		ProcessingTimeService processingTimeService = testHarness.getTask().getProcessingTimeService(0);
+		ProcessingTimeService processingTimeService = ((StreamMap<?, ?>) testHarness.getHeadOperator()).getProcessingTimeService();
 
 		assertEquals(Long.MIN_VALUE, processingTimeService.getCurrentProcessingTime());
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TestProcessingTimeServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TestProcessingTimeServiceTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.StreamMap;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTaskTestHarness;
-import org.apache.flink.streaming.runtime.tasks.ProcessingTimeCallback;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 
@@ -50,7 +49,7 @@ public class TestProcessingTimeServiceTest {
 
 		StreamConfig streamConfig = testHarness.getStreamConfig();
 
-		StreamMap<String, String> mapOperator = new StreamMap<>(new StreamTaskTimerTest.DummyMapFunction<String>());
+		StreamMap<String, String> mapOperator = new StreamMap<>(new StreamTaskTimerTest.DummyMapFunction<>());
 		streamConfig.setStreamOperator(mapOperator);
 		streamConfig.setOperatorID(new OperatorID());
 
@@ -69,19 +68,9 @@ public class TestProcessingTimeServiceTest {
 		assertEquals(processingTimeService.getCurrentProcessingTime(), 16);
 
 		// register 2 tasks
-		processingTimeService.registerTimer(30, new ProcessingTimeCallback() {
-			@Override
-			public void onProcessingTime(long timestamp) {
+		processingTimeService.registerTimer(30, timestamp -> {});
 
-			}
-		});
-
-		processingTimeService.registerTimer(40, new ProcessingTimeCallback() {
-			@Override
-			public void onProcessingTime(long timestamp) {
-
-			}
-		});
+		processingTimeService.registerTimer(40, timestamp -> {});
 
 		assertEquals(2, tp.getNumActiveTimers());
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TestProcessingTimeServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TestProcessingTimeServiceTest.java
@@ -55,6 +55,7 @@ public class TestProcessingTimeServiceTest {
 		streamConfig.setOperatorID(new OperatorID());
 
 		testHarness.invoke();
+		testHarness.waitForTaskRunning();
 
 		ProcessingTimeService processingTimeService = ((StreamMap<?, ?>) testHarness.getHeadOperator()).getProcessingTimeService();
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -84,6 +84,7 @@ import scala.concurrent.duration.Deadline;
 import scala.concurrent.duration.FiniteDuration;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -602,7 +603,7 @@ public class OneInputStreamTaskTest extends TestLogger {
 	}
 
 	@Test
-	public void testHandlingEndOfInput() throws Exception {
+	public void testClosingAllOperatorsOnChainProperly() throws Exception {
 		final OneInputStreamTaskTestHarness<String, String> testHarness = new OneInputStreamTaskTestHarness<>(
 			OneInputStreamTask::new,
 			BasicTypeInfo.STRING_TYPE_INFO,
@@ -616,8 +617,6 @@ public class OneInputStreamTaskTest extends TestLogger {
 				BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()))
 			.finish();
 
-		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
-
 		testHarness.invoke();
 		testHarness.waitForTaskRunning();
 
@@ -626,15 +625,16 @@ public class OneInputStreamTaskTest extends TestLogger {
 
 		testHarness.waitForTaskCompletion();
 
-		expectedOutput.add(new StreamRecord<>("Hello"));
-		expectedOutput.add(new StreamRecord<>("[Operator0]: EndOfInput"));
-		expectedOutput.add(new StreamRecord<>("[Operator0]: Bye"));
-		expectedOutput.add(new StreamRecord<>("[Operator1]: EndOfInput"));
-		expectedOutput.add(new StreamRecord<>("[Operator1]: Bye"));
+		ArrayList<StreamRecord<String>> expected = new ArrayList<>();
+		Collections.addAll(expected,
+			new StreamRecord<>("Hello"),
+			new StreamRecord<>("[Operator0]: End of input"),
+			new StreamRecord<>("[Operator0]: Bye"),
+			new StreamRecord<>("[Operator1]: End of input"),
+			new StreamRecord<>("[Operator1]: Bye"));
 
-		TestHarnessUtil.assertOutputEquals("Output was not correct.",
-			expectedOutput,
-			testHarness.getOutput());
+		final Object[] output = testHarness.getOutput().toArray();
+		assertArrayEquals("Output was not correct.", expected.toArray(), output);
 	}
 
 	private static class TestOperator

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OperatorChainTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OperatorChainTest.java
@@ -38,6 +38,9 @@ import org.apache.flink.streaming.util.MockStreamTaskBuilder;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -72,7 +75,7 @@ public class OperatorChainTest {
 	// ------------------------------------------------------------------------
 
 	@SafeVarargs
-	private static <T, OP extends StreamOperator<T>> OperatorChain<T, OP> setupOperatorChain(
+	public static <T, OP extends StreamOperator<T>> OperatorChain<T, OP> setupOperatorChain(
 			OneInputStreamOperator<T, T>... operators) throws Exception {
 
 		checkNotNull(operators);
@@ -84,7 +87,7 @@ public class OperatorChainTest {
 			final StreamStatusProvider statusProvider = mock(StreamStatusProvider.class);
 			final StreamConfig cfg = new StreamConfig(new Configuration());
 
-			final StreamOperator<?>[] ops = new StreamOperator<?>[operators.length];
+			final List<StreamOperatorWrapper<?, ?>> operatorWrappers = new ArrayList<>();
 
 			// initial output goes to nowhere
 			@SuppressWarnings({"unchecked", "rawtypes"})
@@ -92,23 +95,31 @@ public class OperatorChainTest {
 					new Output[0], statusProvider);
 
 			// build the reverse operators array
-			for (int i = 0; i < ops.length; i++) {
-				OneInputStreamOperator<T, T> op = operators[ops.length - i - 1];
+			for (int i = 0; i < operators.length; i++) {
+				OneInputStreamOperator<T, T> op = operators[operators.length - i - 1];
 				if (op instanceof SetupableStreamOperator) {
 					((SetupableStreamOperator) op).setup(containingTask, cfg, lastWriter);
 				}
 				lastWriter = new ChainingOutput<>(op, statusProvider, null);
-				ops[i] = op;
+
+				ProcessingTimeService processingTimeService = null;
+				if (op instanceof AbstractStreamOperator) {
+					processingTimeService = ((AbstractStreamOperator) op).getProcessingTimeService();
+				}
+				operatorWrappers.add(new StreamOperatorWrapper<>(
+					op,
+					Optional.ofNullable(processingTimeService),
+					containingTask.getMailboxExecutorFactory().createExecutor(i)));
 			}
 
 			@SuppressWarnings("unchecked")
-			final OP head = (OP) operators[0];
+			final StreamOperatorWrapper<T, OP> headOperatorWrapper = (StreamOperatorWrapper<T, OP>) operatorWrappers.get(operatorWrappers.size() - 1);
 
 			return new OperatorChain<>(
-					ops,
-					new RecordWriterOutput<?>[0],
-					lastWriter,
-					head);
+				operatorWrappers,
+				new RecordWriterOutput<?>[0],
+				lastWriter,
+				headOperatorWrapper);
 		}
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeServiceImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeServiceImplTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.NeverCompleteFuture;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link ProcessingTimeServiceImpl}.
+ */
+public class ProcessingTimeServiceImplTest extends TestLogger {
+
+	private static final Time testingTimeout = Time.seconds(10L);
+
+	private SystemProcessingTimeService timerService;
+
+	@Before
+	public void setup() {
+		CompletableFuture<Throwable> errorFuture = new CompletableFuture<>();
+
+		timerService = new SystemProcessingTimeService(errorFuture::complete);
+	}
+
+	@After
+	public void teardown() {
+		timerService.shutdownService();
+	}
+
+	@Test
+	public void testTimerRegistrationAndCancellation() throws TimeoutException, InterruptedException, ExecutionException {
+		ProcessingTimeServiceImpl processingTimeService = new ProcessingTimeServiceImpl(timerService, v -> v);
+
+		// test registerTimer() and cancellation
+		ScheduledFuture<?> neverFiredTimer = processingTimeService.registerTimer(Long.MAX_VALUE, timestamp -> {});
+		assertEquals(1, timerService.getNumTasksScheduled());
+		assertTrue(neverFiredTimer.cancel(false));
+		assertTrue(neverFiredTimer.isDone());
+		assertTrue(neverFiredTimer.isCancelled());
+
+		final CompletableFuture<?> firedTimerFuture = new CompletableFuture<>();
+		ScheduledFuture<?> firedTimer = processingTimeService.registerTimer(0, timestamp -> firedTimerFuture.complete(null));
+		firedTimer.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+		assertTrue(firedTimerFuture.isDone());
+		assertFalse(firedTimer.isCancelled());
+
+		// test scheduleAtFixedRate() and cancellation
+		final CompletableFuture<?> periodicTimerFuture = new CompletableFuture<>();
+		ScheduledFuture<?> periodicTimer = processingTimeService.scheduleAtFixedRate(
+			timestamp -> periodicTimerFuture.complete(null), 0, Long.MAX_VALUE);
+
+		periodicTimerFuture.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+		assertTrue(periodicTimer.cancel(false));
+		assertTrue(periodicTimer.isDone());
+		assertTrue(periodicTimer.isCancelled());
+	}
+
+	@Test
+	public void testQuiesce() throws Exception {
+		ProcessingTimeServiceImpl processingTimeService = new ProcessingTimeServiceImpl(timerService, v -> v);
+
+		final CompletableFuture<?> timerRunFuture = new CompletableFuture();
+		final OneShotLatch timerWaitLatch = new OneShotLatch();
+
+		ScheduledFuture<?> timer = processingTimeService.registerTimer(0, timestamp -> {
+			timerRunFuture.complete(null);
+			timerWaitLatch.await();
+		});
+
+		// wait for the timer to run, then quiesce the time service
+		timerRunFuture.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+		CompletableFuture<?> quiesceCompletedFuture = processingTimeService.quiesce();
+
+		// after the timer server is quiesced, tests #registerTimer() and #scheduleAtFixedRate()
+		assertThat(processingTimeService.registerTimer(0, timestamp -> {}), is(instanceOf(NeverCompleteFuture.class)));
+		assertThat(processingTimeService.scheduleAtFixedRate(
+			timestamp -> {}, 0, Long.MAX_VALUE), is(instanceOf(NeverCompleteFuture.class)));
+
+		// when the timer is finished, the quiesce-completed future should be completed
+		assertFalse(quiesceCompletedFuture.isDone());
+		timerWaitLatch.trigger();
+		timer.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+		assertTrue(quiesceCompletedFuture.isDone());
+	}
+
+	@Test
+	public void testQuiesceWhenNoRunningTimers() {
+		ProcessingTimeServiceImpl processingTimeService = new ProcessingTimeServiceImpl(timerService, v -> v);
+		assertTrue(processingTimeService.quiesce().isDone());
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.MultiShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.execution.CancelTaskException;
@@ -51,6 +52,7 @@ import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
@@ -66,6 +68,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.flink.util.Preconditions.checkState;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -170,7 +173,7 @@ public class SourceStreamTaskTest {
 	}
 
 	@Test
-	public void testMarkingEndOfInput() throws Exception {
+	public void testClosingAllOperatorsOnChainProperly() throws Exception {
 		final StreamTaskTestHarness<String> testHarness = new StreamTaskTestHarness<>(
 			SourceStreamTask::new,
 			BasicTypeInfo.STRING_TYPE_INFO);
@@ -189,20 +192,19 @@ public class SourceStreamTaskTest {
 		StreamConfig streamConfig = testHarness.getStreamConfig();
 		streamConfig.setTimeCharacteristic(TimeCharacteristic.ProcessingTime);
 
-		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
-
 		testHarness.invoke();
 		testHarness.waitForTaskCompletion();
 
-		expectedOutput.add(new StreamRecord<>("Hello"));
-		expectedOutput.add(new StreamRecord<>("[Source0]: EndOfInput"));
-		expectedOutput.add(new StreamRecord<>("[Source0]: Bye"));
-		expectedOutput.add(new StreamRecord<>("[Operator1]: EndOfInput"));
-		expectedOutput.add(new StreamRecord<>("[Operator1]: Bye"));
+		ArrayList<StreamRecord<String>> expected = new ArrayList<>();
+		Collections.addAll(expected,
+			new StreamRecord<>("Hello"),
+			new StreamRecord<>("[Source0]: End of input"),
+			new StreamRecord<>("[Source0]: Bye"),
+			new StreamRecord<>("[Operator1]: End of input"),
+			new StreamRecord<>("[Operator1]: Bye"));
 
-		TestHarnessUtil.assertOutputEquals("Output was not correct.",
-			expectedOutput,
-			testHarness.getOutput());
+		final Object[] output = testHarness.getOutput().toArray();
+		assertArrayEquals("Output was not correct.", expected.toArray(), output);
 	}
 
 	@Test
@@ -228,7 +230,7 @@ public class SourceStreamTaskTest {
 		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
 
 		testHarness.invoke();
-		CancelTestSource.getDataProcessing().get();
+		CancelTestSource.getDataProcessing().await();
 		testHarness.getTask().cancel();
 
 		try {
@@ -616,9 +618,9 @@ public class SourceStreamTaskTest {
 	private static class CancelTestSource extends FromElementsFunction<String> {
 		private static final long serialVersionUID = 8713065281092996067L;
 
-		private static CompletableFuture<Void> dataProcessing = new CompletableFuture<>();
+		private static MultiShotLatch dataProcessing = new MultiShotLatch();
 
-		private static CompletableFuture<Void> cancellationWaiting = new CompletableFuture<>();
+		private static MultiShotLatch cancellationWaiting = new MultiShotLatch();
 
 		public CancelTestSource(TypeSerializer<String> serializer, String... elements) throws IOException {
 			super(serializer, elements);
@@ -628,18 +630,17 @@ public class SourceStreamTaskTest {
 		public void run(SourceContext<String> ctx) throws Exception {
 			super.run(ctx);
 
-			dataProcessing.complete(null);
-			cancellationWaiting.get();
+			dataProcessing.trigger();
+			cancellationWaiting.await();
 		}
 
 		@Override
 		public void cancel() {
 			super.cancel();
-
-			cancellationWaiting.complete(null);
+			cancellationWaiting.trigger();
 		}
 
-		public static CompletableFuture<Void> getDataProcessing() {
+		public static MultiShotLatch getDataProcessing() {
 			return dataProcessing;
 		}
 	}
@@ -696,12 +697,20 @@ public class SourceStreamTaskTest {
 
 		@Override
 		public void endInput() {
-			output.collect(new StreamRecord<>("[" + name + "]: EndOfInput"));
+			output("[" + name + "]: End of input");
 		}
 
 		@Override
-		public void close() {
-			output.collect(new StreamRecord<>("[" + name + "]: Bye"));
+		public void close() throws Exception {
+			ProcessingTimeService timeService = getProcessingTimeService();
+			timeService.registerTimer(timeService.getCurrentProcessingTime(), t -> output("[" + name + "]: Timer registered in close"));
+
+			output("[" + name + "]: Bye");
+			super.close();
+		}
+
+		private void output(String record) {
+			output.collect(new StreamRecord<>(record));
 		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamOperatorWrapperTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamOperatorWrapperTest.java
@@ -1,0 +1,301 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.MailboxExecutor;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.MockStreamTaskBuilder;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link StreamOperatorWrapper}.
+ */
+public class StreamOperatorWrapperTest extends TestLogger {
+
+	private static SystemProcessingTimeService timerService;
+
+	private static final int numOperators = 3;
+
+	private List<StreamOperatorWrapper<?, ?>> operatorWrappers;
+
+	private ConcurrentLinkedQueue<Object> output;
+
+	private volatile StreamTask<?, ?> containingTask;
+
+	@BeforeClass
+	public static void startTimeService() {
+		CompletableFuture<Throwable> errorFuture = new CompletableFuture<>();
+		timerService = new SystemProcessingTimeService(errorFuture::complete);
+	}
+
+	@AfterClass
+	public static void shutdownTimeService() {
+		timerService.shutdownService();
+	}
+
+	@Before
+	public void setup() throws Exception {
+		this.operatorWrappers = new ArrayList<>();
+		this.output = new ConcurrentLinkedQueue<>();
+
+		try (MockEnvironment env = MockEnvironment.builder().build()) {
+			this.containingTask = new MockStreamTaskBuilder(env).build();
+
+			// initialize operator wrappers
+			for (int i = 0; i < numOperators; i++) {
+				MailboxExecutor mailboxExecutor = containingTask.getMailboxExecutorFactory().createExecutor(i);
+
+				TimerMailController timerMailController = new TimerMailController(containingTask, mailboxExecutor);
+				ProcessingTimeServiceImpl processingTimeService = new ProcessingTimeServiceImpl(
+					timerService,
+					timerMailController::wrapCallback);
+
+				TestOneInputStreamOperator streamOperator = new TestOneInputStreamOperator(
+					"Operator" + i, output, processingTimeService, mailboxExecutor, timerMailController);
+				streamOperator.setProcessingTimeService(processingTimeService);
+
+				StreamOperatorWrapper<?, ?> operatorWrapper = new StreamOperatorWrapper<>(
+					streamOperator,
+					Optional.ofNullable(streamOperator.getProcessingTimeService()),
+					mailboxExecutor);
+				operatorWrappers.add(operatorWrapper);
+			}
+
+			StreamOperatorWrapper<?, ?> previous = null;
+			for (StreamOperatorWrapper<?, ?> current : operatorWrappers) {
+				if (previous != null) {
+					previous.setNext(current);
+				}
+				current.setPrevious(previous);
+				previous = current;
+			}
+		}
+	}
+
+	@After
+	public void teardown() throws Exception {
+		containingTask.cleanup();
+	}
+
+	@Test
+	public void testClose() throws Exception {
+		output.clear();
+		operatorWrappers.get(0).close(containingTask.getActionExecutor());
+
+		List<Object> expected = new ArrayList<>();
+		for (int i = 0; i < operatorWrappers.size(); i++) {
+			String prefix = "[" + "Operator" + i + "]";
+			Collections.addAll(expected,
+				prefix + ": End of input",
+				prefix + ": Timer that was in mailbox before closing operator",
+				prefix + ": Bye",
+				prefix + ": Mail to put in mailbox when closing operator");
+		}
+
+		assertArrayEquals(
+			"Output was not correct.",
+			expected.subList(2, expected.size()).toArray(),
+			output.toArray()
+		);
+	}
+
+	@Test
+	public void testClosingOperatorWithException() {
+		AbstractStreamOperator streamOperator = new AbstractStreamOperator<Void>() {
+			@Override
+			public void close() throws Exception {
+				throw new Exception("test exception at closing");
+			}
+		};
+
+		StreamOperatorWrapper<?, ?> operatorWrapper = new StreamOperatorWrapper<>(
+			streamOperator,
+			Optional.ofNullable(streamOperator.getProcessingTimeService()),
+			containingTask.getMailboxExecutorFactory().createExecutor(Integer.MAX_VALUE - 1));
+
+		try {
+			operatorWrapper.close(containingTask.getActionExecutor());
+			fail("should throw an exception");
+		} catch (Throwable t) {
+			Optional<Throwable> optional = ExceptionUtils.findThrowableWithMessage(t, "test exception at closing");
+			assertTrue(optional.isPresent());
+		}
+	}
+
+	@Test
+	public void testReadIterator() {
+		// traverse operators in forward order
+		Iterator<StreamOperatorWrapper<?, ?>> it = new StreamOperatorWrapper.ReadIterator(operatorWrappers.get(0), false);
+		for (int i = 0; i < operatorWrappers.size(); i++) {
+			assertTrue(it.hasNext());
+
+			StreamOperatorWrapper<?, ?> next = it.next();
+			assertNotNull(next);
+
+			TestOneInputStreamOperator operator = getStreamOperatorFromWrapper(next);
+			assertEquals("Operator" + i, operator.getName());
+		}
+		assertFalse(it.hasNext());
+
+		// traverse operators in reverse order
+		it = new StreamOperatorWrapper.ReadIterator(operatorWrappers.get(operatorWrappers.size() - 1), true);
+		for (int i = operatorWrappers.size() - 1; i >= 0; i--) {
+			assertTrue(it.hasNext());
+
+			StreamOperatorWrapper<?, ?> next = it.next();
+			assertNotNull(next);
+
+			TestOneInputStreamOperator operator = getStreamOperatorFromWrapper(next);
+			assertEquals("Operator" + i, operator.getName());
+		}
+		assertFalse(it.hasNext());
+	}
+
+	private TestOneInputStreamOperator getStreamOperatorFromWrapper(StreamOperatorWrapper<?, ?> operatorWrapper) {
+		return (TestOneInputStreamOperator) Objects.requireNonNull(operatorWrapper.getStreamOperator());
+	}
+
+	private static class TimerMailController {
+
+		private final StreamTask<?, ?> containingTask;
+
+		private final MailboxExecutor mailboxExecutor;
+
+		private final ConcurrentHashMap<ProcessingTimeCallback, OneShotLatch> puttingLatches;
+
+		private final ConcurrentHashMap<ProcessingTimeCallback, OneShotLatch> inMailboxLatches;
+
+		TimerMailController(StreamTask<?, ?> containingTask, MailboxExecutor mailboxExecutor) {
+			this.containingTask = containingTask;
+			this.mailboxExecutor = mailboxExecutor;
+
+			this.puttingLatches = new ConcurrentHashMap<>();
+			this.inMailboxLatches = new ConcurrentHashMap<>();
+		}
+
+		OneShotLatch getPuttingLatch(ProcessingTimeCallback callback) {
+			return puttingLatches.get(callback);
+		}
+
+		OneShotLatch getInMailboxLatch(ProcessingTimeCallback callback) {
+			return inMailboxLatches.get(callback);
+		}
+
+		ProcessingTimeCallback wrapCallback(ProcessingTimeCallback callback) {
+			puttingLatches.put(callback, new OneShotLatch());
+			inMailboxLatches.put(callback, new OneShotLatch());
+
+			return timestamp -> {
+				puttingLatches.get(callback).trigger();
+				containingTask.deferCallbackToMailbox(mailboxExecutor, callback).onProcessingTime(timestamp);
+				inMailboxLatches.get(callback).trigger();
+			};
+		}
+	}
+
+	private static class TestOneInputStreamOperator extends AbstractStreamOperator<String>
+		implements OneInputStreamOperator<String, String>, BoundedOneInput {
+
+		private static final long serialVersionUID = 1L;
+
+		private final String name;
+
+		private final ConcurrentLinkedQueue<Object> output;
+
+		private final ProcessingTimeService processingTimeService;
+
+		private final MailboxExecutor mailboxExecutor;
+
+		private final TimerMailController timerMailController;
+
+		TestOneInputStreamOperator(
+			String name,
+			ConcurrentLinkedQueue<Object> output,
+			ProcessingTimeService processingTimeService,
+			MailboxExecutor mailboxExecutor,
+			TimerMailController timerMailController) {
+
+			this.name = name;
+			this.output = output;
+			this.processingTimeService = processingTimeService;
+			this.mailboxExecutor = mailboxExecutor;
+			this.timerMailController = timerMailController;
+
+			processingTimeService.registerTimer(
+				Long.MAX_VALUE, t2 -> output.add("[" + name + "]: Timer not triggered"));
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		@Override
+		public void processElement(StreamRecord<String> element) {}
+
+		@Override
+		public void endInput() throws InterruptedException {
+			output.add("[" + name + "]: End of input");
+
+			ProcessingTimeCallback callback = t1 -> output.add("[" + name + "]: Timer that was in mailbox before closing operator");
+			processingTimeService.registerTimer(0, callback);
+			timerMailController.getInMailboxLatch(callback).await();
+		}
+
+		@Override
+		public void close() throws Exception {
+			ProcessingTimeCallback callback = t1 -> output.add("[" + name + "]: Timer to put in mailbox when closing operator");
+			assertNotNull(processingTimeService.registerTimer(0, callback));
+			assertNull(timerMailController.getPuttingLatch(callback));
+
+			mailboxExecutor.submit(() -> output.add("[" + name + "]: Mail to put in mailbox when closing operator"), "");
+
+			output.add("[" + name + "]: Bye");
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -110,6 +110,7 @@ import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.InternalTimeServiceManager;
 import org.apache.flink.streaming.api.operators.MailboxExecutor;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.StreamMap;
@@ -477,9 +478,10 @@ public class StreamTaskTest extends TestLogger {
 		RunningTask<MockStreamTask> task = runTask(() -> createMockStreamTask(
 			declineDummyEnvironment,
 			operatorChain(
+				streamOperatorWithSnapshotException(testException),
 				streamOperatorWithSnapshot(operatorSnapshotResult1),
-				streamOperatorWithSnapshot(operatorSnapshotResult2),
-				streamOperatorWithSnapshotException(testException))));
+				streamOperatorWithSnapshot(operatorSnapshotResult2)
+				)));
 		MockStreamTask streamTask = task.streamTask;
 
 		waitTaskIsRunning(streamTask, task.invocationFuture);
@@ -737,7 +739,7 @@ public class StreamTaskTest extends TestLogger {
 			DoneFuture.of(SnapshotResult.of(managedOperatorStateHandle)),
 			DoneFuture.of(SnapshotResult.of(rawOperatorStateHandle)));
 
-		final StreamOperator<?> streamOperator = streamOperatorWithSnapshot(operatorSnapshotResult);
+		final OneInputStreamOperator<String, String> streamOperator = streamOperatorWithSnapshot(operatorSnapshotResult);
 
 		final AcknowledgeDummyEnvironment mockEnvironment = new AcknowledgeDummyEnvironment();
 
@@ -814,7 +816,7 @@ public class StreamTaskTest extends TestLogger {
 			checkpointResponder);
 
 		// mock the operator with empty snapshot result (all state handles are null)
-		StreamOperator<?> statelessOperator = streamOperatorWithSnapshot(new OperatorSnapshotFutures());
+		OneInputStreamOperator<String, String> statelessOperator = streamOperatorWithSnapshot(new OperatorSnapshotFutures());
 
 		try (MockEnvironment mockEnvironment = new MockEnvironmentBuilder()
 			.setTaskStateManager(taskStateManager)
@@ -1031,8 +1033,9 @@ public class StreamTaskTest extends TestLogger {
 	//  Test Utilities
 	// ------------------------------------------------------------------------
 
-	private static StreamOperator<?> streamOperatorWithSnapshot(OperatorSnapshotFutures operatorSnapshotResult) throws Exception {
-		StreamOperator<?> operator = mock(StreamOperator.class);
+	private static <T> OneInputStreamOperator<T, T> streamOperatorWithSnapshot(OperatorSnapshotFutures operatorSnapshotResult) throws Exception {
+		@SuppressWarnings("unchecked")
+		OneInputStreamOperator<T, T> operator = mock(OneInputStreamOperator.class);
 		when(operator.getOperatorID()).thenReturn(new OperatorID());
 
 		when(operator.snapshotState(anyLong(), anyLong(), any(CheckpointOptions.class), any(CheckpointStreamFactory.class)))
@@ -1041,8 +1044,9 @@ public class StreamTaskTest extends TestLogger {
 		return operator;
 	}
 
-	private static StreamOperator<?> streamOperatorWithSnapshotException(Exception exception) throws Exception {
-		StreamOperator<?> operator = mock(StreamOperator.class);
+	private static <T> OneInputStreamOperator<T, T> streamOperatorWithSnapshotException(Exception exception) throws Exception {
+		@SuppressWarnings("unchecked")
+		OneInputStreamOperator<T, T> operator = mock(OneInputStreamOperator.class);
 		when(operator.getOperatorID()).thenReturn(new OperatorID());
 
 		when(operator.snapshotState(anyLong(), anyLong(), any(CheckpointOptions.class), any(CheckpointStreamFactory.class)))
@@ -1051,10 +1055,8 @@ public class StreamTaskTest extends TestLogger {
 		return operator;
 	}
 
-	private static <T> OperatorChain<T, AbstractStreamOperator<T>> operatorChain(StreamOperator<?>... streamOperators) {
-		OperatorChain<T, AbstractStreamOperator<T>> operatorChain = mock(OperatorChain.class);
-		when(operatorChain.getAllOperators()).thenReturn(streamOperators);
-		return operatorChain;
+	private static <T> OperatorChain<T, AbstractStreamOperator<T>> operatorChain(OneInputStreamOperator<T, T>... streamOperators) throws Exception {
+		return OperatorChainTest.setupOperatorChain(streamOperators);
 	}
 
 	private static class RunningTask<T extends StreamTask<?, ?>> {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -43,7 +43,6 @@ import org.apache.flink.runtime.state.LocalRecoveryDirectoryProviderImpl;
 import org.apache.flink.runtime.state.TestLocalRecoveryConfig;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.streaming.api.TimeCharacteristic;
-import org.apache.flink.streaming.api.collector.selector.OutputSelector;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.graph.StreamNode;
@@ -90,8 +89,8 @@ public class StreamTaskTestHarness<OUT> {
 
 	private final Function<Environment, ? extends StreamTask<OUT, ?>> taskFactory;
 
-	public long memorySize = 0;
-	public int bufferSize = 0;
+	public long memorySize;
+	public int bufferSize;
 
 	protected StreamMockEnvironment mockEnv;
 	protected ExecutionConfig executionConfig;
@@ -148,7 +147,7 @@ public class StreamTaskTestHarness<OUT> {
 		streamConfig.setBufferTimeout(0);
 
 		outputSerializer = outputType.createSerializer(executionConfig);
-		outputStreamRecordSerializer = new StreamElementSerializer<OUT>(outputSerializer);
+		outputStreamRecordSerializer = new StreamElementSerializer<>(outputSerializer);
 
 		this.taskStateManager = new TestTaskStateManager(localRecoveryConfig);
 	}
@@ -181,9 +180,8 @@ public class StreamTaskTestHarness<OUT> {
 			Collections.singletonMap(checkpointId, taskStateSnapshot));
 	}
 
-	@SuppressWarnings("unchecked")
 	private void initializeOutput() {
-		outputList = new LinkedBlockingQueue<Object>();
+		outputList = new LinkedBlockingQueue<>();
 		mockEnv.addOutput(outputList, outputStreamRecordSerializer);
 	}
 
@@ -200,7 +198,7 @@ public class StreamTaskTestHarness<OUT> {
 		setupCalled = true;
 		streamConfig.setChainStart();
 		streamConfig.setTimeCharacteristic(TimeCharacteristic.EventTime);
-		streamConfig.setOutputSelectors(Collections.<OutputSelector<?>>emptyList());
+		streamConfig.setOutputSelectors(Collections.emptyList());
 		streamConfig.setNumberOfOutputs(1);
 		streamConfig.setTypeSerializerOut(outputSerializer);
 		streamConfig.setVertexID(0);
@@ -210,11 +208,11 @@ public class StreamTaskTestHarness<OUT> {
 			private static final long serialVersionUID = 1L;
 		};
 
-		List<StreamEdge> outEdgesInOrder = new LinkedList<StreamEdge>();
-		StreamNode sourceVertexDummy = new StreamNode(0, "group", null, dummyOperator, "source dummy", new LinkedList<OutputSelector<?>>(), SourceStreamTask.class);
-		StreamNode targetVertexDummy = new StreamNode(1, "group", null, dummyOperator, "target dummy", new LinkedList<OutputSelector<?>>(), SourceStreamTask.class);
+		List<StreamEdge> outEdgesInOrder = new LinkedList<>();
+		StreamNode sourceVertexDummy = new StreamNode(0, "group", null, dummyOperator, "source dummy", new LinkedList<>(), SourceStreamTask.class);
+		StreamNode targetVertexDummy = new StreamNode(1, "group", null, dummyOperator, "target dummy", new LinkedList<>(), SourceStreamTask.class);
 
-		outEdgesInOrder.add(new StreamEdge(sourceVertexDummy, targetVertexDummy, 0, new LinkedList<String>(), new BroadcastPartitioner<Object>(), null /* output tag */));
+		outEdgesInOrder.add(new StreamEdge(sourceVertexDummy, targetVertexDummy, 0, new LinkedList<>(), new BroadcastPartitioner<>(), null /* output tag */));
 
 		streamConfig.setOutEdgesInOrder(outEdgesInOrder);
 		streamConfig.setNonChainedOutputs(outEdgesInOrder);
@@ -267,8 +265,6 @@ public class StreamTaskTestHarness<OUT> {
 
 	/**
 	 * Waits for the task completion.
-	 *
-	 * @throws Exception
 	 */
 	public void waitForTaskCompletion() throws Exception {
 		waitForTaskCompletion(Long.MAX_VALUE);
@@ -279,7 +275,6 @@ public class StreamTaskTestHarness<OUT> {
 	 * TimeoutException is thrown.
 	 *
 	 * @param timeout Timeout for the task completion
-	 * @throws Exception
 	 */
 	public void waitForTaskCompletion(long timeout) throws Exception {
 		Preconditions.checkState(taskThread != null, "Task thread was not started.");
@@ -292,8 +287,6 @@ public class StreamTaskTestHarness<OUT> {
 
 	/**
 	 * Waits for the task to be running.
-	 *
-	 * @throws Exception
 	 */
 	public void waitForTaskRunning() throws Exception {
 		Preconditions.checkState(taskThread != null, "Task thread was not started.");
@@ -335,7 +328,7 @@ public class StreamTaskTestHarness<OUT> {
 		this.mockEnv.getIOManager().close();
 	}
 
-	private void shutdownMemoryManager() throws Exception {
+	private void shutdownMemoryManager() {
 		if (this.memorySize > 0) {
 			MemoryManager memMan = this.mockEnv.getMemoryManager();
 			if (memMan != null) {
@@ -348,7 +341,6 @@ public class StreamTaskTestHarness<OUT> {
 	/**
 	 * Sends the element to input gate 0 on channel 0.
 	 */
-	@SuppressWarnings("unchecked")
 	public void processElement(Object element) {
 		inputGates[0].sendElement(element, 0);
 	}
@@ -356,7 +348,6 @@ public class StreamTaskTestHarness<OUT> {
 	/**
 	 * Sends the element to the specified channel on the specified input gate.
 	 */
-	@SuppressWarnings("unchecked")
 	public void processElement(Object element, int inputGate, int channel) {
 		inputGates[inputGate].sendElement(element, channel);
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -161,6 +161,11 @@ public class StreamTaskTestHarness<OUT> {
 		return taskThread.task.getTimerService();
 	}
 
+	@SuppressWarnings("unchecked")
+	public <OP extends StreamOperator<OUT>> OP getHeadOperator() {
+		return (OP) taskThread.task.getHeadOperator();
+	}
+
 	/**
 	 * This must be overwritten for OneInputStreamTask or TwoInputStreamTask test harnesses.
 	 */

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeServiceTest.java
@@ -101,8 +101,7 @@ public class SystemProcessingTimeServiceTest extends TestLogger {
 			assertFalse(scheduledFuture.isDone());
 
 			// this should cancel our future
-			timer.quiesce();
-			timer.awaitPendingAfterQuiesce();
+			timer.quiesce().get();
 
 			// it may be that the cancelled status is not immediately visible after the
 			// termination (not necessary a volatile update), so we need to "get()" the cancellation
@@ -212,8 +211,7 @@ public class SystemProcessingTimeServiceTest extends TestLogger {
 
 			// after the task triggered, shut the timer down cleanly, waiting for the task to finish
 			latch.await();
-			timer.quiesce();
-			timer.awaitPendingAfterQuiesce();
+			timer.quiesce().get();
 
 			// should be able to immediately acquire the lock, since the task must have exited by now
 			assertTrue(scopeLock.tryLock());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestBoundedOneInputStreamOperator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestBoundedOneInputStreamOperator.java
@@ -44,12 +44,19 @@ public class TestBoundedOneInputStreamOperator extends AbstractStreamOperator<St
 
 	@Override
 	public void endInput() {
-		output.collect(new StreamRecord<>("[" + name + "]: EndOfInput"));
+		output("[" + name + "]: End of input");
 	}
 
 	@Override
 	public void close() throws Exception {
-		output.collect(new StreamRecord<>("[" + name + "]: Bye"));
+		ProcessingTimeService timeService = getProcessingTimeService();
+		timeService.registerTimer(timeService.getCurrentProcessingTime(), t -> output("[" + name + "]: Timer registered in close"));
+
+		output("[" + name + "]: Bye");
 		super.close();
+	}
+
+	private void output(String record) {
+		output.collect(new StreamRecord<>(record));
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestBoundedTwoInputOperator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestBoundedTwoInputOperator.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.util;
+package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedMultiInput;
@@ -49,12 +49,19 @@ public class TestBoundedTwoInputOperator extends AbstractStreamOperator<String>
 
 	@Override
 	public void endInput(int inputId) {
-		output.collect(new StreamRecord<>("[" + name + "-" + inputId + "]: EndOfInput"));
+		output("[" + name + "-" + inputId + "]: End of input");
 	}
 
 	@Override
 	public void close() throws Exception {
+		ProcessingTimeService timeService = getProcessingTimeService();
+		timeService.registerTimer(timeService.getCurrentProcessingTime(), t -> output("[" + name + "]: Timer registered in close"));
+
 		output.collect(new StreamRecord<>("[" + name + "]: Bye"));
 		super.close();
+	}
+
+	private void output(String record) {
+		output.collect(new StreamRecord<>(record));
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
@@ -50,14 +50,15 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.io.StreamTwoInputProcessor;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
-import org.apache.flink.streaming.util.TestBoundedTwoInputOperator;
 import org.apache.flink.streaming.util.TestHarnessUtil;
 
 import org.hamcrest.collection.IsMapContaining;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -65,6 +66,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -579,7 +581,7 @@ public class TwoInputStreamTaskTest {
 	}
 
 	@Test
-	public void testHandlingEndOfInput() throws Exception {
+	public void testClosingAllOperatorsOnChainProperly() throws Exception {
 		final TwoInputStreamTaskTestHarness<String, String, String> testHarness = new TwoInputStreamTaskTestHarness<>(
 			TwoInputStreamTask::new,
 			BasicTypeInfo.STRING_TYPE_INFO,
@@ -596,8 +598,6 @@ public class TwoInputStreamTaskTest {
 				BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()))
 			.finish();
 
-		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
-
 		testHarness.invoke();
 		testHarness.waitForTaskRunning();
 
@@ -611,17 +611,18 @@ public class TwoInputStreamTaskTest {
 
 		testHarness.waitForTaskCompletion();
 
-		expectedOutput.add(new StreamRecord<>("[Operator0-1]: Hello-1"));
-		expectedOutput.add(new StreamRecord<>("[Operator0-1]: EndOfInput"));
-		expectedOutput.add(new StreamRecord<>("[Operator0-2]: Hello-2"));
-		expectedOutput.add(new StreamRecord<>("[Operator0-2]: EndOfInput"));
-		expectedOutput.add(new StreamRecord<>("[Operator0]: Bye"));
-		expectedOutput.add(new StreamRecord<>("[Operator1]: EndOfInput"));
-		expectedOutput.add(new StreamRecord<>("[Operator1]: Bye"));
+		ArrayList<StreamRecord<String>> expected = new ArrayList<>();
+		Collections.addAll(expected,
+			new StreamRecord<>("[Operator0-1]: Hello-1"),
+			new StreamRecord<>("[Operator0-1]: End of input"),
+			new StreamRecord<>("[Operator0-2]: Hello-2"),
+			new StreamRecord<>("[Operator0-2]: End of input"),
+			new StreamRecord<>("[Operator0]: Bye"),
+			new StreamRecord<>("[Operator1]: End of input"),
+			new StreamRecord<>("[Operator1]: Bye"));
 
-		TestHarnessUtil.assertOutputEquals("Output was not correct.",
-			expectedOutput,
-			testHarness.getOutput());
+		final Object[] output = testHarness.getOutput().toArray();
+		assertArrayEquals("Output was not correct.", expected.toArray(), output);
 	}
 
 	/**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractBroadcastStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractBroadcastStreamOperatorTestHarness.java
@@ -32,11 +32,13 @@ public abstract class AbstractBroadcastStreamOperatorTestHarness<IN1, IN2, OUT> 
 		super(operator, maxParallelism, parallelism, subtaskIndex);
 	}
 
-	abstract TwoInputStreamOperator<IN1, IN2, OUT>  getOperator();
+	public TwoInputStreamOperator<IN1, IN2, OUT>  getTwoInputOperator() {
+		return (TwoInputStreamOperator<IN1, IN2, OUT>) operator;
+	}
 
 	public void processElement(StreamRecord<IN1> element) throws Exception {
-		getOperator().setKeyContextElement1(element);
-		getOperator().processElement1(element);
+		getTwoInputOperator().setKeyContextElement1(element);
+		getTwoInputOperator().processElement1(element);
 	}
 
 	public void processElement(IN1 value, long timestamp) throws Exception {
@@ -44,8 +46,8 @@ public abstract class AbstractBroadcastStreamOperatorTestHarness<IN1, IN2, OUT> 
 	}
 
 	public void processBroadcastElement(StreamRecord<IN2> element) throws Exception {
-		getOperator().setKeyContextElement2(element);
-		getOperator().processElement2(element);
+		getTwoInputOperator().setKeyContextElement2(element);
+		getTwoInputOperator().processElement2(element);
 	}
 
 	public void processBroadcastElement(IN2 value, long timestamp) throws Exception {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -362,8 +362,13 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 			if (operator == null) {
 				this.operator = StreamOperatorFactoryUtil.createOperator(factory, mockTask, config,
 						new MockOutput(outputSerializer));
-			} else if (operator instanceof SetupableStreamOperator) {
-				((SetupableStreamOperator) operator).setup(mockTask, config, new MockOutput(outputSerializer));
+			} else {
+				if (operator instanceof AbstractStreamOperator) {
+					((AbstractStreamOperator) operator).setProcessingTimeService(processingTimeService);
+				}
+				if (operator instanceof SetupableStreamOperator) {
+					((SetupableStreamOperator) operator).setup(mockTask, config, new MockOutput(outputSerializer));
+				}
 			}
 			setupCalled = true;
 			this.mockTask.init();
@@ -615,6 +620,14 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 			internalEnvironment.get().close();
 		}
 		mockTask.cleanup();
+	}
+
+	public AbstractStreamOperator<OUT> getOperator() {
+		return (AbstractStreamOperator<OUT>) operator;
+	}
+
+	public StreamOperatorFactory<OUT> getOperatorFactory() {
+		return factory;
 	}
 
 	public void setProcessingTime(long time) throws Exception {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -361,7 +361,7 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 
 			if (operator == null) {
 				this.operator = StreamOperatorFactoryUtil.createOperator(factory, mockTask, config,
-						new MockOutput(outputSerializer));
+						new MockOutput(outputSerializer)).f0;
 			} else {
 				if (operator instanceof AbstractStreamOperator) {
 					((AbstractStreamOperator) operator).setProcessingTimeService(processingTimeService);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/BroadcastOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/BroadcastOperatorTestHarness.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.util;
 
 import org.apache.flink.api.common.state.BroadcastState;
 import org.apache.flink.api.common.state.MapStateDescriptor;
-import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.operators.co.CoBroadcastWithNonKeyedOperator;
 
 /**
@@ -33,8 +32,6 @@ import org.apache.flink.streaming.api.operators.co.CoBroadcastWithNonKeyedOperat
 public class BroadcastOperatorTestHarness<IN1, IN2, OUT>
 	extends AbstractBroadcastStreamOperatorTestHarness<IN1, IN2, OUT> {
 
-	private final CoBroadcastWithNonKeyedOperator<IN1, IN2, OUT> twoInputOperator;
-
 	public BroadcastOperatorTestHarness(
 		CoBroadcastWithNonKeyedOperator<IN1, IN2, OUT> operator,
 		int maxParallelism,
@@ -42,17 +39,10 @@ public class BroadcastOperatorTestHarness<IN1, IN2, OUT>
 		int subtaskIndex)
 		throws Exception {
 		super(operator, maxParallelism, numSubtasks, subtaskIndex);
-
-		this.twoInputOperator = operator;
-	}
-
-	@Override
-	TwoInputStreamOperator<IN1, IN2, OUT> getOperator() {
-		return twoInputOperator;
 	}
 
 	public <KS, V> BroadcastState<KS, V> getBroadcastState(MapStateDescriptor<KS, V> stateDescriptor)
 		throws Exception {
-		return twoInputOperator.getOperatorStateBackend().getBroadcastState(stateDescriptor);
+		return getOperator().getOperatorStateBackend().getBroadcastState(stateDescriptor);
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/KeyedBroadcastOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/KeyedBroadcastOperatorTestHarness.java
@@ -24,9 +24,7 @@ import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.api.java.functions.KeySelector;
-import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.operators.co.CoBroadcastWithKeyedOperator;
-
 
 /**
  * A test harness for testing a {@link CoBroadcastWithKeyedOperator}.
@@ -37,8 +35,6 @@ import org.apache.flink.streaming.api.operators.co.CoBroadcastWithKeyedOperator;
  */
 public class KeyedBroadcastOperatorTestHarness<K, IN1, IN2, OUT>
 	extends AbstractBroadcastStreamOperatorTestHarness<IN1, IN2, OUT> {
-
-	private final CoBroadcastWithKeyedOperator<K, IN1, IN2, OUT> twoInputOperator;
 
 	public KeyedBroadcastOperatorTestHarness(
 		CoBroadcastWithKeyedOperator<K, IN1, IN2, OUT> operator,
@@ -53,18 +49,11 @@ public class KeyedBroadcastOperatorTestHarness<K, IN1, IN2, OUT>
 		ClosureCleaner.clean(keySelector, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, false);
 		config.setStatePartitioner(0, keySelector);
 		config.setStateKeySerializer(keyType.createSerializer(executionConfig));
-
-		this.twoInputOperator = operator;
-	}
-
-	@Override
-	TwoInputStreamOperator<IN1, IN2, OUT> getOperator() {
-		return twoInputOperator;
 	}
 
 	public <KS, V> BroadcastState<KS, V> getBroadcastState(MapStateDescriptor<KS, V> stateDescriptor)
 		throws Exception {
-		return twoInputOperator.getOperatorStateBackend().getBroadcastState(stateDescriptor);
+		return getOperator().getOperatorStateBackend().getBroadcastState(stateDescriptor);
 	}
 
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
@@ -29,6 +29,7 @@ import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeServiceFactory;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
 import org.apache.flink.streaming.runtime.tasks.TimerService;
@@ -162,8 +163,7 @@ public class MockStreamTask<OUT, OP extends StreamOperator<OUT>> extends StreamT
 		return accumulatorMap;
 	}
 
-	@Override
-	public ProcessingTimeService getProcessingTimeService(int operatorIndex) {
-		return processingTimeService;
+	public ProcessingTimeServiceFactory getProcessingTimeServiceFactory() {
+		return mailboxExecutor -> processingTimeService;
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
@@ -163,6 +163,7 @@ public class MockStreamTask<OUT, OP extends StreamOperator<OUT>> extends StreamT
 		return accumulatorMap;
 	}
 
+	@Override
 	public ProcessingTimeServiceFactory getProcessingTimeServiceFactory() {
 		return mailboxExecutor -> processingTimeService;
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamingRuntimeContext.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamingRuntimeContext.java
@@ -94,7 +94,7 @@ public class MockStreamingRuntimeContext extends StreamingRuntimeContext {
 		}
 
 		@Override
-		protected ProcessingTimeService getProcessingTimeService() {
+		public ProcessingTimeService getProcessingTimeService() {
 			if (testProcessingTimeService == null) {
 				testProcessingTimeService = new TestProcessingTimeService();
 			}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.util;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -168,6 +169,12 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
 	public void processWatermark(Watermark mark) throws Exception {
 		currentWatermark = mark.getTimestamp();
 		getOneInputOperator().processWatermark(mark);
+	}
+
+	public void endInput() throws Exception {
+		if (operator instanceof BoundedOneInput) {
+			((BoundedOneInput) operator).endInput();
+		}
 	}
 
 	public long getCurrentWatermark() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
@@ -74,6 +74,10 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
 		this(operator, 1, 1, 0);
 	}
 
+	public OneInputStreamOperatorTestHarness(OneInputStreamOperatorFactory<IN, OUT> factory) throws Exception {
+		this(factory, 1, 1, 0);
+	}
+
 	public OneInputStreamOperatorTestHarness(
 			OneInputStreamOperator<IN, OUT> operator,
 			int maxParallelism,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/OperatorCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/OperatorCodeGenerator.scala
@@ -18,9 +18,9 @@
 package org.apache.flink.table.planner.codegen
 
 import org.apache.flink.streaming.api.graph.StreamConfig
-import org.apache.flink.streaming.api.operators.{BoundedMultiInput, BoundedOneInput, InputSelectable, InputSelection, OneInputStreamOperator, Output, StreamOperator, TwoInputStreamOperator}
+import org.apache.flink.streaming.api.operators.{AbstractStreamOperator, BoundedMultiInput, BoundedOneInput, InputSelectable, InputSelection, OneInputStreamOperator, Output, StreamOperator, TwoInputStreamOperator}
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
-import org.apache.flink.streaming.runtime.tasks.StreamTask
+import org.apache.flink.streaming.runtime.tasks.{ProcessingTimeService, StreamTask}
 import org.apache.flink.table.planner.codegen.CodeGenUtils._
 import org.apache.flink.table.planner.codegen.Indenter.toISC
 import org.apache.flink.table.planner.utils.Logging
@@ -81,10 +81,15 @@ object OperatorCodeGenerator extends Logging {
             Object[] references,
             ${className[StreamTask[_, _]]} task,
             ${className[StreamConfig]} config,
-            ${className[Output[_]]} output) throws Exception {
+            ${className[Output[_]]} output,
+            ${className[ProcessingTimeService]} processingTimeService) throws Exception {
           this.references = references;
           ${ctx.reuseInitCode()}
           this.setup(task, config, output);
+          if (this instanceof ${className[AbstractStreamOperator[_]]}) {
+            ((${className[AbstractStreamOperator[_]]}) this)
+              .setProcessingTimeService(processingTimeService);
+          }
         }
 
         @Override
@@ -194,10 +199,15 @@ object OperatorCodeGenerator extends Logging {
             Object[] references,
             ${className[StreamTask[_, _]]} task,
             ${className[StreamConfig]} config,
-            ${className[Output[_]]} output) throws Exception {
+            ${className[Output[_]]} output,
+            ${className[ProcessingTimeService]} processingTimeService) throws Exception {
           this.references = references;
           ${ctx.reuseInitCode()}
           this.setup(task, config, output);
+          if (this instanceof ${className[AbstractStreamOperator[_]]}) {
+            ((${className[AbstractStreamOperator[_]]}) this)
+              .setProcessingTimeService(processingTimeService);
+          }
         }
 
         @Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/CodeGenOperatorFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/CodeGenOperatorFactory.java
@@ -19,10 +19,9 @@
 package org.apache.flink.table.runtime.operators;
 
 import org.apache.flink.streaming.api.graph.StreamConfig;
-import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.StreamOperator;
-import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.table.runtime.generated.GeneratedClass;
@@ -30,10 +29,9 @@ import org.apache.flink.table.runtime.generated.GeneratedClass;
 /**
  * Stream operator factory for code gen operator.
  */
-public class CodeGenOperatorFactory<OUT> implements StreamOperatorFactory<OUT> {
+public class CodeGenOperatorFactory<OUT> extends AbstractStreamOperatorFactory<OUT> {
 
 	private final GeneratedClass<? extends StreamOperator<OUT>> generatedClass;
-	private ChainingStrategy strategy = ChainingStrategy.ALWAYS;
 
 	public CodeGenOperatorFactory(GeneratedClass<? extends StreamOperator<OUT>> generatedClass) {
 		this.generatedClass = generatedClass;
@@ -44,17 +42,7 @@ public class CodeGenOperatorFactory<OUT> implements StreamOperatorFactory<OUT> {
 	public <T extends StreamOperator<OUT>> T createStreamOperator(StreamTask<?, ?> containingTask,
 			StreamConfig config, Output<StreamRecord<OUT>> output) {
 		return (T) generatedClass.newInstance(containingTask.getUserCodeClassLoader(),
-				generatedClass.getReferences(), containingTask, config, output);
-	}
-
-	@Override
-	public void setChainingStrategy(ChainingStrategy strategy) {
-		this.strategy = strategy;
-	}
-
-	@Override
-	public ChainingStrategy getChainingStrategy() {
-		return strategy;
+				generatedClass.getReferences(), containingTask, config, output, processingTimeService);
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/WindowOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/WindowOperator.java
@@ -234,6 +234,8 @@ public abstract class WindowOperator<K, W extends Window>
 	public void open() throws Exception {
 		super.open();
 
+		functionsClosed = false;
+
 		collector = new TimestampedCollector<>(output);
 		collector.eraseTimestamp();
 
@@ -385,6 +387,10 @@ public abstract class WindowOperator<K, W extends Window>
 
 	@Override
 	public void onProcessingTime(InternalTimer<K, W> timer) throws Exception {
+		if (functionsClosed) {
+			return;
+		}
+
 		setCurrentKey(timer.getKey());
 
 		triggerContext.window = timer.getNamespace();
@@ -629,7 +635,6 @@ public abstract class WindowOperator<K, W extends Window>
 			}
 		}
 	}
-
 
 	// ------------------------------------------------------------------------------
 	// Visible For Testing

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/wmassigners/WatermarkAssignerOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/wmassigners/WatermarkAssignerOperator.java
@@ -28,8 +28,11 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeCallback;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.runtime.generated.WatermarkGenerator;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A stream operator that extracts timestamps from stream elements and
@@ -66,12 +69,19 @@ public class WatermarkAssignerOperator
 	 * @param watermarkGenerator	the watermark generator
 	 * @param idleTimeout   (idleness checking timeout)
 	 */
-	public WatermarkAssignerOperator(int rowtimeFieldIndex, WatermarkGenerator watermarkGenerator, long idleTimeout) {
+	public WatermarkAssignerOperator(
+		int rowtimeFieldIndex,
+		WatermarkGenerator watermarkGenerator,
+		long idleTimeout,
+		ProcessingTimeService processingTimeService) {
+
 		this.rowtimeFieldIndex = rowtimeFieldIndex;
 		this.watermarkGenerator = watermarkGenerator;
 
 		this.idleTimeout = idleTimeout;
 		this.chainingStrategy = ChainingStrategy.ALWAYS;
+
+		this.processingTimeService = checkNotNull(processingTimeService);
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/AsyncLookupJoinHarnessTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/AsyncLookupJoinHarnessTest.java
@@ -107,6 +107,7 @@ public class AsyncLookupJoinHarnessTest {
 
 		// wait until all async collectors in the buffer have been emitted out.
 		synchronized (testHarness.getCheckpointLock()) {
+			testHarness.endInput();
 			testHarness.close();
 		}
 
@@ -137,6 +138,7 @@ public class AsyncLookupJoinHarnessTest {
 
 		// wait until all async collectors in the buffer have been emitted out.
 		synchronized (testHarness.getCheckpointLock()) {
+			testHarness.endInput();
 			testHarness.close();
 		}
 
@@ -166,6 +168,7 @@ public class AsyncLookupJoinHarnessTest {
 
 		// wait until all async collectors in the buffer have been emitted out.
 		synchronized (testHarness.getCheckpointLock()) {
+			testHarness.endInput();
 			testHarness.close();
 		}
 
@@ -198,6 +201,7 @@ public class AsyncLookupJoinHarnessTest {
 
 		// wait until all async collectors in the buffer have been emitted out.
 		synchronized (testHarness.getCheckpointLock()) {
+			testHarness.endInput();
 			testHarness.close();
 		}
 
@@ -264,7 +268,6 @@ public class AsyncLookupJoinHarnessTest {
 	}
 
 	// ---------------------------------------------------------------------------------
-
 
 	/**
 	 * The {@link TestingFetcherFunction} only accepts a single integer lookup key and


### PR DESCRIPTION
## What is the purpose of the change

This pull request handles its processing-time timers after the operator is closed, to ensure that there is no longer output triggered by the timers before the "endInput" methods of its downstream operators in the chain are called.

For the operator chain in a task, such as `OP1 - > OP2 - > ...`, after the (source/network) input of `OP1` are finished, the operators on the chain are closed in the following order:

1. quiesce `ProcessingTimeService` of `OP1` to prevent the pending timers from firing, but wait the timers in running to finish.
2. call `OP1#close()`
3. call `OP2#endInput()`
4. quiesce `ProcessingTimeService` of `OP2` to prevent the pending timers from firing, but wait the timers in running to finish.
5. call `OP2#close()`
...

## Brief change log

  - Adds the `quiesce()` method to `ProcessingTimeServiceImpl`, which prevents the pending timers from firing, but allows the timers in running to finish.
  - Add `StreamOperatorWrapper` that properly handles the close, endInput and processingtime-quiesced of an operator.
  - Changes `StreamTask` to use `StreamOperatorWrapper`  to close operators,  making `endInput` semantics on the operator chain strict.


## Verifying this change

This change added tests and can be verified as follows:

  - Added test for `ProcessingTimeServiceImpl` that validates the quiesce logic.
  - Added tests for `StreamOperatorWrapper` that validates the closes of the operators on the operator chain.
  - Extended test for `SourceStreamTask` to verify that the `endInput` semantics on the chain is still strict when there is timers that trigger output.
  - Extended test for `OneInputStreamTask` to verify that the `endInput` semantics on the chain is still strict when there is timers that trigger output.
  - Extended test for `TwoInputStreamTask` to verify that the `endInput` semantics on the chain is still strict when there is timers that trigger output.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
