### PR TITLE
[FLINK-13995][legal] Properly exclude netty license directory

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch2/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch2/pom.xml
@@ -212,7 +212,7 @@ under the License.
 									<excludes>
 										<!-- Only some of these licenses actually apply to the JAR and have been manually
 										 	placed in this module's resources directory. -->
-										<exclude>META-INF/license</exclude>
+										<exclude>META-INF/license/**</exclude>
 										<!-- Only parts of NOTICE file actually apply to the netty JAR and have been manually
 										 	copied into this modules's NOTICE file. -->
 										<exclude>META-INF/NOTICE.txt</exclude>

--- a/flink-connectors/flink-connector-elasticsearch5/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch5/pom.xml
@@ -275,7 +275,7 @@ under the License.
 									<excludes>
 										<!-- Only some of these licenses actually apply to the JAR and have been manually
 										 	placed in this module's resources directory. -->
-										<exclude>META-INF/license</exclude>
+										<exclude>META-INF/license/**</exclude>
 										<!-- Only parts of NOTICE file actually apply to the netty JAR and have been manually
 										 	copied into this modules's NOTICE file. -->
 										<exclude>META-INF/NOTICE.txt</exclude>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -577,7 +577,7 @@ under the License.
 									<excludes>
 										<!-- Only some of these licenses actually apply to the JAR and have been manually
 										 	placed in this module's resources directory. -->
-										<exclude>META-INF/license</exclude>
+										<exclude>META-INF/license/**</exclude>
 										<!-- Only parts of NOTICE file actually apply to the netty JAR and have been manually
 										 	copied into this modules's NOTICE file. -->
 										<exclude>META-INF/NOTICE.txt</exclude>

--- a/flink-test-utils-parent/flink-test-utils/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils/pom.xml
@@ -150,7 +150,7 @@ under the License.
 										<exclude>META-INF/maven/io.netty/**</exclude>
 										<!-- Only some of these licenses actually apply to the JAR and have been manually
 										 	placed in this module's resources directory. -->
-										<exclude>META-INF/license</exclude>
+										<exclude>META-INF/license/**</exclude>
 										<!-- Only parts of NOTICE file actually apply to the netty JAR and have been manually
 										 	copied into this modules's NOTICE file. -->
 										<exclude>META-INF/NOTICE.txt</exclude>


### PR DESCRIPTION
Corrects the exclusion for netty's `license` directory. Currently the directory not being excluded as it should, since it includes a number of licenses that don't actually apply.