### PR TITLE
[FLINK-14722][hadoop] Optimize mapred.HadoopInputSplit to not serialize conf when split is not configurable

### DIFF
--- a/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/mapred/wrapper/HadoopInputSplit.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/mapred/wrapper/HadoopInputSplit.java
@@ -27,6 +27,8 @@ import org.apache.hadoop.io.WritableFactories;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.JobConfigurable;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -42,18 +44,23 @@ public class HadoopInputSplit extends LocatableInputSplit {
 
 	private final Class<? extends org.apache.hadoop.mapred.InputSplit> splitType;
 
-	private transient JobConf jobConf;
-
 	private transient org.apache.hadoop.mapred.InputSplit hadoopInputSplit;
 
-	public HadoopInputSplit(int splitNumber, org.apache.hadoop.mapred.InputSplit hInputSplit, JobConf jobconf) {
+	@Nullable private transient JobConf jobConf;
+
+	public HadoopInputSplit(
+			int splitNumber,
+			org.apache.hadoop.mapred.InputSplit hInputSplit,
+			@Nullable JobConf jobconf) {
 		super(splitNumber, (String) null);
 
 		if (hInputSplit == null) {
 			throw new NullPointerException("Hadoop input split must not be null");
 		}
-		if (jobconf == null) {
-			throw new NullPointerException("Hadoop JobConf must not be null");
+
+		if (isConfigurable(hInputSplit) && jobconf == null) {
+			throw new NullPointerException(
+					"Hadoop JobConf must not be null when input split is configurable.");
 		}
 
 		this.splitType = hInputSplit.getClass();
@@ -70,18 +77,13 @@ public class HadoopInputSplit extends LocatableInputSplit {
 	public String[] getHostnames() {
 		try {
 			return this.hadoopInputSplit.getLocations();
-		}
-		catch (IOException e) {
+		} catch (IOException e) {
 			return new String[0];
 		}
 	}
 
 	public org.apache.hadoop.mapred.InputSplit getHadoopInputSplit() {
 		return hadoopInputSplit;
-	}
-
-	public JobConf getJobConf() {
-		return this.jobConf;
 	}
 
 	// ------------------------------------------------------------------------
@@ -92,8 +94,11 @@ public class HadoopInputSplit extends LocatableInputSplit {
 		// serialize the parent fields and the final fields
 		out.defaultWriteObject();
 
-		// the job conf knows how to serialize itself
-		jobConf.write(out);
+		if (isConfigurable(hadoopInputSplit)) {
+			// the job conf knows how to serialize itself
+			// noinspection ConstantConditions
+			jobConf.write(out);
+		}
 
 		// write the input split
 		hadoopInputSplit.write(out);
@@ -103,23 +108,28 @@ public class HadoopInputSplit extends LocatableInputSplit {
 		// read the parent fields and the final fields
 		in.defaultReadObject();
 
-		// the job conf knows how to deserialize itself
-		jobConf = new JobConf();
-		jobConf.readFields(in);
-
 		try {
 			hadoopInputSplit = (org.apache.hadoop.mapred.InputSplit) WritableFactories.newInstance(splitType);
-		}
-		catch (Exception e) {
+		} catch (Exception e) {
 			throw new RuntimeException("Unable to instantiate Hadoop InputSplit", e);
 		}
 
-		if (hadoopInputSplit instanceof Configurable) {
-			((Configurable) hadoopInputSplit).setConf(this.jobConf);
+		if (isConfigurable(hadoopInputSplit)) {
+			// the job conf knows how to deserialize itself
+			jobConf = new JobConf();
+			jobConf.readFields(in);
+
+			if (hadoopInputSplit instanceof Configurable) {
+				((Configurable) hadoopInputSplit).setConf(this.jobConf);
+			} else if (hadoopInputSplit instanceof JobConfigurable) {
+				((JobConfigurable) hadoopInputSplit).configure(this.jobConf);
+			}
 		}
-		else if (hadoopInputSplit instanceof JobConfigurable) {
-			((JobConfigurable) hadoopInputSplit).configure(this.jobConf);
-		}
+
 		hadoopInputSplit.readFields(in);
+	}
+
+	private static boolean isConfigurable(org.apache.hadoop.mapred.InputSplit split) {
+		return split instanceof Configurable || split instanceof JobConfigurable;
 	}
 }

--- a/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/mapred/wrapper/HadoopInputSplit.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/mapred/wrapper/HadoopInputSplit.java
@@ -78,6 +78,7 @@ public class HadoopInputSplit extends LocatableInputSplit {
 		try {
 			return this.hadoopInputSplit.getLocations();
 		} catch (IOException e) {
+			e.printStackTrace();
 			return new String[0];
 		}
 	}

--- a/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/mapred/wrapper/HadoopInputSplit.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/mapred/wrapper/HadoopInputSplit.java
@@ -58,7 +58,7 @@ public class HadoopInputSplit extends LocatableInputSplit {
 			throw new NullPointerException("Hadoop input split must not be null");
 		}
 
-		if (isConfigurable(hInputSplit) && jobconf == null) {
+		if (needsJobConf(hInputSplit) && jobconf == null) {
 			throw new NullPointerException(
 					"Hadoop JobConf must not be null when input split is configurable.");
 		}
@@ -78,7 +78,6 @@ public class HadoopInputSplit extends LocatableInputSplit {
 		try {
 			return this.hadoopInputSplit.getLocations();
 		} catch (IOException e) {
-			e.printStackTrace();
 			return new String[0];
 		}
 	}
@@ -95,7 +94,7 @@ public class HadoopInputSplit extends LocatableInputSplit {
 		// serialize the parent fields and the final fields
 		out.defaultWriteObject();
 
-		if (isConfigurable(hadoopInputSplit)) {
+		if (needsJobConf(hadoopInputSplit)) {
 			// the job conf knows how to serialize itself
 			// noinspection ConstantConditions
 			jobConf.write(out);
@@ -115,7 +114,7 @@ public class HadoopInputSplit extends LocatableInputSplit {
 			throw new RuntimeException("Unable to instantiate Hadoop InputSplit", e);
 		}
 
-		if (isConfigurable(hadoopInputSplit)) {
+		if (needsJobConf(hadoopInputSplit)) {
 			// the job conf knows how to deserialize itself
 			jobConf = new JobConf();
 			jobConf.readFields(in);
@@ -130,7 +129,7 @@ public class HadoopInputSplit extends LocatableInputSplit {
 		hadoopInputSplit.readFields(in);
 	}
 
-	private static boolean isConfigurable(org.apache.hadoop.mapred.InputSplit split) {
+	private static boolean needsJobConf(org.apache.hadoop.mapred.InputSplit split) {
 		return split instanceof Configurable || split instanceof JobConfigurable;
 	}
 }

--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/api/java/hadoop/mapred/wrapper/HadoopInputSplitTest.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/api/java/hadoop/mapred/wrapper/HadoopInputSplitTest.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.hadoop.mapred.wrapper;
+
+import org.apache.flink.util.InstantiationUtil;
+
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.JobConfigurable;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Test for {@link HadoopInputSplit}.
+ */
+public class HadoopInputSplitTest {
+
+	private JobConf conf;
+
+	@Before
+	public void before() {
+		Configuration configuration = new Configuration();
+		for (int i = 0; i < 10000; i++) {
+			configuration.set("key-" + i, "value-" + i);
+		}
+		this.conf = new JobConf(configuration);
+	}
+
+	private void testInner(
+			FileSplit fileSplit,
+			Consumer<Integer> serializeSizeChecker,
+			Consumer<InputSplit> splitChecker) throws IOException, ClassNotFoundException {
+		HadoopInputSplit split = new HadoopInputSplit(5, fileSplit, conf);
+
+		byte[] bytes = InstantiationUtil.serializeObject(split);
+		System.out.println(bytes.length);
+		serializeSizeChecker.accept(bytes.length);
+
+		split  = InstantiationUtil.deserializeObject(bytes, split.getClass().getClassLoader());
+		Assert.assertEquals(5, split.getSplitNumber());
+		Assert.assertArrayEquals(new String[]{"host0"}, split.getHostnames());
+		splitChecker.accept(split.getHadoopInputSplit());
+	}
+
+	@Test
+	public void testFileSplit() throws IOException, ClassNotFoundException {
+		FileSplit fileSplit = new FileSplit(new Path("/test"), 0, 100, new String[]{"host0"});
+		testInner(
+				fileSplit,
+				i -> Assert.assertTrue(i < 10000),
+				split -> Assert.assertEquals(fileSplit, split));
+	}
+
+	@Test
+	public void testConfigurable() throws IOException, ClassNotFoundException {
+		ConfigurableFileSplit fileSplit = new ConfigurableFileSplit(
+				new Path("/test"), 0, 100, new String[]{"host0"});
+		testInner(fileSplit, i -> {}, inputSplit -> {
+			ConfigurableFileSplit split = (ConfigurableFileSplit) inputSplit;
+			Assert.assertNotNull(split.getConf());
+			Assert.assertEquals(fileSplit, split);
+		});
+	}
+
+	@Test
+	public void testJobConfigurable() throws IOException, ClassNotFoundException {
+		JobConfigurableFileSplit fileSplit = new JobConfigurableFileSplit(
+				new Path("/test"), 0, 100, new String[]{"host0"});
+		testInner(fileSplit, i -> {}, inputSplit -> {
+			JobConfigurableFileSplit split = (JobConfigurableFileSplit) inputSplit;
+			Assert.assertNotNull(split.getConf());
+			Assert.assertEquals(fileSplit, split);
+		});
+	}
+
+	/**
+	 * Because of test class conflict, we can not use hadoop FileSplit, so we create
+	 * a new FileSplit to test.
+	 */
+	private static class FileSplit implements InputSplit {
+
+		private Path file;
+		private long start;
+		private long length;
+		private String[] hosts;
+
+		public FileSplit() {}
+
+		private FileSplit(Path file, long start, long length, String[] hosts) {
+			this.file = file;
+			this.start = start;
+			this.length = length;
+			this.hosts = hosts;
+		}
+
+		@Override
+		public long getLength() throws IOException {
+			return length;
+		}
+
+		@Override
+		public String[] getLocations() throws IOException {
+			return hosts;
+		}
+
+		@Override
+		public void write(DataOutput out) throws IOException {
+			out.writeUTF(file.toString());
+			out.writeLong(start);
+			out.writeLong(length);
+			out.writeInt(hosts.length);
+			for (String host : hosts) {
+				out.writeUTF(host);
+			}
+		}
+
+		@Override
+		public void readFields(DataInput in) throws IOException {
+			file = new Path(in.readUTF());
+			start = in.readLong();
+			length = in.readLong();
+			int size = in.readInt();
+			hosts = new String[size];
+			for (int i = 0; i < size; i++) {
+				hosts[i] = in.readUTF();
+			}
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			FileSplit fileSplit = (FileSplit) o;
+			return start == fileSplit.start &&
+					length == fileSplit.length &&
+					Objects.equals(file, fileSplit.file) &&
+					Arrays.equals(hosts, fileSplit.hosts);
+		}
+	}
+
+	private static class ConfigurableFileSplit extends FileSplit implements Configurable {
+
+		private Configuration conf;
+
+		public ConfigurableFileSplit() {}
+
+		private ConfigurableFileSplit(Path file, long start, long length, String[] hosts) {
+			super(file, start, length, hosts);
+		}
+
+		@Override
+		public void setConf(Configuration configuration) {
+			this.conf = configuration;
+		}
+
+		@Override
+		public Configuration getConf() {
+			return conf;
+		}
+	}
+
+	private static class JobConfigurableFileSplit extends FileSplit implements JobConfigurable {
+
+		private JobConf jobConf;
+
+		public JobConfigurableFileSplit() {}
+
+		private JobConfigurableFileSplit(Path file, long start, long length, String[] hosts) {
+			super(file, start, length, hosts);
+		}
+
+		@Override
+		public void configure(JobConf jobConf) {
+			this.jobConf = jobConf;
+		}
+
+		private JobConf getConf() {
+			return jobConf;
+		}
+	}
+}

--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/api/java/hadoop/mapred/wrapper/HadoopInputSplitTest.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/api/java/hadoop/mapred/wrapper/HadoopInputSplitTest.java
@@ -60,7 +60,6 @@ public class HadoopInputSplitTest {
 		HadoopInputSplit split = new HadoopInputSplit(5, fileSplit, conf);
 
 		byte[] bytes = InstantiationUtil.serializeObject(split);
-		System.out.println(bytes.length);
 		serializeSizeChecker.accept(bytes.length);
 
 		split  = InstantiationUtil.deserializeObject(bytes, split.getClass().getClassLoader());


### PR DESCRIPTION

## What is the purpose of the change

JobConf may very big, contains hundreds of configurations, if it is serialized by every split, that will significantly reduce performance.

Consider thousands of splits, the akka thread of JobMaster will all on the serialization of conf. That may will lead to various akka timeouts too.

## Brief change log

In HadoopInputSplit, not serialize conf when split is not configurable. This will remove the getConf method. 

## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no