### PR TITLE
[FLINK-14694] [table-planner-blink] Most tests from package o.a.f.table.planner.functions.aggfunctions are not executed during mvn test and fix BinaryGeneric comparison failure

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/AggFunctionTestBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/AggFunctionTestBase.java
@@ -54,6 +54,29 @@ import static org.junit.Assert.assertThat;
  */
 public abstract class AggFunctionTestBase<T, ACC> {
 
+	/**
+	 * Spec for parameterized aggregate function tests.
+	 */
+	protected static class AggFunctionTestSpec<T, ACC> {
+		final AggregateFunction<T, ACC> aggregator;
+		final List<List<T>> inputValueSets;
+		final List<T> expectedResults;
+
+		public AggFunctionTestSpec(
+				AggregateFunction<T, ACC> aggregator,
+				List<List<T>> inputValueSets,
+				List<T> expectedResults) {
+			this.aggregator = aggregator;
+			this.inputValueSets = inputValueSets;
+			this.expectedResults = expectedResults;
+		}
+
+		@Override
+		public String toString() {
+			return aggregator.getClass().getSimpleName();
+		}
+	}
+
 	protected abstract List<List<T>> getInputValueSets();
 
 	protected abstract List<T> getExpectedResults();

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstLastValueAggFunctionWithOrderTestBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstLastValueAggFunctionWithOrderTestBase.java
@@ -68,13 +68,13 @@ public abstract class FirstLastValueAggFunctionWithOrderTestBase<T> extends AggF
 			T expected = expectedResults.get(i);
 			GenericRow acc = accumulateValues(inputValues, inputOrders);
 			T result = aggregator.getValue(acc);
-			validateResult(expected, result);
+			validateResult(expected, result, aggregator.getResultType());
 
 			if (UserDefinedFunctionUtils.ifMethodExistInFunction("retract", aggregator)) {
 				retractValues(acc, inputValues, inputOrders);
 				GenericRow expectedAcc = aggregator.createAccumulator();
 				// The two accumulators should be exactly same
-				validateResult(expectedAcc, acc);
+				validateResult(expectedAcc, acc, aggregator.getAccumulatorType());
 			}
 		}
 	}
@@ -103,7 +103,7 @@ public abstract class FirstLastValueAggFunctionWithOrderTestBase<T> extends AggF
 				resetAccFunc.invoke(aggregator, (Object) acc);
 				GenericRow expectedAcc = aggregator.createAccumulator();
 				//The accumulator after reset should be exactly same as the new accumulator
-				validateResult(expectedAcc, acc);
+				validateResult(expectedAcc, acc, aggregator.getAccumulatorType());
 			}
 		}
 	}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstLastValueAggFunctionWithOrderTestBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstLastValueAggFunctionWithOrderTestBase.java
@@ -36,6 +36,23 @@ import java.util.List;
  */
 public abstract class FirstLastValueAggFunctionWithOrderTestBase<T> extends AggFunctionTestBase<T, GenericRow> {
 
+	/**
+	 * An AggFunctionTestSpec with input order.
+	 */
+	protected static class AggFunctionWithOrderTestSpec<T> extends AggFunctionTestSpec<T, GenericRow> {
+
+		final List<List<Long>> inputOrderSets;
+
+		public AggFunctionWithOrderTestSpec(
+				AggregateFunction<T, GenericRow> aggregator,
+				List<List<Long>> inputOrderSets,
+				List<List<T>> inputValueSets,
+				List<T> expectedResults) {
+			super(aggregator, inputValueSets, expectedResults);
+			this.inputOrderSets = inputOrderSets;
+		}
+	}
+
 	protected Method getAccumulateFunc() throws NoSuchMethodException {
 		return getAggregator().getClass().getMethod("accumulate", getAccClass(), Object.class, Long.class);
 	}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithOrderTest.java
@@ -33,6 +33,9 @@ import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFuncti
 import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.StringFirstValueAggFunction;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -40,12 +43,22 @@ import java.util.List;
  * Test case for built-in FirstValue aggregate function.
  * This class tests `accumulate` method with order argument.
  */
-public abstract class FirstValueAggFunctionWithOrderTest<T> extends FirstLastValueAggFunctionWithOrderTestBase<T> {
+@RunWith(Enclosed.class)
+public class FirstValueAggFunctionWithOrderTest {
+
+	/**
+	 * The base test class for FirstValueAggFunction with order.
+	 */
+	public abstract static class FirstValueAggFunctionWithOrderTestBase<T>
+			extends FirstLastValueAggFunctionWithOrderTestBase<T> {
+
+	}
+
 	/**
 	 * Test FirstValueAggFunction for number type.
 	 */
-	public abstract static class NumberFirstValueAggFunctionWithOrderTest<T>
-			extends FirstValueAggFunctionWithOrderTest<T> {
+	public abstract static class NumberFirstValueAggFunctionWithOrderTestBase<T>
+			extends FirstValueAggFunctionWithOrderTestBase<T> {
 		protected abstract T getValue(String v);
 
 		@Override
@@ -118,7 +131,7 @@ public abstract class FirstValueAggFunctionWithOrderTest<T> extends FirstLastVal
 	 * Test for ByteFirstValueAggFunction.
 	 */
 	public static class ByteFirstValueAggFunctionWithOrderTest
-			extends NumberFirstValueAggFunctionWithOrderTest<Byte> {
+			extends NumberFirstValueAggFunctionWithOrderTestBase<Byte> {
 
 		@Override
 		protected Byte getValue(String v) {
@@ -135,7 +148,7 @@ public abstract class FirstValueAggFunctionWithOrderTest<T> extends FirstLastVal
 	 * Test for ShortFirstValueAggFunction.
 	 */
 	public static class ShortFirstValueAggFunctionWithOrderTest
-			extends NumberFirstValueAggFunctionWithOrderTest<Short> {
+			extends NumberFirstValueAggFunctionWithOrderTestBase<Short> {
 
 		@Override
 		protected Short getValue(String v) {
@@ -152,7 +165,7 @@ public abstract class FirstValueAggFunctionWithOrderTest<T> extends FirstLastVal
 	 * Test for IntFirstValueAggFunction.
 	 */
 	public static class IntFirstValueAggFunctionWithOrderTest
-			extends NumberFirstValueAggFunctionWithOrderTest<Integer> {
+			extends NumberFirstValueAggFunctionWithOrderTestBase<Integer> {
 
 		@Override
 		protected Integer getValue(String v) {
@@ -169,7 +182,7 @@ public abstract class FirstValueAggFunctionWithOrderTest<T> extends FirstLastVal
 	 * Test for LongFirstValueAggFunction.
 	 */
 	public static class LongFirstValueAggFunctionWithOrderTest
-			extends NumberFirstValueAggFunctionWithOrderTest<Long> {
+			extends NumberFirstValueAggFunctionWithOrderTestBase<Long> {
 
 		@Override
 		protected Long getValue(String v) {
@@ -186,7 +199,7 @@ public abstract class FirstValueAggFunctionWithOrderTest<T> extends FirstLastVal
 	 * Test for FloatFirstValueAggFunction.
 	 */
 	public static class FloatFirstValueAggFunctionWithOrderTest
-			extends NumberFirstValueAggFunctionWithOrderTest<Float> {
+			extends NumberFirstValueAggFunctionWithOrderTestBase<Float> {
 
 		@Override
 		protected Float getValue(String v) {
@@ -203,7 +216,7 @@ public abstract class FirstValueAggFunctionWithOrderTest<T> extends FirstLastVal
 	 * Test for DoubleFirstValueAggFunction.
 	 */
 	public static class DoubleFirstValueAggFunctionWithOrderTest
-			extends NumberFirstValueAggFunctionWithOrderTest<Double> {
+			extends NumberFirstValueAggFunctionWithOrderTestBase<Double> {
 
 		@Override
 		protected Double getValue(String v) {
@@ -220,7 +233,7 @@ public abstract class FirstValueAggFunctionWithOrderTest<T> extends FirstLastVal
 	 * Test for BooleanFirstValueAggFunction.
 	 */
 	public static class BooleanFirstValueAggFunctionWithOrderTest
-			extends FirstValueAggFunctionWithOrderTest<Boolean> {
+			extends FirstValueAggFunctionWithOrderTestBase<Boolean> {
 
 		@Override
 		protected List<List<Boolean>> getInputValueSets() {
@@ -310,7 +323,7 @@ public abstract class FirstValueAggFunctionWithOrderTest<T> extends FirstLastVal
 	 * Test for DecimalFirstValueAggFunction.
 	 */
 	public static class DecimalFirstValueAggFunctionWithOrderTest
-			extends FirstValueAggFunctionWithOrderTest<Decimal> {
+			extends FirstValueAggFunctionWithOrderTestBase<Decimal> {
 
 		private int precision = 20;
 		private int scale = 6;
@@ -390,7 +403,7 @@ public abstract class FirstValueAggFunctionWithOrderTest<T> extends FirstLastVal
 	 * Test for StringFirstValueAggFunction.
 	 */
 	public static class StringFirstValueAggFunctionWithOrderTest
-			extends FirstValueAggFunctionWithOrderTest<BinaryString> {
+			extends FirstValueAggFunctionWithOrderTestBase<BinaryString> {
 
 		@Override
 		protected List<List<BinaryString>> getInputValueSets() {

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithOrderTest.java
@@ -33,447 +33,357 @@ import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFuncti
 import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.StringFirstValueAggFunction;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 
-import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Test case for built-in FirstValue aggregate function.
  * This class tests `accumulate` method with order argument.
  */
-@RunWith(Enclosed.class)
-public class FirstValueAggFunctionWithOrderTest {
+@RunWith(Parameterized.class)
+public class FirstValueAggFunctionWithOrderTest<T> extends FirstLastValueAggFunctionWithOrderTestBase<T> {
 
-	/**
-	 * The base test class for FirstValueAggFunction with order.
-	 */
-	public abstract static class FirstValueAggFunctionWithOrderTestBase<T>
-			extends FirstLastValueAggFunctionWithOrderTestBase<T> {
+	@Parameterized.Parameter
+	public AggFunctionWithOrderTestSpec<T> aggFunctionTestSpec;
 
+	private static final int DECIMAL_PRECISION = 20;
+	private static final int DECIMAL_SCALE = 6;
+
+	@Override
+	protected List<List<Long>> getInputOrderSets() {
+		return aggFunctionTestSpec.inputOrderSets;
 	}
 
-	/**
-	 * Test FirstValueAggFunction for number type.
-	 */
-	public abstract static class NumberFirstValueAggFunctionWithOrderTestBase<T>
-			extends FirstValueAggFunctionWithOrderTestBase<T> {
-		protected abstract T getValue(String v);
-
-		@Override
-		protected List<List<T>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							getValue("1"),
-							null,
-							getValue("-99"),
-							getValue("3"),
-							null,
-							getValue("3"),
-							getValue("2"),
-							getValue("-99")
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							getValue("10"),
-							null,
-							getValue("5")
-					)
-			);
-		}
-
-		@Override
-		protected List<List<Long>> getInputOrderSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							10L,
-							2L,
-							5L,
-							6L,
-							11L,
-							3L,
-							7L,
-							5L
-					),
-					Arrays.asList(
-							8L,
-							6L,
-							9L,
-							5L
-					),
-					Arrays.asList(
-							null,
-							6L,
-							4L,
-							3L
-					)
-			);
-		}
-
-		@Override
-		protected List<T> getExpectedResults() {
-			return Arrays.asList(
-					getValue("3"),
-					null,
-					getValue("5")
-			);
-		}
+	@Override
+	protected List<List<T>> getInputValueSets() {
+		return aggFunctionTestSpec.inputValueSets;
 	}
 
-	/**
-	 * Test for ByteFirstValueAggFunction.
-	 */
-	public static class ByteFirstValueAggFunctionWithOrderTest
-			extends NumberFirstValueAggFunctionWithOrderTestBase<Byte> {
-
-		@Override
-		protected Byte getValue(String v) {
-			return Byte.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Byte, GenericRow> getAggregator() {
-			return new ByteFirstValueAggFunction();
-		}
+	@Override
+	protected List<T> getExpectedResults() {
+		return aggFunctionTestSpec.expectedResults;
 	}
 
-	/**
-	 * Test for ShortFirstValueAggFunction.
-	 */
-	public static class ShortFirstValueAggFunctionWithOrderTest
-			extends NumberFirstValueAggFunctionWithOrderTestBase<Short> {
-
-		@Override
-		protected Short getValue(String v) {
-			return Short.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Short, GenericRow> getAggregator() {
-			return new ShortFirstValueAggFunction();
-		}
+	@Override
+	protected AggregateFunction<T, GenericRow> getAggregator() {
+		return aggFunctionTestSpec.aggregator;
 	}
 
-	/**
-	 * Test for IntFirstValueAggFunction.
-	 */
-	public static class IntFirstValueAggFunctionWithOrderTest
-			extends NumberFirstValueAggFunctionWithOrderTestBase<Integer> {
-
-		@Override
-		protected Integer getValue(String v) {
-			return Integer.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Integer, GenericRow> getAggregator() {
-			return new IntFirstValueAggFunction();
-		}
+	@Parameterized.Parameters(name = "{index}: {0}")
+	public static List<AggFunctionTestSpec> testData() {
+		return Arrays.asList(
+				/**
+				 * Test for ByteFirstValueAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new ByteFirstValueAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Byte::valueOf),
+						numberExpectedResults(Byte::valueOf)
+				),
+				/**
+				 * Test for ShortFirstValueAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new ShortFirstValueAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Short::valueOf),
+						numberExpectedResults(Short::valueOf)
+				),
+				/**
+				 * Test for IntFirstValueAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new IntFirstValueAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Integer::valueOf),
+						numberExpectedResults(Integer::valueOf)
+				),
+				/**
+				 * Test for LongFirstValueAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new LongFirstValueAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Long::valueOf),
+						numberExpectedResults(Long::valueOf)
+				),
+				/**
+				 * Test for FloatFirstValueAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new FloatFirstValueAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Float::valueOf),
+						numberExpectedResults(Float::valueOf)
+				),
+				/**
+				 * Test for DoubleFirstValueAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new DoubleFirstValueAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Double::valueOf),
+						numberExpectedResults(Double::valueOf)
+				),
+				/**
+				 * Test for BooleanFirstValueAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new BooleanFirstValueAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										6L,
+										2L,
+										3L
+								),
+								Arrays.asList(
+										1L,
+										2L,
+										3L
+								),
+								Arrays.asList(
+										10L,
+										2L,
+										5L,
+										11L,
+										3L,
+										7L,
+										5L
+								),
+								Arrays.asList(
+										6L,
+										9L,
+										5L
+								),
+								Arrays.asList(
+										4L,
+										3L
+								)
+						),
+						Arrays.asList(
+								Arrays.asList(
+										false,
+										false,
+										false
+								),
+								Arrays.asList(
+										true,
+										true,
+										true
+								),
+								Arrays.asList(
+										true,
+										false,
+										null,
+										true,
+										false,
+										true,
+										null
+								),
+								Arrays.asList(
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										true
+								)
+						),
+						Arrays.asList(
+								false,
+								true,
+								false,
+								null,
+								true
+						)
+				),
+				/**
+				 * Test for DecimalFirstValueAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new DecimalFirstValueAggFunction(DecimalTypeInfo.of(DECIMAL_PRECISION, DECIMAL_SCALE)),
+						Arrays.asList(
+								Arrays.asList(
+										10L,
+										2L,
+										1L,
+										5L,
+										null,
+										3L,
+										1L,
+										5L,
+										2L
+								),
+								Arrays.asList(
+										6L,
+										5L,
+										null,
+										8L,
+										null
+								),
+								Arrays.asList(
+										8L,
+										6L
+								)
+						),
+						Arrays.asList(
+								Arrays.asList(
+										Decimal.castFrom("1", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("1000.000001", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-1", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-999.998999", DECIMAL_PRECISION, DECIMAL_SCALE),
+										null,
+										Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-999.999", DECIMAL_PRECISION, DECIMAL_SCALE),
+										null,
+										Decimal.castFrom("999.999", DECIMAL_PRECISION, DECIMAL_SCALE)
+								),
+								Arrays.asList(
+										null,
+										null,
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE)
+								)
+						),
+						Arrays.asList(
+								Decimal.castFrom("-1", DECIMAL_PRECISION, DECIMAL_SCALE),
+								null,
+								Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE)
+						)
+				),
+				/**
+				 * Test for StringFirstValueAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new StringFirstValueAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										10L,
+										2L,
+										5L,
+										null,
+										3L,
+										1L,
+										5L
+								),
+								Arrays.asList(
+										6L,
+										5L
+								),
+								Arrays.asList(
+										8L,
+										6L
+								),
+								Arrays.asList(
+										6L,
+										4L,
+										3L
+								)
+						),
+						Arrays.asList(
+								Arrays.asList(
+										BinaryString.fromString("abc"),
+										BinaryString.fromString("def"),
+										BinaryString.fromString("ghi"),
+										null,
+										BinaryString.fromString("jkl"),
+										null,
+										BinaryString.fromString("zzz")
+								),
+								Arrays.asList(
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										BinaryString.fromString("a")
+								),
+								Arrays.asList(
+										BinaryString.fromString("x"),
+										null,
+										BinaryString.fromString("e")
+								)
+						),
+						Arrays.asList(
+								BinaryString.fromString("def"),
+								null,
+								BinaryString.fromString("a"),
+								BinaryString.fromString("e")
+						)
+				)
+				);
 	}
 
-	/**
-	 * Test for LongFirstValueAggFunction.
-	 */
-	public static class LongFirstValueAggFunctionWithOrderTest
-			extends NumberFirstValueAggFunctionWithOrderTestBase<Long> {
-
-		@Override
-		protected Long getValue(String v) {
-			return Long.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Long, GenericRow> getAggregator() {
-			return new LongFirstValueAggFunction();
-		}
+	private static List<List<Long>> numberInputOrderSets() {
+		return Arrays.asList(
+				Arrays.asList(
+						10L,
+						2L,
+						5L,
+						6L,
+						11L,
+						3L,
+						7L,
+						5L
+				),
+				Arrays.asList(
+						8L,
+						6L,
+						9L,
+						5L
+				),
+				Arrays.asList(
+						null,
+						6L,
+						4L,
+						3L
+				)
+		);
 	}
 
-	/**
-	 * Test for FloatFirstValueAggFunction.
-	 */
-	public static class FloatFirstValueAggFunctionWithOrderTest
-			extends NumberFirstValueAggFunctionWithOrderTestBase<Float> {
-
-		@Override
-		protected Float getValue(String v) {
-			return Float.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Float, GenericRow> getAggregator() {
-			return new FloatFirstValueAggFunction();
-		}
+	private static <N> List<List<N>> numberInputValueSets(Function<String, N> strToValueFun) {
+		return Arrays.asList(
+				Arrays.asList(
+						strToValueFun.apply("1"),
+						null,
+						strToValueFun.apply("-99"),
+						strToValueFun.apply("3"),
+						null,
+						strToValueFun.apply("3"),
+						strToValueFun.apply("2"),
+						strToValueFun.apply("-99")
+				),
+				Arrays.asList(
+						null,
+						null,
+						null,
+						null
+				),
+				Arrays.asList(
+						null,
+						strToValueFun.apply("10"),
+						null,
+						strToValueFun.apply("5")
+				)
+		);
 	}
 
-	/**
-	 * Test for DoubleFirstValueAggFunction.
-	 */
-	public static class DoubleFirstValueAggFunctionWithOrderTest
-			extends NumberFirstValueAggFunctionWithOrderTestBase<Double> {
-
-		@Override
-		protected Double getValue(String v) {
-			return Double.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Double, GenericRow> getAggregator() {
-			return new DoubleFirstValueAggFunction();
-		}
-	}
-
-	/**
-	 * Test for BooleanFirstValueAggFunction.
-	 */
-	public static class BooleanFirstValueAggFunctionWithOrderTest
-			extends FirstValueAggFunctionWithOrderTestBase<Boolean> {
-
-		@Override
-		protected List<List<Boolean>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							false,
-							false,
-							false
-					),
-					Arrays.asList(
-							true,
-							true,
-							true
-					),
-					Arrays.asList(
-							true,
-							false,
-							null,
-							true,
-							false,
-							true,
-							null
-					),
-					Arrays.asList(
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							true
-					));
-		}
-
-		@Override
-		protected List<List<Long>> getInputOrderSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							6L,
-							2L,
-							3L
-					),
-					Arrays.asList(
-							1L,
-							2L,
-							3L
-					),
-					Arrays.asList(
-							10L,
-							2L,
-							5L,
-							11L,
-							3L,
-							7L,
-							5L
-					),
-					Arrays.asList(
-							6L,
-							9L,
-							5L
-					),
-					Arrays.asList(
-							4L,
-							3L
-					)
-			);
-		}
-
-		@Override
-		protected List<Boolean> getExpectedResults() {
-			return Arrays.asList(
-					false,
-					true,
-					false,
-					null,
-					true
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Boolean, GenericRow> getAggregator() {
-			return new BooleanFirstValueAggFunction();
-		}
-	}
-
-	/**
-	 * Test for DecimalFirstValueAggFunction.
-	 */
-	public static class DecimalFirstValueAggFunctionWithOrderTest
-			extends FirstValueAggFunctionWithOrderTestBase<Decimal> {
-
-		private int precision = 20;
-		private int scale = 6;
-
-		@Override
-		protected List<List<Decimal>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							Decimal.castFrom("1", precision, scale),
-							Decimal.castFrom("1000.000001", precision, scale),
-							Decimal.castFrom("-1", precision, scale),
-							Decimal.castFrom("-999.998999", precision, scale),
-							null,
-							Decimal.castFrom("0", precision, scale),
-							Decimal.castFrom("-999.999", precision, scale),
-							null,
-							Decimal.castFrom("999.999", precision, scale)
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							Decimal.castFrom("0", precision, scale)
-					)
-			);
-		}
-
-		@Override
-		protected List<List<Long>> getInputOrderSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							10L,
-							2L,
-							1L,
-							5L,
-							null,
-							3L,
-							1L,
-							5L,
-							2L
-					),
-					Arrays.asList(
-							6L,
-							5L,
-							null,
-							8L,
-							null
-					),
-					Arrays.asList(
-							8L,
-							6L
-					)
-			);
-		}
-
-		@Override
-		protected List<Decimal> getExpectedResults() {
-			return Arrays.asList(
-					Decimal.castFrom("-1", precision, scale),
-					null,
-					Decimal.castFrom("0", precision, scale)
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Decimal, GenericRow> getAggregator() {
-			return new DecimalFirstValueAggFunction(DecimalTypeInfo.of(precision, scale));
-		}
-	}
-
-	/**
-	 * Test for StringFirstValueAggFunction.
-	 */
-	public static class StringFirstValueAggFunctionWithOrderTest
-			extends FirstValueAggFunctionWithOrderTestBase<BinaryString> {
-
-		@Override
-		protected List<List<BinaryString>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							BinaryString.fromString("abc"),
-							BinaryString.fromString("def"),
-							BinaryString.fromString("ghi"),
-							null,
-							BinaryString.fromString("jkl"),
-							null,
-							BinaryString.fromString("zzz")
-					),
-					Arrays.asList(
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							BinaryString.fromString("a")
-					),
-					Arrays.asList(
-							BinaryString.fromString("x"),
-							null,
-							BinaryString.fromString("e")
-					)
-			);
-		}
-
-		@Override
-		protected List<List<Long>> getInputOrderSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							10L,
-							2L,
-							5L,
-							null,
-							3L,
-							1L,
-							5L
-					),
-					Arrays.asList(
-							6L,
-							5L
-					),
-					Arrays.asList(
-							8L,
-							6L
-					),
-					Arrays.asList(
-							6L,
-							4L,
-							3L
-					)
-			);
-		}
-
-		@Override
-		protected List<BinaryString> getExpectedResults() {
-			return Arrays.asList(
-					BinaryString.fromString("def"),
-					null,
-					BinaryString.fromString("a"),
-					BinaryString.fromString("e")
-			);
-		}
-
-		@Override
-		protected AggregateFunction<BinaryString, GenericRow> getAggregator() {
-			return new StringFirstValueAggFunction();
-		}
+	private static <N> List<N> numberExpectedResults(Function<String, N> strToValueFun) {
+		return Arrays.asList(
+				strToValueFun.apply("3"),
+				null,
+				strToValueFun.apply("5")
+		);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithoutOrderTest.java
@@ -33,6 +33,9 @@ import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFuncti
 import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.StringFirstValueAggFunction;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -40,18 +43,25 @@ import java.util.List;
  * Test case for built-in FirstValue aggregate function.
  * This class tests `accumulate` method without order argument.
  */
-public abstract class FirstValueAggFunctionWithoutOrderTest<T> extends AggFunctionTestBase<T, GenericRow> {
+@RunWith(Enclosed.class)
+public class FirstValueAggFunctionWithoutOrderTest {
 
-	@Override
-	protected Class<?> getAccClass() {
-		return GenericRow.class;
+	/**
+	 * The base test class for FirstValueAggFunction without order.
+	 */
+	public abstract static class FirstValueAggFunctionWithoutOrderTestBase<T>
+			extends AggFunctionTestBase<T, GenericRow> {
+		@Override
+		protected Class<?> getAccClass() {
+			return GenericRow.class;
+		}
 	}
 
 	/**
 	 * Test FirstValueAggFunction for number type.
 	 */
 	public abstract static class NumberFirstValueAggFunctionWithoutOrderTest<T>
-			extends FirstValueAggFunctionWithoutOrderTest<T> {
+			extends FirstValueAggFunctionWithoutOrderTestBase<T> {
 		protected abstract T getValue(String v);
 
 		@Override
@@ -195,7 +205,7 @@ public abstract class FirstValueAggFunctionWithoutOrderTest<T> extends AggFuncti
 	 * Test for BooleanFirstValueAggFunction.
 	 */
 	public static class BooleanFirstValueAggFunctionWithoutOrderTest extends
-			FirstValueAggFunctionWithoutOrderTest<Boolean> {
+			FirstValueAggFunctionWithoutOrderTestBase<Boolean> {
 
 		@Override
 		protected List<List<Boolean>> getInputValueSets() {
@@ -251,7 +261,7 @@ public abstract class FirstValueAggFunctionWithoutOrderTest<T> extends AggFuncti
 	 * Test for DecimalFirstValueAggFunction.
 	 */
 	public static class DecimalFirstValueAggFunctionWithoutOrderTest extends
-			FirstValueAggFunctionWithoutOrderTest<Decimal> {
+			FirstValueAggFunctionWithoutOrderTestBase<Decimal> {
 
 		private int precision = 20;
 		private int scale = 6;
@@ -303,7 +313,7 @@ public abstract class FirstValueAggFunctionWithoutOrderTest<T> extends AggFuncti
 	 * Test for StringFirstValueAggFunction.
 	 */
 	public static class StringFirstValueAggFunctionWithoutOrderTest extends
-			FirstValueAggFunctionWithoutOrderTest<BinaryString> {
+			FirstValueAggFunctionWithoutOrderTestBase<BinaryString> {
 
 		@Override
 		protected List<List<BinaryString>> getInputValueSets() {

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithoutOrderTest.java
@@ -33,329 +33,243 @@ import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFuncti
 import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.StringFirstValueAggFunction;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 
-import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Test case for built-in FirstValue aggregate function.
  * This class tests `accumulate` method without order argument.
  */
-@RunWith(Enclosed.class)
-public class FirstValueAggFunctionWithoutOrderTest {
+@RunWith(Parameterized.class)
+public class FirstValueAggFunctionWithoutOrderTest<T> extends AggFunctionTestBase<T, GenericRow> {
 
-	/**
-	 * The base test class for FirstValueAggFunction without order.
-	 */
-	public abstract static class FirstValueAggFunctionWithoutOrderTestBase<T>
-			extends AggFunctionTestBase<T, GenericRow> {
-		@Override
-		protected Class<?> getAccClass() {
-			return GenericRow.class;
-		}
+	@Parameterized.Parameter
+	public AggFunctionTestSpec<T, GenericRow> aggFunctionTestSpec;
+
+	private static final int DECIMAL_PRECISION = 20;
+	private static final int DECIMAL_SCALE = 6;
+
+	@Override
+	protected List<List<T>> getInputValueSets() {
+		return aggFunctionTestSpec.inputValueSets;
 	}
 
-	/**
-	 * Test FirstValueAggFunction for number type.
-	 */
-	public abstract static class NumberFirstValueAggFunctionWithoutOrderTest<T>
-			extends FirstValueAggFunctionWithoutOrderTestBase<T> {
-		protected abstract T getValue(String v);
-
-		@Override
-		protected List<List<T>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							getValue("1"),
-							null,
-							getValue("-99"),
-							getValue("3"),
-							null
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							getValue("10"),
-							null,
-							getValue("3")
-					)
-			);
-		}
-
-		@Override
-		protected List<T> getExpectedResults() {
-			return Arrays.asList(
-					getValue("1"),
-					null,
-					getValue("10")
-			);
-		}
+	@Override
+	protected List<T> getExpectedResults() {
+		return aggFunctionTestSpec.expectedResults;
 	}
 
-	/**
-	 * Test for ByteFirstValueAggFunction.
-	 */
-	public static class ByteFirstValueAggFunctionWithoutOrderTest
-			extends NumberFirstValueAggFunctionWithoutOrderTest<Byte> {
-
-		@Override
-		protected Byte getValue(String v) {
-			return Byte.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Byte, GenericRow> getAggregator() {
-			return new ByteFirstValueAggFunction();
-		}
+	@Override
+	protected AggregateFunction<T, GenericRow> getAggregator() {
+		return aggFunctionTestSpec.aggregator;
 	}
 
-	/**
-	 * Test for ShortFirstValueAggFunction.
-	 */
-	public static class ShortFirstValueAggFunctionWithoutOrderTest
-			extends NumberFirstValueAggFunctionWithoutOrderTest<Short> {
-
-		@Override
-		protected Short getValue(String v) {
-			return Short.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Short, GenericRow> getAggregator() {
-			return new ShortFirstValueAggFunction();
-		}
+	@Override
+	protected Class<?> getAccClass() {
+		return GenericRow.class;
 	}
 
-	/**
-	 * Test for IntFirstValueAggFunction.
-	 */
-	public static class IntFirstValueAggFunctionWithoutOrderTest
-			extends NumberFirstValueAggFunctionWithoutOrderTest<Integer> {
-
-		@Override
-		protected Integer getValue(String v) {
-			return Integer.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Integer, GenericRow> getAggregator() {
-			return new IntFirstValueAggFunction();
-		}
+	@Parameterized.Parameters(name = "{index}: {0}")
+	public static List<AggFunctionTestSpec> testData() {
+		return Arrays.asList(
+				/**
+				 * Test for ByteFirstValueAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new ByteFirstValueAggFunction(),
+						numberInputValueSets(Byte::valueOf),
+						numberExpectedResults(Byte::valueOf)
+				),
+				/**
+				 * Test for ShortFirstValueAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new ShortFirstValueAggFunction(),
+						numberInputValueSets(Short::valueOf),
+						numberExpectedResults(Short::valueOf)
+				),
+				/**
+				 * Test for IntFirstValueAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new IntFirstValueAggFunction(),
+						numberInputValueSets(Integer::valueOf),
+						numberExpectedResults(Integer::valueOf)
+				),
+				/**
+				 * Test for LongFirstValueAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new LongFirstValueAggFunction(),
+						numberInputValueSets(Long::valueOf),
+						numberExpectedResults(Long::valueOf)
+				),
+				/**
+				 * Test for FloatFirstValueAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new FloatFirstValueAggFunction(),
+						numberInputValueSets(Float::valueOf),
+						numberExpectedResults(Float::valueOf)
+				),
+				/**
+				 * Test for DoubleFirstValueAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new DoubleFirstValueAggFunction(),
+						numberInputValueSets(Double::valueOf),
+						numberExpectedResults(Double::valueOf)
+				),
+				/**
+				 * Test for BooleanFirstValueAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new BooleanFirstValueAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										false,
+										false,
+										false
+								),
+								Arrays.asList(
+										true,
+										true,
+										true
+								),
+								Arrays.asList(
+										true,
+										false,
+										null,
+										true,
+										false,
+										true,
+										null
+								),
+								Arrays.asList(
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										true
+								)
+						),
+						Arrays.asList(
+								false,
+								true,
+								true,
+								null,
+								true
+						)
+				),
+				/**
+				 * Test for DecimalFirstValueAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new DecimalFirstValueAggFunction(DecimalTypeInfo.of(DECIMAL_PRECISION, DECIMAL_SCALE)),
+						Arrays.asList(
+								Arrays.asList(
+										Decimal.castFrom("1", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("1000.000001", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-1", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-999.998999", DECIMAL_PRECISION, DECIMAL_SCALE),
+										null,
+										Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-999.999", DECIMAL_PRECISION, DECIMAL_SCALE),
+										null,
+										Decimal.castFrom("999.999", DECIMAL_PRECISION, DECIMAL_SCALE)
+								),
+								Arrays.asList(
+										null,
+										null,
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE)
+								)
+						),
+						Arrays.asList(
+								Decimal.castFrom("1", DECIMAL_PRECISION, DECIMAL_SCALE),
+								null,
+								Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE)
+						)
+				),
+				/**
+				 * Test for StringFirstValueAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new StringFirstValueAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										BinaryString.fromString("abc"),
+										BinaryString.fromString("def"),
+										BinaryString.fromString("ghi"),
+										null,
+										BinaryString.fromString("jkl"),
+										null,
+										BinaryString.fromString("zzz")
+								),
+								Arrays.asList(
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										BinaryString.fromString("a")
+								),
+								Arrays.asList(
+										BinaryString.fromString("x"),
+										null,
+										BinaryString.fromString("e")
+								)
+						),
+						Arrays.asList(
+								BinaryString.fromString("abc"),
+								null,
+								BinaryString.fromString("a"),
+								BinaryString.fromString("x")
+						)
+				)
+		);
 	}
 
-	/**
-	 * Test for LongFirstValueAggFunction.
-	 */
-	public static class LongFirstValueAggFunctionWithoutOrderTest
-			extends NumberFirstValueAggFunctionWithoutOrderTest<Long> {
-
-		@Override
-		protected Long getValue(String v) {
-			return Long.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Long, GenericRow> getAggregator() {
-			return new LongFirstValueAggFunction();
-		}
+	private static <N> List<List<N>> numberInputValueSets(Function<String, N> strToValueFun) {
+		return Arrays.asList(
+				Arrays.asList(
+						strToValueFun.apply("1"),
+						null,
+						strToValueFun.apply("-99"),
+						strToValueFun.apply("3"),
+						null
+				),
+				Arrays.asList(
+						null,
+						null,
+						null,
+						null
+				),
+				Arrays.asList(
+						null,
+						strToValueFun.apply("10"),
+						null,
+						strToValueFun.apply("3")
+				)
+		);
 	}
 
-	/**
-	 * Test for FloatFirstValueAggFunction.
-	 */
-	public static class FloatFirstValueAggFunctionWithoutOrderTest
-			extends NumberFirstValueAggFunctionWithoutOrderTest<Float> {
-
-		@Override
-		protected Float getValue(String v) {
-			return Float.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Float, GenericRow> getAggregator() {
-			return new FloatFirstValueAggFunction();
-		}
-	}
-
-	/**
-	 * Test for DoubleFirstValueAggFunction.
-	 */
-	public static class DoubleFirstValueAggFunctionWithoutOrderTest
-			extends NumberFirstValueAggFunctionWithoutOrderTest<Double> {
-
-		@Override
-		protected Double getValue(String v) {
-			return Double.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Double, GenericRow> getAggregator() {
-			return new DoubleFirstValueAggFunction();
-		}
-	}
-
-	/**
-	 * Test for BooleanFirstValueAggFunction.
-	 */
-	public static class BooleanFirstValueAggFunctionWithoutOrderTest extends
-			FirstValueAggFunctionWithoutOrderTestBase<Boolean> {
-
-		@Override
-		protected List<List<Boolean>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							false,
-							false,
-							false
-					),
-					Arrays.asList(
-							true,
-							true,
-							true
-					),
-					Arrays.asList(
-							true,
-							false,
-							null,
-							true,
-							false,
-							true,
-							null
-					),
-					Arrays.asList(
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							true
-					));
-		}
-
-		@Override
-		protected List<Boolean> getExpectedResults() {
-			return Arrays.asList(
-					false,
-					true,
-					true,
-					null,
-					true
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Boolean, GenericRow> getAggregator() {
-			return new BooleanFirstValueAggFunction();
-		}
-	}
-
-	/**
-	 * Test for DecimalFirstValueAggFunction.
-	 */
-	public static class DecimalFirstValueAggFunctionWithoutOrderTest extends
-			FirstValueAggFunctionWithoutOrderTestBase<Decimal> {
-
-		private int precision = 20;
-		private int scale = 6;
-
-		@Override
-		protected List<List<Decimal>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							Decimal.castFrom("1", precision, scale),
-							Decimal.castFrom("1000.000001", precision, scale),
-							Decimal.castFrom("-1", precision, scale),
-							Decimal.castFrom("-999.998999", precision, scale),
-							null,
-							Decimal.castFrom("0", precision, scale),
-							Decimal.castFrom("-999.999", precision, scale),
-							null,
-							Decimal.castFrom("999.999", precision, scale)
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							Decimal.castFrom("0", precision, scale)
-					)
-			);
-		}
-
-		@Override
-		protected List<Decimal> getExpectedResults() {
-			return Arrays.asList(
-					Decimal.castFrom("1", precision, scale),
-					null,
-					Decimal.castFrom("0", precision, scale)
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Decimal, GenericRow> getAggregator() {
-			return new DecimalFirstValueAggFunction(DecimalTypeInfo.of(precision, scale));
-		}
-	}
-
-	/**
-	 * Test for StringFirstValueAggFunction.
-	 */
-	public static class StringFirstValueAggFunctionWithoutOrderTest extends
-			FirstValueAggFunctionWithoutOrderTestBase<BinaryString> {
-
-		@Override
-		protected List<List<BinaryString>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							BinaryString.fromString("abc"),
-							BinaryString.fromString("def"),
-							BinaryString.fromString("ghi"),
-							null,
-							BinaryString.fromString("jkl"),
-							null,
-							BinaryString.fromString("zzz")
-					),
-					Arrays.asList(
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							BinaryString.fromString("a")
-					),
-					Arrays.asList(
-							BinaryString.fromString("x"),
-							null,
-							BinaryString.fromString("e")
-					)
-			);
-		}
-
-		@Override
-		protected List<BinaryString> getExpectedResults() {
-			return Arrays.asList(
-					BinaryString.fromString("abc"),
-					null,
-					BinaryString.fromString("a"),
-					BinaryString.fromString("x")
-			);
-		}
-
-		@Override
-		protected AggregateFunction<BinaryString, GenericRow> getAggregator() {
-			return new StringFirstValueAggFunction();
-		}
+	private static <N> List<N> numberExpectedResults(Function<String, N> strToValueFun) {
+		return Arrays.asList(
+				strToValueFun.apply("1"),
+				null,
+				strToValueFun.apply("10")
+		);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithOrderTest.java
@@ -33,6 +33,9 @@ import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetra
 import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.StringFirstValueWithRetractAggFunction;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
@@ -41,19 +44,26 @@ import java.util.List;
  * Test case for built-in FirstValue with retract aggregate function.
  * This class tests `accumulate` method with order argument.
  */
-public abstract class FirstValueWithRetractAggFunctionWithOrderTest<T>
-		extends FirstLastValueAggFunctionWithOrderTestBase<T> {
+@RunWith(Enclosed.class)
+public class FirstValueWithRetractAggFunctionWithOrderTest {
+
+	/**
+	 * The base test class for FirstValueWithRetractAggFunction with order.
+	 */
+	public abstract static class FirstValueWithRetractAggFunctionWithOrderTestBase<T>
+			extends FirstLastValueAggFunctionWithOrderTestBase<T> {
 
 	@Override
-	protected Method getRetractFunc() throws NoSuchMethodException {
-		return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class, Long.class);
+		protected Method getRetractFunc() throws NoSuchMethodException {
+			return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class, Long.class);
+		}
 	}
 
 	/**
 	 * Test FirstValueWithRetractAggFunction for number type.
 	 */
-	public abstract static class NumberFirstValueWithRetractAggFunctionWithOrderTest<T>
-			extends FirstValueWithRetractAggFunctionWithOrderTest<T> {
+	public abstract static class NumberFirstValueWithRetractAggFunctionWithOrderTestBase<T>
+			extends FirstValueWithRetractAggFunctionWithOrderTestBase<T> {
 		protected abstract T getValue(String v);
 
 		@Override
@@ -126,7 +136,7 @@ public abstract class FirstValueWithRetractAggFunctionWithOrderTest<T>
 	 * Test for ByteFirstValueWithRetractAggFunction.
 	 */
 	public static class ByteFirstValueWithRetractAggFunctionWithOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithOrderTest<Byte> {
+			extends NumberFirstValueWithRetractAggFunctionWithOrderTestBase<Byte> {
 
 		@Override
 		protected Byte getValue(String v) {
@@ -143,7 +153,7 @@ public abstract class FirstValueWithRetractAggFunctionWithOrderTest<T>
 	 * Test for ShortFirstValueWithRetractAggFunction.
 	 */
 	public static class ShortFirstValueWithRetractAggFunctionWithOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithOrderTest<Short> {
+			extends NumberFirstValueWithRetractAggFunctionWithOrderTestBase<Short> {
 
 		@Override
 		protected Short getValue(String v) {
@@ -160,7 +170,7 @@ public abstract class FirstValueWithRetractAggFunctionWithOrderTest<T>
 	 * Test for IntFirstValueWithRetractAggFunction.
 	 */
 	public static class IntFirstValueWithRetractAggFunctionWithOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithOrderTest<Integer> {
+			extends NumberFirstValueWithRetractAggFunctionWithOrderTestBase<Integer> {
 
 		@Override
 		protected Integer getValue(String v) {
@@ -177,7 +187,7 @@ public abstract class FirstValueWithRetractAggFunctionWithOrderTest<T>
 	 * Test for LongFirstValueWithRetractAggFunction.
 	 */
 	public static class LongFirstValueWithRetractAggFunctionWithOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithOrderTest<Long> {
+			extends NumberFirstValueWithRetractAggFunctionWithOrderTestBase<Long> {
 
 		@Override
 		protected Long getValue(String v) {
@@ -194,7 +204,7 @@ public abstract class FirstValueWithRetractAggFunctionWithOrderTest<T>
 	 * Test for FloatFirstValueWithRetractAggFunction.
 	 */
 	public static class FloatFirstValueWithRetractAggFunctionWithOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithOrderTest<Float> {
+			extends NumberFirstValueWithRetractAggFunctionWithOrderTestBase<Float> {
 
 		@Override
 		protected Float getValue(String v) {
@@ -211,7 +221,7 @@ public abstract class FirstValueWithRetractAggFunctionWithOrderTest<T>
 	 * Test for DoubleFirstValueWithRetractAggFunction.
 	 */
 	public static class DoubleFirstValueWithRetractAggFunctionWithOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithOrderTest<Double> {
+			extends NumberFirstValueWithRetractAggFunctionWithOrderTestBase<Double> {
 
 		@Override
 		protected Double getValue(String v) {
@@ -228,7 +238,7 @@ public abstract class FirstValueWithRetractAggFunctionWithOrderTest<T>
 	 * Test for BooleanFirstValueWithRetractAggFunction.
 	 */
 	public static class BooleanFirstValueWithRetractAggFunctionWithOrderTest
-			extends FirstValueWithRetractAggFunctionWithOrderTest<Boolean> {
+			extends FirstValueWithRetractAggFunctionWithOrderTestBase<Boolean> {
 
 		@Override
 		protected List<List<Boolean>> getInputValueSets() {
@@ -318,7 +328,7 @@ public abstract class FirstValueWithRetractAggFunctionWithOrderTest<T>
 	 * Test for DecimalFirstValueWithRetractAggFunction.
 	 */
 	public static class DecimalFirstValueWithRetractAggFunctionWithOrderTest
-			extends FirstValueWithRetractAggFunctionWithOrderTest<Decimal> {
+			extends FirstValueWithRetractAggFunctionWithOrderTestBase<Decimal> {
 
 		private int precision = 20;
 		private int scale = 6;
@@ -398,7 +408,7 @@ public abstract class FirstValueWithRetractAggFunctionWithOrderTest<T>
 	 * Test for StringFirstValueWithRetractAggFunction.
 	 */
 	public static class StringFirstValueWithRetractAggFunctionWithOrderTest
-			extends FirstValueWithRetractAggFunctionWithOrderTest<BinaryString> {
+			extends FirstValueWithRetractAggFunctionWithOrderTestBase<BinaryString> {
 
 		@Override
 		protected List<List<BinaryString>> getInputValueSets() {

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithOrderTest.java
@@ -33,452 +33,364 @@ import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetra
 import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.StringFirstValueWithRetractAggFunction;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 
-import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Test case for built-in FirstValue with retract aggregate function.
  * This class tests `accumulate` method with order argument.
  */
-@RunWith(Enclosed.class)
-public class FirstValueWithRetractAggFunctionWithOrderTest {
+@RunWith(Parameterized.class)
+public class FirstValueWithRetractAggFunctionWithOrderTest<T> extends FirstLastValueAggFunctionWithOrderTestBase<T> {
 
-	/**
-	 * The base test class for FirstValueWithRetractAggFunction with order.
-	 */
-	public abstract static class FirstValueWithRetractAggFunctionWithOrderTestBase<T>
-			extends FirstLastValueAggFunctionWithOrderTestBase<T> {
+	@Parameterized.Parameter
+	public AggFunctionWithOrderTestSpec<T> aggFunctionTestSpec;
+
+	private static final int DECIMAL_PRECISION = 20;
+	private static final int DECIMAL_SCALE = 6;
 
 	@Override
-		protected Method getRetractFunc() throws NoSuchMethodException {
-			return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class, Long.class);
-		}
+	protected List<List<Long>> getInputOrderSets() {
+		return aggFunctionTestSpec.inputOrderSets;
 	}
 
-	/**
-	 * Test FirstValueWithRetractAggFunction for number type.
-	 */
-	public abstract static class NumberFirstValueWithRetractAggFunctionWithOrderTestBase<T>
-			extends FirstValueWithRetractAggFunctionWithOrderTestBase<T> {
-		protected abstract T getValue(String v);
-
-		@Override
-		protected List<List<T>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							getValue("1"),
-							null,
-							getValue("-99"),
-							getValue("3"),
-							null,
-							getValue("3"),
-							getValue("2"),
-							getValue("-99")
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							getValue("10"),
-							null,
-							getValue("5")
-					)
-			);
-		}
-
-		@Override
-		protected List<List<Long>> getInputOrderSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							10L,
-							2L,
-							5L,
-							6L,
-							11L,
-							3L,
-							7L,
-							5L
-					),
-					Arrays.asList(
-							8L,
-							6L,
-							9L,
-							5L
-					),
-					Arrays.asList(
-							null,
-							6L,
-							4L,
-							3L
-					)
-			);
-		}
-
-		@Override
-		protected List<T> getExpectedResults() {
-			return Arrays.asList(
-					getValue("3"),
-					null,
-					getValue("5")
-			);
-		}
+	@Override
+	protected List<List<T>> getInputValueSets() {
+		return aggFunctionTestSpec.inputValueSets;
 	}
 
-	/**
-	 * Test for ByteFirstValueWithRetractAggFunction.
-	 */
-	public static class ByteFirstValueWithRetractAggFunctionWithOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithOrderTestBase<Byte> {
-
-		@Override
-		protected Byte getValue(String v) {
-			return Byte.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Byte, GenericRow> getAggregator() {
-			return new ByteFirstValueWithRetractAggFunction();
-		}
+	@Override
+	protected List<T> getExpectedResults() {
+		return aggFunctionTestSpec.expectedResults;
 	}
 
-	/**
-	 * Test for ShortFirstValueWithRetractAggFunction.
-	 */
-	public static class ShortFirstValueWithRetractAggFunctionWithOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithOrderTestBase<Short> {
-
-		@Override
-		protected Short getValue(String v) {
-			return Short.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Short, GenericRow> getAggregator() {
-			return new ShortFirstValueWithRetractAggFunction();
-		}
+	@Override
+	protected AggregateFunction<T, GenericRow> getAggregator() {
+		return aggFunctionTestSpec.aggregator;
 	}
 
-	/**
-	 * Test for IntFirstValueWithRetractAggFunction.
-	 */
-	public static class IntFirstValueWithRetractAggFunctionWithOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithOrderTestBase<Integer> {
-
-		@Override
-		protected Integer getValue(String v) {
-			return Integer.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Integer, GenericRow> getAggregator() {
-			return new IntFirstValueWithRetractAggFunction();
-		}
+	@Override
+	protected Method getRetractFunc() throws NoSuchMethodException {
+		return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class, Long.class);
 	}
 
-	/**
-	 * Test for LongFirstValueWithRetractAggFunction.
-	 */
-	public static class LongFirstValueWithRetractAggFunctionWithOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithOrderTestBase<Long> {
-
-		@Override
-		protected Long getValue(String v) {
-			return Long.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Long, GenericRow> getAggregator() {
-			return new LongFirstValueWithRetractAggFunction();
-		}
+	@Parameterized.Parameters(name = "{index}: {0}")
+	public static List<AggFunctionTestSpec> testData() {
+		return Arrays.asList(
+				/**
+				 * Test for ByteFirstValueWithRetractAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new ByteFirstValueWithRetractAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Byte::valueOf),
+						numberExpectedResults(Byte::valueOf)
+				),
+				/**
+				 * Test for ShortFirstValueWithRetractAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new ShortFirstValueWithRetractAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Short::valueOf),
+						numberExpectedResults(Short::valueOf)
+				),
+				/**
+				 * Test for IntFirstValueWithRetractAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new IntFirstValueWithRetractAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Integer::valueOf),
+						numberExpectedResults(Integer::valueOf)
+				),
+				/**
+				 * Test for LongFirstValueWithRetractAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new LongFirstValueWithRetractAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Long::valueOf),
+						numberExpectedResults(Long::valueOf)
+				),
+				/**
+				 * Test for FloatFirstValueWithRetractAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new FloatFirstValueWithRetractAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Float::valueOf),
+						numberExpectedResults(Float::valueOf)
+				),
+				/**
+				 * Test for DoubleFirstValueWithRetractAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new DoubleFirstValueWithRetractAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Double::valueOf),
+						numberExpectedResults(Double::valueOf)
+				),
+				/**
+				 * Test for BooleanFirstValueWithRetractAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new BooleanFirstValueWithRetractAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										6L,
+										2L,
+										3L
+								),
+								Arrays.asList(
+										1L,
+										2L,
+										3L
+								),
+								Arrays.asList(
+										10L,
+										2L,
+										5L,
+										11L,
+										3L,
+										7L,
+										5L
+								),
+								Arrays.asList(
+										6L,
+										9L,
+										5L
+								),
+								Arrays.asList(
+										4L,
+										3L
+								)
+						),
+						Arrays.asList(
+								Arrays.asList(
+										false,
+										false,
+										false
+								),
+								Arrays.asList(
+										true,
+										true,
+										true
+								),
+								Arrays.asList(
+										true,
+										false,
+										null,
+										true,
+										false,
+										true,
+										null
+								),
+								Arrays.asList(
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										true
+								)
+						),
+						Arrays.asList(
+								false,
+								true,
+								false,
+								null,
+								true
+						)
+				),
+				/**
+				 * Test for DecimalFirstValueWithRetractAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new DecimalFirstValueWithRetractAggFunction(
+								DecimalTypeInfo.of(DECIMAL_PRECISION, DECIMAL_SCALE)),
+						Arrays.asList(
+								Arrays.asList(
+										10L,
+										2L,
+										1L,
+										5L,
+										null,
+										3L,
+										1L,
+										5L,
+										2L
+								),
+								Arrays.asList(
+										6L,
+										5L,
+										null,
+										8L,
+										null
+								),
+								Arrays.asList(
+										8L,
+										6L
+								)
+						),
+						Arrays.asList(
+								Arrays.asList(
+										Decimal.castFrom("1", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("1000.000001", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-1", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-999.998999", DECIMAL_PRECISION, DECIMAL_SCALE),
+										null,
+										Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-999.999", DECIMAL_PRECISION, DECIMAL_SCALE),
+										null,
+										Decimal.castFrom("999.999", DECIMAL_PRECISION, DECIMAL_SCALE)
+								),
+								Arrays.asList(
+										null,
+										null,
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE)
+								)
+						),
+						Arrays.asList(
+								Decimal.castFrom("-1", DECIMAL_PRECISION, DECIMAL_SCALE),
+								null,
+								Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE)
+						)
+				),
+				/**
+				 * Test for StringFirstValueWithRetractAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new StringFirstValueWithRetractAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										10L,
+										2L,
+										5L,
+										null,
+										3L,
+										1L,
+										5L
+								),
+								Arrays.asList(
+										6L,
+										5L
+								),
+								Arrays.asList(
+										8L,
+										6L
+								),
+								Arrays.asList(
+										6L,
+										4L,
+										3L
+								)
+						),
+						Arrays.asList(
+								Arrays.asList(
+										BinaryString.fromString("abc"),
+										BinaryString.fromString("def"),
+										BinaryString.fromString("ghi"),
+										null,
+										BinaryString.fromString("jkl"),
+										null,
+										BinaryString.fromString("zzz")
+								),
+								Arrays.asList(
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										BinaryString.fromString("a")
+								),
+								Arrays.asList(
+										BinaryString.fromString("x"),
+										null,
+										BinaryString.fromString("e")
+								)
+						),
+						Arrays.asList(
+								BinaryString.fromString("def"),
+								null,
+								BinaryString.fromString("a"),
+								BinaryString.fromString("e")
+						)
+				)
+		);
 	}
 
-	/**
-	 * Test for FloatFirstValueWithRetractAggFunction.
-	 */
-	public static class FloatFirstValueWithRetractAggFunctionWithOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithOrderTestBase<Float> {
-
-		@Override
-		protected Float getValue(String v) {
-			return Float.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Float, GenericRow> getAggregator() {
-			return new FloatFirstValueWithRetractAggFunction();
-		}
+	private static List<List<Long>> numberInputOrderSets() {
+		return Arrays.asList(
+				Arrays.asList(
+						10L,
+						2L,
+						5L,
+						6L,
+						11L,
+						3L,
+						7L,
+						5L
+				),
+				Arrays.asList(
+						8L,
+						6L,
+						9L,
+						5L
+				),
+				Arrays.asList(
+						null,
+						6L,
+						4L,
+						3L
+				)
+		);
 	}
 
-	/**
-	 * Test for DoubleFirstValueWithRetractAggFunction.
-	 */
-	public static class DoubleFirstValueWithRetractAggFunctionWithOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithOrderTestBase<Double> {
-
-		@Override
-		protected Double getValue(String v) {
-			return Double.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Double, GenericRow> getAggregator() {
-			return new DoubleFirstValueWithRetractAggFunction();
-		}
+	private static <N> List<List<N>> numberInputValueSets(Function<String, N> strToValueFun) {
+		return Arrays.asList(
+				Arrays.asList(
+						strToValueFun.apply("1"),
+						null,
+						strToValueFun.apply("-99"),
+						strToValueFun.apply("3"),
+						null,
+						strToValueFun.apply("3"),
+						strToValueFun.apply("2"),
+						strToValueFun.apply("-99")
+				),
+				Arrays.asList(
+						null,
+						null,
+						null,
+						null
+				),
+				Arrays.asList(
+						null,
+						strToValueFun.apply("10"),
+						null,
+						strToValueFun.apply("5")
+				)
+		);
 	}
 
-	/**
-	 * Test for BooleanFirstValueWithRetractAggFunction.
-	 */
-	public static class BooleanFirstValueWithRetractAggFunctionWithOrderTest
-			extends FirstValueWithRetractAggFunctionWithOrderTestBase<Boolean> {
-
-		@Override
-		protected List<List<Boolean>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							false,
-							false,
-							false
-					),
-					Arrays.asList(
-							true,
-							true,
-							true
-					),
-					Arrays.asList(
-							true,
-							false,
-							null,
-							true,
-							false,
-							true,
-							null
-					),
-					Arrays.asList(
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							true
-					));
-		}
-
-		@Override
-		protected List<List<Long>> getInputOrderSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							6L,
-							2L,
-							3L
-					),
-					Arrays.asList(
-							1L,
-							2L,
-							3L
-					),
-					Arrays.asList(
-							10L,
-							2L,
-							5L,
-							11L,
-							3L,
-							7L,
-							5L
-					),
-					Arrays.asList(
-							6L,
-							9L,
-							5L
-					),
-					Arrays.asList(
-							4L,
-							3L
-					)
-			);
-		}
-
-		@Override
-		protected List<Boolean> getExpectedResults() {
-			return Arrays.asList(
-					false,
-					true,
-					false,
-					null,
-					true
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Boolean, GenericRow> getAggregator() {
-			return new BooleanFirstValueWithRetractAggFunction();
-		}
-	}
-
-	/**
-	 * Test for DecimalFirstValueWithRetractAggFunction.
-	 */
-	public static class DecimalFirstValueWithRetractAggFunctionWithOrderTest
-			extends FirstValueWithRetractAggFunctionWithOrderTestBase<Decimal> {
-
-		private int precision = 20;
-		private int scale = 6;
-
-		@Override
-		protected List<List<Decimal>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							Decimal.castFrom("1", precision, scale),
-							Decimal.castFrom("1000.000001", precision, scale),
-							Decimal.castFrom("-1", precision, scale),
-							Decimal.castFrom("-999.998999", precision, scale),
-							null,
-							Decimal.castFrom("0", precision, scale),
-							Decimal.castFrom("-999.999", precision, scale),
-							null,
-							Decimal.castFrom("999.999", precision, scale)
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							Decimal.castFrom("0", precision, scale)
-					)
-			);
-		}
-
-		@Override
-		protected List<List<Long>> getInputOrderSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							10L,
-							2L,
-							1L,
-							5L,
-							null,
-							3L,
-							1L,
-							5L,
-							2L
-					),
-					Arrays.asList(
-							6L,
-							5L,
-							null,
-							8L,
-							null
-					),
-					Arrays.asList(
-							8L,
-							6L
-					)
-			);
-		}
-
-		@Override
-		protected List<Decimal> getExpectedResults() {
-			return Arrays.asList(
-					Decimal.castFrom("-1", precision, scale),
-					null,
-					Decimal.castFrom("0", precision, scale)
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Decimal, GenericRow> getAggregator() {
-			return new DecimalFirstValueWithRetractAggFunction(DecimalTypeInfo.of(precision, scale));
-		}
-	}
-
-	/**
-	 * Test for StringFirstValueWithRetractAggFunction.
-	 */
-	public static class StringFirstValueWithRetractAggFunctionWithOrderTest
-			extends FirstValueWithRetractAggFunctionWithOrderTestBase<BinaryString> {
-
-		@Override
-		protected List<List<BinaryString>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							BinaryString.fromString("abc"),
-							BinaryString.fromString("def"),
-							BinaryString.fromString("ghi"),
-							null,
-							BinaryString.fromString("jkl"),
-							null,
-							BinaryString.fromString("zzz")
-					),
-					Arrays.asList(
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							BinaryString.fromString("a")
-					),
-					Arrays.asList(
-							BinaryString.fromString("x"),
-							null,
-							BinaryString.fromString("e")
-					)
-			);
-		}
-
-		@Override
-		protected List<List<Long>> getInputOrderSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							10L,
-							2L,
-							5L,
-							null,
-							3L,
-							1L,
-							5L
-					),
-					Arrays.asList(
-							6L,
-							5L
-					),
-					Arrays.asList(
-							8L,
-							6L
-					),
-					Arrays.asList(
-							6L,
-							4L,
-							3L
-					)
-			);
-		}
-
-		@Override
-		protected List<BinaryString> getExpectedResults() {
-			return Arrays.asList(
-					BinaryString.fromString("def"),
-					null,
-					BinaryString.fromString("a"),
-					BinaryString.fromString("e")
-			);
-		}
-
-		@Override
-		protected AggregateFunction<BinaryString, GenericRow> getAggregator() {
-			return new StringFirstValueWithRetractAggFunction();
-		}
+	private static <N> List<N> numberExpectedResults(Function<String, N> strToValueFun) {
+		return Arrays.asList(
+				strToValueFun.apply("3"),
+				null,
+				strToValueFun.apply("5")
+		);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithoutOrderTest.java
@@ -33,6 +33,9 @@ import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetra
 import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.StringFirstValueWithRetractAggFunction;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
@@ -41,23 +44,31 @@ import java.util.List;
  * Test case for built-in FirstValue with retract aggregate function.
  * This class tests `accumulate` method without order argument.
  */
-public abstract class FirstValueWithRetractAggFunctionWithoutOrderTest<T> extends AggFunctionTestBase<T, GenericRow> {
+@RunWith(Enclosed.class)
+public class FirstValueWithRetractAggFunctionWithoutOrderTest {
 
-	@Override
-	protected Class<?> getAccClass() {
-		return GenericRow.class;
-	}
+	/**
+	 * The base test class for FirstValueWithRetractAggFunction without order.
+	 */
+	public abstract static class FirstValueWithRetractAggFunctionWithoutOrderTestBase<T>
+			extends AggFunctionTestBase<T, GenericRow> {
 
-	@Override
-	protected Method getRetractFunc() throws NoSuchMethodException {
-		return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class);
+		@Override
+		protected Class<?> getAccClass() {
+			return GenericRow.class;
+		}
+
+		@Override
+		protected Method getRetractFunc() throws NoSuchMethodException {
+			return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class);
+		}
 	}
 
 	/**
 	 * Test FirstValueWithRetractAggFunction for number type.
 	 */
-	public abstract static class NumberFirstValueWithRetractAggFunctionWithoutOrderTest<T>
-			extends FirstValueWithRetractAggFunctionWithoutOrderTest<T> {
+	public abstract static class NumberFirstValueWithRetractAggFunctionWithoutOrderTestBase<T>
+			extends FirstValueWithRetractAggFunctionWithoutOrderTestBase<T> {
 		protected abstract T getValue(String v);
 
 		@Override
@@ -99,7 +110,7 @@ public abstract class FirstValueWithRetractAggFunctionWithoutOrderTest<T> extend
 	 * Test for ByteFirstValueWithRetractAggFunction.
 	 */
 	public static class ByteFirstValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTest<Byte> {
+			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTestBase<Byte> {
 
 		@Override
 		protected Byte getValue(String v) {
@@ -116,7 +127,7 @@ public abstract class FirstValueWithRetractAggFunctionWithoutOrderTest<T> extend
 	 * Test for ShortFirstValueWithRetractAggFunction.
 	 */
 	public static class ShortFirstValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTest<Short> {
+			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTestBase<Short> {
 
 		@Override
 		protected Short getValue(String v) {
@@ -133,7 +144,7 @@ public abstract class FirstValueWithRetractAggFunctionWithoutOrderTest<T> extend
 	 * Test for IntFirstValueWithRetractAggFunction.
 	 */
 	public static class IntFirstValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTest<Integer> {
+			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTestBase<Integer> {
 
 		@Override
 		protected Integer getValue(String v) {
@@ -150,7 +161,7 @@ public abstract class FirstValueWithRetractAggFunctionWithoutOrderTest<T> extend
 	 * Test for LongFirstValueWithRetractAggFunction.
 	 */
 	public static class LongFirstValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTest<Long> {
+			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTestBase<Long> {
 
 		@Override
 		protected Long getValue(String v) {
@@ -167,7 +178,7 @@ public abstract class FirstValueWithRetractAggFunctionWithoutOrderTest<T> extend
 	 * Test for FloatFirstValueWithRetractAggFunction.
 	 */
 	public static class FloatFirstValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTest<Float> {
+			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTestBase<Float> {
 
 		@Override
 		protected Float getValue(String v) {
@@ -184,7 +195,7 @@ public abstract class FirstValueWithRetractAggFunctionWithoutOrderTest<T> extend
 	 * Test for DoubleFirstValueWithRetractAggFunction.
 	 */
 	public static class DoubleFirstValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTest<Double> {
+			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTestBase<Double> {
 
 		@Override
 		protected Double getValue(String v) {
@@ -201,7 +212,7 @@ public abstract class FirstValueWithRetractAggFunctionWithoutOrderTest<T> extend
 	 * Test for BooleanFirstValueWithRetractAggFunction.
 	 */
 	public static class BooleanFirstValueWithRetractAggFunctionWithoutOrderTest extends
-			FirstValueWithRetractAggFunctionWithoutOrderTest<Boolean> {
+			FirstValueWithRetractAggFunctionWithoutOrderTestBase<Boolean> {
 
 		@Override
 		protected List<List<Boolean>> getInputValueSets() {
@@ -257,7 +268,7 @@ public abstract class FirstValueWithRetractAggFunctionWithoutOrderTest<T> extend
 	 * Test for DecimalFirstValueWithRetractAggFunction.
 	 */
 	public static class DecimalFirstValueWithRetractAggFunctionWithoutOrderTest extends
-			FirstValueWithRetractAggFunctionWithoutOrderTest<Decimal> {
+			FirstValueWithRetractAggFunctionWithoutOrderTestBase<Decimal> {
 
 		private int precision = 20;
 		private int scale = 6;
@@ -309,7 +320,7 @@ public abstract class FirstValueWithRetractAggFunctionWithoutOrderTest<T> extend
 	 * Test for StringFirstValueWithRetractAggFunction.
 	 */
 	public static class StringFirstValueWithRetractAggFunctionWithoutOrderTest extends
-			FirstValueWithRetractAggFunctionWithoutOrderTest<BinaryString> {
+			FirstValueWithRetractAggFunctionWithoutOrderTestBase<BinaryString> {
 
 		@Override
 		protected List<List<BinaryString>> getInputValueSets() {

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithoutOrderTest.java
@@ -33,336 +33,250 @@ import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetra
 import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.StringFirstValueWithRetractAggFunction;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 
-import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Test case for built-in FirstValue with retract aggregate function.
  * This class tests `accumulate` method without order argument.
  */
-@RunWith(Enclosed.class)
-public class FirstValueWithRetractAggFunctionWithoutOrderTest {
+@RunWith(Parameterized.class)
+public class FirstValueWithRetractAggFunctionWithoutOrderTest<T> extends AggFunctionTestBase<T, GenericRow> {
 
-	/**
-	 * The base test class for FirstValueWithRetractAggFunction without order.
-	 */
-	public abstract static class FirstValueWithRetractAggFunctionWithoutOrderTestBase<T>
-			extends AggFunctionTestBase<T, GenericRow> {
+	@Parameterized.Parameter
+	public AggFunctionTestSpec<T, GenericRow> aggFunctionTestSpec;
 
-		@Override
-		protected Class<?> getAccClass() {
-			return GenericRow.class;
-		}
+	private static final int DECIMAL_PRECISION = 20;
+	private static final int DECIMAL_SCALE = 6;
 
-		@Override
-		protected Method getRetractFunc() throws NoSuchMethodException {
-			return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class);
-		}
+	@Override
+	protected List<List<T>> getInputValueSets() {
+		return aggFunctionTestSpec.inputValueSets;
 	}
 
-	/**
-	 * Test FirstValueWithRetractAggFunction for number type.
-	 */
-	public abstract static class NumberFirstValueWithRetractAggFunctionWithoutOrderTestBase<T>
-			extends FirstValueWithRetractAggFunctionWithoutOrderTestBase<T> {
-		protected abstract T getValue(String v);
-
-		@Override
-		protected List<List<T>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							getValue("1"),
-							null,
-							getValue("-99"),
-							getValue("3"),
-							null
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							getValue("10"),
-							null,
-							getValue("3")
-					)
-			);
-		}
-
-		@Override
-		protected List<T> getExpectedResults() {
-			return Arrays.asList(
-					getValue("1"),
-					null,
-					getValue("10")
-			);
-		}
+	@Override
+	protected List<T> getExpectedResults() {
+		return aggFunctionTestSpec.expectedResults;
 	}
 
-	/**
-	 * Test for ByteFirstValueWithRetractAggFunction.
-	 */
-	public static class ByteFirstValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTestBase<Byte> {
-
-		@Override
-		protected Byte getValue(String v) {
-			return Byte.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Byte, GenericRow> getAggregator() {
-			return new ByteFirstValueWithRetractAggFunction();
-		}
+	@Override
+	protected AggregateFunction<T, GenericRow> getAggregator() {
+		return aggFunctionTestSpec.aggregator;
 	}
 
-	/**
-	 * Test for ShortFirstValueWithRetractAggFunction.
-	 */
-	public static class ShortFirstValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTestBase<Short> {
-
-		@Override
-		protected Short getValue(String v) {
-			return Short.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Short, GenericRow> getAggregator() {
-			return new ShortFirstValueWithRetractAggFunction();
-		}
+	@Override
+	protected Class<?> getAccClass() {
+		return GenericRow.class;
 	}
 
-	/**
-	 * Test for IntFirstValueWithRetractAggFunction.
-	 */
-	public static class IntFirstValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTestBase<Integer> {
-
-		@Override
-		protected Integer getValue(String v) {
-			return Integer.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Integer, GenericRow> getAggregator() {
-			return new IntFirstValueWithRetractAggFunction();
-		}
+	@Override
+	protected Method getRetractFunc() throws NoSuchMethodException {
+		return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class);
 	}
 
-	/**
-	 * Test for LongFirstValueWithRetractAggFunction.
-	 */
-	public static class LongFirstValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTestBase<Long> {
+	@Parameterized.Parameters(name = "{index}: {0}")
+	public static List<AggFunctionTestSpec> testData() {
+		return Arrays.asList(
+				/**
+				 * Test for ByteFirstValueWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new ByteFirstValueWithRetractAggFunction(),
+						numberInputValueSets(Byte::valueOf),
+						numberExpectedResults(Byte::valueOf)
+				),
+				/**
+				 * Test for ShortFirstValueWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new ShortFirstValueWithRetractAggFunction(),
+						numberInputValueSets(Short::valueOf),
+						numberExpectedResults(Short::valueOf)
+				),
+				/**
+				 * Test for IntFirstValueWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new IntFirstValueWithRetractAggFunction(),
+						numberInputValueSets(Integer::valueOf),
+						numberExpectedResults(Integer::valueOf)
+				),
+				/**
+				 * Test for LongFirstValueWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new LongFirstValueWithRetractAggFunction(),
+						numberInputValueSets(Long::valueOf),
+						numberExpectedResults(Long::valueOf)
+				),
+				/**
+				 * Test for FloatFirstValueWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new FloatFirstValueWithRetractAggFunction(),
+						numberInputValueSets(Float::valueOf),
+						numberExpectedResults(Float::valueOf)
+				),
+				/**
+				 * Test for DoubleFirstValueWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new DoubleFirstValueWithRetractAggFunction(),
+						numberInputValueSets(Double::valueOf),
+						numberExpectedResults(Double::valueOf)
+				),
+				/**
+				 * Test for BooleanFirstValueWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new BooleanFirstValueWithRetractAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										false,
+										false,
+										false
+								),
+								Arrays.asList(
+										true,
+										true,
+										true
+								),
+								Arrays.asList(
+										true,
+										false,
+										null,
+										true,
+										false,
+										true,
+										null
+								),
+								Arrays.asList(
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										true
+								)),
+						Arrays.asList(
+								false,
+								true,
+								true,
+								null,
+								true
+						)
+				),
+				/**
+				 * Test for DecimalFirstValueWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new DecimalFirstValueWithRetractAggFunction(
+								DecimalTypeInfo.of(DECIMAL_PRECISION, DECIMAL_SCALE)),
+						Arrays.asList(
+								Arrays.asList(
+										Decimal.castFrom("1", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("1000.000001", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-1", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-999.998999", DECIMAL_PRECISION, DECIMAL_SCALE),
+										null,
+										Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-999.999", DECIMAL_PRECISION, DECIMAL_SCALE),
+										null,
+										Decimal.castFrom("999.999", DECIMAL_PRECISION, DECIMAL_SCALE)
+								),
+								Arrays.asList(
+										null,
+										null,
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE)
+								)
+						),
+						Arrays.asList(
+								Decimal.castFrom("1", DECIMAL_PRECISION, DECIMAL_SCALE),
+								null,
+								Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE)
+						)
+				),
+				/**
+				 * Test for StringLastValueWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new StringFirstValueWithRetractAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										BinaryString.fromString("abc"),
+										BinaryString.fromString("def"),
+										BinaryString.fromString("ghi"),
+										null,
+										BinaryString.fromString("jkl"),
+										null,
+										BinaryString.fromString("zzz")
+								),
+								Arrays.asList(
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										BinaryString.fromString("a")
+								),
+								Arrays.asList(
+										BinaryString.fromString("x"),
+										null,
+										BinaryString.fromString("e")
+								)
+						),
+						Arrays.asList(
+								BinaryString.fromString("abc"),
+								null,
+								BinaryString.fromString("a"),
+								BinaryString.fromString("x")
+						)
+				)
 
-		@Override
-		protected Long getValue(String v) {
-			return Long.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Long, GenericRow> getAggregator() {
-			return new LongFirstValueWithRetractAggFunction();
-		}
+		);
 	}
 
-	/**
-	 * Test for FloatFirstValueWithRetractAggFunction.
-	 */
-	public static class FloatFirstValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTestBase<Float> {
-
-		@Override
-		protected Float getValue(String v) {
-			return Float.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Float, GenericRow> getAggregator() {
-			return new FloatFirstValueWithRetractAggFunction();
-		}
+	private static <N> List<List<N>> numberInputValueSets(Function<String, N> strToValueFun) {
+		return Arrays.asList(
+				Arrays.asList(
+						strToValueFun.apply("1"),
+						null,
+						strToValueFun.apply("-99"),
+						strToValueFun.apply("3"),
+						null
+				),
+				Arrays.asList(
+						null,
+						null,
+						null,
+						null
+				),
+				Arrays.asList(
+						null,
+						strToValueFun.apply("10"),
+						null,
+						strToValueFun.apply("3")
+				)
+		);
 	}
 
-	/**
-	 * Test for DoubleFirstValueWithRetractAggFunction.
-	 */
-	public static class DoubleFirstValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTestBase<Double> {
-
-		@Override
-		protected Double getValue(String v) {
-			return Double.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Double, GenericRow> getAggregator() {
-			return new DoubleFirstValueWithRetractAggFunction();
-		}
-	}
-
-	/**
-	 * Test for BooleanFirstValueWithRetractAggFunction.
-	 */
-	public static class BooleanFirstValueWithRetractAggFunctionWithoutOrderTest extends
-			FirstValueWithRetractAggFunctionWithoutOrderTestBase<Boolean> {
-
-		@Override
-		protected List<List<Boolean>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							false,
-							false,
-							false
-					),
-					Arrays.asList(
-							true,
-							true,
-							true
-					),
-					Arrays.asList(
-							true,
-							false,
-							null,
-							true,
-							false,
-							true,
-							null
-					),
-					Arrays.asList(
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							true
-					));
-		}
-
-		@Override
-		protected List<Boolean> getExpectedResults() {
-			return Arrays.asList(
-					false,
-					true,
-					true,
-					null,
-					true
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Boolean, GenericRow> getAggregator() {
-			return new BooleanFirstValueWithRetractAggFunction();
-		}
-	}
-
-	/**
-	 * Test for DecimalFirstValueWithRetractAggFunction.
-	 */
-	public static class DecimalFirstValueWithRetractAggFunctionWithoutOrderTest extends
-			FirstValueWithRetractAggFunctionWithoutOrderTestBase<Decimal> {
-
-		private int precision = 20;
-		private int scale = 6;
-
-		@Override
-		protected List<List<Decimal>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							Decimal.castFrom("1", precision, scale),
-							Decimal.castFrom("1000.000001", precision, scale),
-							Decimal.castFrom("-1", precision, scale),
-							Decimal.castFrom("-999.998999", precision, scale),
-							null,
-							Decimal.castFrom("0", precision, scale),
-							Decimal.castFrom("-999.999", precision, scale),
-							null,
-							Decimal.castFrom("999.999", precision, scale)
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							Decimal.castFrom("0", precision, scale)
-					)
-			);
-		}
-
-		@Override
-		protected List<Decimal> getExpectedResults() {
-			return Arrays.asList(
-					Decimal.castFrom("1", precision, scale),
-					null,
-					Decimal.castFrom("0", precision, scale)
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Decimal, GenericRow> getAggregator() {
-			return new DecimalFirstValueWithRetractAggFunction(DecimalTypeInfo.of(precision, scale));
-		}
-	}
-
-	/**
-	 * Test for StringFirstValueWithRetractAggFunction.
-	 */
-	public static class StringFirstValueWithRetractAggFunctionWithoutOrderTest extends
-			FirstValueWithRetractAggFunctionWithoutOrderTestBase<BinaryString> {
-
-		@Override
-		protected List<List<BinaryString>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							BinaryString.fromString("abc"),
-							BinaryString.fromString("def"),
-							BinaryString.fromString("ghi"),
-							null,
-							BinaryString.fromString("jkl"),
-							null,
-							BinaryString.fromString("zzz")
-					),
-					Arrays.asList(
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							BinaryString.fromString("a")
-					),
-					Arrays.asList(
-							BinaryString.fromString("x"),
-							null,
-							BinaryString.fromString("e")
-					)
-			);
-		}
-
-		@Override
-		protected List<BinaryString> getExpectedResults() {
-			return Arrays.asList(
-					BinaryString.fromString("abc"),
-					null,
-					BinaryString.fromString("a"),
-					BinaryString.fromString("x")
-			);
-		}
-
-		@Override
-		protected AggregateFunction<BinaryString, GenericRow> getAggregator() {
-			return new StringFirstValueWithRetractAggFunction();
-		}
+	private static <N> List<N> numberExpectedResults(Function<String, N> strToValueFun) {
+		return Arrays.asList(
+				strToValueFun.apply("1"),
+				null,
+				strToValueFun.apply("10")
+		);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithOrderTest.java
@@ -33,6 +33,9 @@ import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunctio
 import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.StringLastValueAggFunction;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -40,13 +43,22 @@ import java.util.List;
  * Test case for built-in LastValue aggregate function.
  * This class tests `accumulate` method with order argument.
  */
-public abstract class LastValueAggFunctionWithOrderTest<T> extends FirstLastValueAggFunctionWithOrderTestBase<T> {
+@RunWith(Enclosed.class)
+public class LastValueAggFunctionWithOrderTest {
+
+	/**
+	 * The base test class for LastValueAggFunction with order.
+	 */
+	public abstract static class LastValueAggFunctionWithOrderTestBase<T>
+			extends FirstLastValueAggFunctionWithOrderTestBase<T> {
+
+	}
 
 	/**
 	 * Test LastValueAggFunction for number type.
 	 */
-	public abstract static class NumberLastValueAggFunctionWithOrderTest<T>
-			extends LastValueAggFunctionWithOrderTest<T> {
+	public abstract static class NumberLastValueAggFunctionWithOrderTestBase<T>
+			extends LastValueAggFunctionWithOrderTestBase<T> {
 		protected abstract T getValue(String v);
 
 		@Override
@@ -119,7 +131,7 @@ public abstract class LastValueAggFunctionWithOrderTest<T> extends FirstLastValu
 	 * Test for ByteLastValueAggFunction.
 	 */
 	public static class ByteLastValueAggFunctionWithOrderTest
-			extends NumberLastValueAggFunctionWithOrderTest<Byte> {
+			extends NumberLastValueAggFunctionWithOrderTestBase<Byte> {
 
 		@Override
 		protected Byte getValue(String v) {
@@ -136,7 +148,7 @@ public abstract class LastValueAggFunctionWithOrderTest<T> extends FirstLastValu
 	 * Test for ShortLastValueAggFunction.
 	 */
 	public static class ShortLastValueAggFunctionWithOrderTest
-			extends NumberLastValueAggFunctionWithOrderTest<Short> {
+			extends NumberLastValueAggFunctionWithOrderTestBase<Short> {
 
 		@Override
 		protected Short getValue(String v) {
@@ -153,7 +165,7 @@ public abstract class LastValueAggFunctionWithOrderTest<T> extends FirstLastValu
 	 * Test for IntLastValueAggFunction.
 	 */
 	public static class IntLastValueAggFunctionWithOrderTest
-			extends NumberLastValueAggFunctionWithOrderTest<Integer> {
+			extends NumberLastValueAggFunctionWithOrderTestBase<Integer> {
 
 		@Override
 		protected Integer getValue(String v) {
@@ -170,7 +182,7 @@ public abstract class LastValueAggFunctionWithOrderTest<T> extends FirstLastValu
 	 * Test for LongLastValueAggFunction.
 	 */
 	public static class LongLastValueAggFunctionWithOrderTest
-			extends NumberLastValueAggFunctionWithOrderTest<Long> {
+			extends NumberLastValueAggFunctionWithOrderTestBase<Long> {
 
 		@Override
 		protected Long getValue(String v) {
@@ -187,7 +199,7 @@ public abstract class LastValueAggFunctionWithOrderTest<T> extends FirstLastValu
 	 * Test for FloatLastValueAggFunction.
 	 */
 	public static class FloatLastValueAggFunctionWithOrderTest
-			extends NumberLastValueAggFunctionWithOrderTest<Float> {
+			extends NumberLastValueAggFunctionWithOrderTestBase<Float> {
 
 		@Override
 		protected Float getValue(String v) {
@@ -204,7 +216,7 @@ public abstract class LastValueAggFunctionWithOrderTest<T> extends FirstLastValu
 	 * Test for DoubleLastValueAggFunction.
 	 */
 	public static class DoubleLastValueAggFunctionWithOrderTest
-			extends NumberLastValueAggFunctionWithOrderTest<Double> {
+			extends NumberLastValueAggFunctionWithOrderTestBase<Double> {
 
 		@Override
 		protected Double getValue(String v) {
@@ -221,7 +233,7 @@ public abstract class LastValueAggFunctionWithOrderTest<T> extends FirstLastValu
 	 * Test for BooleanLastValueAggFunction.
 	 */
 	public static class BooleanLastValueAggFunctionWithOrderTest
-			extends LastValueAggFunctionWithOrderTest<Boolean> {
+			extends LastValueAggFunctionWithOrderTestBase<Boolean> {
 
 		@Override
 		protected List<List<Boolean>> getInputValueSets() {
@@ -311,7 +323,7 @@ public abstract class LastValueAggFunctionWithOrderTest<T> extends FirstLastValu
 	 * Test for DecimalLastValueAggFunction.
 	 */
 	public static class DecimalLastValueAggFunctionWithOrderTest
-			extends LastValueAggFunctionWithOrderTest<Decimal> {
+			extends LastValueAggFunctionWithOrderTestBase<Decimal> {
 
 		private int precision = 20;
 		private int scale = 6;
@@ -391,7 +403,7 @@ public abstract class LastValueAggFunctionWithOrderTest<T> extends FirstLastValu
 	 * Test for StringLastValueAggFunction.
 	 */
 	public static class StringLastValueAggFunctionWithOrderTest
-			extends LastValueAggFunctionWithOrderTest<BinaryString> {
+			extends LastValueAggFunctionWithOrderTestBase<BinaryString> {
 
 		@Override
 		protected List<List<BinaryString>> getInputValueSets() {

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithOrderTest.java
@@ -33,447 +33,357 @@ import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunctio
 import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.StringLastValueAggFunction;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 
-import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Test case for built-in LastValue aggregate function.
  * This class tests `accumulate` method with order argument.
  */
-@RunWith(Enclosed.class)
-public class LastValueAggFunctionWithOrderTest {
+@RunWith(Parameterized.class)
+public class LastValueAggFunctionWithOrderTest<T> extends FirstLastValueAggFunctionWithOrderTestBase<T> {
 
-	/**
-	 * The base test class for LastValueAggFunction with order.
-	 */
-	public abstract static class LastValueAggFunctionWithOrderTestBase<T>
-			extends FirstLastValueAggFunctionWithOrderTestBase<T> {
+	@Parameterized.Parameter
+	public AggFunctionWithOrderTestSpec<T> aggFunctionTestSpec;
 
+	private static final int DECIMAL_PRECISION = 20;
+	private static final int DECIMAL_SCALE = 6;
+
+	@Override
+	protected List<List<Long>> getInputOrderSets() {
+		return aggFunctionTestSpec.inputOrderSets;
 	}
 
-	/**
-	 * Test LastValueAggFunction for number type.
-	 */
-	public abstract static class NumberLastValueAggFunctionWithOrderTestBase<T>
-			extends LastValueAggFunctionWithOrderTestBase<T> {
-		protected abstract T getValue(String v);
-
-		@Override
-		protected List<List<T>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							getValue("1"),
-							null,
-							getValue("-99"),
-							getValue("3"),
-							null,
-							getValue("3"),
-							getValue("2"),
-							getValue("-99")
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							getValue("10"),
-							null,
-							getValue("5")
-					)
-			);
-		}
-
-		@Override
-		protected List<List<Long>> getInputOrderSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							10L,
-							2L,
-							5L,
-							6L,
-							11L,
-							3L,
-							17L,
-							5L
-					),
-					Arrays.asList(
-							8L,
-							6L,
-							9L,
-							5L
-					),
-					Arrays.asList(
-							null,
-							6L,
-							4L,
-							3L
-					)
-			);
-		}
-
-		@Override
-		protected List<T> getExpectedResults() {
-			return Arrays.asList(
-					getValue("2"),
-					null,
-					getValue("10")
-			);
-		}
+	@Override
+	protected List<List<T>> getInputValueSets() {
+		return aggFunctionTestSpec.inputValueSets;
 	}
 
-	/**
-	 * Test for ByteLastValueAggFunction.
-	 */
-	public static class ByteLastValueAggFunctionWithOrderTest
-			extends NumberLastValueAggFunctionWithOrderTestBase<Byte> {
-
-		@Override
-		protected Byte getValue(String v) {
-			return Byte.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Byte, GenericRow> getAggregator() {
-			return new ByteLastValueAggFunction();
-		}
+	@Override
+	protected List<T> getExpectedResults() {
+		return aggFunctionTestSpec.expectedResults;
 	}
 
-	/**
-	 * Test for ShortLastValueAggFunction.
-	 */
-	public static class ShortLastValueAggFunctionWithOrderTest
-			extends NumberLastValueAggFunctionWithOrderTestBase<Short> {
-
-		@Override
-		protected Short getValue(String v) {
-			return Short.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Short, GenericRow> getAggregator() {
-			return new ShortLastValueAggFunction();
-		}
+	@Override
+	protected AggregateFunction<T, GenericRow> getAggregator() {
+		return aggFunctionTestSpec.aggregator;
 	}
 
-	/**
-	 * Test for IntLastValueAggFunction.
-	 */
-	public static class IntLastValueAggFunctionWithOrderTest
-			extends NumberLastValueAggFunctionWithOrderTestBase<Integer> {
-
-		@Override
-		protected Integer getValue(String v) {
-			return Integer.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Integer, GenericRow> getAggregator() {
-			return new IntLastValueAggFunction();
-		}
+	@Parameterized.Parameters(name = "{index}: {0}")
+	public static List<AggFunctionTestSpec> testData() {
+		return Arrays.asList(
+				/**
+				 * Test for ByteLastValueAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new ByteLastValueAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Byte::valueOf),
+						numberExpectedResults(Byte::valueOf)
+				),
+				/**
+				 * Test for ShortLastValueAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new ShortLastValueAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Short::valueOf),
+						numberExpectedResults(Short::valueOf)
+				),
+				/**
+				 * Test for IntLastValueAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new IntLastValueAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Integer::valueOf),
+						numberExpectedResults(Integer::valueOf)
+				),
+				/**
+				 * Test for LongLastValueAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new LongLastValueAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Long::valueOf),
+						numberExpectedResults(Long::valueOf)
+				),
+				/**
+				 * Test for FloatLastValueAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new FloatLastValueAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Float::valueOf),
+						numberExpectedResults(Float::valueOf)
+				),
+				/**
+				 * Test for DoubleLastValueAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new DoubleLastValueAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Double::valueOf),
+						numberExpectedResults(Double::valueOf)
+				),
+				/**
+				 * Test for BooleanLastValueAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new BooleanLastValueAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										6L,
+										2L,
+										3L
+								),
+								Arrays.asList(
+										1L,
+										2L,
+										3L
+								),
+								Arrays.asList(
+										10L,
+										2L,
+										5L,
+										3L,
+										11L,
+										7L,
+										5L
+								),
+								Arrays.asList(
+										6L,
+										9L,
+										5L
+								),
+								Arrays.asList(
+										4L,
+										3L
+								)
+						),
+						Arrays.asList(
+								Arrays.asList(
+										false,
+										false,
+										false
+								),
+								Arrays.asList(
+										true,
+										true,
+										true
+								),
+								Arrays.asList(
+										true,
+										false,
+										null,
+										true,
+										false,
+										true,
+										null
+								),
+								Arrays.asList(
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										true
+								)
+						),
+						Arrays.asList(
+								false,
+								true,
+								false,
+								null,
+								true
+						)
+				),
+				/**
+				 * Test for DecimalLastValueAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new DecimalLastValueAggFunction(DecimalTypeInfo.of(DECIMAL_PRECISION, DECIMAL_SCALE)),
+						Arrays.asList(
+								Arrays.asList(
+										10L,
+										2L,
+										1L,
+										5L,
+										null,
+										3L,
+										1L,
+										5L,
+										2L
+								),
+								Arrays.asList(
+										6L,
+										5L,
+										null,
+										8L,
+										null
+								),
+								Arrays.asList(
+										8L,
+										6L
+								)
+						),
+						Arrays.asList(
+								Arrays.asList(
+										Decimal.castFrom("1", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("1000.000001", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-1", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-999.998999", DECIMAL_PRECISION, DECIMAL_SCALE),
+										null,
+										Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-999.999", DECIMAL_PRECISION, DECIMAL_SCALE),
+										null,
+										Decimal.castFrom("999.999", DECIMAL_PRECISION, DECIMAL_SCALE)
+								),
+								Arrays.asList(
+										null,
+										null,
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE)
+								)
+						),
+						Arrays.asList(
+								Decimal.castFrom("1", DECIMAL_PRECISION, DECIMAL_SCALE),
+								null,
+								Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE)
+						)
+				),
+				/**
+				 * Test for StringLastValueAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new StringLastValueAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										10L,
+										2L,
+										5L,
+										null,
+										3L,
+										1L,
+										15L
+								),
+								Arrays.asList(
+										6L,
+										5L
+								),
+								Arrays.asList(
+										8L,
+										6L
+								),
+								Arrays.asList(
+										6L,
+										4L,
+										3L
+								)
+						),
+						Arrays.asList(
+								Arrays.asList(
+										BinaryString.fromString("abc"),
+										BinaryString.fromString("def"),
+										BinaryString.fromString("ghi"),
+										null,
+										BinaryString.fromString("jkl"),
+										null,
+										BinaryString.fromString("zzz")
+								),
+								Arrays.asList(
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										BinaryString.fromString("a")
+								),
+								Arrays.asList(
+										BinaryString.fromString("x"),
+										null,
+										BinaryString.fromString("e")
+								)
+						),
+						Arrays.asList(
+								BinaryString.fromString("zzz"),
+								null,
+								BinaryString.fromString("a"),
+								BinaryString.fromString("x")
+						)
+				)
+		);
 	}
 
-	/**
-	 * Test for LongLastValueAggFunction.
-	 */
-	public static class LongLastValueAggFunctionWithOrderTest
-			extends NumberLastValueAggFunctionWithOrderTestBase<Long> {
-
-		@Override
-		protected Long getValue(String v) {
-			return Long.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Long, GenericRow> getAggregator() {
-			return new LongLastValueAggFunction();
-		}
+	private static List<List<Long>> numberInputOrderSets() {
+		return Arrays.asList(
+				Arrays.asList(
+						10L,
+						2L,
+						5L,
+						6L,
+						11L,
+						3L,
+						17L,
+						5L
+				),
+				Arrays.asList(
+						8L,
+						6L,
+						9L,
+						5L
+				),
+				Arrays.asList(
+						null,
+						6L,
+						4L,
+						3L
+				)
+		);
 	}
 
-	/**
-	 * Test for FloatLastValueAggFunction.
-	 */
-	public static class FloatLastValueAggFunctionWithOrderTest
-			extends NumberLastValueAggFunctionWithOrderTestBase<Float> {
-
-		@Override
-		protected Float getValue(String v) {
-			return Float.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Float, GenericRow> getAggregator() {
-			return new FloatLastValueAggFunction();
-		}
+	private static <N> List<List<N>> numberInputValueSets(Function<String, N> strToValueFun) {
+		return Arrays.asList(
+				Arrays.asList(
+						strToValueFun.apply("1"),
+						null,
+						strToValueFun.apply("-99"),
+						strToValueFun.apply("3"),
+						null,
+						strToValueFun.apply("3"),
+						strToValueFun.apply("2"),
+						strToValueFun.apply("-99")
+				),
+				Arrays.asList(
+						null,
+						null,
+						null,
+						null
+				),
+				Arrays.asList(
+						null,
+						strToValueFun.apply("10"),
+						null,
+						strToValueFun.apply("5")
+				)
+		);
 	}
 
-	/**
-	 * Test for DoubleLastValueAggFunction.
-	 */
-	public static class DoubleLastValueAggFunctionWithOrderTest
-			extends NumberLastValueAggFunctionWithOrderTestBase<Double> {
-
-		@Override
-		protected Double getValue(String v) {
-			return Double.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Double, GenericRow> getAggregator() {
-			return new DoubleLastValueAggFunction();
-		}
-	}
-
-	/**
-	 * Test for BooleanLastValueAggFunction.
-	 */
-	public static class BooleanLastValueAggFunctionWithOrderTest
-			extends LastValueAggFunctionWithOrderTestBase<Boolean> {
-
-		@Override
-		protected List<List<Boolean>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							false,
-							false,
-							false
-					),
-					Arrays.asList(
-							true,
-							true,
-							true
-					),
-					Arrays.asList(
-							true,
-							false,
-							null,
-							true,
-							false,
-							true,
-							null
-					),
-					Arrays.asList(
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							true
-					));
-		}
-
-		@Override
-		protected List<List<Long>> getInputOrderSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							6L,
-							2L,
-							3L
-					),
-					Arrays.asList(
-							1L,
-							2L,
-							3L
-					),
-					Arrays.asList(
-							10L,
-							2L,
-							5L,
-							3L,
-							11L,
-							7L,
-							5L
-					),
-					Arrays.asList(
-							6L,
-							9L,
-							5L
-					),
-					Arrays.asList(
-							4L,
-							3L
-					)
-			);
-		}
-
-		@Override
-		protected List<Boolean> getExpectedResults() {
-			return Arrays.asList(
-					false,
-					true,
-					false,
-					null,
-					true
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Boolean, GenericRow> getAggregator() {
-			return new BooleanLastValueAggFunction();
-		}
-	}
-
-	/**
-	 * Test for DecimalLastValueAggFunction.
-	 */
-	public static class DecimalLastValueAggFunctionWithOrderTest
-			extends LastValueAggFunctionWithOrderTestBase<Decimal> {
-
-		private int precision = 20;
-		private int scale = 6;
-
-		@Override
-		protected List<List<Decimal>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							Decimal.castFrom("1", precision, scale),
-							Decimal.castFrom("1000.000001", precision, scale),
-							Decimal.castFrom("-1", precision, scale),
-							Decimal.castFrom("-999.998999", precision, scale),
-							null,
-							Decimal.castFrom("0", precision, scale),
-							Decimal.castFrom("-999.999", precision, scale),
-							null,
-							Decimal.castFrom("999.999", precision, scale)
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							Decimal.castFrom("0", precision, scale)
-					)
-			);
-		}
-
-		@Override
-		protected List<List<Long>> getInputOrderSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							10L,
-							2L,
-							1L,
-							5L,
-							null,
-							3L,
-							1L,
-							5L,
-							2L
-					),
-					Arrays.asList(
-							6L,
-							5L,
-							null,
-							8L,
-							null
-					),
-					Arrays.asList(
-							8L,
-							6L
-					)
-			);
-		}
-
-		@Override
-		protected List<Decimal> getExpectedResults() {
-			return Arrays.asList(
-					Decimal.castFrom("1", precision, scale),
-					null,
-					Decimal.castFrom("0", precision, scale)
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Decimal, GenericRow> getAggregator() {
-			return new DecimalLastValueAggFunction(DecimalTypeInfo.of(precision, scale));
-		}
-	}
-
-	/**
-	 * Test for StringLastValueAggFunction.
-	 */
-	public static class StringLastValueAggFunctionWithOrderTest
-			extends LastValueAggFunctionWithOrderTestBase<BinaryString> {
-
-		@Override
-		protected List<List<BinaryString>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							BinaryString.fromString("abc"),
-							BinaryString.fromString("def"),
-							BinaryString.fromString("ghi"),
-							null,
-							BinaryString.fromString("jkl"),
-							null,
-							BinaryString.fromString("zzz")
-					),
-					Arrays.asList(
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							BinaryString.fromString("a")
-					),
-					Arrays.asList(
-							BinaryString.fromString("x"),
-							null,
-							BinaryString.fromString("e")
-					)
-			);
-		}
-
-		@Override
-		protected List<List<Long>> getInputOrderSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							10L,
-							2L,
-							5L,
-							null,
-							3L,
-							1L,
-							15L
-					),
-					Arrays.asList(
-							6L,
-							5L
-					),
-					Arrays.asList(
-							8L,
-							6L
-					),
-					Arrays.asList(
-							6L,
-							4L,
-							3L
-					)
-			);
-		}
-
-		@Override
-		protected List<BinaryString> getExpectedResults() {
-			return Arrays.asList(
-					BinaryString.fromString("zzz"),
-					null,
-					BinaryString.fromString("a"),
-					BinaryString.fromString("x")
-			);
-		}
-
-		@Override
-		protected AggregateFunction<BinaryString, GenericRow> getAggregator() {
-			return new StringLastValueAggFunction();
-		}
+	private static <N> List<N> numberExpectedResults(Function<String, N> strToValueFun) {
+		return Arrays.asList(
+				strToValueFun.apply("2"),
+				null,
+				strToValueFun.apply("10")
+		);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithoutOrderTest.java
@@ -33,6 +33,9 @@ import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunctio
 import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.StringLastValueAggFunction;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -40,18 +43,26 @@ import java.util.List;
  * Test case for built-in LastValue aggregate function.
  * This class tests `accumulate` method without order argument.
  */
-public abstract class LastValueAggFunctionWithoutOrderTest<T> extends AggFunctionTestBase<T, GenericRow> {
+@RunWith(Enclosed.class)
+public class LastValueAggFunctionWithoutOrderTest {
 
-	@Override
-	protected Class<?> getAccClass() {
-		return GenericRow.class;
+	/**
+	 * The base test class for LastValueAggFunction without order.
+	 */
+	public abstract static class LastValueAggFunctionWithoutOrderTestBase<T>
+			extends AggFunctionTestBase<T, GenericRow> {
+
+		@Override
+		protected Class<?> getAccClass() {
+			return GenericRow.class;
+		}
 	}
 
 	/**
 	 * Test LastValueAggFunction for number type.
 	 */
-	public abstract static class NumberLastValueAggFunctionWithoutOrderTest<T>
-			extends LastValueAggFunctionWithoutOrderTest<T> {
+	public abstract static class NumberLastValueAggFunctionWithoutOrderTestBase<T>
+			extends LastValueAggFunctionWithoutOrderTestBase<T> {
 		protected abstract T getValue(String v);
 
 		@Override
@@ -93,7 +104,7 @@ public abstract class LastValueAggFunctionWithoutOrderTest<T> extends AggFunctio
 	 * Test for ByteLastValueAggFunction.
 	 */
 	public static class ByteLastValueAggFunctionWithoutOrderTest
-			extends NumberLastValueAggFunctionWithoutOrderTest<Byte> {
+			extends NumberLastValueAggFunctionWithoutOrderTestBase<Byte> {
 
 		@Override
 		protected Byte getValue(String v) {
@@ -110,7 +121,7 @@ public abstract class LastValueAggFunctionWithoutOrderTest<T> extends AggFunctio
 	 * Test for ShortLastValueAggFunction.
 	 */
 	public static class ShortLastValueAggFunctionWithoutOrderTest
-			extends NumberLastValueAggFunctionWithoutOrderTest<Short> {
+			extends NumberLastValueAggFunctionWithoutOrderTestBase<Short> {
 
 		@Override
 		protected Short getValue(String v) {
@@ -127,7 +138,7 @@ public abstract class LastValueAggFunctionWithoutOrderTest<T> extends AggFunctio
 	 * Test for IntLastValueAggFunction.
 	 */
 	public static class IntLastValueAggFunctionWithoutOrderTest
-			extends NumberLastValueAggFunctionWithoutOrderTest<Integer> {
+			extends NumberLastValueAggFunctionWithoutOrderTestBase<Integer> {
 
 		@Override
 		protected Integer getValue(String v) {
@@ -144,7 +155,7 @@ public abstract class LastValueAggFunctionWithoutOrderTest<T> extends AggFunctio
 	 * Test for LongLastValueAggFunction.
 	 */
 	public static class LongLastValueAggFunctionWithoutOrderTest
-			extends NumberLastValueAggFunctionWithoutOrderTest<Long> {
+			extends NumberLastValueAggFunctionWithoutOrderTestBase<Long> {
 
 		@Override
 		protected Long getValue(String v) {
@@ -161,7 +172,7 @@ public abstract class LastValueAggFunctionWithoutOrderTest<T> extends AggFunctio
 	 * Test for FloatLastValueAggFunction.
 	 */
 	public static class FloatLastValueAggFunctionWithoutOrderTest
-			extends NumberLastValueAggFunctionWithoutOrderTest<Float> {
+			extends NumberLastValueAggFunctionWithoutOrderTestBase<Float> {
 
 		@Override
 		protected Float getValue(String v) {
@@ -178,7 +189,7 @@ public abstract class LastValueAggFunctionWithoutOrderTest<T> extends AggFunctio
 	 * Test for DoubleLastValueAggFunction.
 	 */
 	public static class DoubleLastValueAggFunctionWithoutOrderTest
-			extends NumberLastValueAggFunctionWithoutOrderTest<Double> {
+			extends NumberLastValueAggFunctionWithoutOrderTestBase<Double> {
 
 		@Override
 		protected Double getValue(String v) {
@@ -195,7 +206,7 @@ public abstract class LastValueAggFunctionWithoutOrderTest<T> extends AggFunctio
 	 * Test for BooleanLastValueAggFunction.
 	 */
 	public static class BooleanLastValueAggFunctionWithoutOrderTest extends
-			LastValueAggFunctionWithoutOrderTest<Boolean> {
+			LastValueAggFunctionWithoutOrderTestBase<Boolean> {
 
 		@Override
 		protected List<List<Boolean>> getInputValueSets() {
@@ -251,7 +262,7 @@ public abstract class LastValueAggFunctionWithoutOrderTest<T> extends AggFunctio
 	 * Test for DecimalLastValueAggFunction.
 	 */
 	public static class DecimalLastValueAggFunctionWithoutOrderTest extends
-			LastValueAggFunctionWithoutOrderTest<Decimal> {
+			LastValueAggFunctionWithoutOrderTestBase<Decimal> {
 
 		private int precision = 20;
 		private int scale = 6;
@@ -303,7 +314,7 @@ public abstract class LastValueAggFunctionWithoutOrderTest<T> extends AggFunctio
 	 * Test for StringLastValueAggFunction.
 	 */
 	public static class StringLastValueAggFunctionWithoutOrderTest extends
-			LastValueAggFunctionWithoutOrderTest<BinaryString> {
+			LastValueAggFunctionWithoutOrderTestBase<BinaryString> {
 
 		@Override
 		protected List<List<BinaryString>> getInputValueSets() {

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithoutOrderTest.java
@@ -33,331 +33,244 @@ import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunctio
 import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.StringLastValueAggFunction;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 
-import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Test case for built-in LastValue aggregate function.
  * This class tests `accumulate` method without order argument.
  */
-@RunWith(Enclosed.class)
-public class LastValueAggFunctionWithoutOrderTest {
+@RunWith(Parameterized.class)
+public class LastValueAggFunctionWithoutOrderTest<T> extends AggFunctionTestBase<T, GenericRow> {
 
-	/**
-	 * The base test class for LastValueAggFunction without order.
-	 */
-	public abstract static class LastValueAggFunctionWithoutOrderTestBase<T>
-			extends AggFunctionTestBase<T, GenericRow> {
+	@Parameterized.Parameter
+	public AggFunctionTestSpec<T, GenericRow> aggFunctionTestSpec;
 
-		@Override
-		protected Class<?> getAccClass() {
-			return GenericRow.class;
-		}
+	private static final int DECIMAL_PRECISION = 20;
+	private static final int DECIMAL_SCALE = 6;
+
+	@Override
+	protected List<List<T>> getInputValueSets() {
+		return aggFunctionTestSpec.inputValueSets;
 	}
 
-	/**
-	 * Test LastValueAggFunction for number type.
-	 */
-	public abstract static class NumberLastValueAggFunctionWithoutOrderTestBase<T>
-			extends LastValueAggFunctionWithoutOrderTestBase<T> {
-		protected abstract T getValue(String v);
-
-		@Override
-		protected List<List<T>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							getValue("1"),
-							null,
-							getValue("-99"),
-							getValue("3"),
-							null
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							getValue("10"),
-							null,
-							getValue("3")
-					)
-			);
-		}
-
-		@Override
-		protected List<T> getExpectedResults() {
-			return Arrays.asList(
-					getValue("3"),
-					null,
-					getValue("3")
-			);
-		}
+	@Override
+	protected List<T> getExpectedResults() {
+		return aggFunctionTestSpec.expectedResults;
 	}
 
-	/**
-	 * Test for ByteLastValueAggFunction.
-	 */
-	public static class ByteLastValueAggFunctionWithoutOrderTest
-			extends NumberLastValueAggFunctionWithoutOrderTestBase<Byte> {
-
-		@Override
-		protected Byte getValue(String v) {
-			return Byte.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Byte, GenericRow> getAggregator() {
-			return new ByteLastValueAggFunction();
-		}
+	@Override
+	protected AggregateFunction<T, GenericRow> getAggregator() {
+		return aggFunctionTestSpec.aggregator;
 	}
 
-	/**
-	 * Test for ShortLastValueAggFunction.
-	 */
-	public static class ShortLastValueAggFunctionWithoutOrderTest
-			extends NumberLastValueAggFunctionWithoutOrderTestBase<Short> {
-
-		@Override
-		protected Short getValue(String v) {
-			return Short.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Short, GenericRow> getAggregator() {
-			return new ShortLastValueAggFunction();
-		}
+	@Override
+	protected Class<?> getAccClass() {
+		return GenericRow.class;
 	}
 
-	/**
-	 * Test for IntLastValueAggFunction.
-	 */
-	public static class IntLastValueAggFunctionWithoutOrderTest
-			extends NumberLastValueAggFunctionWithoutOrderTestBase<Integer> {
-
-		@Override
-		protected Integer getValue(String v) {
-			return Integer.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Integer, GenericRow> getAggregator() {
-			return new IntLastValueAggFunction();
-		}
+	@Parameterized.Parameters(name = "{index}: {0}")
+	public static List<AggFunctionTestSpec> testData() {
+		return Arrays.asList(
+				/**
+				 * Test for ByteLastValueAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new ByteLastValueAggFunction(),
+						numberInputValueSets(Byte::valueOf),
+						numberExpectedResults(Byte::valueOf)
+				),
+				/**
+				 * Test for ShortLastValueAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new ShortLastValueAggFunction(),
+						numberInputValueSets(Short::valueOf),
+						numberExpectedResults(Short::valueOf)
+				),
+				/**
+				 * Test for IntLastValueAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new IntLastValueAggFunction(),
+						numberInputValueSets(Integer::valueOf),
+						numberExpectedResults(Integer::valueOf)
+				),
+				/**
+				 * Test for LongLastValueAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new LongLastValueAggFunction(),
+						numberInputValueSets(Long::valueOf),
+						numberExpectedResults(Long::valueOf)
+				),
+				/**
+				 * Test for FloatLastValueAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new FloatLastValueAggFunction(),
+						numberInputValueSets(Float::valueOf),
+						numberExpectedResults(Float::valueOf)
+				),
+				/**
+				 * Test for DoubleLastValueAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new DoubleLastValueAggFunction(),
+						numberInputValueSets(Double::valueOf),
+						numberExpectedResults(Double::valueOf)
+				),
+				/**
+				 * Test for BooleanLastValueAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new BooleanLastValueAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										false,
+										false,
+										false
+								),
+								Arrays.asList(
+										true,
+										true,
+										true
+								),
+								Arrays.asList(
+										true,
+										false,
+										null,
+										true,
+										false,
+										true,
+										null
+								),
+								Arrays.asList(
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										true
+								)
+						),
+						Arrays.asList(
+								false,
+								true,
+								true,
+								null,
+								true
+						)
+				),
+				/**
+				 * Test for DecimalLastValueAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new DecimalLastValueAggFunction(DecimalTypeInfo.of(DECIMAL_PRECISION, DECIMAL_SCALE)),
+						Arrays.asList(
+								Arrays.asList(
+										Decimal.castFrom("1", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("1000.000001", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-1", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-999.998999", DECIMAL_PRECISION, DECIMAL_SCALE),
+										null,
+										Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-999.999", DECIMAL_PRECISION, DECIMAL_SCALE),
+										null,
+										Decimal.castFrom("999.999", DECIMAL_PRECISION, DECIMAL_SCALE)
+								),
+								Arrays.asList(
+										null,
+										null,
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE)
+								)
+						),
+						Arrays.asList(
+								Decimal.castFrom("999.999", DECIMAL_PRECISION, DECIMAL_SCALE),
+								null,
+								Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE)
+						)
+				),
+				/**
+				 * Test for StringLastValueAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new StringLastValueAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										BinaryString.fromString("abc"),
+										BinaryString.fromString("def"),
+										BinaryString.fromString("ghi"),
+										null,
+										BinaryString.fromString("jkl"),
+										null,
+										BinaryString.fromString("zzz")
+								),
+								Arrays.asList(
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										BinaryString.fromString("a"),
+										null
+								),
+								Arrays.asList(
+										BinaryString.fromString("x"),
+										null,
+										BinaryString.fromString("e")
+								)
+						),
+						Arrays.asList(
+								BinaryString.fromString("zzz"),
+								null,
+								BinaryString.fromString("a"),
+								BinaryString.fromString("e")
+						)
+				)
+		);
 	}
 
-	/**
-	 * Test for LongLastValueAggFunction.
-	 */
-	public static class LongLastValueAggFunctionWithoutOrderTest
-			extends NumberLastValueAggFunctionWithoutOrderTestBase<Long> {
-
-		@Override
-		protected Long getValue(String v) {
-			return Long.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Long, GenericRow> getAggregator() {
-			return new LongLastValueAggFunction();
-		}
+	private static <N> List<List<N>> numberInputValueSets(Function<String, N> strToValueFun) {
+		return Arrays.asList(
+				Arrays.asList(
+						strToValueFun.apply("1"),
+						null,
+						strToValueFun.apply("-99"),
+						strToValueFun.apply("3"),
+						null
+				),
+				Arrays.asList(
+						null,
+						null,
+						null,
+						null
+				),
+				Arrays.asList(
+						null,
+						strToValueFun.apply("10"),
+						null,
+						strToValueFun.apply("3")
+				)
+		);
 	}
 
-	/**
-	 * Test for FloatLastValueAggFunction.
-	 */
-	public static class FloatLastValueAggFunctionWithoutOrderTest
-			extends NumberLastValueAggFunctionWithoutOrderTestBase<Float> {
-
-		@Override
-		protected Float getValue(String v) {
-			return Float.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Float, GenericRow> getAggregator() {
-			return new FloatLastValueAggFunction();
-		}
-	}
-
-	/**
-	 * Test for DoubleLastValueAggFunction.
-	 */
-	public static class DoubleLastValueAggFunctionWithoutOrderTest
-			extends NumberLastValueAggFunctionWithoutOrderTestBase<Double> {
-
-		@Override
-		protected Double getValue(String v) {
-			return Double.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Double, GenericRow> getAggregator() {
-			return new DoubleLastValueAggFunction();
-		}
-	}
-
-	/**
-	 * Test for BooleanLastValueAggFunction.
-	 */
-	public static class BooleanLastValueAggFunctionWithoutOrderTest extends
-			LastValueAggFunctionWithoutOrderTestBase<Boolean> {
-
-		@Override
-		protected List<List<Boolean>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							false,
-							false,
-							false
-					),
-					Arrays.asList(
-							true,
-							true,
-							true
-					),
-					Arrays.asList(
-							true,
-							false,
-							null,
-							true,
-							false,
-							true,
-							null
-					),
-					Arrays.asList(
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							true
-					));
-		}
-
-		@Override
-		protected List<Boolean> getExpectedResults() {
-			return Arrays.asList(
-					false,
-					true,
-					true,
-					null,
-					true
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Boolean, GenericRow> getAggregator() {
-			return new BooleanLastValueAggFunction();
-		}
-	}
-
-	/**
-	 * Test for DecimalLastValueAggFunction.
-	 */
-	public static class DecimalLastValueAggFunctionWithoutOrderTest extends
-			LastValueAggFunctionWithoutOrderTestBase<Decimal> {
-
-		private int precision = 20;
-		private int scale = 6;
-
-		@Override
-		protected List<List<Decimal>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							Decimal.castFrom("1", precision, scale),
-							Decimal.castFrom("1000.000001", precision, scale),
-							Decimal.castFrom("-1", precision, scale),
-							Decimal.castFrom("-999.998999", precision, scale),
-							null,
-							Decimal.castFrom("0", precision, scale),
-							Decimal.castFrom("-999.999", precision, scale),
-							null,
-							Decimal.castFrom("999.999", precision, scale)
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							Decimal.castFrom("0", precision, scale)
-					)
-			);
-		}
-
-		@Override
-		protected List<Decimal> getExpectedResults() {
-			return Arrays.asList(
-					Decimal.castFrom("999.999", precision, scale),
-					null,
-					Decimal.castFrom("0", precision, scale)
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Decimal, GenericRow> getAggregator() {
-			return new DecimalLastValueAggFunction(DecimalTypeInfo.of(precision, scale));
-		}
-	}
-
-	/**
-	 * Test for StringLastValueAggFunction.
-	 */
-	public static class StringLastValueAggFunctionWithoutOrderTest extends
-			LastValueAggFunctionWithoutOrderTestBase<BinaryString> {
-
-		@Override
-		protected List<List<BinaryString>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							BinaryString.fromString("abc"),
-							BinaryString.fromString("def"),
-							BinaryString.fromString("ghi"),
-							null,
-							BinaryString.fromString("jkl"),
-							null,
-							BinaryString.fromString("zzz")
-					),
-					Arrays.asList(
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							BinaryString.fromString("a"),
-							null
-					),
-					Arrays.asList(
-							BinaryString.fromString("x"),
-							null,
-							BinaryString.fromString("e")
-					)
-			);
-		}
-
-		@Override
-		protected List<BinaryString> getExpectedResults() {
-			return Arrays.asList(
-					BinaryString.fromString("zzz"),
-					null,
-					BinaryString.fromString("a"),
-					BinaryString.fromString("e")
-			);
-		}
-
-		@Override
-		protected AggregateFunction<BinaryString, GenericRow> getAggregator() {
-			return new StringLastValueAggFunction();
-		}
+	private static <N> List<N> numberExpectedResults(Function<String, N> strToValueFun) {
+		return Arrays.asList(
+				strToValueFun.apply("3"),
+				null,
+				strToValueFun.apply("3")
+		);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithOrderTest.java
@@ -33,6 +33,9 @@ import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetrac
 import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.StringLastValueWithRetractAggFunction;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
@@ -41,19 +44,26 @@ import java.util.List;
  * Test case for built-in LastValue with retract aggregate function.
  * This class tests `accumulate` method with order argument.
  */
-public abstract class LastValueWithRetractAggFunctionWithOrderTest<T>
-		extends FirstLastValueAggFunctionWithOrderTestBase<T> {
+@RunWith(Enclosed.class)
+public class LastValueWithRetractAggFunctionWithOrderTest {
 
-	@Override
-	protected Method getRetractFunc() throws NoSuchMethodException {
-		return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class, Long.class);
+	/**
+	 * The base test class for LastValueWithRetractAggFunction with order.
+	 */
+	public abstract static class LastValueWithRetractAggFunctionWithOrderTestBase<T>
+			extends FirstLastValueAggFunctionWithOrderTestBase<T> {
+
+		@Override
+		protected Method getRetractFunc() throws NoSuchMethodException {
+			return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class, Long.class);
+		}
 	}
 
 	/**
 	 * Test LastValueWithRetractAggFunction for number type.
 	 */
-	public abstract static class NumberLastValueWithRetractAggFunctionWithOrderTest<T>
-			extends LastValueWithRetractAggFunctionWithOrderTest<T> {
+	public abstract static class NumberLastValueWithRetractAggFunctionWithOrderTestBase<T>
+			extends LastValueWithRetractAggFunctionWithOrderTestBase<T> {
 		protected abstract T getValue(String v);
 
 		@Override
@@ -126,7 +136,7 @@ public abstract class LastValueWithRetractAggFunctionWithOrderTest<T>
 	 * Test for ByteLastValueWithRetractAggFunction.
 	 */
 	public static class ByteLastValueWithRetractAggFunctionWithOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithOrderTest<Byte> {
+			extends NumberLastValueWithRetractAggFunctionWithOrderTestBase<Byte> {
 
 		@Override
 		protected Byte getValue(String v) {
@@ -143,7 +153,7 @@ public abstract class LastValueWithRetractAggFunctionWithOrderTest<T>
 	 * Test for ShortLastValueWithRetractAggFunction.
 	 */
 	public static class ShortLastValueWithRetractAggFunctionWithOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithOrderTest<Short> {
+			extends NumberLastValueWithRetractAggFunctionWithOrderTestBase<Short> {
 
 		@Override
 		protected Short getValue(String v) {
@@ -160,7 +170,7 @@ public abstract class LastValueWithRetractAggFunctionWithOrderTest<T>
 	 * Test for IntLastValueWithRetractAggFunction.
 	 */
 	public static class IntLastValueWithRetractAggFunctionWithOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithOrderTest<Integer> {
+			extends NumberLastValueWithRetractAggFunctionWithOrderTestBase<Integer> {
 
 		@Override
 		protected Integer getValue(String v) {
@@ -177,7 +187,7 @@ public abstract class LastValueWithRetractAggFunctionWithOrderTest<T>
 	 * Test for LongLastValueWithRetractAggFunction.
 	 */
 	public static class LongLastValueWithRetractAggFunctionWithOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithOrderTest<Long> {
+			extends NumberLastValueWithRetractAggFunctionWithOrderTestBase<Long> {
 
 		@Override
 		protected Long getValue(String v) {
@@ -194,7 +204,7 @@ public abstract class LastValueWithRetractAggFunctionWithOrderTest<T>
 	 * Test for FloatLastValueWithRetractAggFunction.
 	 */
 	public static class FloatLastValueWithRetractAggFunctionWithOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithOrderTest<Float> {
+			extends NumberLastValueWithRetractAggFunctionWithOrderTestBase<Float> {
 
 		@Override
 		protected Float getValue(String v) {
@@ -211,7 +221,7 @@ public abstract class LastValueWithRetractAggFunctionWithOrderTest<T>
 	 * Test for DoubleLastValueWithRetractAggFunction.
 	 */
 	public static class DoubleLastValueWithRetractAggFunctionWithOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithOrderTest<Double> {
+			extends NumberLastValueWithRetractAggFunctionWithOrderTestBase<Double> {
 
 		@Override
 		protected Double getValue(String v) {
@@ -228,7 +238,7 @@ public abstract class LastValueWithRetractAggFunctionWithOrderTest<T>
 	 * Test for BooleanLastValueWithRetractAggFunction.
 	 */
 	public static class BooleanLastValueWithRetractAggFunctionWithOrderTest
-			extends LastValueWithRetractAggFunctionWithOrderTest<Boolean> {
+			extends LastValueWithRetractAggFunctionWithOrderTestBase<Boolean> {
 
 		@Override
 		protected List<List<Boolean>> getInputValueSets() {
@@ -318,7 +328,7 @@ public abstract class LastValueWithRetractAggFunctionWithOrderTest<T>
 	 * Test for DecimalLastValueWithRetractAggFunction.
 	 */
 	public static class DecimalLastValueWithRetractAggFunctionWithOrderTest
-			extends LastValueWithRetractAggFunctionWithOrderTest<Decimal> {
+			extends LastValueWithRetractAggFunctionWithOrderTestBase<Decimal> {
 
 		private int precision = 20;
 		private int scale = 6;
@@ -398,7 +408,7 @@ public abstract class LastValueWithRetractAggFunctionWithOrderTest<T>
 	 * Test for StringLastValueWithRetractAggFunction.
 	 */
 	public static class StringLastValueWithRetractAggFunctionWithOrderTest
-			extends LastValueWithRetractAggFunctionWithOrderTest<BinaryString> {
+			extends LastValueWithRetractAggFunctionWithOrderTestBase<BinaryString> {
 
 		@Override
 		protected List<List<BinaryString>> getInputValueSets() {

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithOrderTest.java
@@ -33,458 +33,372 @@ import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetrac
 import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.StringLastValueWithRetractAggFunction;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 
-import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Test case for built-in LastValue with retract aggregate function.
  * This class tests `accumulate` method with order argument.
  */
-@RunWith(Enclosed.class)
-public class LastValueWithRetractAggFunctionWithOrderTest {
+@RunWith(Parameterized.class)
+public class LastValueWithRetractAggFunctionWithOrderTest<T> extends FirstLastValueAggFunctionWithOrderTestBase<T> {
 
-	/**
-	 * The base test class for LastValueWithRetractAggFunction with order.
-	 */
-	public abstract static class LastValueWithRetractAggFunctionWithOrderTestBase<T>
-			extends FirstLastValueAggFunctionWithOrderTestBase<T> {
+	@Parameterized.Parameter
+	public AggFunctionWithOrderTestSpec<T> aggFunctionTestSpec;
 
-		@Override
-		protected Method getRetractFunc() throws NoSuchMethodException {
-			return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class, Long.class);
-		}
+	private static final int DECIMAL_PRECISION = 20;
+	private static final int DECIMAL_SCALE = 6;
+
+	@Override
+	protected List<List<Long>> getInputOrderSets() {
+		return aggFunctionTestSpec.inputOrderSets;
 	}
 
-	/**
-	 * Test LastValueWithRetractAggFunction for number type.
-	 */
-	public abstract static class NumberLastValueWithRetractAggFunctionWithOrderTestBase<T>
-			extends LastValueWithRetractAggFunctionWithOrderTestBase<T> {
-		protected abstract T getValue(String v);
-
-		@Override
-		protected List<List<T>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							getValue("1"),
-							null,
-							getValue("-99"),
-							getValue("3"),
-							null,
-							getValue("3"),
-							getValue("2"),
-							getValue("-99")
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							getValue("10"),
-							null,
-							getValue("5")
-					)
-			);
-		}
-
-		@Override
-		protected List<List<Long>> getInputOrderSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							10L,
-							2L,
-							5L,
-							6L,
-							11L,
-							13L,
-							7L,
-							5L
-					),
-					Arrays.asList(
-							8L,
-							6L,
-							9L,
-							5L
-					),
-					Arrays.asList(
-							null,
-							6L,
-							4L,
-							3L
-					)
-			);
-		}
-
-		@Override
-		protected List<T> getExpectedResults() {
-			return Arrays.asList(
-					getValue("3"),
-					null,
-					getValue("10")
-			);
-		}
+	@Override
+	protected List<List<T>> getInputValueSets() {
+		return aggFunctionTestSpec.inputValueSets;
 	}
 
-	/**
-	 * Test for ByteLastValueWithRetractAggFunction.
-	 */
-	public static class ByteLastValueWithRetractAggFunctionWithOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithOrderTestBase<Byte> {
-
-		@Override
-		protected Byte getValue(String v) {
-			return Byte.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Byte, GenericRow> getAggregator() {
-			return new ByteLastValueWithRetractAggFunction();
-		}
+	@Override
+	protected List<T> getExpectedResults() {
+		return aggFunctionTestSpec.expectedResults;
 	}
 
-	/**
-	 * Test for ShortLastValueWithRetractAggFunction.
-	 */
-	public static class ShortLastValueWithRetractAggFunctionWithOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithOrderTestBase<Short> {
-
-		@Override
-		protected Short getValue(String v) {
-			return Short.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Short, GenericRow> getAggregator() {
-			return new ShortLastValueWithRetractAggFunction();
-		}
+	@Override
+	protected AggregateFunction<T, GenericRow> getAggregator() {
+		return aggFunctionTestSpec.aggregator;
 	}
 
-	/**
-	 * Test for IntLastValueWithRetractAggFunction.
-	 */
-	public static class IntLastValueWithRetractAggFunctionWithOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithOrderTestBase<Integer> {
-
-		@Override
-		protected Integer getValue(String v) {
-			return Integer.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Integer, GenericRow> getAggregator() {
-			return new IntLastValueWithRetractAggFunction();
-		}
+	@Override
+	protected Method getRetractFunc() throws NoSuchMethodException {
+		return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class, Long.class);
 	}
 
-	/**
-	 * Test for LongLastValueWithRetractAggFunction.
-	 */
-	public static class LongLastValueWithRetractAggFunctionWithOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithOrderTestBase<Long> {
-
-		@Override
-		protected Long getValue(String v) {
-			return Long.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Long, GenericRow> getAggregator() {
-			return new LongLastValueWithRetractAggFunction();
-		}
+	@Parameterized.Parameters(name = "{index}: {0}")
+	public static List<AggFunctionTestSpec> testData() {
+		return Arrays.asList(
+				/**
+				 * Test for ByteLastValueWithRetractAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new ByteLastValueWithRetractAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Byte::valueOf),
+						numberExpectedResults(Byte::valueOf)
+				),
+				/**
+				 * Test for ShortLastValueWithRetractAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new ShortLastValueWithRetractAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Short::valueOf),
+						numberExpectedResults(Short::valueOf)
+				),
+				/**
+				 * Test for IntLastValueWithRetractAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new IntLastValueWithRetractAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Integer::valueOf),
+						numberExpectedResults(Integer::valueOf)
+				),
+				/**
+				 * Test for LongLastValueWithRetractAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new LongLastValueWithRetractAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Long::valueOf),
+						numberExpectedResults(Long::valueOf)
+				),
+				/**
+				 * Test for FloatLastValueWithRetractAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new FloatLastValueWithRetractAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Float::valueOf),
+						numberExpectedResults(Float::valueOf)
+				),
+				/**
+				 * Test for DoubleLastValueWithRetractAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new DoubleLastValueWithRetractAggFunction(),
+						numberInputOrderSets(),
+						numberInputValueSets(Double::valueOf),
+						numberExpectedResults(Double::valueOf)
+				),
+				/**
+				 * Test for BooleanLastValueWithRetractAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new BooleanLastValueWithRetractAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										6L,
+										2L,
+										3L
+								),
+								Arrays.asList(
+										1L,
+										2L,
+										3L
+								),
+								Arrays.asList(
+										10L,
+										2L,
+										5L,
+										11L,
+										3L,
+										7L,
+										5L
+								),
+								Arrays.asList(
+										6L,
+										9L,
+										5L
+								),
+								Arrays.asList(
+										4L,
+										3L
+								)
+						),
+						Arrays.asList(
+								Arrays.asList(
+										false,
+										false,
+										false
+								),
+								Arrays.asList(
+										true,
+										true,
+										true
+								),
+								Arrays.asList(
+										true,
+										false,
+										null,
+										true,
+										false,
+										true,
+										null
+								),
+								Arrays.asList(
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										true
+								)
+						),
+						Arrays.asList(
+								false,
+								true,
+								true,
+								null,
+								true
+						)
+				),
+				/**
+				 * Test for DecimalLastValueWithRetractAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new DecimalLastValueWithRetractAggFunction(
+								DecimalTypeInfo.of(DECIMAL_PRECISION, DECIMAL_SCALE)),
+						Arrays.asList(
+								Arrays.asList(
+										10L,
+										2L,
+										1L,
+										5L,
+										null,
+										3L,
+										1L,
+										5L,
+										2L
+								),
+								Arrays.asList(
+										6L,
+										5L,
+										null,
+										8L,
+										null
+								),
+								Arrays.asList(
+										8L,
+										6L
+								)
+						),
+						Arrays.asList(
+								Arrays.asList(
+										Decimal.castFrom("1", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("1000.000001", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-1", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-999.998999", DECIMAL_PRECISION, DECIMAL_SCALE),
+										null,
+										Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-999.999", DECIMAL_PRECISION, DECIMAL_SCALE),
+										null,
+										Decimal.castFrom("999.999", DECIMAL_PRECISION, DECIMAL_SCALE)
+								),
+								Arrays.asList(
+										null,
+										null,
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE)
+								)
+						),
+						Arrays.asList(
+								Decimal.castFrom("1", DECIMAL_PRECISION, DECIMAL_SCALE),
+								null,
+								Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE)
+						)
+				),
+				/**
+				 * Test for StringLastValueWithRetractAggFunction.
+				 */
+				new AggFunctionWithOrderTestSpec<>(
+						new StringLastValueWithRetractAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										10L,
+										2L,
+										5L,
+										null,
+										3L,
+										1L,
+										5L,
+										10L,
+										15L,
+										11L
+								),
+								Arrays.asList(
+										6L,
+										5L
+								),
+								Arrays.asList(
+										8L,
+										6L
+								),
+								Arrays.asList(
+										6L,
+										4L,
+										3L
+								)
+						),
+						Arrays.asList(
+								Arrays.asList(
+										BinaryString.fromString("abc"),
+										BinaryString.fromString("def"),
+										BinaryString.fromString("ghi"),
+										null,
+										BinaryString.fromString("jkl"),
+										null,
+										BinaryString.fromString("zzz"),
+										BinaryString.fromString("abc"),
+										BinaryString.fromString("def"),
+										BinaryString.fromString("abc")
+								),
+								Arrays.asList(
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										BinaryString.fromString("a")
+								),
+								Arrays.asList(
+										BinaryString.fromString("x"),
+										null,
+										BinaryString.fromString("e")
+								)
+						),
+						Arrays.asList(
+								BinaryString.fromString("def"),
+								null,
+								BinaryString.fromString("a"),
+								BinaryString.fromString("x")
+						)
+				)
+		);
 	}
 
-	/**
-	 * Test for FloatLastValueWithRetractAggFunction.
-	 */
-	public static class FloatLastValueWithRetractAggFunctionWithOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithOrderTestBase<Float> {
-
-		@Override
-		protected Float getValue(String v) {
-			return Float.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Float, GenericRow> getAggregator() {
-			return new FloatLastValueWithRetractAggFunction();
-		}
+	private static List<List<Long>> numberInputOrderSets() {
+		return Arrays.asList(
+				Arrays.asList(
+						10L,
+						2L,
+						5L,
+						6L,
+						11L,
+						13L,
+						7L,
+						5L
+				),
+				Arrays.asList(
+						8L,
+						6L,
+						9L,
+						5L
+				),
+				Arrays.asList(
+						null,
+						6L,
+						4L,
+						3L
+				)
+		);
 	}
 
-	/**
-	 * Test for DoubleLastValueWithRetractAggFunction.
-	 */
-	public static class DoubleLastValueWithRetractAggFunctionWithOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithOrderTestBase<Double> {
-
-		@Override
-		protected Double getValue(String v) {
-			return Double.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Double, GenericRow> getAggregator() {
-			return new DoubleLastValueWithRetractAggFunction();
-		}
+	private static <N> List<List<N>> numberInputValueSets(Function<String, N> strToValueFun) {
+		return Arrays.asList(
+				Arrays.asList(
+						strToValueFun.apply("1"),
+						null,
+						strToValueFun.apply("-99"),
+						strToValueFun.apply("3"),
+						null,
+						strToValueFun.apply("3"),
+						strToValueFun.apply("2"),
+						strToValueFun.apply("-99")
+				),
+				Arrays.asList(
+						null,
+						null,
+						null,
+						null
+				),
+				Arrays.asList(
+						null,
+						strToValueFun.apply("10"),
+						null,
+						strToValueFun.apply("5")
+				)
+		);
 	}
 
-	/**
-	 * Test for BooleanLastValueWithRetractAggFunction.
-	 */
-	public static class BooleanLastValueWithRetractAggFunctionWithOrderTest
-			extends LastValueWithRetractAggFunctionWithOrderTestBase<Boolean> {
-
-		@Override
-		protected List<List<Boolean>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							false,
-							false,
-							false
-					),
-					Arrays.asList(
-							true,
-							true,
-							true
-					),
-					Arrays.asList(
-							true,
-							false,
-							null,
-							true,
-							false,
-							true,
-							null
-					),
-					Arrays.asList(
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							true
-					));
-		}
-
-		@Override
-		protected List<List<Long>> getInputOrderSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							6L,
-							2L,
-							3L
-					),
-					Arrays.asList(
-							1L,
-							2L,
-							3L
-					),
-					Arrays.asList(
-							10L,
-							2L,
-							5L,
-							11L,
-							3L,
-							7L,
-							5L
-					),
-					Arrays.asList(
-							6L,
-							9L,
-							5L
-					),
-					Arrays.asList(
-							4L,
-							3L
-					)
-			);
-		}
-
-		@Override
-		protected List<Boolean> getExpectedResults() {
-			return Arrays.asList(
-					false,
-					true,
-					true,
-					null,
-					true
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Boolean, GenericRow> getAggregator() {
-			return new BooleanLastValueWithRetractAggFunction();
-		}
-	}
-
-	/**
-	 * Test for DecimalLastValueWithRetractAggFunction.
-	 */
-	public static class DecimalLastValueWithRetractAggFunctionWithOrderTest
-			extends LastValueWithRetractAggFunctionWithOrderTestBase<Decimal> {
-
-		private int precision = 20;
-		private int scale = 6;
-
-		@Override
-		protected List<List<Decimal>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							Decimal.castFrom("1", precision, scale),
-							Decimal.castFrom("1000.000001", precision, scale),
-							Decimal.castFrom("-1", precision, scale),
-							Decimal.castFrom("-999.998999", precision, scale),
-							null,
-							Decimal.castFrom("0", precision, scale),
-							Decimal.castFrom("-999.999", precision, scale),
-							null,
-							Decimal.castFrom("999.999", precision, scale)
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							Decimal.castFrom("0", precision, scale)
-					)
-			);
-		}
-
-		@Override
-		protected List<List<Long>> getInputOrderSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							10L,
-							2L,
-							1L,
-							5L,
-							null,
-							3L,
-							1L,
-							5L,
-							2L
-					),
-					Arrays.asList(
-							6L,
-							5L,
-							null,
-							8L,
-							null
-					),
-					Arrays.asList(
-							8L,
-							6L
-					)
-			);
-		}
-
-		@Override
-		protected List<Decimal> getExpectedResults() {
-			return Arrays.asList(
-					Decimal.castFrom("1", precision, scale),
-					null,
-					Decimal.castFrom("0", precision, scale)
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Decimal, GenericRow> getAggregator() {
-			return new DecimalLastValueWithRetractAggFunction(DecimalTypeInfo.of(precision, scale));
-		}
-	}
-
-	/**
-	 * Test for StringLastValueWithRetractAggFunction.
-	 */
-	public static class StringLastValueWithRetractAggFunctionWithOrderTest
-			extends LastValueWithRetractAggFunctionWithOrderTestBase<BinaryString> {
-
-		@Override
-		protected List<List<BinaryString>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							BinaryString.fromString("abc"),
-							BinaryString.fromString("def"),
-							BinaryString.fromString("ghi"),
-							null,
-							BinaryString.fromString("jkl"),
-							null,
-							BinaryString.fromString("zzz"),
-							BinaryString.fromString("abc"),
-							BinaryString.fromString("def"),
-							BinaryString.fromString("abc")
-					),
-					Arrays.asList(
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							BinaryString.fromString("a")
-					),
-					Arrays.asList(
-							BinaryString.fromString("x"),
-							null,
-							BinaryString.fromString("e")
-					)
-			);
-		}
-
-		@Override
-		protected List<List<Long>> getInputOrderSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							10L,
-							2L,
-							5L,
-							null,
-							3L,
-							1L,
-							5L,
-							10L,
-							15L,
-							11L
-					),
-					Arrays.asList(
-							6L,
-							5L
-					),
-					Arrays.asList(
-							8L,
-							6L
-					),
-					Arrays.asList(
-							6L,
-							4L,
-							3L
-					)
-			);
-		}
-
-		@Override
-		protected List<BinaryString> getExpectedResults() {
-			return Arrays.asList(
-					BinaryString.fromString("def"),
-					null,
-					BinaryString.fromString("a"),
-					BinaryString.fromString("x")
-			);
-		}
-
-		@Override
-		protected AggregateFunction<BinaryString, GenericRow> getAggregator() {
-			return new StringLastValueWithRetractAggFunction();
-		}
+	private static <N> List<N> numberExpectedResults(Function<String, N> strToValueFun) {
+		return Arrays.asList(
+				strToValueFun.apply("3"),
+				null,
+				strToValueFun.apply("10")
+		);
 	}
 }
+
+

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithoutOrderTest.java
@@ -33,6 +33,9 @@ import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetrac
 import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.StringLastValueWithRetractAggFunction;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
@@ -41,23 +44,31 @@ import java.util.List;
  * Test case for built-in LastValue with retract aggregate function.
  * This class tests `accumulate` method without order argument.
  */
-public abstract class LastValueWithRetractAggFunctionWithoutOrderTest<T> extends AggFunctionTestBase<T, GenericRow> {
+@RunWith(Enclosed.class)
+public class LastValueWithRetractAggFunctionWithoutOrderTest {
 
-	@Override
-	protected Class<?> getAccClass() {
-		return GenericRow.class;
-	}
+	/**
+	 * The base test class for LastValueWithRetractAggFunction without order.
+	 */
+	public abstract static class LastValueWithRetractAggFunctionWithoutOrderTestBase<T>
+			extends AggFunctionTestBase<T, GenericRow> {
 
-	@Override
-	protected Method getRetractFunc() throws NoSuchMethodException {
-		return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class);
+		@Override
+		protected Class<?> getAccClass() {
+			return GenericRow.class;
+		}
+
+		@Override
+		protected Method getRetractFunc() throws NoSuchMethodException {
+			return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class);
+		}
 	}
 
 	/**
 	 * Test LastValueWithRetractAggFunction for number type.
 	 */
-	public abstract static class NumberLastValueWithRetractAggFunctionWithoutOrderTest<T>
-			extends LastValueWithRetractAggFunctionWithoutOrderTest<T> {
+	public abstract static class NumberLastValueWithRetractAggFunctionWithoutOrderTestBase<T>
+			extends LastValueWithRetractAggFunctionWithoutOrderTestBase<T> {
 		protected abstract T getValue(String v);
 
 		@Override
@@ -99,7 +110,7 @@ public abstract class LastValueWithRetractAggFunctionWithoutOrderTest<T> extends
 	 * Test for ByteLastValueWithRetractAggFunction.
 	 */
 	public static class ByteLastValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithoutOrderTest<Byte> {
+			extends NumberLastValueWithRetractAggFunctionWithoutOrderTestBase<Byte> {
 
 		@Override
 		protected Byte getValue(String v) {
@@ -116,7 +127,7 @@ public abstract class LastValueWithRetractAggFunctionWithoutOrderTest<T> extends
 	 * Test for ShortLastValueWithRetractAggFunction.
 	 */
 	public static class ShortLastValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithoutOrderTest<Short> {
+			extends NumberLastValueWithRetractAggFunctionWithoutOrderTestBase<Short> {
 
 		@Override
 		protected Short getValue(String v) {
@@ -133,7 +144,7 @@ public abstract class LastValueWithRetractAggFunctionWithoutOrderTest<T> extends
 	 * Test for IntLastValueWithRetractAggFunction.
 	 */
 	public static class IntLastValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithoutOrderTest<Integer> {
+			extends NumberLastValueWithRetractAggFunctionWithoutOrderTestBase<Integer> {
 
 		@Override
 		protected Integer getValue(String v) {
@@ -150,7 +161,7 @@ public abstract class LastValueWithRetractAggFunctionWithoutOrderTest<T> extends
 	 * Test for LongLastValueWithRetractAggFunction.
 	 */
 	public static class LongLastValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithoutOrderTest<Long> {
+			extends NumberLastValueWithRetractAggFunctionWithoutOrderTestBase<Long> {
 
 		@Override
 		protected Long getValue(String v) {
@@ -167,7 +178,7 @@ public abstract class LastValueWithRetractAggFunctionWithoutOrderTest<T> extends
 	 * Test for FloatLastValueWithRetractAggFunction.
 	 */
 	public static class FloatLastValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithoutOrderTest<Float> {
+			extends NumberLastValueWithRetractAggFunctionWithoutOrderTestBase<Float> {
 
 		@Override
 		protected Float getValue(String v) {
@@ -184,7 +195,7 @@ public abstract class LastValueWithRetractAggFunctionWithoutOrderTest<T> extends
 	 * Test for DoubleLastValueWithRetractAggFunction.
 	 */
 	public static class DoubleLastValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithoutOrderTest<Double> {
+			extends NumberLastValueWithRetractAggFunctionWithoutOrderTestBase<Double> {
 
 		@Override
 		protected Double getValue(String v) {
@@ -201,7 +212,7 @@ public abstract class LastValueWithRetractAggFunctionWithoutOrderTest<T> extends
 	 * Test for BooleanLastValueWithRetractAggFunction.
 	 */
 	public static class BooleanLastValueWithRetractAggFunctionWithoutOrderTest extends
-			LastValueWithRetractAggFunctionWithoutOrderTest<Boolean> {
+			LastValueWithRetractAggFunctionWithoutOrderTestBase<Boolean> {
 
 		@Override
 		protected List<List<Boolean>> getInputValueSets() {
@@ -257,7 +268,7 @@ public abstract class LastValueWithRetractAggFunctionWithoutOrderTest<T> extends
 	 * Test for DecimalLastValueWithRetractAggFunction.
 	 */
 	public static class DecimalLastValueWithRetractAggFunctionWithoutOrderTest extends
-			LastValueWithRetractAggFunctionWithoutOrderTest<Decimal> {
+			LastValueWithRetractAggFunctionWithoutOrderTestBase<Decimal> {
 
 		private int precision = 20;
 		private int scale = 6;
@@ -309,7 +320,7 @@ public abstract class LastValueWithRetractAggFunctionWithoutOrderTest<T> extends
 	 * Test for StringLastValueWithRetractAggFunction.
 	 */
 	public static class StringLastValueWithRetractAggFunctionWithoutOrderTest extends
-			LastValueWithRetractAggFunctionWithoutOrderTest<BinaryString> {
+			LastValueWithRetractAggFunctionWithoutOrderTestBase<BinaryString> {
 
 		@Override
 		protected List<List<BinaryString>> getInputValueSets() {

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithoutOrderTest.java
@@ -33,336 +33,251 @@ import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetrac
 import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.StringLastValueWithRetractAggFunction;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 
-import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Test case for built-in LastValue with retract aggregate function.
  * This class tests `accumulate` method without order argument.
  */
-@RunWith(Enclosed.class)
-public class LastValueWithRetractAggFunctionWithoutOrderTest {
+@RunWith(Parameterized.class)
+public class LastValueWithRetractAggFunctionWithoutOrderTest<T> extends AggFunctionTestBase<T, GenericRow> {
 
-	/**
-	 * The base test class for LastValueWithRetractAggFunction without order.
-	 */
-	public abstract static class LastValueWithRetractAggFunctionWithoutOrderTestBase<T>
-			extends AggFunctionTestBase<T, GenericRow> {
+	@Parameterized.Parameter
+	public AggFunctionTestSpec<T, GenericRow> aggFunctionTestSpec;
 
-		@Override
-		protected Class<?> getAccClass() {
-			return GenericRow.class;
-		}
+	private static final int DECIMAL_PRECISION = 20;
+	private static final int DECIMAL_SCALE = 6;
 
-		@Override
-		protected Method getRetractFunc() throws NoSuchMethodException {
-			return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class);
-		}
+	@Override
+	protected List<List<T>> getInputValueSets() {
+		return aggFunctionTestSpec.inputValueSets;
 	}
 
-	/**
-	 * Test LastValueWithRetractAggFunction for number type.
-	 */
-	public abstract static class NumberLastValueWithRetractAggFunctionWithoutOrderTestBase<T>
-			extends LastValueWithRetractAggFunctionWithoutOrderTestBase<T> {
-		protected abstract T getValue(String v);
-
-		@Override
-		protected List<List<T>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							getValue("1"),
-							null,
-							getValue("-99"),
-							getValue("3"),
-							null
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							getValue("10"),
-							null,
-							getValue("3")
-					)
-			);
-		}
-
-		@Override
-		protected List<T> getExpectedResults() {
-			return Arrays.asList(
-					getValue("3"),
-					null,
-					getValue("3")
-			);
-		}
+	@Override
+	protected List<T> getExpectedResults() {
+		return aggFunctionTestSpec.expectedResults;
 	}
 
-	/**
-	 * Test for ByteLastValueWithRetractAggFunction.
-	 */
-	public static class ByteLastValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithoutOrderTestBase<Byte> {
-
-		@Override
-		protected Byte getValue(String v) {
-			return Byte.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Byte, GenericRow> getAggregator() {
-			return new ByteLastValueWithRetractAggFunction();
-		}
+	@Override
+	protected AggregateFunction<T, GenericRow> getAggregator() {
+		return aggFunctionTestSpec.aggregator;
 	}
 
-	/**
-	 * Test for ShortLastValueWithRetractAggFunction.
-	 */
-	public static class ShortLastValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithoutOrderTestBase<Short> {
-
-		@Override
-		protected Short getValue(String v) {
-			return Short.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Short, GenericRow> getAggregator() {
-			return new ShortLastValueWithRetractAggFunction();
-		}
+	@Override
+	protected Class<?> getAccClass() {
+		return GenericRow.class;
 	}
 
-	/**
-	 * Test for IntLastValueWithRetractAggFunction.
-	 */
-	public static class IntLastValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithoutOrderTestBase<Integer> {
-
-		@Override
-		protected Integer getValue(String v) {
-			return Integer.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Integer, GenericRow> getAggregator() {
-			return new IntLastValueWithRetractAggFunction();
-		}
+	@Override
+	protected Method getRetractFunc() throws NoSuchMethodException {
+		return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class);
 	}
 
-	/**
-	 * Test for LongLastValueWithRetractAggFunction.
-	 */
-	public static class LongLastValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithoutOrderTestBase<Long> {
+	@Parameterized.Parameters(name = "{index}: {0}")
+	public static List<AggFunctionTestSpec> testData() {
+		return Arrays.asList(
+				/**
+				 * Test for ByteLastValueWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new ByteLastValueWithRetractAggFunction(),
+						numberInputValueSets(Byte::valueOf),
+						numberExpectedResults(Byte::valueOf)
+				),
+				/**
+				 * Test for ShortLastValueWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new ShortLastValueWithRetractAggFunction(),
+						numberInputValueSets(Short::valueOf),
+						numberExpectedResults(Short::valueOf)
+				),
+				/**
+				 * Test for IntLastValueWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new IntLastValueWithRetractAggFunction(),
+						numberInputValueSets(Integer::valueOf),
+						numberExpectedResults(Integer::valueOf)
+				),
+				/**
+				 * Test for LongLastValueWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new LongLastValueWithRetractAggFunction(),
+						numberInputValueSets(Long::valueOf),
+						numberExpectedResults(Long::valueOf)
+				),
+				/**
+				 * Test for FloatLastValueWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new FloatLastValueWithRetractAggFunction(),
+						numberInputValueSets(Float::valueOf),
+						numberExpectedResults(Float::valueOf)
+				),
+				/**
+				 * Test for DoubleLastValueWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new DoubleLastValueWithRetractAggFunction(),
+						numberInputValueSets(Double::valueOf),
+						numberExpectedResults(Double::valueOf)
+				),
+				/**
+				 * Test for BooleanLastValueWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new BooleanLastValueWithRetractAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										false,
+										false,
+										false
+								),
+								Arrays.asList(
+										true,
+										true,
+										true
+								),
+								Arrays.asList(
+										true,
+										false,
+										null,
+										true,
+										false,
+										true,
+										null
+								),
+								Arrays.asList(
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										true
+								)
+						),
+						Arrays.asList(
+								false,
+								true,
+								true,
+								null,
+								true
+						)
+				),
+				/**
+				 * Test for DecimalLastValueWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new DecimalLastValueWithRetractAggFunction(
+								DecimalTypeInfo.of(DECIMAL_PRECISION, DECIMAL_SCALE)),
+						Arrays.asList(
+								Arrays.asList(
+										Decimal.castFrom("1", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("1000.000001", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-1", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-999.998999", DECIMAL_PRECISION, DECIMAL_SCALE),
+										null,
+										Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-999.999", DECIMAL_PRECISION, DECIMAL_SCALE),
+										null,
+										Decimal.castFrom("999.999", DECIMAL_PRECISION, DECIMAL_SCALE)
+								),
+								Arrays.asList(
+										null,
+										null,
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE)
+								)
+						),
+						Arrays.asList(
+								Decimal.castFrom("999.999", DECIMAL_PRECISION, DECIMAL_SCALE),
+								null,
+								Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE)
+						)
+				),
+				/**
+				 * Test for StringLastValueWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new StringLastValueWithRetractAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										BinaryString.fromString("abc"),
+										BinaryString.fromString("def"),
+										BinaryString.fromString("ghi"),
+										null,
+										BinaryString.fromString("jkl"),
+										null,
+										BinaryString.fromString("zzz")
+								),
+								Arrays.asList(
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										BinaryString.fromString("a")
+								),
+								Arrays.asList(
+										BinaryString.fromString("x"),
+										null,
+										BinaryString.fromString("e")
+								)
+						),
+						Arrays.asList(
+								BinaryString.fromString("zzz"),
+								null,
+								BinaryString.fromString("a"),
+								BinaryString.fromString("e")
+						)
+				)
 
-		@Override
-		protected Long getValue(String v) {
-			return Long.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Long, GenericRow> getAggregator() {
-			return new LongLastValueWithRetractAggFunction();
-		}
+		);
 	}
 
-	/**
-	 * Test for FloatLastValueWithRetractAggFunction.
-	 */
-	public static class FloatLastValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithoutOrderTestBase<Float> {
-
-		@Override
-		protected Float getValue(String v) {
-			return Float.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Float, GenericRow> getAggregator() {
-			return new FloatLastValueWithRetractAggFunction();
-		}
+	private static <N> List<List<N>> numberInputValueSets(Function<String, N> strToValueFun) {
+		return Arrays.asList(
+				Arrays.asList(
+						strToValueFun.apply("1"),
+						null,
+						strToValueFun.apply("-99"),
+						strToValueFun.apply("3"),
+						null
+				),
+				Arrays.asList(
+						null,
+						null,
+						null,
+						null
+				),
+				Arrays.asList(
+						null,
+						strToValueFun.apply("10"),
+						null,
+						strToValueFun.apply("3")
+				)
+		);
 	}
 
-	/**
-	 * Test for DoubleLastValueWithRetractAggFunction.
-	 */
-	public static class DoubleLastValueWithRetractAggFunctionWithoutOrderTest
-			extends NumberLastValueWithRetractAggFunctionWithoutOrderTestBase<Double> {
-
-		@Override
-		protected Double getValue(String v) {
-			return Double.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Double, GenericRow> getAggregator() {
-			return new DoubleLastValueWithRetractAggFunction();
-		}
-	}
-
-	/**
-	 * Test for BooleanLastValueWithRetractAggFunction.
-	 */
-	public static class BooleanLastValueWithRetractAggFunctionWithoutOrderTest extends
-			LastValueWithRetractAggFunctionWithoutOrderTestBase<Boolean> {
-
-		@Override
-		protected List<List<Boolean>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							false,
-							false,
-							false
-					),
-					Arrays.asList(
-							true,
-							true,
-							true
-					),
-					Arrays.asList(
-							true,
-							false,
-							null,
-							true,
-							false,
-							true,
-							null
-					),
-					Arrays.asList(
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							true
-					));
-		}
-
-		@Override
-		protected List<Boolean> getExpectedResults() {
-			return Arrays.asList(
-					false,
-					true,
-					true,
-					null,
-					true
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Boolean, GenericRow> getAggregator() {
-			return new BooleanLastValueWithRetractAggFunction();
-		}
-	}
-
-	/**
-	 * Test for DecimalLastValueWithRetractAggFunction.
-	 */
-	public static class DecimalLastValueWithRetractAggFunctionWithoutOrderTest extends
-			LastValueWithRetractAggFunctionWithoutOrderTestBase<Decimal> {
-
-		private int precision = 20;
-		private int scale = 6;
-
-		@Override
-		protected List<List<Decimal>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							Decimal.castFrom("1", precision, scale),
-							Decimal.castFrom("1000.000001", precision, scale),
-							Decimal.castFrom("-1", precision, scale),
-							Decimal.castFrom("-999.998999", precision, scale),
-							null,
-							Decimal.castFrom("0", precision, scale),
-							Decimal.castFrom("-999.999", precision, scale),
-							null,
-							Decimal.castFrom("999.999", precision, scale)
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							Decimal.castFrom("0", precision, scale)
-					)
-			);
-		}
-
-		@Override
-		protected List<Decimal> getExpectedResults() {
-			return Arrays.asList(
-					Decimal.castFrom("999.999", precision, scale),
-					null,
-					Decimal.castFrom("0", precision, scale)
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Decimal, GenericRow> getAggregator() {
-			return new DecimalLastValueWithRetractAggFunction(DecimalTypeInfo.of(precision, scale));
-		}
-	}
-
-	/**
-	 * Test for StringLastValueWithRetractAggFunction.
-	 */
-	public static class StringLastValueWithRetractAggFunctionWithoutOrderTest extends
-			LastValueWithRetractAggFunctionWithoutOrderTestBase<BinaryString> {
-
-		@Override
-		protected List<List<BinaryString>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							BinaryString.fromString("abc"),
-							BinaryString.fromString("def"),
-							BinaryString.fromString("ghi"),
-							null,
-							BinaryString.fromString("jkl"),
-							null,
-							BinaryString.fromString("zzz")
-					),
-					Arrays.asList(
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							BinaryString.fromString("a")
-					),
-					Arrays.asList(
-							BinaryString.fromString("x"),
-							null,
-							BinaryString.fromString("e")
-					)
-			);
-		}
-
-		@Override
-		protected List<BinaryString> getExpectedResults() {
-			return Arrays.asList(
-					BinaryString.fromString("zzz"),
-					null,
-					BinaryString.fromString("a"),
-					BinaryString.fromString("e")
-			);
-		}
-
-		@Override
-		protected AggregateFunction<BinaryString, GenericRow> getAggregator() {
-			return new StringLastValueWithRetractAggFunction();
-		}
+	private static <N> List<N> numberExpectedResults(Function<String, N> strToValueFun) {
+		return Arrays.asList(
+				strToValueFun.apply("3"),
+				null,
+				strToValueFun.apply("3")
+		);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/ListAggWsWithRetractAggFunctionTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/ListAggWsWithRetractAggFunctionTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.functions.aggfunctions;
 
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.dataformat.BinaryString;
 import org.apache.flink.table.functions.AggregateFunction;
@@ -105,14 +106,14 @@ public class ListAggWsWithRetractAggFunctionTest
 	}
 
 	@Override
-	protected <E> void validateResult(E expected, E result) {
+	protected <E> void validateResult(E expected, E result, TypeInformation<?> typeInfo) {
 		if (expected instanceof ListAggWsWithRetractAccumulator && result instanceof ListAggWsWithRetractAccumulator) {
 			ListAggWsWithRetractAccumulator e = (ListAggWsWithRetractAccumulator) expected;
 			ListAggWsWithRetractAccumulator r = (ListAggWsWithRetractAccumulator) result;
 			assertEquals(e.list, r.list);
 			assertEquals(e.list, r.list);
 		} else {
-			super.validateResult(expected, result);
+			super.validateResult(expected, result, typeInfo);
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunctionTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunctionTest.java
@@ -36,8 +36,8 @@ import org.apache.flink.table.planner.functions.aggfunctions.MaxWithRetractAggFu
 import org.apache.flink.table.planner.functions.aggfunctions.MaxWithRetractAggFunction.TimestampMaxWithRetractAggFunction;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 
-import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.lang.reflect.Method;
 import java.sql.Date;
@@ -45,531 +45,342 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Test case for built-in Max with retraction aggregate function.
  */
-@RunWith(Enclosed.class)
-public class MaxWithRetractAggFunctionTest {
+@RunWith(Parameterized.class)
+public class MaxWithRetractAggFunctionTest<T> extends AggFunctionTestBase<T, MaxWithRetractAccumulator<T>> {
 
-	/**
-	 * The base test class for MaxWithRetractAggFunction.
-	 */
-	public abstract static class MaxWithRetractAggFunctionTestBase<T>
-			extends AggFunctionTestBase<T, MaxWithRetractAccumulator<T>> {
+	@Parameterized.Parameter
+	public AggFunctionTestSpec<T, MaxWithRetractAccumulator<T>> aggFunctionTestSpec;
 
-		@Override
-		protected Class<?> getAccClass() {
-			return MaxWithRetractAccumulator.class;
-		}
+	private static final int DECIMAL_PRECISION = 20;
+	private static final int DECIMAL_SCALE = 6;
 
-		@Override
-		protected Method getRetractFunc() throws NoSuchMethodException {
-			return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class);
-		}
+	@Override
+	protected List<List<T>> getInputValueSets() {
+		return aggFunctionTestSpec.inputValueSets;
 	}
 
-	/**
-	 * Test MaxWithRetractAggFunction for number type.
-	 */
-	public abstract static class NumberMaxWithRetractAggFunctionTest<T> extends MaxWithRetractAggFunctionTestBase {
-		protected abstract T getMinValue();
-
-		protected abstract T getMaxValue();
-
-		protected abstract T getValue(String v);
-
-		@Override
-		protected List<List<T>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							getValue("1"),
-							null,
-							getMaxValue(),
-							getValue("-99"),
-							getValue("3"),
-							getValue("56"),
-							getValue("0"),
-							getMinValue(),
-							getValue("-20"),
-							getValue("17"),
-							null
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							getValue("10")
-					)
-			);
-		}
-
-		@Override
-		protected List<T> getExpectedResults() {
-			return Arrays.asList(
-					getMaxValue(),
-					null,
-					getValue("10")
-			);
-		}
+	@Override
+	protected List<T> getExpectedResults() {
+		return aggFunctionTestSpec.expectedResults;
 	}
 
-	/**
-	 * Test for ByteMaxWithRetractAggFunction.
-	 */
-	public static class ByteMaxWithRetractAggFunctionTest extends NumberMaxWithRetractAggFunctionTest<Byte> {
-
-		@Override
-		protected Byte getMinValue() {
-			return Byte.MIN_VALUE + 1;
-		}
-
-		@Override
-		protected Byte getMaxValue() {
-			return Byte.MAX_VALUE - 1;
-		}
-
-		@Override
-		protected Byte getValue(String v) {
-			return Byte.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Byte, MaxWithRetractAccumulator<Byte>> getAggregator() {
-			return new ByteMaxWithRetractAggFunction();
-		}
+	@Override
+	protected AggregateFunction<T, MaxWithRetractAccumulator<T>> getAggregator() {
+		return aggFunctionTestSpec.aggregator;
 	}
 
-	/**
-	 * Test for ShortMaxWithRetractAggFunction.
-	 */
-	public static class ShortMaxWithRetractAggFunctionTest extends NumberMaxWithRetractAggFunctionTest<Short> {
-
-		@Override
-		protected Short getMinValue() {
-			return Short.MIN_VALUE + 1;
-		}
-
-		@Override
-		protected Short getMaxValue() {
-			return Short.MAX_VALUE - 1;
-		}
-
-		@Override
-		protected Short getValue(String v) {
-			return Short.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Short, MaxWithRetractAccumulator<Short>> getAggregator() {
-			return new ShortMaxWithRetractAggFunction();
-		}
+	@Override
+	protected Class<?> getAccClass() {
+		return MaxWithRetractAccumulator.class;
 	}
 
-	/**
-	 * Test for IntMaxWithRetractAggFunction.
-	 */
-	public static class IntMaxWithRetractAggFunctionTest extends NumberMaxWithRetractAggFunctionTest<Integer> {
-
-		@Override
-		protected Integer getMinValue() {
-			return Integer.MIN_VALUE + 1;
-		}
-
-		@Override
-		protected Integer getMaxValue() {
-			return Integer.MAX_VALUE - 1;
-		}
-
-		@Override
-		protected Integer getValue(String v) {
-			return Integer.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Integer, MaxWithRetractAccumulator<Integer>> getAggregator() {
-			return new IntMaxWithRetractAggFunction();
-		}
+	@Override
+	protected Method getRetractFunc() throws NoSuchMethodException {
+		return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class);
 	}
 
-	/**
-	 * Test for LongMaxWithRetractAggFunction.
-	 */
-	public static class LongMaxWithRetractAggFunctionTest extends NumberMaxWithRetractAggFunctionTest<Long> {
-
-		@Override
-		protected Long getMinValue() {
-			return Long.MIN_VALUE + 1;
-		}
-
-		@Override
-		protected Long getMaxValue() {
-			return Long.MAX_VALUE - 1;
-		}
-
-		@Override
-		protected Long getValue(String v) {
-			return Long.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Long, MaxWithRetractAccumulator<Long>> getAggregator() {
-			return new LongMaxWithRetractAggFunction();
-		}
+	@Parameterized.Parameters(name = "{index}: {0}")
+	public static List<AggFunctionTestSpec> testData() {
+		return Arrays.asList(
+				/**
+				 * Test for ByteMaxWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new ByteMaxWithRetractAggFunction(),
+						numberInputValueSets((byte) (Byte.MIN_VALUE + 1), (byte) (Byte.MAX_VALUE - 1), Byte::valueOf),
+						numberExpectedResults((byte) (Byte.MAX_VALUE - 1), Byte::valueOf)
+				),
+				/**
+				 * Test for ShortMaxWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new ShortMaxWithRetractAggFunction(),
+						numberInputValueSets(
+								(short) (Short.MIN_VALUE + 1), (short) (Short.MAX_VALUE - 1), Short::valueOf),
+						numberExpectedResults((short) (Short.MAX_VALUE - 1), Short::valueOf)
+				),
+				/**
+				 * Test for IntMaxWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new IntMaxWithRetractAggFunction(),
+						numberInputValueSets(Integer.MIN_VALUE + 1, Integer.MAX_VALUE - 1, Integer::valueOf),
+						numberExpectedResults(Integer.MAX_VALUE - 1, Integer::valueOf)
+				),
+				/**
+				 * Test for LongMaxWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new LongMaxWithRetractAggFunction(),
+						numberInputValueSets(Long.MIN_VALUE + 1L, Long.MAX_VALUE - 1L, Long::valueOf),
+						numberExpectedResults(Long.MAX_VALUE - 1L, Long::valueOf)
+				),
+				/**
+				 * Test for FloatMaxWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new FloatMaxWithRetractAggFunction(),
+						numberInputValueSets((-Float.MAX_VALUE / 2), (Float.MAX_VALUE / 2), Float::valueOf),
+						numberExpectedResults((Float.MAX_VALUE / 2), Float::valueOf)
+				),
+				/**
+				 * Test for DoubleMaxWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new DoubleMaxWithRetractAggFunction(),
+						numberInputValueSets((-Double.MAX_VALUE / 2), (Double.MAX_VALUE / 2), Double::valueOf),
+						numberExpectedResults((Double.MAX_VALUE / 2), Double::valueOf)
+				),
+				/**
+				 * Test for BooleanMaxWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new BooleanMaxWithRetractAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										false,
+										false,
+										false
+								),
+								Arrays.asList(
+										true,
+										true,
+										true
+								),
+								Arrays.asList(
+										true,
+										false,
+										null,
+										true,
+										false,
+										true,
+										null
+								),
+								Arrays.asList(
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										true
+								)
+						),
+						Arrays.asList(
+								false,
+								true,
+								true,
+								null,
+								true
+						)
+				),
+				/**
+				 * Test for DecimalMaxWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new DecimalMaxWithRetractAggFunction(DecimalTypeInfo.of(DECIMAL_PRECISION, DECIMAL_SCALE)),
+						Arrays.asList(
+								Arrays.asList(
+										Decimal.castFrom("1", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("1000.000001", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-1", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-999.998999", DECIMAL_PRECISION, DECIMAL_SCALE),
+										null,
+										Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-999.999", DECIMAL_PRECISION, DECIMAL_SCALE),
+										null,
+										Decimal.castFrom("999.999", DECIMAL_PRECISION, DECIMAL_SCALE)
+								),
+								Arrays.asList(
+										null,
+										null,
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE)
+								)
+						),
+						Arrays.asList(
+								Decimal.castFrom("1000.000001", DECIMAL_PRECISION, DECIMAL_SCALE),
+								null,
+								Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE)
+						)
+				),
+				/**
+				 * Test for StringMaxWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new StringMaxWithRetractAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										BinaryString.fromString("abc"),
+										BinaryString.fromString("def"),
+										BinaryString.fromString("ghi"),
+										null,
+										BinaryString.fromString("jkl"),
+										null,
+										BinaryString.fromString("zzz")
+								),
+								Arrays.asList(
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										BinaryString.fromString("a")
+								),
+								Arrays.asList(
+										BinaryString.fromString("x"),
+										null,
+										BinaryString.fromString("e")
+								)
+						),
+						Arrays.asList(
+								BinaryString.fromString("zzz"),
+								null,
+								BinaryString.fromString("a"),
+								BinaryString.fromString("x")
+						)
+				),
+				/**
+				 * Test for TimestampMaxWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new TimestampMaxWithRetractAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										new Timestamp(0),
+										new Timestamp(1000),
+										new Timestamp(100),
+										null,
+										new Timestamp(10)
+								),
+								Arrays.asList(
+										null,
+										null,
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										new Timestamp(1)
+								)
+						),
+						Arrays.asList(
+								new Timestamp(1000),
+								null,
+								new Timestamp(1)
+						)
+				),
+				/**
+				 * Test for DateMaxWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new DateMaxWithRetractAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										new Date(0),
+										new Date(1000),
+										new Date(100),
+										null,
+										new Date(10)
+								),
+								Arrays.asList(
+										null,
+										null,
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										new Date(1)
+								)
+						),
+						Arrays.asList(
+								new Date(1000),
+								null,
+								new Date(1)
+						)
+				),
+				/**
+				 * Test for TimeMaxWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new TimeMaxWithRetractAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										new Time(0),
+										new Time(1000),
+										new Time(100),
+										null,
+										new Time(10)
+								),
+								Arrays.asList(
+										null,
+										null,
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										new Time(1)
+								)
+						),
+						Arrays.asList(
+								new Time(1000),
+								null,
+								new Time(1)
+						)
+				)
+		);
 	}
 
-	/**
-	 * Test for FloatMaxWithRetractAggFunction.
-	 */
-	public static class FloatMaxWithRetractAggFunctionTest extends NumberMaxWithRetractAggFunctionTest<Float> {
-
-		@Override
-		protected Float getMinValue() {
-			return -Float.MAX_VALUE / 2;
-		}
-
-		@Override
-		protected Float getMaxValue() {
-			return Float.MAX_VALUE / 2;
-		}
-
-		@Override
-		protected Float getValue(String v) {
-			return Float.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Float, MaxWithRetractAccumulator<Float>> getAggregator() {
-			return new FloatMaxWithRetractAggFunction();
-		}
+	private static <N> List<List<N>> numberInputValueSets(N minValue, N maxValue, Function<String, N> strToValueFun) {
+		return Arrays.asList(
+				Arrays.asList(
+						strToValueFun.apply("1"),
+						null,
+						maxValue,
+						strToValueFun.apply("-99"),
+						strToValueFun.apply("3"),
+						strToValueFun.apply("56"),
+						strToValueFun.apply("0"),
+						minValue,
+						strToValueFun.apply("-20"),
+						strToValueFun.apply("17"),
+						null
+				),
+				Arrays.asList(
+						null,
+						null,
+						null,
+						null,
+						null,
+						null
+				),
+				Arrays.asList(
+						null,
+						strToValueFun.apply("10")
+				)
+		);
 	}
 
-	/**
-	 * Test for DoubleMaxWithRetractAggFunction.
-	 */
-	public static class DoubleMaxWithRetractAggFunctionTest extends NumberMaxWithRetractAggFunctionTest<Double> {
-
-		@Override
-		protected Double getMinValue() {
-			return -Double.MAX_VALUE / 2;
-		}
-
-		@Override
-		protected Double getMaxValue() {
-			return Double.MAX_VALUE / 2;
-		}
-
-		@Override
-		protected Double getValue(String v) {
-			return Double.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Double, MaxWithRetractAccumulator<Double>> getAggregator() {
-			return new DoubleMaxWithRetractAggFunction();
-		}
-	}
-
-	/**
-	 * Test for BooleanMaxWithRetractAggFunction.
-	 */
-	public static class BooleanMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTestBase<Boolean> {
-
-		@Override
-		protected List<List<Boolean>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							false,
-							false,
-							false
-					),
-					Arrays.asList(
-							true,
-							true,
-							true
-					),
-					Arrays.asList(
-							true,
-							false,
-							null,
-							true,
-							false,
-							true,
-							null
-					),
-					Arrays.asList(
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							true
-					));
-		}
-
-		@Override
-		protected List<Boolean> getExpectedResults() {
-			return Arrays.asList(
-					false,
-					true,
-					true,
-					null,
-					true
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Boolean, MaxWithRetractAccumulator<Boolean>> getAggregator() {
-			return new BooleanMaxWithRetractAggFunction();
-		}
-
-		@Override
-		protected Class<?> getAccClass() {
-			return MaxWithRetractAccumulator.class;
-		}
-
-		@Override
-		protected Method getRetractFunc() throws NoSuchMethodException {
-			return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class);
-		}
-	}
-
-	/**
-	 * Test for DecimalMaxWithRetractAggFunction.
-	 */
-	public static class DecimalMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTestBase<Decimal> {
-
-		private int precision = 20;
-		private int scale = 6;
-
-		@Override
-		protected List<List<Decimal>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							Decimal.castFrom("1", precision, scale),
-							Decimal.castFrom("1000.000001", precision, scale),
-							Decimal.castFrom("-1", precision, scale),
-							Decimal.castFrom("-999.998999", precision, scale),
-							null,
-							Decimal.castFrom("0", precision, scale),
-							Decimal.castFrom("-999.999", precision, scale),
-							null,
-							Decimal.castFrom("999.999", precision, scale)
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							Decimal.castFrom("0", precision, scale)
-					)
-			);
-		}
-
-		@Override
-		protected List<Decimal> getExpectedResults() {
-			return Arrays.asList(
-					Decimal.castFrom("1000.000001", precision, scale),
-					null,
-					Decimal.castFrom("0", precision, scale)
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Decimal, MaxWithRetractAccumulator<Decimal>> getAggregator() {
-			return new DecimalMaxWithRetractAggFunction(DecimalTypeInfo.of(precision, scale));
-		}
-	}
-
-	/**
-	 * Test for StringMaxWithRetractAggFunction.
-	 */
-	public static class StringMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTestBase<BinaryString> {
-
-		@Override
-		protected List<List<BinaryString>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							BinaryString.fromString("abc"),
-							BinaryString.fromString("def"),
-							BinaryString.fromString("ghi"),
-							null,
-							BinaryString.fromString("jkl"),
-							null,
-							BinaryString.fromString("zzz")
-					),
-					Arrays.asList(
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							BinaryString.fromString("a")
-					),
-					Arrays.asList(
-							BinaryString.fromString("x"),
-							null,
-							BinaryString.fromString("e")
-					)
-			);
-		}
-
-		@Override
-		protected List<BinaryString> getExpectedResults() {
-			return Arrays.asList(
-					BinaryString.fromString("zzz"),
-					null,
-					BinaryString.fromString("a"),
-					BinaryString.fromString("x")
-			);
-		}
-
-		@Override
-		protected AggregateFunction<BinaryString, MaxWithRetractAccumulator<BinaryString>> getAggregator() {
-			return new StringMaxWithRetractAggFunction();
-		}
-	}
-
-	/**
-	 * Test for TimestampMaxWithRetractAggFunction.
-	 */
-	public static class TimestampMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTestBase<Timestamp> {
-
-		@Override
-		protected List<List<Timestamp>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							new Timestamp(0),
-							new Timestamp(1000),
-							new Timestamp(100),
-							null,
-							new Timestamp(10)
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							new Timestamp(1)
-					)
-			);
-		}
-
-		@Override
-		protected List<Timestamp> getExpectedResults() {
-			return Arrays.asList(
-					new Timestamp(1000),
-					null,
-					new Timestamp(1)
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Timestamp, MaxWithRetractAccumulator<Timestamp>> getAggregator() {
-			return new TimestampMaxWithRetractAggFunction();
-		}
-	}
-
-	/**
-	 * Test for DateMaxWithRetractAggFunction.
-	 */
-	public static class DateMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTestBase<Date> {
-
-		@Override
-		protected List<List<Date>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							new Date(0),
-							new Date(1000),
-							new Date(100),
-							null,
-							new Date(10)
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							new Date(1)
-					)
-			);
-		}
-
-		@Override
-		protected List<Date> getExpectedResults() {
-			return Arrays.asList(
-					new Date(1000),
-					null,
-					new Date(1)
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Date, MaxWithRetractAccumulator<Date>> getAggregator() {
-			return new DateMaxWithRetractAggFunction();
-		}
-	}
-
-	/**
-	 * Test for TimeMaxWithRetractAggFunction.
-	 */
-	public static class TimeMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTestBase<Time> {
-
-		@Override
-		protected List<List<Time>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							new Time(0),
-							new Time(1000),
-							new Time(100),
-							null,
-							new Time(10)
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							new Time(1)
-					)
-			);
-		}
-
-		@Override
-		protected List<Time> getExpectedResults() {
-			return Arrays.asList(
-					new Time(1000),
-					null,
-					new Time(1)
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Time, MaxWithRetractAccumulator<Time>> getAggregator() {
-			return new TimeMaxWithRetractAggFunction();
-		}
+	private static <N> List<N> numberExpectedResults(N maxValue, Function<String, N> strToValueFun) {
+		return Arrays.asList(
+				maxValue,
+				null,
+				strToValueFun.apply("10")
+		);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunctionTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunctionTest.java
@@ -36,6 +36,9 @@ import org.apache.flink.table.planner.functions.aggfunctions.MaxWithRetractAggFu
 import org.apache.flink.table.planner.functions.aggfunctions.MaxWithRetractAggFunction.TimestampMaxWithRetractAggFunction;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
 import java.lang.reflect.Method;
 import java.sql.Date;
 import java.sql.Time;
@@ -46,22 +49,30 @@ import java.util.List;
 /**
  * Test case for built-in Max with retraction aggregate function.
  */
-public abstract class MaxWithRetractAggFunctionTest<T> extends AggFunctionTestBase<T, MaxWithRetractAccumulator<T>> {
+@RunWith(Enclosed.class)
+public class MaxWithRetractAggFunctionTest {
 
-	@Override
-	protected Class<?> getAccClass() {
-		return MaxWithRetractAccumulator.class;
-	}
+	/**
+	 * The base test class for MaxWithRetractAggFunction.
+	 */
+	public abstract static class MaxWithRetractAggFunctionTestBase<T>
+			extends AggFunctionTestBase<T, MaxWithRetractAccumulator<T>> {
 
-	@Override
-	protected Method getRetractFunc() throws NoSuchMethodException {
-		return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class);
+		@Override
+		protected Class<?> getAccClass() {
+			return MaxWithRetractAccumulator.class;
+		}
+
+		@Override
+		protected Method getRetractFunc() throws NoSuchMethodException {
+			return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class);
+		}
 	}
 
 	/**
 	 * Test MaxWithRetractAggFunction for number type.
 	 */
-	public abstract static class NumberMaxWithRetractAggFunctionTest<T> extends MaxWithRetractAggFunctionTest {
+	public abstract static class NumberMaxWithRetractAggFunctionTest<T> extends MaxWithRetractAggFunctionTestBase {
 		protected abstract T getMinValue();
 
 		protected abstract T getMaxValue();
@@ -268,7 +279,7 @@ public abstract class MaxWithRetractAggFunctionTest<T> extends AggFunctionTestBa
 	/**
 	 * Test for BooleanMaxWithRetractAggFunction.
 	 */
-	public static class BooleanMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest<Boolean> {
+	public static class BooleanMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTestBase<Boolean> {
 
 		@Override
 		protected List<List<Boolean>> getInputValueSets() {
@@ -333,7 +344,7 @@ public abstract class MaxWithRetractAggFunctionTest<T> extends AggFunctionTestBa
 	/**
 	 * Test for DecimalMaxWithRetractAggFunction.
 	 */
-	public static class DecimalMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest<Decimal> {
+	public static class DecimalMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTestBase<Decimal> {
 
 		private int precision = 20;
 		private int scale = 6;
@@ -384,7 +395,7 @@ public abstract class MaxWithRetractAggFunctionTest<T> extends AggFunctionTestBa
 	/**
 	 * Test for StringMaxWithRetractAggFunction.
 	 */
-	public static class StringMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest<BinaryString> {
+	public static class StringMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTestBase<BinaryString> {
 
 		@Override
 		protected List<List<BinaryString>> getInputValueSets() {
@@ -433,7 +444,7 @@ public abstract class MaxWithRetractAggFunctionTest<T> extends AggFunctionTestBa
 	/**
 	 * Test for TimestampMaxWithRetractAggFunction.
 	 */
-	public static class TimestampMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest<Timestamp> {
+	public static class TimestampMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTestBase<Timestamp> {
 
 		@Override
 		protected List<List<Timestamp>> getInputValueSets() {
@@ -477,7 +488,7 @@ public abstract class MaxWithRetractAggFunctionTest<T> extends AggFunctionTestBa
 	/**
 	 * Test for DateMaxWithRetractAggFunction.
 	 */
-	public static class DateMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest<Date> {
+	public static class DateMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTestBase<Date> {
 
 		@Override
 		protected List<List<Date>> getInputValueSets() {
@@ -521,7 +532,7 @@ public abstract class MaxWithRetractAggFunctionTest<T> extends AggFunctionTestBa
 	/**
 	 * Test for TimeMaxWithRetractAggFunction.
 	 */
-	public static class TimeMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest<Time> {
+	public static class TimeMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTestBase<Time> {
 
 		@Override
 		protected List<List<Time>> getInputValueSets() {

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunctionTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunctionTest.java
@@ -36,8 +36,8 @@ import org.apache.flink.table.planner.functions.aggfunctions.MinWithRetractAggFu
 import org.apache.flink.table.planner.functions.aggfunctions.MinWithRetractAggFunction.TimestampMinWithRetractAggFunction;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 
-import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.lang.reflect.Method;
 import java.sql.Date;
@@ -45,523 +45,342 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Test case for built-in Min with retraction aggregate function.
  */
-@RunWith(Enclosed.class)
-public class MinWithRetractAggFunctionTest {
+@RunWith(Parameterized.class)
+public class MinWithRetractAggFunctionTest<T> extends AggFunctionTestBase<T, MinWithRetractAccumulator<T>> {
 
-	/**
-	 * The base test class for MinWithRetractAggFunction.
-	 */
-	public abstract static class MinWithRetractAggFunctionTestBase<T>
-			extends AggFunctionTestBase<T, MinWithRetractAccumulator<T>> {
+	@Parameterized.Parameter
+	public AggFunctionTestSpec<T, MinWithRetractAccumulator<T>> aggFunctionTestSpec;
 
-		@Override
-		protected Class<?> getAccClass() {
-			return MinWithRetractAccumulator.class;
-		}
+	private static final int DECIMAL_PRECISION = 20;
+	private static final int DECIMAL_SCALE = 6;
 
-		@Override
-		protected Method getRetractFunc() throws NoSuchMethodException {
-			return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class);
-		}
+	@Override
+	protected List<List<T>> getInputValueSets() {
+		return aggFunctionTestSpec.inputValueSets;
 	}
 
-	/**
-	 * Test MinWithRetractAggFunction for number type.
-	 */
-	public abstract static class NumberMinWithRetractAggFunctionTestBase<T> extends MinWithRetractAggFunctionTestBase<T> {
-		protected abstract T getMinValue();
-
-		protected abstract T getMaxValue();
-
-		protected abstract T getValue(String v);
-
-		@Override
-		protected List<List<T>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							getValue("1"),
-							null,
-							getMaxValue(),
-							getValue("-99"),
-							getValue("3"),
-							getValue("56"),
-							getValue("0"),
-							getMinValue(),
-							getValue("-20"),
-							getValue("17"),
-							null
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							getValue("10")
-					)
-			);
-		}
-
-		@Override
-		protected List<T> getExpectedResults() {
-			return Arrays.asList(
-					getMinValue(),
-					null,
-					getValue("10")
-			);
-		}
+	@Override
+	protected List<T> getExpectedResults() {
+		return aggFunctionTestSpec.expectedResults;
 	}
 
-	/**
-	 * Test for ByteMinWithRetractAggFunction.
-	 */
-	public static class ByteMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTestBase<Byte> {
-
-		@Override
-		protected Byte getMinValue() {
-			return Byte.MIN_VALUE + 1;
-		}
-
-		@Override
-		protected Byte getMaxValue() {
-			return Byte.MAX_VALUE - 1;
-		}
-
-		@Override
-		protected Byte getValue(String v) {
-			return Byte.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Byte, MinWithRetractAccumulator<Byte>> getAggregator() {
-			return new ByteMinWithRetractAggFunction();
-		}
+	@Override
+	protected AggregateFunction<T, MinWithRetractAccumulator<T>> getAggregator() {
+		return aggFunctionTestSpec.aggregator;
 	}
 
-	/**
-	 * Test for ShortMinWithRetractAggFunction.
-	 */
-	public static class ShortMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTestBase<Short> {
-
-		@Override
-		protected Short getMinValue() {
-			return Short.MIN_VALUE + 1;
-		}
-
-		@Override
-		protected Short getMaxValue() {
-			return Short.MAX_VALUE - 1;
-		}
-
-		@Override
-		protected Short getValue(String v) {
-			return Short.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Short, MinWithRetractAccumulator<Short>> getAggregator() {
-			return new ShortMinWithRetractAggFunction();
-		}
+	@Override
+	protected Class<?> getAccClass() {
+		return MinWithRetractAccumulator.class;
 	}
 
-	/**
-	 * Test for IntMinWithRetractAggFunction.
-	 */
-	public static class IntMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTestBase<Integer> {
-
-		@Override
-		protected Integer getMinValue() {
-			return Integer.MIN_VALUE + 1;
-		}
-
-		@Override
-		protected Integer getMaxValue() {
-			return Integer.MAX_VALUE - 1;
-		}
-
-		@Override
-		protected Integer getValue(String v) {
-			return Integer.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Integer, MinWithRetractAccumulator<Integer>> getAggregator() {
-			return new IntMinWithRetractAggFunction();
-		}
+	@Override
+	protected Method getRetractFunc() throws NoSuchMethodException {
+		return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class);
 	}
 
-	/**
-	 * Test for LongMinWithRetractAggFunction.
-	 */
-	public static class LongMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTestBase<Long> {
-
-		@Override
-		protected Long getMinValue() {
-			return Long.MIN_VALUE + 1;
-		}
-
-		@Override
-		protected Long getMaxValue() {
-			return Long.MAX_VALUE - 1;
-		}
-
-		@Override
-		protected Long getValue(String v) {
-			return Long.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Long, MinWithRetractAccumulator<Long>> getAggregator() {
-			return new LongMinWithRetractAggFunction();
-		}
+	@Parameterized.Parameters(name = "{index}: {0}")
+	public static List<AggFunctionTestSpec> testData() {
+		return Arrays.asList(
+				/**
+				 * Test for ByteMinWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new ByteMinWithRetractAggFunction(),
+						numberInputValueSets((byte) (Byte.MIN_VALUE + 1), (byte) (Byte.MAX_VALUE - 1), Byte::valueOf),
+						numberExpectedResults((byte) (Byte.MIN_VALUE + 1), Byte::valueOf)
+				),
+				/**
+				 * Test for ShortMinWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new ShortMinWithRetractAggFunction(),
+						numberInputValueSets(
+								(short) (Short.MIN_VALUE + 1), (short) (Short.MAX_VALUE - 1), Short::valueOf),
+						numberExpectedResults((short) (Short.MIN_VALUE + 1), Short::valueOf)
+				),
+				/**
+				 * Test for IntMinWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new IntMinWithRetractAggFunction(),
+						numberInputValueSets(Integer.MIN_VALUE + 1, Integer.MAX_VALUE - 1, Integer::valueOf),
+						numberExpectedResults(Integer.MIN_VALUE + 1, Integer::valueOf)
+				),
+				/**
+				 * Test for LongMinWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new LongMinWithRetractAggFunction(),
+						numberInputValueSets(Long.MIN_VALUE + 1L, Long.MAX_VALUE - 1L, Long::valueOf),
+						numberExpectedResults(Long.MIN_VALUE + 1L, Long::valueOf)
+				),
+				/**
+				 * Test for FloatMinWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new FloatMinWithRetractAggFunction(),
+						numberInputValueSets((-Float.MAX_VALUE / 2), (Float.MAX_VALUE / 2), Float::valueOf),
+						numberExpectedResults((-Float.MAX_VALUE / 2), Float::valueOf)
+				),
+				/**
+				 * Test for DoubleMinWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new DoubleMinWithRetractAggFunction(),
+						numberInputValueSets((-Double.MAX_VALUE / 2), (Double.MAX_VALUE / 2), Double::valueOf),
+						numberExpectedResults((-Double.MAX_VALUE / 2), Double::valueOf)
+				),
+				/**
+				 * Test for BooleanMinWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new BooleanMinWithRetractAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										false,
+										false,
+										false
+								),
+								Arrays.asList(
+										true,
+										true,
+										true
+								),
+								Arrays.asList(
+										true,
+										false,
+										null,
+										true,
+										false,
+										true,
+										null
+								),
+								Arrays.asList(
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										true
+								)
+						),
+						Arrays.asList(
+								false,
+								true,
+								false,
+								null,
+								true
+						)
+				),
+				/**
+				 * Test for DecimalMinWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new DecimalMinWithRetractAggFunction(DecimalTypeInfo.of(DECIMAL_PRECISION, DECIMAL_SCALE)),
+						Arrays.asList(
+								Arrays.asList(
+										Decimal.castFrom("1", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("1000", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-1", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-999.998999", DECIMAL_PRECISION, DECIMAL_SCALE),
+										null,
+										Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE),
+										Decimal.castFrom("-999.999", DECIMAL_PRECISION, DECIMAL_SCALE),
+										null,
+										Decimal.castFrom("999.999", DECIMAL_PRECISION, DECIMAL_SCALE)
+								),
+								Arrays.asList(
+										null,
+										null,
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE)
+								)
+						),
+						Arrays.asList(
+								Decimal.castFrom("-999.999", DECIMAL_PRECISION, DECIMAL_SCALE),
+								null,
+								Decimal.castFrom("0", DECIMAL_PRECISION, DECIMAL_SCALE)
+						)
+				),
+				/**
+				 * Test for StringMinWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new StringMinWithRetractAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										BinaryString.fromString("abc"),
+										BinaryString.fromString("def"),
+										BinaryString.fromString("ghi"),
+										null,
+										BinaryString.fromString("jkl"),
+										null,
+										BinaryString.fromString("zzz")
+								),
+								Arrays.asList(
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										BinaryString.fromString("a")
+								),
+								Arrays.asList(
+										BinaryString.fromString("x"),
+										null,
+										BinaryString.fromString("e")
+								)
+						),
+						Arrays.asList(
+								BinaryString.fromString("abc"),
+								null,
+								BinaryString.fromString("a"),
+								BinaryString.fromString("e")
+						)
+				),
+				/**
+				 * Test for TimestampMinWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new TimestampMinWithRetractAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										new Timestamp(0),
+										new Timestamp(1000),
+										new Timestamp(100),
+										null,
+										new Timestamp(10)
+								),
+								Arrays.asList(
+										null,
+										null,
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										new Timestamp(1)
+								)
+						),
+						Arrays.asList(
+								new Timestamp(0),
+								null,
+								new Timestamp(1)
+						)
+				),
+				/**
+				 * Test for DateMinWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new DateMinWithRetractAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										new Date(0),
+										new Date(1000),
+										new Date(100),
+										null,
+										new Date(10)
+								),
+								Arrays.asList(
+										null,
+										null,
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										new Date(1)
+								)
+						),
+						Arrays.asList(
+								new Date(0),
+								null,
+								new Date(1)
+						)
+				),
+				/**
+				 * Test for TimeMinWithRetractAggFunction.
+				 */
+				new AggFunctionTestSpec<>(
+						new TimeMinWithRetractAggFunction(),
+						Arrays.asList(
+								Arrays.asList(
+										new Time(0),
+										new Time(1000),
+										new Time(100),
+										null,
+										new Time(10)
+								),
+								Arrays.asList(
+										null,
+										null,
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										new Time(1)
+								)
+						),
+						Arrays.asList(
+								new Time(0),
+								null,
+								new Time(1)
+						)
+				)
+		);
 	}
 
-	/**
-	 * Test for FloatMinWithRetractAggFunction.
-	 */
-	public static class FloatMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTestBase<Float> {
-
-		@Override
-		protected Float getMinValue() {
-			return -Float.MAX_VALUE / 2;
-		}
-
-		@Override
-		protected Float getMaxValue() {
-			return Float.MAX_VALUE / 2;
-		}
-
-		@Override
-		protected Float getValue(String v) {
-			return Float.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Float, MinWithRetractAccumulator<Float>> getAggregator() {
-			return new FloatMinWithRetractAggFunction();
-		}
+	private static <N> List<List<N>> numberInputValueSets(N minValue, N maxValue, Function<String, N> strToValueFun) {
+		return Arrays.asList(
+				Arrays.asList(
+						strToValueFun.apply("1"),
+						null,
+						maxValue,
+						strToValueFun.apply("-99"),
+						strToValueFun.apply("3"),
+						strToValueFun.apply("56"),
+						strToValueFun.apply("0"),
+						minValue,
+						strToValueFun.apply("-20"),
+						strToValueFun.apply("17"),
+						null
+				),
+				Arrays.asList(
+						null,
+						null,
+						null,
+						null,
+						null,
+						null
+				),
+				Arrays.asList(
+						null,
+						strToValueFun.apply("10")
+				)
+		);
 	}
 
-	/**
-	 * Test for DoubleMinWithRetractAggFunction.
-	 */
-	public static class DoubleMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTestBase<Double> {
-
-		@Override
-		protected Double getMinValue() {
-			return -Double.MAX_VALUE / 2;
-		}
-
-		@Override
-		protected Double getMaxValue() {
-			return Double.MAX_VALUE / 2;
-		}
-
-		@Override
-		protected Double getValue(String v) {
-			return Double.valueOf(v);
-		}
-
-		@Override
-		protected AggregateFunction<Double, MinWithRetractAccumulator<Double>> getAggregator() {
-			return new DoubleMinWithRetractAggFunction();
-		}
-	}
-
-	/**
-	 * Test for BooleanMinWithRetractAggFunction.
-	 */
-	public static class BooleanMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTestBase<Boolean> {
-
-		@Override
-		protected List<List<Boolean>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							false,
-							false,
-							false
-					),
-					Arrays.asList(
-							true,
-							true,
-							true
-					),
-					Arrays.asList(
-							true,
-							false,
-							null,
-							true,
-							false,
-							true,
-							null
-					),
-					Arrays.asList(
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							true
-					));
-		}
-
-		@Override
-		protected List<Boolean> getExpectedResults() {
-			return Arrays.asList(
-					false,
-					true,
-					false,
-					null,
-					true
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Boolean, MinWithRetractAccumulator<Boolean>> getAggregator() {
-			return new BooleanMinWithRetractAggFunction();
-		}
-	}
-
-	/**
-	 * Test for DecimalMinWithRetractAggFunction.
-	 */
-	public static class DecimalMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTestBase<Decimal> {
-
-		private int precision = 20;
-		private int scale = 6;
-
-		@Override
-		protected List<List<Decimal>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							Decimal.castFrom("1", precision, scale),
-							Decimal.castFrom("1000", precision, scale),
-							Decimal.castFrom("-1", precision, scale),
-							Decimal.castFrom("-999.998999", precision, scale),
-							null,
-							Decimal.castFrom("0", precision, scale),
-							Decimal.castFrom("-999.999", precision, scale),
-							null,
-							Decimal.castFrom("999.999", precision, scale)
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							Decimal.castFrom("0", precision, scale)
-					)
-			);
-		}
-
-		@Override
-		protected List<Decimal> getExpectedResults() {
-			return Arrays.asList(
-					Decimal.castFrom("-999.999", precision, scale),
-					null,
-					Decimal.castFrom("0", precision, scale)
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Decimal, MinWithRetractAccumulator<Decimal>> getAggregator() {
-			return new DecimalMinWithRetractAggFunction(DecimalTypeInfo.of(precision, scale));
-		}
-	}
-
-	/**
-	 * Test for StringMinWithRetractAggFunction.
-	 */
-	public static class StringMinWithRetractAggFunctionTest
-			extends MinWithRetractAggFunctionTestBase<BinaryString> {
-
-		@Override
-		protected List<List<BinaryString>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							BinaryString.fromString("abc"),
-							BinaryString.fromString("def"),
-							BinaryString.fromString("ghi"),
-							null,
-							BinaryString.fromString("jkl"),
-							null,
-							BinaryString.fromString("zzz")
-					),
-					Arrays.asList(
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							BinaryString.fromString("a")
-					),
-					Arrays.asList(
-							BinaryString.fromString("x"),
-							null,
-							BinaryString.fromString("e")
-					)
-			);
-		}
-
-		@Override
-		protected List<BinaryString> getExpectedResults() {
-			return Arrays.asList(
-					BinaryString.fromString("abc"),
-					null,
-					BinaryString.fromString("a"),
-					BinaryString.fromString("e")
-			);
-		}
-
-		@Override
-		protected AggregateFunction<BinaryString, MinWithRetractAccumulator<BinaryString>> getAggregator() {
-			return new StringMinWithRetractAggFunction();
-		}
-	}
-
-	/**
-	 * Test for TimestampMinWithRetractAggFunction.
-	 */
-	public static class TimestampMinWithRetractAggFunctionTest
-			extends MinWithRetractAggFunctionTestBase<Timestamp> {
-
-		@Override
-		protected List<List<Timestamp>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							new Timestamp(0),
-							new Timestamp(1000),
-							new Timestamp(100),
-							null,
-							new Timestamp(10)
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							new Timestamp(1)
-					)
-			);
-		}
-
-		@Override
-		protected List<Timestamp> getExpectedResults() {
-			return Arrays.asList(
-					new Timestamp(0),
-					null,
-					new Timestamp(1)
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Timestamp, MinWithRetractAccumulator<Timestamp>> getAggregator() {
-			return new TimestampMinWithRetractAggFunction();
-		}
-	}
-
-	/**
-	 * Test for DateMinWithRetractAggFunction.
-	 */
-	public static class DateMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTestBase<Date> {
-
-		@Override
-		protected List<List<Date>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							new Date(0),
-							new Date(1000),
-							new Date(100),
-							null,
-							new Date(10)
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							new Date(1)
-					)
-			);
-		}
-
-		@Override
-		protected List<Date> getExpectedResults() {
-			return Arrays.asList(
-					new Date(0),
-					null,
-					new Date(1)
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Date, MinWithRetractAccumulator<Date>> getAggregator() {
-			return new DateMinWithRetractAggFunction();
-		}
-	}
-
-	/**
-	 * Test for TimeMinWithRetractAggFunction.
-	 */
-	public static class TimeMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTestBase<Time> {
-
-		@Override
-		protected List<List<Time>> getInputValueSets() {
-			return Arrays.asList(
-					Arrays.asList(
-							new Time(0),
-							new Time(1000),
-							new Time(100),
-							null,
-							new Time(10)
-					),
-					Arrays.asList(
-							null,
-							null,
-							null,
-							null,
-							null
-					),
-					Arrays.asList(
-							null,
-							new Time(1)
-					)
-			);
-		}
-
-		@Override
-		protected List<Time> getExpectedResults() {
-			return Arrays.asList(
-					new Time(0),
-					null,
-					new Time(1)
-			);
-		}
-
-		@Override
-		protected AggregateFunction<Time, MinWithRetractAccumulator<Time>> getAggregator() {
-			return new TimeMinWithRetractAggFunction();
-		}
+	private static <N> List<N> numberExpectedResults(N minValue, Function<String, N> strToValueFun) {
+		return Arrays.asList(
+				minValue,
+				null,
+				strToValueFun.apply("10")
+		);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunctionTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunctionTest.java
@@ -36,6 +36,9 @@ import org.apache.flink.table.planner.functions.aggfunctions.MinWithRetractAggFu
 import org.apache.flink.table.planner.functions.aggfunctions.MinWithRetractAggFunction.TimestampMinWithRetractAggFunction;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
 import java.lang.reflect.Method;
 import java.sql.Date;
 import java.sql.Time;
@@ -46,22 +49,30 @@ import java.util.List;
 /**
  * Test case for built-in Min with retraction aggregate function.
  */
-public abstract class MinWithRetractAggFunctionTest<T> extends AggFunctionTestBase<T, MinWithRetractAccumulator<T>> {
+@RunWith(Enclosed.class)
+public class MinWithRetractAggFunctionTest {
 
-	@Override
-	protected Class<?> getAccClass() {
-		return MinWithRetractAccumulator.class;
-	}
+	/**
+	 * The base test class for MinWithRetractAggFunction.
+	 */
+	public abstract static class MinWithRetractAggFunctionTestBase<T>
+			extends AggFunctionTestBase<T, MinWithRetractAccumulator<T>> {
 
-	@Override
-	protected Method getRetractFunc() throws NoSuchMethodException {
-		return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class);
+		@Override
+		protected Class<?> getAccClass() {
+			return MinWithRetractAccumulator.class;
+		}
+
+		@Override
+		protected Method getRetractFunc() throws NoSuchMethodException {
+			return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class);
+		}
 	}
 
 	/**
 	 * Test MinWithRetractAggFunction for number type.
 	 */
-	public abstract static class NumberMinWithRetractAggFunctionTest<T> extends MinWithRetractAggFunctionTest<T> {
+	public abstract static class NumberMinWithRetractAggFunctionTestBase<T> extends MinWithRetractAggFunctionTestBase<T> {
 		protected abstract T getMinValue();
 
 		protected abstract T getMaxValue();
@@ -112,7 +123,7 @@ public abstract class MinWithRetractAggFunctionTest<T> extends AggFunctionTestBa
 	/**
 	 * Test for ByteMinWithRetractAggFunction.
 	 */
-	public static class ByteMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTest<Byte> {
+	public static class ByteMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTestBase<Byte> {
 
 		@Override
 		protected Byte getMinValue() {
@@ -138,7 +149,7 @@ public abstract class MinWithRetractAggFunctionTest<T> extends AggFunctionTestBa
 	/**
 	 * Test for ShortMinWithRetractAggFunction.
 	 */
-	public static class ShortMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTest<Short> {
+	public static class ShortMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTestBase<Short> {
 
 		@Override
 		protected Short getMinValue() {
@@ -164,7 +175,7 @@ public abstract class MinWithRetractAggFunctionTest<T> extends AggFunctionTestBa
 	/**
 	 * Test for IntMinWithRetractAggFunction.
 	 */
-	public static class IntMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTest<Integer> {
+	public static class IntMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTestBase<Integer> {
 
 		@Override
 		protected Integer getMinValue() {
@@ -190,7 +201,7 @@ public abstract class MinWithRetractAggFunctionTest<T> extends AggFunctionTestBa
 	/**
 	 * Test for LongMinWithRetractAggFunction.
 	 */
-	public static class LongMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTest<Long> {
+	public static class LongMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTestBase<Long> {
 
 		@Override
 		protected Long getMinValue() {
@@ -216,7 +227,7 @@ public abstract class MinWithRetractAggFunctionTest<T> extends AggFunctionTestBa
 	/**
 	 * Test for FloatMinWithRetractAggFunction.
 	 */
-	public static class FloatMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTest<Float> {
+	public static class FloatMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTestBase<Float> {
 
 		@Override
 		protected Float getMinValue() {
@@ -242,7 +253,7 @@ public abstract class MinWithRetractAggFunctionTest<T> extends AggFunctionTestBa
 	/**
 	 * Test for DoubleMinWithRetractAggFunction.
 	 */
-	public static class DoubleMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTest<Double> {
+	public static class DoubleMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTestBase<Double> {
 
 		@Override
 		protected Double getMinValue() {
@@ -268,7 +279,7 @@ public abstract class MinWithRetractAggFunctionTest<T> extends AggFunctionTestBa
 	/**
 	 * Test for BooleanMinWithRetractAggFunction.
 	 */
-	public static class BooleanMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTest<Boolean> {
+	public static class BooleanMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTestBase<Boolean> {
 
 		@Override
 		protected List<List<Boolean>> getInputValueSets() {
@@ -323,7 +334,7 @@ public abstract class MinWithRetractAggFunctionTest<T> extends AggFunctionTestBa
 	/**
 	 * Test for DecimalMinWithRetractAggFunction.
 	 */
-	public static class DecimalMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTest<Decimal> {
+	public static class DecimalMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTestBase<Decimal> {
 
 		private int precision = 20;
 		private int scale = 6;
@@ -375,7 +386,7 @@ public abstract class MinWithRetractAggFunctionTest<T> extends AggFunctionTestBa
 	 * Test for StringMinWithRetractAggFunction.
 	 */
 	public static class StringMinWithRetractAggFunctionTest
-			extends MinWithRetractAggFunctionTest<BinaryString> {
+			extends MinWithRetractAggFunctionTestBase<BinaryString> {
 
 		@Override
 		protected List<List<BinaryString>> getInputValueSets() {
@@ -425,7 +436,7 @@ public abstract class MinWithRetractAggFunctionTest<T> extends AggFunctionTestBa
 	 * Test for TimestampMinWithRetractAggFunction.
 	 */
 	public static class TimestampMinWithRetractAggFunctionTest
-			extends MinWithRetractAggFunctionTest<Timestamp> {
+			extends MinWithRetractAggFunctionTestBase<Timestamp> {
 
 		@Override
 		protected List<List<Timestamp>> getInputValueSets() {
@@ -469,7 +480,7 @@ public abstract class MinWithRetractAggFunctionTest<T> extends AggFunctionTestBa
 	/**
 	 * Test for DateMinWithRetractAggFunction.
 	 */
-	public static class DateMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTest<Date> {
+	public static class DateMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTestBase<Date> {
 
 		@Override
 		protected List<List<Date>> getInputValueSets() {
@@ -513,7 +524,7 @@ public abstract class MinWithRetractAggFunctionTest<T> extends AggFunctionTestBa
 	/**
 	 * Test for TimeMinWithRetractAggFunction.
 	 */
-	public static class TimeMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTest<Time> {
+	public static class TimeMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTestBase<Time> {
 
 		@Override
 		protected List<List<Time>> getInputValueSets() {


### PR DESCRIPTION
## What is the purpose of the change

*Most tests from package o.a.f.table.planner.functions.aggfunctions are not executed during mvn test because those test case classed are abstract class and will be ignored when running `mvn test`. In [FLINK-13702](https://issues.apache.org/jira/browse/FLINK-14694), `BinaryGeneric` can't be compared directly, so those failures are also ignored. This pr aims to fix both. The first one's solution is introducing [Enclosed](https://junit.org/junit4/javadoc/4.12/org/junit/experimental/runners/Enclosed.html) runner, and moving the abstract class as an inner class, and making sure the outer class is a non-abstract class. The second one's solution is verifying `BinaryGeneric` using `BinaryGenericAsserter.equivalent` (should also consider that `GenericRow` has `BinaryGeneric` sub-type)*

## Brief change log

  - *introducing `Enclosed` runner and make sure the outer class is a non-abstract class*
  - *comparing `BinaryGeneric` using `BinaryGenericAsserter.equivalent`*


## Verifying this change

This change is already covered by existing tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
