### PR TITLE
[FLINK-14362][runtime] Change DefaultSchedulingResultPartition to return correct partition state

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -401,10 +401,15 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 					.registerProducedPartitions(logicalSlot.getTaskManagerLocation(), sendScheduleOrUpdateConsumerMessage);
 				executionVertex.tryAssignResource(logicalSlot);
 			} else {
-				handleTaskFailure(executionVertexId, maybeWrapWithNoResourceAvailableException(throwable));
+				handleTaskDeploymentFailure(executionVertexId, maybeWrapWithNoResourceAvailableException(throwable));
 			}
 			return null;
 		};
+	}
+
+	private void handleTaskDeploymentFailure(final ExecutionVertexID executionVertexId, final Throwable error) {
+		log.info("Error while scheduling or deploying task {}.", executionVertexId, error);
+		handleTaskFailure(executionVertexId, error);
 	}
 
 	private static Throwable maybeWrapWithNoResourceAvailableException(final Throwable failure) {
@@ -431,7 +436,7 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 			if (throwable == null) {
 				deployTaskSafe(executionVertexId);
 			} else {
-				handleTaskFailure(executionVertexId, throwable);
+				handleTaskDeploymentFailure(executionVertexId, throwable);
 			}
 			return null;
 		};
@@ -442,7 +447,7 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 			final ExecutionVertex executionVertex = getExecutionVertex(executionVertexId);
 			executionVertexOperations.deploy(executionVertex);
 		} catch (Throwable e) {
-			handleTaskFailure(executionVertexId, e);
+			handleTaskDeploymentFailure(executionVertexId, e);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultResultPartition.java
@@ -22,14 +22,12 @@ import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverResultPart
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.scheduler.strategy.ResultPartitionState;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.DONE;
-import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.EMPTY;
-import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.PRODUCING;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -77,11 +75,10 @@ class DefaultResultPartition implements SchedulingResultPartition<DefaultExecuti
 	public ResultPartitionState getState() {
 		switch (producer.getState()) {
 			case RUNNING:
-				return PRODUCING;
 			case FINISHED:
-				return DONE;
+				return ResultPartitionState.CONSUMABLE;
 			default:
-				return EMPTY;
+				return ResultPartitionState.CREATED;
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultResultPartition.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -42,6 +43,8 @@ class DefaultResultPartition implements SchedulingResultPartition<DefaultExecuti
 
 	private final ResultPartitionType partitionType;
 
+	private final Supplier<ResultPartitionState> resultPartitionStateSupplier;
+
 	private DefaultExecutionVertex producer;
 
 	private final List<DefaultExecutionVertex> consumers;
@@ -49,10 +52,12 @@ class DefaultResultPartition implements SchedulingResultPartition<DefaultExecuti
 	DefaultResultPartition(
 			IntermediateResultPartitionID partitionId,
 			IntermediateDataSetID intermediateDataSetId,
-			ResultPartitionType partitionType) {
+			ResultPartitionType partitionType,
+			Supplier<ResultPartitionState> resultPartitionStateSupplier) {
 		this.resultPartitionId = checkNotNull(partitionId);
 		this.intermediateDataSetId = checkNotNull(intermediateDataSetId);
 		this.partitionType = checkNotNull(partitionType);
+		this.resultPartitionStateSupplier = checkNotNull(resultPartitionStateSupplier);
 		this.consumers = new ArrayList<>();
 	}
 
@@ -73,13 +78,7 @@ class DefaultResultPartition implements SchedulingResultPartition<DefaultExecuti
 
 	@Override
 	public ResultPartitionState getState() {
-		switch (producer.getState()) {
-			case RUNNING:
-			case FINISHED:
-				return ResultPartitionState.CONSUMABLE;
-			default:
-				return ResultPartitionState.CREATED;
-		}
+		return resultPartitionStateSupplier.get();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/InputDependencyConstraintChecker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/InputDependencyConstraintChecker.java
@@ -37,8 +37,6 @@ import java.util.Set;
 import static org.apache.flink.api.common.InputDependencyConstraint.ALL;
 import static org.apache.flink.api.common.InputDependencyConstraint.ANY;
 import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.BLOCKING;
-import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.DONE;
-import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.PRODUCING;
 
 /**
  * A wrapper class for {@link InputDependencyConstraint} checker.
@@ -84,8 +82,8 @@ public class InputDependencyConstraintChecker {
 		if (BLOCKING.equals(partition.getResultType())) {
 			return intermediateDataSetManager.allPartitionsFinished(partition);
 		} else {
-			SchedulingResultPartition.ResultPartitionState state = partition.getState();
-			return PRODUCING.equals(state) || DONE.equals(state);
+			final ResultPartitionState state = partition.getState();
+			return ResultPartitionState.CONSUMABLE.equals(state);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/ResultPartitionState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/ResultPartitionState.java
@@ -18,28 +18,19 @@
 
 package org.apache.flink.runtime.scheduler.strategy;
 
-import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
-import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
-import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
-import org.apache.flink.runtime.topology.Result;
-
 /**
- * Representation of {@link IntermediateResultPartition}.
+ * State of a {@link SchedulingResultPartition}.
  */
-public interface SchedulingResultPartition<V extends SchedulingExecutionVertex<V, R>, R extends SchedulingResultPartition<V, R>>
-	extends Result<ExecutionVertexID, IntermediateResultPartitionID, V, R> {
+public enum ResultPartitionState {
 
 	/**
-	 * Gets id of the intermediate result.
-	 *
-	 * @return id of the intermediate result
+	 * Partition is just created or is just reset.
 	 */
-	IntermediateDataSetID getResultId();
+	CREATED,
 
 	/**
-	 * Gets the {@link ResultPartitionState}.
-	 *
-	 * @return result partition state
+	 * Partition is ready for consuming. For pipelined partition, this indicates it has data produced.
+	 * For blocking partition, this indicates all result partitions in its parent result have finished.
 	 */
-	ResultPartitionState getState();
+	CONSUMABLE
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionVertexTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.scheduler.strategy.ResultPartitionState;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition;
 import org.apache.flink.util.IterableUtils;
 import org.apache.flink.util.TestLogger;
@@ -58,7 +59,8 @@ public class DefaultExecutionVertexTest extends TestLogger {
 		DefaultResultPartition schedulingResultPartition = new DefaultResultPartition(
 			intermediateResultPartitionId,
 			new IntermediateDataSetID(),
-			BLOCKING);
+			BLOCKING,
+			() -> ResultPartitionState.CREATED);
 		producerVertex = new DefaultExecutionVertex(
 			new ExecutionVertexID(new JobVertexID(), 0),
 			Collections.singletonList(schedulingResultPartition),
@@ -104,7 +106,7 @@ public class DefaultExecutionVertexTest extends TestLogger {
 	/**
 	 * A simple implementation of {@link Supplier} for testing.
 	 */
-	static class TestExecutionStateSupplier implements Supplier<ExecutionState> {
+	private static class TestExecutionStateSupplier implements Supplier<ExecutionState> {
 
 		private ExecutionState executionState;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultResultPartitionTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
-import org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition;
+import org.apache.flink.runtime.scheduler.strategy.ResultPartitionState;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Before;
@@ -34,9 +34,6 @@ import java.util.function.Supplier;
 
 import static org.apache.flink.api.common.InputDependencyConstraint.ANY;
 import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.BLOCKING;
-import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.DONE;
-import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.EMPTY;
-import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.PRODUCING;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -70,16 +67,14 @@ public class DefaultResultPartitionTest extends TestLogger {
 	public void testGetPartitionState() {
 		for (ExecutionState state : ExecutionState.values()) {
 			stateProvider.setExecutionState(state);
-			SchedulingResultPartition.ResultPartitionState partitionState = resultPartition.getState();
+			final ResultPartitionState partitionState = resultPartition.getState();
 			switch (state) {
 				case RUNNING:
-					assertEquals(PRODUCING, partitionState);
-					break;
 				case FINISHED:
-					assertEquals(DONE, partitionState);
+					assertEquals(ResultPartitionState.CONSUMABLE, partitionState);
 					break;
 				default:
-					assertEquals(EMPTY, partitionState);
+					assertEquals(ResultPartitionState.CREATED, partitionState);
 					break;
 			}
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultResultPartitionTest.java
@@ -18,21 +18,16 @@
 
 package org.apache.flink.runtime.scheduler.adapter;
 
-import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ResultPartitionState;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.function.Supplier;
 
-import static org.apache.flink.api.common.InputDependencyConstraint.ANY;
 import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.BLOCKING;
 import static org.junit.Assert.assertEquals;
 
@@ -41,7 +36,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class DefaultResultPartitionTest extends TestLogger {
 
-	private static final TestExecutionStateSupplier stateProvider = new TestExecutionStateSupplier();
+	private static final TestResultPartitionStateSupplier resultPartitionState = new TestResultPartitionStateSupplier();
 
 	private final IntermediateResultPartitionID resultPartitionId = new IntermediateResultPartitionID();
 	private final IntermediateDataSetID intermediateResultId = new IntermediateDataSetID();
@@ -53,47 +48,32 @@ public class DefaultResultPartitionTest extends TestLogger {
 		resultPartition = new DefaultResultPartition(
 			resultPartitionId,
 			intermediateResultId,
-			BLOCKING);
-
-		DefaultExecutionVertex producerVertex = new DefaultExecutionVertex(
-			new ExecutionVertexID(new JobVertexID(), 0),
-			Collections.singletonList(resultPartition),
-			stateProvider,
-			ANY);
-		resultPartition.setProducer(producerVertex);
+			BLOCKING,
+			resultPartitionState);
 	}
 
 	@Test
 	public void testGetPartitionState() {
-		for (ExecutionState state : ExecutionState.values()) {
-			stateProvider.setExecutionState(state);
-			final ResultPartitionState partitionState = resultPartition.getState();
-			switch (state) {
-				case RUNNING:
-				case FINISHED:
-					assertEquals(ResultPartitionState.CONSUMABLE, partitionState);
-					break;
-				default:
-					assertEquals(ResultPartitionState.CREATED, partitionState);
-					break;
-			}
+		for (ResultPartitionState state : ResultPartitionState.values()) {
+			resultPartitionState.setResultPartitionState(state);
+			assertEquals(state, resultPartition.getState());
 		}
 	}
 
 	/**
-	 * A simple implementation of {@link Supplier} for testing.
+	 * A test {@link ResultPartitionState} supplier.
 	 */
-	private static class TestExecutionStateSupplier implements Supplier<ExecutionState> {
+	private static class TestResultPartitionStateSupplier implements Supplier<ResultPartitionState> {
 
-		private ExecutionState executionState;
+		private ResultPartitionState resultPartitionState;
 
-		void setExecutionState(ExecutionState state) {
-			executionState = state;
+		void setResultPartitionState(ResultPartitionState state) {
+			resultPartitionState = state;
 		}
 
 		@Override
-		public ExecutionState get() {
-			return executionState;
+		public ResultPartitionState get() {
+			return resultPartitionState;
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/InputDependencyConstraintCheckerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/InputDependencyConstraintCheckerTest.java
@@ -34,9 +34,6 @@ import static org.apache.flink.api.common.InputDependencyConstraint.ALL;
 import static org.apache.flink.api.common.InputDependencyConstraint.ANY;
 import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.BLOCKING;
 import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.PIPELINED;
-import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.DONE;
-import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.EMPTY;
-import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.PRODUCING;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -54,10 +51,10 @@ public class InputDependencyConstraintCheckerTest extends TestLogger {
 	}
 
 	@Test
-	public void testCheckEmptyPipelinedInput() {
+	public void testCheckCreatedPipelinedInput() {
 		final List<TestingSchedulingResultPartition> partitions = addResultPartition()
 			.withPartitionType(PIPELINED)
-			.withPartitionState(EMPTY)
+			.withPartitionState(ResultPartitionState.CREATED)
 			.finish();
 		final TestingSchedulingExecutionVertex vertex = addSchedulingExecutionVertex()
 			.withConsumedPartitions(partitions)
@@ -69,10 +66,10 @@ public class InputDependencyConstraintCheckerTest extends TestLogger {
 	}
 
 	@Test
-	public void testCheckProducingPipelinedInput() {
+	public void testCheckConsumablePipelinedInput() {
 		final List<TestingSchedulingResultPartition> partitions = addResultPartition()
 			.withPartitionType(PIPELINED)
-			.withPartitionState(PRODUCING)
+			.withPartitionState(ResultPartitionState.CONSUMABLE)
 			.finish();
 		final TestingSchedulingExecutionVertex vertex = addSchedulingExecutionVertex()
 			.withConsumedPartitions(partitions)
@@ -252,7 +249,7 @@ public class InputDependencyConstraintCheckerTest extends TestLogger {
 		private int dataSetCnt = 1;
 		private int partitionCntPerDataSet = 1;
 		private ResultPartitionType partitionType = BLOCKING;
-		private SchedulingResultPartition.ResultPartitionState partitionState = DONE;
+		private ResultPartitionState partitionState = ResultPartitionState.CONSUMABLE;
 
 		TestingSchedulingResultPartitionBuilder withDataSetCnt(int dataSetCnt) {
 			this.dataSetCnt = dataSetCnt;
@@ -269,7 +266,7 @@ public class InputDependencyConstraintCheckerTest extends TestLogger {
 			return this;
 		}
 
-		TestingSchedulingResultPartitionBuilder withPartitionState(SchedulingResultPartition.ResultPartitionState state) {
+		TestingSchedulingResultPartitionBuilder withPartitionState(ResultPartitionState state) {
 			this.partitionState = state;
 			return this;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/LazyFromSourcesSchedulingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/LazyFromSourcesSchedulingStrategyTest.java
@@ -36,8 +36,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.flink.api.common.InputDependencyConstraint.ALL;
 import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.PIPELINED;
-import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.EMPTY;
-import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.PRODUCING;
 import static org.apache.flink.runtime.scheduler.strategy.StrategyTestUtil.getExecutionVertexIdsFromDeployOptions;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
@@ -185,17 +183,17 @@ public class LazyFromSourcesSchedulingStrategyTest extends TestLogger {
 	}
 
 	/**
-	 * Tests that when restart {@link ResultPartitionType#PIPELINED} tasks with {@link SchedulingResultPartition.ResultPartitionState#PRODUCING} will be scheduled.
+	 * Tests that when restart {@link ResultPartitionType#PIPELINED} tasks with {@link ResultPartitionState#CONSUMABLE} will be scheduled.
 	 */
 	@Test
-	public void testRestartProducingPipelinedTasks() {
+	public void testRestartConsumablePipelinedTasks() {
 		final TestingSchedulingTopology testingSchedulingTopology = new TestingSchedulingTopology();
 
 		final List<TestingSchedulingExecutionVertex> producers = testingSchedulingTopology.addExecutionVertices()
 			.withParallelism(2).finish();
 		final List<TestingSchedulingExecutionVertex> consumers = testingSchedulingTopology.addExecutionVertices()
 			.withParallelism(2).finish();
-		testingSchedulingTopology.connectAllToAll(producers, consumers).withResultPartitionState(PRODUCING)
+		testingSchedulingTopology.connectAllToAll(producers, consumers).withResultPartitionState(ResultPartitionState.CONSUMABLE)
 			.withResultPartitionType(PIPELINED).finish();
 
 		LazyFromSourcesSchedulingStrategy schedulingStrategy = startScheduling(testingSchedulingTopology);
@@ -213,17 +211,17 @@ public class LazyFromSourcesSchedulingStrategyTest extends TestLogger {
 	}
 
 	/**
-	 * Tests that when restart {@link ResultPartitionType#PIPELINED} tasks with {@link SchedulingResultPartition.ResultPartitionState#EMPTY} will not be scheduled.
+	 * Tests that when restart {@link ResultPartitionType#PIPELINED} tasks with {@link ResultPartitionState#CREATED} will not be scheduled.
 	 */
 	@Test
-	public void testRestartEmptyPipelinedTasks() {
+	public void testRestartCreatedPipelinedTasks() {
 		final TestingSchedulingTopology testingSchedulingTopology = new TestingSchedulingTopology();
 
 		final List<TestingSchedulingExecutionVertex> producers = testingSchedulingTopology.addExecutionVertices()
 			.withParallelism(2).finish();
 		final List<TestingSchedulingExecutionVertex> consumers = testingSchedulingTopology.addExecutionVertices()
 			.withParallelism(2).finish();
-		testingSchedulingTopology.connectAllToAll(producers, consumers).withResultPartitionState(EMPTY)
+		testingSchedulingTopology.connectAllToAll(producers, consumers).withResultPartitionState(ResultPartitionState.CREATED)
 			.withResultPartitionType(PIPELINED).finish();
 
 		LazyFromSourcesSchedulingStrategy schedulingStrategy = startScheduling(testingSchedulingTopology);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
@@ -97,7 +97,7 @@ public class TestingSchedulingResultPartition
 	public static final class Builder {
 		private IntermediateDataSetID intermediateDataSetId = new IntermediateDataSetID();
 		private ResultPartitionType resultPartitionType = ResultPartitionType.BLOCKING;
-		private ResultPartitionState resultPartitionState = ResultPartitionState.DONE;
+		private ResultPartitionState resultPartitionState = ResultPartitionState.CONSUMABLE;
 
 		Builder withIntermediateDataSetID(IntermediateDataSetID intermediateDataSetId) {
 			this.intermediateDataSetId = intermediateDataSetId;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
@@ -33,8 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition.ResultPartitionState.DONE;
-
 /**
  * A simple scheduling topology for testing purposes.
  */
@@ -113,7 +111,7 @@ public class TestingSchedulingTopology
 
 		protected ResultPartitionType resultPartitionType = ResultPartitionType.BLOCKING;
 
-		protected SchedulingResultPartition.ResultPartitionState resultPartitionState = DONE;
+		protected ResultPartitionState resultPartitionState = ResultPartitionState.CONSUMABLE;
 
 		protected ProducerConsumerConnectionBuilder(
 			final List<TestingSchedulingExecutionVertex> producers,
@@ -127,7 +125,7 @@ public class TestingSchedulingTopology
 			return this;
 		}
 
-		public ProducerConsumerConnectionBuilder withResultPartitionState(final SchedulingResultPartition.ResultPartitionState state) {
+		public ProducerConsumerConnectionBuilder withResultPartitionState(final ResultPartitionState state) {
 			this.resultPartitionState = state;
 			return this;
 		}


### PR DESCRIPTION

## What is the purpose of the change

This PR makes a clearer definition of ResultPartitionState as:
- CREATED // partition is just created or is just reset
- CONSUMABLE // pipelined partition has data produced or blocking partition's parent result finishes. Corresponds to IntermediateResultPartition#isConsumable.

The DefaultResultPartition is also fixed to return ResultPartitionState based the true partition state, rather than the vertex state.

## Brief change log

  - *Refactored ResultPartitionState*
  - *Fixed DefaultResultPartition*

## Verifying this change


This change added tests and can be verified as follows:
  - *Adjusted unit tests for DefaultResultPartition and  DefaultExecutonTopology*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
