### PR TITLE
[FLINK-14812][Deployment / Kubernetes][Deployment / Script] Add metric libs to Flink classpath with an environment variable.

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -39,7 +39,7 @@ constructFlinkClassPath() {
         exit 1
     fi
 
-    echo "$FLINK_CLASSPATH""$FLINK_DIST"
+    echo "$FLINK_CLASSPATH""$FLINK_DIST":"$FLINK_METRIC_CLASSPATH"
 }
 
 # These are used to mangle paths that are passed to java when using


### PR DESCRIPTION

**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*

Use environment variables to add the metric lib to the Flink classpath.

## Brief change log

In constructFlinkClassPath (in the config.sh) add the metric lib path to the Flink classpath.

## Verifying this change

This change is a small change in a script file.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented
