### PR TITLE
[FLINK-14761][sql-client] Fix ProgramDeployer#deployJobOnNewCluster potentially leak cluster

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ProgramDeployer.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ProgramDeployer.java
@@ -115,8 +115,7 @@ public class ProgramDeployer<C> implements Runnable {
 			ClassLoader classLoader) throws Exception {
 		ClusterClient<T> clusterClient = null;
 		try {
-			// deploy job cluster with job attached
-			clusterClient = clusterDescriptor.deployJobCluster(context.getClusterSpec(), jobGraph, false);
+			clusterClient = clusterDescriptor.deployJobCluster(context.getClusterSpec(), jobGraph, !awaitJobResult);
 			// save information about the new cluster
 			result.setClusterInformation(clusterClient.getClusterId(), clusterClient.getWebInterfaceURL());
 			// get result


### PR DESCRIPTION
## What is the purpose of the change

Currently `ProgramDeployer#deployJobOnNewCluster` always deploys cluster in attached mode. If `awaitJobResult == false` the cluster won't be closed because `Dispatcher` wait for delivering the result.


## Brief change log

- decide detach/attach based on whether or not `awaitJobResult`.
- clean up code path.


## Verifying this change

I think we lost test coverage on this module. Could it be a follow up we generally add a test suite?

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
