### PR TITLE
[FLINK-10936][kubernetes] Implement Kubernetes command line tools to support session cluster.

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
@@ -28,8 +28,10 @@ import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
+import org.slf4j.Logger;
 
 import java.net.InetSocketAddress;
 
@@ -88,5 +90,39 @@ public abstract class AbstractCustomCommandLine implements CustomCommandLine {
 		}
 
 		return resultingConfiguration;
+	}
+
+	protected void printUsage() {
+		System.out.println("Usage:");
+		HelpFormatter formatter = new HelpFormatter();
+		formatter.setWidth(200);
+		formatter.setLeftPadding(5);
+
+		formatter.setSyntaxPrefix("   Optional");
+		Options options = new Options();
+		addGeneralOptions(options);
+		addRunOptions(options);
+		formatter.printHelp(" ", options);
+	}
+
+	protected static int handleCliArgsException(CliArgsException e, Logger logger) {
+		logger.error("Could not parse the command line arguments.", e);
+
+		System.out.println(e.getMessage());
+		System.out.println();
+		System.out.println("Use the help option (-h or --help) to get help on the command.");
+		return 1;
+	}
+
+	protected static int handleError(Throwable t, Logger logger) {
+		logger.error("Error while running the Flink session.", t);
+
+		System.err.println();
+		System.err.println("------------------------------------------------------------");
+		System.err.println(" The program finished with the following exception:");
+		System.err.println();
+
+		t.printStackTrace();
+		return 1;
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -1074,6 +1074,18 @@ public class CliFrontend {
 			LOG.warn("Could not load CLI class {}.", flinkYarnSessionCLI, e);
 		}
 
+		//	Command line interface of the kubernetes session.
+		final String kubeSessionCLI = "org.apache.flink.kubernetes.cli.FlinkKubernetesCustomCli";
+		try {
+			customCommandLines.add(
+				loadCustomCommandLine(kubeSessionCLI,
+					configuration,
+					"k",
+					"kubernetes"));
+		} catch (NoClassDefFoundError | Exception e) {
+			LOG.warn("Could not load CLI class {}.", kubeSessionCLI, e);
+		}
+
 		customCommandLines.add(new DefaultCLI(configuration));
 
 		return customCommandLines;

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/AbstractClusterClientFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/AbstractClusterClientFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * An abstract {@link ClusterClientFactory} containing some common implementations for different deployment clusters.
+ */
+@Internal
+public abstract class AbstractClusterClientFactory<ClusterID> implements ClusterClientFactory<ClusterID> {
+
+	@Override
+	public ClusterSpecification getClusterSpecification(Configuration configuration) {
+		checkNotNull(configuration);
+
+		// JobManager Memory
+		final int jobManagerMemoryMB = ConfigurationUtils.getJobManagerHeapMemory(configuration).getMebiBytes();
+
+		// Task Managers memory
+		final int taskManagerMemoryMB = TaskExecutorResourceUtils
+			.resourceSpecFromConfig(configuration)
+			.getTotalProcessMemorySize()
+			.getMebiBytes();
+
+		int slotsPerTaskManager = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
+
+		return new ClusterSpecification.ClusterSpecificationBuilder()
+			.setMasterMemoryMB(jobManagerMemoryMB)
+			.setTaskManagerMemoryMB(taskManagerMemoryMB)
+			.setSlotsPerTaskManager(slotsPerTaskManager)
+			.createClusterSpecification();
+	}
+}

--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -162,6 +162,8 @@ under the License.
 									<include>org.yaml:*</include>
 									<include>com.mifmif:*</include>
 									<include>dk.brics.automaton:*</include>
+
+									<include>META-INF/services/org.apache.flink.*</include>
 								</includes>
 							</artifactSet>
 							<filters combine.children="append">
@@ -170,7 +172,7 @@ under the License.
 									<excludes>
 										<exclude>*.aut</exclude>
 										<exclude>META-INF/maven/**</exclude>
-										<exclude>META-INF/services/**</exclude>
+										<exclude>META-INF/services/*com.fasterxml*</exclude>
 										<exclude>META-INF/proguard/**</exclude>
 										<exclude>OSGI-INF/**</exclude>
 										<exclude>schema/**</exclude>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterClientFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterClientFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.client.deployment.AbstractClusterClientFactory;
+import org.apache.flink.client.deployment.ClusterClientFactory;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.executors.KubernetesSessionClusterExecutor;
+import org.apache.flink.kubernetes.kubeclient.KubeClientFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.UUID;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link ClusterClientFactory} for a Kubernetes cluster.
+ */
+@Internal
+public class KubernetesClusterClientFactory extends AbstractClusterClientFactory<String> {
+
+	private static final String CLUSTER_ID_PREFIX = "flink-cluster-";
+
+	@Override
+	public boolean isCompatibleWith(Configuration configuration) {
+		checkNotNull(configuration);
+		final String deploymentTarget = configuration.getString(DeploymentOptions.TARGET);
+		return KubernetesSessionClusterExecutor.NAME.equalsIgnoreCase(deploymentTarget);
+	}
+
+	@Override
+	public KubernetesClusterDescriptor createClusterDescriptor(Configuration configuration) {
+		checkNotNull(configuration);
+		String clusterId = configuration.getString(KubernetesConfigOptions.CLUSTER_ID);
+		if (clusterId == null) {
+			clusterId = generateClusterId();
+			configuration.setString(KubernetesConfigOptions.CLUSTER_ID, clusterId);
+		}
+		return new KubernetesClusterDescriptor(configuration, KubeClientFactory.fromConfiguration(configuration));
+	}
+
+	@Nullable
+	@Override
+	public String getClusterId(Configuration configuration) {
+		checkNotNull(configuration);
+		return configuration.getString(KubernetesConfigOptions.CLUSTER_ID);
+	}
+
+	private String generateClusterId() {
+		return CLUSTER_ID_PREFIX + UUID.randomUUID();
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/FlinkKubernetesCustomCli.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/FlinkKubernetesCustomCli.java
@@ -1,0 +1,335 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.cli;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.client.cli.AbstractCustomCommandLine;
+import org.apache.flink.client.cli.CliArgsException;
+import org.apache.flink.client.deployment.ClusterClientFactory;
+import org.apache.flink.client.deployment.ClusterClientServiceLoader;
+import org.apache.flink.client.deployment.ClusterDescriptor;
+import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptionsInternal;
+import org.apache.flink.kubernetes.executors.KubernetesSessionClusterExecutor;
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
+import org.apache.flink.kubernetes.kubeclient.KubeClientFactory;
+import org.apache.flink.runtime.security.SecurityUtils;
+import org.apache.flink.util.FlinkException;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Properties;
+
+import static org.apache.flink.client.cli.CliFrontendParser.DETACHED_OPTION;
+import static org.apache.flink.configuration.HighAvailabilityOptions.HA_CLUSTER_ID;
+import static org.apache.flink.kubernetes.cli.KubernetesCliOptions.CLUSTER_ID_OPTION;
+import static org.apache.flink.kubernetes.cli.KubernetesCliOptions.DYNAMIC_PROPERTY_OPTION;
+import static org.apache.flink.kubernetes.cli.KubernetesCliOptions.HELP_OPTION;
+import static org.apache.flink.kubernetes.cli.KubernetesCliOptions.IMAGE_OPTION;
+import static org.apache.flink.kubernetes.cli.KubernetesCliOptions.JOB_CLASS_NAME_OPTION;
+import static org.apache.flink.kubernetes.cli.KubernetesCliOptions.JOB_ID_OPTION;
+
+/**
+ * Kubernetes customized commandline.
+ */
+public class FlinkKubernetesCustomCli extends AbstractCustomCommandLine {
+
+	private static final Logger LOG = LoggerFactory.getLogger(FlinkKubernetesCustomCli.class);
+
+	private static final long CLIENT_POLLING_INTERVAL_MS = 3000L;
+
+	private static final String KUBERNETES_CLUSTER_HELP = "Available commands:\n" +
+		"help - show these commands\n" +
+		"stop - stop the kubernetes cluster\n" +
+		"quit - quit attach mode";
+
+	private static final String ID = "kubernetes-cluster";
+
+	// Options with short prefix(k) or long prefix(kubernetes)
+	private final Option imageOption;
+	private final Option clusterIdOption;
+	private final Option jobManagerMemoryOption;
+	private final Option taskManagerMemoryOption;
+	private final Option taskManagerSlotsOption;
+	private final Option dynamicPropertiesOption;
+	private final Option helpOption;
+
+	private final Option jobClassOption;
+	private final Option jobIdOption;
+
+	private final ClusterClientServiceLoader clusterClientServiceLoader;
+
+	public FlinkKubernetesCustomCli(
+		Configuration configuration,
+		String shortPrefix,
+		String longPrefix) {
+		this(configuration, new DefaultClusterClientServiceLoader(), shortPrefix, longPrefix);
+	}
+
+	public FlinkKubernetesCustomCli(
+		Configuration configuration,
+		ClusterClientServiceLoader clusterClientServiceLoader,
+		String shortPrefix,
+		String longPrefix) {
+		super(configuration);
+
+		this.clusterClientServiceLoader = clusterClientServiceLoader;
+
+		this.imageOption = KubernetesCliOptions.getOptionWithPrefix(IMAGE_OPTION, shortPrefix, longPrefix);
+		this.clusterIdOption = KubernetesCliOptions.getOptionWithPrefix(CLUSTER_ID_OPTION, shortPrefix, longPrefix);
+		this.dynamicPropertiesOption = KubernetesCliOptions.getOptionWithPrefix(
+			DYNAMIC_PROPERTY_OPTION, shortPrefix, longPrefix);
+
+		this.jobManagerMemoryOption = KubernetesCliOptions.getOptionWithPrefix(
+			KubernetesCliOptions.JOB_MANAGER_MEMORY_OPTION, shortPrefix, longPrefix);
+		this.taskManagerMemoryOption = KubernetesCliOptions.getOptionWithPrefix(
+			KubernetesCliOptions.TASK_MANAGER_MEMORY_OPTION, shortPrefix, longPrefix);
+		this.taskManagerSlotsOption = KubernetesCliOptions.getOptionWithPrefix(
+			KubernetesCliOptions.TASK_MANAGER_SLOTS_OPTION, shortPrefix, longPrefix);
+
+		this.jobClassOption = KubernetesCliOptions.getOptionWithPrefix(JOB_CLASS_NAME_OPTION, shortPrefix, longPrefix);
+		this.jobIdOption = KubernetesCliOptions.getOptionWithPrefix(JOB_ID_OPTION, shortPrefix, longPrefix);
+
+		this.helpOption = KubernetesCliOptions.getOptionWithPrefix(HELP_OPTION, shortPrefix, longPrefix);
+	}
+
+	/**
+	 * active if commandline contains option -m kubernetes-cluster or -kid.
+	 */
+	@Override
+	public boolean isActive(CommandLine commandLine) {
+		final String jobManagerOption = commandLine.getOptionValue(addressOption.getOpt(), null);
+		final boolean k8sJobManager = ID.equals(jobManagerOption);
+		final boolean k8sClusterId = commandLine.hasOption(clusterIdOption.getOpt());
+		return k8sJobManager || k8sClusterId;
+	}
+
+	@Override
+	public void addRunOptions(Options baseOptions) {
+		baseOptions.addOption(DETACHED_OPTION)
+			.addOption(imageOption)
+			.addOption(clusterIdOption)
+			.addOption(jobManagerMemoryOption)
+			.addOption(taskManagerMemoryOption)
+			.addOption(taskManagerSlotsOption)
+			.addOption(dynamicPropertiesOption)
+			.addOption(helpOption);
+	}
+
+	@Override
+	public void addGeneralOptions(Options baseOptions) {
+		baseOptions.addOption(clusterIdOption);
+	}
+
+	@Override
+	public String getId() {
+		return ID;
+	}
+
+	@Override
+	public Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) {
+		final Configuration effectiveConfiguration = new Configuration(configuration);
+
+		effectiveConfiguration.setString(DeploymentOptions.TARGET, KubernetesSessionClusterExecutor.NAME);
+
+		if (commandLine.hasOption(clusterIdOption.getOpt())) {
+			final String clusterId = commandLine.getOptionValue(clusterIdOption.getOpt());
+			effectiveConfiguration.setString(KubernetesConfigOptions.CLUSTER_ID, clusterId);
+			effectiveConfiguration.setString(HA_CLUSTER_ID, clusterId);
+		}
+
+		if (commandLine.hasOption(imageOption.getOpt())) {
+			effectiveConfiguration.setString(KubernetesConfigOptions.CONTAINER_IMAGE,
+				commandLine.getOptionValue(imageOption.getOpt()));
+		}
+
+		if (commandLine.hasOption(jobManagerMemoryOption.getOpt())) {
+			String jmMemoryVal = commandLine.getOptionValue(jobManagerMemoryOption.getOpt());
+			if (!MemorySize.MemoryUnit.hasUnit(jmMemoryVal)) {
+				jmMemoryVal += "m";
+			}
+			effectiveConfiguration.setString(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, jmMemoryVal);
+		}
+
+		if (commandLine.hasOption(taskManagerMemoryOption.getOpt())) {
+			String tmMemoryVal = commandLine.getOptionValue(taskManagerMemoryOption.getOpt());
+			if (!MemorySize.MemoryUnit.hasUnit(tmMemoryVal)) {
+				tmMemoryVal += "m";
+			}
+			effectiveConfiguration.setString(TaskManagerOptions.TOTAL_PROCESS_MEMORY, tmMemoryVal);
+		}
+
+		if (commandLine.hasOption(taskManagerSlotsOption.getOpt())) {
+			effectiveConfiguration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS,
+				Integer.parseInt(commandLine.getOptionValue(taskManagerSlotsOption.getOpt())));
+		}
+
+		final Properties dynamicProperties = commandLine.getOptionProperties(dynamicPropertiesOption.getOpt());
+		for (String key : dynamicProperties.stringPropertyNames()) {
+			effectiveConfiguration.setString(key, dynamicProperties.getProperty(key));
+		}
+
+		final StringBuilder entryPointClassArgs = new StringBuilder();
+		if (commandLine.hasOption(jobClassOption.getOpt())) {
+			entryPointClassArgs.append(" --")
+				.append(jobClassOption.getLongOpt())
+				.append(" ")
+				.append(commandLine.getOptionValue(jobClassOption.getOpt()));
+		}
+
+		if (commandLine.hasOption(jobIdOption.getOpt())) {
+			entryPointClassArgs.append(" --")
+				.append(jobIdOption.getLongOpt())
+				.append(" ")
+				.append(commandLine.getOptionValue(jobIdOption.getOpt()));
+		}
+		if (!entryPointClassArgs.toString().isEmpty()) {
+			effectiveConfiguration.setString(KubernetesConfigOptionsInternal.ENTRY_POINT_CLASS_ARGS,
+				entryPointClassArgs.toString());
+		}
+
+		return effectiveConfiguration;
+	}
+
+	private int run(String[] args) throws CliArgsException, FlinkException {
+		final CommandLine cmd = parseCommandLineOptions(args, true);
+
+		if (cmd.hasOption(HELP_OPTION.getOpt())) {
+			printUsage();
+			return 0;
+		}
+
+		final Configuration configuration = applyCommandLineOptionsToConfiguration(cmd);
+		final ClusterClientFactory<String> kubernetesClusterClientFactory =
+			clusterClientServiceLoader.getClusterClientFactory(configuration);
+
+		final ClusterDescriptor<String> kubernetesClusterDescriptor =
+			kubernetesClusterClientFactory.createClusterDescriptor(configuration);
+
+		try {
+			final ClusterClient<String> clusterClient;
+			String clusterId = kubernetesClusterClientFactory.getClusterId(configuration);
+			final boolean detached = cmd.hasOption(DETACHED_OPTION.getOpt());
+			final FlinkKubeClient kubeClient = KubeClientFactory.fromConfiguration(configuration);
+
+			// Retrieve or create a session cluster.
+			if (clusterId != null && kubeClient.getInternalService(clusterId) != null) {
+				clusterClient = kubernetesClusterDescriptor.retrieve(clusterId);
+			} else {
+				clusterClient = kubernetesClusterDescriptor.deploySessionCluster(
+					kubernetesClusterClientFactory.getClusterSpecification(configuration));
+				clusterId = clusterClient.getClusterId();
+			}
+
+			try {
+				if (!detached) {
+					Tuple2<Boolean, Boolean> continueRepl = new Tuple2<>(true, false);
+					try (BufferedReader in = new BufferedReader(new InputStreamReader(System.in))) {
+						while (continueRepl.f0) {
+							continueRepl = repStep(in);
+						}
+					} catch (Exception e) {
+						LOG.warn("Exception while running the interactive command line interface.", e);
+					}
+					if (continueRepl.f1) {
+						kubernetesClusterDescriptor.killCluster(clusterId);
+					}
+				}
+				clusterClient.close();
+				kubeClient.close();
+			} catch (Exception e) {
+				LOG.info("Could not properly shutdown cluster client.", e);
+			}
+		} finally {
+			try {
+				kubernetesClusterDescriptor.close();
+			} catch (Exception e) {
+				LOG.info("Could not properly close the kubernetes cluster descriptor.", e);
+			}
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Check whether need to continue or kill the cluster.
+	 * @param in input buffer reader
+	 * @return f0, whether need to continue read from input. f1, whether need to kill the cluster.
+	 */
+	private Tuple2<Boolean, Boolean> repStep(BufferedReader in) throws IOException, InterruptedException {
+		final long startTime = System.currentTimeMillis();
+		while ((System.currentTimeMillis() - startTime) < CLIENT_POLLING_INTERVAL_MS
+			&& (!in.ready())) {
+			Thread.sleep(200L);
+		}
+		//------------- handle interactive command by user. ----------------------
+
+		if (in.ready()) {
+			final String command = in.readLine();
+			switch (command) {
+				case "quit":
+					return new Tuple2<>(false, false);
+				case "stop":
+					return new Tuple2<>(false, true);
+
+				case "help":
+					System.err.println(KUBERNETES_CLUSTER_HELP);
+					break;
+				default:
+					System.err.println("Unknown command '" + command + "'. Showing help:");
+					System.err.println(KUBERNETES_CLUSTER_HELP);
+					break;
+			}
+		}
+
+		return new Tuple2<>(true, false);
+	}
+
+	public static void main(String[] args) {
+		final Configuration configuration = GlobalConfiguration.loadConfiguration();
+
+		int retCode;
+
+		try {
+			final FlinkKubernetesCustomCli cli = new FlinkKubernetesCustomCli(configuration, "", "");
+			retCode = SecurityUtils.getInstalledContext().runSecured(() -> cli.run(args));
+		} catch (CliArgsException e) {
+			retCode = handleCliArgsException(e, LOG);
+		} catch (Exception e) {
+			retCode = handleError(e, LOG);
+		}
+
+		System.exit(retCode);
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/executors/KubernetesSessionClusterExecutor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/executors/KubernetesSessionClusterExecutor.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.executors;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.client.deployment.AbstractSessionClusterExecutor;
+import org.apache.flink.core.execution.Executor;
+import org.apache.flink.kubernetes.KubernetesClusterClientFactory;
+
+/**
+ * The {@link Executor} to be used when executing a job on an already running cluster.
+ */
+@Internal
+public class KubernetesSessionClusterExecutor extends AbstractSessionClusterExecutor<String, KubernetesClusterClientFactory> {
+
+	public static final String NAME = "kubernetes-session-cluster";
+
+	public KubernetesSessionClusterExecutor() {
+		super(new KubernetesClusterClientFactory());
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/executors/KubernetesSessionClusterExecutorFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/executors/KubernetesSessionClusterExecutorFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.executors;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.core.execution.Executor;
+import org.apache.flink.core.execution.ExecutorFactory;
+
+import javax.annotation.Nonnull;
+
+/**
+ * An {@link ExecutorFactory} for executing jobs on an existing (session) cluster.
+ */
+@Internal
+public class KubernetesSessionClusterExecutorFactory implements ExecutorFactory {
+
+	@Override
+	public boolean isCompatibleWith(@Nonnull final Configuration configuration) {
+		return configuration.get(DeploymentOptions.TARGET)
+				.equalsIgnoreCase(KubernetesSessionClusterExecutor.NAME);
+	}
+
+	@Override
+	public Executor getExecutor(@Nonnull final Configuration configuration) {
+		return new KubernetesSessionClusterExecutor();
+	}
+}

--- a/flink-kubernetes/src/main/resources/META-INF/services/org.apache.flink.client.deployment.ClusterClientFactory
+++ b/flink-kubernetes/src/main/resources/META-INF/services/org.apache.flink.client.deployment.ClusterClientFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.kubernetes.KubernetesClusterClientFactory

--- a/flink-kubernetes/src/main/resources/META-INF/services/org.apache.flink.core.execution.ExecutorFactory
+++ b/flink-kubernetes/src/main/resources/META-INF/services/org.apache.flink.core.execution.ExecutorFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.kubernetes.executors.KubernetesSessionClusterExecutorFactory

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/FlinkKubernetesCustomCliTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/FlinkKubernetesCustomCliTest.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes;
+
+import org.apache.flink.client.deployment.ClusterClientFactory;
+import org.apache.flink.client.deployment.ClusterClientServiceLoader;
+import org.apache.flink.client.deployment.ClusterSpecification;
+import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.kubernetes.cli.FlinkKubernetesCustomCli;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the {@link FlinkKubernetesCustomCli}.
+ */
+public class FlinkKubernetesCustomCliTest {
+
+	@Test
+	public void testDynamicProperties() throws Exception {
+
+		final FlinkKubernetesCustomCli cli = new FlinkKubernetesCustomCli(
+			new Configuration(),
+			"",
+			"");
+		Options options = new Options();
+		cli.addGeneralOptions(options);
+		cli.addRunOptions(options);
+
+		final CommandLineParser parser = new DefaultParser();
+		final CommandLine cmd = parser.parse(options, new String[]{
+			"run",
+			"-D", "akka.ask.timeout=5 min",
+			"-D", "env.java.opts=-DappName=foobar"
+		});
+
+		final Configuration executorConfig = cli.applyCommandLineOptionsToConfiguration(cmd);
+		final ClusterClientFactory<String> clientFactory = getClusterClientFactory(executorConfig);
+
+		Assert.assertNotNull(clientFactory);
+
+		final Map<String, String> executorConfigMap = executorConfig.toMap();
+		assertEquals(3, executorConfigMap.size());
+		assertEquals("5 min", executorConfigMap.get("akka.ask.timeout"));
+		assertEquals("-DappName=foobar", executorConfigMap.get("env.java.opts"));
+		assertTrue(executorConfigMap.containsKey(DeploymentOptions.TARGET.key()));
+	}
+
+	@Test
+	public void testCorrectSettingOfMaxSlots() throws Exception {
+		String[] params =
+			new String[] {"-ks", "3"};
+
+		final FlinkKubernetesCustomCli cli = createFlinkKubernetesCustomCliWithTmTotalMemory(1234);
+
+		final CommandLine commandLine = cli.parseCommandLineOptions(params, true);
+
+		final Configuration executorConfig = cli.applyCommandLineOptionsToConfiguration(commandLine);
+		final ClusterClientFactory<String> clientFactory = getClusterClientFactory(executorConfig);
+		final ClusterSpecification clusterSpecification = clientFactory.getClusterSpecification(executorConfig);
+
+		// each task manager has 3 slots but the parallelism is 7. Thus the slots should be increased.
+		assertEquals(3, clusterSpecification.getSlotsPerTaskManager());
+		assertEquals(1, clusterSpecification.getNumberTaskManagers());
+	}
+
+	@Test
+	public void testResumeFromKubernetesID() throws Exception {
+		final FlinkKubernetesCustomCli cli = createFlinkKubernetesCustomCliWithTmTotalMemory(1024);
+
+		final String clusterId = "my-test-CLUSTER_ID";
+		final CommandLine commandLine = cli.parseCommandLineOptions(new String[] {"-kid", clusterId}, true);
+
+		final Configuration executorConfig = cli.applyCommandLineOptionsToConfiguration(commandLine);
+		final ClusterClientFactory clientFactory = getClusterClientFactory(executorConfig);
+
+		assertEquals(clusterId, clientFactory.getClusterId(executorConfig));
+	}
+
+	/**
+	 * Tests that the command line arguments override the configuration settings
+	 * when the {@link ClusterSpecification} is created.
+	 */
+	@Test
+	public void testCommandLineClusterSpecification() throws Exception {
+		final Configuration configuration = new Configuration();
+		final int jobManagerMemory = 1337;
+		final int taskManagerMemory = 7331;
+		final int slotsPerTaskManager = 30;
+
+		configuration.setString(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, jobManagerMemory + "m");
+		configuration.setString(TaskManagerOptions.TOTAL_PROCESS_MEMORY, taskManagerMemory + "m");
+		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, slotsPerTaskManager);
+
+		final String[] args = {"-kjm", String.valueOf(jobManagerMemory) + "m", "-ktm", String.valueOf(taskManagerMemory) +
+			"m", "-ks", String.valueOf(slotsPerTaskManager)};
+		final FlinkKubernetesCustomCli cli = new FlinkKubernetesCustomCli(
+			configuration,
+			"k",
+			"kubernetes");
+
+		CommandLine commandLine = cli.parseCommandLineOptions(args, false);
+
+		Configuration executorConfig = cli.applyCommandLineOptionsToConfiguration(commandLine);
+		ClusterClientFactory<String> clientFactory = getClusterClientFactory(executorConfig);
+		ClusterSpecification clusterSpecification = clientFactory.getClusterSpecification(executorConfig);
+
+		assertThat(clusterSpecification.getMasterMemoryMB(), is(jobManagerMemory));
+		assertThat(clusterSpecification.getTaskManagerMemoryMB(), is(taskManagerMemory));
+		assertThat(clusterSpecification.getSlotsPerTaskManager(), is(slotsPerTaskManager));
+	}
+
+	/**
+	 * Tests that the configuration settings are used to create the
+	 * {@link ClusterSpecification}.
+	 */
+	@Test
+	public void testConfigurationClusterSpecification() throws Exception {
+		final Configuration configuration = new Configuration();
+		final int jobManagerMemory = 1337;
+		configuration.setString(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, jobManagerMemory + "m");
+		final int taskManagerMemory = 7331;
+		configuration.setString(TaskManagerOptions.TOTAL_PROCESS_MEMORY, taskManagerMemory + "m");
+		final int slotsPerTaskManager = 42;
+		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, slotsPerTaskManager);
+
+		final String[] args = {};
+		final FlinkKubernetesCustomCli cli = new FlinkKubernetesCustomCli(
+			configuration,
+			"",
+			"kubernetes");
+
+		CommandLine commandLine = cli.parseCommandLineOptions(args, false);
+
+		Configuration executorConfig = cli.applyCommandLineOptionsToConfiguration(commandLine);
+		ClusterClientFactory<String> clientFactory = getClusterClientFactory(executorConfig);
+		ClusterSpecification clusterSpecification = clientFactory.getClusterSpecification(executorConfig);
+
+		assertThat(clusterSpecification.getMasterMemoryMB(), is(jobManagerMemory));
+		assertThat(clusterSpecification.getTaskManagerMemoryMB(), is(taskManagerMemory));
+		assertThat(clusterSpecification.getSlotsPerTaskManager(), is(slotsPerTaskManager));
+	}
+
+	/**
+	 * Tests the specifying heap memory without unit for job manager and task manager.
+	 */
+	@Test
+	public void testHeapMemoryPropertyWithoutUnit() throws Exception {
+		final String[] args = new String[] { "-kjm", "1024", "-ktm", "2048" };
+		final FlinkKubernetesCustomCli cli = createFlinkKubernetesCustomCliWithTmTotalMemory(1024);
+
+		final CommandLine commandLine = cli.parseCommandLineOptions(args, false);
+
+		final Configuration executorConfig = cli.applyCommandLineOptionsToConfiguration(commandLine);
+		final ClusterClientFactory<String> clientFactory = getClusterClientFactory(executorConfig);
+		final ClusterSpecification clusterSpecification = clientFactory.getClusterSpecification(executorConfig);
+
+		assertThat(clusterSpecification.getMasterMemoryMB(), is(1024));
+		assertThat(clusterSpecification.getTaskManagerMemoryMB(), is(2048));
+	}
+
+	/**
+	 * Tests the specifying heap memory with unit (MB) for job manager and task manager.
+	 */
+	@Test
+	public void testHeapMemoryPropertyWithUnitMB() throws Exception {
+		final String[] args = new String[] { "-kjm", "1024m", "-ktm", "2048m" };
+		final FlinkKubernetesCustomCli cli = createFlinkKubernetesCustomCliWithTmTotalMemory(1024);
+		final CommandLine commandLine = cli.parseCommandLineOptions(args, false);
+
+		final Configuration executorConfig = cli.applyCommandLineOptionsToConfiguration(commandLine);
+		final ClusterClientFactory<String> clientFactory = getClusterClientFactory(executorConfig);
+		final ClusterSpecification clusterSpecification = clientFactory.getClusterSpecification(executorConfig);
+
+		assertThat(clusterSpecification.getMasterMemoryMB(), is(1024));
+		assertThat(clusterSpecification.getTaskManagerMemoryMB(), is(2048));
+	}
+
+	/**
+	 * Tests the specifying heap memory with arbitrary unit for job manager and task manager.
+	 */
+	@Test
+	public void testHeapMemoryPropertyWithArbitraryUnit() throws Exception {
+		final String[] args = new String[] { "-kjm", "1g", "-ktm", "2g" };
+		final FlinkKubernetesCustomCli cli = createFlinkKubernetesCustomCliWithTmTotalMemory(1024);
+		final CommandLine commandLine = cli.parseCommandLineOptions(args, false);
+
+		final Configuration executorConfig = cli.applyCommandLineOptionsToConfiguration(commandLine);
+		final ClusterClientFactory<String> clientFactory = getClusterClientFactory(executorConfig);
+		final ClusterSpecification clusterSpecification = clientFactory.getClusterSpecification(executorConfig);
+
+		assertThat(clusterSpecification.getMasterMemoryMB(), is(1024));
+		assertThat(clusterSpecification.getTaskManagerMemoryMB(), is(2048));
+	}
+
+	/**
+	 * Tests the specifying heap memory with old config key for job manager and task manager.
+	 */
+	@Test
+	public void testHeapMemoryPropertyWithOldConfigKey() throws Exception {
+		Configuration configuration = new Configuration();
+		configuration.setInteger(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY_MB, 2048);
+		configuration.setInteger(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY_MB, 4096);
+
+		final FlinkKubernetesCustomCli cli = new FlinkKubernetesCustomCli(
+			configuration,
+			"k",
+			"kubernetes");
+
+		final CommandLine commandLine = cli.parseCommandLineOptions(new String[0], false);
+
+		final Configuration executorConfig = cli.applyCommandLineOptionsToConfiguration(commandLine);
+		final ClusterClientFactory<String> clientFactory = getClusterClientFactory(executorConfig);
+		final ClusterSpecification clusterSpecification = clientFactory.getClusterSpecification(executorConfig);
+
+		assertThat(clusterSpecification.getMasterMemoryMB(), is(2048));
+		assertThat(clusterSpecification.getTaskManagerMemoryMB(), is(4096));
+	}
+
+	/**
+	 * Tests the specifying heap memory with config default value for job manager and task manager.
+	 */
+	@Test
+	public void testHeapMemoryPropertyWithConfigDefaultValue() throws Exception {
+		final FlinkKubernetesCustomCli cli = createFlinkKubernetesCustomCliWithTmTotalMemory(1024);
+
+		final CommandLine commandLine = cli.parseCommandLineOptions(new String[0], false);
+
+		final Configuration executorConfig = cli.applyCommandLineOptionsToConfiguration(commandLine);
+		final ClusterClientFactory<String> clientFactory = getClusterClientFactory(executorConfig);
+		final ClusterSpecification clusterSpecification = clientFactory.getClusterSpecification(executorConfig);
+
+		assertThat(clusterSpecification.getMasterMemoryMB(), is(1024));
+		assertThat(clusterSpecification.getTaskManagerMemoryMB(), is(1024));
+	}
+
+	private ClusterClientFactory<String> getClusterClientFactory(final Configuration executorConfig) {
+		final ClusterClientServiceLoader clusterClientServiceLoader = new DefaultClusterClientServiceLoader();
+		return clusterClientServiceLoader.getClusterClientFactory(executorConfig);
+	}
+
+	private FlinkKubernetesCustomCli createFlinkKubernetesCustomCliWithTmTotalMemory(int totalMemomory) {
+		Configuration configuration = new Configuration();
+		configuration.setString(TaskManagerOptions.TOTAL_PROCESS_MEMORY, totalMemomory + "m");
+		return new FlinkKubernetesCustomCli(configuration, "k", "kubernetes");
+	}
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterClientFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterClientFactoryTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes;
+
+import org.apache.flink.client.deployment.ClusterClientFactory;
+import org.apache.flink.client.deployment.ClusterClientServiceLoader;
+import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.kubernetes.executors.KubernetesSessionClusterExecutor;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for the {@link KubernetesClusterClientFactory} discovery.
+ */
+public class KubernetesClusterClientFactoryTest {
+
+	@Test
+	public void testKubernetesClusterClientFactoryDiscoveryWithSessionExecutor() {
+		testKubernetesClusterClientFactoryDiscoveryHelper(KubernetesSessionClusterExecutor.NAME);
+	}
+
+	private void testKubernetesClusterClientFactoryDiscoveryHelper(final String targetName) {
+		final Configuration configuration = new Configuration();
+		configuration.setString(DeploymentOptions.TARGET, targetName);
+
+		final ClusterClientServiceLoader serviceLoader = new DefaultClusterClientServiceLoader();
+		final ClusterClientFactory<String> factory = serviceLoader.getClusterClientFactory(configuration);
+
+		assertTrue(factory instanceof KubernetesClusterClientFactory);
+	}
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClientFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClientFactory.java
@@ -19,13 +19,10 @@
 package org.apache.flink.yarn;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.client.deployment.AbstractClusterClientFactory;
 import org.apache.flink.client.deployment.ClusterClientFactory;
-import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.DeploymentOptions;
-import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
 import org.apache.flink.yarn.executors.YarnJobClusterExecutor;
 import org.apache.flink.yarn.executors.YarnSessionClusterExecutor;
@@ -43,7 +40,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * A {@link ClusterClientFactory} for a YARN cluster.
  */
 @Internal
-public class YarnClusterClientFactory implements ClusterClientFactory<ApplicationId> {
+public class YarnClusterClientFactory extends AbstractClusterClientFactory<ApplicationId> {
 
 	@Override
 	public boolean isCompatibleWith(Configuration configuration) {
@@ -65,28 +62,6 @@ public class YarnClusterClientFactory implements ClusterClientFactory<Applicatio
 		checkNotNull(configuration);
 		final String clusterId = configuration.getString(YarnConfigOptions.APPLICATION_ID);
 		return clusterId != null ? ConverterUtils.toApplicationId(clusterId) : null;
-	}
-
-	@Override
-	public ClusterSpecification getClusterSpecification(Configuration configuration) {
-		checkNotNull(configuration);
-
-		// JobManager Memory
-		final int jobManagerMemoryMB = ConfigurationUtils.getJobManagerHeapMemory(configuration).getMebiBytes();
-
-		// Task Managers memory
-		final int taskManagerMemoryMB = TaskExecutorResourceUtils
-			.resourceSpecFromConfig(configuration)
-			.getTotalProcessMemorySize()
-			.getMebiBytes();
-
-		int slotsPerTaskManager = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
-
-		return new ClusterSpecification.ClusterSpecificationBuilder()
-				.setMasterMemoryMB(jobManagerMemoryMB)
-				.setTaskManagerMemoryMB(taskManagerMemoryMB)
-				.setSlotsPerTaskManager(slotsPerTaskManager)
-				.createClusterSpecification();
 	}
 
 	private YarnClusterDescriptor getClusterDescriptor(Configuration configuration) {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -50,7 +50,6 @@ import org.apache.flink.yarn.executors.YarnJobClusterExecutor;
 import org.apache.flink.yarn.executors.YarnSessionClusterExecutor;
 
 import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.lang3.StringUtils;
@@ -295,19 +294,6 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 						return null;
 					});
 		}
-	}
-
-	private void printUsage() {
-		System.out.println("Usage:");
-		HelpFormatter formatter = new HelpFormatter();
-		formatter.setWidth(200);
-		formatter.setLeftPadding(5);
-
-		formatter.setSyntaxPrefix("   Optional");
-		Options options = new Options();
-		addGeneralOptions(options);
-		addRunOptions(options);
-		formatter.printHelp(" ", options);
 	}
 
 	@Override
@@ -620,7 +606,6 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 						LOG);
 					try {
 						runInteractiveCli(
-							clusterClient,
 							yarnApplicationStatusMonitor,
 							acceptInteractiveInput);
 					} finally {
@@ -817,22 +802,20 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 
 			retCode = SecurityUtils.getInstalledContext().runSecured(() -> cli.run(args));
 		} catch (CliArgsException e) {
-			retCode = handleCliArgsException(e);
+			retCode = handleCliArgsException(e, LOG);
 		} catch (Throwable t) {
 			final Throwable strippedThrowable = ExceptionUtils.stripException(t, UndeclaredThrowableException.class);
-			retCode = handleError(strippedThrowable);
+			retCode = handleError(strippedThrowable, LOG);
 		}
 
 		System.exit(retCode);
 	}
 
 	private static void runInteractiveCli(
-			ClusterClient<?> clusterClient,
 			YarnApplicationStatusMonitor yarnApplicationStatusMonitor,
 			boolean readConsoleInput) {
 		try (BufferedReader in = new BufferedReader(new InputStreamReader(System.in))) {
 			boolean continueRepl = true;
-			int numTaskmanagers = 0;
 			boolean isLastStatusUnknown = true;
 			long unknownStatusSince = System.nanoTime();
 
@@ -920,27 +903,6 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 			throw new RuntimeException("Error writing the properties file", e);
 		}
 		propertiesFile.setReadable(true, false); // readable for all.
-	}
-
-	private static int handleCliArgsException(CliArgsException e) {
-		LOG.error("Could not parse the command line arguments.", e);
-
-		System.out.println(e.getMessage());
-		System.out.println();
-		System.out.println("Use the help option (-h or --help) to get help on the command.");
-		return 1;
-	}
-
-	private static int handleError(Throwable t) {
-		LOG.error("Error while running the Flink Yarn session.", t);
-
-		System.err.println();
-		System.err.println("------------------------------------------------------------");
-		System.err.println(" The program finished with the following exception:");
-		System.err.println();
-
-		t.printStackTrace();
-		return 1;
 	}
 
 	public static File getYarnPropertiesLocation(@Nullable String yarnPropertiesFileLocation) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Implement Kubernetes command line tools to support session cluster. The FlinkKubernetesCustomCli will be added to customCommandLines of CliFrotend. The cli will support the following options.

This PR is based on #9957 #9965 #9973 #9984 #9985 #9986.

```
  Options for kubernetes-cluster mode:
     -d,--detached                              If present, runs the job in
                                                detached mode
     -kD <property=value>                       use value for given property
     -kh,--kuberneteshelp                       Help for Kubernetes session CLI.
     -ki,--kubernetesimage <image-name>         Image to use for Flink
                                                containers.
     -kid,--kubernetesclusterId <arg>           The cluster id that will be used
                                                for flink cluster. If it's not
                                                set, the client will generate a
                                                random UUID name.
     -kjm,--kubernetesjobManagerMemory <arg>    Memory for JobManager Container
                                                with optional unit (default: MB)
     -ks,--kubernetesslots <arg>                Number of slots per TaskManager
     -ktm,--kubernetestaskManagerMemory <arg>   Memory per TaskManager Container
                                                with optional unit (default: MB)
```


## Brief change log

* Add FlinkKubernetesCustomCli
* Update CliFrontend to support kubernetes


## Verifying this change
* This PR is covered by unit test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
