### PR TITLE
[FLINK-14762][client] Implement ClusterClientJobClientAdapter

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.client;
 
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobSubmissionResult;
+import org.apache.flink.client.job.JobClient;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.ContextEnvironment;
 import org.apache.flink.client.program.ContextEnvironmentFactory;
@@ -110,7 +111,7 @@ public enum ClientUtils {
 		try {
 			return client
 				.submitJob(jobGraph)
-				.thenApply(JobSubmissionResult::getJobID)
+				.thenApply(JobClient::getJobID)
 				.thenApply(DetachedJobExecutionResult::new)
 				.get();
 		} catch (InterruptedException | ExecutionException e) {
@@ -132,8 +133,7 @@ public enum ClientUtils {
 		try {
 			jobResult = client
 				.submitJob(jobGraph)
-				.thenApply(JobSubmissionResult::getJobID)
-				.thenCompose(client::requestJobResult)
+				.thenCompose(JobClient::requestJobResult)
 				.get();
 		} catch (InterruptedException | ExecutionException e) {
 			ExceptionUtils.checkInterrupted(e);

--- a/flink-clients/src/main/java/org/apache/flink/client/job/ClusterClientJobClientAdapter.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/job/ClusterClientJobClientAdapter.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.job;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.util.OptionalFailure;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * ClusterClientJobClientAdapter.
+ */
+public class ClusterClientJobClientAdapter implements JobClient {
+
+	private final JobID jobID;
+	private final ClusterClient<?> client;
+	private final boolean shared;
+
+	public ClusterClientJobClientAdapter(JobID jobID, ClusterClient<?> client, boolean shared) {
+		this.jobID = jobID;
+		this.client = client;
+		this.shared = shared;
+	}
+
+	@Override
+	public JobID getJobID() {
+		return jobID;
+	}
+
+	@Override
+	public CompletableFuture<JobStatus> getJobStatus() {
+		return client.getJobStatus(jobID);
+	}
+
+	@Override
+	public CompletableFuture<JobResult> requestJobResult() {
+		return client.requestJobResult(jobID);
+	}
+
+	@Override
+	public CompletableFuture<Map<String, OptionalFailure<Object>>> getAccumulators(ClassLoader loader) {
+		return client.getAccumulators(jobID, loader);
+	}
+
+	@Override
+	public CompletableFuture<Acknowledge> cancel() {
+		return client.cancel(jobID);
+	}
+
+	@Override
+	public CompletableFuture<String> stopWithSavepoint(boolean advanceToEndOfEventTime, @Nullable String savepointDirectory) {
+		return client.stopWithSavepoint(jobID, advanceToEndOfEventTime, savepointDirectory);
+	}
+
+	@Override
+	public CompletableFuture<String> triggerSavepoint(@Nullable String savepointDirectory) {
+		return client.triggerSavepoint(jobID, savepointDirectory);
+	}
+
+	@Override
+	public void close() throws Exception {
+		if (!shared) {
+			client.close();
+		}
+	}
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/job/JobClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/job/JobClient.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.job;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.util.OptionalFailure;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * JobClient.
+ */
+public interface JobClient extends AutoCloseable {
+
+	JobID getJobID();
+
+	CompletableFuture<JobStatus> getJobStatus();
+
+	CompletableFuture<JobResult> requestJobResult();
+
+	CompletableFuture<Map<String, OptionalFailure<Object>>> getAccumulators(ClassLoader loader);
+
+	CompletableFuture<Acknowledge> cancel();
+
+	CompletableFuture<String> stopWithSavepoint(boolean advanceToEndOfEventTime, @Nullable String savepointDirectory);
+
+	CompletableFuture<String> triggerSavepoint(@Nullable String savepointDirectory);
+
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -20,6 +20,7 @@ package org.apache.flink.client.program;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobSubmissionResult;
+import org.apache.flink.client.job.JobClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -96,7 +97,7 @@ public interface ClusterClient<T> extends AutoCloseable {
 	 * @param jobGraph to submit
 	 * @return Future which is completed with the {@link JobSubmissionResult}
 	 */
-	CompletableFuture<JobSubmissionResult> submitJob(@Nonnull JobGraph jobGraph);
+	CompletableFuture<JobClient> submitJob(@Nonnull JobGraph jobGraph);
 
 	/**
 	 * Requests the {@link JobStatus} of the job with the given {@link JobID}.
@@ -167,7 +168,6 @@ public interface ClusterClient<T> extends AutoCloseable {
 	 * @param jobId job id
 	 * @param savepointDirectory directory the savepoint should be written to
 	 * @return path future where the savepoint is located
-	 * @throws FlinkException if no connection to the cluster could be established
 	 */
-	CompletableFuture<String> triggerSavepoint(JobID jobId, @Nullable String savepointDirectory) throws FlinkException;
+	CompletableFuture<String> triggerSavepoint(JobID jobId, @Nullable String savepointDirectory);
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -19,7 +19,8 @@
 package org.apache.flink.client.program;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.JobSubmissionResult;
+import org.apache.flink.client.job.ClusterClientJobClientAdapter;
+import org.apache.flink.client.job.JobClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
@@ -66,8 +67,10 @@ public class MiniClusterClient implements ClusterClient<MiniClusterClient.MiniCl
 	}
 
 	@Override
-	public CompletableFuture<JobSubmissionResult> submitJob(@Nonnull JobGraph jobGraph) {
-		return miniCluster.submitJob(jobGraph);
+	public CompletableFuture<JobClient> submitJob(@Nonnull JobGraph jobGraph) {
+		return miniCluster
+			.submitJob(jobGraph)
+			.thenApply(r -> new ClusterClientJobClientAdapter(r.getJobID(), this, true));
 	}
 
 	@Override

--- a/flink-clients/src/test/java/org/apache/flink/client/program/TestingClusterClient.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/TestingClusterClient.java
@@ -19,7 +19,7 @@
 package org.apache.flink.client.program;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.JobSubmissionResult;
+import org.apache.flink.client.job.JobClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -95,7 +95,7 @@ public class TestingClusterClient<T> implements ClusterClient<T> {
 	}
 
 	@Override
-	public CompletableFuture<JobSubmissionResult> submitJob(@Nonnull JobGraph jobGraph) {
+	public CompletableFuture<JobClient> submitJob(@Nonnull JobGraph jobGraph) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
@@ -20,8 +20,8 @@ package org.apache.flink.streaming.api.environment;
 
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.client.RemoteExecutor;
+import org.apache.flink.client.job.ClusterClientJobClientAdapter;
 import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;
@@ -68,7 +68,7 @@ public class RemoteStreamExecutionEnvironmentTest extends TestLogger {
 			.build();
 
 		RestClusterClient mockedClient = Mockito.mock(RestClusterClient.class);
-		when(mockedClient.submitJob(any())).thenReturn(CompletableFuture.completedFuture(new JobSubmissionResult(jobID)));
+		when(mockedClient.submitJob(any())).thenReturn(CompletableFuture.completedFuture(new ClusterClientJobClientAdapter(jobID, mockedClient, true)));
 		when(mockedClient.requestJobResult(any())).thenReturn(CompletableFuture.completedFuture(jobResult));
 
 		PowerMockito.whenNew(RestClusterClient.class).withAnyArguments().thenAnswer((invocation) -> {
@@ -106,7 +106,7 @@ public class RemoteStreamExecutionEnvironmentTest extends TestLogger {
 		RestClusterClient mockedClient = Mockito.mock(RestClusterClient.class);
 
 		PowerMockito.whenNew(RestClusterClient.class).withAnyArguments().thenReturn(mockedClient);
-		when(mockedClient.submitJob(any())).thenReturn(CompletableFuture.completedFuture(new JobSubmissionResult(jobID)));
+		when(mockedClient.submitJob(any())).thenReturn(CompletableFuture.completedFuture(new ClusterClientJobClientAdapter(jobID, mockedClient, true)));
 		when(mockedClient.requestJobResult(eq(jobID))).thenReturn(CompletableFuture.completedFuture(jobResult));
 
 		JobExecutionResult actualResult = env.execute("fakeJobName");

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
@@ -56,7 +56,6 @@ import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.testutils.junit.category.AlsoRunWithSchedulerNG;
 import org.apache.flink.util.Collector;
-import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.AfterClass;
@@ -463,13 +462,7 @@ public class RescalingITCase extends TestLogger {
 			StateSourceBase.workStartedLatch.await();
 
 			CompletableFuture<String> savepointPathFuture = FutureUtils.retryWithDelay(
-				() -> {
-					try {
-						return client.triggerSavepoint(jobID, null);
-					} catch (FlinkException e) {
-						return FutureUtils.completedExceptionally(e);
-					}
-				},
+				() -> client.triggerSavepoint(jobID, null),
 				(int) deadline.timeLeft().getSeconds() / 10,
 				Time.seconds(10),
 				(throwable) -> true,

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/FileBufferReaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/FileBufferReaderITCase.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.test.runtime;
 
-import org.apache.flink.api.common.JobSubmissionResult;
+import org.apache.flink.client.job.JobClient;
 import org.apache.flink.client.program.MiniClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
@@ -99,11 +99,11 @@ public class FileBufferReaderITCase extends TestLogger {
 
 			final MiniClusterClient client = new MiniClusterClient(configuration, miniCluster);
 			final JobGraph jobGraph = createJobGraph();
-			final CompletableFuture<JobSubmissionResult> submitFuture = client.submitJob(jobGraph);
+			final CompletableFuture<JobClient> submitFuture = client.submitJob(jobGraph);
 			// wait for the submission to succeed
-			final JobSubmissionResult result = submitFuture.get();
+			final JobClient jobClient = submitFuture.get();
 
-			final CompletableFuture<JobResult> resultFuture = client.requestJobResult(result.getJobID());
+			final CompletableFuture<JobResult> resultFuture = jobClient.requestJobResult();
 			final JobResult jobResult = resultFuture.get();
 
 			assertThat(jobResult.getSerializedThrowable().isPresent(), is(false));

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/SchedulingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/SchedulingITCase.java
@@ -19,8 +19,8 @@
 package org.apache.flink.test.runtime;
 
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.client.job.JobClient;
 import org.apache.flink.client.program.MiniClusterClient;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
@@ -118,12 +118,11 @@ public class SchedulingITCase extends TestLogger {
 			MiniClusterClient miniClusterClient = new MiniClusterClient(configuration, miniCluster);
 
 			JobGraph jobGraph = createJobGraph(slotIdleTimeout << 1, parallelism);
-			CompletableFuture<JobSubmissionResult> submissionFuture = miniClusterClient.submitJob(jobGraph);
 
 			// wait for the submission to succeed
-			JobSubmissionResult jobSubmissionResult = submissionFuture.get();
+			JobClient jobClient = miniClusterClient.submitJob(jobGraph).get();
 
-			CompletableFuture<JobResult> resultFuture = miniClusterClient.requestJobResult(jobSubmissionResult.getJobID());
+			CompletableFuture<JobResult> resultFuture = jobClient.requestJobResult();
 
 			JobResult jobResult = resultFuture.get();
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
@@ -19,10 +19,10 @@
 package org.apache.flink.yarn;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.client.deployment.ClusterDeploymentException;
 import org.apache.flink.client.deployment.ClusterSpecification;
+import org.apache.flink.client.job.JobClient;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
@@ -81,6 +81,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -300,12 +301,8 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
 		return (RestClusterClient<ApplicationId>) yarnClusterClient;
 	}
 
-	private JobID submitJob(RestClusterClient<ApplicationId> restClusterClient) throws InterruptedException, java.util.concurrent.ExecutionException {
-		final CompletableFuture<JobSubmissionResult> jobSubmissionResultCompletableFuture =
-			restClusterClient.submitJob(job);
-
-		final JobSubmissionResult jobSubmissionResult = jobSubmissionResultCompletableFuture.get();
-		return jobSubmissionResult.getJobID();
+	private JobID submitJob(RestClusterClient<ApplicationId> restClusterClient) throws InterruptedException, ExecutionException {
+		return restClusterClient.submitJob(job).thenApply(JobClient::getJobID).get();
 	}
 
 	private void killApplicationMaster(final String processName) throws IOException, InterruptedException {


### PR DESCRIPTION
## What is the purpose of the change

ClusterClientJobClientAdapter is a minimum viable prototype of JobClient interface. It adapts a ClusterClient as a JobClient which associates with the specific JobID.

## Brief change log

- Implement `ClusterClientJobClientAdapter`
- let `ClusterClient#submitJob` returns `CompletableFuture<JobClient>`

[ ] document
[ ] dedicate tests


## Verifying this change

- adjust several tests for using JobClient as the return value of `ClusterClient#submitJob`
[ ] dedicate tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes, new experimental interface JobClient)
  - If yes, how is the feature documented? (JavaDocs)

