### PR TITLE
 [FLINK-14750][configuration] Migrate duration and memory size ConfigOptions in RestartStrategyOptions

### DIFF
--- a/docs/_includes/generated/failure_rate_restart_strategy_configuration.html
+++ b/docs/_includes/generated/failure_rate_restart_strategy_configuration.html
@@ -10,14 +10,14 @@
     <tbody>
         <tr>
             <td><h5>restart-strategy.failure-rate.delay</h5></td>
-            <td style="word-wrap: break-word;">"1 s"</td>
-            <td>String</td>
+            <td style="word-wrap: break-word;">1000ms</td>
+            <td>Duration</td>
             <td>Delay between two consecutive restart attempts if <span markdown="span">`restart-strategy`</span> has been set to <span markdown="span">`failure-rate`</span>. It can be specified using notation: "1 min", "20 s"</td>
         </tr>
         <tr>
             <td><h5>restart-strategy.failure-rate.failure-rate-interval</h5></td>
-            <td style="word-wrap: break-word;">"1 min"</td>
-            <td>String</td>
+            <td style="word-wrap: break-word;">60000ms</td>
+            <td>Duration</td>
             <td>Time interval for measuring failure rate if <span markdown="span">`restart-strategy`</span> has been set to <span markdown="span">`failure-rate`</span>. It can be specified using notation: "1 min", "20 s"</td>
         </tr>
         <tr>

--- a/docs/_includes/generated/fixed_delay_restart_strategy_configuration.html
+++ b/docs/_includes/generated/fixed_delay_restart_strategy_configuration.html
@@ -16,8 +16,8 @@
         </tr>
         <tr>
             <td><h5>restart-strategy.fixed-delay.delay</h5></td>
-            <td style="word-wrap: break-word;">"1 s"</td>
-            <td>String</td>
+            <td style="word-wrap: break-word;">1000ms</td>
+            <td>Duration</td>
             <td>Delay between two consecutive restart attempts if <span markdown="span">`restart-strategy`</span> has been set to <span markdown="span">`fixed-delay`</span>. Delaying the retries can be helpful when the program interacts with external systems where for example connections or pending transactions should reach a timeout before re-execution is attempted. It can be specified using notation: "1 min", "20 s"</td>
         </tr>
     </tbody>

--- a/flink-core/src/main/java/org/apache/flink/api/common/restartstrategy/RestartStrategies.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/restartstrategy/RestartStrategies.java
@@ -163,6 +163,14 @@ public class RestartStrategies {
 		}
 
 		@Override
+		public String toString() {
+			return "FixedDelayRestartStrategyConfiguration{" +
+				"restartAttempts=" + restartAttempts +
+				", delayBetweenAttemptsInterval=" + delayBetweenAttemptsInterval +
+				'}';
+		}
+
+		@Override
 		public String getDescription() {
 			return "Restart with fixed delay (" + delayBetweenAttemptsInterval + "). #"
 				+ restartAttempts + " restart attempts.";

--- a/flink-core/src/main/java/org/apache/flink/api/common/restartstrategy/RestartStrategies.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/restartstrategy/RestartStrategies.java
@@ -95,6 +95,11 @@ public class RestartStrategies {
 		 * @return Description of the restart strategy
 		 */
 		public abstract String getDescription();
+
+		@Override
+		public String toString() {
+			return getDescription();
+		}
 	}
 
 	/**
@@ -160,14 +165,6 @@ public class RestartStrategies {
 			} else {
 				return false;
 			}
-		}
-
-		@Override
-		public String toString() {
-			return "FixedDelayRestartStrategyConfiguration{" +
-				"restartAttempts=" + restartAttempts +
-				", delayBetweenAttemptsInterval=" + delayBetweenAttemptsInterval +
-				'}';
 		}
 
 		@Override

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestartStrategyOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestartStrategyOptions.java
@@ -23,6 +23,8 @@ import org.apache.flink.annotation.docs.ConfigGroup;
 import org.apache.flink.annotation.docs.ConfigGroups;
 import org.apache.flink.configuration.description.Description;
 
+import java.time.Duration;
+
 import static org.apache.flink.configuration.description.LinkElement.link;
 import static org.apache.flink.configuration.description.TextElement.code;
 import static org.apache.flink.configuration.description.TextElement.text;
@@ -69,6 +71,7 @@ public class RestartStrategyOptions {
 
 	public static final ConfigOption<Integer> RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS = ConfigOptions
 		.key("restart-strategy.fixed-delay.attempts")
+		.intType()
 		.defaultValue(1)
 		.withDescription(
 			Description.builder()
@@ -78,9 +81,10 @@ public class RestartStrategyOptions {
 					code("fixed-delay"))
 				.build());
 
-	public static final ConfigOption<String> RESTART_STRATEGY_FIXED_DELAY_DELAY = ConfigOptions
+	public static final ConfigOption<Duration> RESTART_STRATEGY_FIXED_DELAY_DELAY = ConfigOptions
 		.key("restart-strategy.fixed-delay.delay")
-		.defaultValue("1 s")
+		.durationType()
+		.defaultValue(Duration.ofSeconds(1))
 		.withDescription(
 			Description.builder()
 				.text(
@@ -103,9 +107,10 @@ public class RestartStrategyOptions {
 					code("failure-rate"))
 				.build());
 
-	public static final ConfigOption<String> RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL = ConfigOptions
+	public static final ConfigOption<Duration> RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL = ConfigOptions
 		.key("restart-strategy.failure-rate.failure-rate-interval")
-		.defaultValue("1 min")
+		.durationType()
+		.defaultValue(Duration.ofMinutes(1))
 		.withDescription(
 			Description.builder()
 				.text(
@@ -115,9 +120,10 @@ public class RestartStrategyOptions {
 					code("failure-rate"))
 				.build());
 
-	public static final ConfigOption<String> RESTART_STRATEGY_FAILURE_RATE_DELAY = ConfigOptions
+	public static final ConfigOption<Duration> RESTART_STRATEGY_FAILURE_RATE_DELAY = ConfigOptions
 		.key("restart-strategy.failure-rate.delay")
-		.defaultValue("1 s")
+		.durationType()
+		.defaultValue(Duration.ofSeconds(1))
 		.withDescription(
 			Description.builder()
 				.text(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureRateRestartBackoffTimeStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureRateRestartBackoffTimeStrategy.java
@@ -22,7 +22,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestartStrategyOptions;
 import org.apache.flink.runtime.util.clock.Clock;
 import org.apache.flink.runtime.util.clock.SystemClock;
-import org.apache.flink.util.TimeUtils;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -110,26 +109,9 @@ public class FailureRateRestartBackoffTimeStrategy implements RestartBackoffTime
 
 	public static FailureRateRestartBackoffTimeStrategyFactory createFactory(final Configuration configuration) {
 		int maxFailuresPerInterval = configuration.getInteger(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL);
-		String failuresIntervalString = configuration.getString(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL);
-		String delayString = configuration.getString(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_DELAY);
-
-		long failuresInterval;
-		try {
-			failuresInterval = TimeUtils.parseDuration(failuresIntervalString).toMillis();
-		} catch (IllegalArgumentException ex) {
-			throw new IllegalArgumentException("Invalid config value for " +
-				RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL.key() + ": " + failuresIntervalString +
-				". Value must be a valid duration (such as '100 milli' or '10 s')", ex);
-		}
-
-		long delay;
-		try {
-			delay = TimeUtils.parseDuration(delayString).toMillis();
-		} catch (IllegalArgumentException ex) {
-			throw new IllegalArgumentException("Invalid config value for " +
-				RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_DELAY.key() + ": " + delayString +
-				". Value must be a valid duration (such as '100 milli' or '10 s')", ex);
-		}
+		long failuresInterval = configuration.get(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL)
+			.toMillis();
+		long delay = configuration.get(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_DELAY).toMillis();
 
 		return new FailureRateRestartBackoffTimeStrategyFactory(maxFailuresPerInterval, failuresInterval, delay);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FixedDelayRestartBackoffTimeStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FixedDelayRestartBackoffTimeStrategy.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.executiongraph.failover.flip1;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestartStrategyOptions;
-import org.apache.flink.util.TimeUtils;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 
@@ -84,16 +83,7 @@ public class FixedDelayRestartBackoffTimeStrategy implements RestartBackoffTimeS
 
 	public static FixedDelayRestartBackoffTimeStrategyFactory createFactory(final Configuration configuration) {
 		int maxAttempts = configuration.getInteger(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS);
-		String delayString = configuration.getString(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY);
-
-		long delay;
-		try {
-			delay = TimeUtils.parseDuration(delayString).toMillis();
-		} catch (IllegalArgumentException ex) {
-			throw new IllegalArgumentException("Invalid config value for " +
-				RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY.key() + ": " + delayString +
-				". Value must be a valid duration (such as '100 milli' or '10 s')", ex);
-		}
+		long delay = configuration.get(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY).toMillis();
 
 		return new FixedDelayRestartBackoffTimeStrategyFactory(maxAttempts, delay);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FailureRateRestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FailureRateRestartStrategy.java
@@ -25,9 +25,7 @@ import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.util.Preconditions;
-import org.apache.flink.util.TimeUtils;
 
-import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.concurrent.CompletableFuture;
 
@@ -91,13 +89,14 @@ public class FailureRateRestartStrategy implements RestartStrategy {
 
 	public static FailureRateRestartStrategyFactory createFactory(Configuration configuration) throws Exception {
 		int maxFailuresPerInterval = configuration.getInteger(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL);
-		String failuresIntervalString = configuration.getString(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL);
-		String delayString = configuration.getString(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_DELAY);
+		long failuresInterval = configuration.get(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL)
+			.toMillis();
+		long delay = configuration.get(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_DELAY).toMillis();
 
-		Duration failuresInterval = TimeUtils.parseDuration(failuresIntervalString);
-		Duration delay = TimeUtils.parseDuration(delayString);
-
-		return new FailureRateRestartStrategyFactory(maxFailuresPerInterval, Time.milliseconds(failuresInterval.toMillis()), Time.milliseconds(delay.toMillis()));
+		return new FailureRateRestartStrategyFactory(
+			maxFailuresPerInterval,
+			Time.milliseconds(failuresInterval),
+			Time.milliseconds(delay));
 	}
 
 	public static class FailureRateRestartStrategyFactory extends RestartStrategyFactory {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategy.java
@@ -25,7 +25,6 @@ import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.util.Preconditions;
-import org.apache.flink.util.TimeUtils;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -75,18 +74,7 @@ public class FixedDelayRestartStrategy implements RestartStrategy {
 	 */
 	public static FixedDelayRestartStrategyFactory createFactory(Configuration configuration) throws Exception {
 		int maxAttempts = configuration.getInteger(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS);
-
-		String delayString = configuration.getString(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY);
-
-		long delay;
-
-		try {
-			delay = TimeUtils.parseDuration(delayString).toMillis();
-		} catch (IllegalArgumentException ex) {
-			throw new Exception("Invalid config value for " +
-					RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY.key() + ": " + delayString +
-					". Value must be a valid duration (such as '100 milli' or '10 s')", ex);
-		}
+		long delay = configuration.get(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY).toMillis();
 
 		return new FixedDelayRestartStrategyFactory(maxAttempts, delay);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/restart/RestartStrategyFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/restart/RestartStrategyFactoryTest.java
@@ -61,7 +61,7 @@ public class RestartStrategyFactoryTest extends TestLogger {
 		final Configuration configuration = new Configuration();
 		configuration.setString(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
 		configuration.setInteger(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, attempts);
-		configuration.setString(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY.key(), delayBetweenRestartAttempts.getSeconds() + "s");
+		configuration.set(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY, delayBetweenRestartAttempts);
 
 		final RestartStrategyFactory restartStrategyFactory = RestartStrategyFactory.createRestartStrategyFactory(configuration);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/restart/RestartStrategyFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/restart/RestartStrategyFactoryTest.java
@@ -61,7 +61,7 @@ public class RestartStrategyFactoryTest extends TestLogger {
 		final Configuration configuration = new Configuration();
 		configuration.setString(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
 		configuration.setInteger(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, attempts);
-		configuration.setString(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY, delayBetweenRestartAttempts.getSeconds() + "s");
+		configuration.setString(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY.key(), delayBetweenRestartAttempts.getSeconds() + "s");
 
 		final RestartStrategyFactory restartStrategyFactory = RestartStrategyFactory.createRestartStrategyFactory(configuration);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -1053,7 +1053,7 @@ public class JobMasterTest extends TestLogger {
 	@Test
 	public void testRequestNextInputSplitWithGlobalFailover() throws Exception {
 		configuration.setInteger(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
-		configuration.setString(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY.key(), "0 s");
+		configuration.set(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY, Duration.ofSeconds(0));
 
 		final Function<List<List<InputSplit>>, Collection<InputSplit>> expectAllRemainingInputSplits = this::flattenCollection;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -1053,7 +1053,7 @@ public class JobMasterTest extends TestLogger {
 	@Test
 	public void testRequestNextInputSplitWithGlobalFailover() throws Exception {
 		configuration.setInteger(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
-		configuration.setString(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY, "0 s");
+		configuration.setString(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY.key(), "0 s");
 
 		final Function<List<List<InputSplit>>, Collection<InputSplit>> expectAllRemainingInputSplits = this::flattenCollection;
 

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFailureRateStrategyITBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFailureRateStrategyITBase.java
@@ -27,6 +27,8 @@ import org.apache.flink.testutils.junit.category.AlsoRunWithSchedulerNG;
 import org.junit.ClassRule;
 import org.junit.experimental.categories.Category;
 
+import java.time.Duration;
+
 /**
  * Test cluster configuration with failure-rate recovery.
  */
@@ -45,8 +47,8 @@ public class SimpleRecoveryFailureRateStrategyITBase extends SimpleRecoveryITCas
 		Configuration config = new Configuration();
 		config.setString(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
 		config.setInteger(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL, 1);
-		config.setString(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL.key(), "1 second");
-		config.setString(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_DELAY.key(), "0 s");
+		config.set(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL, Duration.ofSeconds(1));
+		config.set(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_DELAY, Duration.ofSeconds(0));
 
 		return config;
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFailureRateStrategyITBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFailureRateStrategyITBase.java
@@ -45,8 +45,8 @@ public class SimpleRecoveryFailureRateStrategyITBase extends SimpleRecoveryITCas
 		Configuration config = new Configuration();
 		config.setString(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
 		config.setInteger(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL, 1);
-		config.setString(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL, "1 second");
-		config.setString(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_DELAY, "0 s");
+		config.setString(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL.key(), "1 second");
+		config.setString(RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_DELAY.key(), "0 s");
 
 		return config;
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFixedDelayRestartStrategyITBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFixedDelayRestartStrategyITBase.java
@@ -45,7 +45,7 @@ public class SimpleRecoveryFixedDelayRestartStrategyITBase extends SimpleRecover
 		Configuration config = new Configuration();
 		config.setString(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
 		config.setInteger(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
-		config.setString(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY, "100 ms");
+		config.setString(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY.key(), "100 ms");
 
 		return config;
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFixedDelayRestartStrategyITBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFixedDelayRestartStrategyITBase.java
@@ -27,6 +27,8 @@ import org.apache.flink.testutils.junit.category.AlsoRunWithSchedulerNG;
 import org.junit.ClassRule;
 import org.junit.experimental.categories.Category;
 
+import java.time.Duration;
+
 /**
  * Test cluster configuration with fixed-delay recovery.
  */
@@ -45,7 +47,7 @@ public class SimpleRecoveryFixedDelayRestartStrategyITBase extends SimpleRecover
 		Configuration config = new Configuration();
 		config.setString(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
 		config.setInteger(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
-		config.setString(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY.key(), "100 ms");
+		config.set(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY, Duration.ofMillis(100));
 
 		return config;
 	}


### PR DESCRIPTION
## What is the purpose of the change

Use typed `ConfigOptions` for RestartStrategyOptions. The options can be changed directly without deprecating first, because they haven't been released yet. Those options were introduced in 1.10.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
