### PR TITLE
[FLINK-14806][table-planner-blink] Add setTimestamp/getTimestamp inte…

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/AbstractBinaryWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/AbstractBinaryWriter.java
@@ -184,7 +184,6 @@ public abstract class AbstractBinaryWriter implements BinaryWriter {
 	@Override
 	public void writeTimestamp(int pos, SqlTimestamp value, int precision) {
 		if (SqlTimestamp.isCompact(precision)) {
-			assert 0 == value.getNanoOfMillisecond();
 			writeLong(pos, value.getMillisecond());
 		} else {
 			// store the nanoOfMillisecond in fixed-length part as offset and nanoOfMillisecond

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/AbstractBinaryWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/AbstractBinaryWriter.java
@@ -181,6 +181,29 @@ public abstract class AbstractBinaryWriter implements BinaryWriter {
 		}
 	}
 
+	@Override
+	public void writeTimestamp(int pos, SqlTimestamp value, int precision) {
+		if (SqlTimestamp.isCompact(precision)) {
+			assert 0 == value.getNanoOfMillisecond();
+			writeLong(pos, value.getMillisecond());
+		} else {
+			// store the nanoOfMillisecond in fixed-length part as offset and nanoOfMillisecond
+			ensureCapacity(8);
+
+			if (value == null) {
+				setNullBit(pos);
+				// zero-out the bytes
+				segment.putLong(cursor, 0L);
+				setOffsetAndSize(pos, cursor, 0);
+			} else {
+				segment.putLong(cursor, value.getMillisecond());
+				setOffsetAndSize(pos, cursor, value.getNanoOfMillisecond());
+			}
+
+			cursor += 12;
+		}
+	}
+
 	private void zeroBytes(int offset, int size) {
 		for (int i = offset; i < offset + size; i++) {
 			segment.put(i, (byte) 0);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryArray.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryArray.java
@@ -202,10 +202,7 @@ public final class BinaryArray extends BinarySection implements BaseArray {
 
 		int fieldOffset = getElementOffset(pos, 8);
 		final long offsetAndNanoOfMilli = SegmentsUtil.getLong(segments, fieldOffset);
-		final int nanoOfMillisecond = (int) offsetAndNanoOfMilli;
-		final int subOffset = (int) (offsetAndNanoOfMilli >> 32);
-		final long millisecond = SegmentsUtil.getLong(segments, offset + subOffset);
-		return SqlTimestamp.fromEpochMillis(millisecond, nanoOfMillisecond);
+		return SqlTimestamp.readTimestampFieldFromSegments(segments, offset, offsetAndNanoOfMilli);
 	}
 
 	@Override
@@ -393,6 +390,7 @@ public final class BinaryArray extends BinarySection implements BaseArray {
 				setNullAt(pos);
 				// zero-out the bytes
 				SegmentsUtil.setLong(segments, offset + cursor, 0L);
+				// keep the offset for future update
 				SegmentsUtil.setLong(segments, fieldOffset, ((long) cursor) << 32);
 			} else {
 				// write millisecond to the variable length portion.

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryRow.java
@@ -227,6 +227,7 @@ public final class BinaryRow extends BinarySection implements BaseRow {
 				setNullAt(pos);
 				// zero-out the bytes
 				SegmentsUtil.setLong(segments, offset + cursor, 0L);
+				// keep the offset for future update
 				segments[0].putLong(fieldOffset, ((long) cursor) << 32);
 			} else {
 				// write millisecond to the variable length portion.
@@ -339,10 +340,7 @@ public final class BinaryRow extends BinarySection implements BaseRow {
 
 		int fieldOffset = getFieldOffset(pos);
 		final long offsetAndNanoOfMilli = segments[0].getLong(fieldOffset);
-		final int nanoOfMillisecond = (int) offsetAndNanoOfMilli;
-		final int subOffset = (int) (offsetAndNanoOfMilli >> 32);
-		final long millisecond = SegmentsUtil.getLong(segments, offset + subOffset);
-		return SqlTimestamp.fromEpochMillis(millisecond, nanoOfMillisecond);
+		return SqlTimestamp.readTimestampFieldFromSegments(segments, offset, offsetAndNanoOfMilli);
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryWriter.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.runtime.typeutils.BaseRowSerializer;
 import org.apache.flink.table.runtime.typeutils.BinaryGenericSerializer;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.TimestampType;
 
 /**
  * Writer to write a composite data format, like row, array.
@@ -63,6 +64,8 @@ public interface BinaryWriter {
 
 	void writeDecimal(int pos, Decimal value, int precision);
 
+	void writeTimestamp(int pos, SqlTimestamp value, int precision);
+
 	void writeArray(int pos, BaseArray value, BaseArraySerializer serializer);
 
 	void writeMap(int pos, BaseMap value, BaseMapSerializer serializer);
@@ -94,8 +97,11 @@ public interface BinaryWriter {
 			case INTERVAL_YEAR_MONTH:
 				writer.writeInt(pos, (int) o);
 				break;
-			case BIGINT:
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
+				TimestampType timestampType = (TimestampType) type;
+				writer.writeTimestamp(pos, (SqlTimestamp) o, timestampType.getPrecision());
+				break;
+			case BIGINT:
 			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
 			case INTERVAL_DAY_TIME:
 				writer.writeLong(pos, (long) o);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryWriter.java
@@ -24,7 +24,6 @@ import org.apache.flink.table.runtime.typeutils.BaseRowSerializer;
 import org.apache.flink.table.runtime.typeutils.BinaryGenericSerializer;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.TimestampType;
 
 /**
  * Writer to write a composite data format, like row, array.

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryWriter.java
@@ -97,11 +97,8 @@ public interface BinaryWriter {
 			case INTERVAL_YEAR_MONTH:
 				writer.writeInt(pos, (int) o);
 				break;
-			case TIMESTAMP_WITHOUT_TIME_ZONE:
-				TimestampType timestampType = (TimestampType) type;
-				writer.writeTimestamp(pos, (SqlTimestamp) o, timestampType.getPrecision());
-				break;
 			case BIGINT:
+			case TIMESTAMP_WITHOUT_TIME_ZONE:
 			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
 			case INTERVAL_DAY_TIME:
 				writer.writeLong(pos, (long) o);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/ColumnarRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/ColumnarRow.java
@@ -117,6 +117,11 @@ public final class ColumnarRow implements BaseRow {
 	}
 
 	@Override
+	public SqlTimestamp getTimestamp(int ordinal, int precision) {
+		return vectorizedColumnBatch.getTimestamp(rowId, ordinal, precision);
+	}
+
+	@Override
 	public <T> BinaryGeneric<T> getGeneric(int pos) {
 		throw new UnsupportedOperationException("GenericType is not supported.");
 	}
@@ -193,6 +198,11 @@ public final class ColumnarRow implements BaseRow {
 
 	@Override
 	public void setDecimal(int ordinal, Decimal value, int precision) {
+		throw new UnsupportedOperationException("Not support the operation!");
+	}
+
+	@Override
+	public void setTimestamp(int ordinal, SqlTimestamp value, int precision) {
 		throw new UnsupportedOperationException("Not support the operation!");
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/GenericArray.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/GenericArray.java
@@ -198,6 +198,11 @@ public class GenericArray implements BaseArray {
 	}
 
 	@Override
+	public SqlTimestamp getTimestamp(int pos, int precision) {
+		return (SqlTimestamp) getObject(pos);
+	}
+
+	@Override
 	public <T> BinaryGeneric<T> getGeneric(int pos) {
 		return (BinaryGeneric) getObject(pos);
 	}
@@ -282,6 +287,11 @@ public class GenericArray implements BaseArray {
 
 	@Override
 	public void setDecimal(int pos, Decimal value, int precision) {
+		setObject(pos, value);
+	}
+
+	@Override
+	public void setTimestamp(int pos, SqlTimestamp value, int precision) {
 		setObject(pos, value);
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/JoinedRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/JoinedRow.java
@@ -136,6 +136,15 @@ public final class JoinedRow implements BaseRow {
 	}
 
 	@Override
+	public SqlTimestamp getTimestamp(int i, int precision) {
+		if (i < row1.getArity()) {
+			return row1.getTimestamp(i, precision);
+		} else {
+			return row2.getTimestamp(i - row1.getArity(), precision);
+		}
+	}
+
+	@Override
 	public <T> BinaryGeneric<T> getGeneric(int i) {
 		if (i < row1.getArity()) {
 			return row1.getGeneric(i);
@@ -267,6 +276,15 @@ public final class JoinedRow implements BaseRow {
 			row1.setDecimal(i, value, precision);
 		} else {
 			row2.setDecimal(i - row1.getArity(), value, precision);
+		}
+	}
+
+	@Override
+	public void setTimestamp(int i, SqlTimestamp value, int precision) {
+		if (i < row1.getArity()) {
+			row1.setTimestamp(i, value, precision);
+		} else {
+			row2.setTimestamp(i - row1.getArity(), value, precision);
 		}
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/NestedRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/NestedRow.java
@@ -145,6 +145,31 @@ public final class NestedRow extends BinarySection implements BaseRow {
 	}
 
 	@Override
+	public void setTimestamp(int pos, SqlTimestamp value, int precision) {
+		assertIndexIsValid(pos);
+
+		if (SqlTimestamp.isCompact(precision)) {
+			setLong(pos, value.getMillisecond());
+		} else {
+			int fieldOffset = getFieldOffset(pos);
+			int cursor = (int) (SegmentsUtil.getLong(segments, fieldOffset) >>> 32);
+			assert cursor > 0 : "invalid cursor " + cursor;
+
+			if (value == null) {
+				setNullAt(pos);
+				// zero-out the bytes
+				SegmentsUtil.setLong(segments, offset + cursor, 0L);
+				SegmentsUtil.setLong(segments, fieldOffset, ((long) cursor) << 32);
+			} else {
+				// write millisecond to variable length portion.
+				SegmentsUtil.setLong(segments, offset + cursor, value.getMillisecond());
+				// write nanoOfMillisecond to fixed-length portion.
+				setLong(pos, ((long) cursor << 32) | (long) value.getNanoOfMillisecond());
+			}
+		}
+	}
+
+	@Override
 	public void setBoolean(int pos, boolean value) {
 		assertIndexIsValid(pos);
 		setNotNullAt(pos);
@@ -240,6 +265,22 @@ public final class NestedRow extends BinarySection implements BaseRow {
 		int fieldOffset = getFieldOffset(pos);
 		final long offsetAndSize = SegmentsUtil.getLong(segments, fieldOffset);
 		return Decimal.readDecimalFieldFromSegments(segments, offset, offsetAndSize, precision, scale);
+	}
+
+	@Override
+	public SqlTimestamp getTimestamp(int pos, int precision) {
+		assertIndexIsValid(pos);
+
+		if (SqlTimestamp.isCompact(precision)) {
+			return SqlTimestamp.fromEpochMillis(SegmentsUtil.getLong(segments, getFieldOffset(pos)));
+		}
+
+		int fieldOffset = getFieldOffset(pos);
+		final long offsetAndNanoOfMilli = SegmentsUtil.getLong(segments, fieldOffset);
+		final int nanoOfMillisecond = (int) offsetAndNanoOfMilli;
+		final int subOffset = (int) (offsetAndNanoOfMilli >> 32);
+		final long millisecond = SegmentsUtil.getLong(segments, offset + subOffset);
+		return SqlTimestamp.fromEpochMillis(millisecond, nanoOfMillisecond);
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/NestedRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/NestedRow.java
@@ -277,10 +277,7 @@ public final class NestedRow extends BinarySection implements BaseRow {
 
 		int fieldOffset = getFieldOffset(pos);
 		final long offsetAndNanoOfMilli = SegmentsUtil.getLong(segments, fieldOffset);
-		final int nanoOfMillisecond = (int) offsetAndNanoOfMilli;
-		final int subOffset = (int) (offsetAndNanoOfMilli >> 32);
-		final long millisecond = SegmentsUtil.getLong(segments, offset + subOffset);
-		return SqlTimestamp.fromEpochMillis(millisecond, nanoOfMillisecond);
+		return SqlTimestamp.readTimestampFieldFromSegments(segments, offset, offsetAndNanoOfMilli);
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/ObjectArrayRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/ObjectArrayRow.java
@@ -66,6 +66,11 @@ public abstract class ObjectArrayRow implements BaseRow {
 	}
 
 	@Override
+	public void setTimestamp(int ordinal, SqlTimestamp value, int precision) {
+		this.fields[ordinal] = value;
+	}
+
+	@Override
 	public BinaryString getString(int ordinal) {
 		return (BinaryString) this.fields[ordinal];
 	}
@@ -88,6 +93,11 @@ public abstract class ObjectArrayRow implements BaseRow {
 	@Override
 	public Decimal getDecimal(int ordinal, int precision, int scale) {
 		return (Decimal) this.fields[ordinal];
+	}
+
+	@Override
+	public SqlTimestamp getTimestamp(int ordinal, int precision) {
+		return (SqlTimestamp) this.fields[ordinal];
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/SqlTimestamp.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/SqlTimestamp.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.dataformat;
 
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.table.runtime.util.SegmentsUtil;
 import org.apache.flink.util.Preconditions;
 
 import java.sql.Timestamp;
@@ -183,5 +185,21 @@ public class SqlTimestamp implements Comparable<SqlTimestamp> {
 	 */
 	public static boolean isCompact(int precision) {
 		return precision <= 3;
+	}
+
+	/**
+	 * Obtains an instance of {@code SqlTimestamp} from underlying {@link MemorySegment}.
+	 *
+	 * @param segments the underlying MemorySegments
+	 * @param baseOffset the base offset of current instance of {@code SqlTimestamp}
+	 * @param offsetAndNanos the offset of millseconds part and nanoseconds
+	 * @return an instance of {@code SqlTimestamp}
+	 */
+	public static SqlTimestamp readTimestampFieldFromSegments(
+			MemorySegment[] segments, int baseOffset, long offsetAndNanos) {
+		final int nanoOfMillisecond = (int) offsetAndNanos;
+		final int subOffset = (int) (offsetAndNanos >> 32);
+		final long millisecond = SegmentsUtil.getLong(segments, baseOffset + subOffset);
+		return SqlTimestamp.fromEpochMillis(millisecond, nanoOfMillisecond);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/TypeGetterSetters.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/TypeGetterSetters.java
@@ -91,6 +91,11 @@ public interface TypeGetterSetters {
 	Decimal getDecimal(int ordinal, int precision, int scale);
 
 	/**
+	 * Get Timestamp value, internal format is SqlTimestamp.
+	 */
+	SqlTimestamp getTimestamp(int ordinal, int precision);
+
+	/**
 	 * Get generic value, internal format is BinaryGeneric.
 	 */
 	<T> BinaryGeneric<T> getGeneric(int ordinal);
@@ -159,6 +164,16 @@ public interface TypeGetterSetters {
 	 * setDecimal(i, null, precision) because we need update var-length-part.
 	 */
 	void setDecimal(int i, Decimal value, int precision);
+
+	/**
+	 * Set Timestamp value.
+	 *
+	 * <p>Note:
+	 * If precision is compact: can call setNullAt when SqlTimestamp value is null.
+	 * Otherwise: can not call setNullAt when SqlTimestamp value is null, must call
+	 * setTimestamp(ordinal, null, precision) because we need to update var-length-part.
+	 */
+	void setTimestamp(int ordinal, SqlTimestamp value, int precision);
 
 	static Object get(TypeGetterSetters row, int ordinal, LogicalType type) {
 		switch (type.getTypeRoot()) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/UpdatableRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/UpdatableRow.java
@@ -107,6 +107,11 @@ public final class UpdatableRow implements BaseRow {
 	}
 
 	@Override
+	public SqlTimestamp getTimestamp(int ordinal, int precision) {
+		return updated[ordinal] ? (SqlTimestamp) fields[ordinal] : row.getTimestamp(ordinal, precision);
+	}
+
+	@Override
 	public <T> BinaryGeneric<T> getGeneric(int ordinal) {
 		return updated[ordinal] ? (BinaryGeneric<T>) fields[ordinal] : row.getGeneric(ordinal);
 	}
@@ -168,6 +173,11 @@ public final class UpdatableRow implements BaseRow {
 
 	@Override
 	public void setDecimal(int ordinal, Decimal value, int precision) {
+		setField(ordinal, value);
+	}
+
+	@Override
+	public void setTimestamp(int ordinal, SqlTimestamp value, int precision) {
 		setField(ordinal, value);
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/TimestampColumnVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/TimestampColumnVector.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.dataformat.vector;
+
+import org.apache.flink.table.dataformat.SqlTimestamp;
+
+/**
+ * Timestamp column vector.
+ */
+public interface TimestampColumnVector extends ColumnVector {
+	SqlTimestamp getTimestamp(int i, int precision);
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/VectorizedColumnBatch.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/VectorizedColumnBatch.java
@@ -26,7 +26,6 @@ import org.apache.calcite.avatica.util.DateTimeUtils;
 
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
-import java.time.LocalTime;
 
 /**
  * A VectorizedColumnBatch is a set of rows, organized with each column as a vector. It is the

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/VectorizedColumnBatch.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/VectorizedColumnBatch.java
@@ -135,15 +135,6 @@ public class VectorizedColumnBatch implements Serializable {
 	}
 
 	public SqlTimestamp getTimestamp(int rowId, int colId, int precision) {
-		if (isNullAt(rowId, colId)) {
-			return null;
-		}
-
-		if (columns[colId] instanceof TimestampColumnVector) {
-			return ((TimestampColumnVector) (columns[colId])).getTimestamp(rowId, precision);
-		} else {
-			// by default, we assume the underlying LongColumnVector holds millisecond since Epoch.
-			return SqlTimestamp.fromEpochMillis(((LongColumnVector) columns[colId]).getLong(rowId));
-		}
+		return ((TimestampColumnVector) (columns[colId])).getTimestamp(rowId, precision);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/VectorizedColumnBatch.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/VectorizedColumnBatch.java
@@ -159,24 +159,19 @@ public class VectorizedColumnBatch implements Serializable {
 		} else {
 			byte[] bytes = getBytes(rowId, colId);
 			assert bytes.length == 12;
-			long l = 0;
+			long nanoOfDay = 0;
 			for (int i = 0; i < 8; i++) {
-				l <<= 8;
-				l |= (bytes[i] & (0xff));
+				nanoOfDay <<= 8;
+				nanoOfDay |= (bytes[i] & (0xff));
 			}
-			int n = 0;
+			int julianDay = 0;
 			for (int i = 8; i < 12; i++) {
-				n <<= 8;
-				n |= (bytes[i] & (0xff));
+				julianDay <<= 8;
+				julianDay |= (bytes[i] & (0xff));
 			}
-			LocalTime localTime = LocalTime.ofNanoOfDay(l);
 			long millisecond =
-				(n - DateTimeUtils.EPOCH_JULIAN) * DateTimeUtils.MILLIS_PER_DAY +
-				localTime.getHour() * DateTimeUtils.MILLIS_PER_HOUR +
-				localTime.getMinute() * DateTimeUtils.MILLIS_PER_MINUTE +
-				localTime.getSecond() * DateTimeUtils.MILLIS_PER_SECOND +
-				localTime.getNano() / 1000000;
-			int nanoOfMillisecond = localTime.getNano() % 1000000;
+				(julianDay - DateTimeUtils.EPOCH_JULIAN) * DateTimeUtils.MILLIS_PER_DAY + nanoOfDay / 1000000;
+			int nanoOfMillisecond = (int) (nanoOfDay % 1000000);
 			return SqlTimestamp.fromEpochMillis(millisecond, nanoOfMillisecond);
 		}
 	}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/BinaryArrayTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/BinaryArrayTest.java
@@ -35,6 +35,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 import static org.apache.flink.table.dataformat.BinaryString.fromString;
 import static org.apache.flink.table.utils.BinaryGenericAsserter.equivalent;
@@ -501,5 +503,42 @@ public class BinaryArrayTest {
 
 		Assert.assertArrayEquals(bytes1, array.getBinary(0));
 		Assert.assertArrayEquals(bytes2, array.getBinary(1));
+	}
+
+	@Test
+	public void testSqlTimestamp() {
+		BinaryArray array = new BinaryArray();
+		BinaryArrayWriter writer = new BinaryArrayWriter(array, 2, 8);
+
+		// 1. compact
+		{
+			final int precision = 3;
+			writer.reset();
+			writer.writeTimestamp(0, SqlTimestamp.fromEpochMillis(123L), precision);
+			writer.setNullAt(1);
+			writer.complete();
+
+			assertEquals("1970-01-01T00:00:00.123", array.getTimestamp(0, 3).toString());
+			assertTrue(array.isNullAt(1));
+			array.setTimestamp(0, SqlTimestamp.fromEpochMillis(-123L), precision);
+			assertEquals("1969-12-31T23:59:59.877", array.getTimestamp(0, 3).toString());
+		}
+
+		// 2. not compact
+		{
+			final int precision = 9;
+			SqlTimestamp sqlTimestamp1 = SqlTimestamp.fromLocalDateTime(LocalDateTime.of(1970, 1, 1, 0, 0, 0, 123456789));
+			SqlTimestamp sqlTimestamp2 = SqlTimestamp.fromTimestamp(Timestamp.valueOf("1969-01-01 00:00:00.123456789"));
+
+			writer.reset();
+			writer.writeTimestamp(0, sqlTimestamp1, precision);
+			writer.writeTimestamp(1, null, precision);
+			writer.complete();
+
+			assertEquals("1970-01-01T00:00:00.123456789", array.getTimestamp(0, precision).toString());
+			assertTrue(array.isNullAt(1));
+			array.setTimestamp(0, sqlTimestamp2, precision);
+			assertEquals("1969-01-01T00:00:00.123456789", array.getTimestamp(0, precision).toString());
+		}
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/vector/VectorizedColumnBatchTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/vector/VectorizedColumnBatchTest.java
@@ -113,7 +113,7 @@ public class VectorizedColumnBatchTest {
 				int n = 2440588; // Epoch Julian
 				for (int j = 0; j < 4; j++) {
 					bytes[11 - j] = (byte) n;
-					n >>>=8;
+					n >>>= 8;
 				}
 
 				col10.start[i] = start;

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/vector/VectorizedColumnBatchTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/vector/VectorizedColumnBatchTest.java
@@ -198,13 +198,8 @@ public class VectorizedColumnBatchTest {
 			}
 		};
 
-		HeapLongVector col11 = new HeapLongVector(VECTOR_SIZE);
-		for (int i = 0; i < VECTOR_SIZE; i++) {
-			col11.vector[i] = i;
-		}
-
 		VectorizedColumnBatch batch = new VectorizedColumnBatch(
-				new ColumnVector[]{col0, col1, col2, col3, col4, col5, col6, col7, col8, col9, col10, col11});
+				new ColumnVector[]{col0, col1, col2, col3, col4, col5, col6, col7, col8, col9, col10});
 
 		for (int i = 0; i < VECTOR_SIZE; i++) {
 			ColumnarRow row = new ColumnarRow(batch, i);
@@ -220,7 +215,6 @@ public class VectorizedColumnBatchTest {
 			assertEquals(row.getTimestamp(9, 6).getMillisecond(), i);
 			assertEquals(row.getTimestamp(10, 9).getMillisecond(), i * 1000L + 123);
 			assertEquals(row.getTimestamp(10, 9).getNanoOfMillisecond(), 456789);
-			assertEquals(row.getTimestamp(11, 3).getMillisecond(), i);
 		}
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/vector/VectorizedColumnBatchTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/vector/VectorizedColumnBatchTest.java
@@ -30,7 +30,6 @@ import org.apache.flink.table.dataformat.vector.heap.HeapLongVector;
 import org.apache.flink.table.dataformat.vector.heap.HeapShortVector;
 
 import org.apache.calcite.avatica.util.DateTimeUtils;
-
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;


### PR DESCRIPTION
…rface to TypeGetterSetters/VectorizedColumnBatch and writeTimestamp interface to BinaryWriter

## What is the purpose of the change

Since FLINK-14080 introduce a new representation of TimestampType, the binary format should add timestamp related interface to set/get TimestampType objects.

## Brief change log

- 95ec85f1 introduces setTimestamp/getTimestamp interface to TypeGetterSetters/VectorizedColumnBatch and writeTimestamp interface to BinaryWriter

## Verifying this change

This change is already covered by existing tests and new tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)