### PR TITLE
[FLINK-14734][runtime] Add a ResourceSpec in SlotSharingGroup to describe its overall resources

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/common/operators/ResourceSpecTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/operators/ResourceSpecTest.java
@@ -190,4 +190,49 @@ public class ResourceSpecTest extends TestLogger {
 
 		assertSame(ResourceSpec.UNKNOWN, copiedSpec);
 	}
+
+	@Test
+	public void testSubtract() {
+		final ResourceSpec rs1 = ResourceSpec.newBuilder(1.0, 100)
+			.setGPUResource(1.1)
+			.build();
+		final ResourceSpec rs2 = ResourceSpec.newBuilder(0.2, 100)
+			.setGPUResource(0.5)
+			.build();
+
+		final ResourceSpec subtracted = rs1.subtract(rs2);
+		assertEquals(new CPUResource(0.8), subtracted.getCpuCores());
+		assertEquals(0, subtracted.getTaskHeapMemory().getMebiBytes());
+		assertEquals(new GPUResource(0.6), subtracted.getGPUResource());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testSubtractOtherHasLargerResources() {
+		final ResourceSpec rs1 = ResourceSpec.newBuilder(1.0, 100).build();
+		final ResourceSpec rs2 = ResourceSpec.newBuilder(0.2, 200).build();
+
+		rs1.subtract(rs2);
+	}
+
+	@Test
+	public void testSubtractThisUnknown() {
+		final ResourceSpec rs1 = ResourceSpec.UNKNOWN;
+		final ResourceSpec rs2 = ResourceSpec.newBuilder(0.2, 100)
+			.setGPUResource(0.5)
+			.build();
+
+		final ResourceSpec subtracted = rs1.subtract(rs2);
+		assertEquals(ResourceSpec.UNKNOWN, subtracted);
+	}
+
+	@Test
+	public void testSubtractOtherUnknown() {
+		final ResourceSpec rs1 = ResourceSpec.newBuilder(1.0, 100)
+			.setGPUResource(1.1)
+			.build();
+		final ResourceSpec rs2 = ResourceSpec.UNKNOWN;
+
+		final ResourceSpec subtracted = rs1.subtract(rs2);
+		assertEquals(ResourceSpec.UNKNOWN, subtracted);
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
@@ -367,12 +367,12 @@ public class JobVertex implements java.io.Serializable {
 	 */
 	public void setSlotSharingGroup(SlotSharingGroup grp) {
 		if (this.slotSharingGroup != null) {
-			this.slotSharingGroup.removeVertexFromGroup(id);
+			this.slotSharingGroup.removeVertexFromGroup(this.getID(), this.getMinResources());
 		}
 
 		this.slotSharingGroup = grp;
 		if (grp != null) {
-			grp.addVertexToGroup(id);
+			grp.addVertexToGroup(this.getID(), this.getMinResources());
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
@@ -61,22 +61,22 @@ public class JobVertex implements java.io.Serializable {
 	/** The alternative IDs of all operators contained in this vertex. */
 	private final ArrayList<OperatorID> operatorIdsAlternatives = new ArrayList<>();
 
-	/** List of produced data sets, one per writer */
+	/** List of produced data sets, one per writer. */
 	private final ArrayList<IntermediateDataSet> results = new ArrayList<IntermediateDataSet>();
 
 	/** List of edges with incoming data. One per Reader. */
 	private final ArrayList<JobEdge> inputs = new ArrayList<JobEdge>();
 
-	/** Number of subtasks to split this task into at runtime.*/
+	/** Number of subtasks to split this task into at runtime. */
 	private int parallelism = ExecutionConfig.PARALLELISM_DEFAULT;
 
 	/** Maximum number of subtasks to split this task into a runtime. */
 	private int maxParallelism = -1;
 
-	/** The minimum resource of the vertex */
+	/** The minimum resource of the vertex. */
 	private ResourceSpec minResources = ResourceSpec.DEFAULT;
 
-	/** The preferred resource of the vertex */
+	/** The preferred resource of the vertex. */
 	private ResourceSpec preferredResources = ResourceSpec.DEFAULT;
 
 	/** Custom configuration passed to the assigned task at runtime. */
@@ -88,30 +88,30 @@ public class JobVertex implements java.io.Serializable {
 	/** Indicates of this job vertex is stoppable or not. */
 	private boolean isStoppable = false;
 
-	/** Optionally, a source of input splits */
+	/** Optionally, a source of input splits. */
 	private InputSplitSource<?> inputSplitSource;
 
-	/** The name of the vertex. This will be shown in runtime logs and will be in the runtime environment */
+	/** The name of the vertex. This will be shown in runtime logs and will be in the runtime environment. */
 	private String name;
 
-	/** Optionally, a sharing group that allows subtasks from different job vertices to run concurrently in one slot */
+	/** Optionally, a sharing group that allows subtasks from different job vertices to run concurrently in one slot. */
 	private SlotSharingGroup slotSharingGroup;
 
-	/** The group inside which the vertex subtasks share slots */
+	/** The group inside which the vertex subtasks share slots. */
 	private CoLocationGroup coLocationGroup;
 
-	/** Optional, the name of the operator, such as 'Flat Map' or 'Join', to be included in the JSON plan */
+	/** Optional, the name of the operator, such as 'Flat Map' or 'Join', to be included in the JSON plan. */
 	private String operatorName;
 
 	/** Optional, the description of the operator, like 'Hash Join', or 'Sorted Group Reduce',
-	 * to be included in the JSON plan */
+	 * to be included in the JSON plan. */
 	private String operatorDescription;
 
-	/** Optional, pretty name of the operator, to be displayed in the JSON plan */
+	/** Optional, pretty name of the operator, to be displayed in the JSON plan. */
 	private String operatorPrettyName;
 
 	/** Optional, the JSON for the optimizer properties of the operator result,
-	 * to be included in the JSON plan */
+	 * to be included in the JSON plan. */
 	private String resultOptimizerProperties;
 
 	/** The input dependency constraint to schedule this vertex. */
@@ -121,7 +121,7 @@ public class JobVertex implements java.io.Serializable {
 
 	/**
 	 * Constructs a new job vertex and assigns it with the given name.
-	 * 
+	 *
 	 * @param name The name of the new job vertex.
 	 */
 	public JobVertex(String name) {
@@ -130,7 +130,7 @@ public class JobVertex implements java.io.Serializable {
 
 	/**
 	 * Constructs a new job vertex and assigns it with the given name.
-	 * 
+	 *
 	 * @param name The name of the new job vertex.
 	 * @param id The id of the job vertex.
 	 */
@@ -164,7 +164,7 @@ public class JobVertex implements java.io.Serializable {
 
 	/**
 	 * Returns the ID of this job vertex.
-	 * 
+	 *
 	 * @return The ID of this job vertex
 	 */
 	public JobVertexID getID() {
@@ -182,7 +182,7 @@ public class JobVertex implements java.io.Serializable {
 
 	/**
 	 * Returns the name of the vertex.
-	 * 
+	 *
 	 * @return The name of the vertex.
 	 */
 	public String getName() {
@@ -190,8 +190,8 @@ public class JobVertex implements java.io.Serializable {
 	}
 
 	/**
-	 * Sets the name of the vertex
-	 * 
+	 * Sets the name of the vertex.
+	 *
 	 * @param name The new name.
 	 */
 	public void setName(String name) {
@@ -200,7 +200,7 @@ public class JobVertex implements java.io.Serializable {
 
 	/**
 	 * Returns the number of produced intermediate data sets.
-	 * 
+	 *
 	 * @return The number of produced intermediate data sets.
 	 */
 	public int getNumberOfProducedIntermediateDataSets() {
@@ -209,7 +209,7 @@ public class JobVertex implements java.io.Serializable {
 
 	/**
 	 * Returns the number of inputs.
-	 * 
+	 *
 	 * @return The number of inputs.
 	 */
 	public int getNumberOfInputs() {
@@ -226,7 +226,7 @@ public class JobVertex implements java.io.Serializable {
 
 	/**
 	 * Returns the vertex's configuration object which can be used to pass custom settings to the task at runtime.
-	 * 
+	 *
 	 * @return the vertex's configuration object
 	 */
 	public Configuration getConfiguration() {
@@ -243,7 +243,7 @@ public class JobVertex implements java.io.Serializable {
 
 	/**
 	 * Returns the name of the invokable class which represents the task of this vertex.
-	 * 
+	 *
 	 * @return The name of the invokable class, <code>null</code> if not set.
 	 */
 	public String getInvokableClassName() {
@@ -251,8 +251,8 @@ public class JobVertex implements java.io.Serializable {
 	}
 
 	/**
-	 * Returns the invokable class which represents the task of this vertex
-	 * 
+	 * Returns the invokable class which represents the task of this vertex.
+	 *
 	 * @param cl The classloader used to resolve user-defined classes
 	 * @return The invokable class, <code>null</code> if it is not set
 	 */
@@ -277,7 +277,7 @@ public class JobVertex implements java.io.Serializable {
 
 	/**
 	 * Gets the parallelism of the task.
-	 * 
+	 *
 	 * @return The parallelism of the task.
 	 */
 	public int getParallelism() {
@@ -286,7 +286,7 @@ public class JobVertex implements java.io.Serializable {
 
 	/**
 	 * Sets the parallelism for the task.
-	 * 
+	 *
 	 * @param parallelism The parallelism for the task.
 	 */
 	public void setParallelism(int parallelism) {
@@ -362,7 +362,7 @@ public class JobVertex implements java.io.Serializable {
 	/**
 	 * Associates this vertex with a slot sharing group for scheduling. Different vertices in the same
 	 * slot sharing group can run one subtask each in the same slot.
-	 * 
+	 *
 	 * @param grp The slot sharing group to associate the vertex with.
 	 */
 	public void setSlotSharingGroup(SlotSharingGroup grp) {
@@ -380,7 +380,7 @@ public class JobVertex implements java.io.Serializable {
 	 * Gets the slot sharing group that this vertex is associated with. Different vertices in the same
 	 * slot sharing group can run one subtask each in the same slot. If the vertex is not associated with
 	 * a slot sharing group, this method returns {@code null}.
-	 * 
+	 *
 	 * @return The slot sharing group to associate the vertex with, or {@code null}, if not associated with one.
 	 */
 	@Nullable
@@ -392,17 +392,17 @@ public class JobVertex implements java.io.Serializable {
 	 * Tells this vertex to strictly co locate its subtasks with the subtasks of the given vertex.
 	 * Strict co-location implies that the n'th subtask of this vertex will run on the same parallel computing
 	 * instance (TaskManager) as the n'th subtask of the given vertex.
-	 * 
-	 * NOTE: Co-location is only possible between vertices in a slot sharing group.
-	 * 
-	 * NOTE: This vertex must (transitively) depend on the vertex to be co-located with. That means that the
+	 *
+	 * <p>NOTE: Co-location is only possible between vertices in a slot sharing group.
+	 *
+	 * <p>NOTE: This vertex must (transitively) depend on the vertex to be co-located with. That means that the
 	 * respective vertex must be a (transitive) input of this vertex.
-	 * 
+	 *
 	 * @param strictlyCoLocatedWith The vertex whose subtasks to co-locate this vertex's subtasks with.
-	 * 
+	 *
 	 * @throws IllegalArgumentException Thrown, if this vertex and the vertex to co-locate with are not in a common
 	 *                                  slot sharing group.
-	 * 
+	 *
 	 * @see #setSlotSharingGroup(SlotSharingGroup)
 	 */
 	public void setStrictlyCoLocatedWith(JobVertex strictlyCoLocatedWith) {
@@ -513,7 +513,7 @@ public class JobVertex implements java.io.Serializable {
 	/**
 	 * A hook that can be overwritten by sub classes to implement logic that is called by the
 	 * master when the job starts.
-	 * 
+	 *
 	 * @param loader The class loader for user defined code.
 	 * @throws Exception The method may throw exceptions which cause the job to fail immediately.
 	 */
@@ -522,7 +522,7 @@ public class JobVertex implements java.io.Serializable {
 	/**
 	 * A hook that can be overwritten by sub classes to implement logic that is called by the
 	 * master after the job completed.
-	 * 
+	 *
 	 * @param loader The class loader for user defined code.
 	 * @throws Exception The method may throw exceptions which cause the job to fail immediately.
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/SlotSharingGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/SlotSharingGroup.java
@@ -38,14 +38,6 @@ public class SlotSharingGroup implements java.io.Serializable {
 
 	private final SlotSharingGroupId slotSharingGroupId = new SlotSharingGroupId();
 
-	public SlotSharingGroup() {}
-
-	public SlotSharingGroup(JobVertexID ... sharedVertices) {
-		for (JobVertexID id : sharedVertices) {
-			this.ids.add(id);
-		}
-	}
-
 	// --------------------------------------------------------------------------------------------
 
 	public void addVertexToGroup(JobVertexID id) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/SlotSharingGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/SlotSharingGroup.java
@@ -18,12 +18,12 @@
 
 package org.apache.flink.runtime.jobmanager.scheduler;
 
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
 import java.util.Collections;
 import java.util.Set;
 import java.util.TreeSet;
-
-import org.apache.flink.runtime.instance.SlotSharingGroupId;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
 
 /**
  * A slot sharing units defines which different task (from different job vertices) can be
@@ -31,14 +31,15 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
  * defined by a co-location hint.
  */
 public class SlotSharingGroup implements java.io.Serializable {
-	
+
 	private static final long serialVersionUID = 1L;
 
-	private final Set<JobVertexID> ids = new TreeSet<JobVertexID>();
+	private final Set<JobVertexID> ids = new TreeSet<>();
+
 	private final SlotSharingGroupId slotSharingGroupId = new SlotSharingGroupId();
-	
+
 	public SlotSharingGroup() {}
-	
+
 	public SlotSharingGroup(JobVertexID ... sharedVertices) {
 		for (JobVertexID id : sharedVertices) {
 			this.ids.add(id);
@@ -46,15 +47,15 @@ public class SlotSharingGroup implements java.io.Serializable {
 	}
 
 	// --------------------------------------------------------------------------------------------
-	
+
 	public void addVertexToGroup(JobVertexID id) {
 		this.ids.add(id);
 	}
-	
+
 	public void removeVertexFromGroup(JobVertexID id) {
 		this.ids.remove(id);
 	}
-	
+
 	public Set<JobVertexID> getJobVertexIds() {
 		return Collections.unmodifiableSet(ids);
 	}
@@ -62,11 +63,11 @@ public class SlotSharingGroup implements java.io.Serializable {
 	public SlotSharingGroupId getSlotSharingGroupId() {
 		return slotSharingGroupId;
 	}
-	
+
 	// ------------------------------------------------------------------------
 	//  Utilities
 	// ------------------------------------------------------------------------
-	
+
 	@Override
 	public String toString() {
 		return "SlotSharingGroup " + this.ids.toString();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
@@ -36,13 +36,16 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+/**
+ * Tests creating and initializing {@link SlotSharingGroup}.
+ */
 public class VertexSlotSharingTest {
 
-	/*
+	/**
 	 * Test setup:
-	 * - v1 is isolated, no slot sharing
-	 * - v2 and v3 (not connected) share slots
-	 * - v4 and v5 (connected) share slots
+	 * - v1 is isolated, no slot sharing.
+	 * - v2 and v3 (not connected) share slots.
+	 * - v4 and v5 (connected) share slots.
 	 */
 	@Test
 	public void testAssignSlotSharingGroup() {
@@ -52,7 +55,7 @@ public class VertexSlotSharingTest {
 			JobVertex v3 = new JobVertex("v3");
 			JobVertex v4 = new JobVertex("v4");
 			JobVertex v5 = new JobVertex("v5");
-			
+
 			v1.setParallelism(4);
 			v2.setParallelism(5);
 			v3.setParallelism(7);
@@ -67,41 +70,41 @@ public class VertexSlotSharingTest {
 
 			v2.connectNewDataSetAsInput(v1, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
 			v5.connectNewDataSetAsInput(v4, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
-			
+
 			SlotSharingGroup jg1 = new SlotSharingGroup();
 			v2.setSlotSharingGroup(jg1);
 			v3.setSlotSharingGroup(jg1);
-			
+
 			SlotSharingGroup jg2 = new SlotSharingGroup();
 			v4.setSlotSharingGroup(jg2);
 			v5.setSlotSharingGroup(jg2);
-			
+
 			List<JobVertex> vertices = new ArrayList<>(Arrays.asList(v1, v2, v3, v4, v5));
 
 			ExecutionGraph eg = TestingExecutionGraphBuilder.newBuilder().build();
 			eg.attachJobGraph(vertices);
-			
+
 			// verify that the vertices are all in the same slot sharing group
 			SlotSharingGroup group1;
 			SlotSharingGroup group2;
-			
+
 			// verify that v1 tasks have no slot sharing group
 			assertNull(eg.getJobVertex(v1.getID()).getSlotSharingGroup());
-			
+
 			// v2 and v3 are shared
 			group1 = eg.getJobVertex(v2.getID()).getSlotSharingGroup();
 			assertNotNull(group1);
 			assertEquals(group1, eg.getJobVertex(v3.getID()).getSlotSharingGroup());
-			
+
 			assertEquals(2, group1.getJobVertexIds().size());
 			assertTrue(group1.getJobVertexIds().contains(v2.getID()));
 			assertTrue(group1.getJobVertexIds().contains(v3.getID()));
-			
+
 			// v4 and v5 are shared
 			group2 = eg.getJobVertex(v4.getID()).getSlotSharingGroup();
 			assertNotNull(group2);
 			assertEquals(group2, eg.getJobVertex(v5.getID()).getSlotSharingGroup());
-			
+
 			assertEquals(2, group1.getJobVertexIds().size());
 			assertTrue(group2.getJobVertexIds().contains(v4.getID()));
 			assertTrue(group2.getJobVertexIds().contains(v5.getID()));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.executiongraph;
 
+import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -113,5 +114,42 @@ public class VertexSlotSharingTest {
 			e.printStackTrace();
 			fail(e.getMessage());
 		}
+	}
+
+	@Test
+	public void testSlotSharingGroupWithSpecifiedResources() {
+		final ResourceSpec resource1 = ResourceSpec.newBuilder(0.1, 100).build();
+		final ResourceSpec resource2 = ResourceSpec.newBuilder(0.2, 200).build();
+
+		final JobVertex v1 = new JobVertex("v1");
+		final JobVertex v2 = new JobVertex("v2");
+
+		v1.setResources(resource1, resource1);
+		v2.setResources(resource2, resource2);
+
+		final SlotSharingGroup group1 = new SlotSharingGroup();
+		final SlotSharingGroup group2 = new SlotSharingGroup();
+
+		v1.setSlotSharingGroup(group1);
+		assertEquals(resource1, group1.getResourceSpec());
+
+		v2.setSlotSharingGroup(group1);
+		assertEquals(resource1.merge(resource2), group1.getResourceSpec());
+
+		// v1 is moved from group1 to group2
+		v1.setSlotSharingGroup(group2);
+		assertEquals(resource1, group2.getResourceSpec());
+		assertEquals(resource2, group1.getResourceSpec());
+	}
+
+	@Test
+	public void testSlotSharingGroupWithUnknownResources() {
+		final JobVertex v1 = new JobVertex("v1");
+		v1.setResources(ResourceSpec.UNKNOWN, ResourceSpec.UNKNOWN);
+
+		final SlotSharingGroup group1 = new SlotSharingGroup();
+
+		v1.setSlotSharingGroup(group1);
+		assertEquals(ResourceSpec.UNKNOWN, group1.getResourceSpec());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
@@ -97,8 +97,7 @@ public class PartialConsumePipelinedResultTest extends TestLogger {
 
 		final JobGraph jobGraph = new JobGraph("Partial Consume of Pipelined Result", sender, receiver);
 
-		final SlotSharingGroup slotSharingGroup = new SlotSharingGroup(
-			sender.getID(), receiver.getID());
+		final SlotSharingGroup slotSharingGroup = new SlotSharingGroup();
 
 		sender.setSlotSharingGroup(slotSharingGroup);
 		receiver.setSlotSharingGroup(slotSharingGroup);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduleOrUpdateConsumersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduleOrUpdateConsumersTest.java
@@ -115,8 +115,7 @@ public class ScheduleOrUpdateConsumersTest extends TestLogger {
 				DistributionPattern.ALL_TO_ALL,
 				ResultPartitionType.BLOCKING);
 
-		SlotSharingGroup slotSharingGroup = new SlotSharingGroup(
-				sender.getID(), pipelinedReceiver.getID(), blockingReceiver.getID());
+		SlotSharingGroup slotSharingGroup = new SlotSharingGroup();
 
 		sender.setSlotSharingGroup(slotSharingGroup);
 		pipelinedReceiver.setSlotSharingGroup(slotSharingGroup);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
@@ -332,7 +332,7 @@ public class MiniClusterITCase extends TestLogger {
 			receiver.setInvokableClass(AgnosticReceiver.class);
 			receiver.setParallelism(parallelism);
 
-			final SlotSharingGroup sharingGroup = new SlotSharingGroup(sender.getID(), receiver.getID());
+			final SlotSharingGroup sharingGroup = new SlotSharingGroup();
 			sender.setSlotSharingGroup(sharingGroup);
 			forwarder.setSlotSharingGroup(sharingGroup);
 			receiver.setSlotSharingGroup(sharingGroup);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskCancelAsyncProducerConsumerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskCancelAsyncProducerConsumerITCase.java
@@ -103,7 +103,7 @@ public class TaskCancelAsyncProducerConsumerITCase extends TestLogger {
 		consumer.setInvokableClass(AsyncConsumer.class);
 		consumer.connectNewDataSetAsInput(producer, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
 
-		SlotSharingGroup slot = new SlotSharingGroup(producer.getID(), consumer.getID());
+		SlotSharingGroup slot = new SlotSharingGroup();
 		producer.setSlotSharingGroup(slot);
 		consumer.setSlotSharingGroup(slot);
 


### PR DESCRIPTION

## What is the purpose of the change

This PR is to add a ResourceSpec for SlotSharingGroup. Its value is a merge of the resources of all operators in it. It enables FLINK-14314 to allocate task slot regarding the share slot resources.

The change is based on #10079.

## Brief change log

  - *Add subtract method for ResourceSpec*
  - *Add a ResourceSpec in SlotSharingGroup*
  - *Make slot sharing group ResourceSpec updated with vertices added/removed*


## Verifying this change

  - *Added unit tests for ResourceSpec#subtract and SlotSharingGroup#resourceSpec*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
