### PR TITLE
[FLINK-14857] [runtime/task] deprecate StreamTask.getCheckpointLock m…

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -715,7 +715,19 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	/**
 	 * Gets the lock object on which all operations that involve data and state mutation have to lock.
 	 * @return The checkpoint lock object.
+	 * @deprecated This method will be removed in future releases. Use {@linkplain MailboxExecutor mailbox executor}
+	 * to run {@link StreamTask} actions that require synchronization (e.g. checkpointing, collecting output).
+	 * <p>
+	 * For other (non-{@link StreamTask}) actions other synchronization means can be used.
+	 * </p>
+	 * MailboxExecutor {@link MailboxExecutor#yield() yield} or {@link MailboxExecutor#tryYield() tryYield} methods can
+	 * be used for actions that should give control to other actions temporarily.
+	 * <p>
+	 * MailboxExecutor can be accessed by using {@link org.apache.flink.streaming.api.operators.YieldingOperatorFactory YieldingOperatorFactory}.
+	 * Example usage can be found in {@link org.apache.flink.streaming.api.operators.async.AsyncWaitOperator AsyncWaitOperator}.
+	 * </p>
 	 */
+	@Deprecated
 	public Object getCheckpointLock() {
 		return actionExecutor.getMutex();
 	}


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/FLINK-14857
  
## What is the purpose of the change

This pull request deprecates the StreamTask.getCheckpointLock method. Users are advised to use MailboxExecutor instead.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable)
