### PR TITLE
[hotfix][network] Reduce the synchronisation overhead in CreditBasedSequenceNumberingViewReader

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
@@ -115,8 +115,12 @@ class CreditBasedSequenceNumberingViewReader implements BufferAvailabilityListen
 	@Override
 	public boolean isAvailable() {
 		// BEWARE: this must be in sync with #isAvailable(BufferAndBacklog)!
-		return hasBuffersAvailable() &&
-			(numCreditsAvailable > 0 || subpartitionView.nextBufferIsEvent());
+		if (numCreditsAvailable > 0) {
+			return subpartitionView.isAvailable();
+		}
+		else {
+			return subpartitionView.nextBufferIsEvent();
+		}
 	}
 
 	/**
@@ -131,8 +135,12 @@ class CreditBasedSequenceNumberingViewReader implements BufferAvailabilityListen
 	 */
 	private boolean isAvailable(BufferAndBacklog bufferAndBacklog) {
 		// BEWARE: this must be in sync with #isAvailable()!
-		return bufferAndBacklog.isMoreAvailable() &&
-			(numCreditsAvailable > 0 || bufferAndBacklog.nextBufferIsEvent());
+		if (numCreditsAvailable > 0) {
+			return bufferAndBacklog.isMoreAvailable();
+		}
+		else {
+			return bufferAndBacklog.nextBufferIsEvent();
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Previously CreditBasedSequenceNumberingViewReader#isAvailable() was synchronising twice on the lock subpartitionView if there are no credits: first in subpartitionView.isAvailable() and second in subpartitionView.nextBufferIsEvent(). The first one `subpartitionView.isAvailable()` check is redundant (always true) if `subpartitionView.nextBufferIsEvent()` is also true so it should be safe to simplify the code.

## Verifying this change

This change is already covered by existing network stack tests and most of the ITCases/e2e tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
