### PR TITLE
[FLINK-14746][web] Handle uncaught exceptions in HistoryServerArchive…

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
@@ -30,6 +30,8 @@ import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.rest.messages.JobsOverviewHeaders;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
+import org.apache.flink.runtime.util.FatalExitExceptionHandler;
+import org.apache.flink.runtime.util.Runnables;
 import org.apache.flink.util.FileUtils;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonFactory;
@@ -127,7 +129,10 @@ class HistoryServerArchiveFetcher {
 	}
 
 	void start() {
-		executor.scheduleWithFixedDelay(fetcherTask, 0, refreshIntervalMillis, TimeUnit.MILLISECONDS);
+		final Runnable guardedTask = Runnables.withUncaughtExceptionHandler(
+			fetcherTask, FatalExitExceptionHandler.INSTANCE);
+		executor.scheduleWithFixedDelay(
+			guardedTask, 0, refreshIntervalMillis, TimeUnit.MILLISECONDS);
 	}
 
 	void stop() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/Runnables.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/Runnables.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+/**
+ * Utils related to {@link Runnable}.
+ */
+public class Runnables {
+
+	/**
+	 * Guard {@link Runnable} with uncaughtException handler, because
+	 * {@link java.util.concurrent.ScheduledExecutorService} does not respect the one assigned to
+	 * executing {@link Thread} instance.
+	 *
+	 * @param runnable Runnable future to guard.
+	 * @param uncaughtExceptionHandler Handler to call in case of uncaught exception.
+	 * @return Future with handler.
+	 */
+	public static Runnable withUncaughtExceptionHandler(
+		Runnable runnable,
+		Thread.UncaughtExceptionHandler uncaughtExceptionHandler) {
+		return () -> {
+			try {
+				runnable.run();
+			} catch (Throwable t) {
+				uncaughtExceptionHandler.uncaughtException(Thread.currentThread(), t);
+			}
+		};
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/RunnablesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/RunnablesTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.flink.shaded.guava18.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RunnablesTest {
+
+	private static final int TIMEOUT_MS = 100;
+
+	// ------------------------------------------------------------------------
+	// Test ExecutorService/ScheduledExecutorService behaviour.
+	// ------------------------------------------------------------------------
+
+	@Test
+	public void testExecutorService_uncaughtExceptionHandler() throws InterruptedException {
+		final CountDownLatch handlerCalled = new CountDownLatch(1);
+		final ThreadFactory threadFactory = new ThreadFactoryBuilder()
+			.setDaemon(true)
+			.setUncaughtExceptionHandler((t, e) -> handlerCalled.countDown())
+			.build();
+		final ExecutorService scheduledExecutorService =
+			Executors.newSingleThreadExecutor(threadFactory);
+		scheduledExecutorService.execute(() -> {
+			throw new RuntimeException("foo");
+		});
+		Assert.assertTrue(
+			"Expected handler to be called.",
+			handlerCalled.await(TIMEOUT_MS, TimeUnit.MILLISECONDS));
+	}
+
+	@Test
+	public void testScheduledExecutorService_uncaughtExceptionHandler() throws InterruptedException {
+		final CountDownLatch handlerCalled = new CountDownLatch(1);
+		final ThreadFactory threadFactory = new ThreadFactoryBuilder()
+			.setDaemon(true)
+			.setUncaughtExceptionHandler((t, e) -> handlerCalled.countDown())
+			.build();
+		final ScheduledExecutorService scheduledExecutorService =
+			Executors.newSingleThreadScheduledExecutor(threadFactory);
+		scheduledExecutorService.execute(() -> {
+			throw new RuntimeException("foo");
+		});
+		Assert.assertFalse(
+			"Expected handler not to be called.",
+			handlerCalled.await(TIMEOUT_MS, TimeUnit.MILLISECONDS));
+	}
+
+	// ------------------------------------------------------------------------
+	// Test ScheduledFutures.
+	// ------------------------------------------------------------------------
+
+	@Test
+	public void testWithUncaughtExceptionHandler_runtimeException() throws InterruptedException {
+		final RuntimeException expected = new RuntimeException("foo");
+		testWithUncaughtExceptionHandler(() -> {
+			throw expected;
+		}, expected);
+	}
+
+	@Test
+	public void testWithUncaughtExceptionHandler_error() throws InterruptedException {
+		final Error expected = new Error("foo");
+		testWithUncaughtExceptionHandler(() -> {
+			throw expected;
+		}, expected);
+	}
+
+	private static void testWithUncaughtExceptionHandler(Runnable runnable, Throwable expected)
+		throws InterruptedException {
+		final ThreadFactory threadFactory = new ThreadFactoryBuilder()
+			.setDaemon(true)
+			.setNameFormat("ueh-test-%d")
+			.build();
+		ScheduledExecutorService scheduledExecutorService =
+			Executors.newSingleThreadScheduledExecutor(threadFactory);
+		final AtomicReference<Thread> thread = new AtomicReference<>();
+		final AtomicReference<Throwable> throwable = new AtomicReference<>();
+		final CountDownLatch handlerCalled = new CountDownLatch(1);
+		final Runnable guardedRunnable =
+			Runnables.withUncaughtExceptionHandler(runnable, (t, e) -> {
+				thread.set(t);
+				throwable.set(e);
+				handlerCalled.countDown();
+			});
+		scheduledExecutorService.execute(guardedRunnable);
+		Assert.assertTrue(handlerCalled.await(100, TimeUnit.MILLISECONDS));
+		Assert.assertNotNull(thread.get());
+		Assert.assertNotNull(throwable.get());
+		Assert.assertEquals("ueh-test-0", thread.get().getName());
+		Assert.assertEquals(expected.getClass(), throwable.get().getClass());
+		Assert.assertEquals("foo", throwable.get().getMessage());
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Handle uncaught exceptions in history server archive fetcher.

## Brief change log

- Introduced `ScheduledFutures` utility class, that can attach UncaughtExceptionHandler to `ScheduledFuture`.
- Attach UEH to the future created by archive fetcher submission.

## Verifying this change

This change added tests and can be verified as follows:

- ScheduledFutures test suite.
- Manually verified on a cluster with large json archive, that results in OOM.

```
2019-11-13 15:52:13,293 INFO  org.apache.flink.runtime.webmonitor.history.HistoryServer     - Web frontend listening at localhost:8082
2019-11-13 15:52:25,385 ERROR org.apache.flink.runtime.util.FatalExitExceptionHandler       - FATAL: Thread 'Flink-Scheduled-Future-SafeGuard' produced an uncaught exception. Stopping the process...
java.lang.OutOfMemoryError: Java heap space
	at java.util.Arrays.copyOfRange(Arrays.java:3664)
	at java.lang.String.<init>(String.java:207)
	at org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.util.TextBuffer.contentsAsString(TextBuffer.java:392)
	at org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.json.UTF8StreamJsonParser._finishAndReturnString(UTF8StreamJsonParser.java:2414
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
