### PR TITLE
[FLINK-14433][DataStream] Move generated Jaas conf file from /tmp directory to Job specific directory

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
@@ -170,7 +170,7 @@ public class ConfigurationUtils {
 	}
 
 	@Nonnull
-	private static String[] splitPaths(@Nonnull String separatedPaths) {
+	public static String[] splitPaths(@Nonnull String separatedPaths) {
 		return separatedPaths.length() > 0 ? separatedPaths.split(",|" + File.pathSeparator) : EMPTY;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/JaasModule.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/JaasModule.java
@@ -79,7 +79,7 @@ public class JaasModule implements SecurityModule {
 	public JaasModule(SecurityConfiguration securityConfig) {
 		this.securityConfig = checkNotNull(securityConfig);
 		String[] dirs = splitPaths(securityConfig.getFlinkConfig().getString(CoreOptions.TMP_DIRS));
-		// should at least a single directory.
+		// should be at least one directory.
 		checkState(dirs.length > 0);
 		this.workingDir = dirs[0];
 	}
@@ -93,7 +93,7 @@ public class JaasModule implements SecurityModule {
 		if (priorConfigFile == null) {
 			File configFile = generateDefaultConfigFile(workingDir);
 			System.setProperty(JAVA_SECURITY_AUTH_LOGIN_CONFIG, configFile.getAbsolutePath());
-			LOG.info("Jaas file will install into {}.", configFile);
+			LOG.info("Jaas file will be created as {}.", configFile);
 		}
 
 		// read the JAAS configuration file

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/JaasModule.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/JaasModule.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.security.modules;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.runtime.security.DynamicConfiguration;
 import org.apache.flink.runtime.security.KerberosUtils;
 import org.apache.flink.runtime.security.SecurityConfiguration;
@@ -33,9 +34,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 
+import static org.apache.flink.configuration.ConfigurationUtils.splitPaths;
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * Responsible for installing a process-wide JAAS configuration.
@@ -66,19 +71,29 @@ public class JaasModule implements SecurityModule {
 
 	private DynamicConfiguration currentConfig;
 
+	/**
+	 * The working directory that the jaas file will install into.
+	 */
+	private final String workingDir;
+
 	public JaasModule(SecurityConfiguration securityConfig) {
 		this.securityConfig = checkNotNull(securityConfig);
+		String[] dirs = splitPaths(securityConfig.getFlinkConfig().getString(CoreOptions.TMP_DIRS));
+		// should at least a single directory.
+		checkState(dirs.length > 0);
+		this.workingDir = dirs[0];
 	}
 
 	@Override
-	public void install() throws SecurityInstallException {
+	public void install() {
 
 		// ensure that a config file is always defined, for compatibility with
 		// ZK and Kafka which check for the system property and existence of the file
 		priorConfigFile = System.getProperty(JAVA_SECURITY_AUTH_LOGIN_CONFIG, null);
 		if (priorConfigFile == null) {
-			File configFile = generateDefaultConfigFile();
+			File configFile = generateDefaultConfigFile(workingDir);
 			System.setProperty(JAVA_SECURITY_AUTH_LOGIN_CONFIG, configFile.getAbsolutePath());
+			LOG.info("Jaas file will install into {}.", configFile);
 		}
 
 		// read the JAAS configuration file
@@ -140,10 +155,12 @@ public class JaasModule implements SecurityModule {
 	/**
 	 * Generate the default JAAS config file.
 	 */
-	private static File generateDefaultConfigFile() {
+	private static File generateDefaultConfigFile(String workingDir) {
+		checkArgument(workingDir != null, "working directory should not be null.");
 		final File jaasConfFile;
 		try {
-			Path jaasConfPath = Files.createTempFile("jaas-", ".conf");
+			Path path = Paths.get(workingDir);
+			Path jaasConfPath = Files.createTempFile(path, "jaas-", ".conf");
 			try (InputStream resourceStream = JaasModule.class.getClassLoader().getResourceAsStream(JAAS_CONF_RESOURCE_NAME)) {
 				Files.copy(resourceStream, jaasConfPath, StandardCopyOption.REPLACE_EXISTING);
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/modules/JaasModuleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/modules/JaasModuleTest.java
@@ -48,7 +48,7 @@ public class JaasModuleTest {
 	}
 
 	/**
-	 * Test that jaas config file locates in the working directory.
+	 * Test that the jaas config file is created in the working directory.
 	 */
 	@Test
 	public void testJaasModuleFilePath() throws IOException {
@@ -67,7 +67,7 @@ public class JaasModuleTest {
 	}
 
 	/**
-	 * Test that the jaas file will locate in the directory specified by {@link CoreOptions#TMP_DIRS}'s default value
+	 * Test that the jaas file will be created in the directory specified by {@link CoreOptions#TMP_DIRS}'s default value
 	 * if we do not manually specify it.
 	 */
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/modules/JaasModuleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/modules/JaasModuleTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.modules;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.runtime.security.SecurityConfiguration;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.apache.flink.runtime.security.modules.JaasModule.JAVA_SECURITY_AUTH_LOGIN_CONFIG;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for {@link JaasModule}.
+ */
+public class JaasModuleTest {
+	@Rule
+	public TemporaryFolder folder = new TemporaryFolder();
+
+	@Before
+	public void setUp() throws IOException {
+		// clear the property
+		System.getProperties().remove(JAVA_SECURITY_AUTH_LOGIN_CONFIG);
+		folder.create();
+	}
+
+	/**
+	 * Test that jaas config file locates in the working directory.
+	 */
+	@Test
+	public void testJaasModuleFilePath() throws IOException {
+		File file = folder.newFolder();
+		String workingDir = file.toPath().toString();
+
+		Configuration configuration = new Configuration();
+		// set the string for CoreOptions.TMP_DIRS to mock the working directory.
+		configuration.setString(CoreOptions.TMP_DIRS, workingDir);
+		SecurityConfiguration sc = new SecurityConfiguration(configuration);
+		JaasModule module = new JaasModule(sc);
+
+		module.install();
+
+		assertJaasFileLocateInRightDirectory(workingDir);
+	}
+
+	/**
+	 * Test that the jaas file will locate in the directory specified by {@link CoreOptions#TMP_DIRS}'s default value
+	 * if we do not manually specify it.
+	 */
+	@Test
+	public void testCreateJaasModuleFileInTemporary() {
+		Configuration configuration = new Configuration();
+		SecurityConfiguration sc = new SecurityConfiguration(configuration);
+		JaasModule module = new JaasModule(sc);
+
+		module.install();
+
+		assertJaasFileLocateInRightDirectory(CoreOptions.TMP_DIRS.defaultValue());
+	}
+
+	private void assertJaasFileLocateInRightDirectory(String directory) {
+		assertTrue(System.getProperty(JAVA_SECURITY_AUTH_LOGIN_CONFIG).startsWith(directory));
+	}
+}
+


### PR DESCRIPTION
## What is the purpose of the change

Currently, we’ll generate a jaas file under tmp directory[1], files generated the jobs which run on the same machine will all run into the same directory /tmp, this may be problematic because of the reasons:

- Run out of inode for the disk which directory /tmp on
- The performance of /tmp directory will affect the read/write performance of jaas file.
 

So we propose to change place the jaas file under the `CoreOptions.TMP_DIRS` directory other than the `/tmp` directory.



## Verifying this change


This change added tests and can be verified as follows:

  - *JaasModuleTest.java*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
