### PR TITLE
[FLINK-14822][runtime] Increase number of restarts in StreamingFileSinkProgram…

### DIFF
--- a/flink-end-to-end-tests/flink-streaming-file-sink-test/src/main/java/StreamingFileSinkProgram.java
+++ b/flink-end-to-end-tests/flink-streaming-file-sink-test/src/main/java/StreamingFileSinkProgram.java
@@ -58,7 +58,7 @@ public enum StreamingFileSinkProgram {
 
 		env.setParallelism(4);
 		env.enableCheckpointing(5000L);
-		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, Time.of(10L, TimeUnit.SECONDS)));
+		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, Time.of(10L, TimeUnit.SECONDS)));
 
 		final StreamingFileSink<Tuple2<Integer, Integer>> sink = StreamingFileSink
 			.forRowFormat(new Path(outputPath), (Encoder<Tuple2<Integer, Integer>>) (element, stream) -> {


### PR DESCRIPTION
## What is the purpose of the change

*This increases the number of restarts in StreamingFileSinkProgram.*


## Brief change log

  - *Increase number of restarts in StreamingFileSinkProgram*

## Verifying this change


This change is already covered by existing tests, such as *nightlies*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
