### PR TITLE
[FLINK-14821][tests] Enable E2E test to pass with new DefaultScheduler

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_queryable_state_restart_tm.sh
+++ b/flink-end-to-end-tests/test-scripts/test_queryable_state_restart_tm.sh
@@ -91,9 +91,6 @@ function run_test() {
     latest_snapshot_count=$(cat $FLINK_DIR/log/*out* | grep "on snapshot" | tail -n 1 | awk '{print $4}')
     echo "Latest snapshot count was ${latest_snapshot_count}"
 
-    # wait until the TM loss was detected
-    wait_for_job_state_transition ${JOB_ID} "RESTARTING" "CREATED"
-
     start_and_wait_for_tm
 
     wait_job_running ${JOB_ID}


### PR DESCRIPTION
## What is the purpose of the change

*Enable test_queryable_state_restart_tm ('Queryable state (rocksdb) with TM restart') to pass with new DefaultScheduler.*


## Brief change log

  - *Do not wait for job state transition `RESTARTING` -> `CREATED` in test.*


## Verifying this change


This change is already covered by existing tests, such as *test_queryable_state_restart_tm.sh*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
