### PR TITLE
[FLINK-14481]Modify the Flink valid socket port check to 0 to 65535.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/NetUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/NetUtils.java
@@ -432,7 +432,7 @@ public class NetUtils {
 	}
 
 	/**
-	 * Check whether the given port is in right range when connecting to somewhere
+	 * Check whether the given port is in right range when connecting to somewhere.
 	 *
 	 * @param port the port to check
 	 * @return true if the number in the range 1 to 65535
@@ -442,7 +442,7 @@ public class NetUtils {
 	}
 
 	/**
-	 * check whether the given port is in right range when getting port from local system
+	 * check whether the given port is in right range when getting port from local system.
 	 *
 	 * @param port the port to check
 	 * @return true if the number in the range 0 to 65535

--- a/flink-core/src/main/java/org/apache/flink/util/NetUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/NetUtils.java
@@ -190,7 +190,7 @@ public class NetUtils {
 	 * @return host:port where host will be normalized if it is an IPv6 address
 	 */
 	public static String unresolvedHostAndPortToNormalizedString(String host, int port) {
-		Preconditions.checkArgument(port >= 0 && port < 65536,
+		Preconditions.checkArgument(isValidHostPort(port),
 			"Port is not within the valid range,");
 		return unresolvedHostToNormalizedString(host) + ":" + port;
 	}
@@ -350,7 +350,7 @@ public class NetUtils {
 			if (dashIdx == -1) {
 				// only one port in range:
 				final int port = Integer.valueOf(range);
-				if (port < 0 || port > 65535) {
+				if (!isValidHostPort(port)) {
 					throw new IllegalConfigurationException("Invalid port configuration. Port must be between 0" +
 						"and 65535, but was " + port + ".");
 				}
@@ -358,12 +358,12 @@ public class NetUtils {
 			} else {
 				// evaluate range
 				final int start = Integer.valueOf(range.substring(0, dashIdx));
-				if (start < 0 || start > 65535) {
+				if (!isValidHostPort(start)) {
 					throw new IllegalConfigurationException("Invalid port configuration. Port must be between 0" +
 						"and 65535, but was " + start + ".");
 				}
 				final int end = Integer.valueOf(range.substring(dashIdx + 1, range.length()));
-				if (end < 0 || end > 65535) {
+				if (!isValidHostPort(end)) {
 					throw new IllegalConfigurationException("Invalid port configuration. Port must be between 0" +
 						"and 65535, but was " + end + ".");
 				}
@@ -429,5 +429,25 @@ public class NetUtils {
 	@FunctionalInterface
 	public interface SocketFactory {
 		ServerSocket createSocket(int port) throws IOException;
+	}
+
+	/**
+	 * Check whether the given port is in right range when connecting to somewhere
+	 *
+	 * @param port the port to check
+	 * @return true if the number in the range 1 to 65535
+	 */
+	public static boolean isValidClientPort(int port) {
+		return 1 <= port && port <= 65535;
+	}
+
+	/**
+	 * check whether the given port is in right range when getting port from local system
+	 *
+	 * @param port the port to check
+	 * @return true if the number in the range 0 to 65535
+	 */
+	public static boolean isValidHostPort(int port) {
+		return 0 <= port && port <= 65535;
 	}
 }

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDeserializationSchema.java
@@ -147,7 +147,7 @@ public class JsonRowDeserializationSchema implements DeserializationSchema<Row> 
 	/**
 	 * Builder for {@link JsonRowDeserializationSchema}.
 	 */
-	public static class  Builder {
+	public static class Builder {
 
 		private final RowTypeInfo typeInfo;
 		private boolean failOnMissingField = false;

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDeserializationSchema.java
@@ -147,7 +147,7 @@ public class JsonRowDeserializationSchema implements DeserializationSchema<Row> 
 	/**
 	 * Builder for {@link JsonRowDeserializationSchema}.
 	 */
-	public static class Builder {
+	public static class  Builder {
 
 		private final RowTypeInfo typeInfo;
 		private boolean failOnMissingField = false;

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
@@ -28,6 +28,7 @@ import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.Scheduled;
 
 import okhttp3.OkHttpClient;
+import org.apache.flink.util.NetUtils;
 import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDBFactory;
 import org.influxdb.dto.BatchPoints;
@@ -68,7 +69,7 @@ public class InfluxdbReporter extends AbstractReporter<MeasurementInfo> implemen
 	public void open(MetricConfig config) {
 		String host = getString(config, HOST);
 		int port = getInteger(config, PORT);
-		if (!isValidHost(host) || !isValidPort(port)) {
+		if (!isValidHost(host) || !NetUtils.isValidClientPort(port)) {
 			throw new IllegalArgumentException("Invalid host/port configuration. Host: " + host + " Port: " + port);
 		}
 		String database = getString(config, DB);
@@ -147,7 +148,4 @@ public class InfluxdbReporter extends AbstractReporter<MeasurementInfo> implemen
 		return host != null && !host.isEmpty();
 	}
 
-	private static boolean isValidPort(int port) {
-		return 0 <= port && port <= 65535;
-	}
 }

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
@@ -148,6 +148,6 @@ public class InfluxdbReporter extends AbstractReporter<MeasurementInfo> implemen
 	}
 
 	private static boolean isValidPort(int port) {
-		return 0 < port && port <= 65535;
+		return 0 <= port && port <= 65535;
 	}
 }

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
@@ -26,9 +26,9 @@ import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.Scheduled;
+import org.apache.flink.util.NetUtils;
 
 import okhttp3.OkHttpClient;
-import org.apache.flink.util.NetUtils;
 import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDBFactory;
 import org.influxdb.dto.BatchPoints;

--- a/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/client/QueryableStateClient.java
+++ b/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/client/QueryableStateClient.java
@@ -47,6 +47,7 @@ import org.apache.flink.queryablestate.network.Client;
 import org.apache.flink.queryablestate.network.messages.MessageSerializer;
 import org.apache.flink.queryablestate.network.stats.DisabledKvStateRequestStats;
 import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -120,8 +121,8 @@ public class QueryableStateClient {
 	 * @param remotePort the port of the proxy to connect to.
 	 */
 	public QueryableStateClient(final InetAddress remoteAddress, final int remotePort) {
-		Preconditions.checkArgument(remotePort >= 0 && remotePort <= 65535,
-				"Remote Port " + remotePort + " is out of valid port range (0-65536).");
+		Preconditions.checkArgument(NetUtils.isValidHostPort(remotePort),
+				"Remote Port " + remotePort + " is out of valid port range [0-65535].");
 
 		this.remoteAddress = new InetSocketAddress(remoteAddress, remotePort);
 

--- a/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/client/QueryableStateClient.java
+++ b/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/client/QueryableStateClient.java
@@ -120,7 +120,7 @@ public class QueryableStateClient {
 	 * @param remotePort the port of the proxy to connect to.
 	 */
 	public QueryableStateClient(final InetAddress remoteAddress, final int remotePort) {
-		Preconditions.checkArgument(remotePort >= 0 && remotePort <= 65536,
+		Preconditions.checkArgument(remotePort >= 0 && remotePort <= 65535,
 				"Remote Port " + remotePort + " is out of valid port range (0-65536).");
 
 		this.remoteAddress = new InetSocketAddress(remoteAddress, remotePort);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.runtime.net.SSLUtils;
 
+import org.apache.flink.util.NetUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,7 +64,7 @@ public class NettyConfig {
 
 		this.serverAddress = checkNotNull(serverAddress);
 
-		checkArgument(serverPort >= 0 && serverPort <= 65535, "Invalid port number.");
+		checkArgument(NetUtils.isValidHostPort(serverPort), "Invalid port number.");
 		this.serverPort = serverPort;
 
 		checkArgument(memorySegmentSize > 0, "Invalid memory segment size.");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -229,7 +229,7 @@ public class RestClient implements AutoCloseableAsync {
 			Collection<FileUpload> fileUploads,
 			RestAPIVersion apiVersion) throws IOException {
 		Preconditions.checkNotNull(targetAddress);
-		Preconditions.checkArgument(0 <= targetPort && targetPort < 65536, "The target port " + targetPort + " is not in the range (0, 65536].");
+		Preconditions.checkArgument(0 <= targetPort && targetPort < 65536, "The target port " + targetPort + " is not in the range [0, 65536).");
 		Preconditions.checkNotNull(messageHeaders);
 		Preconditions.checkNotNull(request);
 		Preconditions.checkNotNull(messageParameters);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -229,7 +229,7 @@ public class RestClient implements AutoCloseableAsync {
 			Collection<FileUpload> fileUploads,
 			RestAPIVersion apiVersion) throws IOException {
 		Preconditions.checkNotNull(targetAddress);
-		Preconditions.checkArgument(0 <= targetPort && targetPort < 65536, "The target port " + targetPort + " is not in the range [0, 65536).");
+		Preconditions.checkArgument(0 <= targetPort && targetPort <= 65535, "The target port " + targetPort + " is not in the range [0, 65535].");
 		Preconditions.checkNotNull(messageHeaders);
 		Preconditions.checkNotNull(request);
 		Preconditions.checkNotNull(messageParameters);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.rest.versioning.RestAPIVersion;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
 import org.apache.flink.util.AutoCloseableAsync;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
@@ -229,7 +230,7 @@ public class RestClient implements AutoCloseableAsync {
 			Collection<FileUpload> fileUploads,
 			RestAPIVersion apiVersion) throws IOException {
 		Preconditions.checkNotNull(targetAddress);
-		Preconditions.checkArgument(0 <= targetPort && targetPort <= 65535, "The target port " + targetPort + " is not in the range [0, 65535].");
+		Preconditions.checkArgument(NetUtils.isValidHostPort(targetPort), "The target port " + targetPort + " is not in the range [0, 65535].");
 		Preconditions.checkNotNull(messageHeaders);
 		Preconditions.checkNotNull(request);
 		Preconditions.checkNotNull(messageParameters);


### PR DESCRIPTION

## What is the purpose of the change

Modify the Filnk valid socket port check to 0 to 65535

## Brief change log

InfluxdbReporter - include 0 port

QueryableStateClient - exclude 65536 port

RestClient - correct exception error message

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (don't know)
  - The runtime per-record code paths (performance sensitive): (ydon't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (don't know)
  - The S3 file system connector: (don't know)

## Documentation

  - Does this pull request introduce a new feature? (no)
