### PR TITLE
[FLINK-14776][Configuration] Migrate duration and memory size ConfigOptions in RocksDBConfigurableOptions

### DIFF
--- a/docs/_includes/generated/rocks_db_configurable_configuration.html
+++ b/docs/_includes/generated/rocks_db_configurable_configuration.html
@@ -9,27 +9,27 @@
     </thead>
     <tbody>
         <tr>
-            <td><h5>state.backend.rocksdb.block.blocksize</h5></td>
+            <td><h5>state.backend.rocksdb.block.block-memorysize</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
+            <td>MemorySize</td>
             <td>The approximate size (in bytes) of user data packed per block. RocksDB has default blocksize as '4KB'.</td>
         </tr>
         <tr>
-            <td><h5>state.backend.rocksdb.block.cache-size</h5></td>
+            <td><h5>state.backend.rocksdb.block.cache-memorysize</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
+            <td>MemorySize</td>
             <td>The amount of the cache for data blocks in RocksDB. RocksDB has default block-cache size as '8MB'.</td>
         </tr>
         <tr>
-            <td><h5>state.backend.rocksdb.compaction.level.max-size-level-base</h5></td>
+            <td><h5>state.backend.rocksdb.compaction.level.max-memorysize-level-base</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
+            <td>MemorySize</td>
             <td>The upper-bound of the total size of level base files in bytes. RocksDB has default configuration as '10MB'.</td>
         </tr>
         <tr>
-            <td><h5>state.backend.rocksdb.compaction.level.target-file-size-base</h5></td>
+            <td><h5>state.backend.rocksdb.compaction.level.target-file-memorysize-base</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
+            <td>MemorySize</td>
             <td>The target file size for compaction, which determines a level-1 file size. RocksDB has default configuration as '2MB'.</td>
         </tr>
         <tr>
@@ -63,16 +63,16 @@
             <td>Tne maximum number of write buffers that are built up in memory. RocksDB has default configuration as '2'.</td>
         </tr>
         <tr>
+            <td><h5>state.backend.rocksdb.writebuffer.memorysize</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>MemorySize</td>
+            <td>The amount of data built up in memory (backed by an unsorted log on disk) before converting to a sorted on-disk files. RocksDB has default writebuffer size as '4MB'.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.rocksdb.writebuffer.number-to-merge</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
             <td>The minimum number of write buffers that will be merged together before writing to storage. RocksDB has default configuration as '1'.</td>
-        </tr>
-        <tr>
-            <td><h5>state.backend.rocksdb.writebuffer.size</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
-            <td>The amount of data built up in memory (backed by an unsorted log on disk) before converting to a sorted on-disk files. RocksDB has default writebuffer size as '4MB'.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/DefaultConfigurableOptionsFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/DefaultConfigurableOptionsFactory.java
@@ -39,16 +39,21 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.BLOCK_CACHE_SIZE;
+import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.BLOCK_CACHE_SIZE_MEMORYSIZE;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.BLOCK_SIZE;
+import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.BLOCK_SIZE_MEMORYSIZE;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.COMPACTION_STYLE;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.MAX_BACKGROUND_THREADS;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.MAX_OPEN_FILES;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.MAX_SIZE_LEVEL_BASE;
+import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.MAX_SIZE_LEVEL_BASE_MEMORYSIZE;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.MAX_WRITE_BUFFER_NUMBER;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.MIN_WRITE_BUFFER_NUMBER_TO_MERGE;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.TARGET_FILE_SIZE_BASE;
+import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.TARGET_FILE_SIZE_BASE_MEMORYSIZE;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.USE_DYNAMIC_LEVEL_SIZE;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.WRITE_BUFFER_SIZE;
+import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.WRITE_BUFFER_SIZE_MEMORYSIZE;
 
 /**
  * An implementation of {@link ConfigurableOptionsFactory} using options provided by {@link RocksDBConfigurableOptions}
@@ -59,6 +64,14 @@ import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOption
 public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFactory {
 
 	private final Map<String, String> configuredOptions = new HashMap<>();
+	private final Map<String, MemorySize> sizeConfigMap = new HashMap<>();
+	private static final Map<String, String> SIZE_CONFIG_KEY_MAPPING = new HashMap<String, String>() {{
+		put(TARGET_FILE_SIZE_BASE.key(), TARGET_FILE_SIZE_BASE_MEMORYSIZE.key());
+		put(MAX_SIZE_LEVEL_BASE.key(), MAX_SIZE_LEVEL_BASE_MEMORYSIZE.key());
+		put(WRITE_BUFFER_SIZE.key(), WRITE_BUFFER_SIZE_MEMORYSIZE.key());
+		put(BLOCK_SIZE.key(), BLOCK_SIZE_MEMORYSIZE.key());
+		put(BLOCK_CACHE_SIZE.key(), BLOCK_CACHE_SIZE_MEMORYSIZE.key());
+	}};
 
 	@Override
 	public DBOptions createDBOptions(DBOptions currentOptions) {
@@ -83,15 +96,15 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFac
 			currentOptions.setLevelCompactionDynamicLevelBytes(getUseDynamicLevelSize());
 		}
 
-		if (isOptionConfigured(TARGET_FILE_SIZE_BASE)) {
+		if (isOptionConfigured(TARGET_FILE_SIZE_BASE_MEMORYSIZE)) {
 			currentOptions.setTargetFileSizeBase(getTargetFileSizeBase());
 		}
 
-		if (isOptionConfigured(MAX_SIZE_LEVEL_BASE)) {
+		if (isOptionConfigured(MAX_SIZE_LEVEL_BASE_MEMORYSIZE)) {
 			currentOptions.setMaxBytesForLevelBase(getMaxSizeLevelBase());
 		}
 
-		if (isOptionConfigured(WRITE_BUFFER_SIZE)) {
+		if (isOptionConfigured(WRITE_BUFFER_SIZE_MEMORYSIZE)) {
 			currentOptions.setWriteBufferSize(getWriteBufferSize());
 		}
 
@@ -117,11 +130,11 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFac
 			}
 		}
 
-		if (isOptionConfigured(BLOCK_SIZE)) {
+		if (isOptionConfigured(BLOCK_SIZE_MEMORYSIZE)) {
 			blockBasedTableConfig.setBlockSize(getBlockSize());
 		}
 
-		if (isOptionConfigured(BLOCK_CACHE_SIZE)) {
+		if (isOptionConfigured(BLOCK_CACHE_SIZE_MEMORYSIZE)) {
 			blockBasedTableConfig.setBlockCacheSize(getBlockCacheSize());
 		}
 
@@ -133,7 +146,7 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFac
 	}
 
 	private boolean isOptionConfigured(ConfigOption configOption) {
-		return configuredOptions.containsKey(configOption.key());
+		return configuredOptions.containsKey(configOption.key()) || sizeConfigMap.containsKey(configOption.key());
 	}
 
 	//--------------------------------------------------------------------------
@@ -194,29 +207,44 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFac
 	//--------------------------------------------------------------------------
 
 	private long getTargetFileSizeBase() {
-		return MemorySize.parseBytes(getInternal(TARGET_FILE_SIZE_BASE.key()));
+		return sizeConfigMap.get(TARGET_FILE_SIZE_BASE_MEMORYSIZE.key()).getBytes();
 	}
 
+	@Deprecated
 	public DefaultConfigurableOptionsFactory setTargetFileSizeBase(String targetFileSizeBase) {
-		Preconditions.checkArgument(MemorySize.parseBytes(targetFileSizeBase) > 0,
+		MemorySize memorySize = MemorySize.parse(targetFileSizeBase);
+		Preconditions.checkArgument(memorySize.getBytes() > 0,
 			"Invalid configuration " + targetFileSizeBase + " for target file size base.");
-		setInternal(TARGET_FILE_SIZE_BASE.key(), targetFileSizeBase);
+		return setTargetFileSizeBase(memorySize);
+	}
+
+	public DefaultConfigurableOptionsFactory setTargetFileSizeBase(MemorySize targetFileSizeBase) {
+		Preconditions.checkArgument(targetFileSizeBase.getBytes() > 0,
+			"Invalid configuration " + targetFileSizeBase + " for target file size base.");
+		setMemorySizeInternal(TARGET_FILE_SIZE_BASE_MEMORYSIZE.key(), targetFileSizeBase);
 		return this;
 	}
-
 
 	//--------------------------------------------------------------------------
 	// Maximum total data size for a level, i.e., the max total size for level-1
 	//--------------------------------------------------------------------------
 
 	private long getMaxSizeLevelBase() {
-		return MemorySize.parseBytes(getInternal(MAX_SIZE_LEVEL_BASE.key()));
+		return sizeConfigMap.get(MAX_SIZE_LEVEL_BASE_MEMORYSIZE.key()).getBytes();
 	}
 
+	@Deprecated
 	public DefaultConfigurableOptionsFactory setMaxSizeLevelBase(String maxSizeLevelBase) {
-		Preconditions.checkArgument(MemorySize.parseBytes(maxSizeLevelBase) > 0,
+		MemorySize memorySize = MemorySize.parse(maxSizeLevelBase);
+		Preconditions.checkArgument(memorySize.getBytes() > 0,
 			"Invalid configuration " + maxSizeLevelBase + " for max size of level base.");
-		setInternal(MAX_SIZE_LEVEL_BASE.key(), maxSizeLevelBase);
+		return setMaxSizeLevelBase(memorySize);
+	}
+
+	public DefaultConfigurableOptionsFactory setMaxSizeLevelBase(MemorySize maxSizeLevelBase) {
+		Preconditions.checkArgument(maxSizeLevelBase != null && maxSizeLevelBase.getBytes() > 0,
+			"Invalid configuration " + maxSizeLevelBase + " for max size of level base.");
+		setMemorySizeInternal(MAX_SIZE_LEVEL_BASE_MEMORYSIZE.key(), maxSizeLevelBase);
 		return this;
 	}
 
@@ -227,14 +255,22 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFac
 	//--------------------------------------------------------------------------
 
 	private long getWriteBufferSize() {
-		return MemorySize.parseBytes(getInternal(WRITE_BUFFER_SIZE.key()));
+		return sizeConfigMap.get(WRITE_BUFFER_SIZE_MEMORYSIZE.key()).getBytes();
 	}
 
+	@Deprecated
 	public DefaultConfigurableOptionsFactory setWriteBufferSize(String writeBufferSize) {
-		Preconditions.checkArgument(MemorySize.parseBytes(writeBufferSize) > 0,
+		MemorySize memorySize = MemorySize.parse(writeBufferSize);
+		Preconditions.checkArgument(memorySize.getBytes() > 0,
 			"Invalid configuration " + writeBufferSize + " for write-buffer size.");
 
-		setInternal(WRITE_BUFFER_SIZE.key(), writeBufferSize);
+		return setWriteBufferSize(memorySize);
+	}
+
+	public DefaultConfigurableOptionsFactory setWriteBufferSize(MemorySize writeBufferSize) {
+		Preconditions.checkArgument(writeBufferSize != null && writeBufferSize.getBytes() > 0,
+			"Invalid configuration " + writeBufferSize + " frr write-buffer size.");
+		setMemorySizeInternal(WRITE_BUFFER_SIZE_MEMORYSIZE.key(), writeBufferSize);
 		return this;
 	}
 
@@ -275,13 +311,20 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFac
 	//--------------------------------------------------------------------------
 
 	private long getBlockSize() {
-		return MemorySize.parseBytes(getInternal(BLOCK_SIZE.key()));
+		return sizeConfigMap.get(BLOCK_SIZE_MEMORYSIZE.key()).getBytes();
 	}
 
+	@Deprecated
 	public DefaultConfigurableOptionsFactory setBlockSize(String blockSize) {
-		Preconditions.checkArgument(MemorySize.parseBytes(blockSize) > 0,
+		MemorySize memorySize = MemorySize.parse(blockSize);
+		Preconditions.checkArgument(memorySize.getBytes() > 0,
 			"Invalid configuration " + blockSize + " for block size.");
-		setInternal(BLOCK_SIZE.key(), blockSize);
+		return setBlockSize(memorySize);
+	}
+
+	public DefaultConfigurableOptionsFactory setBlockSize(MemorySize blockSize) {
+		Preconditions.checkArgument(blockSize != null && blockSize.getBytes() > 0, "Invalid configuration " + blockSize + " for block size");
+		setMemorySizeInternal(BLOCK_SIZE_MEMORYSIZE.key(), blockSize);
 		return this;
 	}
 
@@ -290,13 +333,20 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFac
 	//--------------------------------------------------------------------------
 
 	private long getBlockCacheSize() {
-		return MemorySize.parseBytes(getInternal(BLOCK_CACHE_SIZE.key()));
+		return sizeConfigMap.get(BLOCK_CACHE_SIZE_MEMORYSIZE.key()).getBytes();
 	}
 
+	@Deprecated
 	public DefaultConfigurableOptionsFactory setBlockCacheSize(String blockCacheSize) {
-		Preconditions.checkArgument(MemorySize.parseBytes(blockCacheSize) > 0,
+		MemorySize memorySize = MemorySize.parse(blockCacheSize);
+		Preconditions.checkArgument(memorySize.getBytes() > 0,
 			"Invalid configuration " + blockCacheSize + " for block cache size.");
-		setInternal(BLOCK_CACHE_SIZE.key(), blockCacheSize);
+		return setBlockCacheSize(memorySize);
+	}
+
+	public DefaultConfigurableOptionsFactory setBlockCacheSize(MemorySize blockCacheSize) {
+		Preconditions.checkArgument(blockCacheSize != null && blockCacheSize.getBytes() > 0, "Invalid configuration " + blockCacheSize + " fo  block cache seee.");
+		setMemorySizeInternal(BLOCK_CACHE_SIZE_MEMORYSIZE.key(), blockCacheSize);
 
 		return this;
 	}
@@ -315,7 +365,13 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFac
 		MAX_WRITE_BUFFER_NUMBER.key(),
 		MIN_WRITE_BUFFER_NUMBER_TO_MERGE.key(),
 		BLOCK_SIZE.key(),
-		BLOCK_CACHE_SIZE.key()
+		BLOCK_CACHE_SIZE.key(),
+
+		TARGET_FILE_SIZE_BASE_MEMORYSIZE.key(),
+		MAX_SIZE_LEVEL_BASE_MEMORYSIZE.key(),
+		WRITE_BUFFER_SIZE_MEMORYSIZE.key(),
+		BLOCK_SIZE_MEMORYSIZE.key(),
+		BLOCK_CACHE_SIZE_MEMORYSIZE.key()
 	};
 
 	private static final Set<String> POSITIVE_INT_CONFIG_SET = new HashSet<>(Arrays.asList(
@@ -324,13 +380,21 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFac
 		MIN_WRITE_BUFFER_NUMBER_TO_MERGE.key()
 	));
 
-	private static final Set<String> SIZE_CONFIG_SET = new HashSet<>(Arrays.asList(
+	private static final Set<String> DEPRECATED_SIZE_CONFIG_SET = new HashSet<>(Arrays.asList(
 		TARGET_FILE_SIZE_BASE.key(),
 		MAX_SIZE_LEVEL_BASE.key(),
 		WRITE_BUFFER_SIZE.key(),
 		BLOCK_SIZE.key(),
 		BLOCK_CACHE_SIZE.key()
 	));
+
+	private static final Map<String, ConfigOption<MemorySize>> SIZE_CONFIG_SET = new HashMap<String, ConfigOption<MemorySize>>() {{
+		put(TARGET_FILE_SIZE_BASE_MEMORYSIZE.key(), TARGET_FILE_SIZE_BASE_MEMORYSIZE);
+		put(MAX_SIZE_LEVEL_BASE_MEMORYSIZE.key(), MAX_SIZE_LEVEL_BASE_MEMORYSIZE);
+		put(WRITE_BUFFER_SIZE_MEMORYSIZE.key(), WRITE_BUFFER_SIZE_MEMORYSIZE);
+		put(BLOCK_SIZE_MEMORYSIZE.key(), BLOCK_SIZE_MEMORYSIZE);
+		put(BLOCK_CACHE_SIZE_MEMORYSIZE.key(), BLOCK_CACHE_SIZE_MEMORYSIZE);
+	}};
 
 	private static final Set<String> BOOLEAN_CONFIG_SET = new HashSet<>(Collections.singletonList(
 		USE_DYNAMIC_LEVEL_SIZE.key()
@@ -350,12 +414,25 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFac
 	 */
 	@Override
 	public DefaultConfigurableOptionsFactory configure(Configuration configuration) {
+		preCheckSizeConfigKey(configuration);
 		for (String key : CANDIDATE_CONFIGS) {
-			String newValue = configuration.getString(key, null);
+			if (SIZE_CONFIG_SET.containsKey(key)) {
+				if (configuration.containsKey(key)) {
+					MemorySize memorySize = configuration.get(SIZE_CONFIG_SET.get(key));
+					Preconditions.checkArgument(memorySize.getBytes() > 0, "Configuration for " + key + " must be positive.");
+					this.sizeConfigMap.put(key, memorySize);
+				}
+			} else {
+				String newValue = configuration.getString(key, null);
 
-			if (newValue != null) {
-				if (checkArgumentValid(key, newValue)) {
-					this.configuredOptions.put(key, newValue);
+				if (newValue != null) {
+					if (checkArgumentValid(key, newValue)) {
+						if (DEPRECATED_SIZE_CONFIG_SET.contains(key)) {
+							this.sizeConfigMap.put(SIZE_CONFIG_KEY_MAPPING.get(key), MemorySize.parse(newValue));
+						} else {
+							this.configuredOptions.put(key, newValue);
+						}
+					}
 				}
 			}
 		}
@@ -382,7 +459,7 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFac
 
 			Preconditions.checkArgument(Integer.parseInt(value) > 0,
 				"Configured value for key: " + key + " must be larger than 0.");
-		} else if (SIZE_CONFIG_SET.contains(key)) {
+		} else if (DEPRECATED_SIZE_CONFIG_SET.contains(key)) {
 
 			Preconditions.checkArgument(MemorySize.parseBytes(value) > 0,
 				"Configured size for key" + key + " must be larger than 0.");
@@ -411,6 +488,11 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFac
 		configuredOptions.put(key, value);
 	}
 
+	private void setMemorySizeInternal(String key, MemorySize value) {
+		Preconditions.checkArgument(value != null && value.getBytes() > 0, "The configuration value must not be null and be positive.");
+		sizeConfigMap.put(key, value);
+	}
+
 	/**
 	 * Returns the value in string format with the given key.
 	 *
@@ -421,5 +503,15 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFac
 			"The configuration " + key + " has not been configured.");
 
 		return configuredOptions.get(key);
+	}
+
+	/**
+	 * Check that whether there configured both the size key and deprecated size key, throw IllegalArgumentException if set both.
+	 * @param config Which used to check
+	 */
+	private void preCheckSizeConfigKey(Configuration config) {
+		for (Map.Entry<String, String> entry : SIZE_CONFIG_KEY_MAPPING.entrySet()) {
+			Preconditions.checkArgument(!(config.containsKey(entry.getKey()) && config.containsKey(entry.getValue())), "Can not set both key " + entry.getValue() + " add deprecated key " + entry.getKey());
+		}
 	}
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.contrib.streaming.state;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.description.Description;
 
 import java.io.Serializable;
@@ -78,23 +80,51 @@ public class RocksDBConfigurableOptions implements Serializable {
 						"RocksDB's doc."))
 				.build());
 
-	public static final ConfigOption<String> TARGET_FILE_SIZE_BASE =
-		key("state.backend.rocksdb.compaction.level.target-file-size-base")
+	@PublicEvolving
+	public static final ConfigOption<MemorySize> TARGET_FILE_SIZE_BASE_MEMORYSIZE =
+		key("state.backend.rocksdb.compaction.level.target-file-memorysize-base")
+			.memoryType()
 			.noDefaultValue()
 			.withDescription("The target file size for compaction, which determines a level-1 file size. " +
 				"RocksDB has default configuration as '2MB'.");
 
-	public static final ConfigOption<String> MAX_SIZE_LEVEL_BASE =
-		key("state.backend.rocksdb.compaction.level.max-size-level-base")
+	@Deprecated
+	public static final ConfigOption<String> TARGET_FILE_SIZE_BASE =
+		key("state.backend.rocksdb.compaction.level.target-file-size-base")
+			.noDefaultValue()
+			.withDescription("The target file size for compaction, which determines a level-1 file size. " +
+				"RocksDB has default configuration as '2MB'. This config has been deprecated, please use " + TARGET_FILE_SIZE_BASE_MEMORYSIZE.key() + ".");
+
+	@PublicEvolving
+	public static final ConfigOption<MemorySize> MAX_SIZE_LEVEL_BASE_MEMORYSIZE =
+		key("state.backend.rocksdb.compaction.level.max-memorysize-level-base")
+			.memoryType()
 			.noDefaultValue()
 			.withDescription("The upper-bound of the total size of level base files in bytes. " +
 				"RocksDB has default configuration as '10MB'.");
 
+	@Deprecated
+	public static final ConfigOption<String> MAX_SIZE_LEVEL_BASE =
+		key("state.backend.rocksdb.compaction.level.max-size-level-base")
+			.noDefaultValue()
+			.withDescription("The upper-bound of the total size of level base files in bytes. " +
+				"RocksDB has default configuration as '10MB'. This config has been deprecated, please use " + MAX_SIZE_LEVEL_BASE_MEMORYSIZE.key() + ".");
+
+	@PublicEvolving
+	public static final ConfigOption<MemorySize> WRITE_BUFFER_SIZE_MEMORYSIZE =
+		key("state.backend.rocksdb.writebuffer.memorysize")
+			.memoryType()
+			.noDefaultValue()
+			.withDescription("The amount of data built up in memory (backed by an unsorted log on disk) " +
+				"before converting to a sorted on-disk files. RocksDB has default writebuffer size as '4MB'.");
+
+	@Deprecated
 	public static final ConfigOption<String> WRITE_BUFFER_SIZE =
 		key("state.backend.rocksdb.writebuffer.size")
 			.noDefaultValue()
 			.withDescription("The amount of data built up in memory (backed by an unsorted log on disk) " +
-				"before converting to a sorted on-disk files. RocksDB has default writebuffer size as '4MB'.");
+				"before converting to a sorted on-disk files. RocksDB has default writebuffer size as '4MB'. " +
+				"This config has been deprecated, please use " + WRITE_BUFFER_SIZE_MEMORYSIZE.key() + ".");
 
 	public static final ConfigOption<String> MAX_WRITE_BUFFER_NUMBER =
 		key("state.backend.rocksdb.writebuffer.count")
@@ -108,16 +138,34 @@ public class RocksDBConfigurableOptions implements Serializable {
 			.withDescription("The minimum number of write buffers that will be merged together before writing to storage. " +
 				"RocksDB has default configuration as '1'.");
 
-	public static final ConfigOption<String> BLOCK_SIZE =
-		key("state.backend.rocksdb.block.blocksize")
+	@PublicEvolving
+	public static final ConfigOption<MemorySize> BLOCK_SIZE_MEMORYSIZE =
+		key("state.backend.rocksdb.block.block-memorysize")
+			.memoryType()
 			.noDefaultValue()
 			.withDescription("The approximate size (in bytes) of user data packed per block. " +
 				"RocksDB has default blocksize as '4KB'.");
 
+	@Deprecated
+	public static final ConfigOption<String> BLOCK_SIZE =
+		key("state.backend.rocksdb.block.blocksize")
+			.noDefaultValue()
+			.withDescription("The approximate size (in bytes) of user data packed per block. " +
+				"RocksDB has default blocksize as '4KB'. This config has been deprecated, please use " + BLOCK_SIZE_MEMORYSIZE.key() + ".");
+
+	@PublicEvolving
+	public static final ConfigOption<MemorySize> BLOCK_CACHE_SIZE_MEMORYSIZE =
+		key("state.backend.rocksdb.block.cache-memorysize")
+			.memoryType()
+			.noDefaultValue()
+			.withDescription("The amount of the cache for data blocks in RocksDB. " +
+				"RocksDB has default block-cache size as '8MB'.");
+
+	@Deprecated
 	public static final ConfigOption<String> BLOCK_CACHE_SIZE =
 		key("state.backend.rocksdb.block.cache-size")
 			.noDefaultValue()
 			.withDescription("The amount of the cache for data blocks in RocksDB. " +
-				"RocksDB has default block-cache size as '8MB'.");
+				"RocksDB has default block-cache size as '8MB'. This config has been deprecated, please uee " + BLOCK_CACHE_SIZE_MEMORYSIZE.key() + ".");
 
 }


### PR DESCRIPTION
## What is the purpose of the change

Migrate duration and memory size ConfigOptions in RocksDBConfigurableOptions

## Brief change log

- add new config `BLOCK_SIZE_MEMORYSIZE`, `BLOCK_CACHE_SIZE_MEMORYSIZE`, `WRITE_BUFFER_SIZE_MEMORYSIZE`, `MAX_SIZE_LEVEL_BASE_MEMORYSIZE` and `TARGET_FILE_SIZE_BASE_MEMORYSIZE` and mark as `@PublicEvolving`
- deprecated the exist config
- add new function and deprecated the exist function in `DefaultConfigurableOptionsFactory.java` which used the `RocksDBConfigurableOptions`


## Verifying this change

This change added tests and can be verified as follows:

  - RocksDBStateBackendConfigTest#testConfigurableOptionsFromConfigWithMemorySize
  - RocksDBStateBackendConfigTest#testSetBothKeyAndDeprecatedKey

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
