### PR TITLE
[FLINK-14631] Account for netty direct allocations in direct memory limit (Netty Shuffle)

### DIFF
--- a/docs/_includes/generated/network_netty_configuration.html
+++ b/docs/_includes/generated/network_netty_configuration.html
@@ -22,9 +22,9 @@
         </tr>
         <tr>
             <td><h5>taskmanager.network.netty.num-arenas</h5></td>
-            <td style="word-wrap: break-word;">-1</td>
+            <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>
-            <td>The number of Netty arenas.</td>
+            <td>The number of Netty arenas. Netty based shuffle implementation takes part of the configured task manager shuffle memory for the arenas. Each arena is accounted for as 6 chunks of 16Mb (96Mb). This number of arenas might have to be increased if the network is congested by many connections between task managers, e.g. because of high back pressure.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.netty.sendReceiveBufferSize</h5></td>

--- a/docs/_includes/generated/task_manager_memory_configuration.html
+++ b/docs/_includes/generated/task_manager_memory_configuration.html
@@ -88,7 +88,7 @@
         </tr>
         <tr>
             <td><h5>taskmanager.memory.shuffle.min</h5></td>
-            <td style="word-wrap: break-word;">"64m"</td>
+            <td style="word-wrap: break-word;">"160m"</td>
             <td>String</td>
             <td>Min Shuffle Memory size for TaskExecutors. Shuffle Memory is off-heap memory reserved for ShuffleEnvironment (e.g., network buffers). Shuffle Memory size is derived to make up the configured fraction of the Total Flink Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of Shuffle Memory can be explicitly specified by setting the min/max to the same value.</td>
         </tr>

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -175,9 +175,14 @@ public class NettyShuffleEnvironmentOptions {
 
 	public static final ConfigOption<Integer> NUM_ARENAS =
 		key("taskmanager.network.netty.num-arenas")
-			.defaultValue(-1)
+			.intType()
+			.defaultValue(1)
 			.withDeprecatedKeys("taskmanager.net.num-arenas")
-			.withDescription("The number of Netty arenas.");
+			.withDescription(
+				"The number of Netty arenas. Netty based shuffle implementation takes part of the configured " +
+					"task manager shuffle memory for the arenas. Each arena is accounted for as 6 chunks of 16Mb (96Mb). " +
+					"This number of arenas might have to be increased if the network is congested by many connections " +
+					"between task managers, e.g. because of high back pressure.");
 
 	public static final ConfigOption<Integer> NUM_THREADS_SERVER =
 		key("taskmanager.network.netty.server.numThreads")

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -358,7 +358,8 @@ public class TaskManagerOptions {
 	 */
 	public static final ConfigOption<String> SHUFFLE_MEMORY_MIN =
 		key("taskmanager.memory.shuffle.min")
-			.defaultValue("64m")
+			.stringType()
+			.defaultValue("160m")
 			.withDeprecatedKeys(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MIN.key())
 			.withDescription("Min Shuffle Memory size for TaskExecutors. Shuffle Memory is off-heap memory reserved for"
 				+ " ShuffleEnvironment (e.g., network buffers). Shuffle Memory size is derived to make up the configured"

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
@@ -23,6 +23,8 @@ import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.io.network.netty.NettyBufferPool;
+import org.apache.flink.runtime.io.network.netty.NettyConfig;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
 
 import java.util.HashMap;
@@ -385,7 +387,8 @@ public class TaskExecutorResourceUtils {
 		@SuppressWarnings("deprecation")
 		final long numOfBuffers = config.getInteger(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS);
 		final long pageSize =  ConfigurationParserUtils.getPageSize(config);
-		return new MemorySize(numOfBuffers * pageSize);
+		final long numberOfArenas = NettyConfig.getNumberOfArenas(config);
+		return new MemorySize(numOfBuffers * pageSize + numberOfArenas * NettyBufferPool.ARENA_SIZE);
 	}
 
 	private static RangeFraction getShuffleMemoryRangeFraction(final Configuration config) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
@@ -90,10 +90,6 @@ public class NettyConfig {
 		return memorySegmentSize;
 	}
 
-	public int getNumberOfSlots() {
-		return numberOfSlots;
-	}
-
 	// ------------------------------------------------------------------------
 	// Getters
 	// ------------------------------------------------------------------------
@@ -103,9 +99,7 @@ public class NettyConfig {
 	}
 
 	public int getNumberOfArenas() {
-		// default: number of slots
-		final int configValue = config.getInteger(NettyShuffleEnvironmentOptions.NUM_ARENAS);
-		return configValue == -1 ? numberOfSlots : configValue;
+		return getNumberOfArenas(config);
 	}
 
 	public int getServerNumThreads() {
@@ -188,5 +182,9 @@ public class NettyConfig {
 				getServerConnectBacklog(), getServerConnectBacklog() == 0 ? def : man,
 				getClientConnectTimeoutSeconds(), getSendAndReceiveBufferSize(),
 				getSendAndReceiveBufferSize() == 0 ? def : man);
+	}
+
+	public static int getNumberOfArenas(Configuration config) {
+		return config.getInteger(NettyShuffleEnvironmentOptions.NUM_ARENAS);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManagerTest.java
@@ -41,26 +41,29 @@ import static org.junit.Assert.assertEquals;
 public class NettyConnectionManagerTest {
 
 	/**
-	 * Tests that the number of arenas and number of threads of the client and
+	 * Tests that the number of arenas is correctly configured and number of threads of the client and
 	 * server are set to the same number, that is the number of configured
 	 * task slots.
 	 */
 	@Test
 	public void testMatchingNumberOfArenasAndThreadsAsDefault() throws Exception {
-		// Expected number of arenas and threads
 		int numberOfSlots = 2;
+		int numberOfArenas = 3;
+
+		Configuration configuration = new Configuration();
+		configuration.setInteger(NettyShuffleEnvironmentOptions.NUM_ARENAS, numberOfArenas);
 
 		NettyConfig config = new NettyConfig(
 				InetAddress.getLocalHost(),
 				NetUtils.getAvailablePort(),
 				1024,
 				numberOfSlots,
-				new Configuration());
+			configuration);
 
 		NettyConnectionManager connectionManager = createNettyConnectionManager(config);
 		connectionManager.start();
 
-		assertEquals(numberOfSlots, connectionManager.getBufferPool().getNumberOfArenas());
+		assertEquals(numberOfArenas, connectionManager.getBufferPool().getNumberOfArenas());
 
 		{
 			// Client event loop group


### PR DESCRIPTION
## What is the purpose of the change

At the moment after [FLINK-13982](https://jira.apache.org/jira/browse/FLINK-14631), when we calculate JVM direct memory limit, we only account for memory segment network buffers but not for direct allocations from netty arenas in `org.apache.flink.runtime.io.network.netty.NettyBufferPool`. We should include netty arenas into shuffle memory calculations.

The arenas should not be used too much after adding credit based control. They should be immediately copied into network buffers. Therefore, having number of arenas equal to the number of slots by default seems to be redundant and we can have just one 16Mb arena by default. Eventually, arena usage should become almost zero after #7368 except sending task events etc.

Other off-heap memory uncontrollable usages in Flink dependencies can be addressed by framework off-heap memory config introduced in #10124.

## Brief change log

  - Adjust default number of netty arenas to 1
  - Add netty arenas to shuffle memory calculations for legacy config
  - Add test and adjust others

## Verifying this change

Unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
