### PR TITLE
[FLINK-14789] [table-planner-blink] extends max/min type in ColumnStats from Number to Comparable

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/plan/stats/ColumnStats.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/plan/stats/ColumnStats.java
@@ -50,22 +50,22 @@ public final class ColumnStats {
 	private final Integer maxLen;
 
 	/**
-	 * max value of column values.
+	 * max value of column values, null for none-comparable type.
 	 */
-	private final Number max;
+	private final Comparable<?> max;
 
 	/**
-	 * min value of column values.
+	 * min value of column values, null for none-comparable type.
 	 */
-	private final Number min;
+	private final Comparable<?> min;
 
 	public ColumnStats(
 		Long ndv,
 		Long nullCount,
 		Double avgLen,
 		Integer maxLen,
-		Number max,
-		Number min) {
+		Comparable<?> max,
+		Comparable<?> min) {
 		this.ndv = ndv;
 		this.nullCount = nullCount;
 		this.avgLen = avgLen;
@@ -90,11 +90,11 @@ public final class ColumnStats {
 		return maxLen;
 	}
 
-	public Number getMaxValue() {
+	public Comparable<?> getMaxValue() {
 		return max;
 	}
 
-	public Number getMinValue() {
+	public Comparable<?> getMinValue() {
 		return min;
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/plan/stats/ColumnStats.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/plan/stats/ColumnStats.java
@@ -50,28 +50,72 @@ public final class ColumnStats {
 	private final Integer maxLen;
 
 	/**
-	 * max value of column values, null for none-comparable type.
+	 * Deprecated because not well supported comparable type,
+	 * e.g. {@link java.util.Date}, {@link java.sql.Timestamp}.
+	 */
+	@Deprecated
+	private final Number maxValue;
+
+	/**
+	 * max value of column values, null if the value is not comparable.
 	 */
 	private final Comparable<?> max;
 
 	/**
-	 * min value of column values, null for none-comparable type.
+	 * Deprecated because not well supported comparable type,
+	 * e.g. {@link java.util.Date}, {@link java.sql.Timestamp}.
+	 */
+	@Deprecated
+	private final Number minValue;
+
+	/**
+	 * min value of column values, null if the value is not comparable.
 	 */
 	private final Comparable<?> min;
 
+	/**
+	 * Deprecated because Number type max/min is not well supported comparable type,
+	 * e.g. {@link java.util.Date}, {@link java.sql.Timestamp}.
+	 *  please use {@link ColumnStats.Builder} to construct ColumnStats instance.
+	 */
+	@Deprecated
 	public ColumnStats(
-		Long ndv,
-		Long nullCount,
-		Double avgLen,
-		Integer maxLen,
-		Comparable<?> max,
-		Comparable<?> min) {
+			Long ndv,
+			Long nullCount,
+			Double avgLen,
+			Integer maxLen,
+			Number max,
+			Number min) {
+		this.ndv = ndv;
+		this.nullCount = nullCount;
+		this.avgLen = avgLen;
+		this.maxLen = maxLen;
+		this.maxValue = max;
+		this.minValue = min;
+		this.max = null;
+		this.min = null;
+	}
+
+	/**
+	 * Private because to avoid "cannot resolve constructor" error.
+	 * please use {@link ColumnStats.Builder} to construct ColumnStats instance.
+	 * could change to public if the deprecated constructor is removed in the future.
+	 */
+	private ColumnStats(
+			Long ndv,
+			Long nullCount,
+			Double avgLen,
+			Integer maxLen,
+			Comparable<?> max,
+			Comparable<?> min) {
 		this.ndv = ndv;
 		this.nullCount = nullCount;
 		this.avgLen = avgLen;
 		this.maxLen = maxLen;
 		this.max = max;
 		this.min = min;
+		this.maxValue = null;
+		this.minValue = null;
 	}
 
 	public Long getNdv() {
@@ -90,11 +134,41 @@ public final class ColumnStats {
 		return maxLen;
 	}
 
-	public Comparable<?> getMaxValue() {
+	/**
+	 * Deprecated because Number type max/min is not well supported comparable type,
+	 * e.g. {@link java.util.Date}, {@link java.sql.Timestamp}.
+	 *
+	 * <p>Returns null if this instance is constructed by {@link ColumnStats.Builder}.
+	 */
+	@Deprecated
+	public Number getMaxValue() {
+		return maxValue;
+	}
+
+	/**
+	 * Returns null if this instance is constructed by
+	 * {@link ColumnStats#ColumnStats(Long, Long, Double, Integer, Number, Number)}.
+	 */
+	public Comparable<?> getMax() {
 		return max;
 	}
 
-	public Comparable<?> getMinValue() {
+	/**
+	 * Deprecated because Number type max/min is not well supported comparable type,
+	 * e.g. {@link java.util.Date}, {@link java.sql.Timestamp}.
+	 *
+	 * <p>Returns null if this instance is constructed by {@link ColumnStats.Builder}.
+	 */
+	@Deprecated
+	public Number getMinValue() {
+		return minValue;
+	}
+
+	/**
+	 * Returns null if this instance is constructed by
+	 * {@link ColumnStats#ColumnStats(Long, Long, Double, Integer, Number, Number)}.
+	 */
+	public Comparable<?> getMin() {
 		return min;
 	}
 
@@ -115,8 +189,14 @@ public final class ColumnStats {
 		if (max != null) {
 			columnStats.add("max=" + max);
 		}
+		if (maxValue != null) {
+			columnStats.add("max=" + maxValue);
+		}
 		if (min != null) {
 			columnStats.add("min=" + min);
+		}
+		if (minValue != null) {
+			columnStats.add("min=" + minValue);
 		}
 		String columnStatsStr = String.join(", ", columnStats);
 		return "ColumnStats(" + columnStatsStr + ")";
@@ -124,11 +204,66 @@ public final class ColumnStats {
 
 	/**
 	 * Create a deep copy of "this" instance.
+	 *
 	 * @return a deep copy
 	 */
 	public ColumnStats copy() {
-		return new ColumnStats(this.ndv, this.nullCount, this.avgLen, this.maxLen,
-			this.max, this.min);
+		if (maxValue != null) {
+			return new ColumnStats(this.ndv, this.nullCount, this.avgLen, this.maxLen,
+					this.maxValue, this.minValue);
+		} else {
+			return new ColumnStats(this.ndv, this.nullCount, this.avgLen, this.maxLen,
+					this.max, this.min);
+		}
 	}
 
+	/**
+	 * ColumnStats builder.
+	 */
+	public static class Builder {
+		private Long ndv = null;
+		private Long nullCount = null;
+		private Double avgLen = null;
+		private Integer maxLen = null;
+		private Comparable<?> max;
+		private Comparable<?> min;
+
+		public static Builder builder() {
+			return new Builder();
+		}
+
+		public Builder setNdv(Long ndv) {
+			this.ndv = ndv;
+			return this;
+		}
+
+		public Builder setNullCount(Long nullCount) {
+			this.nullCount = nullCount;
+			return this;
+		}
+
+		public Builder setAvgLen(Double avgLen) {
+			this.avgLen = avgLen;
+			return this;
+		}
+
+		public Builder setMaxLen(Integer maxLen) {
+			this.maxLen = maxLen;
+			return this;
+		}
+
+		public Builder setMax(Comparable<?> max) {
+			this.max = max;
+			return this;
+		}
+
+		public Builder setMin(Comparable<?> min) {
+			this.min = min;
+			return this;
+		}
+
+		public ColumnStats build() {
+			return new ColumnStats(ndv, nullCount, avgLen, maxLen, max, min);
+		}
+	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/plan/stats/ColumnStats.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/plan/stats/ColumnStats.java
@@ -57,7 +57,7 @@ public final class ColumnStats {
 	private final Number maxValue;
 
 	/**
-	 * max value of column values, null if the value is not comparable.
+	 * max value of column values, null if the value is unknown or not comparable.
 	 */
 	private final Comparable<?> max;
 
@@ -69,7 +69,7 @@ public final class ColumnStats {
 	private final Number minValue;
 
 	/**
-	 * min value of column values, null if the value is not comparable.
+	 * min value of column values, null if the value is unknown or not comparable.
 	 */
 	private final Comparable<?> min;
 
@@ -208,7 +208,7 @@ public final class ColumnStats {
 	 * @return a deep copy
 	 */
 	public ColumnStats copy() {
-		if (maxValue != null) {
+		if (maxValue != null || minValue != null) {
 			return new ColumnStats(this.ndv, this.nullCount, this.avgLen, this.maxLen,
 					this.maxValue, this.minValue);
 		} else {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/util/CatalogTableStatisticsConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/util/CatalogTableStatisticsConverter.java
@@ -124,6 +124,14 @@ public class CatalogTableStatisticsConverter {
 			throw new TableException("Unsupported CatalogColumnStatisticsDataBase: " +
 					columnStatisticsData.getClass().getCanonicalName());
 		}
-		return new ColumnStats(ndv, nullCount, avgLen, maxLen, max, min);
+		return ColumnStats.Builder
+				.builder()
+				.setNdv(ndv)
+				.setNullCount(nullCount)
+				.setAvgLen(avgLen)
+				.setMaxLen(maxLen)
+				.setMax(max)
+				.setMin(min)
+				.build();
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/util/CatalogTableStatisticsConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/util/CatalogTableStatisticsConverter.java
@@ -31,6 +31,9 @@ import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
 import org.apache.flink.table.plan.stats.ColumnStats;
 import org.apache.flink.table.plan.stats.TableStats;
 
+import org.apache.calcite.avatica.util.DateTimeUtils;
+
+import java.sql.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -73,8 +76,8 @@ public class CatalogTableStatisticsConverter {
 		Long nullCount = columnStatisticsData.getNullCount();
 		Double avgLen = null;
 		Integer maxLen = null;
-		Number max = null;
-		Number min = null;
+		Comparable<?> max = null;
+		Comparable<?> min = null;
 		if (columnStatisticsData instanceof CatalogColumnStatisticsDataBoolean) {
 			CatalogColumnStatisticsDataBoolean booleanData = (CatalogColumnStatisticsDataBoolean) columnStatisticsData;
 			avgLen = 1.0;
@@ -111,6 +114,12 @@ public class CatalogTableStatisticsConverter {
 		} else if (columnStatisticsData instanceof CatalogColumnStatisticsDataDate) {
 			CatalogColumnStatisticsDataDate dateData = (CatalogColumnStatisticsDataDate) columnStatisticsData;
 			ndv = dateData.getNdv();
+			if (dateData.getMax() != null) {
+				max = Date.valueOf(DateTimeUtils.unixDateToString((int) dateData.getMax().getDaysSinceEpoch()));
+			}
+			if (dateData.getMin() != null) {
+				min = Date.valueOf(DateTimeUtils.unixDateToString((int) dateData.getMin().getDaysSinceEpoch()));
+			}
 		} else {
 			throw new TableException("Unsupported CatalogColumnStatisticsDataBase: " +
 					columnStatisticsData.getClass().getCanonicalName());

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnInterval.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnInterval.scala
@@ -66,12 +66,20 @@ class FlinkRelMdColumnInterval private extends MetadataHandler[ColumnInterval] {
     val statistic = relOptTable.getFlinkStatistic
     val colStats = statistic.getColumnStats(fieldName)
     if (colStats != null) {
-      val min = colStats.getMinValue
-      val max = colStats.getMaxValue
-      if (min == null && max == null) {
-        null
-      } else {
+      val minValue = colStats.getMinValue
+      val maxValue = colStats.getMaxValue
+      val min = colStats.getMin
+      val max = colStats.getMax
+
+      Preconditions.checkArgument(
+        (minValue == null && maxValue == null) || (max == null && min == null))
+
+      if (minValue != null || maxValue != null) {
+        ValueInterval(minValue, maxValue)
+      } else if (max != null || min != null) {
         ValueInterval(min, max)
+      } else {
+        null
       }
     } else {
       null

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/catalog/CatalogStatisticsTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/catalog/CatalogStatisticsTest.java
@@ -44,6 +44,7 @@ import org.apache.flink.table.planner.utils.TableTestUtil;
 import org.apache.flink.table.planner.utils.TestTableSource;
 import org.apache.flink.table.types.DataType;
 
+import org.apache.calcite.avatica.util.DateTimeUtils;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.junit.Test;
@@ -161,7 +162,11 @@ public class CatalogStatisticsTest {
 		// date type
 		assertEquals(100.0, mq.getDistinctRowCount(t1, ImmutableBitSet.of(3), null), 0.0);
 		assertEquals(0.0, mq.getColumnNullCount(t1, 3), 0.0);
-		assertNull(mq.getColumnInterval(t1, 3));
+		assertEquals(
+				ValueInterval$.MODULE$.apply(
+						java.sql.Date.valueOf(DateTimeUtils.unixDateToString(71)),
+						java.sql.Date.valueOf(DateTimeUtils.unixDateToString(17923)), true, true),
+				mq.getColumnInterval(t1, 3));
 
 		// double type
 		assertEquals(73.0, mq.getDistinctRowCount(t1, ImmutableBitSet.of(4), null), 0.0);

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/AggCallSelectivityEstimatorTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/AggCallSelectivityEstimatorTest.scala
@@ -171,13 +171,17 @@ class AggCallSelectivityEstimatorTest {
       avgLen: Option[JDouble] = None,
       maxLen: Option[Integer] = None,
       min: Option[Comparable[_]] = None,
-      max: Option[Comparable[_]] = None): ColumnStats = new ColumnStats(
-    ndv.getOrElse(null.asInstanceOf[JLong]),
-    nullCount.getOrElse(null.asInstanceOf[JLong]),
-    avgLen.getOrElse(null.asInstanceOf[JDouble]),
-    maxLen.getOrElse(null.asInstanceOf[Integer]),
-    max.orNull,
-    min.orNull)
+      max: Option[Comparable[_]] = None): ColumnStats = {
+    ColumnStats.Builder
+      .builder
+      .setNdv(ndv.getOrElse(null.asInstanceOf[JLong]))
+      .setNullCount(nullCount.getOrElse(null.asInstanceOf[JLong]))
+      .setAvgLen(avgLen.getOrElse(null.asInstanceOf[JDouble]))
+      .setMaxLen(maxLen.getOrElse(null.asInstanceOf[Integer]))
+      .setMax(max.orNull)
+      .setMin(min.orNull)
+      .build
+  }
 
   private def createFlinkStatistic(
       rowCount: Option[JLong] = None,

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/AggCallSelectivityEstimatorTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/AggCallSelectivityEstimatorTest.scala
@@ -170,8 +170,8 @@ class AggCallSelectivityEstimatorTest {
       nullCount: Option[JLong] = None,
       avgLen: Option[JDouble] = None,
       maxLen: Option[Integer] = None,
-      min: Option[Number] = None,
-      max: Option[Number] = None): ColumnStats = new ColumnStats(
+      min: Option[Comparable[_]] = None,
+      max: Option[Comparable[_]] = None): ColumnStats = new ColumnStats(
     ndv.getOrElse(null.asInstanceOf[JLong]),
     nullCount.getOrElse(null.asInstanceOf[JLong]),
     avgLen.getOrElse(null.asInstanceOf[JDouble]),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/SelectivityEstimatorTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/SelectivityEstimatorTest.scala
@@ -20,12 +20,14 @@ package org.apache.flink.table.planner.plan.metadata
 
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
+import org.apache.flink.table.module.ModuleManager
 import org.apache.flink.table.plan.stats.{ColumnStats, TableStats}
 import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkContextImpl, FlinkTypeFactory, FlinkTypeSystem}
 import org.apache.flink.table.planner.plan.schema._
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
 import org.apache.flink.table.planner.{JDouble, JLong}
 import org.apache.flink.util.Preconditions
+
 import org.apache.calcite.plan.{AbstractRelOptPlanner, RelOptCluster}
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.TableScan
@@ -42,9 +44,9 @@ import org.junit.{Before, BeforeClass, Test}
 import org.powermock.api.mockito.PowerMockito._
 import org.powermock.core.classloader.annotations.PrepareForTest
 import org.powermock.modules.junit4.PowerMockRunner
-import java.math.BigDecimal
 
-import org.apache.flink.table.module.ModuleManager
+import java.math.BigDecimal
+import java.sql.{Date, Time, Timestamp}
 
 import scala.collection.JavaConverters._
 
@@ -165,8 +167,8 @@ class SelectivityEstimatorTest {
       nullCount: Option[JLong] = None,
       avgLen: Option[JDouble] = None,
       maxLen: Option[Integer] = None,
-      min: Option[Number] = None,
-      max: Option[Number] = None): ColumnStats = {
+      min: Option[Comparable[_]] = None,
+      max: Option[Comparable[_]] = None): ColumnStats = {
     new ColumnStats(
       ndv.getOrElse(null.asInstanceOf[JLong]),
       nullCount.getOrElse(null.asInstanceOf[JLong]),
@@ -245,13 +247,16 @@ class SelectivityEstimatorTest {
 
     // test with statistics
     val statistic = createFlinkStatistic(Some(1000L), Some(Map("name" ->
-      createColumnStats(Some(800L), Some(0L), Some(16.0), Some(32), None, None))))
+      createColumnStats(Some(800L), Some(0L), Some(16.0), Some(32), Some("aaa"), Some("max")))))
+
     val estimator2 = new SelectivityEstimator(mockScan(statistic), mq)
-    assertEquals(estimator1.defaultEqualsSelectivity, estimator2.evaluate(predicate1))
+    // ["aaa", "max"] contains "abc"
+    assertEquals(Some(0.00125), estimator2.evaluate(predicate1))
 
     // name = "xyz"
     val predicate2 = createCall(EQUALS, createInputRef(name_idx), createStringLiteral("xyz"))
-    assertEquals(estimator1.defaultEqualsSelectivity, estimator2.evaluate(predicate2))
+    // ["aaa", "max"] contains "xyz"
+    assertEquals(Some(0.0), estimator2.evaluate(predicate2))
   }
 
   @Test
@@ -273,9 +278,15 @@ class SelectivityEstimatorTest {
 
     // test with statistics
     val statistic = createFlinkStatistic(Some(1000L), Some(Map("flag" ->
-      createColumnStats(Some(2L), Some(0L), Some(1.0), Some(1), None, None))))
+      createColumnStats(Some(2L), Some(0L), Some(1.0), Some(1), Some(false), Some(true)))))
     val estimator2 = new SelectivityEstimator(mockScan(statistic), mq)
-    assertEquals(estimator1.defaultEqualsSelectivity, estimator2.evaluate(predicate1))
+    // [false, true] contains true
+    assertEquals(Some(0.5), estimator2.evaluate(predicate1))
+
+    // flag = false
+    val predicate5 = createCall(EQUALS, createInputRef(flag_idx), createBooleanLiteral(false))
+    // [false, true] contains false
+    assertEquals(Some(0.5), estimator2.evaluate(predicate5))
   }
 
   @Test
@@ -291,10 +302,22 @@ class SelectivityEstimatorTest {
         None,
         None,
         None,
-        None,
-        None))))
+        Some(Date.valueOf("2017-10-01")),
+        Some(Date.valueOf("2018-10-01"))))))
+
     val estimator = new SelectivityEstimator(mockScan(statistic), mq)
-    assertEquals(estimator.defaultEqualsSelectivity, estimator.evaluate(predicate))
+    // ["2017-10-01", "2018-10-01"] contains "2017-10-11"
+    assertEquals(Some(1.0 / 80.0), estimator.evaluate(predicate))
+
+    // date_col = "2018-10-02"
+    val predicate2 = createCall(
+      EQUALS,
+      createInputRef(date_idx),
+      createDateLiteral("2018-10-02")
+    )
+
+    // ["2017-10-01", "2018-10-01"] does not contain "2018-10-02"
+    assertEquals(Some(0.0), estimator.evaluate(predicate2))
   }
 
   @Test
@@ -310,10 +333,21 @@ class SelectivityEstimatorTest {
         None,
         None,
         None,
-        None,
-        None))))
+        Some(Time.valueOf("10:00:00")),
+        Some(Time.valueOf("12:00:00"))))))
+
     val estimator = new SelectivityEstimator(mockScan(statistic), mq)
-    assertEquals(estimator.defaultEqualsSelectivity, estimator.evaluate(predicate))
+    // ["10:00:00", "12:00:00"] contains "11:00:00"
+    assertEquals(Some(1.0 / 80.0), estimator.evaluate(predicate))
+
+    // time_col = "13:00:00"
+    val predicate2 = createCall(
+      EQUALS,
+      createInputRef(time_idx),
+      createTimeLiteral("13:00:00"))
+
+    // ["10:00:00", "12:00:00"] does not contains "13:00:00"
+    assertEquals(Some(0.0), estimator.evaluate(predicate2))
   }
 
   @Test
@@ -328,10 +362,19 @@ class SelectivityEstimatorTest {
         None,
         None,
         None,
-        None,
-        None))))
+        Some(new Timestamp(0L)),
+        Some(new Timestamp(2000L))))))
+
     val estimator = new SelectivityEstimator(mockScan(statistic), mq)
-    assertEquals(estimator.defaultEqualsSelectivity, estimator.evaluate(predicate))
+    assertEquals(Some(1.0 / 80.0), estimator.evaluate(predicate))
+
+    val predicate2 = createCall(
+      EQUALS,
+      createInputRef(timestamp_idx),
+      createTimeStampLiteral(3000L))
+
+    // ["2017-10-01 10:00:00", "2018-10-01 10:00:00"] does not contains "2018-10-01 10:00:01"
+    assertEquals(Some(0.0), estimator.evaluate(predicate2))
   }
 
   @Test
@@ -410,7 +453,7 @@ class SelectivityEstimatorTest {
 
     // test with statistics
     val statistic = createFlinkStatistic(Some(1000L), Some(Map("name" ->
-      createColumnStats(Some(800L), Some(0L), Some(16.0), Some(32), None, None))))
+      createColumnStats(Some(800L), Some(0L), Some(16.0), Some(32), Some("aaa"), Some("max")))))
     val estimator2 = new SelectivityEstimator(mockScan(statistic), mq)
     assertEquals(estimator2.defaultComparisonSelectivity, estimator2.evaluate(predicate))
   }
@@ -1051,8 +1094,7 @@ class SelectivityEstimatorTest {
 
     // test with statistics
     val statistic = createFlinkStatistic(Some(1000L), Some(Map("name" ->
-      createColumnStats(Some(800L), Some(0L), Some(16.0), Some(32), None, None))))
-    // TODO
+      createColumnStats(Some(800L), Some(0L), Some(16.0), Some(32), Some("aaa"), Some("max")))))
     assertEquals(Some(selectivity * selectivity),
       new SelectivityEstimator(mockScan(statistic), mq).evaluate(predicate1))
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/SelectivityEstimatorTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/SelectivityEstimatorTest.scala
@@ -346,7 +346,7 @@ class SelectivityEstimatorTest {
       createInputRef(time_idx),
       createTimeLiteral("13:00:00"))
 
-    // ["10:00:00", "12:00:00"] does not contains "13:00:00"
+    // ["10:00:00", "12:00:00"] does not contain "13:00:00"
     assertEquals(Some(0.0), estimator.evaluate(predicate2))
   }
 
@@ -373,7 +373,7 @@ class SelectivityEstimatorTest {
       createInputRef(timestamp_idx),
       createTimeStampLiteral(3000L))
 
-    // ["2017-10-01 10:00:00", "2018-10-01 10:00:00"] does not contains "2018-10-01 10:00:01"
+    // ["2017-10-01 10:00:00", "2018-10-01 10:00:00"] does not contain "2018-10-01 10:00:01"
     assertEquals(Some(0.0), estimator.evaluate(predicate2))
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/SelectivityEstimatorTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/SelectivityEstimatorTest.scala
@@ -169,13 +169,15 @@ class SelectivityEstimatorTest {
       maxLen: Option[Integer] = None,
       min: Option[Comparable[_]] = None,
       max: Option[Comparable[_]] = None): ColumnStats = {
-    new ColumnStats(
-      ndv.getOrElse(null.asInstanceOf[JLong]),
-      nullCount.getOrElse(null.asInstanceOf[JLong]),
-      avgLen.getOrElse(null.asInstanceOf[JDouble]),
-      maxLen.getOrElse(null.asInstanceOf[Integer]),
-      max.orNull,
-      min.orNull)
+    ColumnStats.Builder
+      .builder()
+      .setNdv(ndv.getOrElse(null.asInstanceOf[JLong]))
+      .setNullCount(nullCount.getOrElse(null.asInstanceOf[JLong]))
+      .setAvgLen(avgLen.getOrElse(null.asInstanceOf[JDouble]))
+      .setMaxLen(maxLen.getOrElse(null.asInstanceOf[Integer]))
+      .setMax(max.orNull)
+      .setMin(min.orNull)
+      .build()
   }
 
   private def createFlinkStatistic(


### PR DESCRIPTION

## What is the purpose of the change

*extends max/min type in ColumnStats from Number to Comparable the help planner to find a better plan if a query has predicate on non-number column(e.g. date, time, timestamp)*


## Brief change log

  - *change max/min type from Number to Comparable in ColumnStats*
  - *convert max/min info in CatalogColumnStatisticsDataDate to ColumnStats*


## Verifying this change

This change added tests and can be verified as follows:

  - *Updated SelectivityEstimatorTest for selectivity on Boolean, Date, Time, Timestamp, String column*
  - *Updated CatalogStatisticsTest for date max/min*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
