### PR TITLE
[1.9][FLINK-14104][build] Add opt-in jackson 2.10.1 profile

### DIFF
--- a/docs/dev/projectsetup/dependencies.md
+++ b/docs/dev/projectsetup/dependencies.md
@@ -196,7 +196,7 @@ you can use the following shade plugin definition:
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>3.0.0</version>
+            <version>3.1.1</version>
             <executions>
                 <execution>
                     <phase>package</phase>

--- a/docs/dev/projectsetup/dependencies.zh.md
+++ b/docs/dev/projectsetup/dependencies.zh.md
@@ -159,7 +159,7 @@ Scala 版本(2.10、2.11、2.12等)互相是不兼容的。因此，依赖 Scala
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>3.0.0</version>
+            <version>3.1.1</version>
             <executions>
                 <execution>
                     <phase>package</phase>

--- a/docs/flinkDev/building.md
+++ b/docs/flinkDev/building.md
@@ -170,5 +170,15 @@ The workaround is to add:
 
 in the compiler configuration of the `pom.xml` file of the module causing the error. For example, if the error appears in the `flink-yarn` module, the above code should be added under the `<configuration>` tag of `scala-maven-plugin`. See [this issue](https://issues.apache.org/jira/browse/FLINK-2003) for more information.
 
+## Jackson
+
+Multiple Flink components use [Jackson](https://github.com/FasterXML/jackson). Older versions of jackson (<`2.10.1`) are subject to a variety of security vulnerabilities.
+
+Flink 1.8.3+ offers an opt-in profile (`use-jackson-2.10.1`) for building Flink against Jackson `2.10.1`; including `jackson-annotations`, `jackson-core` and `jackson-databind`.
+
+Usage: `mvn package -Puse-jackson-2.10.1`
+
+When you build a maven application against this Flink version it is recommended to bump the `maven-shade-plugin` version to at least `3.1.1` to prevent packaging errors.
+
 {% top %}
 

--- a/docs/flinkDev/building.zh.md
+++ b/docs/flinkDev/building.zh.md
@@ -170,5 +170,15 @@ The workaround is to add:
 
 in the compiler configuration of the `pom.xml` file of the module causing the error. For example, if the error appears in the `flink-yarn` module, the above code should be added under the `<configuration>` tag of `scala-maven-plugin`. See [this issue](https://issues.apache.org/jira/browse/FLINK-2003) for more information.
 
+## Jackson
+
+Multiple Flink components use [Jackson](https://github.com/FasterXML/jackson). Older versions of jackson (<`2.10.1`) are subject to a variety of security vulnerabilities.
+
+Flink 1.9.2+ offers an opt-in profile (`use-jackson-2.10.1`) for building Flink against Jackson `2.10.1`; including `jackson-annotations`, `jackson-core` and `jackson-databind`.
+
+Usage: `mvn package -Puse-jackson-2.10.1`
+
+When you build a maven application against this Flink version it is recommended to bump the `maven-shade-plugin` version to at least `3.1.1` to prevent packaging errors.
+
 {% top %}
 

--- a/flink-metrics/flink-metrics-influxdb/pom.xml
+++ b/flink-metrics/flink-metrics-influxdb/pom.xml
@@ -120,6 +120,33 @@ under the License.
 		</dependencies>
 	</dependencyManagement>
 
+	<profiles>
+		<profile>
+			<id>use-jackson-2.10.1</id>
+			<dependencyManagement>
+				<dependencies>
+					<dependency>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-annotations</artifactId>
+						<version>2.10.1</version>
+					</dependency>
+
+					<dependency>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-databind</artifactId>
+						<version>2.10.1</version>
+					</dependency>
+
+					<dependency>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-core</artifactId>
+						<version>2.10.1</version>
+					</dependency>
+				</dependencies>
+			</dependencyManagement>
+		</profile>
+	</profiles>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
@@ -113,7 +113,7 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.1.1</version>
 				<executions>
 					<!-- Run shade goal on package phase -->
 					<execution>
@@ -168,7 +168,7 @@ under the License.
 									<pluginExecutionFilter>
 										<groupId>org.apache.maven.plugins</groupId>
 										<artifactId>maven-shade-plugin</artifactId>
-										<versionRange>[3.0.0,)</versionRange>
+										<versionRange>[3.1.1,)</versionRange>
 										<goals>
 											<goal>shade</goal>
 										</goals>

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
@@ -108,7 +108,7 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.1.1</version>
 				<executions>
 					<!-- Run shade goal on package phase -->
 					<execution>

--- a/flink-table/flink-table-planner-blink/pom.xml
+++ b/flink-table/flink-table-planner-blink/pom.xml
@@ -267,6 +267,33 @@ under the License.
 		</dependency>
 	</dependencies>
 
+	<profiles>
+		<profile>
+			<id>use-jackson-2.10.1</id>
+			<dependencyManagement>
+				<dependencies>
+					<dependency>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-annotations</artifactId>
+						<version>2.10.1</version>
+					</dependency>
+
+					<dependency>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-databind</artifactId>
+						<version>2.10.1</version>
+					</dependency>
+
+					<dependency>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-core</artifactId>
+						<version>2.10.1</version>
+					</dependency>
+				</dependencies>
+			</dependencyManagement>
+		</profile>
+	</profiles>
+
 	<build>
 		<plugins>
 			<!-- Scala Compiler -->

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -268,6 +268,33 @@ under the License.
 		</dependency>
 	</dependencies>
 
+	<profiles>
+		<profile>
+			<id>use-jackson-2.10.1</id>
+			<dependencyManagement>
+				<dependencies>
+					<dependency>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-annotations</artifactId>
+						<version>2.10.1</version>
+					</dependency>
+
+					<dependency>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-databind</artifactId>
+						<version>2.10.1</version>
+					</dependency>
+
+					<dependency>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-core</artifactId>
+						<version>2.10.1</version>
+					</dependency>
+				</dependencies>
+			</dependencyManagement>
+		</profile>
+	</profiles>
+
 	<build>
 		<plugins>
 			<!-- Scala Compiler -->

--- a/pom.xml
+++ b/pom.xml
@@ -763,11 +763,6 @@ under the License.
 							<version>1.7</version>
 						</plugin>
 						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-shade-plugin</artifactId>
-							<version>3.1.1</version>
-						</plugin>
-						<plugin>
 							<groupId>com.github.siom79.japicmp</groupId>
 							<artifactId>japicmp-maven-plugin</artifactId>
 							<dependencies>
@@ -1660,7 +1655,7 @@ under the License.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>3.0.0</version>
+					<version>3.1.1</version>
 				</plugin>
 
 				<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -749,6 +749,31 @@ under the License.
 		</profile>
 
 		<profile>
+			<id>use-jackson-2.10.1</id>
+			<dependencyManagement>
+				<dependencies>
+					<dependency>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-annotations</artifactId>
+						<version>2.10.1</version>
+					</dependency>
+
+					<dependency>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-databind</artifactId>
+						<version>2.10.1</version>
+					</dependency>
+
+					<dependency>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-core</artifactId>
+						<version>2.10.1</version>
+					</dependency>
+				</dependencies>
+			</dependencyManagement>
+		</profile>
+
+		<profile>
 			<id>java9</id>
 			<activation>
 				<jdk>9</jdk>


### PR DESCRIPTION
This PR adds an opt-in profile that bumps jackson dependencies to 2.10.1. This version contains fixes for a large number of security fixes.
This upgrade is an opt-in feature as we usually don't bump dependencies for bugfix releases, and this is done shortly before the next release, giving us little time to let it mature.

green cron job that I ran yesterday: https://travis-ci.com/flink-ci/flink/builds/136505913