### PR TITLE
[FLINK-14745] Add dependencies of job as list of URLs in config.

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
@@ -27,7 +27,6 @@ import org.apache.flink.client.program.DetachedJobExecutionResult;
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.client.program.ProgramMissingJobException;
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -55,20 +54,6 @@ public enum ClientUtils {
 	;
 
 	private static final Logger LOG = LoggerFactory.getLogger(ClientUtils.class);
-
-	/**
-	 * Adds the given jar files to the {@link JobGraph} via {@link JobGraph#addJar}. This will
-	 * throw an exception if a jar URL is not valid.
-	 */
-	public static void addJarFiles(JobGraph jobGraph, List<URL> jarFilesToAttach) {
-		for (URL jar : jarFilesToAttach) {
-			try {
-				jobGraph.addJar(new Path(jar.toURI()));
-			} catch (URISyntaxException e) {
-				throw new RuntimeException("URL is invalid. This should not happen.", e);
-			}
-		}
-	}
 
 	public static void checkJarFile(URL jar) throws IOException {
 		File jarFile;

--- a/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
@@ -143,13 +143,11 @@ public enum ClientUtils {
 
 			LOG.info("Starting program (detached: {})", detached);
 
-			final List<URL> libraries = program.getAllLibraries();
-
 			final AtomicReference<JobExecutionResult> jobExecutionResult = new AtomicReference<>();
 
 			ContextEnvironmentFactory factory = new ContextEnvironmentFactory(
 				client,
-				libraries,
+				program.getAllLibraries(),
 				program.getClasspaths(),
 				program.getUserCodeClassLoader(),
 				parallelism,

--- a/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
@@ -147,7 +147,7 @@ public enum ClientUtils {
 
 			ContextEnvironmentFactory factory = new ContextEnvironmentFactory(
 				client,
-				program.getAllLibraries(),
+				program.getJobJarAndDependencies(),
 				program.getClasspaths(),
 				program.getUserCodeClassLoader(),
 				parallelism,

--- a/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
@@ -108,7 +108,7 @@ public class RemoteExecutor extends PlanExecutor {
 				clientConfiguration,
 				getDefaultParallelism());
 
-		ClientUtils.addJarFiles(jobGraph, jarFiles);
+		jobGraph.addJars(jarFiles);
 		jobGraph.setClasspaths(globalClasspaths);
 
 		ClassLoader userCodeClassLoader = ClientUtils.buildUserCodeClassLoader(

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -211,7 +211,8 @@ public class CliFrontend {
 		final CustomCommandLine customCommandLine = getActiveCustomCommandLine(commandLine);
 		final Configuration executorConfig = customCommandLine.applyCommandLineOptionsToConfiguration(commandLine);
 
-		final ExecutionConfigAccessor executionParameters = ExecutionConfigAccessor.fromProgramOptions(programOptions);
+		final List<URL> jobJars = program.getJobJarAndDependencies();
+		final ExecutionConfigAccessor executionParameters = ExecutionConfigAccessor.fromProgramOptions(programOptions, jobJars);
 		final Configuration executionConfig = executionParameters.getConfiguration();
 
 		try {

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -278,11 +278,8 @@ public class CliFrontend {
 				try {
 					int userParallelism = executionParameters.getParallelism();
 					LOG.debug("User parallelism is set to {}", userParallelism);
-					if (ExecutionConfig.PARALLELISM_DEFAULT == userParallelism) {
-						userParallelism = defaultParallelism;
-					}
 
-					executeProgram(program, client, userParallelism, executionParameters.getDetachedMode());
+					executeProgram(executionConfig, program, client);
 				} finally {
 					if (clusterId == null && !executionParameters.getDetachedMode()) {
 						// terminate the cluster only if we have started it before and if it's not detached
@@ -742,13 +739,12 @@ public class CliFrontend {
 	// --------------------------------------------------------------------------------------------
 
 	protected void executeProgram(
+			Configuration configuration,
 			PackagedProgram program,
-			ClusterClient<?> client,
-			int parallelism,
-			boolean detached) throws ProgramMissingJobException, ProgramInvocationException {
+			ClusterClient<?> client) throws ProgramMissingJobException, ProgramInvocationException {
 		logAndSysout("Starting execution of program");
 
-		JobSubmissionResult result = ClientUtils.executeProgram(client, program, parallelism, detached);
+		JobSubmissionResult result = ClientUtils.executeProgram(configuration, client, program);
 
 		if (result.isJobExecutionResult()) {
 			logAndSysout("Program execution finished");

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutionConfigAccessor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutionConfigAccessor.java
@@ -65,9 +65,7 @@ public class ExecutionConfigAccessor {
 		configuration.setBoolean(DeploymentOptions.ATTACHED, !options.getDetachedMode());
 		configuration.setBoolean(DeploymentOptions.SHUTDOWN_IF_ATTACHED, options.isShutdownOnAttachedExit());
 
-		if (options.getClasspaths() != null) {
-			ConfigUtils.encodeStreamToConfig(configuration, PipelineOptions.CLASSPATHS, options.getClasspaths().stream(), URL::toString);
-		}
+		ConfigUtils.encodeCollectionToConfig(configuration, PipelineOptions.CLASSPATHS, options.getClasspaths(), URL::toString);
 
 		parseJarURLToConfig(options.getJarFilePath(), configuration);
 
@@ -84,7 +82,7 @@ public class ExecutionConfigAccessor {
 		try {
 			final URL jarUrl = new File(jarFile).getAbsoluteFile().toURI().toURL();
 			final List<URL> jarUrlSingleton = Collections.singletonList(jarUrl);
-			ConfigUtils.encodeStreamToConfig(configuration, PipelineOptions.JARS, jarUrlSingleton.stream(), URL::toString);
+			ConfigUtils.encodeCollectionToConfig(configuration, PipelineOptions.JARS, jarUrlSingleton, URL::toString);
 		} catch (MalformedURLException e) {
 			throw new IllegalArgumentException("JAR file path invalid", e);
 		}

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutionConfigAccessor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutionConfigAccessor.java
@@ -27,10 +27,8 @@ import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 
-import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Collections;
 import java.util.List;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -67,37 +65,13 @@ public class ExecutionConfigAccessor {
 
 		ConfigUtils.encodeCollectionToConfig(configuration, PipelineOptions.CLASSPATHS, options.getClasspaths(), URL::toString);
 
-		parseJarURLToConfig(options.getJarFilePath(), configuration);
-
 		SavepointRestoreSettings.toConfiguration(options.getSavepointRestoreSettings(), configuration);
 
 		return new ExecutionConfigAccessor(configuration);
 	}
 
-	private static void parseJarURLToConfig(final String jarFile, final Configuration configuration) {
-		if (jarFile == null) {
-			return;
-		}
-
-		try {
-			final URL jarUrl = new File(jarFile).getAbsoluteFile().toURI().toURL();
-			final List<URL> jarUrlSingleton = Collections.singletonList(jarUrl);
-			ConfigUtils.encodeCollectionToConfig(configuration, PipelineOptions.JARS, jarUrlSingleton, URL::toString);
-		} catch (MalformedURLException e) {
-			throw new IllegalArgumentException("JAR file path invalid", e);
-		}
-	}
-
 	public Configuration getConfiguration() {
 		return configuration;
-	}
-
-	public String getJarFilePath() {
-		final List<URL> jarURL =  decodeUrlList(configuration, PipelineOptions.JARS);
-		if (jarURL != null && !jarURL.isEmpty()) {
-			return jarURL.get(0).getPath();
-		}
-		return null;
 	}
 
 	public List<URL> getClasspaths() {

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutionConfigAccessor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutionConfigAccessor.java
@@ -55,15 +55,18 @@ public class ExecutionConfigAccessor {
 	/**
 	 * Creates an {@link ExecutionConfigAccessor} based on the provided {@link ProgramOptions} as provided by the user through the CLI.
 	 */
-	public static ExecutionConfigAccessor fromProgramOptions(final ProgramOptions options) {
+	public static ExecutionConfigAccessor fromProgramOptions(final ProgramOptions options, final List<URL> jobJars) {
 		checkNotNull(options);
+		checkNotNull(jobJars);
 
 		final Configuration configuration = new Configuration();
+
 		configuration.setInteger(CoreOptions.DEFAULT_PARALLELISM, options.getParallelism());
 		configuration.setBoolean(DeploymentOptions.ATTACHED, !options.getDetachedMode());
 		configuration.setBoolean(DeploymentOptions.SHUTDOWN_IF_ATTACHED, options.isShutdownOnAttachedExit());
 
 		ConfigUtils.encodeCollectionToConfig(configuration, PipelineOptions.CLASSPATHS, options.getClasspaths(), URL::toString);
+		ConfigUtils.encodeCollectionToConfig(configuration, PipelineOptions.JARS, jobJars, URL::toString);
 
 		SavepointRestoreSettings.toConfiguration(options.getSavepointRestoreSettings(), configuration);
 
@@ -72,6 +75,10 @@ public class ExecutionConfigAccessor {
 
 	public Configuration getConfiguration() {
 		return configuration;
+	}
+
+	public List<URL> getJars() {
+		return decodeUrlList(configuration, PipelineOptions.JARS);
 	}
 
 	public List<URL> getClasspaths() {

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutionConfigAccessor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutionConfigAccessor.java
@@ -19,6 +19,7 @@
 package org.apache.flink.client.cli;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigUtils;
 import org.apache.flink.configuration.Configuration;
@@ -61,7 +62,10 @@ public class ExecutionConfigAccessor {
 
 		final Configuration configuration = new Configuration();
 
-		configuration.setInteger(CoreOptions.DEFAULT_PARALLELISM, options.getParallelism());
+		if (options.getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT) {
+			configuration.setInteger(CoreOptions.DEFAULT_PARALLELISM, options.getParallelism());
+		}
+
 		configuration.setBoolean(DeploymentOptions.ATTACHED, !options.getDetachedMode());
 		configuration.setBoolean(DeploymentOptions.SHUTDOWN_IF_ATTACHED, options.isShutdownOnAttachedExit());
 

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -84,7 +84,7 @@ public class ContextEnvironment extends ExecutionEnvironment {
 				client.getFlinkConfiguration(),
 				getParallelism());
 
-		ClientUtils.addJarFiles(jobGraph, this.jarFilesToAttach);
+		jobGraph.addJars(this.jarFilesToAttach);
 		jobGraph.setClasspaths(this.classpathsToAttach);
 
 		if (detached) {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -140,7 +140,7 @@ public class PackagedProgram {
 		// now that we have an entry point, we can extract the nested jar files (if any)
 		this.extractedTempLibraries = jarFileUrl == null ? Collections.emptyList() : extractContainedLibraries(jarFileUrl);
 		this.classpaths = classpaths;
-		this.userCodeClassLoader = ClientUtils.buildUserCodeClassLoader(getAllLibraries(), classpaths, getClass().getClassLoader());
+		this.userCodeClassLoader = ClientUtils.buildUserCodeClassLoader(getJobJarAndDependencies(), classpaths, getClass().getClassLoader());
 
 		// load the entry point class
 		this.mainClass = loadMainClass(entryPointClassName, userCodeClassLoader);
@@ -227,7 +227,7 @@ public class PackagedProgram {
 	/**
 	 * Returns all provided libraries needed to run the program.
 	 */
-	public List<URL> getAllLibraries() {
+	public List<URL> getJobJarAndDependencies() {
 		List<URL> libs = new ArrayList<URL>(this.extractedTempLibraries.size() + 1);
 
 		if (jarFile != null) {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -46,13 +46,13 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.List;
 import java.util.Random;
 import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.client.program.PackagedProgramUtils.isPython;
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -427,100 +427,80 @@ public class PackagedProgram {
 	 * @throws ProgramInvocationException Thrown, if the extraction process failed.
 	 */
 	public static List<File> extractContainedLibraries(URL jarFile) throws ProgramInvocationException {
+		try (final JarFile jar = new JarFile(new File(jarFile.toURI()))) {
 
-		Random rnd = new Random();
-
-		JarFile jar = null;
-		try {
-			jar = new JarFile(new File(jarFile.toURI()));
-			final List<JarEntry> containedJarFileEntries = new ArrayList<JarEntry>();
-
-			Enumeration<JarEntry> entries = jar.entries();
-			while (entries.hasMoreElements()) {
-				JarEntry entry = entries.nextElement();
-				String name = entry.getName();
-
-				if (name.length() > 8 && name.startsWith("lib/") && name.endsWith(".jar")) {
-					containedJarFileEntries.add(entry);
-				}
-			}
-
+			final List<JarEntry> containedJarFileEntries = getContainedJarEntries(jar);
 			if (containedJarFileEntries.isEmpty()) {
 				return Collections.emptyList();
-			} else {
-				// go over all contained jar files
-				final List<File> extractedTempLibraries = new ArrayList<File>(containedJarFileEntries.size());
+			}
+
+			final List<File> extractedTempLibraries = new ArrayList<>(containedJarFileEntries.size());
+			boolean incomplete = true;
+
+			try {
+				final Random rnd = new Random();
 				final byte[] buffer = new byte[4096];
 
-				boolean incomplete = true;
-
-				try {
-					for (int i = 0; i < containedJarFileEntries.size(); i++) {
-						final JarEntry entry = containedJarFileEntries.get(i);
-						String name = entry.getName();
-						// '/' as in case of zip, jar
-						// java.util.zip.ZipEntry#isDirectory always looks only for '/' not for File.separator
-						name = name.replace('/', '_');
-
-						File tempFile;
-						try {
-							tempFile = File.createTempFile(rnd.nextInt(Integer.MAX_VALUE) + "_", name);
-							tempFile.deleteOnExit();
-						} catch (IOException e) {
-							throw new ProgramInvocationException(
-								"An I/O error occurred while creating temporary file to extract nested library '" +
-									entry.getName() + "'.", e);
-						}
-
-						extractedTempLibraries.add(tempFile);
-
-						// copy the temp file contents to a temporary File
-						OutputStream out = null;
-						InputStream in = null;
-						try {
-
-							out = new FileOutputStream(tempFile);
-							in = new BufferedInputStream(jar.getInputStream(entry));
-
-							int numRead = 0;
-							while ((numRead = in.read(buffer)) != -1) {
-								out.write(buffer, 0, numRead);
-							}
-						} catch (IOException e) {
-							throw new ProgramInvocationException("An I/O error occurred while extracting nested library '"
-								+ entry.getName() + "' to temporary file '" + tempFile.getAbsolutePath() + "'.");
-						} finally {
-							if (out != null) {
-								out.close();
-							}
-							if (in != null) {
-								in.close();
-							}
-						}
-					}
-
-					incomplete = false;
-				} finally {
-					if (incomplete) {
-						deleteExtractedLibraries(extractedTempLibraries);
-					}
+				for (final JarEntry entry : containedJarFileEntries) {
+					// '/' as in case of zip, jar
+					// java.util.zip.ZipEntry#isDirectory always looks only for '/' not for File.separator
+					final String name = entry.getName().replace('/', '_');
+					final File tempFile = copyLibToTempFile(name, rnd, jar, entry, buffer);
+					extractedTempLibraries.add(tempFile);
 				}
 
-				return extractedTempLibraries;
+				incomplete = false;
+			} finally {
+				if (incomplete) {
+					deleteExtractedLibraries(extractedTempLibraries);
+				}
 			}
+
+			return extractedTempLibraries;
 		} catch (Throwable t) {
 			throw new ProgramInvocationException("Unknown I/O error while extracting contained jar files.", t);
-		} finally {
-			if (jar != null) {
-				try {
-					jar.close();
-				} catch (Throwable t) {
-				}
-			}
 		}
 	}
 
-	public static void deleteExtractedLibraries(List<File> tempLibraries) {
+	private static File copyLibToTempFile(String name, Random rnd, JarFile jar, JarEntry input, byte[] buffer) throws ProgramInvocationException {
+		final File output = createTempFile(rnd, input, name);
+		try (
+				final OutputStream out = new FileOutputStream(output);
+				final InputStream in = new BufferedInputStream(jar.getInputStream(input))
+		) {
+			int numRead = 0;
+			while ((numRead = in.read(buffer)) != -1) {
+				out.write(buffer, 0, numRead);
+			}
+			return output;
+		} catch (IOException e) {
+			throw new ProgramInvocationException("An I/O error occurred while extracting nested library '"
+					+ input.getName() + "' to temporary file '" + output.getAbsolutePath() + "'.");
+		}
+	}
+
+	private static File createTempFile(Random rnd, JarEntry entry, String name) throws ProgramInvocationException {
+		try {
+			final File tempFile = File.createTempFile(rnd.nextInt(Integer.MAX_VALUE) + "_", name);
+			tempFile.deleteOnExit();
+			return tempFile;
+		} catch (IOException e) {
+			throw new ProgramInvocationException(
+					"An I/O error occurred while creating temporary file to extract nested library '" +
+							entry.getName() + "'.", e);
+		}
+	}
+
+	private static List<JarEntry> getContainedJarEntries(JarFile jar) {
+		return jar.stream()
+				.filter(jarEntry -> {
+					final String name = jarEntry.getName();
+					return name.length() > 8 && name.startsWith("lib/") && name.endsWith(".jar");
+				})
+				.collect(Collectors.toList());
+	}
+
+	private static void deleteExtractedLibraries(List<File> tempLibraries) {
 		for (File f : tempLibraries) {
 			f.delete();
 		}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
@@ -63,7 +63,7 @@ public class PackagedProgramUtils {
 		if (jobID != null) {
 			jobGraph.setJobID(jobID);
 		}
-		jobGraph.addJars(packagedProgram.getAllLibraries());
+		jobGraph.addJars(packagedProgram.getJobJarAndDependencies());
 		jobGraph.setClasspaths(packagedProgram.getClasspaths());
 		jobGraph.setSavepointRestoreSettings(packagedProgram.getSavepointSettings());
 

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
@@ -20,7 +20,6 @@ package org.apache.flink.client.program;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.dag.Pipeline;
-import org.apache.flink.client.ClientUtils;
 import org.apache.flink.client.FlinkPipelineTranslationUtil;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.optimizer.CompilerException;
@@ -64,7 +63,7 @@ public class PackagedProgramUtils {
 		if (jobID != null) {
 			jobGraph.setJobID(jobID);
 		}
-		ClientUtils.addJarFiles(jobGraph, packagedProgram.getAllLibraries());
+		jobGraph.addJars(packagedProgram.getAllLibraries());
 		jobGraph.setClasspaths(packagedProgram.getClasspaths());
 		jobGraph.setSavepointRestoreSettings(packagedProgram.getSavepointSettings());
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendPackageProgramTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendPackageProgramTest.java
@@ -80,11 +80,10 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 	@Test
 	public void testNonExistingJarFile() throws Exception {
 		ProgramOptions programOptions = mock(ProgramOptions.class);
-		ExecutionConfigAccessor executionOptions = mock(ExecutionConfigAccessor.class);
-		when(executionOptions.getJarFilePath()).thenReturn("/some/none/existing/path");
+		when(programOptions.getJarFilePath()).thenReturn("/some/none/existing/path");
 
 		try {
-			frontend.buildProgram(programOptions, executionOptions);
+			frontend.buildProgram(programOptions);
 			fail("should throw an exception");
 		}
 		catch (FileNotFoundException e) {
@@ -95,12 +94,11 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 	@Test
 	public void testFileNotJarFile() throws Exception {
 		ProgramOptions programOptions = mock(ProgramOptions.class);
-		ExecutionConfigAccessor executionOptions = mock(ExecutionConfigAccessor.class);
-		when(executionOptions.getJarFilePath()).thenReturn(getNonJarFilePath());
+		when(programOptions.getJarFilePath()).thenReturn(getNonJarFilePath());
 		when(programOptions.getProgramArgs()).thenReturn(new String[0]);
 
 		try {
-			frontend.buildProgram(programOptions, executionOptions);
+			frontend.buildProgram(programOptions);
 			fail("should throw an exception");
 		}
 		catch (ProgramInvocationException e) {
@@ -120,13 +118,12 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 
 		CommandLine commandLine = CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, arguments, true);
 		ProgramOptions programOptions = new ProgramOptions(commandLine);
-		ExecutionConfigAccessor executionOptions = ExecutionConfigAccessor.fromProgramOptions(programOptions);
 
-		assertEquals(getTestJarPath(), executionOptions.getJarFilePath());
-		assertArrayEquals(classpath, executionOptions.getClasspaths().toArray());
+		assertEquals(getTestJarPath(), programOptions.getJarFilePath());
+		assertArrayEquals(classpath, programOptions.getClasspaths().toArray());
 		assertArrayEquals(reducedArguments, programOptions.getProgramArgs());
 
-		PackagedProgram prog = frontend.buildProgram(programOptions, executionOptions);
+		PackagedProgram prog = frontend.buildProgram(programOptions);
 
 		Assert.assertArrayEquals(reducedArguments, prog.getArguments());
 		Assert.assertEquals(TEST_JAR_MAIN_CLASS, prog.getMainClassName());
@@ -144,13 +141,12 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 
 		CommandLine commandLine = CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, arguments, true);
 		ProgramOptions programOptions = new ProgramOptions(commandLine);
-		ExecutionConfigAccessor executionOptions = ExecutionConfigAccessor.fromProgramOptions(programOptions);
 
-		assertEquals(getTestJarPath(), executionOptions.getJarFilePath());
-		assertArrayEquals(classpath, executionOptions.getClasspaths().toArray());
+		assertEquals(getTestJarPath(), programOptions.getJarFilePath());
+		assertArrayEquals(classpath, programOptions.getClasspaths().toArray());
 		assertArrayEquals(reducedArguments, programOptions.getProgramArgs());
 
-		PackagedProgram prog = frontend.buildProgram(programOptions, executionOptions);
+		PackagedProgram prog = frontend.buildProgram(programOptions);
 
 		Assert.assertArrayEquals(reducedArguments, prog.getArguments());
 		Assert.assertEquals(TEST_JAR_MAIN_CLASS, prog.getMainClassName());
@@ -168,13 +164,12 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 
 		CommandLine commandLine = CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, arguments, true);
 		ProgramOptions programOptions = new ProgramOptions(commandLine);
-		ExecutionConfigAccessor executionOptions = ExecutionConfigAccessor.fromProgramOptions(programOptions);
 
-		assertEquals(getTestJarPath(), executionOptions.getJarFilePath());
-		assertArrayEquals(classpath, executionOptions.getClasspaths().toArray());
+		assertEquals(getTestJarPath(), programOptions.getJarFilePath());
+		assertArrayEquals(classpath, programOptions.getClasspaths().toArray());
 		assertArrayEquals(reducedArguments, programOptions.getProgramArgs());
 
-		PackagedProgram prog = frontend.buildProgram(programOptions, executionOptions);
+		PackagedProgram prog = frontend.buildProgram(programOptions);
 
 		Assert.assertArrayEquals(reducedArguments, prog.getArguments());
 		Assert.assertEquals(TEST_JAR_MAIN_CLASS, prog.getMainClassName());
@@ -197,14 +192,13 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 
 		CommandLine commandLine = CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, arguments, true);
 		ProgramOptions programOptions = new ProgramOptions(commandLine);
-		ExecutionConfigAccessor executionOptions = ExecutionConfigAccessor.fromProgramOptions(programOptions);
 
-		assertEquals(arguments[4], executionOptions.getJarFilePath());
-		assertArrayEquals(classpath, executionOptions.getClasspaths().toArray());
+		assertEquals(arguments[4], programOptions.getJarFilePath());
+		assertArrayEquals(classpath, programOptions.getClasspaths().toArray());
 		assertArrayEquals(reducedArguments, programOptions.getProgramArgs());
 
 		try {
-			frontend.buildProgram(programOptions, executionOptions);
+			frontend.buildProgram(programOptions);
 			fail("Should fail with an exception");
 		}
 		catch (FileNotFoundException e) {
@@ -218,13 +212,12 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 
 		CommandLine commandLine = CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, arguments, true);
 		ProgramOptions programOptions = new ProgramOptions(commandLine);
-		ExecutionConfigAccessor executionOptions = ExecutionConfigAccessor.fromProgramOptions(programOptions);
 
-		assertEquals(arguments[0], executionOptions.getJarFilePath());
+		assertEquals(arguments[0], programOptions.getJarFilePath());
 		assertArrayEquals(new String[0], programOptions.getProgramArgs());
 
 		try {
-			frontend.buildProgram(programOptions, executionOptions);
+			frontend.buildProgram(programOptions);
 		}
 		catch (FileNotFoundException e) {
 			// that's what we want
@@ -279,14 +272,13 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 
 			CommandLine commandLine = CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, arguments, true);
 			ProgramOptions programOptions = new ProgramOptions(commandLine);
-			ExecutionConfigAccessor executionOptions = ExecutionConfigAccessor.fromProgramOptions(programOptions);
 
-			assertEquals(getTestJarPath(), executionOptions.getJarFilePath());
-			assertArrayEquals(classpath, executionOptions.getClasspaths().toArray());
+			assertEquals(getTestJarPath(), programOptions.getJarFilePath());
+			assertArrayEquals(classpath, programOptions.getClasspaths().toArray());
 			assertEquals(TEST_JAR_CLASSLOADERTEST_CLASS, programOptions.getEntryPointClassName());
 			assertArrayEquals(reducedArguments, programOptions.getProgramArgs());
 
-			PackagedProgram prog = spy(frontend.buildProgram(programOptions, executionOptions));
+			PackagedProgram prog = spy(frontend.buildProgram(programOptions));
 
 			ClassLoader testClassLoader = new ClassLoader(prog.getUserCodeClassLoader()) {
 				@Override

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -198,9 +198,10 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 		}
 
 		@Override
-		protected void executeProgram(PackagedProgram program, ClusterClient client, int parallelism, boolean detached) {
-			assertEquals(isDetached, detached);
-			assertEquals(expectedParallelism, parallelism);
+		protected void executeProgram(Configuration configuration, PackagedProgram program, ClusterClient client) {
+			final ExecutionConfigAccessor executionConfigAccessor = ExecutionConfigAccessor.fromConfiguration(configuration);
+			assertEquals(isDetached, executionConfigAccessor.getDetachedMode());
+			assertEquals(expectedParallelism, executionConfigAccessor.getParallelism());
 		}
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -85,7 +85,7 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 
 			CommandLine commandLine = CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, parameters, true);
 			ProgramOptions programOptions = new ProgramOptions(commandLine);
-			ExecutionConfigAccessor executionOptions = ExecutionConfigAccessor.fromProgramOptions(programOptions);
+			ExecutionConfigAccessor executionOptions = ExecutionConfigAccessor.fromProgramOptions(programOptions, Collections.emptyList());
 
 			SavepointRestoreSettings savepointSettings = executionOptions.getSavepointRestoreSettings();
 			assertTrue(savepointSettings.restoreSavepoint());
@@ -99,7 +99,7 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 
 			CommandLine commandLine = CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, parameters, true);
 			ProgramOptions programOptions = new ProgramOptions(commandLine);
-			ExecutionConfigAccessor executionOptions = ExecutionConfigAccessor.fromProgramOptions(programOptions);
+			ExecutionConfigAccessor executionOptions = ExecutionConfigAccessor.fromProgramOptions(programOptions, Collections.emptyList());
 
 			SavepointRestoreSettings savepointSettings = executionOptions.getSavepointRestoreSettings();
 			assertTrue(savepointSettings.restoreSavepoint());

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -160,7 +160,7 @@ public class ClientTest extends TestLogger {
 				new Configuration(),
 				1);
 
-		ClientUtils.addJarFiles(jobGraph, Collections.emptyList());
+		jobGraph.addJars(Collections.emptyList());
 		jobGraph.setClasspaths(Collections.emptyList());
 
 		JobSubmissionResult result = ClientUtils.submitJob(clusterClient, jobGraph);

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigUtilsTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.configuration.ConfigOptions.key;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests the {@link ConfigUtils} methods.
+ */
+public class ConfigUtilsTest {
+
+	private static final ConfigOption<List<String>> TEST_OPTION =
+			key("test.option.key")
+					.stringType()
+					.asList()
+					.noDefaultValue();
+
+	private static final Integer[] intArray = {1, 3, 2, 4};
+	private static final List<Integer> intList = Arrays.asList(intArray);
+
+	@Test
+	public void collectionIsCorrectlyPutAndFetched() {
+		final Configuration configurationUnderTest = new Configuration();
+		ConfigUtils.encodeCollectionToConfig(configurationUnderTest, TEST_OPTION, intList, Object::toString);
+
+		final List<Integer> recovered = ConfigUtils.decodeListFromConfig(configurationUnderTest, TEST_OPTION, Integer::valueOf);
+		assertThat(recovered, equalTo(intList));
+	}
+
+	@Test
+	public void arrayIsCorrectlyPutAndFetched() {
+		final Configuration configurationUnderTest = new Configuration();
+		ConfigUtils.encodeArrayToConfig(configurationUnderTest, TEST_OPTION, intArray, Object::toString);
+
+		final List<Integer> recovered = ConfigUtils.decodeListFromConfig(configurationUnderTest, TEST_OPTION, Integer::valueOf);
+		assertThat(recovered, equalTo(intList));
+	}
+
+	@Test
+	public void nullCollectionPutsNothingInConfig() {
+		final Configuration configurationUnderTest = new Configuration();
+		ConfigUtils.encodeCollectionToConfig(configurationUnderTest, TEST_OPTION, null, Object::toString);
+
+		assertThat(configurationUnderTest.keySet(), is(empty()));
+
+		final Object recovered = configurationUnderTest.get(TEST_OPTION);
+		assertThat(recovered, is(nullValue()));
+
+		final List<Integer> recoveredList = ConfigUtils.decodeListFromConfig(configurationUnderTest, TEST_OPTION, Integer::valueOf);
+		assertThat(recoveredList, is(empty()));
+	}
+
+	@Test
+	public void nullArrayPutsNothingInConfig() {
+		final Configuration configurationUnderTest = new Configuration();
+		ConfigUtils.encodeArrayToConfig(configurationUnderTest, TEST_OPTION, null, Object::toString);
+
+		assertThat(configurationUnderTest.keySet(), is(empty()));
+
+		final Object recovered = configurationUnderTest.get(TEST_OPTION);
+		assertThat(recovered, is(nullValue()));
+
+		final List<Integer> recoveredList = ConfigUtils.decodeListFromConfig(configurationUnderTest, TEST_OPTION, Integer::valueOf);
+		assertThat(recoveredList, is(empty()));
+	}
+
+	@Test
+	public void emptyCollectionPutsNothingInConfig() {
+		final Configuration configurationUnderTest = new Configuration();
+		ConfigUtils.encodeCollectionToConfig(configurationUnderTest, TEST_OPTION, Collections.emptyList(), Object::toString);
+
+		assertThat(configurationUnderTest.keySet(), is(empty()));
+
+		final Object recovered = configurationUnderTest.get(TEST_OPTION);
+		assertThat(recovered, is(nullValue()));
+
+		final List<Integer> recoveredList = ConfigUtils.decodeListFromConfig(configurationUnderTest, TEST_OPTION, Integer::valueOf);
+		assertThat(recoveredList, is(empty()));
+	}
+
+	@Test
+	public void emptyArrayPutsNothingInConfig() {
+		final Configuration configurationUnderTest = new Configuration();
+		ConfigUtils.encodeArrayToConfig(configurationUnderTest, TEST_OPTION, new Integer[5], Object::toString);
+
+		assertThat(configurationUnderTest.keySet(), is(empty()));
+
+		final Object recovered = configurationUnderTest.get(TEST_OPTION);
+		assertThat(recovered, is(nullValue()));
+
+		final List<Integer> recoveredList = ConfigUtils.decodeListFromConfig(configurationUnderTest, TEST_OPTION, Integer::valueOf);
+		assertThat(recoveredList, is(empty()));
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -31,6 +31,7 @@ import org.apache.flink.util.SerializedValue;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -470,6 +471,22 @@ public class JobGraph implements Serializable {
 
 		if (!userJars.contains(jar)) {
 			userJars.add(jar);
+		}
+	}
+
+	/**
+	 * Adds the given jar files to the {@link JobGraph} via {@link JobGraph#addJar}.
+	 *
+	 * @param jarFilesToAttach a list of the {@link URL URLs} of the jar files to attach to the jobgraph.
+	 * @throws RuntimeException if a jar URL is not valid.
+	 */
+	public void addJars(final List<URL> jarFilesToAttach) {
+		for (URL jar : jarFilesToAttach) {
+			try {
+				addJar(new Path(jar.toURI()));
+			} catch (URISyntaxException e) {
+				throw new RuntimeException("URL is invalid. This should not happen.", e);
+			}
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamContextEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamContextEnvironment.java
@@ -51,7 +51,7 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
 				ctx.getClient().getFlinkConfiguration(),
 				getParallelism());
 
-		ClientUtils.addJarFiles(jobGraph, ctx.getJars());
+		jobGraph.addJars(ctx.getJars());
 		jobGraph.setClasspaths(ctx.getClasspaths());
 
 		// running from the CLI will override the savepoint restore settings

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.api.java.ExecutionEnvironment;
-import org.apache.flink.client.ClientUtils;
 import org.apache.flink.client.FlinkPipelineTranslationUtil;
 import org.apache.flink.client.cli.CliArgsException;
 import org.apache.flink.client.cli.CustomCommandLine;
@@ -488,7 +487,7 @@ public class ExecutionContext<ClusterID> {
 					flinkConfig,
 					parallelism);
 
-			ClientUtils.addJarFiles(jobGraph, dependencies);
+			jobGraph.addJars(dependencies);
 			jobGraph.setClasspaths(executionParameters.getClasspaths());
 			jobGraph.setSavepointRestoreSettings(executionParameters.getSavepointRestoreSettings());
 


### PR DESCRIPTION
## What is the purpose of the change

Currently, the PackagedProgram has methods that allow the "flattening" of the job jar, in case it contains other jars. This issue will allow to put the list of URLs in the configuration directly and independently from the PackagedProgram, so that then they can be picked up by the Executors.

## Verifying this change

This change is already covered by existing tests and it should also be tested during execution of the end-to-end tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
