### PR TITLE
[FLINK-14822][tests] Enable E2E test to pass with new DefaultScheduler

### DIFF
--- a/flink-end-to-end-tests/flink-streaming-file-sink-test/src/main/java/StreamingFileSinkProgram.java
+++ b/flink-end-to-end-tests/flink-streaming-file-sink-test/src/main/java/StreamingFileSinkProgram.java
@@ -58,7 +58,7 @@ public enum StreamingFileSinkProgram {
 
 		env.setParallelism(4);
 		env.enableCheckpointing(5000L);
-		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, Time.of(10L, TimeUnit.SECONDS)));
+		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, Time.of(10L, TimeUnit.SECONDS)));
 
 		final StreamingFileSink<Tuple2<Integer, Integer>> sink = StreamingFileSink
 			.forRowFormat(new Path(outputPath), (Encoder<Tuple2<Integer, Integer>>) (element, stream) -> {

--- a/flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh
@@ -31,6 +31,8 @@ set_conf_ssl "mutual" "OPENSSL" "${OPENSSL_LINKAGE}"
 set_config_key "metrics.fetcher.update-interval" "2000"
 # this test relies on global failovers
 set_config_key "jobmanager.execution.failover-strategy" "full"
+set_config_key "heartbeat.interval" "2000"
+set_config_key "heartbeat.timeout" "10000"
 
 OUT=temp/test_streaming_file_sink-$(uuidgen)
 OUTPUT_PATH="$TEST_DATA_DIR/$OUT"
@@ -161,16 +163,6 @@ echo "Starting TM"
 "$FLINK_DIR/bin/taskmanager.sh" start
 
 wait_for_restart_to_complete 0 ${JOB_ID}
-
-echo "Killing 2 TMs"
-kill_random_taskmanager
-kill_random_taskmanager
-
-echo "Starting 2 TMs"
-"$FLINK_DIR/bin/taskmanager.sh" start
-"$FLINK_DIR/bin/taskmanager.sh" start
-
-wait_for_restart_to_complete 1 ${JOB_ID}
 
 echo "Waiting until all values have been produced"
 wait_for_complete_result 60000 900


### PR DESCRIPTION
## What is the purpose of the change

*Enable test_streaming_file_sink ('Streaming File Sink end-to-end test') to pass with new DefaultScheduler.*


## Brief change log

  - *Reduce heartbeat interval and timeout. This speeds up TM loss detection.*
  - *Reduce number of TM kills to 1.*
  - *Increase number of accepted restarts.*


## Verifying this change

This change is already covered by existing tests, such as *test_streaming_file_sink.sh*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
