### PR TITLE
[FLINK-14758] Add Executor-related interfaces and executor discovery.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/execution/DefaultExecutorServiceLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/DefaultExecutorServiceLoader.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.execution;
+
+import org.apache.flink.configuration.Configuration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The default implementation of the {@link ExecutorServiceLoader}. This implementation uses
+ * Java service discovery to find the available {@link ExecutorFactory executor factories}.
+ */
+public class DefaultExecutorServiceLoader implements ExecutorServiceLoader {
+
+	// TODO: This code is almost identical to the ClusterClientServiceLoader and its default implementation.
+	// The reason of this duplication is the package structure which does not allow for the ExecutorServiceLoader
+	// to know about the ClusterClientServiceLoader. Remove duplication when package structure has improved.
+
+	private static final Logger LOG = LoggerFactory.getLogger(DefaultExecutorServiceLoader.class);
+
+	private static final ServiceLoader<ExecutorFactory> defaultLoader = ServiceLoader.load(ExecutorFactory.class);
+
+	@Override
+	public ExecutorFactory getExecutorFactory(final Configuration configuration) {
+		checkNotNull(configuration);
+
+		final List<ExecutorFactory> compatibleFactories = new ArrayList<>();
+		final Iterator<ExecutorFactory> factories = defaultLoader.iterator();
+		while (factories.hasNext()) {
+			try {
+				final ExecutorFactory factory = factories.next();
+				if (factory != null && factory.isCompatibleWith(configuration)) {
+					compatibleFactories.add(factory);
+				}
+			} catch (Throwable e) {
+				if (e.getCause() instanceof NoClassDefFoundError) {
+					LOG.info("Could not load factory due to missing dependencies.");
+				} else {
+					throw e;
+				}
+			}
+		}
+
+		if (compatibleFactories.size() > 1) {
+			final List<String> configStr =
+					configuration.toMap().entrySet().stream()
+							.map(e -> e.getKey() + "=" + e.getValue())
+							.collect(Collectors.toList());
+
+			throw new IllegalStateException("Multiple compatible client factories found for:\n" + String.join("\n", configStr) + ".");
+		}
+
+		return compatibleFactories.isEmpty() ? null : compatibleFactories.get(0);
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/core/execution/Executor.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/Executor.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.execution;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.dag.Pipeline;
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * The entity responsible for executing a {@link Pipeline}, i.e. a user job.
+ */
+public interface Executor {
+
+	/**
+	 * Executes a {@link Pipeline} based on the provided configuration.
+	 * @param pipeline the {@link Pipeline} to execute
+	 * @param executionConfig the {@link Configuration} with the required execution parameters
+	 * @return the {@link JobExecutionResult} corresponding to the pipeline execution.
+	 */
+	JobExecutionResult execute(Pipeline pipeline, Configuration executionConfig) throws Exception;
+}

--- a/flink-core/src/main/java/org/apache/flink/core/execution/ExecutorFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/ExecutorFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.execution;
+
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * A factory for selecting and instantiating the adequate {@link Executor}
+ * based on a provided {@link Configuration}.
+ */
+public interface ExecutorFactory {
+
+	/**
+	 * Returns {@code true} if this factory is compatible with the options in the
+	 * provided configuration, {@code false} otherwise.
+	 */
+	boolean isCompatibleWith(Configuration configuration);
+
+	/**
+	 * Instantiates an {@link Executor} compatible with the provided configuration.
+	 * @return the executor instance.
+	 */
+	Executor getExecutor(Configuration configuration);
+}

--- a/flink-core/src/main/java/org/apache/flink/core/execution/ExecutorServiceLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/ExecutorServiceLoader.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.execution;
+
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * An interface to be implemented by the entity responsible for finding the correct {@link Executor} to
+ * execute a given {@link org.apache.flink.api.dag.Pipeline}.
+ */
+public interface ExecutorServiceLoader {
+
+	/**
+	 * Loads the {@link ExecutorFactory} which is compatible with the provided configuration.
+	 * There can be at most one compatible factory among the available ones, otherwise an exception
+	 * will be thrown.
+	 *
+	 * @return a compatible {@link ExecutorFactory}.
+	 * @throws Exception if there is more than one compatible factories, or something went wrong when
+	 * 			loading the registered factories.
+	 */
+	ExecutorFactory getExecutorFactory(Configuration configuration) throws Exception;
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/ExecutorDiscoveryTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/ExecutorDiscoveryTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.core.execution.Executor;
+import org.apache.flink.core.execution.ExecutorFactory;
+import org.apache.flink.util.OptionalFailure;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+/**
+ * Tests the {@link ExecutorFactory} discovery in the {@link ExecutionEnvironment}.
+ */
+public class ExecutorDiscoveryTest {
+
+	@Test
+	public void correctExecutorShouldBeInstantiatedBasedOnConfigurationOption() throws Exception {
+		final Configuration configuration = new Configuration();
+		configuration.set(DeploymentOptions.TARGET, IDReportingExecutorFactory.ID);
+
+		final JobExecutionResult result = executeTestJobBasedOnConfig(configuration);
+
+		final String executorName = result.getAllAccumulatorResults().get(DeploymentOptions.TARGET.key()).toString();
+		assertThat(executorName, is(equalTo(IDReportingExecutorFactory.ID)));
+	}
+
+	private JobExecutionResult executeTestJobBasedOnConfig(final Configuration configuration) throws Exception {
+		final ExecutionEnvironment env = new ExecutionEnvironment(configuration);
+		env.fromCollection(Collections.singletonList(42))
+				.output(new DiscardingOutputFormat<>());
+		return env.execute();
+	}
+
+	/**
+	 * An {@link ExecutorFactory} that returns an {@link Executor} that instead of executing, it simply
+	 * returns its name in the {@link JobExecutionResult}.
+	 */
+	public static class IDReportingExecutorFactory implements ExecutorFactory {
+
+		public static final String ID = "test-executor-A";
+
+		@Override
+		public boolean isCompatibleWith(Configuration configuration) {
+			return ID.equals(configuration.get(DeploymentOptions.TARGET));
+		}
+
+		@Override
+		public Executor getExecutor(Configuration configuration) {
+			return (pipeline, executionConfig) -> {
+				final Map<String, OptionalFailure<Object>> res = new HashMap<>();
+				res.put(DeploymentOptions.TARGET.key(), OptionalFailure.of(ID));
+				return new JobExecutionResult(new JobID(), 12L, res);
+			};
+		}
+	}
+}

--- a/flink-java/src/test/resources/META-INF/services/org.apache.flink.core.execution.ExecutorFactory
+++ b/flink-java/src/test/resources/META-INF/services/org.apache.flink.core.execution.ExecutorFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.api.java.ExecutorDiscoveryTest$IDReportingExecutorFactory

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
@@ -64,10 +64,6 @@ public class LocalStreamEnvironment extends StreamExecutionEnvironment {
 		setParallelism(1);
 	}
 
-	protected Configuration getConfiguration() {
-		return configuration;
-	}
-
 	/**
 	 * Executes the JobGraph of the on a mini cluster of ClusterUtil with a user
 	 * specified name.

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/environment/ExecutorDiscoveryTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/environment/ExecutorDiscoveryTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.environment;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.core.execution.Executor;
+import org.apache.flink.core.execution.ExecutorFactory;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.util.OptionalFailure;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+/**
+ * Tests the {@link ExecutorFactory} discovery in the {@link StreamExecutionEnvironment}.
+ */
+public class ExecutorDiscoveryTest {
+
+	@Test
+	public void correctExecutorShouldBeInstantiatedBasedOnConfigurationOption() throws Exception {
+		final Configuration configuration = new Configuration();
+		configuration.set(DeploymentOptions.TARGET, IDReportingExecutorFactory.ID);
+
+		final JobExecutionResult result = executeTestJobBasedOnConfig(configuration);
+
+		final String executorName = result.getAllAccumulatorResults().get(DeploymentOptions.TARGET.key()).toString();
+		assertThat(executorName, is(equalTo(IDReportingExecutorFactory.ID)));
+	}
+
+	private JobExecutionResult executeTestJobBasedOnConfig(final Configuration configuration) throws Exception {
+		final StreamExecutionEnvironment env = new StreamExecutionEnvironment(configuration);
+		env.fromCollection(Collections.singletonList(42))
+				.addSink(new DiscardingSink<>());
+		return env.execute();
+	}
+
+	/**
+	 * An {@link ExecutorFactory} that returns an {@link Executor} that instead of executing, it simply
+	 * returns its name in the {@link JobExecutionResult}.
+	 */
+	public static class IDReportingExecutorFactory implements ExecutorFactory {
+
+		public static final String ID = "test-executor-A";
+
+		@Override
+		public boolean isCompatibleWith(Configuration configuration) {
+			return ID.equals(configuration.get(DeploymentOptions.TARGET));
+		}
+
+		@Override
+		public Executor getExecutor(Configuration configuration) {
+			return (pipeline, executionConfig) -> {
+				final Map<String, OptionalFailure<Object>> res = new HashMap<>();
+				res.put(DeploymentOptions.TARGET.key(), OptionalFailure.of(ID));
+				return new JobExecutionResult(new JobID(), 12L, res);
+			};
+		}
+	}
+}

--- a/flink-streaming-java/src/test/resources/META-INF/services/org.apache.flink.core.execution.ExecutorFactory
+++ b/flink-streaming-java/src/test/resources/META-INF/services/org.apache.flink.core.execution.ExecutorFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.streaming.environment.ExecutorDiscoveryTest$IDReportingExecutorFactory


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces the basic mechanisms for the `Executors` and [FLIP-73](https://cwiki.apache.org/confluence/display/FLINK/FLIP-73%3A+Introducing+Executors+for+job+submission). Namely the `Executor` interface, the `ExecutorFactory` and their discovery based on java service discovery. In addition, it wires the discovery to the `ExecutionEnvironment` and the `StreamExecutionEnvironment` but this has no effect, as the existing environments override the `execute()` method.

## Brief change log

Described above and in the referenced FLIP.

## Verifying this change

This change added tests and can be verified by running the two `ExecutorDiscoveryTest`s, one in `flink-java` and one in `flink-streaming-java`. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
