### PR TITLE
[FLINK-14687][sql] Add database related ddl support to SQL Parser

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -34,6 +34,7 @@
     "org.apache.flink.sql.parser.ddl.SqlWatermark",
     "org.apache.flink.sql.parser.ddl.SqlUseCatalog",
     "org.apache.flink.sql.parser.ddl.SqlUseDatabase",
+    "org.apache.flink.sql.parser.ddl.SqlCreateDatabase",
     "org.apache.flink.sql.parser.dml.RichSqlInsert",
     "org.apache.flink.sql.parser.dml.RichSqlInsertKeyword",
     "org.apache.flink.sql.parser.dql.SqlShowCatalogs",
@@ -424,7 +425,8 @@
   # Each must accept arguments "(SqlParserPos pos, boolean replace)".
   createStatementParserMethods: [
     "SqlCreateTable",
-    "SqlCreateView"
+    "SqlCreateView",
+    "SqlCreateDatabase"
   ]
 
   # List of methods for parsing extensions to "DROP" calls.

--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -37,6 +37,7 @@
     "org.apache.flink.sql.parser.dml.RichSqlInsertKeyword",
     "org.apache.flink.sql.parser.dql.SqlShowCatalogs",
     "org.apache.flink.sql.parser.dql.SqlDescribeCatalog",
+    "org.apache.flink.sql.parser.dql.SqlShowDatabases",
     "org.apache.flink.sql.parser.type.ExtendedSqlBasicTypeNameSpec",
     "org.apache.flink.sql.parser.type.ExtendedSqlCollectionTypeNameSpec",
     "org.apache.flink.sql.parser.utils.SqlTimeUnit",
@@ -60,7 +61,8 @@
     "STRING",
     "BYTES",
     "CATALOGS",
-    "USE"
+    "USE",
+    "DATABASES"
   ]
 
   # List of keywords from "keywords" section that are not reserved.
@@ -118,6 +120,7 @@
     "CURSOR_NAME"
     "DATA"
     "DATABASE"
+    "DATABASES"
     "DATETIME_INTERVAL_CODE"
     "DATETIME_INTERVAL_PRECISION"
     "DECADE"
@@ -383,7 +386,8 @@
     "RichSqlInsert()",
     "SqlShowCatalogs()",
     "SqlDescribeCatalog()",
-    "SqlUseCatalog()"
+    "SqlUseCatalog()",
+    "SqlShowDatabases()"
   ]
 
   # List of methods for parsing custom literals.

--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -36,6 +36,7 @@
     "org.apache.flink.sql.parser.ddl.SqlUseDatabase",
     "org.apache.flink.sql.parser.ddl.SqlCreateDatabase",
     "org.apache.flink.sql.parser.ddl.SqlDropDatabase",
+    "org.apache.flink.sql.parser.ddl.SqlAlterDatabase",
     "org.apache.flink.sql.parser.dml.RichSqlInsert",
     "org.apache.flink.sql.parser.dml.RichSqlInsertKeyword",
     "org.apache.flink.sql.parser.dql.SqlShowCatalogs",
@@ -391,7 +392,8 @@
     "SqlDescribeCatalog()",
     "SqlUseCatalog()",
     "SqlShowDatabases()",
-    "SqlUseDatabase()"
+    "SqlUseDatabase()",
+    "SqlAlterDatabase()"
   ]
 
   # List of methods for parsing custom literals.

--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -42,6 +42,7 @@
     "org.apache.flink.sql.parser.dql.SqlShowCatalogs",
     "org.apache.flink.sql.parser.dql.SqlDescribeCatalog",
     "org.apache.flink.sql.parser.dql.SqlShowDatabases",
+    "org.apache.flink.sql.parser.dql.SqlDescribeDatabase",
     "org.apache.flink.sql.parser.type.ExtendedSqlBasicTypeNameSpec",
     "org.apache.flink.sql.parser.type.ExtendedSqlCollectionTypeNameSpec",
     "org.apache.flink.sql.parser.utils.SqlTimeUnit",
@@ -66,7 +67,8 @@
     "BYTES",
     "CATALOGS",
     "USE",
-    "DATABASES"
+    "DATABASES",
+    "EXTENDED"
   ]
 
   # List of keywords from "keywords" section that are not reserved.
@@ -152,6 +154,7 @@
     "EXCEPTION"
     "EXCLUDE"
     "EXCLUDING"
+    "EXTENDED"
     "FINAL"
     "FIRST"
     "FOLLOWING"
@@ -393,7 +396,8 @@
     "SqlUseCatalog()",
     "SqlShowDatabases()",
     "SqlUseDatabase()",
-    "SqlAlterDatabase()"
+    "SqlAlterDatabase()",
+    "SqlDescribeDatabase()"
   ]
 
   # List of methods for parsing custom literals.

--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -35,6 +35,7 @@
     "org.apache.flink.sql.parser.ddl.SqlUseCatalog",
     "org.apache.flink.sql.parser.ddl.SqlUseDatabase",
     "org.apache.flink.sql.parser.ddl.SqlCreateDatabase",
+    "org.apache.flink.sql.parser.ddl.SqlDropDatabase",
     "org.apache.flink.sql.parser.dml.RichSqlInsert",
     "org.apache.flink.sql.parser.dml.RichSqlInsertKeyword",
     "org.apache.flink.sql.parser.dql.SqlShowCatalogs",
@@ -433,7 +434,8 @@
   # Each must accept arguments "(Span s)".
   dropStatementParserMethods: [
     "SqlDropTable",
-    "SqlDropView"
+    "SqlDropView",
+    "SqlDropDatabase"
   ]
 
   # Binary operators tokens

--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -33,6 +33,7 @@
     "org.apache.flink.sql.parser.ddl.SqlTableOption",
     "org.apache.flink.sql.parser.ddl.SqlWatermark",
     "org.apache.flink.sql.parser.ddl.SqlUseCatalog",
+    "org.apache.flink.sql.parser.ddl.SqlUseDatabase",
     "org.apache.flink.sql.parser.dml.RichSqlInsert",
     "org.apache.flink.sql.parser.dml.RichSqlInsertKeyword",
     "org.apache.flink.sql.parser.dql.SqlShowCatalogs",
@@ -387,7 +388,8 @@
     "SqlShowCatalogs()",
     "SqlDescribeCatalog()",
     "SqlUseCatalog()",
-    "SqlShowDatabases()"
+    "SqlShowDatabases()",
+    "SqlUseDatabase()"
   ]
 
   # List of methods for parsing custom literals.

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -117,6 +117,33 @@ SqlCreate SqlCreateDatabase(Span s, boolean replace) :
 
 }
 
+SqlDrop SqlDropDatabase(Span s, boolean replace) :
+{
+    SqlIdentifier databaseName = null;
+    boolean ifExists = false;
+    boolean isRestrict = true;
+}
+{
+    <DATABASE>
+
+    (
+        <IF> <EXISTS> { ifExists = true; }
+    |
+        { ifExists = false; }
+    )
+
+    databaseName = CompoundIdentifier()
+    [
+                <RESTRICT> { isRestrict = true; }
+        |
+                <CASCADE>  { isRestrict = false; }
+    ]
+
+    {
+         return new SqlDropDatabase(s.pos(), databaseName, ifExists, isRestrict);
+    }
+}
+
 void TableColumn(TableCreationContext context) :
 {
 }

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -55,6 +55,19 @@ SqlParserPos pos;
     }
 }
 
+/**
+* Parse a "Show Catalogs" metadata query command.
+*/
+SqlShowDatabases SqlShowDatabases() :
+{
+}
+{
+    <SHOW> <DATABASES>
+    {
+        return new SqlShowDatabases(getPos());
+    }
+}
+
 void TableColumn(TableCreationContext context) :
 {
 }

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -88,7 +88,6 @@ SqlParserPos pos;
 SqlCreate SqlCreateDatabase(Span s, boolean replace) :
 {
     SqlParserPos startPos;
-    SqlParserPos pos;
     SqlIdentifier databaseName;
     SqlCharStringLiteral comment = null;
     SqlNodeList propertyList = SqlNodeList.EMPTY;
@@ -115,6 +114,24 @@ SqlCreate SqlCreateDatabase(Span s, boolean replace) :
                     comment,
                     ifNotExists); }
 
+}
+
+SqlAlterDatabase SqlAlterDatabase() :
+{
+    SqlParserPos startPos;
+    SqlIdentifier databaseName;
+    SqlNodeList propertyList = SqlNodeList.EMPTY;
+}
+{
+    <ALTER> <DATABASE> { startPos = getPos(); }
+    databaseName = CompoundIdentifier()
+    <SET>
+    propertyList = TableProperties()
+    {
+        return new SqlAlterDatabase(startPos.plus(getPos()),
+                    databaseName,
+                    propertyList);
+    }
 }
 
 SqlDrop SqlDropDatabase(Span s, boolean replace) :

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -161,6 +161,22 @@ SqlDrop SqlDropDatabase(Span s, boolean replace) :
     }
 }
 
+SqlDescribeDatabase SqlDescribeDatabase() :
+{
+    SqlIdentifier databaseName;
+    SqlParserPos pos;
+    boolean isExtended = false;
+}
+{
+    <DESCRIBE> <DATABASE> { pos = getPos();}
+    [ <EXTENDED> { isExtended = true;} ]
+    databaseName = CompoundIdentifier()
+    {
+        return new SqlDescribeDatabase(pos, databaseName, isExtended);
+    }
+
+}
+
 void TableColumn(TableCreationContext context) :
 {
 }

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -68,6 +68,19 @@ SqlShowDatabases SqlShowDatabases() :
     }
 }
 
+SqlUseDatabase SqlUseDatabase() :
+{
+SqlIdentifier databaseName;
+SqlParserPos pos;
+}
+{
+    <USE> { pos = getPos();}
+    databaseName = CompoundIdentifier()
+    {
+        return new SqlUseDatabase(pos, databaseName);
+    }
+}
+
 void TableColumn(TableCreationContext context) :
 {
 }

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -44,11 +44,11 @@ SqlDescribeCatalog SqlDescribeCatalog() :
 
 SqlUseCatalog SqlUseCatalog() :
 {
-SqlIdentifier catalogName;
-SqlParserPos pos;
+    SqlIdentifier catalogName;
+    SqlParserPos pos;
 }
 {
-<USE> <CATALOG> { pos = getPos();}
+    <USE> <CATALOG> { pos = getPos();}
     catalogName = SimpleIdentifier()
     {
         return new SqlUseCatalog(pos, catalogName);
@@ -70,8 +70,8 @@ SqlShowDatabases SqlShowDatabases() :
 
 SqlUseDatabase SqlUseDatabase() :
 {
-SqlIdentifier databaseName;
-SqlParserPos pos;
+    SqlIdentifier databaseName;
+    SqlParserPos pos;
 }
 {
     <USE> { pos = getPos();}

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -81,6 +81,42 @@ SqlParserPos pos;
     }
 }
 
+/**
+* Parses a create database statement.
+* CREATE DATABASE database_name [COMMENT database_comment] [WITH (property_name=property_value, ...)];
+*/
+SqlCreate SqlCreateDatabase(Span s, boolean replace) :
+{
+    SqlParserPos startPos;
+    SqlParserPos pos;
+    SqlIdentifier databaseName;
+    SqlCharStringLiteral comment = null;
+    SqlNodeList propertyList = SqlNodeList.EMPTY;
+    boolean ifNotExists = false;
+}
+{
+    <DATABASE> { startPos = getPos(); }
+    [ <IF> <NOT> <EXISTS> { ifNotExists = true; } ]
+    databaseName = CompoundIdentifier()
+    [ <COMMENT> <QUOTED_STRING>
+        {
+            String p = SqlParserUtil.parseString(token.image);
+            comment = SqlLiteral.createCharString(p, getPos());
+        }
+    ]
+    [
+        <WITH>
+        propertyList = TableProperties()
+    ]
+
+    { return new SqlCreateDatabase(startPos.plus(getPos()),
+                    databaseName,
+                    propertyList,
+                    comment,
+                    ifNotExists); }
+
+}
+
 void TableColumn(TableCreationContext context) :
 {
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterDatabase.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterDatabase.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * ALTER Database DDL sql call.
+ */
+public class SqlAlterDatabase extends SqlCall {
+
+	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("ALTER DATABASE", SqlKind.OTHER);
+
+	private final SqlIdentifier databaseName;
+
+	private final SqlNodeList propertyList;
+
+	public SqlAlterDatabase(
+			SqlParserPos pos,
+			SqlIdentifier databaseName,
+			SqlNodeList propertyList) {
+		super(pos);
+		this.databaseName = requireNonNull(databaseName, "tableName should not be null");
+		this.propertyList = requireNonNull(propertyList, "propertyList should not be null");
+	}
+
+	@Override
+	public SqlOperator getOperator() {
+		return OPERATOR;
+	}
+
+	@Override
+	public List<SqlNode> getOperandList() {
+		return ImmutableNullableList.of(databaseName, propertyList);
+	}
+
+	public SqlIdentifier getDatabaseName() {
+		return databaseName;
+	}
+
+	public SqlNodeList getPropertyList() {
+		return propertyList;
+	}
+
+	@Override
+	public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+		writer.keyword("ALTER DATABASE");
+		databaseName.unparse(writer, leftPrec, rightPrec);
+		writer.keyword("SET");
+		SqlWriter.Frame withFrame = writer.startList("(", ")");
+		for (SqlNode property : propertyList) {
+			printIndent(writer);
+			property.unparse(writer, leftPrec, rightPrec);
+		}
+		writer.newlineAndIndent();
+		writer.endList(withFrame);
+	}
+
+	private void printIndent(SqlWriter writer) {
+		writer.sep(",", false);
+		writer.newlineAndIndent();
+		writer.print("  ");
+	}
+
+	public String[] fullDatabaseName() {
+		return databaseName.names.toArray(new String[0]);
+	}
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateDatabase.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateDatabase.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl;
+
+import org.apache.flink.sql.parser.ExtendedSqlNode;
+import org.apache.flink.sql.parser.error.SqlValidateException;
+
+import org.apache.calcite.sql.SqlCharStringLiteral;
+import org.apache.calcite.sql.SqlCreate;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * CREATE Database DDL sql call.
+ */
+public class SqlCreateDatabase extends SqlCreate implements ExtendedSqlNode {
+
+	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("CREATE DATABASE", SqlKind.OTHER);
+
+	private final SqlIdentifier databaseName;
+
+	private final SqlNodeList propertyList;
+
+	@Nullable
+	private final SqlCharStringLiteral comment;
+
+	public SqlCreateDatabase(
+			SqlParserPos pos,
+			SqlIdentifier databaseName,
+			SqlNodeList propertyList,
+			SqlCharStringLiteral comment,
+			boolean ifNotExists) {
+		super(OPERATOR, pos, false, ifNotExists);
+		this.databaseName = requireNonNull(databaseName, "tableName should not be null");
+		this.propertyList = requireNonNull(propertyList, "propertyList should not be null");
+		this.comment = comment;
+	}
+
+	@Override
+	public SqlOperator getOperator() {
+		return OPERATOR;
+	}
+
+	@Override
+	public List<SqlNode> getOperandList() {
+		return ImmutableNullableList.of(databaseName, propertyList, comment);
+	}
+
+	public SqlIdentifier getDatabaseName() {
+		return databaseName;
+	}
+
+	public SqlNodeList getPropertyList() {
+		return propertyList;
+	}
+
+	public Optional<SqlCharStringLiteral> getComment() {
+		return Optional.ofNullable(comment);
+	}
+
+	public boolean isIfNotExists() {
+		return ifNotExists;
+	}
+
+	@Override
+	public void validate() throws SqlValidateException {
+
+	}
+
+	@Override
+	public void unparse(
+			SqlWriter writer,
+			int leftPrec,
+			int rightPrec) {
+		writer.keyword("CREATE DATABASE");
+		if (isIfNotExists()) {
+			writer.keyword("IF NOT EXISTS");
+		}
+		databaseName.unparse(writer, leftPrec, rightPrec);
+
+		if (comment != null) {
+			writer.newlineAndIndent();
+			writer.keyword("COMMENT");
+			comment.unparse(writer, leftPrec, rightPrec);
+		}
+
+		if (this.propertyList.size() > 0) {
+			writer.keyword("WITH");
+			SqlWriter.Frame withFrame = writer.startList("(", ")");
+			for (SqlNode property : propertyList) {
+				printIndent(writer);
+				property.unparse(writer, leftPrec, rightPrec);
+			}
+			writer.newlineAndIndent();
+			writer.endList(withFrame);
+		}
+	}
+
+	private void printIndent(SqlWriter writer) {
+		writer.sep(",", false);
+		writer.newlineAndIndent();
+		writer.print("  ");
+	}
+
+	public String[] fullDatabaseName() {
+		return databaseName.names.toArray(new String[0]);
+	}
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropDatabase.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropDatabase.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl;
+
+import org.apache.flink.sql.parser.ExtendedSqlNode;
+
+import org.apache.calcite.sql.SqlDrop;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+
+/**
+ * DROP DATABASE DDL sql call.
+ */
+public class SqlDropDatabase extends SqlDrop implements ExtendedSqlNode {
+	private static final SqlOperator OPERATOR =
+		new SqlSpecialOperator("DROP DATABASE", SqlKind.OTHER);
+
+	private SqlIdentifier databaseName;
+	private boolean ifExists;
+	private boolean isRestrict = true;
+
+	public SqlDropDatabase(SqlParserPos pos,
+			SqlIdentifier databaseName,
+			boolean ifExists,
+			boolean isRestrict) {
+		super(OPERATOR, pos, ifExists);
+		this.databaseName = databaseName;
+		this.ifExists = ifExists;
+		this.isRestrict = isRestrict;
+	}
+
+	@Override
+	public List<SqlNode> getOperandList() {
+		return ImmutableNullableList.of(databaseName);
+	}
+
+	public SqlIdentifier getDatabaseName() {
+		return databaseName;
+	}
+
+	public void setDatabaseName(SqlIdentifier viewName) {
+		this.databaseName = viewName;
+	}
+
+	public boolean getIfExists() {
+		return this.ifExists;
+	}
+
+	public void setIfExists(boolean ifExists) {
+		this.ifExists = ifExists;
+	}
+
+	@Override
+	public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+		writer.keyword("DROP");
+		writer.keyword("DATABASE");
+		if (ifExists) {
+			writer.keyword("IF EXISTS");
+		}
+		databaseName.unparse(writer, leftPrec, rightPrec);
+		if (isRestrict) {
+			writer.keyword("RESTRICT");
+		} else {
+			writer.keyword("CASCADE");
+		}
+	}
+
+	public void validate() {
+		// no-op
+	}
+
+	public String[] fullDatabaseName() {
+		return databaseName.names.toArray(new String[0]);
+	}
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlUseDatabase.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlUseDatabase.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * USE [catalog.]database sql call.
+ */
+public class SqlUseDatabase extends SqlCall {
+
+	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("USE DATABASE", SqlKind.OTHER);
+	private final SqlIdentifier databaseName;
+
+	public SqlUseDatabase(SqlParserPos pos, SqlIdentifier databaseName) {
+		super(pos);
+		this.databaseName = databaseName;
+
+	}
+
+	@Override
+	public SqlOperator getOperator() {
+		return OPERATOR;
+	}
+
+	@Override
+	public List<SqlNode> getOperandList() {
+		return Collections.singletonList(databaseName);
+	}
+
+	public SqlIdentifier getDatabaseName() {
+		return databaseName;
+	}
+
+	public String[] fullDatabaseName() {
+		return databaseName.names.toArray(new String[0]);
+	}
+
+	@Override
+	public void unparse(
+			SqlWriter writer,
+			int leftPrec,
+			int rightPrec) {
+		writer.keyword("USE");
+		databaseName.unparse(writer, leftPrec, rightPrec);
+	}
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlDescribeDatabase.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlDescribeDatabase.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.dql;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * DESCRIBE DATABASE [ EXTENDED] [ databaseName.] dataBasesName sql call.
+ */
+public class SqlDescribeDatabase extends SqlCall {
+
+	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("DESCRIBE DATABASE", SqlKind.OTHER);
+	private final SqlIdentifier databaseName;
+	private boolean isExtended = false;
+
+	public SqlDescribeDatabase(SqlParserPos pos, SqlIdentifier databaseName, boolean isExtended) {
+		super(pos);
+		this.databaseName = databaseName;
+		this.isExtended = isExtended;
+	}
+
+	@Override
+	public SqlOperator getOperator() {
+		return OPERATOR;
+	}
+
+	@Override
+	public List<SqlNode> getOperandList() {
+		return Collections.singletonList(databaseName);
+	}
+
+	public String getDatabaseName() {
+		return databaseName.getSimple();
+	}
+
+	public boolean isExtended() {
+		return isExtended;
+	}
+
+	public String[] fullDatabaseName() {
+		return databaseName.names.toArray(new String[0]);
+	}
+
+	@Override
+	public void unparse(
+			SqlWriter writer,
+			int leftPrec,
+			int rightPrec) {
+		writer.keyword("DESCRIBE DATABASE");
+		if (isExtended) {
+			writer.keyword("EXTENDED");
+		}
+		databaseName.unparse(writer, leftPrec, rightPrec);
+	}
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowDatabases.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowDatabases.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.dql;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * SHOW Databases sql call.
+ */
+public class SqlShowDatabases extends SqlCall {
+
+	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("SHOW DATABASES", SqlKind.OTHER);
+
+	public SqlShowDatabases(SqlParserPos pos) {
+		super(pos);
+	}
+
+	@Override
+	public SqlOperator getOperator() {
+		return OPERATOR;
+	}
+
+	@Override
+	public List<SqlNode> getOperandList() {
+		return Collections.EMPTY_LIST;
+	}
+
+	@Override
+	public void unparse(
+			SqlWriter writer,
+			int leftPrec,
+			int rightPrec) {
+		writer.keyword("SHOW DATABASES");
+	}
+}

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -96,6 +96,11 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	}
 
 	@Test
+	public void testShowDataBases() {
+		check("show databases", "SHOW DATABASES");
+	}
+
+	@Test
 	public void testCreateTable() {
 		check("CREATE TABLE tbl1 (\n" +
 				"  a bigint,\n" +

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -132,6 +132,15 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	}
 
 	@Test
+	public void testAlterDatabase() {
+		check("alter database db1 set ('key1' = 'value1','key2.a' = 'value2.a')",
+			"ALTER DATABASE `DB1` SET (\n" +
+			"  'key1' = 'value1',\n" +
+			"  'key2.a' = 'value2.a'\n" +
+			")");
+	}
+
+	@Test
 	public void testCreateTable() {
 		check("CREATE TABLE tbl1 (\n" +
 				"  a bigint,\n" +

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -124,6 +124,14 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	}
 
 	@Test
+	public void testDropDatabase() {
+		check("drop database db1", "DROP DATABASE `DB1` RESTRICT");
+		check("drop database catalog1.db1", "DROP DATABASE `CATALOG1`.`DB1` RESTRICT");
+		check("drop database db1 RESTRICT", "DROP DATABASE `DB1` RESTRICT");
+		check("drop database db1 CASCADE", "DROP DATABASE `DB1` CASCADE");
+	}
+
+	@Test
 	public void testCreateTable() {
 		check("CREATE TABLE tbl1 (\n" +
 				"  a bigint,\n" +

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -101,6 +101,12 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	}
 
 	@Test
+	public void testUseDataBase() {
+		check("use default_db", "USE `DEFAULT_DB`");
+		check("use defaultCatalog.default_db", "USE `DEFAULTCATALOG`.`DEFAULT_DB`");
+	}
+
+	@Test
 	public void testCreateTable() {
 		check("CREATE TABLE tbl1 (\n" +
 				"  a bigint,\n" +

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -141,6 +141,13 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	}
 
 	@Test
+	public void testDescribeDatabase() {
+		check("describe database db1", "DESCRIBE DATABASE `DB1`");
+		check("describe database catlog1.db1", "DESCRIBE DATABASE `CATLOG1`.`DB1`");
+		check("describe database extended db1", "DESCRIBE DATABASE EXTENDED `DB1`");
+	}
+
+	@Test
 	public void testCreateTable() {
 		check("CREATE TABLE tbl1 (\n" +
 				"  a bigint,\n" +

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -107,6 +107,23 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	}
 
 	@Test
+	public void testCreateDatabase() {
+		check("create database db1", "CREATE DATABASE `DB1`");
+		check("create database if not exists db1", "CREATE DATABASE IF NOT EXISTS `DB1`");
+		check("create database catalog1.db1", "CREATE DATABASE `CATALOG1`.`DB1`");
+		check("create database db1 comment 'test create database'",
+			"CREATE DATABASE `DB1`\n" +
+			"COMMENT 'test create database'");
+		check("create database db1 comment 'test create database'" +
+			"with ( 'key1' = 'value1', 'key2.a' = 'value2.a')",
+			"CREATE DATABASE `DB1`\n" +
+			"COMMENT 'test create database' WITH (\n" +
+			"  'key1' = 'value1',\n" +
+			"  'key2.a' = 'value2.a'\n" +
+			")");
+	}
+
+	@Test
 	public void testCreateTable() {
 		check("CREATE TABLE tbl1 (\n" +
 				"  a bigint,\n" +


### PR DESCRIPTION
## What is the purpose of the change

According to FLIP-69, we should introduce such following DDLs related to the database in the sql parser.
1. createDatabaseStatement:
CREATE DATABASE [ IF NOT EXISTS ] [ catalogName.] dataBaseName
[ COMMENT database_comment ]
[WITH ( name=value [, name=value]*)]
2. dropDatabaseStatement:
DROP DATABASE [ IF EXISTS ] [ catalogName.] dataBaseName
[ (RESTRICT|CASCADE)]
3. alterDatabaseStatement:
ALTER DATABASE [ catalogName.] dataBaseName SET
( name=value [, name=value]*)
4. useDatabaseStatement:
USE [ catalogName.] dataBaseName
5. showDatabasesStatement:
SHOW DATABASES
6. descDatabaseStatement:
DESCRIBE DATABASE [ EXTENDED] [ catalogName.] dataBasesName

The PR is only about parser related changes to support catalog related commands and Hooking up with table env will come later.

## Brief change log
  - [c9b2309](https://github.com/apache/flink/commit/c9b2309a888bb05db2fcf126c89b8b4623a9976a)Add show databases parser support
  - [6afcc4d](https://github.com/apache/flink/commit/6afcc4d58a09b663524bbf4d353082f3ed7122db)add use database support in parser
  - [0eb9dba](https://github.com/apache/flink/commit/0eb9dba5f221514e7d8d81d07ff5faa4b2bd76b9)add creata database support in parser
  - [86f418b](https://github.com/apache/flink/commit/86f418b942a4bad069597f8f2d6d8875edb7ab43)add drop database support in parser
  - [210ce6a](https://github.com/apache/flink/commit/210ce6a12d00f458851c7c4e4fc63ad72ffebae1)add alter database support in parser
  - [f513a1d](https://github.com/apache/flink/commit/f513a1dd566673c9c60e2bab0259f82ea14fb2c4)add describe database support in parser


## Verifying this change
This change added tests and can be verified as follows:
  - *FlinkSqlParserImplTest#testShowDataBases*
  - *FlinkSqlParserImplTest#testUseDataBase*
  - *FlinkSqlParserImplTest#testCreateDatabase*
  - *FlinkSqlParserImplTest#testDropDatabase*
  - *FlinkSqlParserImplTest#testAlterDatabase*
  - *FlinkSqlParserImplTest#testAlterDatabase* 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? (not applicable)
