### PR TITLE
[FLINK-14800][hive] Introduce parallelism inference for HiveSource

### DIFF
--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -72,6 +72,13 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
 		<!-- format dependencies -->
 
 		<dependency>
@@ -366,13 +373,6 @@ under the License.
 			<artifactId>flink-table-api-java</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
@@ -33,4 +33,16 @@ public class HiveOptions {
 					.withDescription(
 							"If it is false, using flink native vectorized reader to read orc files; " +
 									"If it is true, using hadoop mapred record reader to read orc files.");
+
+	public static final ConfigOption<Boolean> TABLE_EXEC_HIVE_INFER_SOURCE_PARALLELISM =
+			key("table.exec.hive.infer-source-parallelism")
+					.defaultValue(true)
+					.withDescription(
+							"If is false, parallelism of source are set by config.\n" +
+							"If is true, source parallelism is inferred according to splits number.\n");
+
+	public static final ConfigOption<Integer> TABLE_EXEC_HIVE_INFER_SOURCE_PARALLELISM_MAX =
+			key("table.exec.hive.infer-source-parallelism.max")
+					.defaultValue(1000)
+					.withDescription("Sets max infer parallelism for source operator.");
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableFactory.java
@@ -28,7 +28,7 @@ import org.apache.flink.table.factories.TableSinkFactory;
 import org.apache.flink.table.factories.TableSourceFactory;
 import org.apache.flink.table.sinks.OutputFormatTableSink;
 import org.apache.flink.table.sinks.TableSink;
-import org.apache.flink.table.sources.InputFormatTableSource;
+import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
@@ -78,19 +78,19 @@ public class HiveTableFactory
 		Preconditions.checkNotNull(table);
 		Preconditions.checkArgument(table instanceof CatalogTableImpl);
 
-		boolean isGeneric = Boolean.valueOf(table.getProperties().get(CatalogConfig.IS_GENERIC));
+		boolean isGeneric = Boolean.parseBoolean(table.getProperties().get(CatalogConfig.IS_GENERIC));
 
 		if (!isGeneric) {
-			return createInputFormatTableSource(tablePath, table);
+			return createHiveTableSource(tablePath, table);
 		} else {
 			return TableFactoryUtil.findAndCreateTableSource(table);
 		}
 	}
 
 	/**
-	 * Creates and configures a {@link org.apache.flink.table.sources.InputFormatTableSource} using the given {@link CatalogTable}.
+	 * Creates and configures a {@link StreamTableSource} using the given {@link CatalogTable}.
 	 */
-	private InputFormatTableSource<BaseRow> createInputFormatTableSource(ObjectPath tablePath, CatalogTable table) {
+	private StreamTableSource<BaseRow> createHiveTableSource(ObjectPath tablePath, CatalogTable table) {
 		return new HiveTableSource(new JobConf(hiveConf), tablePath, table);
 	}
 
@@ -99,7 +99,7 @@ public class HiveTableFactory
 		Preconditions.checkNotNull(table);
 		Preconditions.checkArgument(table instanceof CatalogTableImpl);
 
-		boolean isGeneric = Boolean.valueOf(table.getProperties().get(CatalogConfig.IS_GENERIC));
+		boolean isGeneric = Boolean.parseBoolean(table.getProperties().get(CatalogConfig.IS_GENERIC));
 
 		if (!isGeneric) {
 			return createOutputFormatTableSink(tablePath, table);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -18,8 +18,13 @@
 
 package org.apache.flink.connectors.hive;
 
-import org.apache.flink.api.common.io.InputFormat;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.connectors.hive.read.HiveTableInputFormat;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectPath;
@@ -27,10 +32,10 @@ import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientFactory;
 import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientWrapper;
 import org.apache.flink.table.catalog.hive.descriptors.HiveCatalogValidator;
 import org.apache.flink.table.dataformat.BaseRow;
-import org.apache.flink.table.sources.InputFormatTableSource;
 import org.apache.flink.table.sources.LimitableTableSource;
 import org.apache.flink.table.sources.PartitionableTableSource;
 import org.apache.flink.table.sources.ProjectableTableSource;
+import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
@@ -41,7 +46,10 @@ import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.thrift.TException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.sql.Date;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -49,11 +57,21 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.connectors.hive.HiveOptions.TABLE_EXEC_HIVE_INFER_SOURCE_PARALLELISM;
+import static org.apache.flink.connectors.hive.HiveOptions.TABLE_EXEC_HIVE_INFER_SOURCE_PARALLELISM_MAX;
+import static org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter.fromDataTypeToTypeInfo;
+import static org.apache.flink.table.utils.TableConnectorUtils.generateRuntimeName;
+
 /**
  * A TableSource implementation to read data from Hive tables.
  */
-public class HiveTableSource extends InputFormatTableSource<BaseRow>
-		implements PartitionableTableSource, ProjectableTableSource<BaseRow>, LimitableTableSource<BaseRow> {
+public class HiveTableSource implements
+		StreamTableSource<BaseRow>,
+		PartitionableTableSource,
+		ProjectableTableSource<BaseRow>,
+		LimitableTableSource<BaseRow> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(HiveTableSource.class);
 
 	private final JobConf jobConf;
 	private final ObjectPath tablePath;
@@ -103,11 +121,44 @@ public class HiveTableSource extends InputFormatTableSource<BaseRow>
 	}
 
 	@Override
-	public InputFormat<BaseRow, ?> getInputFormat() {
+	public boolean isBounded() {
+		return true;
+	}
+
+	@Override
+	public DataStream<BaseRow> getDataStream(StreamExecutionEnvironment execEnv) {
 		if (!initAllPartitions) {
 			initAllPartitions();
 		}
-		return new HiveTableInputFormat(jobConf, catalogTable, allHivePartitions, projectedFields, limit, hiveVersion);
+
+		@SuppressWarnings("unchecked")
+		TypeInformation<BaseRow> typeInfo = (TypeInformation<BaseRow>) fromDataTypeToTypeInfo(getProducedDataType());
+		HiveTableInputFormat inputFormat = getInputFormat();
+		DataStreamSource<BaseRow> source = execEnv.createInput(inputFormat, typeInfo);
+
+		Configuration conf = GlobalConfiguration.loadConfiguration();
+		if (conf.getBoolean(TABLE_EXEC_HIVE_INFER_SOURCE_PARALLELISM)) {
+			int max = conf.getInteger(TABLE_EXEC_HIVE_INFER_SOURCE_PARALLELISM_MAX);
+			int splitNum;
+			try {
+				long nano1 = System.nanoTime();
+				splitNum = inputFormat.createInputSplits(0).length;
+				long nano2 = System.nanoTime();
+				LOG.info(
+						"Hive source({}}) createInputSplits use time: {} ms",
+						tablePath,
+						(nano2 - nano1) / 1_000_000);
+			} catch (IOException e) {
+				throw new FlinkHiveException(e);
+			}
+			source.setParallelism(Math.min(Math.max(1, splitNum), max));
+		}
+		return source.name(explainSource());
+	}
+
+	private HiveTableInputFormat getInputFormat() {
+		return new HiveTableInputFormat(
+				jobConf, catalogTable, allHivePartitions, projectedFields, limit, hiveVersion);
 	}
 
 	@Override
@@ -255,7 +306,7 @@ public class HiveTableSource extends InputFormatTableSource<BaseRow>
 		if (isLimitPushDown) {
 			explain += String.format(", LimitPushDown %s, Limit %d", isLimitPushDown, limit);
 		}
-		return super.explainSource() + explain;
+		return generateRuntimeName(getClass(), getTableSchema().getFieldNames()) + explain;
 	}
 
 	@Override


### PR DESCRIPTION

## What is the purpose of the change

In batch processing scenarios, unlike streams, batches have many dimension tables (sources that need to be scanned), which are often very small. If we still use the current unified parallelism method, a large number of shuffle files will be generated, and too much parallelism will seriously affect performance, which will directly lead that we can not set high parallelism.

Because new source api is not ready, we can not finish FLINK-14676
Let's introduce parallelism inference for HiveSource first.

## Brief change log

- Use splits number to infer parallelism.
- Introduce config to limit max parallelism.
- Introduce config to close inference. Maybe some scenarios are not suitable for accessing h on the client.

## Verifying this change

HiveTableSourceTest.testParallelismSetting

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? JavaDocs
