### PR TITLE
[FLINK-14503][coordination] Add partition report to heartbeat

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionInfo.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 
 import java.util.Objects;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -32,9 +33,13 @@ public final class TaskExecutorPartitionInfo {
 	private final ResultPartitionID resultPartitionId;
 	private final IntermediateDataSetID intermediateDataSetId;
 
-	public TaskExecutorPartitionInfo(ResultPartitionID resultPartitionId, IntermediateDataSetID intermediateDataSetId) {
+	private final int numberOfPartitions;
+
+	public TaskExecutorPartitionInfo(ResultPartitionID resultPartitionId, IntermediateDataSetID intermediateDataSetId, int numberOfPartitions) {
 		this.resultPartitionId = checkNotNull(resultPartitionId);
 		this.intermediateDataSetId = checkNotNull(intermediateDataSetId);
+		checkArgument(numberOfPartitions > 0);
+		this.numberOfPartitions = numberOfPartitions;
 	}
 
 	public IntermediateDataSetID getIntermediateDataSetId() {
@@ -43,6 +48,10 @@ public final class TaskExecutorPartitionInfo {
 
 	public ResultPartitionID getResultPartitionId() {
 		return resultPartitionId;
+	}
+
+	public int getNumberOfPartitions() {
+		return numberOfPartitions;
 	}
 
 	@Override
@@ -67,6 +76,7 @@ public final class TaskExecutorPartitionInfo {
 	public static TaskExecutorPartitionInfo from(ResultPartitionDeploymentDescriptor resultPartitionDeploymentDescriptor) {
 		return new TaskExecutorPartitionInfo(
 			resultPartitionDeploymentDescriptor.getShuffleDescriptor().getResultPartitionID(),
-			resultPartitionDeploymentDescriptor.getResultId());
+			resultPartitionDeploymentDescriptor.getResultId(),
+			resultPartitionDeploymentDescriptor.getTotalNumberOfPartitions());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionInfo.java
@@ -17,23 +17,32 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 
 import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Encapsulates meta-information the TaskExecutor requires to be kept for each partition.
  */
 public final class TaskExecutorPartitionInfo {
 
+	private final ResultPartitionID resultPartitionId;
 	private final IntermediateDataSetID intermediateDataSetId;
 
-	public TaskExecutorPartitionInfo(IntermediateDataSetID intermediateDataSetId) {
-		this.intermediateDataSetId = intermediateDataSetId;
+	public TaskExecutorPartitionInfo(ResultPartitionID resultPartitionId, IntermediateDataSetID intermediateDataSetId) {
+		this.resultPartitionId = checkNotNull(resultPartitionId);
+		this.intermediateDataSetId = checkNotNull(intermediateDataSetId);
 	}
 
 	public IntermediateDataSetID getIntermediateDataSetId() {
 		return intermediateDataSetId;
+	}
+
+	public ResultPartitionID getResultPartitionId() {
+		return resultPartitionId;
 	}
 
 	@Override
@@ -53,5 +62,11 @@ public final class TaskExecutorPartitionInfo {
 	public int hashCode() {
 		// only use the dataset ID here, so we can use this as an efficient place for meta data
 		return Objects.hash(intermediateDataSetId);
+	}
+
+	public static TaskExecutorPartitionInfo from(ResultPartitionDeploymentDescriptor resultPartitionDeploymentDescriptor) {
+		return new TaskExecutorPartitionInfo(
+			resultPartitionDeploymentDescriptor.getShuffleDescriptor().getResultPartitionID(),
+			resultPartitionDeploymentDescriptor.getResultId());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTracker.java
@@ -18,7 +18,6 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 
 import java.util.Collection;
 
@@ -31,9 +30,9 @@ public interface TaskExecutorPartitionTracker extends PartitionTracker<JobID, Ta
 	 * Starts the tracking of the given partition for the given job.
 	 *
 	 * @param producingJobId ID of job by which the partition is produced
-	 * @param intermediateDataSetId the corresponding dataset ID
+	 * @param partitionInfo information about the partition
 	 */
-	void startTrackingPartition(JobID producingJobId, ResultPartitionID resultPartitionId, IntermediateDataSetID intermediateDataSetId);
+	void startTrackingPartition(JobID producingJobId, TaskExecutorPartitionInfo partitionInfo);
 
 	/**
 	 * Releases the given partitions and stop the tracking of partitions that were released.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTracker.java
@@ -18,6 +18,7 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.taskexecutor.partition.ClusterPartitionReport;
 
 import java.util.Collection;
 
@@ -53,4 +54,9 @@ public interface TaskExecutorPartitionTracker extends PartitionTracker<JobID, Ta
 	 * Releases and stops tracking all partitions.
 	 */
 	void stopTrackingAndReleaseAllClusterPartitions();
+
+	/**
+	 * Creates a {@link ClusterPartitionReport}, describing which cluster partitions are currently available.
+	 */
+	ClusterPartitionReport createClusterPartitionReport();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTrackerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTrackerImpl.java
@@ -18,7 +18,6 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
@@ -42,12 +41,11 @@ public class TaskExecutorPartitionTrackerImpl extends AbstractPartitionTracker<J
 	}
 
 	@Override
-	public void startTrackingPartition(JobID producingJobId, ResultPartitionID resultPartitionId, IntermediateDataSetID intermediateDataSetId) {
+	public void startTrackingPartition(JobID producingJobId, TaskExecutorPartitionInfo partitionInfo) {
 		Preconditions.checkNotNull(producingJobId);
-		Preconditions.checkNotNull(resultPartitionId);
-		Preconditions.checkNotNull(intermediateDataSetId);
+		Preconditions.checkNotNull(partitionInfo);
 
-		startTrackingPartition(producingJobId, resultPartitionId, new TaskExecutorPartitionInfo(intermediateDataSetId));
+		startTrackingPartition(producingJobId, partitionInfo.getResultPartitionId(), partitionInfo);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -1841,7 +1841,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		@Override
 		public TaskExecutorHeartbeatPayload retrievePayload(ResourceID resourceID) {
 			validateRunsInMainThread();
-			return new TaskExecutorHeartbeatPayload(taskSlotTable.createSlotReport(getResourceID()));
+			return new TaskExecutorHeartbeatPayload(taskSlotTable.createSlotReport(getResourceID()), partitionTracker.createClusterPartitionReport());
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -54,6 +54,7 @@ import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.TaskExecutorPartitionInfo;
 import org.apache.flink.runtime.io.network.partition.TaskExecutorPartitionTracker;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.jobmaster.AllocatedSlotInfo;
@@ -624,7 +625,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 			Collection<ResultPartitionDeploymentDescriptor> producedResultPartitions,
 			CompletableFuture<ExecutionState> terminationFuture) {
 		final Set<ResultPartitionID> partitionsRequiringRelease = filterPartitionsRequiringRelease(producedResultPartitions)
-			.peek(rpdd -> partitionTracker.startTrackingPartition(jobId, rpdd.getShuffleDescriptor().getResultPartitionID(), rpdd.getResultId()))
+			.peek(rpdd -> partitionTracker.startTrackingPartition(jobId, TaskExecutorPartitionInfo.from(rpdd)))
 			.map(ResultPartitionDeploymentDescriptor::getShuffleDescriptor)
 			.map(ShuffleDescriptor::getResultPartitionID)
 			.collect(Collectors.toSet());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorHeartbeatPayload.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorHeartbeatPayload.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.runtime.taskexecutor;
 
+import org.apache.flink.runtime.taskexecutor.partition.ClusterPartitionReport;
+
 import java.io.Serializable;
 
 /**
@@ -27,19 +29,26 @@ public class TaskExecutorHeartbeatPayload implements Serializable {
 	private static final long serialVersionUID = -4556838854992435612L;
 
 	private final SlotReport slotReport;
+	private final ClusterPartitionReport clusterPartitionReport;
 
-	public TaskExecutorHeartbeatPayload(SlotReport slotReport) {
+	public TaskExecutorHeartbeatPayload(SlotReport slotReport, ClusterPartitionReport clusterPartitionReport) {
 		this.slotReport = slotReport;
+		this.clusterPartitionReport = clusterPartitionReport;
 	}
 
 	public SlotReport getSlotReport() {
 		return slotReport;
 	}
 
+	public ClusterPartitionReport getClusterPartitionReport() {
+		return clusterPartitionReport;
+	}
+
 	@Override
 	public String toString() {
 		return "TaskExecutorHeartbeatPayload{" +
 			"slotReport=" + slotReport +
+			", clusterPartitionReport=" + clusterPartitionReport +
 			'}';
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/partition/ClusterPartitionReport.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/partition/ClusterPartitionReport.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor.partition;
+
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Set;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A report about the current status of all cluster partitions of the TaskExecutor, describing
+ * which partitions are available.
+ */
+public class ClusterPartitionReport implements Serializable {
+
+	private static final long serialVersionUID = -3150175198722481689L;
+
+	private final Collection<ClusterPartitionReportEntry> entries;
+
+	public ClusterPartitionReport(final Collection<ClusterPartitionReportEntry> entries) {
+		this.entries = checkNotNull(entries);
+	}
+
+	public Collection<ClusterPartitionReportEntry> getEntries() {
+		return entries;
+	}
+
+	@Override
+	public String toString() {
+		return "PartitionReport{" +
+			"entries=" + entries +
+			'}';
+	}
+
+	/**
+	 * An entry describing all partitions belonging to one dataset.
+	 */
+	public static class ClusterPartitionReportEntry implements Serializable {
+
+		private static final long serialVersionUID = -666517548300250601L;
+
+		private final IntermediateDataSetID dataSetId;
+		private final Set<ResultPartitionID> hostedPartitions;
+		private final int numTotalPartitions;
+
+		public ClusterPartitionReportEntry(IntermediateDataSetID dataSetId, Set<ResultPartitionID> hostedPartitions, int numTotalPartitions) {
+			this.dataSetId = dataSetId;
+			this.hostedPartitions = hostedPartitions;
+			this.numTotalPartitions = numTotalPartitions;
+		}
+
+		public IntermediateDataSetID getDataSetId() {
+			return dataSetId;
+		}
+
+		public Set<ResultPartitionID> getHostedPartitions() {
+			return hostedPartitions;
+		}
+
+		public int getNumTotalPartitions() {
+			return numTotalPartitions;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTrackerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTrackerImplTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.taskexecutor.partition.ClusterPartitionReport;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Tests for the {@link TaskExecutorPartitionTrackerImpl}.
+ */
+public class TaskExecutorPartitionTrackerImplTest extends TestLogger {
+
+	@Test
+	public void createClusterPartitionReport() {
+		final TaskExecutorPartitionTrackerImpl partitionTracker = new TaskExecutorPartitionTrackerImpl(new NettyShuffleEnvironmentBuilder().build());
+
+		assertThat(partitionTracker.createClusterPartitionReport().getEntries(), is(empty()));
+
+		final IntermediateDataSetID dataSetId = new IntermediateDataSetID();
+		final JobID jobId = new JobID();
+		final ResultPartitionID clusterPartitionId = new ResultPartitionID();
+		final ResultPartitionID jobPartitionId = new ResultPartitionID();
+		final int numberOfPartitions = 1;
+
+		partitionTracker.startTrackingPartition(jobId, new TaskExecutorPartitionInfo(clusterPartitionId, dataSetId, numberOfPartitions));
+		partitionTracker.startTrackingPartition(jobId, new TaskExecutorPartitionInfo(jobPartitionId, dataSetId, numberOfPartitions + 1));
+
+		partitionTracker.promoteJobPartitions(Collections.singleton(clusterPartitionId));
+
+		final ClusterPartitionReport clusterPartitionReport = partitionTracker.createClusterPartitionReport();
+
+		final ClusterPartitionReport.ClusterPartitionReportEntry reportEntry = Iterables.getOnlyElement(clusterPartitionReport.getEntries());
+		assertThat(reportEntry.getDataSetId(), is(dataSetId));
+		assertThat(reportEntry.getNumTotalPartitions(), is(numberOfPartitions));
+		assertThat(reportEntry.getHostedPartitions(), hasItems(clusterPartitionId));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
@@ -87,7 +87,7 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
 
 	private volatile Function<Tuple3<ResourceID, InstanceID, SlotReport>, CompletableFuture<Acknowledge>> sendSlotReportFunction;
 
-	private volatile BiConsumer<ResourceID, SlotReport> taskExecutorHeartbeatConsumer;
+	private volatile BiConsumer<ResourceID, TaskExecutorHeartbeatPayload> taskExecutorHeartbeatConsumer;
 
 	private volatile Consumer<Tuple3<InstanceID, SlotID, AllocationID>> notifySlotAvailableConsumer;
 
@@ -153,7 +153,7 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
 		this.sendSlotReportFunction = sendSlotReportFunction;
 	}
 
-	public void setTaskExecutorHeartbeatConsumer(BiConsumer<ResourceID, SlotReport> taskExecutorHeartbeatConsumer) {
+	public void setTaskExecutorHeartbeatConsumer(BiConsumer<ResourceID, TaskExecutorHeartbeatPayload> taskExecutorHeartbeatConsumer) {
 		this.taskExecutorHeartbeatConsumer = taskExecutorHeartbeatConsumer;
 	}
 
@@ -248,10 +248,10 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
 
 	@Override
 	public void heartbeatFromTaskManager(ResourceID heartbeatOrigin, TaskExecutorHeartbeatPayload heartbeatPayload) {
-		final BiConsumer<ResourceID, SlotReport> currentTaskExecutorHeartbeatConsumer = taskExecutorHeartbeatConsumer;
+		final BiConsumer<ResourceID, TaskExecutorHeartbeatPayload> currentTaskExecutorHeartbeatConsumer = taskExecutorHeartbeatConsumer;
 
 		if (currentTaskExecutorHeartbeatConsumer != null) {
-			currentTaskExecutorHeartbeatConsumer.accept(heartbeatOrigin, heartbeatPayload.getSlotReport());
+			currentTaskExecutorHeartbeatConsumer.accept(heartbeatOrigin, heartbeatPayload);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -45,6 +45,7 @@ import org.apache.flink.runtime.io.network.partition.PartitionTestUtils;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.io.network.partition.TaskExecutorPartitionInfo;
 import org.apache.flink.runtime.io.network.partition.TaskExecutorPartitionTracker;
 import org.apache.flink.runtime.io.network.partition.TaskExecutorPartitionTrackerImpl;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
@@ -190,8 +191,7 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 
 			runInTaskExecutorThreadAndWait(taskExecutor, () -> partitionTracker.startTrackingPartition(
 				jobId,
-				resultPartitionId,
-				resultPartitionDeploymentDescriptor.getResultId()));
+				TaskExecutorPartitionInfo.from(resultPartitionDeploymentDescriptor)));
 
 			final CompletableFuture<Collection<ResultPartitionID>> firstReleasePartitionsCallFuture = new CompletableFuture<>();
 			runInTaskExecutorThreadAndWait(taskExecutor, () -> shuffleEnvironment.releasePartitionsLocallyFuture = firstReleasePartitionsCallFuture);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -471,7 +471,7 @@ public class TaskExecutorTest extends TestLogger {
 		});
 
 		final CompletableFuture<SlotReport> heartbeatSlotReportFuture = new CompletableFuture<>();
-		rmGateway.setTaskExecutorHeartbeatConsumer((resourceID, slotReport) -> heartbeatSlotReportFuture.complete(slotReport));
+		rmGateway.setTaskExecutorHeartbeatConsumer((resourceID, heartbeatPayload) -> heartbeatSlotReportFuture.complete(heartbeatPayload.getSlotReport()));
 
 		rpc.registerGateway(rmAddress, rmGateway);
 
@@ -1780,9 +1780,9 @@ public class TaskExecutorTest extends TestLogger {
 		final OneShotLatch terminateSlotReportVerification = new OneShotLatch();
 		final TestingResourceManagerGateway testingResourceManagerGateway = new TestingResourceManagerGateway();
 		// Assertions for this test
-		testingResourceManagerGateway.setTaskExecutorHeartbeatConsumer((ignored, slotReport) -> {
+		testingResourceManagerGateway.setTaskExecutorHeartbeatConsumer((ignored, heartbeatPayload) -> {
 			try {
-				final ArrayList<SlotStatus> slots = Lists.newArrayList(slotReport);
+				final ArrayList<SlotStatus> slots = Lists.newArrayList(heartbeatPayload.getSlotReport());
 				assertThat(slots, hasSize(1));
 				final SlotStatus slotStatus = slots.get(0);
 


### PR DESCRIPTION
~~Based on #10135.~~

With this PR the TaskExecutor includes a `ClusterPartitionReport` in it's heartbeat payload. This report contains the set of cluster partitions that the TaskExecutor is currently hosting, along with some additional meta data.

The ResourceManager currently includes this part of the heartbeat, which is fine since in production it is currently always empty anyway ;)