### PR TITLE
[FLINK-14724] [table-planner-blink] Join condition could be simplified in logical phase

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -257,6 +257,7 @@ object FlinkBatchRuleSets {
 
     // join rules
     FlinkJoinPushExpressionsRule.INSTANCE,
+    SimplifyJoinConditionRule.INSTANCE,
 
     // remove union with only a single child
     UnionEliminatorRule.INSTANCE,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -236,6 +236,7 @@ object FlinkStreamRuleSets {
 
     // join rules
     FlinkJoinPushExpressionsRule.INSTANCE,
+    SimplifyJoinConditionRule.INSTANCE,
 
     // remove union with only a single child
     UnionEliminatorRule.INSTANCE,

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/SetOperatorsTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/SetOperatorsTest.xml
@@ -19,6 +19,7 @@ limitations under the License.
   <TestCase name="testIntersect">
     <Resource name="sql">
       <![CDATA[SELECT c FROM T1 INTERSECT SELECT f FROM T2]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -28,6 +29,7 @@ LogicalIntersect(all=[false])
 +- LogicalProject(f=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -40,11 +42,13 @@ HashAggregate(isMerge=[false], groupBy=[c], select=[c])
       +- Calc(select=[f])
          +- TableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testIntersectAll">
     <Resource name="sql">
       <![CDATA[SELECT c FROM T1 INTERSECT ALL SELECT f FROM T2]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -54,6 +58,7 @@ LogicalIntersect(all=[true])
 +- LogicalProject(f=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -69,11 +74,13 @@ Calc(select=[c0 AS c])
                   +- Calc(select=[f, null:BOOLEAN AS vcol_left_marker, true AS vcol_right_marker])
                      +- TableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testIntersectLeftIsEmpty">
     <Resource name="sql">
       <![CDATA[SELECT c FROM T1 WHERE 1=0 INTERSECT SELECT f FROM T2]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -84,16 +91,19 @@ LogicalIntersect(all=[false])
 +- LogicalProject(f=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Values(type=[RecordType(VARCHAR(2147483647) c)], tuples=[[]], values=[c])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testIntersectRightIsEmpty">
     <Resource name="sql">
       <![CDATA[SELECT c FROM T1 INTERSECT SELECT f FROM T2 WHERE 1=0]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -104,16 +114,50 @@ LogicalIntersect(all=[false])
    +- LogicalFilter(condition=[=(1, 0)])
       +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Values(type=[RecordType(VARCHAR(2147483647) c)], tuples=[[]], values=[c])
 ]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testIntersectWithOuterProject">
+    <Resource name="sql">
+      <![CDATA[SELECT a FROM (SELECT a, b FROM T1 INTERSECT SELECT d, e FROM T2)]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0])
++- LogicalIntersect(all=[false])
+   :- LogicalProject(a=[$0], b=[$1])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a, b, c)]]])
+   +- LogicalProject(d=[$0], e=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a])
++- HashAggregate(isMerge=[false], groupBy=[a, b], select=[a, b])
+   +- HashJoin(joinType=[LeftSemiJoin], where=[AND(IS NOT DISTINCT FROM(a, d), IS NOT DISTINCT FROM(b, e))], select=[a, b], build=[left])
+      :- Exchange(distribution=[hash[a, b]])
+      :  +- Calc(select=[a, b])
+      :     +- TableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+      +- Exchange(distribution=[hash[d, e]])
+         +- Calc(select=[d, e])
+            +- TableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
+]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testMinus">
     <Resource name="sql">
       <![CDATA[SELECT c FROM T1 EXCEPT SELECT f FROM T2]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -123,6 +167,7 @@ LogicalMinus(all=[false])
 +- LogicalProject(f=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -135,11 +180,13 @@ HashAggregate(isMerge=[false], groupBy=[c], select=[c])
       +- Calc(select=[f])
          +- TableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testMinusAll">
     <Resource name="sql">
       <![CDATA[SELECT c FROM T1 EXCEPT ALL SELECT f FROM T2]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -149,6 +196,7 @@ LogicalMinus(all=[true])
 +- LogicalProject(f=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -164,11 +212,13 @@ Calc(select=[c0 AS c])
                   +- Calc(select=[f, -1:BIGINT AS vcol_marker])
                      +- TableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testMinusLeftIsEmpty">
     <Resource name="sql">
       <![CDATA[SELECT c FROM T1 WHERE 1=0 EXCEPT SELECT f FROM T2]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -179,16 +229,19 @@ LogicalMinus(all=[false])
 +- LogicalProject(f=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Values(type=[RecordType(VARCHAR(2147483647) c)], tuples=[[]], values=[c])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testMinusRightIsEmpty">
     <Resource name="sql">
       <![CDATA[SELECT c FROM T1 EXCEPT SELECT f FROM T2 WHERE 1=0]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -199,6 +252,7 @@ LogicalMinus(all=[false])
    +- LogicalFilter(condition=[=(1, 0)])
       +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -208,11 +262,13 @@ HashAggregate(isMerge=[true], groupBy=[c], select=[c])
       +- Calc(select=[c])
          +- TableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testMinusWithNestedTypes">
     <Resource name="sql">
       <![CDATA[SELECT * FROM MyTable EXCEPT SELECT * FROM MyTable]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -222,6 +278,7 @@ LogicalMinus(all=[false])
 +- LogicalProject(a=[$0], b=[$1], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -231,11 +288,13 @@ HashAggregate(isMerge=[false], groupBy=[a, b, c], select=[a, b, c])
    :  +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
    +- Reused(reference_id=[1])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testUnionNullableTypes">
     <Resource name="sql">
       <![CDATA[SELECT a FROM A UNION ALL SELECT CASE WHEN c > 0 THEN b ELSE NULL END FROM A]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -245,6 +304,7 @@ LogicalUnion(all=[true])
 +- LogicalProject(EXPR$0=[CASE(>($2, 0), $1, null:RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" _2))])
    +- LogicalTableScan(table=[[default_catalog, default_database, A, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -254,11 +314,13 @@ Union(all=[true], union=[a])
 +- Calc(select=[CASE(>(c, 0), b, null:RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" _2)) AS EXPR$0])
    +- Reused(reference_id=[1])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testUnionAnyType">
     <Resource name="sql">
       <![CDATA[SELECT a FROM A UNION ALL SELECT b FROM A]]>
+
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -268,6 +330,7 @@ LogicalUnion(all=[true])
 +- LogicalProject(b=[$1])
    +- LogicalTableScan(table=[[default_catalog, default_database, A, source: [TestTableSource(a, b)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -277,6 +340,7 @@ Union(all=[true], union=[a])
 +- Calc(select=[b])
    +- Reused(reference_id=[1])
 ]]>
+
     </Resource>
   </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/SetOperatorsTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/SetOperatorsTest.xml
@@ -19,7 +19,6 @@ limitations under the License.
   <TestCase name="testIntersect">
     <Resource name="sql">
       <![CDATA[SELECT c FROM T1 INTERSECT SELECT f FROM T2]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -29,7 +28,6 @@ LogicalIntersect(all=[false])
 +- LogicalProject(f=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -42,13 +40,11 @@ HashAggregate(isMerge=[false], groupBy=[c], select=[c])
       +- Calc(select=[f])
          +- TableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testIntersectAll">
     <Resource name="sql">
       <![CDATA[SELECT c FROM T1 INTERSECT ALL SELECT f FROM T2]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -58,7 +54,6 @@ LogicalIntersect(all=[true])
 +- LogicalProject(f=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -74,13 +69,11 @@ Calc(select=[c0 AS c])
                   +- Calc(select=[f, null:BOOLEAN AS vcol_left_marker, true AS vcol_right_marker])
                      +- TableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testIntersectLeftIsEmpty">
     <Resource name="sql">
       <![CDATA[SELECT c FROM T1 WHERE 1=0 INTERSECT SELECT f FROM T2]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -91,19 +84,16 @@ LogicalIntersect(all=[false])
 +- LogicalProject(f=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Values(type=[RecordType(VARCHAR(2147483647) c)], tuples=[[]], values=[c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testIntersectRightIsEmpty">
     <Resource name="sql">
       <![CDATA[SELECT c FROM T1 INTERSECT SELECT f FROM T2 WHERE 1=0]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -114,19 +104,16 @@ LogicalIntersect(all=[false])
    +- LogicalFilter(condition=[=(1, 0)])
       +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Values(type=[RecordType(VARCHAR(2147483647) c)], tuples=[[]], values=[c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testIntersectWithOuterProject">
     <Resource name="sql">
       <![CDATA[SELECT a FROM (SELECT a, b FROM T1 INTERSECT SELECT d, e FROM T2)]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -137,7 +124,6 @@ LogicalProject(a=[$0])
    +- LogicalProject(d=[$0], e=[$1])
       +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -151,13 +137,11 @@ Calc(select=[a])
          +- Calc(select=[d, e])
             +- TableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testMinus">
     <Resource name="sql">
       <![CDATA[SELECT c FROM T1 EXCEPT SELECT f FROM T2]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -167,7 +151,6 @@ LogicalMinus(all=[false])
 +- LogicalProject(f=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -180,13 +163,11 @@ HashAggregate(isMerge=[false], groupBy=[c], select=[c])
       +- Calc(select=[f])
          +- TableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testMinusAll">
     <Resource name="sql">
       <![CDATA[SELECT c FROM T1 EXCEPT ALL SELECT f FROM T2]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -196,7 +177,6 @@ LogicalMinus(all=[true])
 +- LogicalProject(f=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -212,13 +192,11 @@ Calc(select=[c0 AS c])
                   +- Calc(select=[f, -1:BIGINT AS vcol_marker])
                      +- TableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testMinusLeftIsEmpty">
     <Resource name="sql">
       <![CDATA[SELECT c FROM T1 WHERE 1=0 EXCEPT SELECT f FROM T2]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -229,19 +207,16 @@ LogicalMinus(all=[false])
 +- LogicalProject(f=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Values(type=[RecordType(VARCHAR(2147483647) c)], tuples=[[]], values=[c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testMinusRightIsEmpty">
     <Resource name="sql">
       <![CDATA[SELECT c FROM T1 EXCEPT SELECT f FROM T2 WHERE 1=0]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -252,7 +227,6 @@ LogicalMinus(all=[false])
    +- LogicalFilter(condition=[=(1, 0)])
       +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -262,13 +236,11 @@ HashAggregate(isMerge=[true], groupBy=[c], select=[c])
       +- Calc(select=[c])
          +- TableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testMinusWithNestedTypes">
     <Resource name="sql">
       <![CDATA[SELECT * FROM MyTable EXCEPT SELECT * FROM MyTable]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -278,7 +250,6 @@ LogicalMinus(all=[false])
 +- LogicalProject(a=[$0], b=[$1], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -288,13 +259,11 @@ HashAggregate(isMerge=[false], groupBy=[a, b, c], select=[a, b, c])
    :  +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
    +- Reused(reference_id=[1])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testUnionNullableTypes">
     <Resource name="sql">
       <![CDATA[SELECT a FROM A UNION ALL SELECT CASE WHEN c > 0 THEN b ELSE NULL END FROM A]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -304,7 +273,6 @@ LogicalUnion(all=[true])
 +- LogicalProject(EXPR$0=[CASE(>($2, 0), $1, null:RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" _2))])
    +- LogicalTableScan(table=[[default_catalog, default_database, A, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -314,13 +282,11 @@ Union(all=[true], union=[a])
 +- Calc(select=[CASE(>(c, 0), b, null:RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" _2)) AS EXPR$0])
    +- Reused(reference_id=[1])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testUnionAnyType">
     <Resource name="sql">
       <![CDATA[SELECT a FROM A UNION ALL SELECT b FROM A]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -330,7 +296,6 @@ LogicalUnion(all=[true])
 +- LogicalProject(b=[$1])
    +- LogicalTableScan(table=[[default_catalog, default_database, A, source: [TestTableSource(a, b)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -340,7 +305,6 @@ Union(all=[true], union=[a])
 +- Calc(select=[b])
    +- Reused(reference_id=[1])
 ]]>
-
     </Resource>
   </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/DagOptimizationTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/DagOptimizationTest.xml
@@ -50,7 +50,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[b,
                   +- LogicalFilter(condition=[LIKE($2, _UTF-16LE'%world%')])
                      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -78,7 +77,6 @@ Sink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[b, cnt], 
 +- Calc(select=[b, cnt], where=[AND(>=(b, 4), <(b, 6))], updateAsRetraction=[false], accMode=[AccRetract])
    +- Reused(reference_id=[3])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testMultiSinks1">
@@ -98,7 +96,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[t
          +- LogicalProject(c=[$2], a=[$0])
             +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -117,7 +114,6 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[total_mi
 +- GroupAggregate(select=[MIN_RETRACT(sum_a) AS total_min], updateAsRetraction=[false], accMode=[Acc])
    +- Reused(reference_id=[1])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testMultiSinks2">
@@ -149,7 +145,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[a
             :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
             +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c, d, e)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -171,7 +166,6 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink1`], fields=[a, b1], 
 Sink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[a, b1], updateAsRetraction=[false], accMode=[Acc])
 +- Reused(reference_id=[2])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testMultiSinks3">
@@ -199,7 +193,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[a
             :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
             +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c, d, e)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -222,7 +215,6 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[a, b1], 
    :- Reused(reference_id=[1])
    +- Reused(reference_id=[2])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testMultiSinks4">
@@ -262,7 +254,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[a
                            +- LogicalFilter(condition=[>=($0, 0)])
                               +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -292,7 +283,6 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[a1, b, c
       +- Exchange(distribution=[hash[a1]], updateAsRetraction=[true], accMode=[Acc])
          +- Reused(reference_id=[3])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testMultiSinks5">
@@ -308,7 +298,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[t
    +- LogicalProject(a=[random_udf($0)])
       +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -324,7 +313,6 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[total_mi
 +- GroupAggregate(select=[MIN(a) AS total_min], updateAsRetraction=[false], accMode=[Acc])
    +- Reused(reference_id=[1])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testMultiSinksWithUDTF">
@@ -364,7 +352,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[a
             +- LogicalFilter(condition=[>=($1, UNIX_TIMESTAMP(_UTF-16LE'${startTime}'))])
                +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -395,7 +382,6 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[a, total
    +- Calc(select=[a, CAST(total_c) AS total_c], where=[<(a, 50)], updateAsRetraction=[false], accMode=[Acc])
       +- Reused(reference_id=[3])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testMultiSinksSplitOnUnion1">
@@ -419,7 +405,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`retractSink`], fields=[t
          +- LogicalProject(d=[$0], f=[$2])
             +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1, source: [TestTableSource(d, e, f)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -439,7 +424,6 @@ Sink(name=[`default_catalog`.`default_database`.`retractSink`], fields=[total_mi
 +- GroupAggregate(select=[MIN(a) AS total_min], updateAsRetraction=[true], accMode=[AccRetract])
    +- Reused(reference_id=[1])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testMultiSinksSplitOnUnion2">
@@ -477,7 +461,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink3`], fields=[a
       +- LogicalProject(d=[$0], f=[$2])
          +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1, source: [TestTableSource(d, e, f)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -505,7 +488,6 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[total_mi
 Sink(name=[`default_catalog`.`default_database`.`appendSink3`], fields=[a])
 +- Reused(reference_id=[2])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testMultiSinksSplitOnUnion3">
@@ -544,7 +526,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[to
          +- LogicalProject(a=[$0], c=[$2])
             +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -572,7 +553,6 @@ Sink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[total_min
 +- GroupAggregate(select=[MIN(a) AS total_min], updateAsRetraction=[false], accMode=[Acc])
    +- Reused(reference_id=[2])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testMultiSinksSplitOnUnion4">
@@ -602,7 +582,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`retractSink`], fields=[t
          +- LogicalProject(a=[$0], c=[$2])
             +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -625,7 +604,6 @@ Sink(name=[`default_catalog`.`default_database`.`retractSink`], fields=[total_mi
 +- GroupAggregate(select=[MIN(a) AS total_min], updateAsRetraction=[true], accMode=[AccRetract])
    +- Reused(reference_id=[1])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testSharedUnionNode">
@@ -673,7 +651,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[b,
                   +- LogicalFilter(condition=[LIKE($2, _UTF-16LE'%world%')])
                      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -709,7 +686,6 @@ Sink(name=[`default_catalog`.`default_database`.`retractSink2`], fields=[b, cnt]
 Sink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[b, cnt], updateAsRetraction=[false], accMode=[AccRetract])
 +- Reused(reference_id=[4])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testSingleSink1">
@@ -730,7 +706,6 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[c, cnt], 
       +- Calc(select=[c, a], updateAsRetraction=[true], accMode=[Acc])
          +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c], updateAsRetraction=[true], accMode=[Acc])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testSingleSink2">
@@ -757,7 +732,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[a1
                            +- LogicalFilter(condition=[>=($0, 0)])
                               +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -777,7 +751,6 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[a1, b, c1
                   +- Calc(select=[a AS a2, c], where=[AND(>=(a, 0), >=(b, 5))], updateAsRetraction=[true], accMode=[Acc])
                      +- Reused(reference_id=[1])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testSingleSink3">
@@ -796,7 +769,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[a1
             :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
             +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -811,7 +783,6 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[a1, b1], 
          +- Exchange(distribution=[hash[a]], updateAsRetraction=[true], accMode=[Acc])
             +- DataStreamScan(table=[[default_catalog, default_database, MyTable2]], fields=[a, b, c, d, e], updateAsRetraction=[true], accMode=[Acc])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testSingleSink4">
@@ -844,7 +815,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[a,
                                     +- LogicalFilter(condition=[>=($0, 0)])
                                        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -870,7 +840,6 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[a, b, c],
                            +- Calc(select=[a AS a2, c], where=[AND(>=(a, 0), >=(b, 5))], updateAsRetraction=[true], accMode=[Acc])
                               +- Reused(reference_id=[1])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testSingleSinkWithUDTF">
@@ -888,7 +857,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[a,
       :        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(i, j, k, l, m)]]])
       +- LogicalTableFunctionScan(invocation=[split($cor0.c)], rowType=[RecordType(VARCHAR(2147483647) f0)], elementType=[class [Ljava.lang.Object;])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -904,7 +872,6 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[a, b, c, 
       +- Exchange(distribution=[hash[i]], updateAsRetraction=[true], accMode=[Acc])
          +- TableSourceScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(i, j, k, l, m)]]], fields=[i, j, k, l, m], updateAsRetraction=[true], accMode=[Acc])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testSingleSinkSplitOnUnion">
@@ -919,7 +886,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`retractSink`], fields=[t
          +- LogicalProject(d=[$0], f=[$2])
             +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1, source: [TestTableSource(d, e, f)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -932,7 +898,6 @@ Sink(name=[`default_catalog`.`default_database`.`retractSink`], fields=[total_su
          +- Calc(select=[d AS a], updateAsRetraction=[true], accMode=[Acc])
             +- TableSourceScan(table=[[default_catalog, default_database, MyTable1, source: [TestTableSource(d, e, f)]]], fields=[d, e, f], updateAsRetraction=[true], accMode=[Acc])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testUpdateAsRetractConsumedAtSourceBlock">
@@ -954,7 +919,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[a,
             +- LogicalProject(a=[$0], b=[$1], c=[$2], rank_num=[ROW_NUMBER() OVER (PARTITION BY $1 ORDER BY $2 DESC NULLS LAST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)])
                +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -970,7 +934,6 @@ Sink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[a, b], up
 +- Calc(select=[a, b], where=[<(a, 6)], updateAsRetraction=[false], accMode=[AccRetract])
    +- Reused(reference_id=[1])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testUnionAndAggWithDifferentGroupings">
@@ -986,7 +949,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[b,
          +- LogicalProject(c=[$2], a=[$0])
             +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -1001,7 +963,6 @@ Sink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[b, c, a_s
             +- Calc(select=[c, a], updateAsRetraction=[true], accMode=[Acc])
                +- Reused(reference_id=[1])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testUpdateAsRetractConsumedAtSinkBlock">
@@ -1019,7 +980,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[a,
       +- LogicalProject(a=[$0], b=[$1], c=[$2])
          +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -1034,7 +994,6 @@ Sink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[a, b], up
 +- Calc(select=[a, b], where=[<(a, 6)], updateAsRetraction=[false], accMode=[Acc])
    +- Reused(reference_id=[1])
 ]]>
-
     </Resource>
   </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/DagOptimizationTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/DagOptimizationTest.xml
@@ -696,7 +696,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[c,
    +- LogicalProject(c=[$2], a=[$0])
       +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/DagOptimizationTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/DagOptimizationTest.xml
@@ -50,6 +50,7 @@ LogicalSink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[b,
                   +- LogicalFilter(condition=[LIKE($2, _UTF-16LE'%world%')])
                      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -77,6 +78,7 @@ Sink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[b, cnt], 
 +- Calc(select=[b, cnt], where=[AND(>=(b, 4), <(b, 6))], updateAsRetraction=[false], accMode=[AccRetract])
    +- Reused(reference_id=[3])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testMultiSinks1">
@@ -96,6 +98,7 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[t
          +- LogicalProject(c=[$2], a=[$0])
             +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -114,6 +117,7 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[total_mi
 +- GroupAggregate(select=[MIN_RETRACT(sum_a) AS total_min], updateAsRetraction=[false], accMode=[Acc])
    +- Reused(reference_id=[1])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testMultiSinks2">
@@ -145,17 +149,18 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[a
             :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
             +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c, d, e)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Calc(select=[a, b], where=[<=(a, 10)], updateAsRetraction=[false], accMode=[Acc], reuse_id=[1])
+Calc(select=[a AS a1, b AS b1], where=[<=(a, 10)], updateAsRetraction=[false], accMode=[Acc], reuse_id=[1])
 +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c], updateAsRetraction=[false], accMode=[Acc])
 
-Union(all=[true], union=[a, b], updateAsRetraction=[false], accMode=[Acc], reuse_id=[2])
+Union(all=[true], union=[a1, b1], updateAsRetraction=[false], accMode=[Acc], reuse_id=[2])
 :- Reused(reference_id=[1])
 +- Calc(select=[a, b1], updateAsRetraction=[false], accMode=[Acc])
-   +- Join(joinType=[InnerJoin], where=[=(a0, a)], select=[a, b, a0, b0, c, d, e], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey], updateAsRetraction=[false], accMode=[Acc])
-      :- Exchange(distribution=[hash[a]], updateAsRetraction=[true], accMode=[Acc])
+   +- Join(joinType=[InnerJoin], where=[=(a, a1)], select=[a1, b1, a, b, c, d, e], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey], updateAsRetraction=[false], accMode=[Acc])
+      :- Exchange(distribution=[hash[a1]], updateAsRetraction=[true], accMode=[Acc])
       :  +- Reused(reference_id=[1])
       +- Exchange(distribution=[hash[a]], updateAsRetraction=[true], accMode=[Acc])
          +- TableSourceScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e], updateAsRetraction=[true], accMode=[Acc])
@@ -166,6 +171,7 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink1`], fields=[a, b1], 
 Sink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[a, b1], updateAsRetraction=[false], accMode=[Acc])
 +- Reused(reference_id=[2])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testMultiSinks3">
@@ -193,6 +199,7 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[a
             :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
             +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c, d, e)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -215,6 +222,7 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[a, b1], 
    :- Reused(reference_id=[1])
    +- Reused(reference_id=[2])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testMultiSinks4">
@@ -254,6 +262,7 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[a
                            +- LogicalFilter(condition=[>=($0, 0)])
                               +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -283,6 +292,7 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[a1, b, c
       +- Exchange(distribution=[hash[a1]], updateAsRetraction=[true], accMode=[Acc])
          +- Reused(reference_id=[3])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testMultiSinks5">
@@ -298,6 +308,7 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[t
    +- LogicalProject(a=[random_udf($0)])
       +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -313,6 +324,7 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[total_mi
 +- GroupAggregate(select=[MIN(a) AS total_min], updateAsRetraction=[false], accMode=[Acc])
    +- Reused(reference_id=[1])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testMultiSinksWithUDTF">
@@ -352,6 +364,7 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[a
             +- LogicalFilter(condition=[>=($1, UNIX_TIMESTAMP(_UTF-16LE'${startTime}'))])
                +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -382,6 +395,7 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[a, total
    +- Calc(select=[a, CAST(total_c) AS total_c], where=[<(a, 50)], updateAsRetraction=[false], accMode=[Acc])
       +- Reused(reference_id=[3])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testMultiSinksSplitOnUnion1">
@@ -405,6 +419,7 @@ LogicalSink(name=[`default_catalog`.`default_database`.`retractSink`], fields=[t
          +- LogicalProject(d=[$0], f=[$2])
             +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1, source: [TestTableSource(d, e, f)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -424,6 +439,7 @@ Sink(name=[`default_catalog`.`default_database`.`retractSink`], fields=[total_mi
 +- GroupAggregate(select=[MIN(a) AS total_min], updateAsRetraction=[true], accMode=[AccRetract])
    +- Reused(reference_id=[1])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testMultiSinksSplitOnUnion2">
@@ -461,6 +477,7 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink3`], fields=[a
       +- LogicalProject(d=[$0], f=[$2])
          +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1, source: [TestTableSource(d, e, f)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -488,6 +505,7 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink2`], fields=[total_mi
 Sink(name=[`default_catalog`.`default_database`.`appendSink3`], fields=[a])
 +- Reused(reference_id=[2])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testMultiSinksSplitOnUnion3">
@@ -526,6 +544,7 @@ LogicalSink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[to
          +- LogicalProject(a=[$0], c=[$2])
             +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -553,6 +572,7 @@ Sink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[total_min
 +- GroupAggregate(select=[MIN(a) AS total_min], updateAsRetraction=[false], accMode=[Acc])
    +- Reused(reference_id=[2])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testMultiSinksSplitOnUnion4">
@@ -582,6 +602,7 @@ LogicalSink(name=[`default_catalog`.`default_database`.`retractSink`], fields=[t
          +- LogicalProject(a=[$0], c=[$2])
             +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -604,6 +625,7 @@ Sink(name=[`default_catalog`.`default_database`.`retractSink`], fields=[total_mi
 +- GroupAggregate(select=[MIN(a) AS total_min], updateAsRetraction=[true], accMode=[AccRetract])
    +- Reused(reference_id=[1])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testSharedUnionNode">
@@ -651,6 +673,7 @@ LogicalSink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[b,
                   +- LogicalFilter(condition=[LIKE($2, _UTF-16LE'%world%')])
                      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -686,6 +709,7 @@ Sink(name=[`default_catalog`.`default_database`.`retractSink2`], fields=[b, cnt]
 Sink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[b, cnt], updateAsRetraction=[false], accMode=[AccRetract])
 +- Reused(reference_id=[4])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testSingleSink1">
@@ -696,6 +720,7 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[c,
    +- LogicalProject(c=[$2], a=[$0])
       +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -705,6 +730,7 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[c, cnt], 
       +- Calc(select=[c, a], updateAsRetraction=[true], accMode=[Acc])
          +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c], updateAsRetraction=[true], accMode=[Acc])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testSingleSink2">
@@ -731,6 +757,7 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[a1
                            +- LogicalFilter(condition=[>=($0, 0)])
                               +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -750,6 +777,7 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[a1, b, c1
                   +- Calc(select=[a AS a2, c], where=[AND(>=(a, 0), >=(b, 5))], updateAsRetraction=[true], accMode=[Acc])
                      +- Reused(reference_id=[1])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testSingleSink3">
@@ -768,6 +796,7 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[a1
             :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
             +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -782,6 +811,7 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[a1, b1], 
          +- Exchange(distribution=[hash[a]], updateAsRetraction=[true], accMode=[Acc])
             +- DataStreamScan(table=[[default_catalog, default_database, MyTable2]], fields=[a, b, c, d, e], updateAsRetraction=[true], accMode=[Acc])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testSingleSink4">
@@ -814,6 +844,7 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[a,
                                     +- LogicalFilter(condition=[>=($0, 0)])
                                        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -839,6 +870,7 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[a, b, c],
                            +- Calc(select=[a AS a2, c], where=[AND(>=(a, 0), >=(b, 5))], updateAsRetraction=[true], accMode=[Acc])
                               +- Reused(reference_id=[1])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testSingleSinkWithUDTF">
@@ -856,6 +888,7 @@ LogicalSink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[a,
       :        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(i, j, k, l, m)]]])
       +- LogicalTableFunctionScan(invocation=[split($cor0.c)], rowType=[RecordType(VARCHAR(2147483647) f0)], elementType=[class [Ljava.lang.Object;])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -871,6 +904,7 @@ Sink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[a, b, c, 
       +- Exchange(distribution=[hash[i]], updateAsRetraction=[true], accMode=[Acc])
          +- TableSourceScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(i, j, k, l, m)]]], fields=[i, j, k, l, m], updateAsRetraction=[true], accMode=[Acc])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testSingleSinkSplitOnUnion">
@@ -885,6 +919,7 @@ LogicalSink(name=[`default_catalog`.`default_database`.`retractSink`], fields=[t
          +- LogicalProject(d=[$0], f=[$2])
             +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1, source: [TestTableSource(d, e, f)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -897,6 +932,7 @@ Sink(name=[`default_catalog`.`default_database`.`retractSink`], fields=[total_su
          +- Calc(select=[d AS a], updateAsRetraction=[true], accMode=[Acc])
             +- TableSourceScan(table=[[default_catalog, default_database, MyTable1, source: [TestTableSource(d, e, f)]]], fields=[d, e, f], updateAsRetraction=[true], accMode=[Acc])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testUpdateAsRetractConsumedAtSourceBlock">
@@ -918,6 +954,7 @@ LogicalSink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[a,
             +- LogicalProject(a=[$0], b=[$1], c=[$2], rank_num=[ROW_NUMBER() OVER (PARTITION BY $1 ORDER BY $2 DESC NULLS LAST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)])
                +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -933,6 +970,7 @@ Sink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[a, b], up
 +- Calc(select=[a, b], where=[<(a, 6)], updateAsRetraction=[false], accMode=[AccRetract])
    +- Reused(reference_id=[1])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testUnionAndAggWithDifferentGroupings">
@@ -948,6 +986,7 @@ LogicalSink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[b,
          +- LogicalProject(c=[$2], a=[$0])
             +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -962,6 +1001,7 @@ Sink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[b, c, a_s
             +- Calc(select=[c, a], updateAsRetraction=[true], accMode=[Acc])
                +- Reused(reference_id=[1])
 ]]>
+
     </Resource>
   </TestCase>
   <TestCase name="testUpdateAsRetractConsumedAtSinkBlock">
@@ -979,6 +1019,7 @@ LogicalSink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[a,
       +- LogicalProject(a=[$0], b=[$1], c=[$2])
          +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
+
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -993,6 +1034,7 @@ Sink(name=[`default_catalog`.`default_database`.`upsertSink`], fields=[a, b], up
 +- Calc(select=[a, b], where=[<(a, 6)], updateAsRetraction=[false], accMode=[Acc])
    +- Reused(reference_id=[1])
 ]]>
+
     </Resource>
   </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SetOperatorsTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SetOperatorsTest.xml
@@ -111,6 +111,35 @@ Values(type=[RecordType(VARCHAR(2147483647) c)], tuples=[[]])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testIntersectWithOuterProject">
+    <Resource name="sql">
+      <![CDATA[SELECT a FROM (SELECT a, b FROM T1 INTERSECT SELECT d, e FROM T2)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0])
++- LogicalIntersect(all=[false])
+   :- LogicalProject(a=[$0], b=[$1])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a, b, c)]]])
+   +- LogicalProject(d=[$0], e=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a])
++- GroupAggregate(groupBy=[a, b], select=[a, b])
+   +- Exchange(distribution=[hash[a, b]])
+      +- Join(joinType=[LeftSemiJoin], where=[AND(IS NOT DISTINCT FROM(a, d), IS NOT DISTINCT FROM(b, e))], select=[a, b], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+         :- Exchange(distribution=[hash[a, b]])
+         :  +- Calc(select=[a, b])
+         :     +- TableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+         +- Exchange(distribution=[hash[d, e]])
+            +- Calc(select=[d, e])
+               +- TableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testMinus">
     <Resource name="sql">
       <![CDATA[SELECT c FROM T1 EXCEPT SELECT f FROM T2]]>
@@ -226,8 +255,8 @@ LogicalMinus(all=[false])
       <![CDATA[
 GroupAggregate(groupBy=[a, b, c], select=[a, b, c])
 +- Exchange(distribution=[hash[a, b, c]])
-   +- Join(joinType=[LeftAntiJoin], where=[CAST(AND(IS NOT DISTINCT FROM(a, a0), IS NOT DISTINCT FROM(b, b0), IS NOT DISTINCT FROM(c, c0)))], select=[a, b, c], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
-      :- Exchange(distribution=[single], reuse_id=[1])
+   +- Join(joinType=[LeftAntiJoin], where=[AND(IS NOT DISTINCT FROM(a, a0), IS NOT DISTINCT FROM(b, b0), IS NOT DISTINCT FROM(c, c0))], select=[a, b, c], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+      :- Exchange(distribution=[hash[a, b, c]], reuse_id=[1])
       :  +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
       +- Reused(reference_id=[1])
 ]]>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/SetOperatorsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/SetOperatorsTest.scala
@@ -128,4 +128,9 @@ class SetOperatorsTest extends TableTestBase {
       Array("a", "b"))
     util.verifyPlan("SELECT a FROM A UNION ALL SELECT b FROM A")
   }
+
+  @Test
+  def testIntersectWithOuterProject(): Unit = {
+    util.verifyPlan("SELECT a FROM (SELECT a, b FROM T1 INTERSECT SELECT d, e FROM T2)")
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/SetOperatorsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/SetOperatorsTest.scala
@@ -125,4 +125,9 @@ class SetOperatorsTest extends TableTestBase {
       Array("a", "b"))
     util.verifyPlan("SELECT a FROM A UNION ALL SELECT b FROM A")
   }
+
+  @Test
+  def testIntersectWithOuterProject(): Unit = {
+    util.verifyPlan("SELECT a FROM (SELECT a, b FROM T1 INTERSECT SELECT d, e FROM T2)")
+  }
 }


### PR DESCRIPTION

## What is the purpose of the change

*the plan of tpcds q38.sql contains NestedLoopJoin, because it's join condition is CAST(AND(IS NOT DISTINCT FROM($2, $3), IS NOT DISTINCT FROM($1, $4), IS NOT DISTINCT FROM($0, $5))):BOOLEAN, and planner can't find equal join keys from the condition by Join#analyzeCondition. add SimplifyJoinConditionRule into logical phase to simplify join condition*


## Brief change log

  - *add SimplifyJoinConditionRule into logical phase to simplify join condition for batch and stream program*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added test that validates the plan from sql like tpcds-q38.sql in SetOperatorsTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no)**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no)**
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no)**
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
