### PR TITLE
[FLINK-14839][config] Let JobGraph#classpaths become non-null

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
@@ -109,7 +109,7 @@ public class RemoteExecutor extends PlanExecutor {
 				getDefaultParallelism());
 
 		jobGraph.addJars(jarFiles);
-		jobGraph.setClasspaths(globalClasspaths);
+		jobGraph.addClasspaths(globalClasspaths);
 
 		ClassLoader userCodeClassLoader = ClientUtils.buildUserCodeClassLoader(
 				jarFiles,

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ExecutorUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ExecutorUtils.java
@@ -51,7 +51,7 @@ public class ExecutorUtils {
 				.getJobGraph(pipeline, configuration, executionConfigAccessor.getParallelism());
 
 		jobGraph.addJars(executionConfigAccessor.getJars());
-		jobGraph.setClasspaths(executionConfigAccessor.getClasspaths());
+		jobGraph.addClasspaths(executionConfigAccessor.getClasspaths());
 		jobGraph.setSavepointRestoreSettings(executionConfigAccessor.getSavepointRestoreSettings());
 
 		return jobGraph;

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
@@ -64,7 +64,7 @@ public class PackagedProgramUtils {
 			jobGraph.setJobID(jobID);
 		}
 		jobGraph.addJars(packagedProgram.getJobJarAndDependencies());
-		jobGraph.setClasspaths(packagedProgram.getClasspaths());
+		jobGraph.addClasspaths(packagedProgram.getClasspaths());
 		jobGraph.setSavepointRestoreSettings(packagedProgram.getSavepointSettings());
 
 		return jobGraph;

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -200,7 +200,7 @@ public class ClientTest extends TestLogger {
 				1);
 
 		jobGraph.addJars(Collections.emptyList());
-		jobGraph.setClasspaths(Collections.emptyList());
+		jobGraph.addClasspaths(Collections.emptyList());
 
 		JobSubmissionResult result = ClientUtils.submitJob(clusterClient, jobGraph);
 		assertNotNull(result);
@@ -393,7 +393,7 @@ public class ClientTest extends TestLogger {
 
 						final ExecutionConfigAccessor accessor = ExecutionConfigAccessor.fromConfiguration(config);
 						jobGraph.addJars(accessor.getJars());
-						jobGraph.setClasspaths(accessor.getClasspaths());
+						jobGraph.addClasspaths(accessor.getClasspaths());
 
 						final JobID jobID = ClientUtils.submitJob(clusterClient, jobGraph).getJobID();
 						return CompletableFuture.completedFuture(new ClusterClientJobClientAdapter<>(clusterClient, jobID, false));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/FileJobGraphRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/FileJobGraphRetriever.java
@@ -32,9 +32,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -63,23 +60,13 @@ public class FileJobGraphRetriever extends AbstractUserClassPathJobGraphRetrieve
 		try (FileInputStream input = new FileInputStream(fp);
 			ObjectInputStream obInput = new ObjectInputStream(input)) {
 			final JobGraph jobGraph = (JobGraph) obInput.readObject();
-			addUserClassPathsToJobGraph(jobGraph);
+			jobGraph.addClasspaths(getUserClassPaths());
 			return jobGraph;
 		} catch (FileNotFoundException e) {
 			throw new FlinkException("Could not find the JobGraph file.", e);
 		} catch (ClassNotFoundException | IOException e) {
 			throw new FlinkException("Could not load the JobGraph from file.", e);
 		}
-	}
-
-	private void addUserClassPathsToJobGraph(JobGraph jobGraph) {
-		final List<URL> classPaths = new ArrayList<>();
-
-		if (jobGraph.getClasspaths() != null) {
-			classPaths.addAll(jobGraph.getClasspaths());
-		}
-		classPaths.addAll(getUserClassPaths());
-		jobGraph.setClasspaths(classPaths);
 	}
 
 	public static FileJobGraphRetriever createFrom(Configuration configuration, @Nullable File usrLibDir) throws IOException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -28,14 +28,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -86,27 +84,23 @@ public class BlobLibraryCacheManager implements LibraryCacheManager {
 	}
 
 	@Override
-	public void registerJob(JobID id, Collection<PermanentBlobKey> requiredJarFiles, Collection<URL> requiredClasspaths)
-		throws IOException {
+	public void registerJob(
+			JobID id,
+			Collection<PermanentBlobKey> requiredJarFiles,
+			Collection<URL> requiredClasspaths) throws IOException {
 		registerTask(id, JOB_ATTEMPT_ID, requiredJarFiles, requiredClasspaths);
 	}
 
 	@Override
 	public void registerTask(
-		JobID jobId,
-		ExecutionAttemptID task,
-		@Nullable Collection<PermanentBlobKey> requiredJarFiles,
-		@Nullable Collection<URL> requiredClasspaths) throws IOException {
-
+			JobID jobId,
+			ExecutionAttemptID task,
+			Collection<PermanentBlobKey> requiredJarFiles,
+			Collection<URL> requiredClasspaths) throws IOException {
 		checkNotNull(jobId, "The JobId must not be null.");
 		checkNotNull(task, "The task execution id must not be null.");
-
-		if (requiredJarFiles == null) {
-			requiredJarFiles = Collections.emptySet();
-		}
-		if (requiredClasspaths == null) {
-			requiredClasspaths = Collections.emptySet();
-		}
+		checkNotNull(requiredJarFiles, "Required jar files must not be null.");
+		checkNotNull(requiredClasspaths, "Required classpaths must not be null.");
 
 		synchronized (lockObject) {
 			LibraryCacheEntry entry = cacheEntries.get(jobId);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -91,7 +91,7 @@ public class JobGraph implements Serializable {
 	// --- attached resources ---
 
 	/** Set of JAR files required to run this job. */
-	private final List<Path> userJars = new ArrayList<Path>();
+	private final List<Path> userJars = new ArrayList<>();
 
 	/** Set of custom files required to run this job. */
 	private final Map<String, DistributedCache.DistributedCacheEntry> userArtifacts = new HashMap<>();
@@ -100,7 +100,7 @@ public class JobGraph implements Serializable {
 	private final List<PermanentBlobKey> userJarBlobKeys = new ArrayList<>();
 
 	/** List of classpaths required to run this job. */
-	private List<URL> classpaths = Collections.emptyList();
+	private final List<URL> classpaths = new ArrayList<>();
 
 	// --------------------------------------------------------------------------------------------
 
@@ -352,8 +352,8 @@ public class JobGraph implements Serializable {
 	 *
 	 * @param paths paths of the directories/JAR files required to run the job on a task manager
 	 */
-	public void setClasspaths(List<URL> paths) {
-		classpaths = paths;
+	public void addClasspaths(List<URL> paths) {
+		classpaths.addAll(paths);
 	}
 
 	public List<URL> getClasspaths() {
@@ -465,9 +465,7 @@ public class JobGraph implements Serializable {
 	 *        path of the JAR file required to run the job on a task manager
 	 */
 	public void addJar(Path jar) {
-		if (jar == null) {
-			throw new IllegalArgumentException();
-		}
+		checkNotNull(jar);
 
 		if (!userJars.contains(jar)) {
 			userJars.add(jar);
@@ -536,15 +534,6 @@ public class JobGraph implements Serializable {
 		if (!userJarBlobKeys.contains(key)) {
 			userJarBlobKeys.add(key);
 		}
-	}
-
-	/**
-	 * Checks whether the JobGraph has user code JAR files attached.
-	 *
-	 * @return True, if the JobGraph has user code JAR files attached, false otherwise.
-	 */
-	public boolean hasUsercodeJarFiles() {
-		return this.userJars.size() > 0;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -358,7 +358,7 @@ public class JobGraph implements Serializable {
 	}
 
 	public List<URL> getClasspaths() {
-		return classpaths;
+		return Collections.unmodifiableList(classpaths);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -34,6 +34,7 @@ import java.io.Serializable;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -352,7 +353,7 @@ public class JobGraph implements Serializable {
 	 *
 	 * @param paths paths of the directories/JAR files required to run the job on a task manager
 	 */
-	public void addClasspaths(List<URL> paths) {
+	public void addClasspaths(Collection<URL> paths) {
 		classpaths.addAll(paths);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/FileJobGraphRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/FileJobGraphRetrieverTest.java
@@ -72,7 +72,7 @@ public class FileJobGraphRetrieverTest {
 		final JobVertex target = new JobVertex("target");
 		final JobGraph jobGraph = new JobGraph(new JobID(), "test", source, target);
 
-		jobGraph.setClasspaths(Collections.singletonList(jarFileInJobGraph.toUri().toURL()));
+		jobGraph.addClasspaths(Collections.singletonList(jarFileInJobGraph.toUri().toURL()));
 
 		try (ObjectOutputStream objectOutputStream =
 				new ObjectOutputStream(Files.newOutputStream(jobGraphPath, CREATE))) {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -486,7 +486,7 @@ public class ExecutionContext<ClusterID> {
 					parallelism);
 
 			jobGraph.addJars(executionParameters.getJars());
-			jobGraph.setClasspaths(executionParameters.getClasspaths());
+			jobGraph.addClasspaths(executionParameters.getClasspaths());
 			jobGraph.setSavepointRestoreSettings(executionParameters.getSavepointRestoreSettings());
 
 			return jobGraph;

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
@@ -73,7 +73,7 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
 			jobGraph.addJar(jarFile);
 		}
 
-		jobGraph.setClasspaths(new ArrayList<>(classPaths));
+		jobGraph.addClasspaths(new ArrayList<>(classPaths));
 
 		return jobExecutor.executeJobBlocking(jobGraph);
 	}

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestEnvironment.java
@@ -106,7 +106,7 @@ public class TestEnvironment extends ExecutionEnvironment {
 			jobGraph.addJar(jarFile);
 		}
 
-		jobGraph.setClasspaths(new ArrayList<>(classPaths));
+		jobGraph.addClasspaths(new ArrayList<>(classPaths));
 
 		this.lastJobExecutionResult = jobExecutor.executeJobBlocking(jobGraph);
 		return this.lastJobExecutionResult;


### PR DESCRIPTION
## What is the purpose of the change

JobGraph#userJars & JobGraph#classpaths are non-null, so we can improve our codes a bit.

## Brief change log

- Let JobGraph#classpaths become non-null. Preciously, we now add classpaths into an `ArrayList` instead of changing the reference.
- Thus, rename `setClasspaths` to `addClasspaths`
- BlobLibraryCacheManager#registerTask never receives nullable parameter, indeed.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @zentol @GJL 
