### PR TITLE
 [FLINK-14787][configuration] Add configure method to StreamExecutionEnvironment

### DIFF
--- a/docs/_includes/generated/execution_configuration.html
+++ b/docs/_includes/generated/execution_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>execution.buffer-timeout</h5></td>
+            <td style="word-wrap: break-word;">100ms</td>
+            <td>Duration</td>
+            <td>The maximum time frequency (milliseconds) for the flushing of the output buffers. By default the output buffers flush frequently to provide low latency and to aid smooth developer experience. Setting the parameter can result in three logical modes:<ul><li>A positive value triggers flushing periodically by that interval</li><li>0 triggers flushing after every record thus minimizing latency</li><li>-1 ms triggers flushing only when the output buffer is full thus maximizing throughput</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>execution.checkpointing.snapshot-compression</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/_includes/generated/pipeline_configuration.html
+++ b/docs/_includes/generated/pipeline_configuration.html
@@ -27,6 +27,12 @@
             <td>The interval of the automatic watermark emission. Watermarks are used throughout the streaming system to keep track of the progress of time. They are used, for example, for time based windowing.</td>
         </tr>
         <tr>
+            <td><h5>pipeline.cached-files</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>List&lt;String&gt;</td>
+            <td>Files to be registered at the distributed cache under the given name. The files will be accessible from any user-defined function in the (distributed) runtime under a local path. Files may be local files (which will be distributed via BlobServer), or files in a distributed file system. The runtime will copy the files temporarily to a local cache, if needed.</td>
+        </tr>
+        <tr>
             <td><h5>pipeline.classpaths</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>List&lt;String&gt;</td>
@@ -85,6 +91,12 @@
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>When enabled objects that Flink internally uses for deserialization and passing data to user-code functions will be reused. Keep in mind that this can lead to bugs when the user-code function of an operation is not aware of this behaviour.</td>
+        </tr>
+        <tr>
+            <td><h5>pipeline.operator-chaining</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Operator chaining allows non-shuffle operations to be co-located in the same thread fully avoiding serialization and de-serialization.</td>
         </tr>
         <tr>
             <td><h5>pipeline.registered-kryo-types</h5></td>

--- a/docs/_includes/generated/stream_pipeline_configuration.html
+++ b/docs/_includes/generated/stream_pipeline_configuration.html
@@ -1,0 +1,18 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>pipeline.time-characteristic</h5></td>
+            <td style="word-wrap: break-word;">ProcessingTime</td>
+            <td><p>Enum</p>Possible values: [ProcessingTime, IngestionTime, EventTime]</td>
+            <td>The time characteristic for all created streams, e.g., processingtime, event time, or ingestion time.<br /><br />If you set the characteristic to IngestionTime or EventTime this will set a default watermark update interval of 200 ms. If this is not applicable for your application you should change it using <span markdown="span">`pipeline.auto-watermark-interval`</span>.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -193,6 +193,7 @@ The configuration keys in this section are independent of the used resource mana
 ### Pipeline
 
 {% include generated/pipeline_configuration.html %}
+{% include generated/stream_pipeline_configuration.html %}
 
 ### Checkpointing
 

--- a/docs/ops/config.zh.md
+++ b/docs/ops/config.zh.md
@@ -192,6 +192,7 @@ The configuration keys in this section are independent of the used resource mana
 ### Pipeline
 
 {% include generated/pipeline_configuration.html %}
+{% include generated/stream_pipeline_configuration.html %}
 
 ### Checkpointing
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/cache/DistributedCache.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/cache/DistributedCache.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -77,6 +78,28 @@ public class DistributedCache {
 		/** Server-side constructor used during job-submission for files. */
 		public DistributedCacheEntry(String filePath, Boolean isExecutable, byte[] blobKey){
 			this(filePath, isExecutable, blobKey, false);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			DistributedCacheEntry that = (DistributedCacheEntry) o;
+			return isZipped == that.isZipped &&
+				Objects.equals(filePath, that.filePath) &&
+				Objects.equals(isExecutable, that.isExecutable) &&
+				Arrays.equals(blobKey, that.blobKey);
+		}
+
+		@Override
+		public int hashCode() {
+			int result = Objects.hash(filePath, isExecutable, isZipped);
+			result = 31 * result + Arrays.hashCode(blobKey);
+			return result;
 		}
 
 		@Override

--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -928,7 +928,12 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 			return (E) o;
 		}
 
-		return Enum.valueOf(clazz, o.toString().toUpperCase(Locale.ROOT));
+		return Arrays.stream(clazz.getEnumConstants())
+			.filter(e -> e.toString().toUpperCase(Locale.ROOT).equals(o.toString().toUpperCase(Locale.ROOT)))
+			.findAny()
+			.orElseThrow(() -> new IllegalArgumentException(
+				String.format("Could not parse value for enum %s. Expected one of: [%s]", clazz,
+					Arrays.toString(clazz.getEnumConstants()))));
 	}
 
 	private Duration convertToDuration(Object o) {

--- a/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
@@ -19,6 +19,10 @@
 package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.description.Description;
+import org.apache.flink.configuration.description.TextElement;
+
+import java.time.Duration;
 
 /**
  * {@link ConfigOption}s specific for a single execution of a user program.
@@ -35,4 +39,20 @@ public class ExecutionOptions {
 			.booleanType()
 			.defaultValue(false)
 		.withDescription("Tells if we should use compression for the state snapshot data or not");
+
+	public static final ConfigOption<Duration> BUFFER_TIMEOUT =
+		ConfigOptions.key("execution.buffer-timeout")
+			.durationType()
+			.defaultValue(Duration.ofMillis(100))
+			.withDescription(Description.builder()
+				.text("The maximum time frequency (milliseconds) for the flushing of the output buffers. By default " +
+					"the output buffers flush frequently to provide low latency and to aid smooth developer " +
+					"experience. Setting the parameter can result in three logical modes:")
+				.list(
+					TextElement.text("A positive value triggers flushing periodically by that interval"),
+					TextElement.text("0 triggers flushing after every record thus minimizing latency"),
+					TextElement.text("-1 ms triggers flushing only when the output buffer is full thus maximizing " +
+						"throughput")
+				)
+				.build());
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
@@ -208,4 +208,22 @@ public class PipelineOptions {
 					" sure that only tags are written.")
 				.build());
 
+	public static final ConfigOption<Boolean> OPERATOR_CHAINING =
+		key("pipeline.operator-chaining")
+			.booleanType()
+			.defaultValue(true)
+			.withDescription("Operator chaining allows non-shuffle operations to be co-located in the same thread " +
+				"fully avoiding serialization and de-serialization.");
+
+	public static final ConfigOption<List<String>> CACHED_FILES =
+		key("pipeline.cached-files")
+			.stringType()
+			.asList()
+			.noDefaultValue()
+			.withDescription(Description.builder()
+				.text("Files to be registered at the distributed cache under the given name. The files will be " +
+					"accessible from any user-defined function in the (distributed) runtime under a local path. " +
+					"Files may be local files (which will be distributed via BlobServer), or files in a distributed " +
+					"file system. The runtime will copy the files temporarily to a local cache, if needed.")
+				.build());
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/ReadableConfigToConfigurationAdapter.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ReadableConfigToConfigurationAdapter.java
@@ -1,0 +1,326 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * A very naive adapter between {@link ReadableConfig} and {@link Configuration}.
+ * It is used to bridge some of the old public interfaces that work with {@link Configuration} even though they
+ * should actually work with {@link ReadableConfig}.
+ */
+@Internal
+public class ReadableConfigToConfigurationAdapter extends Configuration {
+	private final ReadableConfig backingConfig;
+
+	public ReadableConfigToConfigurationAdapter(ReadableConfig backingConfig) {
+		this.backingConfig = backingConfig;
+	}
+
+	@Override
+	public String getString(ConfigOption<String> configOption) {
+		return backingConfig.get(configOption);
+	}
+
+	@Override
+	public String getString(ConfigOption<String> configOption, String overrideDefault) {
+		return backingConfig.getOptional(configOption).orElse(overrideDefault);
+	}
+
+	@Override
+	public int getInteger(ConfigOption<Integer> configOption) {
+		return backingConfig.get(configOption);
+	}
+
+	@Override
+	public int getInteger(ConfigOption<Integer> configOption, int overrideDefault) {
+		return backingConfig.getOptional(configOption).orElse(overrideDefault);
+	}
+
+	@Override
+	public long getLong(ConfigOption<Long> configOption) {
+		return backingConfig.get(configOption);
+	}
+
+	@Override
+	public long getLong(ConfigOption<Long> configOption, long overrideDefault) {
+		return backingConfig.getOptional(configOption).orElse(overrideDefault);
+	}
+
+	@Override
+	public boolean getBoolean(ConfigOption<Boolean> configOption) {
+		return backingConfig.get(configOption);
+	}
+
+	@Override
+	public boolean getBoolean(ConfigOption<Boolean> configOption, boolean overrideDefault) {
+		return backingConfig.getOptional(configOption).orElse(overrideDefault);
+	}
+
+	@Override
+	public float getFloat(ConfigOption<Float> configOption) {
+		return backingConfig.get(configOption);
+	}
+
+	@Override
+	public float getFloat(ConfigOption<Float> configOption, float overrideDefault) {
+		return backingConfig.getOptional(configOption).orElse(overrideDefault);
+	}
+
+	@Override
+	public double getDouble(ConfigOption<Double> configOption) {
+		return backingConfig.get(configOption);
+	}
+
+	@Override
+	public double getDouble(ConfigOption<Double> configOption, double overrideDefault) {
+		return backingConfig.getOptional(configOption).orElse(overrideDefault);
+	}
+
+	@Override
+	public <T> T get(ConfigOption<T> option) {
+		return backingConfig.get(option);
+	}
+
+	@Override
+	public <T> Optional<T> getOptional(ConfigOption<T> option) {
+		return backingConfig.getOptional(option);
+	}
+
+	@Override
+	public boolean contains(ConfigOption<?> configOption) {
+		return this.backingConfig.getOptional(configOption).isPresent();
+	}
+
+	@Override
+	public int hashCode() {
+		return backingConfig.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return backingConfig.equals(obj);
+	}
+
+	@Override
+	public String toString() {
+		return backingConfig.toString();
+	}
+
+	/*
+		Modifying methods
+	*/
+
+	@Override
+	public void setClass(String key, Class<?> klazz) {
+		throw new UnsupportedOperationException("The configuration is read only");
+	}
+
+	@Override
+	public void setString(String key, String value) {
+		throw new UnsupportedOperationException("The configuration is read only");
+	}
+
+	@Override
+	public void setString(ConfigOption<String> key, String value) {
+		throw new UnsupportedOperationException("The configuration is read only");
+	}
+
+	@Override
+	public void setInteger(String key, int value) {
+		throw new UnsupportedOperationException("The configuration is read only");
+	}
+
+	@Override
+	public void setInteger(ConfigOption<Integer> key, int value) {
+		throw new UnsupportedOperationException("The configuration is read only");
+	}
+
+	@Override
+	public void setLong(String key, long value) {
+		throw new UnsupportedOperationException("The configuration is read only");
+	}
+
+	@Override
+	public void setLong(ConfigOption<Long> key, long value) {
+		throw new UnsupportedOperationException("The configuration is read only");
+	}
+
+	@Override
+	public void setBoolean(String key, boolean value) {
+		throw new UnsupportedOperationException("The configuration is read only");
+	}
+
+	@Override
+	public void setBoolean(ConfigOption<Boolean> key, boolean value) {
+		throw new UnsupportedOperationException("The configuration is read only");
+	}
+
+	@Override
+	public void setFloat(String key, float value) {
+		throw new UnsupportedOperationException("The configuration is read only");
+	}
+
+	@Override
+	public void setFloat(ConfigOption<Float> key, float value) {
+		throw new UnsupportedOperationException("The configuration is read only");
+	}
+
+	@Override
+	public void setDouble(String key, double value) {
+		throw new UnsupportedOperationException("The configuration is read only");
+	}
+
+	@Override
+	public void setDouble(ConfigOption<Double> key, double value) {
+		throw new UnsupportedOperationException("The configuration is read only");
+	}
+
+	@Override
+	public void setBytes(String key, byte[] bytes) {
+		throw new UnsupportedOperationException("The configuration is read only");
+	}
+
+	@Override
+	public void addAllToProperties(Properties props) {
+		throw new UnsupportedOperationException("The configuration is read only");
+	}
+
+	@Override
+	public void addAll(Configuration other) {
+		throw new UnsupportedOperationException("The configuration is read only");
+	}
+
+	@Override
+	public void addAll(Configuration other, String prefix) {
+		throw new UnsupportedOperationException("The configuration is read only");
+	}
+
+	@Override
+	public <T> WritableConfig set(ConfigOption<T> option, T value) {
+		throw new UnsupportedOperationException("The configuration is read only");
+	}
+
+	@Override
+	<T> void setValueInternal(String key, T value) {
+		throw new UnsupportedOperationException("The configuration is read only");
+	}
+
+	@Override
+	public <T> boolean removeConfig(ConfigOption<T> configOption) {
+		throw new UnsupportedOperationException("The configuration is read only");
+	}
+
+	/*
+	 * Other unsupported options.
+	 */
+
+	@Override
+	public byte[] getBytes(String key, byte[] defaultValue) {
+		throw new UnsupportedOperationException("The adapter does not support this method");
+	}
+
+	@Override
+	public String getValue(ConfigOption<?> configOption) {
+		throw new UnsupportedOperationException("The adapter does not support this method");
+	}
+
+	@Override
+	public <T extends Enum<T>> T getEnum(
+		Class<T> enumClass,
+		ConfigOption<String> configOption) {
+		throw new UnsupportedOperationException("The adapter does not support this method");
+	}
+
+	@Override
+	public Configuration clone() {
+		throw new UnsupportedOperationException("The adapter does not support this method");
+	}
+
+	@Override
+	public boolean containsKey(String key) {
+		throw new UnsupportedOperationException("The adapter does not support this method");
+	}
+
+	@Override
+	public double getDouble(String key, double defaultValue) {
+		throw new UnsupportedOperationException("The adapter does not support this method");
+	}
+
+	@Override
+	public <T> Class<T> getClass(
+		String key,
+		Class<? extends T> defaultValue,
+		ClassLoader classLoader) throws ClassNotFoundException {
+		throw new UnsupportedOperationException("The adapter does not support this method");
+	}
+
+	@Override
+	public String getString(String key, String defaultValue) {
+		throw new UnsupportedOperationException("The adapter does not support this method");
+	}
+
+	@Override
+	public int getInteger(String key, int defaultValue) {
+		throw new UnsupportedOperationException("The adapter does not support this method");
+	}
+
+	@Override
+	public long getLong(String key, long defaultValue) {
+		throw new UnsupportedOperationException("The adapter does not support this method");
+	}
+
+	@Override
+	public boolean getBoolean(String key, boolean defaultValue) {
+		throw new UnsupportedOperationException("The adapter does not support this method");
+	}
+
+	@Override
+	public float getFloat(String key, float defaultValue) {
+		throw new UnsupportedOperationException("The adapter does not support this method");
+	}
+
+	@Override
+	public Set<String> keySet() {
+		throw new UnsupportedOperationException("The adapter does not support this method");
+	}
+
+	@Override
+	public Map<String, String> toMap() {
+		throw new UnsupportedOperationException("The adapter does not support this method");
+	}
+
+	@Override
+	public void read(DataInputView in) throws IOException {
+		throw new UnsupportedOperationException("The adapter does not support this method");
+	}
+
+	@Override
+	public void write(DataOutputView out) throws IOException {
+		throw new UnsupportedOperationException("The adapter does not support this method");
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/configuration/ReadableConfigToConfigurationAdapter.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ReadableConfigToConfigurationAdapter.java
@@ -28,8 +28,10 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
- * A very naive adapter between {@link ReadableConfig} and {@link Configuration}.
+ * A simple adapter between {@link ReadableConfig} and {@link Configuration}.
  * It is used to bridge some of the old public interfaces that work with {@link Configuration} even though they
  * should actually work with {@link ReadableConfig}.
  */
@@ -38,7 +40,7 @@ public class ReadableConfigToConfigurationAdapter extends Configuration {
 	private final ReadableConfig backingConfig;
 
 	public ReadableConfigToConfigurationAdapter(ReadableConfig backingConfig) {
-		this.backingConfig = backingConfig;
+		this.backingConfig = checkNotNull(backingConfig);
 	}
 
 	@Override

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
@@ -48,7 +48,7 @@ class StreamExecutionEnvironmentCompletenessTests(PythonAPICompletenessTestCase,
                 'readFileStream', 'isForceCheckpointing', 'readFile', 'clean',
                 'createInput', 'createLocalEnvironmentWithWebUI', 'fromCollection',
                 'socketTextStream', 'initializeContextEnvironment', 'readTextFile', 'addSource',
-                'setNumberOfExecutionRetries'}
+                'setNumberOfExecutionRetries', 'configure'}
 
 
 if __name__ == '__main__':

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamPipelineOptions.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamPipelineOptions.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.environment;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.configuration.description.Description;
+import org.apache.flink.configuration.description.TextElement;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+
+/**
+ * The {@link ConfigOption} configuration options for job execution. Those are stream specific options.
+ * See also {@link org.apache.flink.configuration.PipelineOptions}.
+ */
+@PublicEvolving
+public class StreamPipelineOptions {
+	public static final ConfigOption<TimeCharacteristic> TIME_CHARACTERISTIC =
+		ConfigOptions.key("pipeline.time-characteristic")
+			.enumType(TimeCharacteristic.class)
+			.defaultValue(TimeCharacteristic.ProcessingTime)
+			.withDescription(Description.builder()
+				.text("The time characteristic for all created streams, e.g., processing" +
+					"time, event time, or ingestion time.")
+				.linebreak()
+				.linebreak()
+				.text("If you set the characteristic to IngestionTime or EventTime this will set a default " +
+					"watermark update interval of 200 ms. If this is not applicable for your application " +
+					"you should change it using %s.", TextElement.code(PipelineOptions.AUTO_WATERMARK_INTERVAL.key()))
+				.build());
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamPipelineOptions.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamPipelineOptions.java
@@ -27,7 +27,7 @@ import org.apache.flink.configuration.description.TextElement;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 
 /**
- * The {@link ConfigOption} configuration options for job execution. Those are stream specific options.
+ * The {@link ConfigOption configuration options} for job execution. Those are stream specific options.
  * See also {@link org.apache.flink.configuration.PipelineOptions}.
  */
 @PublicEvolving

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironmentComplexConfigurationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironmentComplexConfigurationTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.environment;
+
+import org.apache.flink.api.common.cache.DistributedCache;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for configuring {@link StreamExecutionEnvironment} via
+ * {@link StreamExecutionEnvironment#configure(ReadableConfig, ClassLoader)} with complex types.
+ *
+ * @see StreamExecutionEnvironmentConfigurationTest
+ */
+public class StreamExecutionEnvironmentComplexConfigurationTest {
+	@Test
+	public void testLoadingStateBackendFromConfiguration() {
+		StreamExecutionEnvironment envFromConfiguration = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		Configuration configuration = new Configuration();
+		configuration.setString("state.backend", "jobmanager");
+
+		// mutate config according to configuration
+		envFromConfiguration.configure(configuration, Thread.currentThread().getContextClassLoader());
+
+		StateBackend actualStateBackend = envFromConfiguration.getStateBackend();
+		assertThat(actualStateBackend, instanceOf(MemoryStateBackend.class));
+	}
+
+	@Test
+	public void testLoadingCachedFilesFromConfiguration() {
+		StreamExecutionEnvironment envFromConfiguration = StreamExecutionEnvironment.getExecutionEnvironment();
+		envFromConfiguration.registerCachedFile("/tmp3", "file3", true);
+
+		Configuration configuration = new Configuration();
+		configuration.setString("pipeline.cached-files", "name:file1,path:/tmp1,executable:true;name:file2,path:/tmp2");
+
+		// mutate config according to configuration
+		envFromConfiguration.configure(configuration, Thread.currentThread().getContextClassLoader());
+
+		assertThat(envFromConfiguration.getCachedFiles(), equalTo(Arrays.asList(
+			Tuple2.of("file1", new DistributedCache.DistributedCacheEntry("/tmp1", true)),
+			Tuple2.of("file2", new DistributedCache.DistributedCacheEntry("/tmp2", false))
+		)));
+	}
+
+	@Test
+	public void testNotOverridingStateBackendWithDefaultsFromConfiguration() {
+		StreamExecutionEnvironment envFromConfiguration = StreamExecutionEnvironment.getExecutionEnvironment();
+		envFromConfiguration.setStateBackend(new MemoryStateBackend());
+
+		// mutate config according to configuration
+		envFromConfiguration.configure(new Configuration(), Thread.currentThread().getContextClassLoader());
+
+		StateBackend actualStateBackend = envFromConfiguration.getStateBackend();
+		assertThat(actualStateBackend, instanceOf(MemoryStateBackend.class));
+	}
+
+	@Test
+	public void testNotOverridingCachedFilesFromConfiguration() {
+		StreamExecutionEnvironment envFromConfiguration = StreamExecutionEnvironment.getExecutionEnvironment();
+		envFromConfiguration.registerCachedFile("/tmp3", "file3", true);
+
+		Configuration configuration = new Configuration();
+
+		// mutate config according to configuration
+		envFromConfiguration.configure(configuration, Thread.currentThread().getContextClassLoader());
+
+		assertThat(envFromConfiguration.getCachedFiles(), equalTo(Arrays.asList(
+			Tuple2.of("file3", new DistributedCache.DistributedCacheEntry("/tmp3", true))
+		)));
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironmentConfigurationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironmentConfigurationTest.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.environment;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.ExecutionConfigTest;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for configuring {@link StreamExecutionEnvironment} via
+ * {@link StreamExecutionEnvironment#configure(ReadableConfig, ClassLoader)}.
+ *
+ * @see StreamExecutionEnvironmentComplexConfigurationTest
+ */
+@RunWith(Parameterized.class)
+public class StreamExecutionEnvironmentConfigurationTest {
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Collection<TestSpec> specs() {
+		return Arrays.asList(
+			TestSpec.testValue(TimeCharacteristic.IngestionTime)
+				.whenSetFromFile("pipeline.time-characteristic", "IngestionTime")
+				.viaSetter(StreamExecutionEnvironment::setStreamTimeCharacteristic)
+				.getterVia(StreamExecutionEnvironment::getStreamTimeCharacteristic)
+				.nonDefaultValue(TimeCharacteristic.EventTime),
+
+			TestSpec.testValue(60000L)
+				.whenSetFromFile("execution.buffer-timeout", "1 min")
+				.viaSetter(StreamExecutionEnvironment::setBufferTimeout)
+				.getterVia(StreamExecutionEnvironment::getBufferTimeout)
+				.nonDefaultValue(12000L),
+
+			TestSpec.testValue(false)
+				.whenSetFromFile("pipeline.operator-chaining", "false")
+				.viaSetter((env, b) -> {
+					if (b) {
+						throw new IllegalArgumentException("Cannot programatically enable operator chaining");
+					} else {
+						env.disableOperatorChaining();
+					}
+				})
+				.getterVia(StreamExecutionEnvironment::isChainingEnabled)
+				.nonDefaultValue(false),
+
+			TestSpec.testValue(ExecutionConfig.ClosureCleanerLevel.TOP_LEVEL)
+				.whenSetFromFile("pipeline.closure-cleaner-level", "TOP_LEVEL")
+				.viaSetter((env, v) -> env.getConfig().setClosureCleanerLevel(v))
+				.getterVia(env -> env.getConfig().getClosureCleanerLevel())
+				.nonDefaultValue(ExecutionConfig.ClosureCleanerLevel.NONE),
+
+			TestSpec.testValue(12000L)
+				.whenSetFromFile("execution.checkpointing.timeout", "12 s")
+				.viaSetter((env, v) -> env.getCheckpointConfig().setCheckpointTimeout(v))
+				.getterVia(env -> env.getCheckpointConfig().getCheckpointTimeout())
+				.nonDefaultValue(100L)
+		);
+	}
+
+	@Parameterized.Parameter
+	public TestSpec spec;
+
+	@Test
+	public void testLoadingFromConfiguration() {
+		StreamExecutionEnvironment configFromSetters = StreamExecutionEnvironment.getExecutionEnvironment();
+		StreamExecutionEnvironment configFromFile = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		Configuration configuration = new Configuration();
+		configuration.setString(spec.key, spec.value);
+		configFromFile.configure(configuration, ExecutionConfigTest.class.getClassLoader());
+
+		spec.setValue(configFromSetters);
+		spec.assertEqual(configFromFile, configFromSetters);
+	}
+
+	@Test
+	public void testNotOverridingIfNotSet() {
+		StreamExecutionEnvironment environment = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		spec.setNonDefaultValue(environment);
+		Configuration configuration = new Configuration();
+		environment.configure(configuration, ExecutionConfigTest.class.getClassLoader());
+
+		spec.assertEqualNonDefault(environment);
+	}
+
+	private static class TestSpec<T> {
+		private String key;
+		private String value;
+		private final T objectValue;
+		private T nonDefaultValue;
+		private BiConsumer<StreamExecutionEnvironment, T> setter;
+		private Function<StreamExecutionEnvironment, T> getter;
+
+		private TestSpec(T value) {
+			this.objectValue = value;
+		}
+
+		public static <T> TestSpec<T> testValue(T value) {
+			return new TestSpec<>(value);
+		}
+
+		public TestSpec<T> whenSetFromFile(String key, String value) {
+			this.key = key;
+			this.value = value;
+			return this;
+		}
+
+		public TestSpec<T> viaSetter(BiConsumer<StreamExecutionEnvironment, T> setter) {
+			this.setter = setter;
+			return this;
+		}
+
+		public TestSpec<T> getterVia(Function<StreamExecutionEnvironment, T> getter) {
+			this.getter = getter;
+			return this;
+		}
+
+		public TestSpec<T> nonDefaultValue(T nonDefaultValue) {
+			this.nonDefaultValue = nonDefaultValue;
+			return this;
+		}
+
+		public void setValue(StreamExecutionEnvironment config) {
+			setter.accept(config, objectValue);
+		}
+
+		public void setNonDefaultValue(StreamExecutionEnvironment config) {
+			setter.accept(config, nonDefaultValue);
+		}
+
+		public void assertEqual(StreamExecutionEnvironment configFromFile, StreamExecutionEnvironment configFromSetters) {
+			assertThat(getter.apply(configFromFile), equalTo(getter.apply(configFromSetters)));
+		}
+
+		public void assertEqualNonDefault(StreamExecutionEnvironment configFromFile) {
+			assertThat(getter.apply(configFromFile), equalTo(nonDefaultValue));
+		}
+
+		@Override
+		public String toString() {
+			return "key='" + key + '\'';
+		}
+	}
+}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -696,10 +696,10 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
     * may be local files (which will be distributed via BlobServer), or files in a distributed file
     * system. The runtime will copy the files temporarily to a local cache, if needed.
     *
-    * The {@link org.apache.flink.api.common.functions.RuntimeContext} can be obtained inside UDFs
-    * via {@link org.apache.flink.api.common.functions.RichFunction#getRuntimeContext()} and
-    * provides access {@link org.apache.flink.api.common.cache.DistributedCache} via
-    * {@link org.apache.flink.api.common.functions.RuntimeContext#getDistributedCache()}.
+    * The [[org.apache.flink.api.common.functions.RuntimeContext]] can be obtained inside UDFs
+    * via [[org.apache.flink.api.common.functions.RichFunction#getRuntimeContext()]] and
+    * provides access [[org.apache.flink.api.common.cache.DistributedCache]] via
+    * [[org.apache.flink.api.common.functions.RuntimeContext#getDistributedCache()]].
     *
     * @param filePath The path of the file, as a URI (e.g. "file:///some/path" or
     *                 "hdfs://host:port/and/path")
@@ -715,10 +715,10 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
     * may be local files (which will be distributed via BlobServer), or files in a distributed file
     * system. The runtime will copy the files temporarily to a local cache, if needed.
     *
-    * The {@link org.apache.flink.api.common.functions.RuntimeContext} can be obtained inside UDFs
-    * via {@link org.apache.flink.api.common.functions.RichFunction#getRuntimeContext()} and
-    * provides access {@link org.apache.flink.api.common.cache.DistributedCache} via
-    * {@link org.apache.flink.api.common.functions.RuntimeContext#getDistributedCache()}.
+    * The [[org.apache.flink.api.common.functions.RuntimeContext]] can be obtained inside UDFs
+    * via [[org.apache.flink.api.common.functions.RichFunction#getRuntimeContext()]] and
+    * provides access [[org.apache.flink.api.common.cache.DistributedCache]] via
+    * [[org.apache.flink.api.common.functions.RuntimeContext#getDistributedCache()]].
     *
     * @param filePath   The path of the file, as a URI (e.g. "file:///some/path" or
     *                   "hdfs://host:port/and/path")

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -26,7 +26,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.api.scala.ClosureCleaner
-import org.apache.flink.configuration.Configuration
+import org.apache.flink.configuration.{Configuration, ReadableConfig}
 import org.apache.flink.runtime.state.AbstractStateBackend
 import org.apache.flink.runtime.state.StateBackend
 import org.apache.flink.streaming.api.environment.{StreamExecutionEnvironment => JavaEnv}
@@ -403,6 +403,25 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    */
   @PublicEvolving
   def getStreamTimeCharacteristic = javaEnv.getStreamTimeCharacteristic()
+
+  /**
+   * Sets all relevant options contained in the [[ReadableConfig]] such as e.g.
+   * [[org.apache.flink.streaming.api.environment.StreamPipelineOptions#TIME_CHARACTERISTIC]].
+   * It will reconfigure [[StreamExecutionEnvironment]],
+   * [[org.apache.flink.api.common.ExecutionConfig]] and
+   * [[org.apache.flink.streaming.api.environment.CheckpointConfig]].
+   *
+   * It will change the value of a setting only if a corresponding option was set in the
+   * `configuration`. If a key is not present, the current value of a field will remain
+   * untouched.
+   *
+   * @param configuration a configuration to read the values from
+   * @param classLoader   a class loader to use when loading classes
+   */
+  @PublicEvolving
+  def configure(configuration: ReadableConfig, classLoader: ClassLoader): Unit = {
+    javaEnv.configure(configuration, classLoader)
+  }
 
   // --------------------------------------------------------------------------------------------
   // Data stream creations


### PR DESCRIPTION
## What is the purpose of the change

This PR adds ability to configure StreamExecutionEnvironment from ReadableConfig

It is based on #10222 

## Brief change log

- Added necessary ConfigOptions
- Added possibility to configure StreamExecutionEnvironment from ReadableConfig
- Make the enum matching in Configuration more lenient in regards to case sensitivity (this is needed to match enums that do not follow enum naming convention e.g. `TimeCharacteristic`)
- Regenerated corresponding documentation tables

## Verifying this change

This change added tests:
* StreamExecutionEnvironmentConfigurationTest
* StreamExecutionEnvironmentComplexConfigurationTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no /** don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
