### PR TITLE
[hotfix][docs] clarify some rocksdb configuration options

### DIFF
--- a/docs/_includes/generated/rocks_db_configurable_configuration.html
+++ b/docs/_includes/generated/rocks_db_configurable_configuration.html
@@ -40,12 +40,12 @@
         <tr>
             <td><h5>state.backend.rocksdb.files.open</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>The maximum number of open files that can be used by the DB, '-1' means no limit. RocksDB has default configuration as '5000'.</td>
+            <td>The maximum number of open files (per TaskManager) that can be used by the DB, '-1' means no limit. RocksDB has default configuration as '5000'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.thread.num</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>The maximum number of concurrent background flush and compaction jobs. RocksDB has default configuration as '1'.</td>
+            <td>The maximum number of concurrent background flush and compaction jobs (per TaskManager). RocksDB has default configuration as '1'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.writebuffer.count</h5></td>

--- a/docs/_includes/generated/rocks_db_configuration.html
+++ b/docs/_includes/generated/rocks_db_configuration.html
@@ -10,7 +10,7 @@
         <tr>
             <td><h5>state.backend.rocksdb.checkpoint.transfer.thread.num</h5></td>
             <td style="word-wrap: break-word;">1</td>
-            <td>The number of threads used to transfer (download and upload) files in RocksDBStateBackend.</td>
+            <td>The number of threads (per stateful operator) used to transfer (download and upload) files in RocksDBStateBackend.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.localdir</h5></td>

--- a/docs/ops/state/state_backends.md
+++ b/docs/ops/state/state_backends.md
@@ -146,15 +146,20 @@ env.setStateBackend(new FsStateBackend("hdfs://namenode:40010/flink/checkpoints"
 </div>
 </div>
 
-If you want to use the `RocksDBStateBackend`, then you have to add the following dependency to your Flink project.
+If you want to use the `RocksDBStateBackend` in your IDE or configure it programmatically in your Flink job, you will have to add the following dependency to your Flink project.
 
 {% highlight xml %}
 <dependency>
     <groupId>org.apache.flink</groupId>
     <artifactId>flink-statebackend-rocksdb{{ site.scala_version_suffix }}</artifactId>
     <version>{{ site.version }}</version>
+    <scope>provided</scope>
 </dependency>
 {% endhighlight %}
+
+<div class="alert alert-info" markdown="span">
+  <strong>Note:</strong> Since RocksDB is part of the default Flink distribution, you do not need this dependency if you are not using any RocksDB code in your job and configure the state backend via `state.backend` and further [checkpointing]({{ site.baseurl }}/ops/config.html#checkpointing) and [RocksDB-specific]({{ site.baseurl }}/ops/config.html#rocksdb-state-backend) parameters in your `flink-conf.yaml`.
+</div>
 
 
 ### Setting Default State Backend

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -46,13 +46,13 @@ public class RocksDBConfigurableOptions implements Serializable {
 	public static final ConfigOption<String> MAX_BACKGROUND_THREADS =
 		key("state.backend.rocksdb.thread.num")
 			.noDefaultValue()
-			.withDescription("The maximum number of concurrent background flush and compaction jobs. " +
+			.withDescription("The maximum number of concurrent background flush and compaction jobs (per TaskManager). " +
 				"RocksDB has default configuration as '1'.");
 
 	public static final ConfigOption<String> MAX_OPEN_FILES =
 		key("state.backend.rocksdb.files.open")
 			.noDefaultValue()
-			.withDescription("The maximum number of open files that can be used by the DB, '-1' means no limit. " +
+			.withDescription("The maximum number of open files (per TaskManager) that can be used by the DB, '-1' means no limit. " +
 				"RocksDB has default configuration as '5000'.");
 
 	//--------------------------------------------------------------------------

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
@@ -56,7 +56,7 @@ public class RocksDBOptions {
 	public static final ConfigOption<Integer> CHECKPOINT_TRANSFER_THREAD_NUM = ConfigOptions
 		.key("state.backend.rocksdb.checkpoint.transfer.thread.num")
 		.defaultValue(1)
-		.withDescription("The number of threads used to transfer (download and upload) files in RocksDBStateBackend.");
+		.withDescription("The number of threads (per stateful operator) used to transfer (download and upload) files in RocksDBStateBackend.");
 
 	/** This determines if compaction filter to cleanup state with TTL is enabled. */
 	public static final ConfigOption<Boolean> TTL_COMPACT_FILTER_ENABLED = ConfigOptions


### PR DESCRIPTION
## What is the purpose of the change

This is to address some documentation deficiencies with respect to RocksDB configuration and setup.

## Brief change log

- clarify that `state.backend.rocksdb.thread.num` and `state.backend.rocksdb.files.open` are actually per TM
- clarify that `state.backend.rocksdb.checkpoint.transfer.thread.num` is per stateful operator
- clarify that the user may not need to setup a dependency to `flink-statebackend-rocksdb_<scala>`
- fix this `flink-statebackend-rocksdb_<scala>` dependency to `<scope>provided</scope>` since it is in the flink-dist.jar nowadays

Once reviewed, I will forward-port this to 1.9 and master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/flink/10164)
<!-- Reviewable:end -->
