### PR TITLE
[FLINK-14625][table-planner-blink] Add a rule to eliminate cross join as much as possible without statistics

### DIFF
--- a/docs/_includes/generated/optimizer_config_configuration.html
+++ b/docs/_includes/generated/optimizer_config_configuration.html
@@ -33,7 +33,17 @@ ONE_PHASE: Enforce to use one stage aggregate which only has CompleteGlobalAggre
             <td><h5>table.optimizer.join-reorder-enabled</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Enables join reorder in optimizer. Default is disabled.</td>
+            <td>Enables join reorder in optimizer. Default is disabled.
+If this option is enabled, the join reorder strategy is determined by table.optimizer.join-reorder-strategy</td>
+        </tr>
+        <tr>
+            <td><h5>table.optimizer.join-reorder-strategy</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">"COST_BASED"</td>
+            <td>String</td>
+            <td>Sets join reorder strategy in optimizer. This option is ignored if table.optimizer.join-reorder-enabled is false.
+Currently only COST_BASED and ELIMINATE_CROSS_JOIN can be set.
+COST_BASED: Optimizer will perform join reorders according to cost-based model. Statistics are needed for this strategy.
+ELIMINATE_CROSS_JOIN: Optimizer will try to eliminate cross joins as much as possible without the help of statistics.</td>
         </tr>
         <tr>
             <td><h5>table.optimizer.join.broadcast-threshold</h5><br> <span class="label label-primary">Batch</span></td>

--- a/docs/dev/table/common.md
+++ b/docs/dev/table/common.md
@@ -1428,6 +1428,8 @@ This includes a series of rule and cost-based optimizations such as:
     * Converts NOT IN and NOT EXISTS into left anti-join
 * Optional join reordering
     * Enabled via `table.optimizer.join-reorder-enabled`
+    * To use the cost-based join reordering, set `table.optimizer.join-reorder-strategy` to `COST_BASED` (default strategy)
+    * To use the rule-based join reordering which eliminates cross joins as much as possible, set `table.optimizer.join-reorder-strategy` to `ELIMINATE_CROSS_JOIN`
 
 **Note:** IN/EXISTS/NOT IN/NOT EXISTS are currently only supported in conjunctive conditions in subquery rewriting.
 

--- a/docs/dev/table/common.zh.md
+++ b/docs/dev/table/common.zh.md
@@ -1409,6 +1409,8 @@ Apache Flink 使用并扩展了 Apache Calcite 来执行复杂的查询优化。
     * 将 NOT IN 和 NOT EXISTS 转换为 left anti-join
 * 可选 join 重新排序
     * 通过 `table.optimizer.join-reorder-enabled` 启用
+    * 将 `table.optimizer.join-reorder-mode` 设为 `COST_BASED` 以使用 cost-based 的 join 重新排序策略（默认策略）
+    * 将 `table.optimizer.join-reorder-mode` 设为 `ELIMINATE_CROSS_JOIN` 以使用 rule-based 的 join 重新排序策略，该策略将会尽可能减少 cross join
 
 **注意：** 当前仅在子查询重写的结合条件下支持 IN / EXISTS / NOT IN / NOT EXISTS。
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
@@ -93,8 +93,22 @@ public class OptimizerConfigOptions {
 				"Default value is true.");
 
 	@Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
+	public static final ConfigOption<String> TABLE_OPTIMIZER_JOIN_REORDER_STRATEGY =
+		key("table.optimizer.join-reorder-strategy")
+			.defaultValue("COST_BASED")
+			.withDescription("Sets join reorder strategy in optimizer. " +
+				"This option is ignored if table.optimizer.join-reorder-enabled is false.\n" +
+				"Currently only COST_BASED and ELIMINATE_CROSS_JOIN can be set.\n" +
+				"COST_BASED: Optimizer will perform join reorders according to cost-based model. " +
+				"Statistics are needed for this strategy.\n" +
+				"ELIMINATE_CROSS_JOIN: Optimizer will try to eliminate cross joins as much as possible " +
+				"without the help of statistics.");
+
+	@Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
 	public static final ConfigOption<Boolean> TABLE_OPTIMIZER_JOIN_REORDER_ENABLED =
 		key("table.optimizer.join-reorder-enabled")
 			.defaultValue(false)
-			.withDescription("Enables join reorder in optimizer. Default is disabled.");
+			.withDescription("Enables join reorder in optimizer. Default is disabled.\n" +
+				"If this option is enabled, the join reorder strategy is determined by " +
+				"table.optimizer.join-reorder-strategy");
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/EliminateCrossJoinRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/EliminateCrossJoinRule.java
@@ -1,0 +1,526 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical;
+
+import org.apache.flink.util.Preconditions;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.rules.LoptMultiJoin;
+import org.apache.calcite.rel.rules.MultiJoin;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.mapping.Mappings;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * This rule tries to eliminate cross joins by reordering joins.
+ * The new order of joins are determined with the following steps:
+ *
+ * <p>1. The inputs related with an equi-join filter (= or IS NOT DISTINCT FROM) will be joined first.
+ *       Inputs with smaller indices has higher priority to preserve original join order as mush as it is possible.
+ *
+ * <p>2. The inputs related with other join filters will then be joined.
+ *
+ * <p>3. If not all inner join inputs are joined, they will be cross-joined in input order.
+ * 		 We are unable to eliminate these cross joins.
+ *
+ * <p>4. Outer joins are added.
+ *
+ * <p>For example, consider the following SQL:
+ * <blockquote><pre><code>
+ *     SELECT * FROM A, B, C, D, E, F, G, H
+ *     WHERE A.f1 = C.f1
+ *     AND C.f2 = D.f2
+ *     AND D.f3 = B.f3
+ *     AND C.f4 = B.f4
+ *     AND E.f5 = G.f5
+ *     AND F.f6 = H.f6
+ *     AND (A.f7 < E.f7 OR B.f8 > G.f8)
+ * </code></pre></blockquote>
+ *
+ * <p>The inputs are joined with the following steps:
+ * <ol>
+ *     <li>Join (A&C, B&C, B&D), (E&G), (F&H) as they are related with an equi-join filter.</li>
+ *     <li>Join ABCD & EG, as there is a non-equal filter between them.</li>
+ *     <li>Join ABCDEG & FH, as all filters are consumed and not all inputs have been joined together.</li>
+ * </ol>
+ */
+public class EliminateCrossJoinRule extends RelOptRule {
+
+	public static final EliminateCrossJoinRule INSTANCE = new EliminateCrossJoinRule();
+
+	private EliminateCrossJoinRule() {
+		super(operand(MultiJoin.class, any()), "EliminateCrossJoinRule");
+	}
+
+	@Override
+	public void onMatch(RelOptRuleCall call) {
+		MultiJoin join = call.rel(0);
+		RelBuilder relBuilder = call.builder();
+
+		if (join.isFullOuterJoin()) {
+			// full outer join, do not reorder joins
+			Preconditions.checkArgument(
+				join.getInputs().size() == 2,
+				"Full outer join must have exactly 2 inputs. This is a bug.");
+
+			relBuilder
+				.push(join.getInput(0))
+				.push(join.getInput(1))
+				.join(JoinRelType.FULL, join.getJoinFilter());
+			if (join.getPostJoinFilter() != null) {
+				relBuilder.filter(join.getPostJoinFilter());
+			}
+		} else {
+			validateOuterJoins(join);
+
+			LoptMultiJoin loptMultiJoin = new LoptMultiJoin(join);
+
+			// try to eliminate cross join
+			Vertex joinVertexTree = multiJoinToJoinVertexTree(loptMultiJoin);
+			Mappings.TargetMapping mapping = joinVertexTreeToJoinRelTree(joinVertexTree, loptMultiJoin, relBuilder);
+
+			// apply post-join filters
+			if (join.getPostJoinFilter() != null) {
+				RexNode adjustedFilter = adjustInputRefsInFilter(join.getPostJoinFilter(), mapping);
+				relBuilder.filter(adjustedFilter);
+			}
+
+			// use projections to keep the output of the join unchanged
+			List<RexNode> projects = generateProjection(join, mapping);
+			relBuilder.project(projects);
+		}
+
+		RelNode rel = relBuilder.build();
+		call.transformTo(rel);
+	}
+
+	private Vertex multiJoinToJoinVertexTree(LoptMultiJoin multiJoin) {
+		JoinVertexTreeBuilder builder = new JoinVertexTreeBuilder(
+			multiJoin,
+			(left, right) -> {
+				boolean leftIsEqui = isEquiFilter(left.filter);
+				boolean rightIsEqui = isEquiFilter(right.filter);
+				if (leftIsEqui ^ rightIsEqui) {
+					// one of the filter is not an equi-filter
+					// equi-filter has higher priority
+					return leftIsEqui ? -1 : 1;
+				} else {
+					// both or none of the filter is an equi-filter
+					// the one with the smallest input wins
+					int leftSetBit = -1;
+					int rightSetBit = -1;
+					do {
+						leftSetBit = left.inputBitSet.nextSetBit(leftSetBit + 1);
+						rightSetBit = right.inputBitSet.nextSetBit(rightSetBit + 1);
+					} while (leftSetBit == rightSetBit && leftSetBit >= 0);
+
+					if (leftSetBit >= 0 && rightSetBit >= 0) {
+						return leftSetBit - rightSetBit;
+					} else if (leftSetBit < 0 && rightSetBit < 0) {
+						return 0;
+					} else {
+						return leftSetBit;
+					}
+				}
+			});
+
+		JoinFilter bestFilter;
+		while ((bestFilter = builder.getBestFilter()) != null) {
+			builder.innerJoin(bestFilter.inputBitSet);
+		}
+
+		return builder.toJoinVertexTree();
+	}
+
+	private void validateOuterJoins(MultiJoin join) {
+		int outerJoinCount = 0;
+		for (int i = 0; i < join.getInputs().size(); i++) {
+			if (join.getJoinTypes().get(i) != JoinRelType.INNER) {
+				outerJoinCount++;
+			}
+		}
+		Preconditions.checkState(
+			outerJoinCount <= 1,
+			"EliminateCrossJoinRule assumes that there is at most 1 outer join " +
+				"in a layer of multi-join, but " + outerJoinCount + " outer joins were found.");
+		if (outerJoinCount == 1) {
+			int numInputs = join.getInputs().size();
+			Preconditions.checkState(
+				join.getJoinTypes().get(0) == JoinRelType.RIGHT ||
+					join.getJoinTypes().get(numInputs - 1) == JoinRelType.LEFT,
+				"EliminateCrossJoinRule assumes that " +
+					"the only left outer join input must locate at the end, or" +
+					"the only right outer join input must locate at the beginning");
+		}
+	}
+
+	private boolean isEquiFilter(RexNode filter) {
+		if (filter.isA(SqlKind.EQUALS) || filter.isA(SqlKind.IS_NOT_DISTINCT_FROM)) {
+			RexCall rexCall = (RexCall) filter;
+			Preconditions.checkState(
+				rexCall.operands.size() == 2,
+				"Expecting EQUALS and IS_NOT_DISTINCT_FROM filters to have exactly 2 inputs, " +
+					"but found " + rexCall.operands.size());
+			RexNode left = rexCall.operands.get(0);
+			RexNode right = rexCall.operands.get(1);
+			return left instanceof RexInputRef && right instanceof RexInputRef;
+		}
+		return false;
+	}
+
+	private static Mappings.TargetMapping joinVertexTreeToJoinRelTree(
+		Vertex joinVertexTree,
+		LoptMultiJoin multiJoin,
+		RelBuilder relBuilder) {
+		if (joinVertexTree instanceof LeafVertex) {
+			LeafVertex leaf = (LeafVertex) joinVertexTree;
+			int numFields = multiJoin.getNumFieldsInJoinFactor(leaf.smallestInputIdx);
+			int joinStart = multiJoin.getJoinStart(leaf.smallestInputIdx);
+
+			relBuilder.push(leaf.input).filter(leaf.filters);
+			return Mappings.createShiftMapping(
+				joinStart + numFields, 0, joinStart, numFields);
+		} else {
+			JoinVertex joinVertex = (JoinVertex) joinVertexTree;
+			Mappings.TargetMapping leftMapping =
+				joinVertexTreeToJoinRelTree(joinVertex.left, multiJoin, relBuilder);
+			Mappings.TargetMapping rightMapping =
+				joinVertexTreeToJoinRelTree(joinVertex.right, multiJoin, relBuilder);
+			Mappings.TargetMapping mergedMapping = mergeMapping(leftMapping, rightMapping);
+			RexBuilder rexBuilder = multiJoin.getMultiJoinRel().getCluster().getRexBuilder();
+
+			RexNode adjustedFilter = adjustInputRefsInFilter(
+				RexUtil.composeConjunction(rexBuilder, joinVertex.filters, false),
+				mergedMapping);
+			relBuilder.join(joinVertex.joinType, adjustedFilter);
+			return mergedMapping;
+		}
+	}
+
+	private static List<RexNode> generateProjection(MultiJoin join, Mappings.TargetMapping mapping) {
+		List<RelDataTypeField> fields = join.getRowType().getFieldList();
+		List<RexNode> projects = new ArrayList<>();
+		for (int i = 0; i < mapping.getSourceCount(); i++) {
+			int newIdx = mapping.getTargetOpt(i);
+			projects.add(new RexInputRef(newIdx, fields.get(i).getType()));
+		}
+		return projects;
+	}
+
+	private static RexNode adjustInputRefsInFilter(RexNode filter, Mappings.TargetMapping mapping) {
+		return filter.accept(new RexInputConverter(mapping));
+	}
+
+	private static Mappings.TargetMapping mergeMapping(Mappings.TargetMapping left, Mappings.TargetMapping right) {
+		return Mappings.merge(left, Mappings.offsetTarget(right, left.getTargetCount()));
+	}
+
+	/**
+	 * A wrapper class for a join filter.
+	 * The bit set and list indicate that which inputs this filter is related to.
+	 */
+	private static class JoinFilter {
+		final RexNode filter;
+		final ImmutableBitSet inputBitSet;
+
+		JoinFilter(RexNode filter, ImmutableBitSet inputBitSet) {
+			this.filter = filter;
+			this.inputBitSet = inputBitSet;
+		}
+	}
+
+	/**
+	 * A vertex in the join tree.
+	 */
+	private abstract static class Vertex {
+		final int numFields;
+		final ImmutableBitSet inputBitSet;
+		final int smallestInputIdx;
+		final List<RexNode> filters;
+
+		/**
+		 * @param numFields				Total number of input fields in this join tree
+		 * @param inputBitSet			Indices of inputs in this join tree
+		 * @param smallestInputIdx		Smallest input index in this join tree
+		 * @param filters				All filters that can be applied to this join tree
+		 */
+		Vertex(int numFields, ImmutableBitSet inputBitSet, int smallestInputIdx, List<RexNode> filters) {
+			this.numFields = numFields;
+			this.inputBitSet = inputBitSet;
+			this.smallestInputIdx = smallestInputIdx;
+			this.filters = filters;
+		}
+	}
+
+	/**
+	 * A non-leaf vertex in the join tree.
+	 */
+	private static class JoinVertex extends Vertex {
+		final JoinRelType joinType;
+		final Vertex left;
+		final Vertex right;
+
+		/**
+		 * @param joinType			Join type of this join vertex (INNER, LEFT, RIGHT or FULL)
+		 * @param left				The left input of this join vertex
+		 * @param right				The right input of this join vertex
+		 * @param joinFilters		A list of join filters applicable to this join vertex
+		 */
+		JoinVertex(
+			JoinRelType joinType,
+			Vertex left,
+			Vertex right,
+			List<RexNode> joinFilters) {
+			super(left.numFields + right.numFields,
+				left.inputBitSet.union(right.inputBitSet),
+				Math.min(left.smallestInputIdx, right.smallestInputIdx),
+				joinFilters);
+			this.joinType = joinType;
+			this.left = left;
+			this.right = right;
+		}
+	}
+
+	/**
+	 * A leaf vertex of a join tree, representing an input of the join.
+	 */
+	private static class LeafVertex extends Vertex {
+		final RelNode input;
+
+		/**
+		 * @param input				The input
+		 * @param inputIdx			The index of this input in the original multi-join
+		 * @param filters			Filters which can be applied on leaf nodes
+		 */
+		LeafVertex(RelNode input, int inputIdx, List<RexNode> filters) {
+			super(
+				input.getRowType().getFieldCount(),
+				ImmutableBitSet.of(inputIdx),
+				inputIdx,
+				filters);
+			this.input = input;
+		}
+	}
+
+	/**
+	 * Build a {@link Vertex} tree from a {@link LoptMultiJoin}.
+	 */
+	private static class JoinVertexTreeBuilder {
+		private final LoptMultiJoin multiJoin;
+		private final Vertex[] rootVertex;
+
+		private final Comparator<JoinFilter> comparator;
+		private final List<JoinFilter> filters;
+		private JoinFilter bestFilter;
+
+		private boolean finished = false;
+
+		JoinVertexTreeBuilder(LoptMultiJoin multiJoin, Comparator<JoinFilter> comparator) {
+			this.multiJoin = multiJoin;
+			this.comparator = comparator;
+
+			this.filters = new LinkedList<>();
+			List<RexNode> rexFilters = multiJoin.getJoinFilters();
+			for (RexNode rex : rexFilters) {
+				filters.add(new JoinFilter(rex, multiJoin.getFactorsRefByJoinFilter(rex)));
+			}
+
+			int numInputs = multiJoin.getNumJoinFactors();
+			this.rootVertex = new Vertex[numInputs];
+			for (int i = 0; i < numInputs; i++) {
+				RelNode input = multiJoin.getJoinFactor(i);
+				// current method to extract filters on input is not efficient (O(n^2) complexity in total),
+				// but as there will not be many filters and this method is easy to write and understand,
+				// we will not optimize it until a bad case in performance really occurs
+				List<RexNode> filtersOnInput = pickJoinFilters(ImmutableBitSet.of(i), filters);
+				rootVertex[i] = new LeafVertex(input, i, filtersOnInput);
+			}
+
+			updateBestFilter();
+		}
+
+		/**
+		 * This method will iterate through a list of filters.
+		 * If all the input refs in a filter have appeared in the given bit set,
+		 * it will be put into the returned list and be removed from the original list.
+		 *
+		 * @param mergedBitSet		All the input refs in a filter must also appear in this bit set,
+		 *                          so that the filter can be picked out
+		 * @param filters			List of filters to check.
+		 * 							{@link java.util.LinkedList} (or other lists whose iterator can remove
+		 * 							current element in O(1) time) is recommended for better performance
+		 */
+		static List<RexNode> pickJoinFilters(ImmutableBitSet mergedBitSet, List<JoinFilter> filters) {
+			List<RexNode> ret = new ArrayList<>();
+			Iterator<JoinFilter> iter = filters.iterator();
+			while (iter.hasNext()) {
+				JoinFilter filter = iter.next();
+				if (mergedBitSet.contains(filter.inputBitSet)) {
+					ret.add(filter.filter);
+					iter.remove();
+				}
+			}
+			return ret;
+		}
+
+		JoinFilter getBestFilter() {
+			return bestFilter;
+		}
+
+		/**
+		 * Perform inner joins between the inputs specified by the bit set.
+		 * If the inputs have been joined into other {@link Vertex}, those vertices will be joined instead.
+		 *
+		 * @param joinedInput			A bit set specifying which inputs to join
+		 */
+		void innerJoin(ImmutableBitSet joinedInput) {
+			innerJoin(joinedInput.toList());
+		}
+
+		/**
+		 * @param joinedInput			A list specifying which inputs to join
+		 */
+		void innerJoin(List<Integer> joinedInput) {
+			Preconditions.checkArgument(
+				joinedInput.size() >= 2, "At least 2 inputs are needed to perform a join.");
+			for (int i = 1; i < joinedInput.size(); i++) {
+				Vertex left = findRootVertex(joinedInput.get(i - 1));
+				Vertex right = findRootVertex(joinedInput.get(i));
+				if (left.smallestInputIdx < right.smallestInputIdx) {
+					innerJoin(left, right);
+				} else if (left.smallestInputIdx > right.smallestInputIdx) {
+					innerJoin(right, left);
+				}
+			}
+		}
+
+		/**
+		 * NOTE: This method can only be called once for each builder instance.
+		 *
+		 * @return		A {@link Vertex} tree equivalent to the given {@link LoptMultiJoin}
+		 */
+		Vertex toJoinVertexTree() {
+			Preconditions.checkState(
+				!finished,
+				"`toJoinVertexTree` can only be called once for each builder instance");
+			finished = true;
+
+			// if not all filters have been applied, join and apply them first
+			while (!filters.isEmpty()) {
+				innerJoin(filters.get(0).inputBitSet);
+			}
+
+			// it is possible that all inner join inputs haven't been joined together,
+			// so join them in order
+			List<JoinRelType> joinTypes = multiJoin.getMultiJoinRel().getJoinTypes();
+			Vertex lastVertex = null;
+			for (int i = 0; i < rootVertex.length; i++) {
+				if (joinTypes.get(i) == JoinRelType.INNER) {
+					Vertex currentVertex = findRootVertex(i);
+					if (lastVertex == null) {
+						lastVertex = currentVertex;
+					} else if (lastVertex.smallestInputIdx != currentVertex.smallestInputIdx) {
+						lastVertex = innerJoin(lastVertex, currentVertex);
+					}
+				}
+			}
+			Preconditions.checkNotNull(lastVertex, "Inner join input not found. This is a bug.");
+
+			// finally add outer join
+			int numInputs = joinTypes.size();
+			if (joinTypes.get(0) == JoinRelType.RIGHT) {
+				lastVertex = new JoinVertex(
+					JoinRelType.RIGHT,
+					findRootVertex(0),
+					lastVertex,
+					Collections.singletonList(multiJoin.getOuterJoinCond(0)));
+			} else if (joinTypes.get(numInputs - 1) == JoinRelType.LEFT) {
+				lastVertex = new JoinVertex(
+					JoinRelType.LEFT,
+					lastVertex,
+					findRootVertex(numInputs - 1),
+					Collections.singletonList(multiJoin.getOuterJoinCond(numInputs - 1)));
+			}
+
+			return lastVertex;
+		}
+
+		private Vertex innerJoin(Vertex left, Vertex right) {
+			List<RexNode> pickedFilters = pickJoinFilters(left.inputBitSet.union(right.inputBitSet), filters);
+			updateBestFilter();
+			Vertex merged = new JoinVertex(JoinRelType.INNER, left, right, pickedFilters);
+			rootVertex[left.smallestInputIdx] = merged;
+			rootVertex[right.smallestInputIdx] = merged;
+			return merged;
+		}
+
+		private Vertex findRootVertex(int inputIdx) {
+			// union-find algorithm to find out
+			// which join vertex this inputIdx belongs to
+			if (rootVertex[inputIdx].smallestInputIdx != inputIdx) {
+				rootVertex[inputIdx] = findRootVertex(rootVertex[inputIdx].smallestInputIdx);
+			}
+			return rootVertex[inputIdx];
+		}
+
+		private void updateBestFilter() {
+			bestFilter = null;
+			for (JoinFilter joinFilter : filters) {
+				if (bestFilter == null || comparator.compare(joinFilter, bestFilter) < 0) {
+					bestFilter = joinFilter;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Simple converter which converts input refs to a new index according to a {@link Mappings.TargetMapping}.
+	 */
+	private static class RexInputConverter extends RexShuttle {
+		private Mappings.TargetMapping mapping;
+
+		RexInputConverter(Mappings.TargetMapping mapping) {
+			this.mapping = mapping;
+		}
+
+		@Override
+		public RexNode visitInputRef(RexInputRef ref) {
+			int target = mapping.getTargetOpt(ref.getIndex());
+			return new RexInputRef(target, ref.getType());
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/JoinReorderStrategy.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/JoinReorderStrategy.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.utils;
+
+import org.apache.flink.table.api.config.OptimizerConfigOptions;
+
+/**
+ * Aggregate phase strategy which could be specified in
+ * {@link OptimizerConfigOptions#TABLE_OPTIMIZER_JOIN_REORDER_STRATEGY}.
+ */
+public enum JoinReorderStrategy {
+
+	/**
+	 * Optimizer will perform join reorders according to cost-based model.
+	 * Statistics are needed for this strategy.
+	 */
+	COST_BASED,
+
+	/**
+	 * Optimizer will try to eliminate cross joins as much as possible without the help of statistics.
+	 */
+	ELIMINATE_CROSS_JOIN
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.Configuration
 import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.rules.{FlinkBatchRuleSets, FlinkStreamRuleSets}
+import org.apache.flink.table.planner.utils.JoinReorderStrategy
 
 import org.apache.calcite.plan.hep.HepMatchOrder
 
@@ -133,21 +134,33 @@ object FlinkStreamProgram {
         .build())
 
     // join reorder
-    if (config.getBoolean(OptimizerConfigOptions.TABLE_OPTIMIZER_JOIN_REORDER_ENABLED)) {
-      chainedProgram.addLast(
-        JOIN_REORDER,
-        FlinkGroupProgramBuilder.newBuilder[StreamOptimizeContext]
-          .addProgram(FlinkHepRuleSetProgramBuilder.newBuilder
-            .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_COLLECTION)
-            .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
-            .add(FlinkStreamRuleSets.JOIN_REORDER_PREPARE_RULES)
-            .build(), "merge join into MultiJoin")
-          .addProgram(FlinkHepRuleSetProgramBuilder.newBuilder
+    val joinReorderEnabled =
+      config.getBoolean(OptimizerConfigOptions.TABLE_OPTIMIZER_JOIN_REORDER_ENABLED)
+    val joinReorderStrategy = JoinReorderStrategy.valueOf(
+      config.getString(OptimizerConfigOptions.TABLE_OPTIMIZER_JOIN_REORDER_STRATEGY))
+
+    if (joinReorderEnabled) {
+      val builder = FlinkGroupProgramBuilder.newBuilder[StreamOptimizeContext]
+        .addProgram(FlinkHepRuleSetProgramBuilder.newBuilder
+          .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_COLLECTION)
+          .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+          .add(FlinkBatchRuleSets.JOIN_REORDER_PREPARE_RULES)
+          .build(), "merge join into MultiJoin")
+      joinReorderStrategy match {
+        case JoinReorderStrategy.COST_BASED =>
+          builder.addProgram(FlinkHepRuleSetProgramBuilder.newBuilder
             .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
             .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
-            .add(FlinkStreamRuleSets.JOIN_REORDER_RULES)
-            .build(), "do join reorder")
-          .build())
+            .add(FlinkBatchRuleSets.JOIN_REORDER_RULES)
+            .build(), "do cost-based join reorder")
+        case JoinReorderStrategy.ELIMINATE_CROSS_JOIN =>
+          builder.addProgram(FlinkHepRuleSetProgramBuilder.newBuilder
+            .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
+            .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+            .add(FlinkBatchRuleSets.ELIMINATE_CROSS_JOIN_RULES)
+            .build(), "do eliminate cross join")
+      }
+      chainedProgram.addLast(JOIN_REORDER, builder.build())
     }
 
     // optimize the logical plan

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -232,6 +232,10 @@ object FlinkBatchRuleSets {
     FilterMultiJoinMergeRule.INSTANCE
   )
 
+  val ELIMINATE_CROSS_JOIN_RULES: RuleSet = RuleSets.ofList(
+    EliminateCrossJoinRule.INSTANCE
+  )
+
   val JOIN_REORDER_RULES: RuleSet = RuleSets.ofList(
     // equi-join predicates transfer
     RewriteMultiJoinConditionRule.INSTANCE,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -213,6 +213,10 @@ object FlinkStreamRuleSets {
     JoinToMultiJoinRule.INSTANCE
   )
 
+  val ELIMINATE_CROSS_JOIN_RULES: RuleSet = RuleSets.ofList(
+    EliminateCrossJoinRule.INSTANCE
+  )
+
   val JOIN_REORDER_RULES: RuleSet = RuleSets.ofList(
     // equi-join predicates transfer
     RewriteMultiJoinConditionRule.INSTANCE,

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/EliminateCrossJoinRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/EliminateCrossJoinRuleTest.xml
@@ -1,0 +1,862 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testConstantFilter">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM T1
+  INNER JOIN T2 ON 5 < 3
+]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3], c2=[$4])
++- LogicalJoin(condition=[<(5, 3)], joinType=[inner])
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalJoin(condition=[true], joinType=[inner])
+:- LogicalValues(tuples=[[]])
++- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testDisconnectedGraph">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM T1, T2, T3, T4, T5, T6
+  WHERE a1 = a4
+  AND b2 = b5
+  AND c3 = c6
+]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3], c2=[$4], a3=[$5], b3=[$6], c3=[$7], d3=[$8], a4=[$9], b4=[$10], c4=[$11], d4=[$12], e4=[$13], a5=[$14], b5=[$15], c5=[$16], a6=[$17], b6=[$18], c6=[$19])
++- LogicalFilter(condition=[AND(=($0, $9), =($3, $15), =($7, $19))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalJoin(condition=[true], joinType=[inner])
+      :  :- LogicalJoin(condition=[true], joinType=[inner])
+      :  :  :- LogicalJoin(condition=[true], joinType=[inner])
+      :  :  :  :- LogicalJoin(condition=[true], joinType=[inner])
+      :  :  :  :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+      :  :  :  :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+      :  :  :  +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+      :  :  +- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, T5, source: [TestTableSource(a5, b5, c5)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6, c6)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$7], b2=[$8], c2=[$9], a3=[$13], b3=[$14], c3=[$15], d3=[$16], a4=[$2], b4=[$3], c4=[$4], d4=[$5], e4=[$6], a5=[$10], b5=[$11], c5=[$12], a6=[$17], b6=[$18], c6=[$19])
++- LogicalJoin(condition=[true], joinType=[inner])
+   :- LogicalJoin(condition=[true], joinType=[inner])
+   :  :- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+   :  :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+   :  :  +- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+   :  +- LogicalJoin(condition=[=($1, $4)], joinType=[inner])
+   :     :- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, T5, source: [TestTableSource(a5, b5, c5)]]])
+   +- LogicalJoin(condition=[=($2, $6)], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6, c6)]]])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testFilterWithOuterJoin">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM (
+  SELECT a1, b1, a2 FROM T1
+    LEFT JOIN T2 ON a1 = a2
+  ) T
+  INNER JOIN T3 ON a1 = a3
+  WHERE a2 IS NOT NULL
+  AND b1 > b3
+]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], a3=[$3], b3=[$4], c3=[$5], d3=[$6])
++- LogicalFilter(condition=[AND(IS NOT NULL($2), >($1, $4))])
+   +- LogicalJoin(condition=[=($0, $3)], joinType=[inner])
+      :- LogicalProject(a1=[$0], b1=[$1], a2=[$2])
+      :  +- LogicalJoin(condition=[=($0, $2)], joinType=[left])
+      :     :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+      :     +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalJoin(condition=[AND(=($0, $3), >($1, $4))], joinType=[inner])
+:- LogicalFilter(condition=[IS NOT NULL($2)])
+:  +- LogicalProject(a1=[$0], b1=[$1], a2=[$2])
+:     +- LogicalJoin(condition=[=($0, $2)], joinType=[left])
+:        :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+:        +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testFullOuterJoin">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM T1
+  INNER JOIN T2 ON a1 = a2
+  FULL JOIN T3 ON b1 = b3
+  INNER JOIN T4 ON c2 = c4
+  WHERE b2 IS NOT NULL OR a3 IS NOT NULL
+]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3], c2=[$4], a3=[$5], b3=[$6], c3=[$7], d3=[$8], a4=[$9], b4=[$10], c4=[$11], d4=[$12], e4=[$13])
++- LogicalFilter(condition=[OR(IS NOT NULL($3), IS NOT NULL($5))])
+   +- LogicalJoin(condition=[=($4, $11)], joinType=[inner])
+      :- LogicalJoin(condition=[=($1, $6)], joinType=[full])
+      :  :- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+      :  :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+      :  :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalFilter(condition=[OR(IS NOT NULL($3), IS NOT NULL($5))])
++- LogicalJoin(condition=[=($4, $11)], joinType=[inner])
+   :- LogicalFilter(condition=[OR(IS NOT NULL($3), IS NOT NULL($5))])
+   :  +- LogicalJoin(condition=[=($1, $6)], joinType=[full])
+   :     :- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+   :     :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+   :     :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testFullOuterJoinWithSubQuery">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM (
+  SELECT b2, a3, c3 FROM T1, T2, T3
+    WHERE a1 = a3
+    AND b3 = b2
+) T FULL JOIN (
+  SELECT a4, b5 FROM T4, T5, T6
+    WHERE a4 = a6
+    AND b6 = b5
+) S ON a3 = a4 AND b2 = b5
+INNER JOIN T7 ON c3 = c7
+]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(b2=[$0], a3=[$1], c3=[$2], a4=[$3], b5=[$4], a7=[$5], b7=[$6], c7=[$7])
++- LogicalJoin(condition=[=($2, $7)], joinType=[inner])
+   :- LogicalJoin(condition=[AND(=($1, $3), =($0, $4))], joinType=[full])
+   :  :- LogicalProject(b2=[$3], a3=[$5], c3=[$7])
+   :  :  +- LogicalFilter(condition=[AND(=($0, $5), =($6, $3))])
+   :  :     +- LogicalJoin(condition=[true], joinType=[inner])
+   :  :        :- LogicalJoin(condition=[true], joinType=[inner])
+   :  :        :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+   :  :        :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+   :  :        +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+   :  +- LogicalProject(a4=[$0], b5=[$6])
+   :     +- LogicalFilter(condition=[AND(=($0, $8), =($9, $6))])
+   :        +- LogicalJoin(condition=[true], joinType=[inner])
+   :           :- LogicalJoin(condition=[true], joinType=[inner])
+   :           :  :- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+   :           :  +- LogicalTableScan(table=[[default_catalog, default_database, T5, source: [TestTableSource(a5, b5, c5)]]])
+   :           +- LogicalTableScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6, c6)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T7, source: [TestTableSource(a7, b7, c7)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalJoin(condition=[=($2, $7)], joinType=[inner])
+:- LogicalJoin(condition=[AND(=($1, $3), =($0, $4))], joinType=[full])
+:  :- LogicalProject(b2=[$3], a3=[$5], c3=[$7])
+:  :  +- LogicalProject(a1=[$0], b1=[$1], a2=[$6], b2=[$7], c2=[$8], a3=[$2], b3=[$3], c3=[$4], d3=[$5])
+:  :     +- LogicalJoin(condition=[=($3, $7)], joinType=[inner])
+:  :        :- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+:  :        :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+:  :        :  +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+:  :        +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+:  +- LogicalProject(a4=[$0], b5=[$6])
+:     +- LogicalProject(a4=[$0], b4=[$1], c4=[$2], d4=[$3], e4=[$4], a5=[$8], b5=[$9], c5=[$10], a6=[$5], b6=[$6], c6=[$7])
+:        +- LogicalJoin(condition=[=($6, $9)], joinType=[inner])
+:           :- LogicalJoin(condition=[=($0, $5)], joinType=[inner])
+:           :  :- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+:           :  +- LogicalTableScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6, c6)]]])
+:           +- LogicalTableScan(table=[[default_catalog, default_database, T5, source: [TestTableSource(a5, b5, c5)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, T7, source: [TestTableSource(a7, b7, c7)]]])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoin">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM T1, T2, T3, T4
+  WHERE a2 = a4
+  AND b1 = b3
+  AND c2 = c3
+]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3], c2=[$4], a3=[$5], b3=[$6], c3=[$7], d3=[$8], a4=[$9], b4=[$10], c4=[$11], d4=[$12], e4=[$13])
++- LogicalFilter(condition=[AND(=($2, $9), =($1, $6), =($4, $7))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalJoin(condition=[true], joinType=[inner])
+      :  :- LogicalJoin(condition=[true], joinType=[inner])
+      :  :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+      :  :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$6], b2=[$7], c2=[$8], a3=[$2], b3=[$3], c3=[$4], d3=[$5], a4=[$9], b4=[$10], c4=[$11], d4=[$12], e4=[$13])
++- LogicalJoin(condition=[=($6, $9)], joinType=[inner])
+   :- LogicalJoin(condition=[=($8, $4)], joinType=[inner])
+   :  :- LogicalJoin(condition=[=($1, $3)], joinType=[inner])
+   :  :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+   :  :  +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testInnerJoinWithCompleteGraph">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM T1, T2, T3, T4
+  WHERE a2 = a4
+  AND b1 = b3
+  AND c2 = c3
+  AND a1 = a4
+  AND b2 = b1
+  AND d4 = d3
+]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3], c2=[$4], a3=[$5], b3=[$6], c3=[$7], d3=[$8], a4=[$9], b4=[$10], c4=[$11], d4=[$12], e4=[$13])
++- LogicalFilter(condition=[AND(=($2, $9), =($1, $6), =($4, $7), =($0, $9), =($3, $1), =($12, $8))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalJoin(condition=[true], joinType=[inner])
+      :  :- LogicalJoin(condition=[true], joinType=[inner])
+      :  :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+      :  :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalJoin(condition=[AND(=($2, $9), =($0, $9), =($12, $8))], joinType=[inner])
+:- LogicalJoin(condition=[AND(=($1, $6), =($4, $7))], joinType=[inner])
+:  :- LogicalJoin(condition=[=($3, $1)], joinType=[inner])
+:  :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+:  :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+:  +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftOuterJoin">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM T1
+  INNER JOIN T2 ON a1 = a2
+  LEFT JOIN T3 ON b1 = b3
+  INNER JOIN T4 ON c2 = c4
+  WHERE b2 IS NOT NULL OR a3 IS NOT NULL
+]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3], c2=[$4], a3=[$5], b3=[$6], c3=[$7], d3=[$8], a4=[$9], b4=[$10], c4=[$11], d4=[$12], e4=[$13])
++- LogicalFilter(condition=[OR(IS NOT NULL($3), IS NOT NULL($5))])
+   +- LogicalJoin(condition=[=($4, $11)], joinType=[inner])
+      :- LogicalJoin(condition=[=($1, $6)], joinType=[left])
+      :  :- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+      :  :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+      :  :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalFilter(condition=[OR(IS NOT NULL($3), IS NOT NULL($5))])
++- LogicalJoin(condition=[=($4, $11)], joinType=[inner])
+   :- LogicalFilter(condition=[OR(IS NOT NULL($3), IS NOT NULL($5))])
+   :  +- LogicalJoin(condition=[=($1, $6)], joinType=[left])
+   :     :- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+   :     :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+   :     :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftOuterJoinWithSubQuery">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM (
+  SELECT b2, a3, c3 FROM T1, T2, T3
+    WHERE a1 = a3
+    AND b3 = b2
+) T LEFT JOIN (
+  SELECT a4, b5 FROM T4, T5, T6
+    WHERE a4 = a6
+    AND b6 = b5
+) S ON a3 = a4 AND b2 = b5
+INNER JOIN T7 ON c3 = c7
+]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(b2=[$0], a3=[$1], c3=[$2], a4=[$3], b5=[$4], a7=[$5], b7=[$6], c7=[$7])
++- LogicalJoin(condition=[=($2, $7)], joinType=[inner])
+   :- LogicalJoin(condition=[AND(=($1, $3), =($0, $4))], joinType=[left])
+   :  :- LogicalProject(b2=[$3], a3=[$5], c3=[$7])
+   :  :  +- LogicalFilter(condition=[AND(=($0, $5), =($6, $3))])
+   :  :     +- LogicalJoin(condition=[true], joinType=[inner])
+   :  :        :- LogicalJoin(condition=[true], joinType=[inner])
+   :  :        :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+   :  :        :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+   :  :        +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+   :  +- LogicalProject(a4=[$0], b5=[$6])
+   :     +- LogicalFilter(condition=[AND(=($0, $8), =($9, $6))])
+   :        +- LogicalJoin(condition=[true], joinType=[inner])
+   :           :- LogicalJoin(condition=[true], joinType=[inner])
+   :           :  :- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+   :           :  +- LogicalTableScan(table=[[default_catalog, default_database, T5, source: [TestTableSource(a5, b5, c5)]]])
+   :           +- LogicalTableScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6, c6)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T7, source: [TestTableSource(a7, b7, c7)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalJoin(condition=[=($2, $7)], joinType=[inner])
+:- LogicalJoin(condition=[AND(=($1, $3), =($0, $4))], joinType=[left])
+:  :- LogicalProject(b2=[$3], a3=[$5], c3=[$7])
+:  :  +- LogicalProject(a1=[$0], b1=[$1], a2=[$6], b2=[$7], c2=[$8], a3=[$2], b3=[$3], c3=[$4], d3=[$5])
+:  :     +- LogicalJoin(condition=[=($3, $7)], joinType=[inner])
+:  :        :- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+:  :        :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+:  :        :  +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+:  :        +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+:  +- LogicalProject(a4=[$0], b5=[$6])
+:     +- LogicalProject(a4=[$0], b4=[$1], c4=[$2], d4=[$3], e4=[$4], a5=[$8], b5=[$9], c5=[$10], a6=[$5], b6=[$6], c6=[$7])
+:        +- LogicalJoin(condition=[=($6, $9)], joinType=[inner])
+:           :- LogicalJoin(condition=[=($0, $5)], joinType=[inner])
+:           :  :- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+:           :  +- LogicalTableScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6, c6)]]])
+:           +- LogicalTableScan(table=[[default_catalog, default_database, T5, source: [TestTableSource(a5, b5, c5)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, T7, source: [TestTableSource(a7, b7, c7)]]])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testLongJoinFilter">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM T1, T2, T3, T4, T5, T6
+  WHERE a1 = a4
+  AND b5 = b4
+  AND c6 = c4
+  AND a3 = a6
+  AND b2 = b6
+  AND (b6 < b1 OR a1 > a5 OR b4 > b6)
+  AND (c3 < c6 OR a1 > a6 OR d4 < d3)
+]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3], c2=[$4], a3=[$5], b3=[$6], c3=[$7], d3=[$8], a4=[$9], b4=[$10], c4=[$11], d4=[$12], e4=[$13], a5=[$14], b5=[$15], c5=[$16], a6=[$17], b6=[$18], c6=[$19])
++- LogicalFilter(condition=[AND(=($0, $9), =($15, $10), =($19, $11), =($5, $17), =($3, $18), OR(<($18, $1), >($0, $14), >($10, $18)), OR(<($7, $19), >($0, $17), <($12, $8)))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalJoin(condition=[true], joinType=[inner])
+      :  :- LogicalJoin(condition=[true], joinType=[inner])
+      :  :  :- LogicalJoin(condition=[true], joinType=[inner])
+      :  :  :  :- LogicalJoin(condition=[true], joinType=[inner])
+      :  :  :  :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+      :  :  :  :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+      :  :  :  +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+      :  :  +- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, T5, source: [TestTableSource(a5, b5, c5)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6, c6)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$10], b2=[$11], c2=[$12], a3=[$16], b3=[$17], c3=[$18], d3=[$19], a4=[$2], b4=[$3], c4=[$4], d4=[$5], e4=[$6], a5=[$7], b5=[$8], c5=[$9], a6=[$13], b6=[$14], c6=[$15])
++- LogicalJoin(condition=[AND(=($15, $4), OR(<($14, $1), >($0, $7), >($3, $14)), OR(<($18, $15), >($0, $13), <($5, $19)))], joinType=[inner])
+   :- LogicalJoin(condition=[=($8, $3)], joinType=[inner])
+   :  :- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+   :  :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+   :  :  +- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, T5, source: [TestTableSource(a5, b5, c5)]]])
+   +- LogicalJoin(condition=[=($6, $3)], joinType=[inner])
+      :- LogicalJoin(condition=[=($1, $4)], joinType=[inner])
+      :  :- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6, c6)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testOnlyOneLeftOuterJoin">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM T1
+  LEFT JOIN T2 ON a1 = a2
+]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3], c2=[$4])
++- LogicalJoin(condition=[=($0, $2)], joinType=[left])
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalJoin(condition=[=($0, $2)], joinType=[left])
+:- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testManyOuterJoins">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM (
+  SELECT a1, b4, c5 FROM T4, T5, T1
+    INNER JOIN T2 ON a1 = a2
+    LEFT JOIN T3 ON a1 = a3
+    WHERE a1 = a4
+    AND a1 = a5
+) T
+  RIGHT JOIN T6 ON a1 = a6
+  FULL JOIN T7 ON a1 = a7
+]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], b4=[$1], c5=[$2], a6=[$3], b6=[$4], c6=[$5], a7=[$6], b7=[$7], c7=[$8])
++- LogicalJoin(condition=[=($0, $6)], joinType=[full])
+   :- LogicalJoin(condition=[=($0, $3)], joinType=[right])
+   :  :- LogicalProject(a1=[$8], b4=[$1], c5=[$7])
+   :  :  +- LogicalFilter(condition=[AND(=($8, $0), =($8, $5))])
+   :  :     +- LogicalJoin(condition=[=($8, $13)], joinType=[left])
+   :  :        :- LogicalJoin(condition=[=($8, $10)], joinType=[inner])
+   :  :        :  :- LogicalJoin(condition=[true], joinType=[inner])
+   :  :        :  :  :- LogicalJoin(condition=[true], joinType=[inner])
+   :  :        :  :  :  :- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+   :  :        :  :  :  +- LogicalTableScan(table=[[default_catalog, default_database, T5, source: [TestTableSource(a5, b5, c5)]]])
+   :  :        :  :  +- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+   :  :        :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+   :  :        +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6, c6)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T7, source: [TestTableSource(a7, b7, c7)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalJoin(condition=[=($0, $6)], joinType=[full])
+:- LogicalJoin(condition=[=($0, $3)], joinType=[right])
+:  :- LogicalProject(a1=[$8], b4=[$1], c5=[$7])
+:  :  +- LogicalProject(a4=[$0], b4=[$1], c4=[$2], d4=[$3], e4=[$4], a5=[$7], b5=[$8], c5=[$9], a1=[$5], b1=[$6], a2=[$10], b2=[$11], c2=[$12], a3=[$13], b3=[$14], c3=[$15], d3=[$16])
+:  :     +- LogicalJoin(condition=[=($5, $13)], joinType=[left])
+:  :        :- LogicalJoin(condition=[=($5, $10)], joinType=[inner])
+:  :        :  :- LogicalJoin(condition=[=($5, $7)], joinType=[inner])
+:  :        :  :  :- LogicalJoin(condition=[=($5, $0)], joinType=[inner])
+:  :        :  :  :  :- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+:  :        :  :  :  +- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+:  :        :  :  +- LogicalTableScan(table=[[default_catalog, default_database, T5, source: [TestTableSource(a5, b5, c5)]]])
+:  :        :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+:  :        +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+:  +- LogicalTableScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6, c6)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, T7, source: [TestTableSource(a7, b7, c7)]]])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testOneInputFilter">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM T1
+  INNER JOIN T2 ON a1 = 1
+]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3], c2=[$4])
++- LogicalJoin(condition=[=($0, 1)], joinType=[inner])
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalJoin(condition=[true], joinType=[inner])
+:- LogicalFilter(condition=[=($0, 1)])
+:  +- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testOnlyOneFullOuterJoin">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM T1
+  FULL JOIN T2 ON a1 = a2
+]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3], c2=[$4])
++- LogicalJoin(condition=[=($0, $2)], joinType=[full])
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalJoin(condition=[=($0, $2)], joinType=[full])
+:- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testOnlyOneInnerJoin">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM T1
+  INNER JOIN T2 ON a1 = a2
+]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3], c2=[$4])
++- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+:- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testRightOuterJoinWithSubQuery">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM (
+  SELECT b2, a3, c3 FROM T1, T2, T3
+    WHERE a1 = a3
+    AND b3 = b2
+) T RIGHT JOIN (
+  SELECT a4, b5 FROM T4, T5, T6
+    WHERE a4 = a6
+    AND b6 = b5
+) S ON a3 = a4 AND b2 = b5
+INNER JOIN T7 ON c3 = c7
+]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(b2=[$0], a3=[$1], c3=[$2], a4=[$3], b5=[$4], a7=[$5], b7=[$6], c7=[$7])
++- LogicalJoin(condition=[=($2, $7)], joinType=[inner])
+   :- LogicalJoin(condition=[AND(=($1, $3), =($0, $4))], joinType=[right])
+   :  :- LogicalProject(b2=[$3], a3=[$5], c3=[$7])
+   :  :  +- LogicalFilter(condition=[AND(=($0, $5), =($6, $3))])
+   :  :     +- LogicalJoin(condition=[true], joinType=[inner])
+   :  :        :- LogicalJoin(condition=[true], joinType=[inner])
+   :  :        :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+   :  :        :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+   :  :        +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+   :  +- LogicalProject(a4=[$0], b5=[$6])
+   :     +- LogicalFilter(condition=[AND(=($0, $8), =($9, $6))])
+   :        +- LogicalJoin(condition=[true], joinType=[inner])
+   :           :- LogicalJoin(condition=[true], joinType=[inner])
+   :           :  :- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+   :           :  +- LogicalTableScan(table=[[default_catalog, default_database, T5, source: [TestTableSource(a5, b5, c5)]]])
+   :           +- LogicalTableScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6, c6)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T7, source: [TestTableSource(a7, b7, c7)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalJoin(condition=[=($2, $7)], joinType=[inner])
+:- LogicalJoin(condition=[AND(=($1, $3), =($0, $4))], joinType=[right])
+:  :- LogicalProject(b2=[$3], a3=[$5], c3=[$7])
+:  :  +- LogicalProject(a1=[$0], b1=[$1], a2=[$6], b2=[$7], c2=[$8], a3=[$2], b3=[$3], c3=[$4], d3=[$5])
+:  :     +- LogicalJoin(condition=[=($3, $7)], joinType=[inner])
+:  :        :- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+:  :        :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+:  :        :  +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+:  :        +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+:  +- LogicalProject(a4=[$0], b5=[$6])
+:     +- LogicalProject(a4=[$0], b4=[$1], c4=[$2], d4=[$3], e4=[$4], a5=[$8], b5=[$9], c5=[$10], a6=[$5], b6=[$6], c6=[$7])
+:        +- LogicalJoin(condition=[=($6, $9)], joinType=[inner])
+:           :- LogicalJoin(condition=[=($0, $5)], joinType=[inner])
+:           :  :- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+:           :  +- LogicalTableScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6, c6)]]])
+:           +- LogicalTableScan(table=[[default_catalog, default_database, T5, source: [TestTableSource(a5, b5, c5)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, T7, source: [TestTableSource(a7, b7, c7)]]])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testNonEquiFilters">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM T1, T2, T3, T4
+  WHERE a1 = a3
+  AND b2 = b3
+  AND d4 = d3
+  AND b1 < b3
+  AND c2 > c3
+]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3], c2=[$4], a3=[$5], b3=[$6], c3=[$7], d3=[$8], a4=[$9], b4=[$10], c4=[$11], d4=[$12], e4=[$13])
++- LogicalFilter(condition=[AND(=($0, $5), =($3, $6), =($12, $8), <($1, $6), >($4, $7))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalJoin(condition=[true], joinType=[inner])
+      :  :- LogicalJoin(condition=[true], joinType=[inner])
+      :  :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+      :  :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$6], b2=[$7], c2=[$8], a3=[$2], b3=[$3], c3=[$4], d3=[$5], a4=[$9], b4=[$10], c4=[$11], d4=[$12], e4=[$13])
++- LogicalJoin(condition=[=($12, $5)], joinType=[inner])
+   :- LogicalJoin(condition=[AND(=($7, $3), >($8, $4))], joinType=[inner])
+   :  :- LogicalJoin(condition=[AND(=($0, $2), <($1, $3))], joinType=[inner])
+   :  :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+   :  :  +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testOnlyOneRightOuterJoin">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM T1
+  RIGHT JOIN T2 ON a1 = a2
+]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3], c2=[$4])
++- LogicalJoin(condition=[=($0, $2)], joinType=[right])
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalJoin(condition=[=($0, $2)], joinType=[right])
+:- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testStarSchema">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM T1, T2, T3, T4
+  WHERE a1 = a3
+  AND b2 = b3
+  AND c4 = c3
+]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3], c2=[$4], a3=[$5], b3=[$6], c3=[$7], d3=[$8], a4=[$9], b4=[$10], c4=[$11], d4=[$12], e4=[$13])
++- LogicalFilter(condition=[AND(=($0, $5), =($3, $6), =($11, $7))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalJoin(condition=[true], joinType=[inner])
+      :  :- LogicalJoin(condition=[true], joinType=[inner])
+      :  :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+      :  :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$6], b2=[$7], c2=[$8], a3=[$2], b3=[$3], c3=[$4], d3=[$5], a4=[$9], b4=[$10], c4=[$11], d4=[$12], e4=[$13])
++- LogicalJoin(condition=[=($11, $4)], joinType=[inner])
+   :- LogicalJoin(condition=[=($7, $3)], joinType=[inner])
+   :  :- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+   :  :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+   :  :  +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testRightOuterJoin">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM T1
+  INNER JOIN T2 ON a1 = a2
+  RIGHT JOIN T3 ON b1 = b3
+  INNER JOIN T4 ON c2 = c4
+  WHERE b2 IS NOT NULL OR a3 IS NOT NULL
+]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3], c2=[$4], a3=[$5], b3=[$6], c3=[$7], d3=[$8], a4=[$9], b4=[$10], c4=[$11], d4=[$12], e4=[$13])
++- LogicalFilter(condition=[OR(IS NOT NULL($3), IS NOT NULL($5))])
+   +- LogicalJoin(condition=[=($4, $11)], joinType=[inner])
+      :- LogicalJoin(condition=[=($1, $6)], joinType=[right])
+      :  :- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+      :  :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+      :  :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalFilter(condition=[OR(IS NOT NULL($3), IS NOT NULL($5))])
++- LogicalJoin(condition=[=($4, $11)], joinType=[inner])
+   :- LogicalFilter(condition=[OR(IS NOT NULL($3), IS NOT NULL($5))])
+   :  +- LogicalJoin(condition=[=($1, $6)], joinType=[right])
+   :     :- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+   :     :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+   :     :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4, e4)]]])
+]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testTwoInputRefsOnSameSide">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM T1, T2, T3
+  WHERE a1 + a2 = 1
+  AND b2 = b3
+]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3], c2=[$4], a3=[$5], b3=[$6], c3=[$7], d3=[$8])
++- LogicalFilter(condition=[AND(=(+($0, $2), 1), =($3, $6))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalJoin(condition=[true], joinType=[inner])
+      :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalJoin(condition=[=(+($0, $2), 1)], joinType=[inner])
+:- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1)]]])
++- LogicalJoin(condition=[=($1, $4)], joinType=[inner])
+   :- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+]]>
+
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/EliminateCrossJoinRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/EliminateCrossJoinRuleTest.scala
@@ -1,0 +1,352 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.planner.plan.optimize.program.{BatchOptimizeContext, FlinkChainedProgram, FlinkHepRuleSetProgramBuilder, HEP_RULES_EXECUTION_TYPE}
+import org.apache.flink.table.planner.utils.TableTestBase
+
+import org.apache.calcite.plan.hep.HepMatchOrder
+import org.apache.calcite.rel.rules.{FilterJoinRule, FilterMultiJoinMergeRule, JoinToMultiJoinRule, ProjectMultiJoinMergeRule}
+import org.apache.calcite.tools.RuleSets
+import org.junit.{Before, Test}
+
+class EliminateCrossJoinRuleTest extends TableTestBase {
+  private val util = batchTestUtil()
+
+  @Before
+  def setup(): Unit = {
+    val programs = new FlinkChainedProgram[BatchOptimizeContext]()
+    programs.addLast(
+      "filter_on_join",
+      FlinkHepRuleSetProgramBuilder.newBuilder
+        .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
+        .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+        .add(RuleSets.ofList(
+          FilterJoinRule.FILTER_ON_JOIN))
+        .build())
+    programs.addLast(
+      "prepare_join_reorder",
+      FlinkHepRuleSetProgramBuilder.newBuilder
+        .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_COLLECTION)
+        .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+        .add(RuleSets.ofList(
+          JoinToMultiJoinRule.INSTANCE,
+          ProjectMultiJoinMergeRule.INSTANCE,
+          FilterMultiJoinMergeRule.INSTANCE))
+        .build())
+    programs.addLast(
+      "eliminate_cross_join",
+      FlinkHepRuleSetProgramBuilder.newBuilder
+        .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
+        .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+        .add(RuleSets.ofList(
+          EliminateCrossJoinRule.INSTANCE))
+        .build())
+    util.replaceBatchProgram(programs)
+
+    util.addTableSource[(Int, Int)]("T1", 'a1, 'b1)
+    util.addTableSource[(Int, Int, Int)]("T2", 'a2, 'b2, 'c2)
+    util.addTableSource[(Int, Int, Int, Int)]("T3", 'a3, 'b3, 'c3, 'd3)
+    util.addTableSource[(Int, Int, Int, Int, Int)]("T4", 'a4, 'b4, 'c4, 'd4, 'e4)
+    util.addTableSource[(Int, Int, Int)]("T5", 'a5, 'b5, 'c5)
+    util.addTableSource[(Int, Int, Int)]("T6", 'a6, 'b6, 'c6)
+    util.addTableSource[(Int, Int, Int)]("T7", 'a7, 'b7, 'c7)
+  }
+
+  @Test
+  def testInnerJoin(): Unit = {
+    util.verifyPlan(
+      """
+        |SELECT * FROM T1, T2, T3, T4
+        |  WHERE a2 = a4
+        |  AND b1 = b3
+        |  AND c2 = c3
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testOnlyOneInnerJoin(): Unit = {
+    util.verifyPlan(
+      """
+        |SELECT * FROM T1
+        |  INNER JOIN T2 ON a1 = a2
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testInnerJoinWithCompleteGraph(): Unit = {
+    util.verifyPlan(
+      """
+        |SELECT * FROM T1, T2, T3, T4
+        |  WHERE a2 = a4
+        |  AND b1 = b3
+        |  AND c2 = c3
+        |  AND a1 = a4
+        |  AND b2 = b1
+        |  AND d4 = d3
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testStarSchema(): Unit = {
+    util.verifyPlan(
+      """
+        |SELECT * FROM T1, T2, T3, T4
+        |  WHERE a1 = a3
+        |  AND b2 = b3
+        |  AND c4 = c3
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testLeftOuterJoin(): Unit = {
+    util.verifyPlan(
+      """
+        |SELECT * FROM T1
+        |  INNER JOIN T2 ON a1 = a2
+        |  LEFT JOIN T3 ON b1 = b3
+        |  INNER JOIN T4 ON c2 = c4
+        |  WHERE b2 IS NOT NULL OR a3 IS NOT NULL
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testOnlyOneLeftOuterJoin(): Unit = {
+    util.verifyPlan(
+      """
+        |SELECT * FROM T1
+        |  LEFT JOIN T2 ON a1 = a2
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testLeftOuterJoinWithSubQuery(): Unit = {
+    util.verifyPlan(
+      """
+        |SELECT * FROM (
+        |  SELECT b2, a3, c3 FROM T1, T2, T3
+        |    WHERE a1 = a3
+        |    AND b3 = b2
+        |) T LEFT JOIN (
+        |  SELECT a4, b5 FROM T4, T5, T6
+        |    WHERE a4 = a6
+        |    AND b6 = b5
+        |) S ON a3 = a4 AND b2 = b5
+        |INNER JOIN T7 ON c3 = c7
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testRightOuterJoin(): Unit = {
+    util.verifyPlan(
+      """
+        |SELECT * FROM T1
+        |  INNER JOIN T2 ON a1 = a2
+        |  RIGHT JOIN T3 ON b1 = b3
+        |  INNER JOIN T4 ON c2 = c4
+        |  WHERE b2 IS NOT NULL OR a3 IS NOT NULL
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testOnlyOneRightOuterJoin(): Unit = {
+    util.verifyPlan(
+      """
+        |SELECT * FROM T1
+        |  RIGHT JOIN T2 ON a1 = a2
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testRightOuterJoinWithSubQuery(): Unit = {
+    util.verifyPlan(
+      """
+        |SELECT * FROM (
+        |  SELECT b2, a3, c3 FROM T1, T2, T3
+        |    WHERE a1 = a3
+        |    AND b3 = b2
+        |) T RIGHT JOIN (
+        |  SELECT a4, b5 FROM T4, T5, T6
+        |    WHERE a4 = a6
+        |    AND b6 = b5
+        |) S ON a3 = a4 AND b2 = b5
+        |INNER JOIN T7 ON c3 = c7
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testFullOuterJoin(): Unit = {
+    util.verifyPlan(
+      """
+        |SELECT * FROM T1
+        |  INNER JOIN T2 ON a1 = a2
+        |  FULL JOIN T3 ON b1 = b3
+        |  INNER JOIN T4 ON c2 = c4
+        |  WHERE b2 IS NOT NULL OR a3 IS NOT NULL
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testOnlyOneFullOuterJoin(): Unit = {
+    util.verifyPlan(
+      """
+        |SELECT * FROM T1
+        |  FULL JOIN T2 ON a1 = a2
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testFullOuterJoinWithSubQuery(): Unit = {
+    util.verifyPlan(
+      """
+        |SELECT * FROM (
+        |  SELECT b2, a3, c3 FROM T1, T2, T3
+        |    WHERE a1 = a3
+        |    AND b3 = b2
+        |) T FULL JOIN (
+        |  SELECT a4, b5 FROM T4, T5, T6
+        |    WHERE a4 = a6
+        |    AND b6 = b5
+        |) S ON a3 = a4 AND b2 = b5
+        |INNER JOIN T7 ON c3 = c7
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testManyOuterJoins(): Unit = {
+    util.verifyPlan(
+      """
+        |SELECT * FROM (
+        |  SELECT a1, b4, c5 FROM T4, T5, T1
+        |    INNER JOIN T2 ON a1 = a2
+        |    LEFT JOIN T3 ON a1 = a3
+        |    WHERE a1 = a4
+        |    AND a1 = a5
+        |) T
+        |  RIGHT JOIN T6 ON a1 = a6
+        |  FULL JOIN T7 ON a1 = a7
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testDisconnectedGraph(): Unit = {
+    util.verifyPlan(
+      """
+        |SELECT * FROM T1, T2, T3, T4, T5, T6
+        |  WHERE a1 = a4
+        |  AND b2 = b5
+        |  AND c3 = c6
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testNonEquiFilters(): Unit = {
+    util.verifyPlan(
+      """
+        |SELECT * FROM T1, T2, T3, T4
+        |  WHERE a1 = a3
+        |  AND b2 = b3
+        |  AND d4 = d3
+        |  AND b1 < b3
+        |  AND c2 > c3
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testFilterWithOuterJoin(): Unit = {
+    util.verifyPlan(
+      """
+        |SELECT * FROM (
+        |  SELECT a1, b1, a2 FROM T1
+        |    LEFT JOIN T2 ON a1 = a2
+        |  ) T
+        |  INNER JOIN T3 ON a1 = a3
+        |  WHERE a2 IS NOT NULL
+        |  AND b1 > b3
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testLongJoinFilter(): Unit = {
+    util.verifyPlan(
+      """
+        |SELECT * FROM T1, T2, T3, T4, T5, T6
+        |  WHERE a1 = a4
+        |  AND b5 = b4
+        |  AND c6 = c4
+        |  AND a3 = a6
+        |  AND b2 = b6
+        |  AND (b6 < b1 OR a1 > a5 OR b4 > b6)
+        |  AND (c3 < c6 OR a1 > a6 OR d4 < d3)
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testConstantFilter(): Unit = {
+    // this join ought to be pruned by other rules,
+    // we create this test only for corner case checking
+    util.verifyPlan(
+      """
+        |SELECT * FROM T1
+        |  INNER JOIN T2 ON 5 < 3
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testOneInputFilter(): Unit = {
+    util.verifyPlan(
+      """
+        |SELECT * FROM T1
+        |  INNER JOIN T2 ON a1 = 1
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testTwoInputRefsOnSameSide(): Unit = {
+    util.verifyPlan(
+      """
+        |SELECT * FROM T1, T2, T3
+        |  WHERE a1 + a2 = 1
+        |  AND b2 = b3
+        |""".stripMargin
+    )
+  }
+}


### PR DESCRIPTION
# What is the purpose of the change

This PR introduces a rule to eliminate cross join as much as possible (the EliminateCrossJoinRule) without the help of statistics. A detailed explanation of this rule can be seen [here](https://issues.apache.org/jira/browse/FLINK-14625?focusedCommentId=16973011&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16973011).

As the newly introduced rule is in conflict with the cost-based join reorder rule to some extent, the old "table.optimizer.join-reorder-enabled" config key is now deprecated. This PR also introduces a new "table.optimizer.join-reorder-strategy" config key to select which join reorder rule to apply (NONE, ELIMINATE_CROSS_JOIN or COST_BASED).

## Brief change log
  - Introduce the new EliminateCrossJoinRule.
  - Deprecate "table.optimizer.join-reorder-enabled" and add a new config key "table.optimizer.join-reorder-strategy". This decision is similar to presto ([see here](https://prestodb.io/docs/current/release/release-0.207.html)).

## Verifying this change

This change added tests and can be verified as follows: run the newly added EliminateCrossJoinRuleTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
