### PR TITLE
[FLINK-14859][runtime] Avoid leaking unassigned slots 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DeploymentHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DeploymentHandle.java
@@ -75,7 +75,7 @@ class DeploymentHandle {
 		final CompletableFuture<LogicalSlot> logicalSlotFuture = slotExecutionVertexAssignment.getLogicalSlotFuture();
 		Preconditions.checkState(logicalSlotFuture.isDone(), "method can only be called after slot future is done");
 
-		if (logicalSlotFuture.isCompletedExceptionally() || logicalSlotFuture.isCancelled()) {
+		if (logicalSlotFuture.isCompletedExceptionally()) {
 			return Optional.empty();
 		}
 		return Optional.ofNullable(logicalSlotFuture.getNow(null));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DeploymentHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DeploymentHandle.java
@@ -20,8 +20,12 @@
 package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.util.Preconditions;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * This class is a tuple holding the information necessary to deploy an {@link ExecutionVertex}.
@@ -65,5 +69,15 @@ class DeploymentHandle {
 
 	public SlotExecutionVertexAssignment getSlotExecutionVertexAssignment() {
 		return slotExecutionVertexAssignment;
+	}
+
+	public Optional<LogicalSlot> getLogicalSlot() {
+		final CompletableFuture<LogicalSlot> logicalSlotFuture = slotExecutionVertexAssignment.getLogicalSlotFuture();
+		Preconditions.checkState(logicalSlotFuture.isDone(), "method can only be called after slot future is done");
+
+		if (logicalSlotFuture.isCompletedExceptionally() || logicalSlotFuture.isCancelled()) {
+			return Optional.empty();
+		}
+		return Optional.ofNullable(logicalSlotFuture.getNow(null));
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
@@ -296,6 +296,21 @@ public class DefaultSchedulerTest extends TestLogger {
 	}
 
 	@Test
+	public void releaseSlotIfVertexVersionOutdated() {
+		testExecutionSlotAllocator.disableAutoCompletePendingRequests();
+
+		final JobGraph jobGraph = singleNonParallelJobVertexJobGraph();
+		final ExecutionVertexID onlyExecutionVertexId = new ExecutionVertexID(getOnlyJobVertex(jobGraph).getID(), 0);
+
+		createSchedulerAndStartScheduling(jobGraph);
+
+		executionVertexVersioner.recordModification(onlyExecutionVertexId);
+		testExecutionSlotAllocator.completePendingRequests();
+
+		assertThat(testExecutionSlotAllocator.getReturnedSlots(), hasSize(1));
+	}
+
+	@Test
 	public void vertexIsResetBeforeRestarted() throws Exception {
 		final JobGraph jobGraph = singleNonParallelJobVertexJobGraph();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DeploymentHandleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DeploymentHandleTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Unit tests for {@link DeploymentHandle}.
+ */
+public class DeploymentHandleTest {
+
+	private static final JobVertexID TEST_JOB_VERTEX_ID = new JobVertexID(0, 0);
+
+	private static final ExecutionVertexID TEST_EXECUTION_VERTEX_ID = new ExecutionVertexID(TEST_JOB_VERTEX_ID, 0);
+
+	private static final ExecutionVertexVersion TEST_EXECUTION_VERTEX_VERSION = new ExecutionVertexVersion(TEST_EXECUTION_VERTEX_ID, 0);
+
+	private static final ExecutionVertexDeploymentOption TEST_DEPLOYMENT_OPTION = new ExecutionVertexDeploymentOption(
+		TEST_EXECUTION_VERTEX_ID,
+		new DeploymentOption(true));
+
+	private CompletableFuture<LogicalSlot> logicalSlotFuture;
+
+	private DeploymentHandle deploymentHandle;
+
+	@Before
+	public void setUp() {
+		logicalSlotFuture = new CompletableFuture<>();
+		final SlotExecutionVertexAssignment slotExecutionVertexAssignment = new SlotExecutionVertexAssignment(TEST_EXECUTION_VERTEX_ID, logicalSlotFuture);
+		deploymentHandle = new DeploymentHandle(
+			TEST_EXECUTION_VERTEX_VERSION,
+			TEST_DEPLOYMENT_OPTION,
+			slotExecutionVertexAssignment);
+	}
+
+	@Test
+	public void getLogicalSlotThrowsExceptionIfSlotFutureNotCompleted() {
+		try {
+			assertFalse(deploymentHandle.getLogicalSlot().isPresent());
+			fail();
+		} catch (IllegalStateException e) {
+			assertThat(e.getMessage(), containsString("method can only be called after slot future is done"));
+		}
+	}
+
+	@Test
+	public void slotIsNotPresentIfFutureWasCancelled() {
+		logicalSlotFuture.cancel(false);
+		assertFalse(deploymentHandle.getLogicalSlot().isPresent());
+	}
+
+	@Test
+	public void slotIsNotPresentIfFutureWasCompletedExceptionally() {
+		logicalSlotFuture.completeExceptionally(new RuntimeException("expected"));
+		assertFalse(deploymentHandle.getLogicalSlot().isPresent());
+	}
+
+	@Test
+	public void getLogicalSlotReturnsSlotIfFutureCompletedNormally() {
+		final LogicalSlot logicalSlot = new TestingLogicalSlotBuilder().createTestingLogicalSlot();
+		logicalSlotFuture.complete(logicalSlot);
+		assertTrue(deploymentHandle.getLogicalSlot().isPresent());
+		assertSame(logicalSlot, deploymentHandle.getLogicalSlot().get());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestExecutionSlotAllocator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestExecutionSlotAllocator.java
@@ -20,6 +20,7 @@
 package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SlotOwner;
 import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 
@@ -36,11 +37,13 @@ import static org.apache.flink.util.Preconditions.checkState;
 /**
  * Test {@link ExecutionSlotAllocator} implementation.
  */
-public class TestExecutionSlotAllocator implements ExecutionSlotAllocator {
+public class TestExecutionSlotAllocator implements ExecutionSlotAllocator, SlotOwner {
 
 	private final Map<ExecutionVertexID, SlotExecutionVertexAssignment> pendingRequests = new HashMap<>();
 
 	private boolean autoCompletePendingRequests = true;
+
+	private final List<LogicalSlot> returnedSlots = new ArrayList<>();
 
 	@Override
 	public Collection<SlotExecutionVertexAssignment> allocateSlotsFor(final Collection<ExecutionVertexSchedulingRequirements> schedulingRequirementsCollection) {
@@ -84,7 +87,9 @@ public class TestExecutionSlotAllocator implements ExecutionSlotAllocator {
 		checkState(slotVertexAssignment != null);
 		slotVertexAssignment
 			.getLogicalSlotFuture()
-			.complete(new TestingLogicalSlotBuilder().createTestingLogicalSlot());
+			.complete(new TestingLogicalSlotBuilder()
+				.setSlotOwner(this)
+				.createTestingLogicalSlot());
 	}
 
 	private SlotExecutionVertexAssignment removePendingRequest(final ExecutionVertexID executionVertexId) {
@@ -125,5 +130,14 @@ public class TestExecutionSlotAllocator implements ExecutionSlotAllocator {
 	@Override
 	public CompletableFuture<Void> stop() {
 		return CompletableFuture.completedFuture(null);
+	}
+
+	@Override
+	public void returnLogicalSlot(final LogicalSlot logicalSlot) {
+		returnedSlots.add(logicalSlot);
+	}
+
+	public List<LogicalSlot> getReturnedSlots() {
+		return new ArrayList<>(returnedSlots);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

*This avoids leaking `LogicalSlot` instances when a deployment is aborted due to being outdated.*


## Brief change log

  - *Release `LogicalSlot` if deployment is outdated.*
  - *Add `checkState` asserting that slot is released when in `DefaultScheduler#deployOrHandleError()`*
  - *Add unit tests*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit test to `DefaultSchedulerTest`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
