### PR TITLE
[FLINK-14749] Migrate duration and memory size ConfigOptions in JobManagerOptions

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
@@ -49,12 +49,12 @@ public class ConfigurationUtils {
 	 */
 	public static MemorySize getJobManagerHeapMemory(Configuration configuration) {
 		if (configuration.containsKey(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY.key())) {
-			return MemorySize.parse(configuration.getString(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY));
+			return configuration.get(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY);
 		} else if (configuration.containsKey(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY_MB.key())) {
-			return MemorySize.parse(configuration.getInteger(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY_MB) + "m");
+			return configuration.get(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY_MB);
 		} else {
 			//use default value
-			return MemorySize.parse(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY.defaultValue());
+			return JobManagerOptions.JOB_MANAGER_HEAP_MEMORY.defaultValue();
 		}
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -80,9 +80,10 @@ public class JobManagerOptions {
 	 * JVM heap size for the JobManager with memory size.
 	 */
 	@Documentation.CommonOption(position = Documentation.CommonOption.POSITION_MEMORY)
-	public static final ConfigOption<String> JOB_MANAGER_HEAP_MEMORY =
+	public static final ConfigOption<MemorySize> JOB_MANAGER_HEAP_MEMORY =
 		key("jobmanager.heap.size")
-		.defaultValue("1024m")
+		.memoryType()
+		.defaultValue(MemorySize.parse("1024m"))
 		.withDescription("JVM heap size for the JobManager.");
 
 	/**
@@ -90,9 +91,10 @@ public class JobManagerOptions {
 	 * @deprecated use {@link #JOB_MANAGER_HEAP_MEMORY}
 	 */
 	@Deprecated
-	public static final ConfigOption<Integer> JOB_MANAGER_HEAP_MEMORY_MB =
+	public static final ConfigOption<MemorySize> JOB_MANAGER_HEAP_MEMORY_MB =
 		key("jobmanager.heap.mb")
-		.defaultValue(1024)
+		.memoryType()
+		.defaultValue(MemorySize.parse("1024", MemorySize.MemoryUnit.MEGA_BYTES))
 		.withDescription("JVM heap size (in megabytes) for the JobManager.");
 
 	/**

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -368,7 +368,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 			if (!MemorySize.MemoryUnit.hasUnit(jmMemoryVal)) {
 				jmMemoryVal += "m";
 			}
-			effectiveConfiguration.setString(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, jmMemoryVal);
+			effectiveConfiguration.set(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, MemorySize.parse(jmMemoryVal));
 		}
 
 		if (commandLine.hasOption(tmMemory.getOpt())) {

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
@@ -325,7 +326,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 		final int taskManagerMemory = 7331;
 		final int slotsPerTaskManager = 30;
 
-		configuration.setString(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, jobManagerMemory + "m");
+		configuration.set(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, MemorySize.parse(jobManagerMemory + "m"));
 		configuration.setString(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY, taskManagerMemory + "m");
 		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, slotsPerTaskManager);
 
@@ -355,7 +356,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 	public void testConfigurationClusterSpecification() throws Exception {
 		final Configuration configuration = new Configuration();
 		final int jobManagerMemory = 1337;
-		configuration.setString(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, jobManagerMemory + "m");
+		configuration.set(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, MemorySize.parse(jobManagerMemory + "m"));
 		final int taskManagerMemory = 7331;
 		configuration.setString(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY, taskManagerMemory + "m");
 		final int slotsPerTaskManager = 42;
@@ -449,7 +450,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 	@Test
 	public void testHeapMemoryPropertyWithOldConfigKey() throws Exception {
 		Configuration configuration = new Configuration();
-		configuration.setInteger(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY_MB, 2048);
+		configuration.set(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY_MB, MemorySize.parse(2048 + "m"));
 		configuration.setInteger(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY_MB, 4096);
 
 		final FlinkYarnSessionCli flinkYarnSessionCli = new FlinkYarnSessionCli(


### PR DESCRIPTION
## What is the purpose of the change

*This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

  - *Migrate duration and memory size ConfigOptions in JobManagerOptions*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
