### PR TITLE
[FLINK-14811][runtime] Replace Java Streams in input check methods with for-loops

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -50,7 +50,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -61,7 +60,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.IntStream;
 
 import static org.apache.flink.runtime.execution.ExecutionState.FINISHED;
 
@@ -804,13 +802,37 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 	 * @return whether the input constraint is satisfied
 	 */
 	boolean checkInputDependencyConstraints() {
-		if (getInputDependencyConstraint() == InputDependencyConstraint.ANY) {
-			// InputDependencyConstraint == ANY
-			return IntStream.range(0, inputEdges.length).anyMatch(this::isInputConsumable);
-		} else {
-			// InputDependencyConstraint == ALL
-			return IntStream.range(0, inputEdges.length).allMatch(this::isInputConsumable);
+		if (inputEdges.length == 0) {
+			return true;
 		}
+
+		final InputDependencyConstraint inputDependencyConstraint = getInputDependencyConstraint();
+		switch (inputDependencyConstraint) {
+			case ANY:
+				return isAnyInputConsumable();
+			case ALL:
+				return areAllInputsConsumable();
+			default:
+				throw new IllegalStateException("Unknown InputDependencyConstraint " + inputDependencyConstraint);
+		}
+	}
+
+	private boolean isAnyInputConsumable() {
+		for (int inputNumber = 0; inputNumber < inputEdges.length; inputNumber++) {
+			if (isInputConsumable(inputNumber)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private boolean areAllInputsConsumable() {
+		for (int inputNumber = 0; inputNumber < inputEdges.length; inputNumber++) {
+			if (!isInputConsumable(inputNumber)) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	/**
@@ -822,8 +844,12 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 	 * @return whether the input is consumable
 	 */
 	boolean isInputConsumable(int inputNumber) {
-		return Arrays.stream(inputEdges[inputNumber]).map(ExecutionEdge::getSource).anyMatch(
-				IntermediateResultPartition::isConsumable);
+		for (ExecutionEdge executionEdge : inputEdges[inputNumber]) {
+			if (executionEdge.getSource().isConsumable()) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/InputDependencyConstraintChecker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/InputDependencyConstraintChecker.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.InputDependencyConstraint;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
-import org.apache.flink.util.IterableUtils;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 
@@ -34,8 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.flink.api.common.InputDependencyConstraint.ALL;
-import static org.apache.flink.api.common.InputDependencyConstraint.ANY;
 import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.BLOCKING;
 
 /**
@@ -46,13 +43,18 @@ public class InputDependencyConstraintChecker {
 		new SchedulingIntermediateDataSetManager();
 
 	public boolean check(final SchedulingExecutionVertex<?, ?> schedulingExecutionVertex) {
+		if (Iterables.isEmpty(schedulingExecutionVertex.getConsumedResults())) {
+			return true;
+		}
+
 		final InputDependencyConstraint inputConstraint = schedulingExecutionVertex.getInputDependencyConstraint();
-		if (Iterables.isEmpty(schedulingExecutionVertex.getConsumedResults()) || ALL.equals(inputConstraint)) {
-			return checkAll(schedulingExecutionVertex);
-		} else if (ANY.equals(inputConstraint)) {
-			return checkAny(schedulingExecutionVertex);
-		} else {
-			throw new IllegalArgumentException();
+		switch (inputConstraint) {
+			case ANY:
+				return checkAny(schedulingExecutionVertex);
+			case ALL:
+				return checkAll(schedulingExecutionVertex);
+			default:
+				throw new IllegalStateException("Unknown InputDependencyConstraint " + inputConstraint);
 		}
 	}
 
@@ -69,13 +71,21 @@ public class InputDependencyConstraintChecker {
 	}
 
 	private boolean checkAll(final SchedulingExecutionVertex<?, ?> schedulingExecutionVertex) {
-		return IterableUtils.toStream(schedulingExecutionVertex.getConsumedResults())
-			.allMatch(this::partitionConsumable);
+		for (SchedulingResultPartition<?, ?> consumedResultPartition : schedulingExecutionVertex.getConsumedResults()) {
+			if (!partitionConsumable(consumedResultPartition)) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	private boolean checkAny(final SchedulingExecutionVertex<?, ?> schedulingExecutionVertex) {
-		return IterableUtils.toStream(schedulingExecutionVertex.getConsumedResults())
-			.anyMatch(this::partitionConsumable);
+		for (SchedulingResultPartition<?, ?> consumedResultPartition : schedulingExecutionVertex.getConsumedResults()) {
+			if (partitionConsumable(consumedResultPartition)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private boolean partitionConsumable(SchedulingResultPartition<?, ?> partition) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/LazyFromSourcesSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/LazyFromSourcesSchedulingStrategy.java
@@ -142,7 +142,7 @@ public class LazyFromSourcesSchedulingStrategy implements SchedulingStrategy {
 
 		schedulerOperations.allocateSlotsAndDeploy(
 			IterableUtils.toStream(vertices)
-				.filter(isInputConstraintSatisfied().and(IS_IN_CREATED_EXECUTION_STATE))
+				.filter(IS_IN_CREATED_EXECUTION_STATE.and(isInputConstraintSatisfied()))
 				.map(SchedulingExecutionVertex::getId)
 				.map(executionVertexID -> new ExecutionVertexDeploymentOption(
 					executionVertexID,


### PR DESCRIPTION

## What is the purpose of the change

Vertex input checking is invoked in lazily triggered scheduling by a FINISHED vertex state update RPC or a scheduleOrUpdateConsumers RPC.
Java Streams is used in it, but it should be avoided since it is performance critical code. 
This PR is to refactor these Java Streams to improve the performance, for both legacy scheduler and NG schedulers.

## Brief change log

  - *Replaced Java Streams in input check methods with for-loops*


## Verifying this change

This change is already covered by existing tests, such as InputDependencyConstraintCheckerTest and ExecutionVertexInputConstraintTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
