### PR TITLE
[FLINK-14467][runtime] Let MesosJobClusterEntrypoint use user code class loader

### DIFF
--- a/docs/ops/deployment/mesos.md
+++ b/docs/ops/deployment/mesos.md
@@ -202,7 +202,10 @@ try (FileOutputStream output = new FileOutputStream(jobGraphFile);
 {% endhighlight %}
 
 Note: 
-1. Make sure that all Mesos processes have the user code jar on the classpath (e.g. putting them in the lib directory)
+1. Make sure that all Mesos processes have the user code jar on the classpath. There are two ways:
+    1. One way is putting them in the `lib/` directory, which means the user code jar would be loaded by the system classloader. 
+    1. The other way is making a `usrlib/` directory in the parent directory of `lib/` and putting the user code jar in the `usrlib/`.
+    Then launching job cluster via `bin/mesos-appmaster-job.sh ....` cmd. The user code jar would be loaded by the user code classloader by this way.  
 
 #### General configuration
 

--- a/docs/ops/deployment/mesos.zh.md
+++ b/docs/ops/deployment/mesos.zh.md
@@ -177,16 +177,16 @@ In contrast to that, the task managers will be run as Mesos tasks in the Mesos c
 
 ### Flink job cluster on Mesos
 
-A Flink job cluster is a dedicated cluster which runs a single job.
+A Flink job cluster is a dedicated cluster which runs a single job. 
 There is no extra job submission needed.
 
-In the `/bin` directory of the Flink distribution, you find one startup script
+In the `/bin` directory of the Flink distribution, you find one startup script 
 which manage the Flink processes in a Mesos cluster:
 
 1. `mesos-appmaster-job.sh`
-   This starts the Mesos application master which will register the Mesos scheduler, retrieve the job graph and then launch the task managers accordingly.
+   This starts the Mesos application master which will register the Mesos scheduler, retrieve the job graph and then launch the task managers accordingly. 
 
-In order to run the `mesos-appmaster-job.sh` script you have to define `mesos.master` and `internal.jobgraph-path` in the `flink-conf.yaml`
+In order to run the `mesos-appmaster-job.sh` script you have to define `mesos.master` and `internal.jobgraph-path` in the `flink-conf.yaml` 
 or pass it via `-Dmesos.master=... -Dinterval.jobgraph-path=...` to the Java process.
 
 The job graph file may be generated like this way:
@@ -201,8 +201,11 @@ try (FileOutputStream output = new FileOutputStream(jobGraphFile);
 }
 {% endhighlight %}
 
-Note:
-1. Make sure that all Mesos processes have the user code jar on the classpath (e.g. putting them in the lib directory)
+Note: 
+1. Make sure that all Mesos processes have the user code jar on the classpath. There are two ways:
+    1. One way is putting them in the `lib/` directory, which means the user code jar would be loaded by the system classloader. 
+    1. The other way is making a `usrlib/` directory in the parent directory of `lib/` and putting the user code jar in the `usrlib/`.
+    Then launching job cluster via `bin/mesos-appmaster-job.sh ....` cmd. The user code jar would be loaded by the user code classloader by this way.  
 
 #### General configuration
 
@@ -234,7 +237,7 @@ Here is an example configuration for Marathon:
 
     {
         "id": "flink",
-        "cmd": "$FLINK_HOME/bin/mesos-appmaster.sh -Djobmanager.heap.size=1024m -Djobmanager.rpc.port=6123 -Drest.port=8081 -Dmesos.resourcemanager.tasks.mem=1024 -Dtaskmanager.heap.mb=1024 -Dtaskmanager.numberOfTaskSlots=2 -Dparallelism.default=2 -Dmesos.resourcemanager.tasks.cpus=1",
+        "cmd": "$FLINK_HOME/bin/mesos-appmaster.sh -Djobmanager.heap.size=1024m -Djobmanager.rpc.port=6123 -Drest.port=8081 -Dmesos.resourcemanager.tasks.mem=1024 -Dtaskmanager.heap.size=1024m -Dtaskmanager.numberOfTaskSlots=2 -Dparallelism.default=2 -Dmesos.resourcemanager.tasks.cpus=1",
         "cpus": 1.0,
         "mem": 1024
     }

--- a/docs/ops/deployment/mesos.zh.md
+++ b/docs/ops/deployment/mesos.zh.md
@@ -177,16 +177,16 @@ In contrast to that, the task managers will be run as Mesos tasks in the Mesos c
 
 ### Flink job cluster on Mesos
 
-A Flink job cluster is a dedicated cluster which runs a single job. 
+A Flink job cluster is a dedicated cluster which runs a single job.
 There is no extra job submission needed.
 
-In the `/bin` directory of the Flink distribution, you find one startup script 
+In the `/bin` directory of the Flink distribution, you find one startup script
 which manage the Flink processes in a Mesos cluster:
 
 1. `mesos-appmaster-job.sh`
-   This starts the Mesos application master which will register the Mesos scheduler, retrieve the job graph and then launch the task managers accordingly. 
+   This starts the Mesos application master which will register the Mesos scheduler, retrieve the job graph and then launch the task managers accordingly.
 
-In order to run the `mesos-appmaster-job.sh` script you have to define `mesos.master` and `internal.jobgraph-path` in the `flink-conf.yaml` 
+In order to run the `mesos-appmaster-job.sh` script you have to define `mesos.master` and `internal.jobgraph-path` in the `flink-conf.yaml`
 or pass it via `-Dmesos.master=... -Dinterval.jobgraph-path=...` to the Java process.
 
 The job graph file may be generated like this way:
@@ -237,7 +237,7 @@ Here is an example configuration for Marathon:
 
     {
         "id": "flink",
-        "cmd": "$FLINK_HOME/bin/mesos-appmaster.sh -Djobmanager.heap.size=1024m -Djobmanager.rpc.port=6123 -Drest.port=8081 -Dmesos.resourcemanager.tasks.mem=1024 -Dtaskmanager.heap.size=1024m -Dtaskmanager.numberOfTaskSlots=2 -Dparallelism.default=2 -Dmesos.resourcemanager.tasks.cpus=1",
+        "cmd": "$FLINK_HOME/bin/mesos-appmaster.sh -Djobmanager.heap.size=1024m -Djobmanager.rpc.port=6123 -Drest.port=8081 -Dmesos.resourcemanager.tasks.mem=1024 -Dtaskmanager.heap.mb=1024 -Dtaskmanager.numberOfTaskSlots=2 -Dparallelism.default=2 -Dmesos.resourcemanager.tasks.cpus=1",
         "cpus": 1.0,
         "mem": 1024
     }

--- a/docs/ops/deployment/mesos.zh.md
+++ b/docs/ops/deployment/mesos.zh.md
@@ -177,16 +177,16 @@ In contrast to that, the task managers will be run as Mesos tasks in the Mesos c
 
 ### Flink job cluster on Mesos
 
-A Flink job cluster is a dedicated cluster which runs a single job.
+A Flink job cluster is a dedicated cluster which runs a single job. 
 There is no extra job submission needed.
 
-In the `/bin` directory of the Flink distribution, you find one startup script
+In the `/bin` directory of the Flink distribution, you find one startup script 
 which manage the Flink processes in a Mesos cluster:
 
 1. `mesos-appmaster-job.sh`
-   This starts the Mesos application master which will register the Mesos scheduler, retrieve the job graph and then launch the task managers accordingly.
+   This starts the Mesos application master which will register the Mesos scheduler, retrieve the job graph and then launch the task managers accordingly. 
 
-In order to run the `mesos-appmaster-job.sh` script you have to define `mesos.master` and `internal.jobgraph-path` in the `flink-conf.yaml`
+In order to run the `mesos-appmaster-job.sh` script you have to define `mesos.master` and `internal.jobgraph-path` in the `flink-conf.yaml` 
 or pass it via `-Dmesos.master=... -Dinterval.jobgraph-path=...` to the Java process.
 
 The job graph file may be generated like this way:
@@ -237,7 +237,7 @@ Here is an example configuration for Marathon:
 
     {
         "id": "flink",
-        "cmd": "$FLINK_HOME/bin/mesos-appmaster.sh -Djobmanager.heap.size=1024m -Djobmanager.rpc.port=6123 -Drest.port=8081 -Dmesos.resourcemanager.tasks.mem=1024 -Dtaskmanager.heap.mb=1024 -Dtaskmanager.numberOfTaskSlots=2 -Dparallelism.default=2 -Dmesos.resourcemanager.tasks.cpus=1",
+        "cmd": "$FLINK_HOME/bin/mesos-appmaster.sh -Djobmanager.heap.size=1024m -Djobmanager.rpc.port=6123 -Drest.port=8081 -Dmesos.resourcemanager.tasks.mem=1024 -Dtaskmanager.heap.size=1024m -Dtaskmanager.numberOfTaskSlots=2 -Dparallelism.default=2 -Dmesos.resourcemanager.tasks.cpus=1",
         "cpus": 1.0,
         "mem": 1024
     }

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
 import org.apache.flink.runtime.entrypoint.JobClusterEntrypoint;
 import org.apache.flink.runtime.entrypoint.component.DefaultDispatcherResourceManagerComponentFactory;
 import org.apache.flink.runtime.entrypoint.component.FileJobGraphRetriever;
+import org.apache.flink.runtime.util.ClusterEntrypointUtils;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.JvmShutdownSafeguard;
 import org.apache.flink.runtime.util.SignalHandler;
@@ -100,7 +101,7 @@ public class MesosJobClusterEntrypoint extends JobClusterEntrypoint {
 			new MesosResourceManagerFactory(
 				mesosServices,
 				schedulerConfiguration),
-			FileJobGraphRetriever.createFrom(configuration, null));
+			FileJobGraphRetriever.createFrom(configuration, ClusterEntrypointUtils.tryFindUserLibDirectory().orElse(null)));
 	}
 
 	public static void main(String[] args) {

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosUtils.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosUtils.java
@@ -33,6 +33,8 @@ import org.apache.flink.runtime.clusterframework.overlays.HadoopUserOverlay;
 import org.apache.flink.runtime.clusterframework.overlays.KeytabOverlay;
 import org.apache.flink.runtime.clusterframework.overlays.Krb5ConfOverlay;
 import org.apache.flink.runtime.clusterframework.overlays.SSLStoreOverlay;
+import org.apache.flink.runtime.clusterframework.overlays.UserLibOverlay;
+import org.apache.flink.runtime.util.ClusterEntrypointUtils;
 
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
@@ -143,6 +145,7 @@ public class MesosUtils {
 		// create the overlays that will produce the specification
 		CompositeContainerOverlay overlay = new CompositeContainerOverlay(
 			FlinkDistributionOverlay.newBuilder().fromEnvironment(configuration).build(),
+			UserLibOverlay.newBuilder().setUsrLibDirectory(ClusterEntrypointUtils.tryFindUserLibDirectory().orElse(null)).build(),
 			HadoopConfOverlay.newBuilder().fromEnvironment(configuration).build(),
 			HadoopUserOverlay.newBuilder().fromEnvironment(configuration).build(),
 			KeytabOverlay.newBuilder().fromEnvironment(configuration).build(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlay.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlay.java
@@ -43,13 +43,14 @@ import static org.apache.flink.util.Preconditions.checkState;
  * possible to bypass this overlay and rely on the normal installation method.
  *
  * <p>The following files are copied to the container:
- *  - flink/bin/
- *  - flink/conf/
- *  - flink/lib/
+ *  - bin/
+ *  - conf/
+ *  - lib/
+ *  - plugins/
  */
 public class FlinkDistributionOverlay extends AbstractContainerOverlay {
 
-	static final Path TARGET_ROOT = new Path("flink");
+	static final File TARGET_ROOT = new File(Path.CUR_DIR);
 
 	private final File flinkBinPath;
 	private final File flinkConfPath;
@@ -67,15 +68,19 @@ public class FlinkDistributionOverlay extends AbstractContainerOverlay {
 	@Override
 	public void configure(ContainerSpecification container) throws IOException {
 
-		container.getEnvironmentVariables().put(ENV_FLINK_HOME_DIR, TARGET_ROOT.toString());
+		container.getEnvironmentVariables().put(ENV_FLINK_HOME_DIR, TARGET_ROOT.getName());
 
 		// add the paths to the container specification.
-		addPathRecursively(flinkBinPath, TARGET_ROOT, container);
-		addPathRecursively(flinkConfPath, TARGET_ROOT, container);
-		addPathRecursively(flinkLibPath, TARGET_ROOT, container);
+		addPathRecursively(flinkBinPath, new Path(TARGET_ROOT.getName()), container);
+		addPathRecursively(flinkConfPath, new Path(TARGET_ROOT.getName()), container);
+		addPathRecursively(flinkLibPath, new Path(TARGET_ROOT.getName()), container);
 		if (flinkPluginsPath != null) {
-			addPathRecursively(flinkPluginsPath, TARGET_ROOT, container);
+			addPathRecursively(flinkPluginsPath, new Path(TARGET_ROOT.getName()), container);
 		}
+	}
+
+	public static File getTargetRoot() {
+		return TARGET_ROOT;
 	}
 
 	public static Builder newBuilder() {
@@ -91,7 +96,6 @@ public class FlinkDistributionOverlay extends AbstractContainerOverlay {
 		File flinkLibPath;
 		@Nullable
 		File flinkPluginsPath;
-
 		/**
 		 * Configures the overlay using the current environment.
 		 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlay.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlay.java
@@ -50,7 +50,9 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 public class FlinkDistributionOverlay extends AbstractContainerOverlay {
 
-	static final File TARGET_ROOT = new File(Path.CUR_DIR);
+	static final String TARGET_ROOT_STR = Path.CUR_DIR;
+
+	static final Path TARGET_ROOT = new Path(TARGET_ROOT_STR);
 
 	private final File flinkBinPath;
 	private final File flinkConfPath;
@@ -68,19 +70,15 @@ public class FlinkDistributionOverlay extends AbstractContainerOverlay {
 	@Override
 	public void configure(ContainerSpecification container) throws IOException {
 
-		container.getEnvironmentVariables().put(ENV_FLINK_HOME_DIR, TARGET_ROOT.getName());
+		container.getEnvironmentVariables().put(ENV_FLINK_HOME_DIR, TARGET_ROOT_STR);
 
 		// add the paths to the container specification.
-		addPathRecursively(flinkBinPath, new Path(TARGET_ROOT.getName()), container);
-		addPathRecursively(flinkConfPath, new Path(TARGET_ROOT.getName()), container);
-		addPathRecursively(flinkLibPath, new Path(TARGET_ROOT.getName()), container);
+		addPathRecursively(flinkBinPath, TARGET_ROOT, container);
+		addPathRecursively(flinkConfPath, TARGET_ROOT, container);
+		addPathRecursively(flinkLibPath, TARGET_ROOT, container);
 		if (flinkPluginsPath != null) {
-			addPathRecursively(flinkPluginsPath, new Path(TARGET_ROOT.getName()), container);
+			addPathRecursively(flinkPluginsPath, TARGET_ROOT, container);
 		}
-	}
-
-	public static File getTargetRoot() {
-		return TARGET_ROOT;
 	}
 
 	public static Builder newBuilder() {
@@ -96,6 +94,7 @@ public class FlinkDistributionOverlay extends AbstractContainerOverlay {
 		File flinkLibPath;
 		@Nullable
 		File flinkPluginsPath;
+
 		/**
 		 * Configures the overlay using the current environment.
 		 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/UserLibOverlay.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/UserLibOverlay.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.clusterframework.overlays;
+
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.clusterframework.ContainerSpecification;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Overlays the user library into a container.
+ * The following directory and files in the directory are copied to the container if it exists:
+ *  - {@link ConfigConstants#DEFAULT_FLINK_USR_LIB_DIR}/
+ */
+public class UserLibOverlay extends AbstractContainerOverlay {
+
+	@Nullable
+	private final File usrLibDirectory;
+
+	private UserLibOverlay(@Nullable File usrLibDirectory) {
+		this.usrLibDirectory = usrLibDirectory;
+	}
+
+	@Override
+	public void configure(ContainerSpecification container) throws IOException {
+		if (usrLibDirectory != null) {
+			addPathRecursively(usrLibDirectory, new Path(FlinkDistributionOverlay.getTargetRoot().getName()), container);
+		}
+	}
+
+	public static UserLibOverlay.Builder newBuilder() {
+		return new UserLibOverlay.Builder();
+	}
+
+	/**
+	 * A builder for the {@link UserLibOverlay}.
+	 */
+	public static class Builder {
+
+		@Nullable
+		File usrLibDirectory;
+
+		public UserLibOverlay.Builder setUsrLibDirectory(@Nullable File usrLibDirectory) {
+			this.usrLibDirectory = usrLibDirectory;
+			return this;
+		}
+
+		public UserLibOverlay build() {
+			return new UserLibOverlay(usrLibDirectory);
+		}
+
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/UserLibOverlay.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/UserLibOverlay.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.clusterframework.overlays;
 
 import org.apache.flink.configuration.ConfigConstants;
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
 
 import javax.annotation.Nullable;
@@ -44,7 +43,7 @@ public class UserLibOverlay extends AbstractContainerOverlay {
 	@Override
 	public void configure(ContainerSpecification container) throws IOException {
 		if (usrLibDirectory != null) {
-			addPathRecursively(usrLibDirectory, new Path(FlinkDistributionOverlay.getTargetRoot().getName()), container);
+			addPathRecursively(usrLibDirectory, FlinkDistributionOverlay.TARGET_ROOT, container);
 		}
 	}
 
@@ -58,7 +57,7 @@ public class UserLibOverlay extends AbstractContainerOverlay {
 	public static class Builder {
 
 		@Nullable
-		File usrLibDirectory;
+		private File usrLibDirectory;
 
 		public UserLibOverlay.Builder setUsrLibDirectory(@Nullable File usrLibDirectory) {
 			this.usrLibDirectory = usrLibDirectory;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlayTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/FlinkDistributionOverlayTest.java
@@ -41,6 +41,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
+/**
+ * Test {@link FlinkDistributionOverlay}.
+ */
 public class FlinkDistributionOverlayTest extends ContainerOverlayTestBase {
 
 	@Rule
@@ -83,7 +86,7 @@ public class FlinkDistributionOverlayTest extends ContainerOverlayTestBase {
 		overlay.configure(containerSpecification);
 
 		for (Path file : files) {
-			checkArtifact(containerSpecification, new Path(TARGET_ROOT, file.toString()));
+			checkArtifact(containerSpecification, new Path(TARGET_ROOT.getName(), file.toString()));
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/UserLibOverlayTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/UserLibOverlayTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.clusterframework.overlays;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.clusterframework.ContainerSpecification;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+
+import static org.apache.flink.configuration.ConfigConstants.DEFAULT_FLINK_USR_LIB_DIR;
+
+/**
+ * Test {@link UserLibOverlay}.
+ */
+public class UserLibOverlayTest extends ContainerOverlayTestBase {
+
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+
+	@Test
+	public void testConfigure() throws Exception {
+		final File userLibFolder = tempFolder.newFolder(DEFAULT_FLINK_USR_LIB_DIR);
+
+		final Path[] files = createPaths(
+			tempFolder.getRoot(),
+			"usrlib/job_a.jar",
+			"usrlib/lib/dep1.jar",
+			"usrlib/lib/dep2.jar");
+
+		final ContainerSpecification containerSpecification = new ContainerSpecification();
+		final UserLibOverlay overlay = UserLibOverlay.newBuilder().setUsrLibDirectory(userLibFolder).build();
+		overlay.configure(containerSpecification);
+
+		for (Path file : files) {
+			checkArtifact(containerSpecification, new Path(FlinkDistributionOverlay.getTargetRoot().getName(), file.toString()));
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/UserLibOverlayTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/UserLibOverlayTest.java
@@ -52,7 +52,7 @@ public class UserLibOverlayTest extends ContainerOverlayTestBase {
 		overlay.configure(containerSpecification);
 
 		for (Path file : files) {
-			checkArtifact(containerSpecification, new Path(FlinkDistributionOverlay.getTargetRoot().getName(), file.toString()));
+			checkArtifact(containerSpecification, new Path(FlinkDistributionOverlay.TARGET_ROOT, file.toString()));
 		}
 	}
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request makes MesosJobClusterEntrypoint could use the user code classloader if the user puts the user code jar in the `usrlib`.
## Brief change log

  - The `MesosJobClusterEntrypoint` tries to add the jars in the `usrlib` to the user classpath if the directory exists.
  - Add `UserLibOverlay` using to overlay the `usrlib` directory to a container.

## Verifying this change

This change added tests and can be verified as follows:
  - *Manually verified the Mesos perjob mode could use the user code classloader*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
