### PR TITLE
[FLINK-14782][table] CoreModule#getFunctionDefinition should return empty optional when function does not exist

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/module/CoreModule.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/module/CoreModule.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.functions.FunctionDefinition;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -44,10 +45,9 @@ public class CoreModule implements Module {
 
 	@Override
 	public Optional<FunctionDefinition> getFunctionDefinition(String name) {
-		return Optional.ofNullable(
-			BuiltInFunctionDefinitions.getDefinitions().stream()
+		return BuiltInFunctionDefinitions.getDefinitions().stream()
 				.filter(f -> f.getName().equalsIgnoreCase(name))
 				.findFirst()
-				.get());
+				.map(Function.identity());
 	}
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/module/CoreModuleTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/module/CoreModuleTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.module;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+
+public class CoreModuleTest {
+	@Test
+	public void testGetNonExistFunction() {
+		assertFalse(CoreModule.INSTANCE.getFunctionDefinition("nonexist").isPresent());
+	}
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/module/CoreModuleTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/module/CoreModuleTest.java
@@ -22,6 +22,9 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
 
+/**
+ * Test for {@link CoreModule}.
+ */
 public class CoreModuleTest {
 	@Test
 	public void testGetNonExistFunction() {


### PR DESCRIPTION
## What is the purpose of the change

CoreModule#getFunctionDefinition should return empty optional when function does not exist.

## Brief change log

- fixed the bug
- added UT

## Verifying this change

This change added tests and can be verified as `CoreModuleTest`

## Does this pull request potentially affect one of the following parts:

n/a

## Documentation

n/a
