### PR TITLE
[FLINK-12846][table-common] Carry primary key information in TableSchema

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TableSchemaValidation.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TableSchemaValidation.java
@@ -59,13 +59,12 @@ public final class TableSchemaValidation {
 	}
 
 	/**
-	 * Validate table columns, watermark specification, primary key and unique keys.
+	 * Validate table columns, watermark specification and primary key.
 	 */
 	public static void validateSchema(
 			List<TableColumn> columns,
 			List<WatermarkSpec> watermarkSpecs,
-			List<String> primaryKey,
-			List<List<String>> uniqueKeys) {
+			List<String> primaryKey) {
 		// validate and create nested field name to type mapping.
 		// we need nested field name to type mapping because the row time attribute
 		// field can be nested.
@@ -79,7 +78,7 @@ public final class TableSchemaValidation {
 				"");
 		}
 
-		// primary key and unique key requires the key field is top-level (non-nested)
+		// primary key requires the key field is top-level (non-nested)
 		Map<String, TableColumn> nameToColumn = columns.stream()
 			.collect(Collectors.toMap(TableColumn::getName, Function.identity()));
 
@@ -92,20 +91,6 @@ public final class TableSchemaValidation {
 			} else if (column.isGenerated()) {
 				throw new ValidationException("The primary key field '" + key +
 					"' should not be a generated column.");
-			}
-		}
-
-		// validate unique keys
-		for (List<String> uniqueKey : uniqueKeys) {
-			for (String key : uniqueKey) {
-				TableColumn column = nameToColumn.get(key);
-				if (column == null) {
-					throw new ValidationException("The unique key field '" + key +
-						"' is not existed in the schema.");
-				} else if (column.isGenerated()) {
-					throw new ValidationException("The unique key field '" + key +
-						"' should not be a generated column.");
-				}
 			}
 		}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TableSchemaValidation.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TableSchemaValidation.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.utils;
+
+import org.apache.flink.table.api.TableColumn;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.WatermarkSpec;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.FieldsDataType;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE;
+
+/**
+ * Utilities for {@link org.apache.flink.table.api.TableSchema} validation.
+ */
+public final class TableSchemaValidation {
+
+	/**
+	 * Validate the field names {@code fieldNames} and field types {@code fieldTypes}
+	 * have equal number.
+	 *
+	 * @param fieldNames Field names
+	 * @param fieldTypes Field data types
+	 */
+	public static void validateNameTypeNumberEqual(String[] fieldNames, DataType[] fieldTypes) {
+		if (fieldNames.length != fieldTypes.length) {
+			throw new ValidationException(
+				"Number of field names and field data types must be equal.\n" +
+					"Number of names is " + fieldNames.length +
+					", number of data types is " + fieldTypes.length + ".\n" +
+					"List of field names: " + Arrays.toString(fieldNames) + "\n" +
+					"List of field data types: " + Arrays.toString(fieldTypes));
+		}
+	}
+
+	/**
+	 * Validate table columns, watermark specification, primary key and unique keys.
+	 */
+	public static void validateSchema(
+			List<TableColumn> columns,
+			List<WatermarkSpec> watermarkSpecs,
+			List<String> primaryKey,
+			List<List<String>> uniqueKeys) {
+		// validate and create nested field name to type mapping.
+		// we need nested field name to type mapping because the row time attribute
+		// field can be nested.
+
+		// this also check duplicate fields.
+		final Map<String, DataType> fieldNameToType = new HashMap<>();
+		for (TableColumn column : columns) {
+			validateAndBuildNameToTypeMapping(fieldNameToType,
+				column.getName(),
+				column.getType(),
+				"");
+		}
+
+		// primary key and unique key requires the key field is top-level (non-nested)
+		Map<String, TableColumn> nameToColumn = columns.stream()
+			.collect(Collectors.toMap(TableColumn::getName, Function.identity()));
+
+		// validate primary key
+		for (String key : primaryKey) {
+			TableColumn column = nameToColumn.get(key);
+			if (column == null) {
+				throw new ValidationException("The primary key field '" + key +
+					"' is not existed in the schema.");
+			} else if (column.isGenerated()) {
+				throw new ValidationException("The primary key field '" + key +
+					"' should not be a generated column.");
+			}
+		}
+
+		// validate unique keys
+		for (List<String> uniqueKey : uniqueKeys) {
+			for (String key : uniqueKey) {
+				TableColumn column = nameToColumn.get(key);
+				if (column == null) {
+					throw new ValidationException("The unique key field '" + key +
+						"' is not existed in the schema.");
+				} else if (column.isGenerated()) {
+					throw new ValidationException("The unique key field '" + key +
+						"' should not be a generated column.");
+				}
+			}
+		}
+
+		// validate watermark and rowtime attribute.
+		for (WatermarkSpec watermark : watermarkSpecs) {
+			String rowtimeAttribute = watermark.getRowtimeAttribute();
+			DataType rowtimeType = Optional.ofNullable(fieldNameToType.get(rowtimeAttribute))
+				.orElseThrow(() -> new ValidationException(String.format(
+					"Rowtime attribute '%s' is not defined in schema.", rowtimeAttribute)));
+			if (rowtimeType.getLogicalType().getTypeRoot() != TIMESTAMP_WITHOUT_TIME_ZONE) {
+				throw new ValidationException(String.format(
+					"Rowtime attribute '%s' must be of type TIMESTAMP but is of type '%s'.",
+					rowtimeAttribute, rowtimeType));
+			}
+			LogicalType watermarkOutputType = watermark.getWatermarkExprOutputType().getLogicalType();
+			if (watermarkOutputType.getTypeRoot() != TIMESTAMP_WITHOUT_TIME_ZONE) {
+				throw new ValidationException(String.format(
+					"Watermark strategy '%s' must be of type TIMESTAMP but is of type '%s'.",
+					watermark.getWatermarkExpressionString(),
+					watermarkOutputType.asSerializableString()));
+			}
+		}
+	}
+
+	/**
+	 * Builds a mapping from field name to data type, the field name can be a nested field.
+	 * This is mainly used for validating whether the rowtime attribute (might be nested) exists
+	 * in the schema. During creating, it also validates whether there is duplicate field names.
+	 *
+	 * <p>For example, a "f0" field of ROW type has two nested fields "q1" and "q2". Then the
+	 * mapping will be ["f0" -> ROW, "f0.q1" -> INT, "f0.q2" -> STRING].
+	 *
+	 * <pre>
+	 * {@code
+	 *     f0 ROW<q1 INT, q2 STRING>
+	 * }
+	 * </pre>
+	 *
+	 * @param fieldNameToType Field name to type mapping that to update
+	 * @param fieldName       Name of this field, e.g. "q1" or "q2" in the above example
+	 * @param fieldType       Data type of this field
+	 * @param parentFieldName Field name of parent type, e.g. "f0" in the above example
+	 */
+	private static void validateAndBuildNameToTypeMapping(
+		Map<String, DataType> fieldNameToType,
+		String fieldName,
+		DataType fieldType,
+		String parentFieldName) {
+		String fullFieldName = parentFieldName.isEmpty() ? fieldName : parentFieldName + "." + fieldName;
+		DataType oldType = fieldNameToType.put(fullFieldName, fieldType);
+		if (oldType != null) {
+			throw new ValidationException("Field names must be unique. Duplicate field: '" + fullFieldName + "'");
+		}
+		if (fieldType instanceof FieldsDataType) {
+			Map<String, DataType> fieldDataTypes = ((FieldsDataType) fieldType).getFieldDataTypes();
+			fieldDataTypes.forEach((key, value) ->
+				validateAndBuildNameToTypeMapping(fieldNameToType, key, value, fullFieldName));
+		}
+	}
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/api/TableSchemaTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/api/TableSchemaTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -57,8 +58,6 @@ public class TableSchemaTest {
 			.field("f3", DataTypes.BIGINT(), "f0 + 1")
 			.watermark("f1.q2", WATERMARK_EXPRESSION, WATERMARK_DATATYPE)
 			.primaryKey("f0", "f2")
-			.uniqueKey("f0", "f1")
-			.uniqueKey("f2", "f1")
 			.build();
 
 		// test toString()
@@ -68,9 +67,7 @@ public class TableSchemaTest {
 			" |-- f2: STRING\n" +
 			" |-- f3: BIGINT AS f0 + 1\n" +
 			" |-- WATERMARK FOR f1.q2 AS now()\n" +
-			" |-- PRIMARY KEY (f0, f2)\n" +
-			" |-- UNIQUE (f0, f1)\n" +
-			" |-- UNIQUE (f2, f1)\n";
+			" |-- PRIMARY KEY (f0, f2)\n";
 		assertEquals(expected, schema.toString());
 
 		// test getFieldNames and getFieldDataType
@@ -81,6 +78,7 @@ public class TableSchemaTest {
 		assertEquals(Optional.of(DataTypes.STRING()), schema.getFieldDataType("f2"));
 		assertEquals(Optional.of(DataTypes.STRING()), schema.getFieldDataType("f1")
 			.map(r -> ((FieldsDataType) r).getFieldDataTypes().get("q1")));
+		assertEquals(Arrays.asList("f0", "f2"), schema.getPrimaryKey());
 		assertFalse(schema.getFieldName(4).isPresent());
 		assertFalse(schema.getFieldType(-1).isPresent());
 		assertFalse(schema.getFieldType("c").isPresent());
@@ -233,17 +231,6 @@ public class TableSchemaTest {
 			.field("c", DataTypes.BIGINT())
 			.primaryKey("a")
 			.primaryKey("b")
-			.build();
-	}
-
-	@Test
-	public void testInvalidUniqueKeyFieldName() {
-		thrown.expectMessage("The unique key field 'd' is not existed in the schema");
-		TableSchema.builder()
-			.field("a", DataTypes.INT())
-			.field("b", DataTypes.STRING())
-			.field("c", DataTypes.BIGINT())
-			.uniqueKey("a", "d")
 			.build();
 	}
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/api/TableSchemaTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/api/TableSchemaTest.java
@@ -56,6 +56,9 @@ public class TableSchemaTest {
 			.field("f2", DataTypes.STRING())
 			.field("f3", DataTypes.BIGINT(), "f0 + 1")
 			.watermark("f1.q2", WATERMARK_EXPRESSION, WATERMARK_DATATYPE)
+			.primaryKey("f0", "f2")
+			.uniqueKey("f0", "f1")
+			.uniqueKey("f2", "f1")
 			.build();
 
 		// test toString()
@@ -64,7 +67,10 @@ public class TableSchemaTest {
 			" |-- f1: ROW<`q1` STRING, `q2` TIMESTAMP(3)>\n" +
 			" |-- f2: STRING\n" +
 			" |-- f3: BIGINT AS f0 + 1\n" +
-			" |-- WATERMARK FOR f1.q2 AS now()";
+			" |-- WATERMARK FOR f1.q2 AS now()\n" +
+			" |-- PRIMARY KEY (f0, f2)\n" +
+			" |-- UNIQUE (f0, f1)\n" +
+			" |-- UNIQUE (f2, f1)\n";
 		assertEquals(expected, schema.toString());
 
 		// test getFieldNames and getFieldDataType
@@ -192,4 +198,52 @@ public class TableSchemaTest {
 		});
 	}
 
+	@Test
+	public void testInvalidPrimaryKeyFieldName() {
+		thrown.expectMessage("The primary key field 'd' is not existed in the schema");
+		TableSchema.builder()
+			.field("a", DataTypes.INT())
+			.field("b", DataTypes.STRING())
+			.field("c", DataTypes.BIGINT())
+			.primaryKey("a", "d")
+			.build();
+	}
+
+	@Test
+	public void testInvalidPrimaryKeyNestedFieldName() {
+		thrown.expectMessage(
+			"The primary key field 'c.q1' is not existed in the schema");
+		TableSchema.builder()
+			.field("a", DataTypes.INT())
+			.field("b", DataTypes.STRING())
+			.field("c", DataTypes.ROW(
+				DataTypes.FIELD("q1", DataTypes.STRING()),
+				DataTypes.FIELD("q2", DataTypes.TIMESTAMP(3))))
+			.primaryKey("b", "c.q1")
+			.build();
+	}
+
+	@Test
+	public void testInvalidMultiPrimaryKey() {
+		thrown.expectMessage(
+			"A primary key [a] have been defined, can not define another primary key [b]");
+		TableSchema.builder()
+			.field("a", DataTypes.INT())
+			.field("b", DataTypes.STRING())
+			.field("c", DataTypes.BIGINT())
+			.primaryKey("a")
+			.primaryKey("b")
+			.build();
+	}
+
+	@Test
+	public void testInvalidUniqueKeyFieldName() {
+		thrown.expectMessage("The unique key field 'd' is not existed in the schema");
+		TableSchema.builder()
+			.field("a", DataTypes.INT())
+			.field("b", DataTypes.STRING())
+			.field("c", DataTypes.BIGINT())
+			.uniqueKey("a", "d")
+			.build();
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change

The primary key is a standard meta information in SQL. And they are important information for optimization, for example, AggregateRemove, AggregateReduceGrouping and state layout optimization for TopN and Join.

So in this PR, we extend TableSchema to carry more information about primary key. 

Bridge the primary key of TableSchema to the planner metadata will be done in other PRs. 

## Brief change log

1. Add primary key to `TableSchema` with some Javadocs. 


## Verifying this change

1. Adds some tests in `TableSchemaTest` to check the primary key.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
