### PR TITLE
[FLINK-14688] Add table related DDLs support in SQL Parser

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -77,13 +77,9 @@
     "DATABASES",
     "FUNCTIONS",
     "EXTENDED",
-<<<<<<< HEAD
-    "SCALA"
-    "TABLES"
-=======
+    "SCALA",
     "TABLES",
     "RENAME"
->>>>>>> add alter table support in parser
   ]
 
   # List of keywords from "keywords" section that are not reserved.

--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -40,6 +40,7 @@
     "org.apache.flink.sql.parser.ddl.SqlAlterFunction",
     "org.apache.flink.sql.parser.ddl.SqlCreateFunction",
     "org.apache.flink.sql.parser.ddl.SqlDropFunction",
+    "org.apache.flink.sql.parser.ddl.SqlAlterTable",
     "org.apache.flink.sql.parser.dml.RichSqlInsert",
     "org.apache.flink.sql.parser.dml.RichSqlInsertKeyword",
     "org.apache.flink.sql.parser.dql.SqlShowCatalogs",
@@ -76,8 +77,13 @@
     "DATABASES",
     "FUNCTIONS",
     "EXTENDED",
+<<<<<<< HEAD
     "SCALA"
     "TABLES"
+=======
+    "TABLES",
+    "RENAME"
+>>>>>>> add alter table support in parser
   ]
 
   # List of keywords from "keywords" section that are not reserved.
@@ -259,6 +265,7 @@
     "QUARTER"
     "READ"
     "RELATIVE"
+    "RENAME"
     "REPEATABLE"
     "REPLACE"
     "RESPECT"
@@ -412,7 +419,8 @@
     "SqlAlterFunction()",
     "SqlShowFunctions()",
     "SqlShowTables()",
-    "SqlRichDescribeTable()"
+    "SqlRichDescribeTable()",
+    "SqlAlterTable()"
   ]
 
   # List of methods for parsing custom literals.

--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -47,6 +47,7 @@
     "org.apache.flink.sql.parser.dql.SqlShowDatabases",
     "org.apache.flink.sql.parser.dql.SqlShowFunctions",
     "org.apache.flink.sql.parser.dql.SqlDescribeDatabase",
+    "org.apache.flink.sql.parser.dql.SqlShowTables",
     "org.apache.flink.sql.parser.type.ExtendedSqlBasicTypeNameSpec",
     "org.apache.flink.sql.parser.type.ExtendedSqlCollectionTypeNameSpec",
     "org.apache.flink.sql.parser.utils.SqlTimeUnit",
@@ -75,6 +76,7 @@
     "FUNCTIONS",
     "EXTENDED",
     "SCALA"
+    "TABLES"
   ]
 
   # List of keywords from "keywords" section that are not reserved.
@@ -348,6 +350,7 @@
     "STYLE"
     "SUBCLASS_ORIGIN"
     "SUBSTITUTE"
+    "TABLES"
     "TABLE_NAME"
     "TEMPORARY"
     "TIES"
@@ -406,7 +409,8 @@
     "SqlAlterDatabase()",
     "SqlDescribeDatabase()",
     "SqlAlterFunction()",
-    "SqlShowFunctions()"
+    "SqlShowFunctions()",
+    "SqlShowTables()"
   ]
 
   # List of methods for parsing custom literals.

--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -48,6 +48,7 @@
     "org.apache.flink.sql.parser.dql.SqlShowFunctions",
     "org.apache.flink.sql.parser.dql.SqlDescribeDatabase",
     "org.apache.flink.sql.parser.dql.SqlShowTables",
+    "org.apache.flink.sql.parser.dql.SqlRichDescribeTable",
     "org.apache.flink.sql.parser.type.ExtendedSqlBasicTypeNameSpec",
     "org.apache.flink.sql.parser.type.ExtendedSqlCollectionTypeNameSpec",
     "org.apache.flink.sql.parser.utils.SqlTimeUnit",
@@ -410,7 +411,8 @@
     "SqlDescribeDatabase()",
     "SqlAlterFunction()",
     "SqlShowFunctions()",
-    "SqlShowTables()"
+    "SqlShowTables()",
+    "SqlRichDescribeTable()"
   ]
 
   # List of methods for parsing custom literals.

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -317,7 +317,33 @@ SqlRichDescribeTable SqlRichDescribeTable() :
     {
         return new SqlRichDescribeTable(pos, tableName, isExtended);
     }
+}
 
+SqlAlterTable SqlAlterTable() :
+{
+    SqlParserPos startPos;
+    SqlIdentifier tableName;
+    SqlIdentifier newTableName = null;
+    SqlNodeList propertyList = SqlNodeList.EMPTY;
+    boolean isRename = true;
+}
+{
+    <ALTER> <TABLE> { startPos = getPos(); }
+    tableName = CompoundIdentifier()
+    (
+        <RENAME> <TO> { isRename = true; }
+        newTableName = SimpleIdentifier()
+    |
+        <SET>   { isRename = false; }
+        propertyList = TableProperties()
+    )
+    {
+        return new SqlAlterTable(startPos.plus(getPos()),
+            tableName,
+            newTableName,
+            propertyList,
+            isRename);
+    }
 }
 
 void TableColumn(TableCreationContext context) :

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -290,6 +290,17 @@ SqlShowFunctions SqlShowFunctions() :
     [database = CompoundIdentifier()]
     {
         return new SqlShowFunctions(pos, database);
+
+/**
+* Parse a "Show Tables" metadata query command.
+*/
+SqlShowTables SqlShowTables() :
+{
+}
+{
+    <SHOW> <TABLES>
+    {
+        return new SqlShowTables(getPos());
     }
 }
 

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -304,6 +304,10 @@ SqlShowTables SqlShowTables() :
     }
 }
 
+/**
+ * DESCRIBE [ EXTENDED] [[catalogName.] dataBasesName].tableName sql call.
+ * Here we add Rich in className to distinguish from calcite's original SqlDescribeTable.
+ */
 SqlRichDescribeTable SqlRichDescribeTable() :
 {
     SqlIdentifier tableName;
@@ -332,7 +336,7 @@ SqlAlterTable SqlAlterTable() :
     tableName = CompoundIdentifier()
     (
         <RENAME> <TO> { isRename = true; }
-        newTableName = SimpleIdentifier()
+        newTableName = CompoundIdentifier()
     |
         <SET>   { isRename = false; }
         propertyList = TableProperties()

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -304,6 +304,22 @@ SqlShowTables SqlShowTables() :
     }
 }
 
+SqlRichDescribeTable SqlRichDescribeTable() :
+{
+    SqlIdentifier tableName;
+    SqlParserPos pos;
+    boolean isExtended = false;
+}
+{
+    <DESCRIBE> { pos = getPos();}
+    [ <EXTENDED> { isExtended = true;} ]
+    tableName = CompoundIdentifier()
+    {
+        return new SqlRichDescribeTable(pos, tableName, isExtended);
+    }
+
+}
+
 void TableColumn(TableCreationContext context) :
 {
 }

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -290,6 +290,8 @@ SqlShowFunctions SqlShowFunctions() :
     [database = CompoundIdentifier()]
     {
         return new SqlShowFunctions(pos, database);
+    }
+}
 
 /**
 * Parse a "Show Tables" metadata query command.
@@ -326,25 +328,25 @@ SqlRichDescribeTable SqlRichDescribeTable() :
 SqlAlterTable SqlAlterTable() :
 {
     SqlParserPos startPos;
-    SqlIdentifier tableName;
-    SqlIdentifier newTableName = null;
+    SqlIdentifier tableIdentifier;
+    SqlIdentifier newTableIdentifier = null;
     SqlNodeList propertyList = SqlNodeList.EMPTY;
     boolean isRename = true;
 }
 {
     <ALTER> <TABLE> { startPos = getPos(); }
-    tableName = CompoundIdentifier()
+        tableIdentifier = CompoundIdentifier()
     (
         <RENAME> <TO> { isRename = true; }
-        newTableName = CompoundIdentifier()
+        newTableIdentifier = CompoundIdentifier()
     |
         <SET>   { isRename = false; }
         propertyList = TableProperties()
     )
     {
         return new SqlAlterTable(startPos.plus(getPos()),
-            tableName,
-            newTableName,
+            tableIdentifier,
+            newTableIdentifier,
             propertyList,
             isRename);
     }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterTable.java
@@ -34,7 +34,7 @@ import java.util.List;
 import static java.util.Objects.requireNonNull;
 
 /**
- * ALTER TABLE [[catalogName.] dataBasesName].tableName RENAME TO newTableName or
+ * ALTER TABLE [[catalogName.] dataBasesName].tableName RENAME TO [[catalogName.] dataBasesName].newTableName or
  * ALTER TABLE [[catalogName.] dataBasesName].tableName SET ( name=value [, name=value]*) sql call.
  */
 public class SqlAlterTable extends SqlCall {
@@ -74,10 +74,6 @@ public class SqlAlterTable extends SqlCall {
 		return tableName;
 	}
 
-	public String getNewTableName() {
-		return newTableName.getSimple();
-	}
-
 	public boolean isRename() {
 		return isRename;
 	}
@@ -113,5 +109,9 @@ public class SqlAlterTable extends SqlCall {
 
 	public String[] fullDatabaseName() {
 		return tableName.names.toArray(new String[0]);
+	}
+
+	public String[] fullNewDatabaseName() {
+		return newTableName.names.toArray(new String[0]);
 	}
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterTable.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * ALTER TABLE [[catalogName.] dataBasesName].tableName RENAME TO newTableName or
+ * ALTER TABLE [[catalogName.] dataBasesName].tableName SET ( name=value [, name=value]*) sql call.
+ */
+public class SqlAlterTable extends SqlCall {
+
+	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("ALTER TABLE", SqlKind.ALTER_TABLE);
+
+	private final SqlIdentifier tableName;
+	private final SqlIdentifier newTableName;
+
+	private final SqlNodeList propertyList;
+	private final boolean isRename;
+
+	public SqlAlterTable(
+			SqlParserPos pos,
+			SqlIdentifier tableName,
+			SqlIdentifier newTableName,
+			SqlNodeList propertyList,
+			boolean isRename) {
+		super(pos);
+		this.tableName = requireNonNull(tableName, "tableName should not be null");
+		this.newTableName = newTableName;
+		this.propertyList = requireNonNull(propertyList, "propertyList should not be null");
+		this.isRename = isRename;
+	}
+
+	@Override
+	public SqlOperator getOperator() {
+		return OPERATOR;
+	}
+
+	@Override
+	public List<SqlNode> getOperandList() {
+		return ImmutableNullableList.of(tableName, propertyList);
+	}
+
+	public SqlIdentifier getTableName() {
+		return tableName;
+	}
+
+	public String getNewTableName() {
+		return newTableName.getSimple();
+	}
+
+	public boolean isRename() {
+		return isRename;
+	}
+
+	public SqlNodeList getPropertyList() {
+		return propertyList;
+	}
+
+	@Override
+	public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+		writer.keyword("ALTER TABLE");
+		tableName.unparse(writer, leftPrec, rightPrec);
+		if (isRename) {
+			writer.keyword("RENAME TO");
+			newTableName.unparse(writer, leftPrec, rightPrec);
+		} else {
+			writer.keyword("SET");
+			SqlWriter.Frame withFrame = writer.startList("(", ")");
+			for (SqlNode property : propertyList) {
+				printIndent(writer);
+				property.unparse(writer, leftPrec, rightPrec);
+			}
+			writer.newlineAndIndent();
+			writer.endList(withFrame);
+		}
+	}
+
+	private void printIndent(SqlWriter writer) {
+		writer.sep(",", false);
+		writer.newlineAndIndent();
+		writer.print("  ");
+	}
+
+	public String[] fullDatabaseName() {
+		return tableName.names.toArray(new String[0]);
+	}
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterTable.java
@@ -41,8 +41,8 @@ public class SqlAlterTable extends SqlCall {
 
 	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("ALTER TABLE", SqlKind.ALTER_TABLE);
 
-	private final SqlIdentifier tableName;
-	private final SqlIdentifier newTableName;
+	private final SqlIdentifier tableIdentifier;
+	private final SqlIdentifier newTableIdentifier;
 
 	private final SqlNodeList propertyList;
 	private final boolean isRename;
@@ -54,8 +54,8 @@ public class SqlAlterTable extends SqlCall {
 			SqlNodeList propertyList,
 			boolean isRename) {
 		super(pos);
-		this.tableName = requireNonNull(tableName, "tableName should not be null");
-		this.newTableName = newTableName;
+		this.tableIdentifier = requireNonNull(tableName, "tableName should not be null");
+		this.newTableIdentifier = newTableName;
 		this.propertyList = requireNonNull(propertyList, "propertyList should not be null");
 		this.isRename = isRename;
 	}
@@ -67,11 +67,11 @@ public class SqlAlterTable extends SqlCall {
 
 	@Override
 	public List<SqlNode> getOperandList() {
-		return ImmutableNullableList.of(tableName, propertyList);
+		return ImmutableNullableList.of(tableIdentifier, newTableIdentifier, propertyList);
 	}
 
 	public SqlIdentifier getTableName() {
-		return tableName;
+		return tableIdentifier;
 	}
 
 	public boolean isRename() {
@@ -85,10 +85,10 @@ public class SqlAlterTable extends SqlCall {
 	@Override
 	public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
 		writer.keyword("ALTER TABLE");
-		tableName.unparse(writer, leftPrec, rightPrec);
+		tableIdentifier.unparse(writer, leftPrec, rightPrec);
 		if (isRename) {
 			writer.keyword("RENAME TO");
-			newTableName.unparse(writer, leftPrec, rightPrec);
+			newTableIdentifier.unparse(writer, leftPrec, rightPrec);
 		} else {
 			writer.keyword("SET");
 			SqlWriter.Frame withFrame = writer.startList("(", ")");
@@ -107,11 +107,11 @@ public class SqlAlterTable extends SqlCall {
 		writer.print("  ");
 	}
 
-	public String[] fullDatabaseName() {
-		return tableName.names.toArray(new String[0]);
+	public String[] fullTableName() {
+		return tableIdentifier.names.toArray(new String[0]);
 	}
 
-	public String[] fullNewDatabaseName() {
-		return newTableName.names.toArray(new String[0]);
+	public String[] fullNewTableName() {
+		return newTableIdentifier.names.toArray(new String[0]);
 	}
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlRichDescribeTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlRichDescribeTable.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.dql;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * DESCRIBE [ EXTENDED] [[catalogName.] dataBasesName].tableName sql call.
+ * Here we add Rich in className to distinguish from calcite's original SqlDescribeTable.
+ */
+public class SqlRichDescribeTable extends SqlCall {
+
+	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("DESCRIBE TABLE", SqlKind.DESCRIBE_TABLE);
+	private final SqlIdentifier tableName;
+	private boolean isExtended = false;
+
+	public SqlRichDescribeTable(SqlParserPos pos, SqlIdentifier tableName, boolean isExtended) {
+		super(pos);
+		this.tableName = tableName;
+		this.isExtended = isExtended;
+	}
+
+	@Override
+	public SqlOperator getOperator() {
+		return OPERATOR;
+	}
+
+	@Override
+	public List<SqlNode> getOperandList() {
+		return Collections.singletonList(tableName);
+	}
+
+	public String getDatabaseName() {
+		return tableName.getSimple();
+	}
+
+	public boolean isExtended() {
+		return isExtended;
+	}
+
+	public String[] fullTableName() {
+		return tableName.names.toArray(new String[0]);
+	}
+
+	@Override
+	public void unparse(
+			SqlWriter writer,
+			int leftPrec,
+			int rightPrec) {
+		writer.keyword("DESCRIBE");
+		if (isExtended) {
+			writer.keyword("EXTENDED");
+		}
+		tableName.unparse(writer, leftPrec, rightPrec);
+	}
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlRichDescribeTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlRichDescribeTable.java
@@ -31,18 +31,18 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * DESCRIBE [ EXTENDED] [[catalogName.] dataBasesName].tableName sql call.
+ * DESCRIBE [ EXTENDED] [[catalogName.] dataBasesName].sqlIdentifier sql call.
  * Here we add Rich in className to distinguish from calcite's original SqlDescribeTable.
  */
 public class SqlRichDescribeTable extends SqlCall {
 
 	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("DESCRIBE TABLE", SqlKind.DESCRIBE_TABLE);
-	private final SqlIdentifier tableName;
+	private final SqlIdentifier tableNameIdentifier;
 	private boolean isExtended = false;
 
-	public SqlRichDescribeTable(SqlParserPos pos, SqlIdentifier tableName, boolean isExtended) {
+	public SqlRichDescribeTable(SqlParserPos pos, SqlIdentifier tableNameIdentifier, boolean isExtended) {
 		super(pos);
-		this.tableName = tableName;
+		this.tableNameIdentifier = tableNameIdentifier;
 		this.isExtended = isExtended;
 	}
 
@@ -53,11 +53,7 @@ public class SqlRichDescribeTable extends SqlCall {
 
 	@Override
 	public List<SqlNode> getOperandList() {
-		return Collections.singletonList(tableName);
-	}
-
-	public String getDatabaseName() {
-		return tableName.getSimple();
+		return Collections.singletonList(tableNameIdentifier);
 	}
 
 	public boolean isExtended() {
@@ -65,7 +61,7 @@ public class SqlRichDescribeTable extends SqlCall {
 	}
 
 	public String[] fullTableName() {
-		return tableName.names.toArray(new String[0]);
+		return tableNameIdentifier.names.toArray(new String[0]);
 	}
 
 	@Override
@@ -77,6 +73,6 @@ public class SqlRichDescribeTable extends SqlCall {
 		if (isExtended) {
 			writer.keyword("EXTENDED");
 		}
-		tableName.unparse(writer, leftPrec, rightPrec);
+		tableNameIdentifier.unparse(writer, leftPrec, rightPrec);
 	}
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowTables.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowTables.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.dql;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * SHOW Tables sql call.
+ */
+public class SqlShowTables extends SqlCall {
+
+	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("SHOW TABLES", SqlKind.OTHER);
+
+	public SqlShowTables(SqlParserPos pos) {
+		super(pos);
+	}
+
+	@Override
+	public SqlOperator getOperator() {
+		return OPERATOR;
+	}
+
+	@Override
+	public List<SqlNode> getOperandList() {
+		return Collections.EMPTY_LIST;
+	}
+
+	@Override
+	public void unparse(
+			SqlWriter writer,
+			int leftPrec,
+			int rightPrec) {
+		writer.keyword("SHOW TABLES");
+	}
+}

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -178,6 +178,20 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	}
 
 	@Test
+	public void testDescribeTable() {
+		check("describe tbl", "DESCRIBE `TBL`");
+		check("describe catlog1.db1.tbl", "DESCRIBE `CATLOG1`.`DB1`.`TBL`");
+		check("describe extended db1", "DESCRIBE EXTENDED `DB1`");
+	}
+
+	/**
+	 * Here we override the super method to avoid test error from `describe statement` supported in original calcite.
+	 */
+	@Override
+	public void testDescribeStatement() {
+	}
+
+	@Test
 	public void testCreateTable() {
 		check("CREATE TABLE tbl1 (\n" +
 				"  a bigint,\n" +

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -173,6 +173,11 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	}
 
 	@Test
+	public void testShowTables() {
+		check("show tables", "SHOW TABLES");
+	}
+
+	@Test
 	public void testCreateTable() {
 		check("CREATE TABLE tbl1 (\n" +
 				"  a bigint,\n" +

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -192,6 +192,16 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	}
 
 	@Test
+	public void testAlterTable() {
+		check("alter table t1 rename to t2", "ALTER TABLE `T1` RENAME TO `T2`");
+		check("alter table c1.d1.t1 rename to t2", "ALTER TABLE `C1`.`D1`.`T1` RENAME TO `T2`");
+		check("alter table t1 set ('key1'='value1')",
+			"ALTER TABLE `T1` SET (\n" +
+			"  'key1' = 'value1'\n" +
+			")");
+	}
+
+	@Test
 	public void testCreateTable() {
 		check("CREATE TABLE tbl1 (\n" +
 				"  a bigint,\n" +


### PR DESCRIPTION
## What is the purpose of the change

The PR is only about parser related changes to support table-related commands and Hooking up with table env will come later. We add such parser support:
1. showTablesStatement:
SHOW TABLES
2. descTableStatement:
DESCRIBE [ EXTENDED] [[catalogName.] dataBasesName].tableName
3. alterTableStatement:
ALTER TABLE [[catalogName.] dataBasesName].tableName
RENAME TO newTableName
4. ALTER TABLE [[catalogName.] dataBasesName].tableName
SET ( name=value [, name=value]*)


## Brief change log
  - *add show tables syntax support in parsre*
  - *add describe table support in parser*
  - *add alter table support in parser*


## Verifying this change
This change added tests and can be verified as follows:
  - *FlinkSqlParserImplTest#testShowTables*
  - *FlinkSqlParserImplTest#testDescribeTable*
  - *FlinkSqlParserImplTest#testAlterTable*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yno)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? (not applicable)
