### PR TITLE
[FLINK-14062][runtime] Calculate managed memory fraction based on slot sharing groups

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -45,6 +45,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
+
 /**
  * Internal configuration for a {@link StreamOperator}. This is created and populated by the
  * {@link StreamingJobGraphGenerator}.
@@ -133,6 +135,10 @@ public class StreamConfig implements Serializable {
 	}
 
 	public void setManagedMemoryFractionOnHeap(double managedMemFractionOnHeap) {
+		checkArgument(
+			managedMemFractionOnHeap >= 0.0 && managedMemFractionOnHeap <= 1.0,
+			String.format("managedMemFractionOnHeap should be in range [0.0, 1.0], but was: %s", managedMemFractionOnHeap));
+
 		config.setDouble(MANAGED_MEMORY_FRACTION_ON_HEAP, managedMemFractionOnHeap);
 	}
 
@@ -141,6 +147,10 @@ public class StreamConfig implements Serializable {
 	}
 
 	public void setManagedMemoryFractionOffHeap(double managedMemFractionOffHeap) {
+		checkArgument(
+			managedMemFractionOffHeap >= 0.0 && managedMemFractionOffHeap <= 1.0,
+			String.format("managedMemFractionOffHeap should be in range [0.0, 1.0], but was: %s", managedMemFractionOffHeap));
+
 		config.setDouble(MANAGED_MEMORY_FRACTION_OFF_HEAP, managedMemFractionOffHeap);
 	}
 


### PR DESCRIPTION

## What is the purpose of the change

This PR calculates managed memory fraction for each operator based on the slot sharing group resources and set the result into StreamConfig.
 - For operators with specified ResourceSpecs, calculate fractions according to operators ResourceSpecs
 - For operators with unknown ResourceSpecs, calculate fractions according to number of operators

This change is based on #10079 and #10179.

## Brief change log

  - *Changed StreamingJobGraphGenerator to calculate and set operator managed memory fractions*


## Verifying this change

This change added tests and can be verified as follows:
  - *Added unit tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
