### PR TITLE
[FLINK-14743][table-blink] Optimize BaseRowSerializer to use Projection instead of switch

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ProjectionCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ProjectionCodeGenerator.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.codegen
 
+import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.dataformat._
 import org.apache.flink.table.planner.codegen.CodeGenUtils._
 import org.apache.flink.table.planner.codegen.GenerateUtils.generateRecordStatement
@@ -211,4 +212,18 @@ object ProjectionCodeGenerator {
       inputMapping: Array[Int]): GeneratedProjection =
     generateProjection(
       ctx, name, inputType, outputType, inputMapping, inputTerm = DEFAULT_INPUT1_TERM)
+
+  /**
+    * For java reflection invoke.
+    */
+  def generateProjection(
+      name: String,
+      inputType: RowType,
+      inputMapping: Array[Int]): GeneratedProjection = {
+    val ctx = CodeGeneratorContext.apply(new TableConfig)
+    val outputType = RowType.of(
+      inputMapping.map(inputType.getChildren.get),
+      inputMapping.map(inputType.getFieldNames.get))
+    generateProjection(ctx, name, inputType, outputType, inputMapping)
+  }
 }


### PR DESCRIPTION

## What is the purpose of the change

In BaseRowSerializer, we use `BinaryWriter.write` and `TypeGetterSetters.get` to convert BaseRow to BinaryRow. However, they use switch to select type to invoke specific method. This will cause a lot of branch prediction errors for CPU. Results in low performance.

## Brief change log

Use ProjectionCodeGenerator to code generate these logical.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no