### PR TITLE
[FLINK-8949] Add dedicated watermarks metric retrieval endpoint

### DIFF
--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -1894,14 +1894,14 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
       </td>
     </tr>
     <tr>
-        <td colspan="2">Query parameters</td>
+      <td colspan="2">Query parameters</td>
     </tr>
     <tr>
-        <td colspan="2">
-            <ul>
-                <li><code>maxExceptions</code> (optional): Comma-separated list of integer values that specifies the upper limit of exceptions to return.</li>
-            </ul>
-        </td>
+      <td colspan="2">
+        <ul>
+<li><code>maxExceptions</code> (optional): Comma-separated list of integer values that specifies the upper limit of exceptions to return.</li>
+        </ul>
+      </td>
     </tr>
     <tr>
       <td colspan="2">
@@ -2526,7 +2526,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
       "type" : "array",
       "items" : {
         "type" : "object",
-        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:SubtaskExecutionAttemptDetailsInfo",
+        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:SubtaskExecutionAttemptDetailsInfo",
         "properties" : {
           "subtask" : {
             "type" : "integer"
@@ -2580,11 +2580,11 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
               }
             }
           },
-          "start_time" : {
-            "type" : "integer"
-          },
           "taskmanager-id" : {
             "type" : "string"
+          },
+          "start_time" : {
+            "type" : "integer"
           }
         }
       }
@@ -3065,6 +3065,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     },
     "taskmanager-id" : {
       "type" : "string"
+    },
+    "start_time" : {
+      "type" : "integer"
     }
   }
 }            </code>
@@ -3174,6 +3177,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     },
     "taskmanager-id" : {
       "type" : "string"
+    },
+    "start_time" : {
+      "type" : "integer"
     }
   }
 }            </code>
@@ -3527,6 +3533,55 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
       }
     }
   }
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><h5><strong>/jobs/:jobid/vertices/:vertexid/watermarks</strong></h5></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">Returns the watermarks for all subtasks of a task.</td>
+    </tr>
+    <tr>
+      <td colspan="2">Path parameters</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <ul>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
+<li><code>vertexid</code> - 32-character hexadecimal string value that identifies a job vertex.</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#1153325552">Request</button>
+        <div id="1153325552" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#1464053913">Response</button>
+        <div id="1464053913" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "any"
 }            </code>
           </pre>
          </div>

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -2330,6 +2330,27 @@
       }
     }
   }, {
+    "url" : "/jobs/:jobid/vertices/:vertexid/watermarks",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      }, {
+        "key" : "vertexid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "any"
+    }
+  }, {
     "url" : "/overview",
     "method" : "GET",
     "status-code" : "200 OK",

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/watermarks/job-overview-drawer-watermarks.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/watermarks/job-overview-drawer-watermarks.component.ts
@@ -42,7 +42,7 @@ export class JobOverviewDrawerWatermarksComponent implements OnInit, OnDestroy {
     this.jobService.jobWithVertex$
       .pipe(
         takeUntil(this.destroy$),
-        flatMap(data => this.metricsService.getWatermarks(data.job.jid, data.vertex!.id, data.vertex!.parallelism))
+        flatMap(data => this.metricsService.getWatermarks(data.job.jid, data.vertex!.id))
       )
       .subscribe(
         data => {

--- a/flink-runtime-web/web-dashboard/src/app/services/metrics.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/metrics.service.ts
@@ -79,36 +79,37 @@ export class MetricsService {
   }
 
   /**
-   * Get watermarks data
+   * Gets the watermarks for a given vertex id.
    * @param jobId
    * @param vertexId
-   * @param parallelism
    */
-  getWatermarks(jobId: string, vertexId: string, parallelism: number) {
-    const listOfMetricName = new Array(parallelism).fill(0).map((_, index) => `${index}.currentInputWatermark`);
-    return this.getMetrics(jobId, vertexId, listOfMetricName).pipe(
-      map(metrics => {
-        let minValue = NaN;
-        let lowWatermark = NaN;
-        const watermarks: { [id: string]: number } = {};
-        const ref = metrics.values;
-        for (const key in ref) {
-          const value = ref[key];
-          const subTaskIndex = key.replace('.currentInputWatermark', '');
-          watermarks[subTaskIndex] = value;
-          if (isNaN(minValue) || value < minValue) {
-            minValue = value;
+  getWatermarks(jobId: string, vertexId: string) {
+    return this.httpClient
+      .get<Array<{ id: string; value: string }>>(
+        `${BASE_URL}/jobs/${jobId}/vertices/${vertexId}/watermarks`
+      )
+      .pipe(
+        map(arr => {
+          let minValue = NaN;
+          let lowWatermark = NaN;
+          const watermarks: { [id: string]: number } = {};
+          arr.forEach(item => {
+            const value = parseInt(item.value, 10);
+            const subTaskIndex = item.id.replace('.currentInputWatermark', '');
+            watermarks[subTaskIndex] = value;
+            if (isNaN(minValue) || value < minValue) {
+              minValue = value;
+            }
+          });
+          if (!isNaN(minValue) && minValue > LONG_MIN_VALUE) {
+            lowWatermark = minValue;
+          } else {
+            lowWatermark = NaN;
           }
-        }
-        if (!isNaN(minValue) && minValue > LONG_MIN_VALUE) {
-          lowWatermark = minValue;
-        } else {
-          lowWatermark = NaN;
-        }
-        return {
-          lowWatermark,
-          watermarks
-        };
+          return {
+            lowWatermark,
+            watermarks
+          };
       })
     );
   }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/JobVertexWatermarksHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/JobVertexWatermarksHandler.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job.metrics;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.handler.job.AbstractJobVertexHandler;
+import org.apache.flink.runtime.rest.handler.legacy.ExecutionGraphCache;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricStore;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.JobVertexMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.metrics.JobVertexWatermarksHeaders;
+import org.apache.flink.runtime.rest.messages.job.metrics.Metric;
+import org.apache.flink.runtime.rest.messages.job.metrics.MetricCollectionResponseBody;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+
+/**
+ * Handler that returns the watermarks given a {@link JobID} and {@link JobVertexID}.
+ */
+public class JobVertexWatermarksHandler extends AbstractJobVertexHandler<MetricCollectionResponseBody, JobVertexMessageParameters> {
+
+	private final MetricFetcher metricFetcher;
+
+	public JobVertexWatermarksHandler(
+			GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+			Time timeout,
+			Map<String, String> responseHeaders,
+			MetricFetcher metricFetcher,
+			ExecutionGraphCache executionGraphCache,
+			Executor executor) {
+		super(leaderRetriever,
+			timeout,
+			responseHeaders,
+			JobVertexWatermarksHeaders.INSTANCE,
+			executionGraphCache,
+			executor);
+		this.metricFetcher = metricFetcher;
+	}
+
+	@Override
+	protected MetricCollectionResponseBody handleRequest(
+			HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request,
+			AccessExecutionJobVertex jobVertex) throws RestHandlerException {
+
+		String jobID = request.getPathParameter(JobIDPathParameter.class).toString();
+		String taskID = jobVertex.getJobVertexId().toString();
+
+		metricFetcher.update();
+		MetricStore.TaskMetricStore taskMetricStore = metricFetcher.getMetricStore().getTaskMetricStore(jobID, taskID);
+		if (taskMetricStore == null) {
+			return new MetricCollectionResponseBody(Collections.emptyList());
+		}
+
+		AccessExecutionVertex[] taskVertices = jobVertex.getTaskVertices();
+		List<Metric> metrics = new ArrayList<>(taskVertices.length);
+
+		for (AccessExecutionVertex taskVertex : taskVertices) {
+			String id = taskVertex.getParallelSubtaskIndex() + "." + MetricNames.IO_CURRENT_INPUT_WATERMARK;
+			String watermarkValue = taskMetricStore.getMetric(id);
+			if (watermarkValue != null) {
+				metrics.add(new Metric(id, watermarkValue));
+			}
+		}
+
+		return new MetricCollectionResponseBody(metrics);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/JobVertexWatermarksHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/JobVertexWatermarksHeaders.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.metrics;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.JobVertexIdPathParameter;
+import org.apache.flink.runtime.rest.messages.JobVertexMessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * {@link MessageHeaders} for retrieving watermarks.
+ */
+public final class JobVertexWatermarksHeaders implements MessageHeaders<EmptyRequestBody, MetricCollectionResponseBody, JobVertexMessageParameters> {
+
+	public static final JobVertexWatermarksHeaders INSTANCE = new JobVertexWatermarksHeaders();
+
+	private JobVertexWatermarksHeaders() {
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.GET;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return "/jobs/:" + JobIDPathParameter.KEY + "/vertices/:" + JobVertexIdPathParameter.KEY + "/watermarks";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Returns the watermarks for all subtasks of a task.";
+	}
+
+	@Override
+	public Class<MetricCollectionResponseBody> getResponseClass() {
+		return MetricCollectionResponseBody.class;
+	}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.OK;
+	}
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public JobVertexMessageParameters getUnresolvedMessageParameters() {
+		return new JobVertexMessageParameters();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -65,6 +65,7 @@ import org.apache.flink.runtime.rest.handler.job.metrics.AggregatingTaskManagers
 import org.apache.flink.runtime.rest.handler.job.metrics.JobManagerMetricsHandler;
 import org.apache.flink.runtime.rest.handler.job.metrics.JobMetricsHandler;
 import org.apache.flink.runtime.rest.handler.job.metrics.JobVertexMetricsHandler;
+import org.apache.flink.runtime.rest.handler.job.metrics.JobVertexWatermarksHandler;
 import org.apache.flink.runtime.rest.handler.job.metrics.SubtaskMetricsHandler;
 import org.apache.flink.runtime.rest.handler.job.metrics.TaskManagerMetricsHandler;
 import org.apache.flink.runtime.rest.handler.job.rescaling.RescalingHandlers;
@@ -357,6 +358,14 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 			responseHeaders,
 			metricFetcher);
 
+		final JobVertexWatermarksHandler jobVertexWatermarksHandler = new JobVertexWatermarksHandler(
+			leaderRetriever,
+			timeout,
+			responseHeaders,
+			metricFetcher,
+			executionGraphCache,
+			executor);
+
 		final JobMetricsHandler jobMetricsHandler = new JobMetricsHandler(
 			leaderRetriever,
 			timeout,
@@ -560,6 +569,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 		handlers.add(Tuple2.of(taskManagerDetailsHandler.getMessageHeaders(), taskManagerDetailsHandler));
 		handlers.add(Tuple2.of(subtasksTimesHandler.getMessageHeaders(), subtasksTimesHandler));
 		handlers.add(Tuple2.of(jobVertexMetricsHandler.getMessageHeaders(), jobVertexMetricsHandler));
+		handlers.add(Tuple2.of(jobVertexWatermarksHandler.getMessageHeaders(), jobVertexWatermarksHandler));
 		handlers.add(Tuple2.of(jobMetricsHandler.getMessageHeaders(), jobMetricsHandler));
 		handlers.add(Tuple2.of(subtaskMetricsHandler.getMessageHeaders(), subtaskMetricsHandler));
 		handlers.add(Tuple2.of(taskManagerMetricsHandler.getMessageHeaders(), taskManagerMetricsHandler));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/JobVertexWatermarksHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/JobVertexWatermarksHandlerTest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job.metrics;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.legacy.ExecutionGraphCache;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricStore;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.JobVertexIdPathParameter;
+import org.apache.flink.runtime.rest.messages.JobVertexMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.metrics.Metric;
+import org.apache.flink.runtime.rest.messages.job.metrics.MetricCollectionResponseBody;
+import org.apache.flink.runtime.webmonitor.retriever.LeaderGatewayRetriever;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Executor;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link JobVertexWatermarksHandler}.
+ */
+public class JobVertexWatermarksHandlerTest {
+
+	private static final JobID TEST_JOB_ID = new JobID();
+
+	private static final JobVertexID TEST_VERTEX_ID = new JobVertexID();
+
+	private MetricFetcher metricFetcher;
+	private MetricStore.TaskMetricStore taskMetricStore;
+	private JobVertexWatermarksHandler watermarkHandler;
+	private HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request;
+	private AccessExecutionJobVertex vertex;
+
+	@Before
+	public void before() throws Exception {
+		taskMetricStore = Mockito.mock(MetricStore.TaskMetricStore.class);
+
+		MetricStore metricStore = Mockito.mock(MetricStore.class);
+		Mockito.when(metricStore.getTaskMetricStore(TEST_JOB_ID.toString(), TEST_VERTEX_ID.toString()))
+			.thenReturn(taskMetricStore);
+
+		metricFetcher = Mockito.mock(MetricFetcher.class);
+		Mockito.when(metricFetcher.getMetricStore()).thenReturn(metricStore);
+
+		watermarkHandler = new JobVertexWatermarksHandler(
+			Mockito.mock(LeaderGatewayRetriever.class),
+			Time.seconds(1),
+			Collections.emptyMap(),
+			metricFetcher,
+			Mockito.mock(ExecutionGraphCache.class),
+			Mockito.mock(Executor.class));
+
+		final Map<String, String> pathParameters = new HashMap<>();
+		pathParameters.put(JobIDPathParameter.KEY, TEST_JOB_ID.toString());
+		pathParameters.put(JobVertexIdPathParameter.KEY, TEST_VERTEX_ID.toString());
+
+		request = new HandlerRequest<>(EmptyRequestBody.getInstance(), new JobVertexMessageParameters(),
+				pathParameters, Collections.emptyMap());
+
+		vertex = Mockito.mock(AccessExecutionJobVertex.class);
+		Mockito.when(vertex.getJobVertexId()).thenReturn(TEST_VERTEX_ID);
+
+		AccessExecutionVertex firstTask = Mockito.mock(AccessExecutionVertex.class);
+		AccessExecutionVertex secondTask = Mockito.mock(AccessExecutionVertex.class);
+		Mockito.when(firstTask.getParallelSubtaskIndex()).thenReturn(0);
+		Mockito.when(secondTask.getParallelSubtaskIndex()).thenReturn(1);
+
+		AccessExecutionVertex[] accessExecutionVertices = {firstTask, secondTask};
+		Mockito.when(vertex.getTaskVertices()).thenReturn(accessExecutionVertices);
+	}
+
+	@After
+	public void after() {
+		Mockito.verify(metricFetcher).update();
+	}
+
+	@Test
+	public void testWatermarksRetrieval() throws Exception {
+		Mockito.when(taskMetricStore.getMetric("0.currentInputWatermark")).thenReturn("23");
+		Mockito.when(taskMetricStore.getMetric("1.currentInputWatermark")).thenReturn("42");
+
+		MetricCollectionResponseBody response = watermarkHandler.handleRequest(request, vertex);
+
+		assertThat(response.getMetrics(),
+			containsInAnyOrder(
+				new MetricMatcher("0.currentInputWatermark", "23"),
+				new MetricMatcher("1.currentInputWatermark", "42")));
+	}
+
+	@Test
+	public void testPartialWatermarksAvailable() throws Exception {
+		Mockito.when(taskMetricStore.getMetric("0.currentInputWatermark")).thenReturn("23");
+		Mockito.when(taskMetricStore.getMetric("1.currentInputWatermark")).thenReturn(null);
+
+		MetricCollectionResponseBody response = watermarkHandler.handleRequest(request, vertex);
+
+		assertThat(response.getMetrics(),
+			contains(
+				new MetricMatcher("0.currentInputWatermark", "23")));
+	}
+
+	@Test
+	public void testNoWatermarksAvailable() throws Exception {
+		Mockito.when(taskMetricStore.getMetric("0.currentInputWatermark")).thenReturn(null);
+		Mockito.when(taskMetricStore.getMetric("1.currentInputWatermark")).thenReturn(null);
+
+		MetricCollectionResponseBody response = watermarkHandler.handleRequest(request, vertex);
+
+		assertThat(response.getMetrics(), is(empty()));
+	}
+
+	private static class MetricMatcher extends BaseMatcher<Metric> {
+
+		private String id;
+		@Nullable private String value;
+
+		MetricMatcher(String id, @Nullable String value) {
+			this.id = id;
+			this.value = value;
+		}
+
+		@Override
+		public boolean matches(Object o) {
+			if (!(o instanceof Metric)) {
+				return false;
+			}
+			Metric actual = (Metric) o;
+			return actual.getId().equals(id) && Objects.equals(value, actual.getValue());
+		}
+
+		@Override
+		public void describeTo(Description description) {
+			description.appendValue(new Metric(id, value));
+		}
+	}
+}


### PR DESCRIPTION
Without this, watermarks for jobs with a parallelism of >= 160 cannot be
displayed correctly and will result in a "/bad-request" error message. The
reason is that the watermark for each subtask will be retrieved in a giant
metrics request like the following (abbreviated):

```
http://localhost:8081/jobs/32f2205231d280ad105b011198dd9e5f/vertices/8b69eb2c39b9caf941896fdafa7ca05f/metrics?get=0.currentInputWatermark,1.currentInputWatermark,2.currentInputWatermark,3.currentInputWatermark,...,160.currentInputWatermark
```

We debated raising the maximum header length or lifting the header length
restriction. Instead, we opted for a seperate metrics endpoint which returns the
watermarks for the entire job vertex:

```
/jobs/:jobid/vertices/:vertexid/watermarks
```