### PR TITLE
[FLINK-10937][dist] Add kubernetes-entry.sh and kubernetes-session.sh.

### DIFF
--- a/flink-dist/src/main/assemblies/bin.xml
+++ b/flink-dist/src/main/assemblies/bin.xml
@@ -140,6 +140,13 @@ under the License.
 			<outputDirectory>bin</outputDirectory>
 			<fileMode>0755</fileMode>
 		</fileSet>
+
+		<!-- copy kubernetes start scripts -->
+		<fileSet>
+			<directory>src/main/flink-bin/kubernetes-bin</directory>
+			<outputDirectory>bin</outputDirectory>
+			<fileMode>0755</fileMode>
+		</fileSet>
 		
 		<!-- copy default configuration -->
 		<fileSet>

--- a/flink-dist/src/main/flink-bin/kubernetes-bin/kubernetes-entry.sh
+++ b/flink-dist/src/main/flink-bin/kubernetes-bin/kubernetes-entry.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# The entrypoint script of flink-kubernetes integration. It is the command of jobmanager and taskmanager container.
+USAGE="Usage: kubernetes-entry.sh (session|job) [args]"
+
+bin=`dirname "$0"`
+bin=`cd "$bin"; pwd`
+
+. "$bin"/config.sh
+
+FLINK_CLASSPATH=`manglePathList $(constructFlinkClassPath):$INTERNAL_HADOOP_CLASSPATHS`
+# FLINK_CLASSPATH will be used by KubernetesUtils.java to generate jobmanager and taskmanager start command.
+export FLINK_CLASSPATH
+
+echo "Start command : $@"
+
+exec "$@"

--- a/flink-dist/src/main/flink-bin/kubernetes-bin/kubernetes-session.sh
+++ b/flink-dist/src/main/flink-bin/kubernetes-bin/kubernetes-session.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+bin=`dirname "$0"`
+bin=`cd "$bin"; pwd`
+
+# get Flink config
+. "$bin"/config.sh
+
+if [ "$FLINK_IDENT_STRING" = "" ]; then
+        FLINK_IDENT_STRING="$USER"
+fi
+
+JVM_ARGS="$JVM_ARGS -Xmx512m"
+
+CC_CLASSPATH=`manglePathList $(constructFlinkClassPath):$INTERNAL_HADOOP_CLASSPATHS`
+
+log=$FLINK_LOG_DIR/flink-$FLINK_IDENT_STRING-k8s-session-$HOSTNAME.log
+log_setting="-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j-console.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback-console.xml"
+
+export FLINK_CONF_DIR
+
+$JAVA_RUN $JVM_ARGS -classpath "$CC_CLASSPATH" $log_setting org.apache.flink.kubernetes.cli.FlinkKubernetesCustomCli "$@"


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Add kubernetes-entry.sh for JobManager and TaskManager container entrypoint. Add kubernetes-session.sh for starting session cluster.

```
wangyang-pc:build-target danrtsey.wy$ ./bin/kubernetes-session.sh -h
Usage:
   Required

   Optional
     -d,--detached                   If present, runs the job in detached mode
     -D <property=value>             use value for given property
     -h,--help                       Help for Kubernetes session CLI.
     -i,--image <image-name>         Image to use for Flink containers.
     -id,--clusterId <arg>           The cluster id that will be used for flink cluster. If it's not set, the client will generate a random UUID name.
     -jm,--jobManagerMemory <arg>    Memory for JobManager Container with optional unit (default: MB)
     -s,--slots <arg>                Number of slots per TaskManager
     -tm,--taskManagerMemory <arg>   Memory per TaskManager Container with optional unit (default: MB)
```


## Brief change log

* Add kubernetes-entry.sh and kubernetes-session.sh
* Update conf/log4j-cli.properties to support kubernetes


## Verifying this change

* This PR could be manually checked. After this PR, active Flink integration could be used.
* Start a new session
```
./bin/kubernetes-session.sh -d -id flink-native-k8s-session-1 \
-i flink:flink-1.10-SNAPSHOT-k8s \
-jm 2048 -tm 4096 -s 8 \
-Dkubernetes.jobmanager.cpu=0.5 -Dkubernetes.taskmanager.cpu=2 \
-Dkubernetes.container.image.pullPolicy=Always
```
* Submit a job to the existed session
```
./bin/flink run -d -kid flink-native-k8s-session-1 examples/streaming/WindowJoin.jar
```
* Stop the session
```
echo 'stop' | ./bin/kubernetes-session.sh -id flink-native-k8s-session-1
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (will add doc in a new PR)
