### PR TITLE
[FLINK-13938][yarn] Enable configure shared libraries on YARN

### DIFF
--- a/docs/_includes/generated/readable_configuration.html
+++ b/docs/_includes/generated/readable_configuration.html
@@ -1,0 +1,11 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+    </tbody>
+</table>

--- a/docs/_includes/generated/writable_configuration.html
+++ b/docs/_includes/generated/writable_configuration.html
@@ -1,0 +1,11 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+    </tbody>
+</table>

--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -103,6 +103,11 @@
             <td>When a Flink job is submitted to YARN, the JobManager’s host and the number of available processing slots is written into a properties file, so that the Flink client is able to pick those details up. This configuration parameter allows changing the default location of that file (for example for environments sharing a Flink installation between users).</td>
         </tr>
         <tr>
+            <td><h5>yarn.shared-libraries</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>specify the path to use public visibility feature of YARN NodeManager localizing resources.</td>
+        </tr>
+        <tr>
             <td><h5>yarn.ship-directories</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>A semicolon-separated list of directories to be shipped to the YARN cluster.</td>

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -239,7 +239,7 @@ public final class Utils {
 	 *
 	 * @return YARN resource
 	 */
-	private static LocalResource registerLocalResource(
+	static LocalResource registerLocalResource(
 			Path remoteRsrcPath,
 			long resourceSize,
 			long resourceModificationTime) {
@@ -252,14 +252,18 @@ public final class Utils {
 		return localResource;
 	}
 
-	private static LocalResource registerLocalResource(FileSystem fs, Path remoteRsrcPath) throws IOException {
+	static LocalResource registerLocalResource(FileSystem fs, Path remoteRsrcPath) throws IOException {
+		return registerLocalResource(fs, remoteRsrcPath, LocalResourceVisibility.APPLICATION);
+	}
+
+	static LocalResource registerLocalResource(FileSystem fs, Path remoteRsrcPath, LocalResourceVisibility localResourceVisibility) throws IOException {
 		LocalResource localResource = Records.newRecord(LocalResource.class);
 		FileStatus jarStat = fs.getFileStatus(remoteRsrcPath);
 		localResource.setResource(ConverterUtils.getYarnUrlFromURI(remoteRsrcPath.toUri()));
 		localResource.setSize(jarStat.getLen());
 		localResource.setTimestamp(jarStat.getModificationTime());
 		localResource.setType(LocalResourceType.FILE);
-		localResource.setVisibility(LocalResourceVisibility.APPLICATION);
+		localResource.setVisibility(localResourceVisibility);
 		return localResource;
 	}
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -215,6 +215,14 @@ public class YarnConfigOptions {
 				.noDefaultValue()
 				.withDescription("A semicolon-separated list of directories to be shipped to the YARN cluster.");
 
+	public static final ConfigOption<List<String>> SHARED_LIBRARIES =
+			key("yarn.shared-libraries")
+				.stringType()
+				.asList()
+				.noDefaultValue()
+				.withDescription("specify the path to use public visibility feature of " +
+					"YARN NodeManager localizing resources.");
+
 	public static final ConfigOption<String> FLINK_DIST_JAR =
 			key("yarn.flink-dist-jar")
 				.stringType()


### PR DESCRIPTION
## What is the purpose of the change

Enable configure shared libraries on YARN. See also https://issues.apache.org/jira/browse/FLINK-13938

## Brief change log

- Add command-line option `-ysl` `--yarnsharedLibs` and config option `yarn.shared-libraries`
- respect options

## Verifying this change

I am looking for adding a test case but it seems hard without a real HDFS env. Maybe e2e tests required. But one can still verify it manually.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes, enable configure shared libs on YARN)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

cc @wangyang0918 