### PR TITLE
[FLINK-14708][FLINK-14131][FLINK-14682] Introduce RestartAllStrategy

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategyFactoryLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategyFactoryLoader.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.flip1;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.JobManagerOptions;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A utility class to load NG failover strategy factories from the configuration.
+ */
+public class FailoverStrategyFactoryLoader {
+
+	/** Config name for the {@link RestartAllStrategy}. */
+	public static final String FULL_RESTART_STRATEGY_NAME = "full";
+
+	/** Config name for the {@link RestartPipelinedRegionStrategy}. */
+	public static final String PIPELINED_REGION_RESTART_STRATEGY_NAME = "region";
+
+	/**
+	 * Loads a {@link FailoverStrategy.Factory} from the given configuration.
+	 *
+	 * @param config which specifies the failover strategy factory to load
+	 * @return failover strategy factory loaded
+	 */
+	public static FailoverStrategy.Factory loadFailoverStrategyFactory(final Configuration config) {
+		checkNotNull(config);
+
+		// the default NG failover strategy is region failover strategy.
+		// TODO: Remove the overridden default value when removing legacy scheduler
+		//  and changing the default value of JobManagerOptions.EXECUTION_FAILOVER_STRATEGY
+		//  to be "region"
+		final String strategyParam = config.getString(
+			JobManagerOptions.EXECUTION_FAILOVER_STRATEGY,
+			PIPELINED_REGION_RESTART_STRATEGY_NAME);
+
+		switch (strategyParam.toLowerCase()) {
+			case FULL_RESTART_STRATEGY_NAME:
+				return new RestartAllStrategy.Factory();
+
+			case PIPELINED_REGION_RESTART_STRATEGY_NAME:
+				return new RestartPipelinedRegionStrategy.Factory();
+
+			default:
+				throw new IllegalConfigurationException("Unknown failover strategy: " + strategyParam);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartAllStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartAllStrategy.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.flip1;
+
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.util.IterableUtils;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A failover strategy that proposes to restart all vertices when a vertex fails.
+ */
+public class RestartAllStrategy implements FailoverStrategy {
+
+	private final FailoverTopology<?, ?> topology;
+
+	public RestartAllStrategy(final FailoverTopology<?, ?> topology) {
+		this.topology = checkNotNull(topology);
+	}
+
+	/**
+	 * Returns all vertices on any task failure.
+	 *
+	 * @param executionVertexId ID of the failed task
+	 * @param cause cause of the failure
+	 * @return set of IDs of vertices to restart
+	 */
+	@Override
+	public Set<ExecutionVertexID> getTasksNeedingRestart(ExecutionVertexID executionVertexId, Throwable cause) {
+		final Set<ExecutionVertexID> tasksToRestart = IterableUtils.toStream(topology.getVertices())
+			.map(FailoverVertex::getId)
+			.collect(Collectors.toSet());
+
+		return tasksToRestart;
+	}
+
+	/**
+	 * The factory to instantiate {@link RestartAllStrategy}.
+	 */
+	public static class Factory implements FailoverStrategy.Factory {
+
+		@Override
+		public FailoverStrategy create(
+				final FailoverTopology<?, ?> topology,
+				final ResultPartitionAvailabilityChecker resultPartitionAvailabilityChecker) {
+
+			return new RestartAllStrategy(topology);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -139,9 +139,14 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 		this.executionVertexOperations = checkNotNull(executionVertexOperations);
 		this.executionVertexVersioner = checkNotNull(executionVertexVersioner);
 
+		final FailoverStrategy failoverStrategy = failoverStrategyFactory.create(
+			getFailoverTopology(),
+			getResultPartitionAvailabilityChecker());
+		log.info("Using failover strategy {} for {} ({}).", failoverStrategy, jobGraph.getName(), jobGraph.getJobID());
+
 		this.executionFailureHandler = new ExecutionFailureHandler(
 			getFailoverTopology(),
-			failoverStrategyFactory.create(getFailoverTopology(), getResultPartitionAvailabilityChecker()),
+			failoverStrategy,
 			restartBackoffTimeStrategy);
 		this.schedulingStrategy = schedulingStrategyFactory.createInstance(this, getSchedulingTopology(), getJobGraph());
 		this.executionSlotAllocator = checkNotNull(executionSlotAllocatorFactory).createInstance(getInputsLocationsRetriever());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -25,9 +25,9 @@ import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.runtime.executiongraph.SlotProviderStrategy;
+import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverStrategyFactoryLoader;
 import org.apache.flink.runtime.executiongraph.failover.flip1.RestartBackoffTimeStrategy;
 import org.apache.flink.runtime.executiongraph.failover.flip1.RestartBackoffTimeStrategyFactoryLoader;
-import org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionStrategy;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.ScheduleMode;
@@ -101,7 +101,7 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
 			shuffleMaster,
 			partitionTracker,
 			schedulingStrategyFactory,
-			new RestartPipelinedRegionStrategy.Factory(),
+			FailoverStrategyFactoryLoader.loadFailoverStrategyFactory(jobMasterConfiguration),
 			restartBackoffTimeStrategy,
 			new DefaultExecutionVertexOperations(),
 			new ExecutionVertexVersioner(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategyFactoryLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategyFactoryLoaderTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.flip1;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link FailoverStrategyFactoryLoader}.
+ */
+public class FailoverStrategyFactoryLoaderTest extends TestLogger {
+
+	@Test
+	public void testLoadRestartAllStrategyFactory() {
+		final Configuration config = new Configuration();
+		config.setString(
+			JobManagerOptions.EXECUTION_FAILOVER_STRATEGY,
+			FailoverStrategyFactoryLoader.FULL_RESTART_STRATEGY_NAME);
+		assertThat(
+			FailoverStrategyFactoryLoader.loadFailoverStrategyFactory(config),
+			instanceOf(RestartAllStrategy.Factory.class));
+	}
+
+	@Test
+	public void testLoadRestartPipelinedRegionStrategyFactory() {
+		final Configuration config = new Configuration();
+		config.setString(
+			JobManagerOptions.EXECUTION_FAILOVER_STRATEGY,
+			FailoverStrategyFactoryLoader.PIPELINED_REGION_RESTART_STRATEGY_NAME);
+		assertThat(
+			FailoverStrategyFactoryLoader.loadFailoverStrategyFactory(config),
+			instanceOf(RestartPipelinedRegionStrategy.Factory.class));
+	}
+
+	@Test
+	public void testDefaultFailoverStrategyIsRegion() {
+		final Configuration config = new Configuration();
+		assertThat(
+			FailoverStrategyFactoryLoader.loadFailoverStrategyFactory(config),
+			instanceOf(RestartPipelinedRegionStrategy.Factory.class));
+	}
+
+	@Test(expected = IllegalConfigurationException.class)
+	public void testLoadFromInvalidConfiguration() {
+		final Configuration config = new Configuration();
+		config.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "invalidStrategy");
+		FailoverStrategyFactoryLoader.loadFailoverStrategyFactory(config);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartAllStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartAllStrategyTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.flip1;
+
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link RestartAllStrategy}.
+ */
+public class RestartAllStrategyTest extends TestLogger {
+
+	@Test
+	public void testGetTasksNeedingRestart() {
+		final TestFailoverTopology.Builder topologyBuilder = new TestFailoverTopology.Builder();
+
+		final TestFailoverTopology.TestFailoverVertex v1 = topologyBuilder.newVertex();
+		final TestFailoverTopology.TestFailoverVertex v2 = topologyBuilder.newVertex();
+		final TestFailoverTopology.TestFailoverVertex v3 = topologyBuilder.newVertex();
+
+		topologyBuilder.connect(v1, v2, ResultPartitionType.PIPELINED);
+		topologyBuilder.connect(v2, v3, ResultPartitionType.BLOCKING);
+
+		final TestFailoverTopology topology = topologyBuilder.build();
+
+		final RestartAllStrategy strategy = new RestartAllStrategy(topology);
+
+		assertEquals(
+			new HashSet<>(Arrays.asList(v1.getId(), v2.getId(), v3.getId())),
+			strategy.getTasksNeedingRestart(v1.getId(), new Exception("Test failure")));
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -104,6 +104,7 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 2);
 		config.setString(TaskManagerOptions.LEGACY_MANAGED_MEMORY_SIZE, "4m");
 		config.setInteger(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS, 100);
+		config.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "full");
 
 		try (final StandaloneSessionClusterEntrypoint clusterEntrypoint = new StandaloneSessionClusterEntrypoint(config)) {
 


### PR DESCRIPTION

## What is the purpose of the change

See each related JIRA [FLINK-14708][FLINK-14131][FLINK-14682].

## Brief change log

  - *Introduced RestartAllStrategy*
  - *Introduced FailoverStrategyFactoryLoader for DefaultScheduler*
  - *Fixed AbstractTaskManagerProcessFailureRecoveryTest*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added IT cases for RestartAllStrategy and FailoverStrategyFactoryLoader*
  - *Other changes can be covered by existing IT cases*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
