### PR TITLE
[FLINK-14104][build] Pin jackson version to 2.10.1

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch2/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch2/src/main/resources/META-INF/NOTICE
@@ -7,7 +7,7 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.carrotsearch:hppc:0.7.1
-- com.fasterxml.jackson.core:jackson-core:2.6.6
+- com.fasterxml.jackson.core:jackson-core:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.6.6
 - com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.6.6
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.6.6

--- a/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
@@ -7,7 +7,7 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.carrotsearch:hppc:0.7.1
-- com.fasterxml.jackson.core:jackson-core:2.8.1
+- com.fasterxml.jackson.core:jackson-core:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.8.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.1

--- a/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-core:2.8.10
+- com.fasterxml.jackson.core:jackson-core:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.8.10
 - com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.10
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.10

--- a/flink-connectors/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-core:2.8.11
+- com.fasterxml.jackson.core:jackson-core:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.8.11
 - com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.11
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.11

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -6,9 +6,9 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.7.0
-- com.fasterxml.jackson.core:jackson-core:2.7.8
-- com.fasterxml.jackson.core:jackson-databind:2.7.8
+- com.fasterxml.jackson.core:jackson-annotations:2.10.1
+- com.fasterxml.jackson.core:jackson-core:2.10.1
+- com.fasterxml.jackson.core:jackson-databind:2.10.1
 - com.google.guava:guava:11.0.2
 - com.microsoft.azure:azure-keyvault-core:0.8.0
 - com.microsoft.azure:azure-storage:5.4.0

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -18,9 +18,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-logging:commons-logging:1.1.3
 - commons-beanutils:commons-beanutils:1.9.3
 - com.google.guava:guava:11.0.2
-- com.fasterxml.jackson.core:jackson-annotations:2.7.0
-- com.fasterxml.jackson.core:jackson-core:2.7.8
-- com.fasterxml.jackson.core:jackson-databind:2.7.8
+- com.fasterxml.jackson.core:jackson-annotations:2.10.1
+- com.fasterxml.jackson.core:jackson-core:2.10.1
+- com.fasterxml.jackson.core:jackson-databind:2.10.1
 - com.fasterxml.woodstox:woodstox-core:5.0.3
 
 This project bundles the following dependencies under the Go License (https://golang.org/LICENSE).

--- a/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -11,9 +11,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.aliyun:aliyun-java-sdk-ecs:4.2.0
 - com.aliyun:aliyun-java-sdk-ram:3.0.0
 - com.aliyun:aliyun-java-sdk-sts:3.0.0
-- com.fasterxml.jackson.core:jackson-annotations:2.7.0
-- com.fasterxml.jackson.core:jackson-core:2.7.8
-- com.fasterxml.jackson.core:jackson-databind:2.7.8
+- com.fasterxml.jackson.core:jackson-annotations:2.10.1
+- com.fasterxml.jackson.core:jackson-core:2.10.1
+- com.fasterxml.jackson.core:jackson-databind:2.10.1
 - com.fasterxml.woodstox:woodstox-core:5.0.3
 - com.github.stephenc.jcip:jcip-annotations:1.0-1
 - com.google.code.gson:gson:2.2.4

--- a/flink-filesystems/flink-s3-fs-base/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-base/src/main/resources/META-INF/NOTICE
@@ -17,8 +17,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.amazonaws:aws-java-sdk-s3:1.11.271
 - com.amazonaws:jmespath-java:1.11.271
 - software.amazon.ion:ion-java:1.0.2
-- com.fasterxml.jackson.core:jackson-annotations:2.6.0
-- com.fasterxml.jackson.core:jackson-core:2.6.7
-- com.fasterxml.jackson.core:jackson-databind:2.6.7.1
+- com.fasterxml.jackson.core:jackson-annotations:2.10.1
+- com.fasterxml.jackson.core:jackson-core:2.10.1
+- com.fasterxml.jackson.core:jackson-databind:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.6.7
 - joda-time:joda-time:2.5

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -14,9 +14,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.airlift:stats:0.153
 - io.airlift:units:1.0
 - io.airlift:slice:0.31
-- com.fasterxml.jackson.core:jackson-annotations:2.8.1
-- com.fasterxml.jackson.core:jackson-core:2.8.1
-- com.fasterxml.jackson.core:jackson-databind:2.8.1
+- com.fasterxml.jackson.core:jackson-annotations:2.10.1
+- com.fasterxml.jackson.core:jackson-core:2.10.1
+- com.fasterxml.jackson.core:jackson-databind:2.10.1
 - joda-time:joda-time:2.5
 - org.weakref:jmxutils:1.19
 

--- a/flink-formats/flink-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -7,9 +7,9 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt) 
 
 - com.101tec:zkclient:0.10
-- com.fasterxml.jackson.core:jackson-databind:2.8.4
-- com.fasterxml.jackson.core:jackson-annotations:2.8.0
-- com.fasterxml.jackson.core:jackson-core:2.8.4
+- com.fasterxml.jackson.core:jackson-databind:2.10.1
+- com.fasterxml.jackson.core:jackson-annotations:2.10.1
+- com.fasterxml.jackson.core:jackson-core:2.10.1
 - io.confluent:common-utils:3.3.1
 - io.confluent:kafka-schema-registry-client:3.3.1
 - org.apache.zookeeper:zookeeper:3.4.10

--- a/flink-mesos/src/main/resources/META-INF/NOTICE
+++ b/flink-mesos/src/main/resources/META-INF/NOTICE
@@ -8,9 +8,9 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - com.netflix.fenzo:fenzo-core:0.10.1
 - org.apache.mesos:mesos:1.0.1
-- com.fasterxml.jackson.core:jackson-annotations:2.4.0
-- com.fasterxml.jackson.core:jackson-core:2.4.5
-- com.fasterxml.jackson.core:jackson-databind:2.4.5
+- com.fasterxml.jackson.core:jackson-annotations:2.10.1
+- com.fasterxml.jackson.core:jackson-core:2.10.1
+- com.fasterxml.jackson.core:jackson-databind:2.10.1
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.

--- a/flink-metrics/flink-metrics-influxdb/pom.xml
+++ b/flink-metrics/flink-metrics-influxdb/pom.xml
@@ -102,21 +102,6 @@ under the License.
 				<artifactId>okio</artifactId>
 				<version>1.14.0</version>
 			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-annotations</artifactId>
-				<version>2.8.11</version>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-databind</artifactId>
-				<version>2.8.11.2</version>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-core</artifactId>
-				<version>2.8.11</version>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -173,24 +173,6 @@ under the License.
 				<artifactId>protobuf-java</artifactId>
 				<version>${protoc.version}</version>
 			</dependency>
-
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-core</artifactId>
-				<version>2.9.9</version>
-			</dependency>
-
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-databind</artifactId>
-				<version>2.9.9</version>
-			</dependency>
-
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-annotations</artifactId>
-				<version>2.9.9</version>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -6,9 +6,9 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.9.9
-- com.fasterxml.jackson.core:jackson-core:2.9.9
-- com.fasterxml.jackson.core:jackson-databind:2.9.9
+- com.fasterxml.jackson.core:jackson-annotations:2.10.1
+- com.fasterxml.jackson.core:jackson-core:2.10.1
+- com.fasterxml.jackson.core:jackson-databind:2.10.1
 - com.google.api.grpc:proto-google-common-protos:1.12.0
 - com.google.code.gson:gson:2.7
 - com.google.guava:guava:26.0-jre

--- a/flink-table/flink-table-planner-blink/pom.xml
+++ b/flink-table/flink-table-planner-blink/pom.xml
@@ -59,22 +59,6 @@ under the License.
 				<artifactId>janino</artifactId>
 				<version>${janino.version}</version>
 			</dependency>
-			<!-- Common dependencies within calcite-core -->
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-annotations</artifactId>
-				<version>2.9.6</version>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-core</artifactId>
-				<version>2.9.6</version>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-databind</artifactId>
-				<version>2.9.6</version>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/flink-table/flink-table-planner-blink/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner-blink/src/main/resources/META-INF/NOTICE
@@ -7,9 +7,9 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.google.guava:guava:19.0
-- com.fasterxml.jackson.core:jackson-annotations:2.9.6
-- com.fasterxml.jackson.core:jackson-core:2.9.6
-- com.fasterxml.jackson.core:jackson-databind:2.9.6
+- com.fasterxml.jackson.core:jackson-annotations:2.10.1
+- com.fasterxml.jackson.core:jackson-core:2.10.1
+- com.fasterxml.jackson.core:jackson-databind:2.10.1
 - com.jayway.jsonpath:json-path:2.4.0
 - joda-time:joda-time:2.5
 - org.apache.calcite:calcite-core:1.21.0

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -68,11 +68,6 @@ under the License.
 				<artifactId>jackson-core</artifactId>
 				<version>2.9.6</version>
 			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-databind</artifactId>
-				<version>2.9.6</version>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
@@ -7,9 +7,9 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.google.guava:guava:19.0
-- com.fasterxml.jackson.core:jackson-annotations:2.9.6
-- com.fasterxml.jackson.core:jackson-core:2.9.6
-- com.fasterxml.jackson.core:jackson-databind:2.9.6
+- com.fasterxml.jackson.core:jackson-annotations:2.10.1
+- com.fasterxml.jackson.core:jackson-core:2.10.1
+- com.fasterxml.jackson.core:jackson-databind:2.10.1
 - com.jayway.jsonpath:json-path:2.4.0
 - joda-time:joda-time:2.5
 - org.apache.calcite:calcite-core:1.21.0

--- a/pom.xml
+++ b/pom.xml
@@ -383,6 +383,24 @@ under the License.
 				<version>1.1.3</version>
 			</dependency>
 
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-annotations</artifactId>
+				<version>2.10.1</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-databind</artifactId>
+				<version>2.10.1</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-core</artifactId>
+				<version>2.10.1</version>
+			</dependency>
+
 			<!-- For dependency convergence -->
 			<dependency>
 				<groupId>junit</groupId>


### PR DESCRIPTION
This PR bumps all jackson[core|databind|annotations] dependencies to 2.10.1, to eliminate a host of security vulnerabilities.

Reasonably green cron job: https://travis-ci.com/flink-ci/flink/builds/136347350