### PR TITLE
[Flink-14599][table-planner-blink] Support precision of TimestampType in blink planner

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TimestampType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TimestampType.java
@@ -58,7 +58,8 @@ public final class TimestampType extends LogicalType {
 
 	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
 		java.sql.Timestamp.class.getName(),
-		java.time.LocalDateTime.class.getName());
+		java.time.LocalDateTime.class.getName(),
+		"org.apache.flink.table.dataformat.SqlTimestamp");
 
 	private static final Class<?> DEFAULT_CONVERSION = java.time.LocalDateTime.class;
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverter.java
@@ -37,6 +37,7 @@ import org.apache.flink.table.planner.expressions.RexNodeExpression;
 import org.apache.flink.table.planner.expressions.converter.CallExpressionConvertRule.ConvertContext;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.TimestampType;
 
 import org.apache.calcite.avatica.util.DateTimeUtils;
 import org.apache.calcite.avatica.util.TimeUnit;
@@ -54,6 +55,8 @@ import org.apache.calcite.util.TimestampString;
 import org.apache.calcite.util.TimestampWithTimeZoneString;
 
 import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
@@ -135,8 +138,24 @@ public class ExpressionConverter implements ExpressionVisitor<RexNode> {
 				return relBuilder.getRexBuilder().makeTimeLiteral(TimeString.fromCalendarFields(
 						valueAsCalendar(extractValue(valueLiteral, java.sql.Time.class))), 0);
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
-				return relBuilder.getRexBuilder().makeTimestampLiteral(TimestampString.fromCalendarFields(
-						valueAsCalendar(extractValue(valueLiteral, java.sql.Timestamp.class))), 3);
+				TimestampType timestampType = (TimestampType) type;
+				Class<?> clazz = valueLiteral.getOutputDataType().getConversionClass();
+				LocalDateTime datetime = null;
+				if (clazz == LocalDateTime.class) {
+					datetime = extractValue(valueLiteral, LocalDateTime.class);
+				} else if (clazz == Timestamp.class) {
+					datetime = extractValue(valueLiteral, Timestamp.class).toLocalDateTime();
+				} else {
+					throw new TableException(String.format("Invalid literal of %s.", clazz.getCanonicalName()));
+				}
+				return relBuilder.getRexBuilder().makeTimestampLiteral(
+					new TimestampString(
+						datetime.getYear(),
+						datetime.getMonthValue(),
+						datetime.getDayOfMonth(),
+						datetime.getHour(),
+						datetime.getMinute(),
+						datetime.getSecond()).withNanos(datetime.getNano()), timestampType.getPrecision());
 			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
 				TimeZone timeZone = TimeZone.getTimeZone(((FlinkContext) ((FlinkRelBuilder) this.relBuilder)
 						.getCluster().getPlanner().getContext()).getTableConfig().getLocalTimeZone());

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverter.java
@@ -55,7 +55,6 @@ import org.apache.calcite.util.TimestampString;
 import org.apache.calcite.util.TimestampWithTimeZoneString;
 
 import java.math.BigDecimal;
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -139,15 +138,7 @@ public class ExpressionConverter implements ExpressionVisitor<RexNode> {
 						valueAsCalendar(extractValue(valueLiteral, java.sql.Time.class))), 0);
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
 				TimestampType timestampType = (TimestampType) type;
-				Class<?> clazz = valueLiteral.getOutputDataType().getConversionClass();
-				LocalDateTime datetime = null;
-				if (clazz == LocalDateTime.class) {
-					datetime = extractValue(valueLiteral, LocalDateTime.class);
-				} else if (clazz == Timestamp.class) {
-					datetime = extractValue(valueLiteral, Timestamp.class).toLocalDateTime();
-				} else {
-					throw new TableException(String.format("Invalid literal of %s.", clazz.getCanonicalName()));
-				}
+				LocalDateTime datetime = extractValue(valueLiteral, LocalDateTime.class);
 				return relBuilder.getRexBuilder().makeTimestampLiteral(
 					new TimestampString(
 						datetime.getYear(),

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LeadLagAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LeadLagAggFunction.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.runtime.operators.over.frame.OffsetOverFrame;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
 
 import static org.apache.flink.table.expressions.utils.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.planner.expressions.ExpressionBuilder.cast;
@@ -279,13 +280,16 @@ public abstract class LeadLagAggFunction extends DeclarativeAggregateFunction {
 	 */
 	public static class TimestampLeadLagAggFunction extends LeadLagAggFunction {
 
-		public TimestampLeadLagAggFunction(int operandCount) {
+		private final TimestampType type;
+
+		public TimestampLeadLagAggFunction(int operandCount, TimestampType type) {
 			super(operandCount);
+			this.type = type;
 		}
 
 		@Override
 		public DataType getResultType() {
-			return DataTypes.TIMESTAMP(3);
+			return DataTypes.TIMESTAMP(type.getPrecision());
 		}
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MaxAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MaxAggFunction.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
 
 import static org.apache.flink.table.expressions.utils.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.planner.expressions.ExpressionBuilder.greaterThan;
@@ -212,9 +213,16 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Timestamp Max aggregate function.
 	 */
 	public static class TimestampMaxAggFunction extends MaxAggFunction {
+
+		private final TimestampType type;
+
+		public TimestampMaxAggFunction(TimestampType type) {
+			this.type = type;
+		}
+
 		@Override
 		public DataType getResultType() {
-			return DataTypes.TIMESTAMP(3);
+			return DataTypes.TIMESTAMP(type.getPrecision());
 		}
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MinAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MinAggFunction.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
 
 import static org.apache.flink.table.expressions.utils.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.planner.expressions.ExpressionBuilder.ifThenElse;
@@ -212,9 +213,16 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Timestamp Min aggregate function.
 	 */
 	public static class TimestampMinAggFunction extends MinAggFunction {
+
+		private final TimestampType type;
+
+		public TimestampMinAggFunction(TimestampType type) {
+			this.type = type;
+		}
+
 		@Override
 		public DataType getResultType() {
-			return DataTypes.TIMESTAMP(3);
+			return DataTypes.TIMESTAMP(type.getPrecision());
 		}
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/SingleValueAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/SingleValueAggFunction.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
 
 import java.util.Arrays;
 
@@ -284,9 +285,15 @@ public abstract class SingleValueAggFunction extends DeclarativeAggregateFunctio
 
 		private static final long serialVersionUID = 320495723666949978L;
 
+		private final TimestampType type;
+
+		public TimestampSingleValueAggFunction(TimestampType type) {
+			this.type = type;
+		}
+
 		@Override
 		public DataType getResultType() {
-			return DataTypes.TIMESTAMP(3);
+			return DataTypes.TIMESTAMP(type.getPrecision());
 		}
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -647,7 +647,7 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 	public static final SqlFunction TO_TIMESTAMP = new SqlFunction(
 		"TO_TIMESTAMP",
 		SqlKind.OTHER_FUNCTION,
-		ReturnTypes.cascade(ReturnTypes.explicit(SqlTypeName.TIMESTAMP), SqlTypeTransforms.FORCE_NULLABLE),
+		ReturnTypes.cascade(ReturnTypes.explicit(SqlTypeName.TIMESTAMP, 3), SqlTypeTransforms.FORCE_NULLABLE),
 		null,
 		OperandTypes.or(
 			OperandTypes.family(SqlTypeFamily.CHARACTER),

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -644,6 +644,9 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 		OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.INTEGER),
 		SqlFunctionCategory.STRING);
 
+	// TODO: the return type of TO_TIMESTAMP should be TIMESTAMP(9)
+	//  but conversion of DataType and TypeInformation only support TIMESTAMP(3) now.
+	//  change to TIMESTAMP(9) when FLINK-14645 is fixed.
 	public static final SqlFunction TO_TIMESTAMP = new SqlFunction(
 		"TO_TIMESTAMP",
 		SqlKind.OTHER_FUNCTION,

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -647,6 +647,7 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 	// TODO: the return type of TO_TIMESTAMP should be TIMESTAMP(9)
 	//  but conversion of DataType and TypeInformation only support TIMESTAMP(3) now.
 	//  change to TIMESTAMP(9) when FLINK-14645 is fixed.
+	//  https://issues.apache.org/jira/browse/FLINK-14925
 	public static final SqlFunction TO_TIMESTAMP = new SqlFunction(
 		"TO_TIMESTAMP",
 		SqlKind.OTHER_FUNCTION,

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/ProctimeMaterializeSqlFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/ProctimeMaterializeSqlFunction.java
@@ -42,7 +42,7 @@ public class ProctimeMaterializeSqlFunction extends SqlFunction {
 			"PROCTIME_MATERIALIZE",
 			SqlKind.OTHER_FUNCTION,
 			ReturnTypes.cascade(
-					ReturnTypes.explicit(SqlTypeName.TIMESTAMP),
+					ReturnTypes.explicit(SqlTypeName.TIMESTAMP, 3),
 					SqlTypeTransforms.TO_NULLABLE),
 			InferTypes.RETURN_TYPE,
 			OperandTypes.family(SqlTypeFamily.TIMESTAMP),

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
@@ -133,7 +133,7 @@ class FlinkTypeFactory(typeSystem: RelDataTypeSystem) extends JavaTypeFactoryImp
         timestampType.getKind match {
           case TimestampKind.PROCTIME => createProctimeIndicatorType(true)
           case TimestampKind.ROWTIME => createRowtimeIndicatorType(true)
-          case TimestampKind.REGULAR => createSqlType(TIMESTAMP)
+          case TimestampKind.REGULAR => createSqlType(TIMESTAMP, timestampType.getPrecision)
         }
       case _ =>
         seenTypes.get(t) match {
@@ -424,11 +424,12 @@ object FlinkTypeFactory {
         // blink runner support precision 3, but for consistent with flink runner, we set to 0.
         new TimeType()
       case TIMESTAMP =>
-        if (relDataType.getPrecision > 3) {
+        val precision = relDataType.getPrecision
+        if (precision > TimestampType.MAX_PRECISION || precision < TimestampType.MIN_PRECISION) {
           throw new TableException(
-            s"TIMESTAMP precision is not supported: ${relDataType.getPrecision}")
+            s"TIMESTAMP precision is not supported: $precision")
         }
-        new TimestampType(3)
+        new TimestampType(precision)
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
         if (relDataType.getPrecision > 3) {
           throw new TableException(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
@@ -424,12 +424,7 @@ object FlinkTypeFactory {
         // blink runner support precision 3, but for consistent with flink runner, we set to 0.
         new TimeType()
       case TIMESTAMP =>
-        val precision = relDataType.getPrecision
-        if (precision > TimestampType.MAX_PRECISION || precision < TimestampType.MIN_PRECISION) {
-          throw new TableException(
-            s"TIMESTAMP precision is not supported: $precision")
-        }
-        new TimestampType(precision)
+        new TimestampType(relDataType.getPrecision)
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
         if (relDataType.getPrecision > 3) {
           throw new TableException(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeSystem.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeSystem.scala
@@ -19,8 +19,7 @@
 package org.apache.flink.table.planner.calcite
 
 import org.apache.flink.table.runtime.typeutils.TypeCheckUtils
-import org.apache.flink.table.types.logical.{DecimalType, LogicalType}
-
+import org.apache.flink.table.types.logical.{DecimalType, LogicalType, TimestampType}
 import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeFactory, RelDataTypeSystemImpl}
 import org.apache.calcite.sql.`type`.{SqlTypeName, SqlTypeUtil}
 
@@ -41,8 +40,12 @@ class FlinkTypeSystem extends RelDataTypeSystemImpl {
     case SqlTypeName.VARCHAR | SqlTypeName.VARBINARY =>
       Int.MaxValue
 
-    // we currently support only timestamps with milliseconds precision
-    case SqlTypeName.TIMESTAMP | SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
+    // by default we support timestamp with microseconds precision (Timestamp(6))
+    case SqlTypeName.TIMESTAMP =>
+      TimestampType.DEFAULT_PRECISION
+
+    // we currently support only timestamp with local time zone with milliseconds precision
+    case SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
       3
 
     case _ =>
@@ -52,6 +55,10 @@ class FlinkTypeSystem extends RelDataTypeSystemImpl {
   override def getMaxPrecision(typeName: SqlTypeName): Int = typeName match {
     case SqlTypeName.VARCHAR | SqlTypeName.CHAR | SqlTypeName.VARBINARY | SqlTypeName.BINARY =>
       Int.MaxValue
+
+    // The maximum precision of TIMESTAMP is 3 in Calcite,
+    // change it to 9 to support nanoseconds precision
+    case SqlTypeName.TIMESTAMP => TimestampType.MAX_PRECISION
 
     case _ =>
       super.getMaxPrecision(typeName)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -592,14 +592,11 @@ object CodeGenUtils {
     case TINYINT => s"$arrayTerm.setNullByte($index)"
     case SMALLINT => s"$arrayTerm.setNullShort($index)"
     case INTEGER => s"$arrayTerm.setNullInt($index)"
-    case BIGINT => s"$arrayTerm.setNullLong($index)"
     case FLOAT => s"$arrayTerm.setNullFloat($index)"
     case DOUBLE => s"$arrayTerm.setNullDouble($index)"
     case TIME_WITHOUT_TIME_ZONE => s"$arrayTerm.setNullInt($index)"
     case DATE => s"$arrayTerm.setNullInt($index)"
-    case TIMESTAMP_WITH_LOCAL_TIME_ZONE => s"$arrayTerm.setNullLong($index)"
     case INTERVAL_YEAR_MONTH => s"$arrayTerm.setNullInt($index)"
-    case INTERVAL_DAY_TIME => s"$arrayTerm.setNullLong($index)"
     case _ => s"$arrayTerm.setNullLong($index)"
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -520,6 +520,8 @@ object CodeGenUtils {
   def binaryRowSetNull(indexTerm: String, rowTerm: String, t: LogicalType): String = t match {
     case d: DecimalType if !Decimal.isCompact(d.getPrecision) =>
       s"$rowTerm.setDecimal($indexTerm, null, ${d.getPrecision})"
+    case d: TimestampType if !SqlTimestamp.isCompact(d.getPrecision) =>
+      s"$rowTerm.setTimestamp($indexTerm, null, ${d.getPrecision})"
     case _ => s"$rowTerm.setNullAt($indexTerm)"
   }
 
@@ -611,6 +613,8 @@ object CodeGenUtils {
       t: LogicalType): String = t match {
     case d: DecimalType if !Decimal.isCompact(d.getPrecision) =>
       s"$writerTerm.writeDecimal($indexTerm, null, ${d.getPrecision})"
+    case d: TimestampType if !SqlTimestamp.isCompact(d.getPrecision) =>
+      s"$writerTerm.writeTimestamp($indexTerm, null, ${d.getPrecision})"
     case _ => s"$writerTerm.setNullAt($indexTerm)"
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -97,6 +97,8 @@ object CodeGenUtils {
 
   val STRING_UTIL: String = className[BinaryStringUtil]
 
+  val SQL_TIMESTAMP: String = className[SqlTimestamp]
+
   // ----------------------------------------------------------------------------------------
 
   private val nameCounter = new AtomicInteger
@@ -133,7 +135,7 @@ object CodeGenUtils {
 
     case DATE => "int"
     case TIME_WITHOUT_TIME_ZONE => "int"
-    case TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE => "long"
+    case TIMESTAMP_WITH_LOCAL_TIME_ZONE => "long"
     case INTERVAL_YEAR_MONTH => "int"
     case INTERVAL_DAY_TIME => "long"
 
@@ -151,7 +153,7 @@ object CodeGenUtils {
 
     case DATE => className[JInt]
     case TIME_WITHOUT_TIME_ZONE => className[JInt]
-    case TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE => className[JLong]
+    case TIMESTAMP_WITH_LOCAL_TIME_ZONE => className[JLong]
     case INTERVAL_YEAR_MONTH => className[JInt]
     case INTERVAL_DAY_TIME => className[JLong]
 
@@ -162,6 +164,7 @@ object CodeGenUtils {
     case ARRAY => className[BaseArray]
     case MULTISET | MAP => className[BaseMap]
     case ROW => className[BaseRow]
+    case TIMESTAMP_WITHOUT_TIME_ZONE => className[SqlTimestamp]
 
     case RAW => className[BinaryGeneric[_]]
   }
@@ -190,7 +193,7 @@ object CodeGenUtils {
     case VARCHAR | CHAR => s"$BINARY_STRING.EMPTY_UTF8"
 
     case DATE | TIME_WITHOUT_TIME_ZONE => "-1"
-    case TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE => "-1L"
+    case TIMESTAMP_WITH_LOCAL_TIME_ZONE => "-1L"
     case INTERVAL_YEAR_MONTH => "-1"
     case INTERVAL_DAY_TIME => "-1L"
 
@@ -223,7 +226,8 @@ object CodeGenUtils {
     case DECIMAL => s"$term.hashCode()"
     case DATE => s"${className[JInt]}.hashCode($term)"
     case TIME_WITHOUT_TIME_ZONE => s"${className[JInt]}.hashCode($term)"
-    case TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
+    case TIMESTAMP_WITHOUT_TIME_ZONE => s"$term.hashCode()"
+    case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
       s"${className[JLong]}.hashCode($term)"
     case INTERVAL_YEAR_MONTH => s"${className[JInt]}.hashCode($term)"
     case INTERVAL_DAY_TIME => s"${className[JLong]}.hashCode($term)"
@@ -414,8 +418,10 @@ object CodeGenUtils {
       // temporal types
       case DATE => s"$rowTerm.getInt($indexTerm)"
       case TIME_WITHOUT_TIME_ZONE => s"$rowTerm.getInt($indexTerm)"
-      case TIMESTAMP_WITHOUT_TIME_ZONE |
-           TIMESTAMP_WITH_LOCAL_TIME_ZONE => s"$rowTerm.getLong($indexTerm)"
+      case TIMESTAMP_WITHOUT_TIME_ZONE =>
+        val dt = t.asInstanceOf[TimestampType]
+        s"$rowTerm.getTimestamp($indexTerm, ${dt.getPrecision})"
+      case TIMESTAMP_WITH_LOCAL_TIME_ZONE => s"$rowTerm.getLong($indexTerm)"
       case INTERVAL_YEAR_MONTH => s"$rowTerm.getInt($indexTerm)"
       case INTERVAL_DAY_TIME => s"$rowTerm.getLong($indexTerm)"
 
@@ -539,8 +545,10 @@ object CodeGenUtils {
       case BOOLEAN => s"$binaryRowTerm.setBoolean($index, $fieldValTerm)"
       case DATE =>  s"$binaryRowTerm.setInt($index, $fieldValTerm)"
       case TIME_WITHOUT_TIME_ZONE =>  s"$binaryRowTerm.setInt($index, $fieldValTerm)"
-      case TIMESTAMP_WITHOUT_TIME_ZONE |
-           TIMESTAMP_WITH_LOCAL_TIME_ZONE => s"$binaryRowTerm.setLong($index, $fieldValTerm)"
+      case TIMESTAMP_WITHOUT_TIME_ZONE =>
+        val dt = t.asInstanceOf[TimestampType]
+        s"$binaryRowTerm.setTimestamp($index, $fieldValTerm, ${dt.getPrecision})"
+      case TIMESTAMP_WITH_LOCAL_TIME_ZONE => s"$binaryRowTerm.setLong($index, $fieldValTerm)"
       case INTERVAL_YEAR_MONTH =>  s"$binaryRowTerm.setInt($index, $fieldValTerm)"
       case INTERVAL_DAY_TIME =>  s"$binaryRowTerm.setLong($index, $fieldValTerm)"
       case DECIMAL =>
@@ -568,8 +576,7 @@ object CodeGenUtils {
       case BOOLEAN => s"$rowTerm.setBoolean($indexTerm, $fieldTerm)"
       case DATE =>  s"$rowTerm.setInt($indexTerm, $fieldTerm)"
       case TIME_WITHOUT_TIME_ZONE =>  s"$rowTerm.setInt($indexTerm, $fieldTerm)"
-      case TIMESTAMP_WITHOUT_TIME_ZONE |
-           TIMESTAMP_WITH_LOCAL_TIME_ZONE => s"$rowTerm.setLong($indexTerm, $fieldTerm)"
+      case TIMESTAMP_WITH_LOCAL_TIME_ZONE => s"$rowTerm.setLong($indexTerm, $fieldTerm)"
       case INTERVAL_YEAR_MONTH => s"$rowTerm.setInt($indexTerm, $fieldTerm)"
       case INTERVAL_DAY_TIME => s"$rowTerm.setLong($indexTerm, $fieldTerm)"
       case _ => s"$rowTerm.setNonPrimitiveValue($indexTerm, $fieldTerm)"
@@ -590,8 +597,7 @@ object CodeGenUtils {
     case DOUBLE => s"$arrayTerm.setNullDouble($index)"
     case TIME_WITHOUT_TIME_ZONE => s"$arrayTerm.setNullInt($index)"
     case DATE => s"$arrayTerm.setNullInt($index)"
-    case TIMESTAMP_WITHOUT_TIME_ZONE |
-         TIMESTAMP_WITH_LOCAL_TIME_ZONE => s"$arrayTerm.setNullLong($index)"
+    case TIMESTAMP_WITH_LOCAL_TIME_ZONE => s"$arrayTerm.setNullLong($index)"
     case INTERVAL_YEAR_MONTH => s"$arrayTerm.setNullInt($index)"
     case INTERVAL_DAY_TIME => s"$arrayTerm.setNullLong($index)"
     case _ => s"$arrayTerm.setNullLong($index)"
@@ -640,8 +646,10 @@ object CodeGenUtils {
         s"$writerTerm.writeDecimal($indexTerm, $fieldValTerm, ${dt.getPrecision})"
       case DATE => s"$writerTerm.writeInt($indexTerm, $fieldValTerm)"
       case TIME_WITHOUT_TIME_ZONE => s"$writerTerm.writeInt($indexTerm, $fieldValTerm)"
-      case TIMESTAMP_WITHOUT_TIME_ZONE |
-           TIMESTAMP_WITH_LOCAL_TIME_ZONE => s"$writerTerm.writeLong($indexTerm, $fieldValTerm)"
+      case TIMESTAMP_WITHOUT_TIME_ZONE =>
+        val dt = t.asInstanceOf[TimestampType]
+        s"$writerTerm.writeTimestamp($indexTerm, $fieldValTerm, ${dt.getPrecision})"
+      case TIMESTAMP_WITH_LOCAL_TIME_ZONE => s"$writerTerm.writeLong($indexTerm, $fieldValTerm)"
       case INTERVAL_YEAR_MONTH => s"$writerTerm.writeInt($indexTerm, $fieldValTerm)"
       case INTERVAL_DAY_TIME => s"$writerTerm.writeLong($indexTerm, $fieldValTerm)"
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
@@ -410,7 +410,8 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
     val fieldTerm = s"timestamp"
     val field =
       s"""
-         |final long $fieldTerm = java.lang.System.currentTimeMillis();
+         |final $SQL_TIMESTAMP $fieldTerm =
+         |  $SQL_TIMESTAMP.fromEpochMillis(java.lang.System.currentTimeMillis());
          |""".stripMargin
     reusablePerRecordStatements.add(field)
     fieldTerm
@@ -431,7 +432,7 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
     // adopted from org.apache.calcite.runtime.SqlFunctions.currentTime()
     val field =
       s"""
-         |$fieldTerm = (int) ($timestamp % ${DateTimeUtils.MILLIS_PER_DAY});
+         |$fieldTerm = (int) ($timestamp.getMillisecond() % ${DateTimeUtils.MILLIS_PER_DAY});
          |if (time < 0) {
          |  time += ${DateTimeUtils.MILLIS_PER_DAY};
          |}
@@ -449,12 +450,14 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
     val timestamp = addReusableTimestamp()
 
     // declaration
-    reusableMemberStatements.add(s"private long $fieldTerm;")
+    reusableMemberStatements.add(s"private $SQL_TIMESTAMP $fieldTerm;")
 
     // assignment
     val field =
       s"""
-         |$fieldTerm = $timestamp + java.util.TimeZone.getDefault().getOffset($timestamp);
+         |$fieldTerm = $SQL_TIMESTAMP.fromEpochMillis(
+         |  $timestamp.getMillisecond() +
+         |  java.util.TimeZone.getDefault().getOffset($timestamp.getMillisecond()));
          |""".stripMargin
     reusablePerRecordStatements.add(field)
     fieldTerm
@@ -475,7 +478,7 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
     // adopted from org.apache.calcite.runtime.SqlFunctions.localTime()
     val field =
     s"""
-       |$fieldTerm = (int) ($localtimestamp % ${DateTimeUtils.MILLIS_PER_DAY});
+       |$fieldTerm = (int) ($localtimestamp.getMillisecond() % ${DateTimeUtils.MILLIS_PER_DAY});
        |""".stripMargin
     reusablePerRecordStatements.add(field)
     fieldTerm
@@ -497,7 +500,7 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
     // adopted from org.apache.calcite.runtime.SqlFunctions.currentDate()
     val field =
       s"""
-         |$fieldTerm = (int) ($timestamp / ${DateTimeUtils.MILLIS_PER_DAY});
+         |$fieldTerm = (int) ($timestamp.getMillisecond() / ${DateTimeUtils.MILLIS_PER_DAY});
          |if ($time < 0) {
          |  $fieldTerm -= 1;
          |}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
@@ -37,10 +37,10 @@ import org.apache.flink.table.runtime.typeutils.TypeCheckUtils
 import org.apache.flink.table.runtime.typeutils.TypeCheckUtils.{isNumeric, isTemporal, isTimeInterval}
 import org.apache.flink.table.types.logical._
 import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
-
 import org.apache.calcite.rex._
 import org.apache.calcite.sql.SqlOperator
 import org.apache.calcite.sql.`type`.{ReturnTypes, SqlTypeName}
+import org.apache.calcite.util.TimestampString
 
 import scala.collection.JavaConversions._
 
@@ -388,7 +388,12 @@ class ExprCodeGenerator(ctx: CodeGeneratorContext, nullableInput: Boolean)
 
   override def visitLiteral(literal: RexLiteral): GeneratedExpression = {
     val resultType = FlinkTypeFactory.toLogicalType(literal.getType)
-    val value = literal.getValue3
+    val value = resultType.getTypeRoot match {
+      case LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE =>
+        literal.getValueAs(classOf[TimestampString])
+      case _ =>
+        literal.getValue3
+    }
     generateLiteral(ctx, resultType, value)
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
@@ -33,11 +33,10 @@ import org.apache.flink.table.types.logical.RowType
 import org.apache.calcite.avatica.util.ByteString
 import org.apache.calcite.rex.{RexBuilder, RexExecutor, RexNode}
 import org.apache.calcite.sql.`type`.SqlTypeName
+import org.apache.calcite.util.TimestampString
 import org.apache.commons.lang3.StringEscapeUtils
 import java.io.File
 import java.util.TimeZone
-
-import org.apache.calcite.util.TimestampString
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
@@ -23,19 +23,17 @@ import org.apache.flink.configuration.Configuration
 import org.apache.flink.metrics.MetricGroup
 import org.apache.flink.table.api.{TableConfig, TableException}
 import org.apache.flink.table.dataformat.BinaryStringUtil.safeToString
-import org.apache.flink.table.dataformat.{BinaryString, Decimal, GenericRow}
+import org.apache.flink.table.dataformat.{BinaryString, Decimal, GenericRow, SqlTimestamp}
 import org.apache.flink.table.functions.{FunctionContext, UserDefinedFunction}
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.codegen.FunctionCodeGenerator.generateFunction
 import org.apache.flink.table.planner.plan.utils.PythonUtil.containsPythonCall
 import org.apache.flink.table.runtime.functions.SqlDateTimeUtils
 import org.apache.flink.table.types.logical.RowType
-
 import org.apache.calcite.avatica.util.ByteString
 import org.apache.calcite.rex.{RexBuilder, RexExecutor, RexNode}
 import org.apache.calcite.sql.`type`.SqlTypeName
 import org.apache.commons.lang3.StringEscapeUtils
-
 import java.io.File
 import java.util.TimeZone
 
@@ -167,6 +165,15 @@ class ExpressionReducer(
             val reducedValue = reduced.getField(reducedIdx)
             val value = if (reducedValue != null) {
               reducedValue.asInstanceOf[Decimal].toBigDecimal
+            } else {
+              reducedValue
+            }
+            reducedValues.add(maySkipNullLiteralReduce(rexBuilder, value, unreduced))
+            reducedIdx += 1
+          case SqlTypeName.TIMESTAMP =>
+            val reducedValue = reduced.getField(reducedIdx)
+            val value = if (reducedValue != null) {
+              Long.box(reducedValue.asInstanceOf[SqlTimestamp].getMillisecond)
             } else {
               reducedValue
             }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
@@ -37,6 +37,8 @@ import org.apache.commons.lang3.StringEscapeUtils
 import java.io.File
 import java.util.TimeZone
 
+import org.apache.calcite.util.TimestampString
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 
@@ -173,7 +175,16 @@ class ExpressionReducer(
           case SqlTypeName.TIMESTAMP =>
             val reducedValue = reduced.getField(reducedIdx)
             val value = if (reducedValue != null) {
-              Long.box(reducedValue.asInstanceOf[SqlTimestamp].getMillisecond)
+              val dt = reducedValue.asInstanceOf[SqlTimestamp].toLocalDateTime
+              val timestampString =
+                new TimestampString(
+                  dt.getYear,
+                  dt.getMonthValue,
+                  dt.getDayOfMonth,
+                  dt.getHour,
+                  dt.getMinute,
+                  dt.getSecond)
+              timestampString.withNanos(dt.getNano)
             } else {
               reducedValue
             }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -33,11 +33,16 @@ import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical._
 
 import org.apache.calcite.avatica.util.ByteString
-import org.apache.commons.lang3.StringEscapeUtils
+import org.apache.calcite.util.TimestampString
 
+import org.apache.commons.lang3.StringEscapeUtils
 import java.math.{BigDecimal => JBigDecimal}
+import java.lang.{Integer => JInteger}
+
+import org.apache.flink.table.runtime.functions.SqlDateTimeUtils
 
 import scala.collection.mutable
+import scala.math.pow
 
 /**
   * Utilities to generate code for general purpose.
@@ -370,12 +375,14 @@ object GenerateUtils {
         generateNonNullLiteral(literalType, literalValue.toString, literalValue)
 
       case TIMESTAMP_WITHOUT_TIME_ZONE =>
-        // TODO: support Timestamp(3) now
         val fieldTerm = newName("timestamp")
-        val millis = literalValue.asInstanceOf[Long]
+        val millis = literalValue.asInstanceOf[TimestampString].getMillisSinceEpoch
+        val nanoOfMillis = SqlDateTimeUtils.getNanoOfMillisSinceEpoch(
+          literalValue.asInstanceOf[TimestampString].toString)
         val fieldTimestamp =
           s"""
-             |$SQL_TIMESTAMP $fieldTerm = $SQL_TIMESTAMP.fromEpochMillis(${millis}L);
+             |$SQL_TIMESTAMP $fieldTerm =
+             |  $SQL_TIMESTAMP.fromEpochMillis(${millis}L, $nanoOfMillis);
            """.stripMargin
         ctx.addReusableMember(fieldTimestamp)
         generateNonNullLiteral(literalType, fieldTerm, literalType)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -26,6 +26,7 @@ import org.apache.flink.table.planner.codegen.CodeGenUtils._
 import org.apache.flink.table.planner.codegen.GeneratedExpression.{ALWAYS_NULL, NEVER_NULL, NO_CODE}
 import org.apache.flink.table.planner.codegen.calls.CurrentTimePointCallGen
 import org.apache.flink.table.planner.plan.utils.SortUtil
+import org.apache.flink.table.runtime.functions.SqlDateTimeUtils
 import org.apache.flink.table.runtime.functions.SqlDateTimeUtils.unixTimestampToLocalDateTime
 import org.apache.flink.table.runtime.types.PlannerTypeUtils
 import org.apache.flink.table.runtime.typeutils.TypeCheckUtils.{isCharacterString, isReference, isTemporal}
@@ -37,12 +38,9 @@ import org.apache.calcite.util.TimestampString
 
 import org.apache.commons.lang3.StringEscapeUtils
 import java.math.{BigDecimal => JBigDecimal}
-import java.lang.{Integer => JInteger}
 
-import org.apache.flink.table.runtime.functions.SqlDateTimeUtils
 
 import scala.collection.mutable
-import scala.math.pow
 
 /**
   * Utilities to generate code for general purpose.

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -662,8 +662,7 @@ object GenerateUtils {
       leftTerm: String,
       rightTerm: String): String = t.getTypeRoot match {
     case BOOLEAN => s"($leftTerm == $rightTerm ? 0 : ($leftTerm ? 1 : -1))"
-    case DATE | TIME_WITHOUT_TIME_ZONE | TIMESTAMP_WITHOUT_TIME_ZONE |
-         TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
+    case DATE | TIME_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
       s"($leftTerm > $rightTerm ? 1 : $leftTerm < $rightTerm ? -1 : 0)"
     case _ if PlannerTypeUtils.isPrimitive(t) =>
       s"($leftTerm > $rightTerm ? 1 : $leftTerm < $rightTerm ? -1 : 0)"

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -370,8 +370,15 @@ object GenerateUtils {
         generateNonNullLiteral(literalType, literalValue.toString, literalValue)
 
       case TIMESTAMP_WITHOUT_TIME_ZONE =>
+        // TODO: support Timestamp(3) now
+        val fieldTerm = newName("timestamp")
         val millis = literalValue.asInstanceOf[Long]
-        generateNonNullLiteral(literalType, millis + "L", millis)
+        val fieldTimestamp =
+          s"""
+             |$SQL_TIMESTAMP $fieldTerm = $SQL_TIMESTAMP.fromEpochMillis(${millis}L);
+           """.stripMargin
+        ctx.addReusableMember(fieldTimestamp)
+        generateNonNullLiteral(literalType, fieldTerm, literalType)
 
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
         val millis = unixTimestampToLocalDateTime(literalValue.asInstanceOf[Long])

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/LongHashJoinGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/LongHashJoinGenerator.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.planner.codegen
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.metrics.Gauge
 import org.apache.flink.table.api.TableConfig
-import org.apache.flink.table.dataformat.{BaseRow, JoinedRow}
+import org.apache.flink.table.dataformat.{BaseRow, JoinedRow, SqlTimestamp}
 import org.apache.flink.table.planner.codegen.CodeGenUtils.{BASE_ROW, BINARY_ROW, baseRowFieldReadAccess, className, newName}
 import org.apache.flink.table.planner.codegen.OperatorCodeGenerator.{INPUT_SELECTION, generateCollect}
 import org.apache.flink.table.runtime.generated.{GeneratedJoinCondition, GeneratedProjection}
@@ -29,7 +29,7 @@ import org.apache.flink.table.runtime.hashtable.{LongHashPartition, LongHybridHa
 import org.apache.flink.table.runtime.operators.CodeGenOperatorFactory
 import org.apache.flink.table.runtime.operators.join.HashJoinType
 import org.apache.flink.table.runtime.typeutils.BinaryRowSerializer
-import org.apache.flink.table.types.logical.LogicalTypeRoot._
+import org.apache.flink.table.types.logical.LogicalTypeRoot.{TIMESTAMP_WITHOUT_TIME_ZONE, _}
 import org.apache.flink.table.types.logical._
 
 /**
@@ -49,8 +49,10 @@ object LongHashJoinGenerator {
         keyType.getFieldCount == 1 && {
       keyType.getTypeAt(0).getTypeRoot match {
         case BIGINT | INTEGER | SMALLINT | TINYINT | FLOAT | DOUBLE | DATE |
-             TIME_WITHOUT_TIME_ZONE | TIMESTAMP_WITHOUT_TIME_ZONE |
-             TIMESTAMP_WITH_LOCAL_TIME_ZONE => true
+             TIME_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE => true
+        case TIMESTAMP_WITHOUT_TIME_ZONE =>
+          val timestampType = keyType.getTypeAt(0).asInstanceOf[TimestampType]
+          if (SqlTimestamp.isCompact(timestampType.getPrecision)) true else false
         case _ => false
       }
       // TODO decimal and multiKeys support.

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/MatchCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/MatchCodeGenerator.scala
@@ -388,13 +388,15 @@ class MatchCodeGenerator(
   }
 
   private def generateProctimeTimestamp(): GeneratedExpression = {
-    val resultTerm = ctx.addReusableLocalVariable("long", "result")
+    val resultType = new TimestampType(3)
+    val resultTypeTerm = primitiveTypeTermForType(resultType)
+    val resultTerm = ctx.addReusableLocalVariable(resultTypeTerm, "result")
     val resultCode =
       s"""
-         |$resultTerm = $contextTerm.currentProcessingTime();
+         |$resultTerm = $SQL_TIMESTAMP.fromEpochMillis($contextTerm.currentProcessingTime());
          |""".stripMargin.trim
     // the proctime has been materialized, so it's TIMESTAMP now, not PROCTIME_INDICATOR
-    GeneratedExpression(resultTerm, NEVER_NULL, resultCode, new TimestampType(3))
+    GeneratedExpression(resultTerm, NEVER_NULL, resultCode, resultType)
   }
 
   /**

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/WatermarkGeneratorCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/WatermarkGeneratorCodeGenerator.scala
@@ -74,7 +74,7 @@ object WatermarkGeneratorCodeGenerator {
           if (${generatedExpr.nullTerm}) {
             return null;
           } else {
-            return ${generatedExpr.resultTerm};
+            return ${generatedExpr.resultTerm}.getMillisecond();
           }
         }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/AggsHandlerCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/AggsHandlerCodeGenerator.scala
@@ -941,20 +941,29 @@ class AggsHandlerCodeGenerator(
       windowProperties: Seq[PlannerWindowProperty]): Seq[GeneratedExpression] = {
     windowProperties.map {
       case w: PlannerWindowStart =>
-        // return a Timestamp(Internal is long)
+        // return a Timestamp(Internal is SqlTimestamp)
         GeneratedExpression(
-          s"$NAMESPACE_TERM.getStart()", "false", "", w.resultType)
+          s"$SQL_TIMESTAMP.fromEpochMillis($NAMESPACE_TERM.getStart())",
+          "false",
+          "",
+          w.resultType)
       case w: PlannerWindowEnd =>
-        // return a Timestamp(Internal is long)
+        // return a Timestamp(Internal is SqlTimestamp)
         GeneratedExpression(
-          s"$NAMESPACE_TERM.getEnd()", "false", "", w.resultType)
+          s"$SQL_TIMESTAMP.fromEpochMillis($NAMESPACE_TERM.getEnd())",
+          "false",
+          "",
+          w.resultType)
       case r: PlannerRowtimeAttribute =>
-        // return a rowtime, use long as internal type
+        // return a rowtime, use SqlTimestamp as internal type
         GeneratedExpression(
-          s"$NAMESPACE_TERM.getEnd() - 1", "false", "", r.resultType)
+          s"$SQL_TIMESTAMP.fromEpochMillis($NAMESPACE_TERM.getEnd() - 1)",
+          "false",
+          "",
+          r.resultType)
       case p: PlannerProctimeAttribute =>
         // ignore this property, it will be null at the position later
-        GeneratedExpression("-1L", "true", "", p.resultType)
+        GeneratedExpression(s"$SQL_TIMESTAMP.fromEpochMillis(-1L)", "true", "", p.resultType)
     }
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/WindowCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/WindowCodeGenerator.scala
@@ -26,7 +26,7 @@ import org.apache.flink.table.functions.{AggregateFunction, UserDefinedFunction}
 import org.apache.flink.table.planner.JLong
 import org.apache.flink.table.planner.calcite.FlinkRelBuilder.PlannerNamedWindowProperty
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
-import org.apache.flink.table.planner.codegen.CodeGenUtils.{BINARY_ROW, boxedTypeTermForType, newName}
+import org.apache.flink.table.planner.codegen.CodeGenUtils.{BINARY_ROW, SQL_TIMESTAMP, boxedTypeTermForType, newName}
 import org.apache.flink.table.planner.codegen.GenerateUtils.generateFieldAccess
 import org.apache.flink.table.planner.codegen.GeneratedExpression.{NEVER_NULL, NO_CODE}
 import org.apache.flink.table.planner.codegen.OperatorCodeGenerator.generateCollect
@@ -47,7 +47,6 @@ import org.apache.flink.table.runtime.util.RowIterator
 import org.apache.flink.table.types.logical.LogicalTypeRoot.INTERVAL_DAY_TIME
 import org.apache.flink.table.types.logical._
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot
-
 import org.apache.calcite.avatica.util.DateTimeUtils
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.AggregateCall
@@ -632,17 +631,17 @@ abstract class WindowCodeGenerator(
       // get assigned window start timestamp
       def windowProps(size: Expression) = {
         val (startWValue, endWValue, rowTimeValue) = (
-            s"$currentWindowTerm.getStart()",
-            s"$currentWindowTerm.getEnd()",
-            s"$currentWindowTerm.maxTimestamp()")
+            s"$SQL_TIMESTAMP.fromEpochMillis($currentWindowTerm.getStart())",
+            s"$SQL_TIMESTAMP.fromEpochMillis($currentWindowTerm.getEnd())",
+            s"$SQL_TIMESTAMP.fromEpochMillis($currentWindowTerm.maxTimestamp())")
         val start = if (startPos.isDefined) {
-          s"$propTerm.setLong($lastPos + ${startPos.get}, $startWValue);"
+          s"$propTerm.setTimestamp($lastPos + ${startPos.get}, $startWValue, 3);"
         } else ""
         val end = if (endPos.isDefined) {
-          s"$propTerm.setLong($lastPos + ${endPos.get}, $endWValue);"
+          s"$propTerm.setTimestamp($lastPos + ${endPos.get}, $endWValue, 3);"
         } else ""
         val rowTime = if (rowTimePos.isDefined) {
-          s"$propTerm.setLong($lastPos + ${rowTimePos.get}, $rowTimeValue);"
+          s"$propTerm.setTimestamp($lastPos + ${rowTimePos.get}, $rowTimeValue, 3);"
         } else ""
         (start, end, rowTime)
       }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -256,8 +256,8 @@ object BuiltInMethods {
   val DATE_FORMAT_STIRNG_STRING = Types.lookupMethod(
     classOf[SqlDateTimeUtils], "dateFormat", classOf[String], classOf[String])
 
-  val DATE_FORMAT_LONG_STRING = Types.lookupMethod(
-    classOf[SqlDateTimeUtils], "dateFormat", classOf[Long], classOf[String])
+  val DATE_FORMAT_TIMESTAMP_STRING = Types.lookupMethod(
+    classOf[SqlDateTimeUtils], "dateFormat", classOf[SqlTimestamp], classOf[String])
 
   val UNIX_TIMESTAMP_FORMAT = Types.lookupMethod(
     classOf[SqlDateTimeUtils],

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -346,12 +346,12 @@ object BuiltInMethods {
 
   val STRING_TO_TIMESTAMP = Types.lookupMethod(
     classOf[SqlDateTimeUtils],
-    "toTimestamp",
+    "toSqlTimestamp",
     classOf[String])
 
   val STRING_TO_TIMESTAMP_WITH_FORMAT = Types.lookupMethod(
     classOf[SqlDateTimeUtils],
-    "toTimestamp",
+    "toSqlTimestamp",
     classOf[String], classOf[String])
 
   val STRING_TO_TIMESTAMP_TIME_ZONE = Types.lookupMethod(
@@ -461,4 +461,7 @@ object BuiltInMethods {
   //  https://issues.apache.org/jira/browse/CALCITE-3199
   val UNIX_DATE_CEIL = Types.lookupMethod(classOf[SqlDateTimeUtils], "unixDateCeil",
     classOf[TimeUnitRange], classOf[Int])
+
+  val TRUNCATE_SQL_TIMESTAMP = Types.lookupMethod(classOf[SqlDateTimeUtils], "truncate",
+    classOf[SqlTimestamp], classOf[Int])
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -18,13 +18,11 @@
 
 package org.apache.flink.table.planner.codegen.calls
 
-import org.apache.flink.table.dataformat.Decimal
+import org.apache.flink.table.dataformat.{Decimal, SqlTimestamp}
 import org.apache.flink.table.runtime.functions._
-
 import org.apache.calcite.avatica.util.TimeUnitRange
 import org.apache.calcite.linq4j.tree.Types
 import org.apache.calcite.runtime.SqlFunctions
-
 import java.lang.reflect.Method
 import java.lang.{Byte => JByte, Integer => JInteger, Long => JLong, Short => JShort}
 import java.util.TimeZone
@@ -220,7 +218,7 @@ object BuiltInMethods {
   val TIMESTAMP_TO_STRING = Types.lookupMethod(
     classOf[SqlDateTimeUtils],
     "timestampToString",
-    classOf[Long], classOf[Int])
+    classOf[SqlTimestamp])
 
   val TIMESTAMP_TO_STRING_TIME_ZONE = Types.lookupMethod(
     classOf[SqlDateTimeUtils],

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FloorCeilCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FloorCeilCallGen.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.codegen.calls
 
-import org.apache.flink.table.planner.codegen.CodeGenUtils.{getEnum, primitiveTypeTermForType, qualifyMethod}
+import org.apache.flink.table.planner.codegen.CodeGenUtils.{getEnum, primitiveTypeTermForType, qualifyMethod, SQL_TIMESTAMP}
 import org.apache.flink.table.planner.codegen.GenerateUtils.generateCallIfArgsNotNull
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, GeneratedExpression}
 import org.apache.flink.table.types.logical.{LogicalType, LogicalTypeRoot}
@@ -78,15 +78,36 @@ class FloorCeilCallGen(
 
             // for Unix Date / Unix Time
             case YEAR | MONTH =>
-              s"""
-                |($internalType) ${qualifyMethod(temporalMethod.get)}(${terms(1)}, ${terms.head})
-                |""".stripMargin
+              operand.resultType.getTypeRoot match {
+                case LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE =>
+                  val longTerm = s"${terms.head}.getMillisecond()"
+                  s"""
+                     |$SQL_TIMESTAMP.fromEpochMillis(
+                     |  ${qualifyMethod(temporalMethod.get)}(${terms(1)}, $longTerm))
+                   """.stripMargin
+                case _ =>
+                  s"""
+                     |($internalType) ${qualifyMethod(temporalMethod.get)}(
+                     |  ${terms(1)}, ${terms.head})
+                     |""".stripMargin
+              }
             case _ =>
-              s"""
-                |${qualifyMethod(arithmeticMethod)}(
-                |  ($internalType) ${terms.head},
-                |  ($internalType) ${unit.startUnit.multiplier.intValue()})
-                |""".stripMargin
+              operand.resultType.getTypeRoot match {
+                case LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE =>
+                  val longTerm = s"${terms.head}.getMillisecond()"
+                  s"""
+                     |$SQL_TIMESTAMP.fromEpochMillis(${qualifyMethod(arithmeticMethod)}(
+                     |  $longTerm,
+                     |  (long) ${unit.startUnit.multiplier.intValue()}))
+                   """.stripMargin
+                case _ =>
+                  s"""
+                     |${qualifyMethod(arithmeticMethod)}(
+                     |  ($internalType) ${terms.head},
+                     |  ($internalType) ${unit.startUnit.multiplier.intValue()})
+                     |""".stripMargin
+              }
+
           }
       }
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/MethodCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/MethodCallGen.scala
@@ -18,10 +18,10 @@
 
 package org.apache.flink.table.planner.codegen.calls
 
-import org.apache.flink.table.planner.codegen.CodeGenUtils.{BINARY_STRING, qualifyMethod, SQL_TIMESTAMP}
+import org.apache.flink.table.planner.codegen.CodeGenUtils.{BINARY_STRING, qualifyMethod}
 import org.apache.flink.table.planner.codegen.GenerateUtils.generateCallIfArgsNotNull
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, GeneratedExpression}
-import org.apache.flink.table.types.logical.{LogicalType, LogicalTypeRoot}
+import org.apache.flink.table.types.logical.{LogicalType}
 import java.lang.reflect.Method
 import java.util.TimeZone
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/MethodCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/MethodCallGen.scala
@@ -33,14 +33,13 @@ class MethodCallGen(method: Method) extends CallGenerator {
       returnType: LogicalType): GeneratedExpression = {
     generateCallIfArgsNotNull(ctx, returnType, operands, !method.getReturnType.isPrimitive) {
       originalTerms => {
-        val terms = originalTerms.zipWithIndex.zip(method.getParameterTypes).map {
-          case ((term, i), clazz) =>
-            // convert the BinaryString parameter to String if the method parameter accept String
-            if (clazz == classOf[String]) {
-              s"$term.toString()"
-            } else {
-              term
-            }
+        val terms = originalTerms.zip(method.getParameterTypes).map { case (term, clazz) =>
+          // convert the BinaryString parameter to String if the method parameter accept String
+          if (clazz == classOf[String]) {
+            s"$term.toString()"
+          } else {
+            term
+          }
         }
 
         // generate method invoke code and adapt when it's a time zone related function

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/MethodCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/MethodCallGen.scala
@@ -18,11 +18,10 @@
 
 package org.apache.flink.table.planner.codegen.calls
 
-import org.apache.flink.table.planner.codegen.CodeGenUtils.{BINARY_STRING, qualifyMethod}
+import org.apache.flink.table.planner.codegen.CodeGenUtils.{BINARY_STRING, qualifyMethod, SQL_TIMESTAMP}
 import org.apache.flink.table.planner.codegen.GenerateUtils.generateCallIfArgsNotNull
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, GeneratedExpression}
-import org.apache.flink.table.types.logical.LogicalType
-
+import org.apache.flink.table.types.logical.{LogicalType, LogicalTypeRoot}
 import java.lang.reflect.Method
 import java.util.TimeZone
 
@@ -34,13 +33,18 @@ class MethodCallGen(method: Method) extends CallGenerator {
       returnType: LogicalType): GeneratedExpression = {
     generateCallIfArgsNotNull(ctx, returnType, operands, !method.getReturnType.isPrimitive) {
       originalTerms => {
-        val terms = originalTerms.zip(method.getParameterTypes).map { case (term, clazz) =>
-          // convert the BinaryString parameter to String if the method parameter accept String
-          if (clazz == classOf[String]) {
-            s"$term.toString()"
-          } else {
-            term
-          }
+        val terms = originalTerms.zipWithIndex.zip(method.getParameterTypes).map {
+          case ((term, i), clazz) =>
+            // convert the BinaryString parameter to String if the method parameter accept String
+            if (clazz == classOf[String]) {
+              s"$term.toString()"
+            } else if ((clazz == classOf[Long] || clazz == classOf[java.lang.Long]) &&
+                operands(i).resultType.getTypeRoot == LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) {
+              // convert the SqlTimestamp parameter to Long if the method parameter accept Long
+              s"$term.getMillisecond()"
+            } else {
+              term
+            }
         }
 
         // generate method invoke code and adapt when it's a time zone related function
@@ -60,6 +64,11 @@ class MethodCallGen(method: Method) extends CallGenerator {
         // convert String to BinaryString if the return type is String
         if (method.getReturnType == classOf[String]) {
           s"$BINARY_STRING.fromString($call)"
+        } else if ((method.getReturnType == classOf[Long]
+            || method.getReturnType == classOf[java.lang.Long]) &&
+            returnType.getTypeRoot == LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) {
+          // convert Long to SqlTimestamp if the return type is Timestamp
+          s"$SQL_TIMESTAMP.fromEpochMillis($call)"
         } else {
           call
         }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/MethodCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/MethodCallGen.scala
@@ -38,10 +38,6 @@ class MethodCallGen(method: Method) extends CallGenerator {
             // convert the BinaryString parameter to String if the method parameter accept String
             if (clazz == classOf[String]) {
               s"$term.toString()"
-            } else if ((clazz == classOf[Long] || clazz == classOf[java.lang.Long]) &&
-                operands(i).resultType.getTypeRoot == LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) {
-              // convert the SqlTimestamp parameter to Long if the method parameter accept Long
-              s"$term.getMillisecond()"
             } else {
               term
             }
@@ -64,11 +60,6 @@ class MethodCallGen(method: Method) extends CallGenerator {
         // convert String to BinaryString if the return type is String
         if (method.getReturnType == classOf[String]) {
           s"$BINARY_STRING.fromString($call)"
-        } else if ((method.getReturnType == classOf[Long]
-            || method.getReturnType == classOf[java.lang.Long]) &&
-            returnType.getTypeRoot == LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) {
-          // convert Long to SqlTimestamp if the return type is Timestamp
-          s"$SQL_TIMESTAMP.fromEpochMillis($call)"
         } else {
           call
         }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -2236,8 +2236,9 @@ object ScalarOperatorGens {
       case TIME_WITHOUT_TIME_ZONE =>
         s"${qualifyMethod(BuiltInMethods.UNIX_TIME_TO_STRING)}($operandTerm)"
       case TIMESTAMP_WITHOUT_TIME_ZONE => // including rowtime indicator
-        val longTerm = s"$operandTerm.getMillisecond()"
-        s"${qualifyMethod(BuiltInMethod.UNIX_TIMESTAMP_TO_STRING.method)}($longTerm, 3)"
+        // The interpreted string conforms to the definition of timestamp literal
+        // SQL 2011 Part 2 Section 6.13 General Rules 11) d)
+        s"${qualifyMethod(BuiltInMethods.TIMESTAMP_TO_STRING)}($operandTerm)"
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
         val method = qualifyMethod(BuiltInMethods.TIMESTAMP_TO_STRING_TIME_ZONE)
         val zone = ctx.addReusableTimeZone()

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -2169,7 +2169,8 @@ object ScalarOperatorGens {
         s"${qualifyMethod(BuiltInMethods.STRING_TO_TIME)}($operandTerm.toString())"
       case TIMESTAMP_WITHOUT_TIME_ZONE =>
         s"""
-           |${qualifyMethod(BuiltInMethod.STRING_TO_TIMESTAMP.method)}($operandTerm.toString())
+           |${SQL_TIMESTAMP}.fromEpochMillis(
+           |  ${qualifyMethod(BuiltInMethod.STRING_TO_TIMESTAMP.method)}($operandTerm.toString()))
            |""".stripMargin
       case _ => throw new UnsupportedOperationException
     }
@@ -2184,7 +2185,8 @@ object ScalarOperatorGens {
       case TIME_WITHOUT_TIME_ZONE =>
         s"${qualifyMethod(BuiltInMethods.UNIX_TIME_TO_STRING)}($operandTerm)"
       case TIMESTAMP_WITHOUT_TIME_ZONE => // including rowtime indicator
-        s"${qualifyMethod(BuiltInMethod.UNIX_TIMESTAMP_TO_STRING.method)}($operandTerm, 3)"
+        val longTerm = s"$operandTerm.getMillisecond()"
+        s"${qualifyMethod(BuiltInMethod.UNIX_TIMESTAMP_TO_STRING.method)}($longTerm, 3)"
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
         val method = qualifyMethod(BuiltInMethods.TIMESTAMP_TO_STRING_TIME_ZONE)
         val zone = ctx.addReusableTimeZone()

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -193,7 +193,8 @@ object ScalarOperatorGens {
         generateOperatorIfNotNull(ctx, left.resultType, left, right) {
           (l, r) => {
             val leftTerm = s"$l.getMillisecond()"
-            s"$SQL_TIMESTAMP.fromEpochMillis($leftTerm $op $r)"
+            val nanoTerm = s"$l.getNanoOfMillisecond()"
+            s"$SQL_TIMESTAMP.fromEpochMillis($leftTerm $op $r, $nanoTerm)"
           }
         }
 
@@ -201,9 +202,11 @@ object ScalarOperatorGens {
         generateOperatorIfNotNull(ctx, left.resultType, left, right) {
           (l, r) => {
             val leftTerm = s"$l.getMillisecond()"
+            val nanoTerm = s"$l.getNanoOfMillisecond()"
             s"""
                |$SQL_TIMESTAMP.fromEpochMillis(
-               |  ${qualifyMethod(BuiltInMethod.ADD_MONTHS.method)}($leftTerm, $op($r)))
+               |  ${qualifyMethod(BuiltInMethod.ADD_MONTHS.method)}($leftTerm, $op($r)),
+               |  $nanoTerm)
              """.stripMargin
           }
         }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -832,7 +832,7 @@ object ScalarOperatorGens {
       val fromType = operand.resultType.asInstanceOf[TimestampType]
       val toType = targetType.asInstanceOf[TimestampType]
       if (fromType.getPrecision <= toType.getPrecision) {
-        operand
+        operand.copy(resultType = targetType)
       } else {
         val method = qualifyMethod(BuiltInMethods.TRUNCATE_SQL_TIMESTAMP)
         generateUnaryOperatorIfNotNull(ctx, targetType, operand) {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -830,7 +830,7 @@ object ScalarOperatorGens {
       generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
         operandTerm =>
           val timeZone = ctx.addReusableTimeZone()
-          s"$method($SQL_TIMESTAMP.fromEpochMillis($operandTerm), $timeZone)"
+          s"$method($operandTerm.getMillisecond(), $timeZone)"
       }
 
     case (TIMESTAMP_WITH_LOCAL_TIME_ZONE, TIMESTAMP_WITHOUT_TIME_ZONE) =>

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/StringCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/StringCallGen.scala
@@ -205,7 +205,7 @@ object StringCallGen {
       case DATE_FORMAT if operands.size == 2 &&
           isTimestamp(operands.head.resultType) &&
           isCharacterString(operands(1).resultType) =>
-        methodGen(BuiltInMethods.DATE_FORMAT_LONG_STRING)
+        methodGen(BuiltInMethods.DATE_FORMAT_TIMESTAMP_STRING)
 
       case DATE_FORMAT if operands.size == 2 &&
           isTimestampWithLocalZone(operands.head.resultType) &&

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/TimestampDiffCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/TimestampDiffCallGen.scala
@@ -42,11 +42,22 @@ class TimestampDiffCallGen extends CallGenerator {
            TimeUnit.MONTH |
            TimeUnit.QUARTER =>
         (operands(1).resultType.getTypeRoot, operands(2).resultType.getTypeRoot) match {
+          case (TIMESTAMP_WITHOUT_TIME_ZONE, TIMESTAMP_WITHOUT_TIME_ZONE) =>
+            generateCallIfArgsNotNull(ctx, new IntType(), operands) {
+              terms =>
+                val leftTerm = s"${terms(1)}.getMillisecond()"
+                val rightTerm = s"${terms(2)}.getMillisecond()"
+                s"""
+                   |${qualifyMethod(BuiltInMethod.SUBTRACT_MONTHS.method)}(
+                   |  $leftTerm, $rightTerm) / ${unit.multiplier.intValue()}
+                 """.stripMargin
+            }
           case (TIMESTAMP_WITHOUT_TIME_ZONE, DATE) =>
             generateCallIfArgsNotNull(ctx, new IntType(), operands) {
               terms =>
+                val leftTerm = s"${terms(1)}.getMillisecond()"
                 s"""
-                   |${qualifyMethod(BuiltInMethod.SUBTRACT_MONTHS.method)}(${terms(1)},
+                   |${qualifyMethod(BuiltInMethod.SUBTRACT_MONTHS.method)}($leftTerm,
                    |  ${terms(2)} * ${MILLIS_PER_DAY}L) / ${unit.multiplier.intValue()}
                    |""".stripMargin
             }
@@ -54,9 +65,10 @@ class TimestampDiffCallGen extends CallGenerator {
           case (DATE, TIMESTAMP_WITHOUT_TIME_ZONE) =>
             generateCallIfArgsNotNull(ctx, new IntType(), operands) {
               terms =>
+                val rightTerm = s"${terms(2)}.getMillisecond()"
                 s"""
                    |${qualifyMethod(BuiltInMethod.SUBTRACT_MONTHS.method)}(
-                   |${terms(1)} * ${MILLIS_PER_DAY}L, ${terms(2)}) / ${unit.multiplier.intValue()}
+                   |${terms(1)} * ${MILLIS_PER_DAY}L, $rightTerm) / ${unit.multiplier.intValue()}
                    |""".stripMargin
             }
 
@@ -79,16 +91,19 @@ class TimestampDiffCallGen extends CallGenerator {
           case (TIMESTAMP_WITHOUT_TIME_ZONE, TIMESTAMP_WITHOUT_TIME_ZONE) =>
             generateCallIfArgsNotNull(ctx, new IntType(), operands) {
               terms =>
+                val leftTerm = s"${terms(1)}.getMillisecond()"
+                val rightTerm = s"${terms(2)}.getMillisecond()"
                 s"""
-                   |(int)((${terms(1)} - ${terms(2)}) / ${unit.multiplier.intValue()})
+                   |(int)(($leftTerm - $rightTerm) / ${unit.multiplier.intValue()})
                    |""".stripMargin
             }
 
           case (TIMESTAMP_WITHOUT_TIME_ZONE, DATE) =>
             generateCallIfArgsNotNull(ctx, new IntType(), operands) {
               terms =>
+                val leftTerm = s"${terms(1)}.getMillisecond()"
                 s"""
-                   |(int)((${terms(1)} -
+                   |(int)(($leftTerm -
                    |  ${terms(2)} * ${MILLIS_PER_DAY}L) / ${unit.multiplier.intValue()})
                    |""".stripMargin
             }
@@ -96,9 +111,10 @@ class TimestampDiffCallGen extends CallGenerator {
           case (DATE, TIMESTAMP_WITHOUT_TIME_ZONE) =>
             generateCallIfArgsNotNull(ctx, new IntType(), operands) {
               terms =>
+                val rightTerm = s"${terms(2)}.getMillisecond()"
                 s"""
                    |(int)((${terms(1)} * ${MILLIS_PER_DAY}L -
-                   |  ${terms(2)}) / ${unit.multiplier.intValue()})
+                   |  $rightTerm) / ${unit.multiplier.intValue()})
                    |""".stripMargin
             }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/sort/SortCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/sort/SortCodeGenerator.scala
@@ -19,14 +19,14 @@
 package org.apache.flink.table.planner.codegen.sort
 
 import org.apache.flink.table.api.TableConfig
-import org.apache.flink.table.dataformat.{BinaryRow, Decimal}
+import org.apache.flink.table.dataformat.{BinaryRow, Decimal, SqlTimestamp}
 import org.apache.flink.table.planner.codegen.CodeGenUtils.{BASE_ROW, SEGMENT, newName}
 import org.apache.flink.table.planner.codegen.Indenter.toISC
 import org.apache.flink.table.runtime.generated.{GeneratedNormalizedKeyComputer, GeneratedRecordComparator, NormalizedKeyComputer, RecordComparator}
 import org.apache.flink.table.runtime.operators.sort.SortUtil
 import org.apache.flink.table.runtime.types.PlannerTypeUtils
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
-import org.apache.flink.table.types.logical.{DecimalType, LogicalType}
+import org.apache.flink.table.types.logical.{DecimalType, LogicalType, TimestampType}
 
 import scala.collection.mutable
 
@@ -389,6 +389,8 @@ class SortCodeGenerator(
     t match {
       case dt: DecimalType =>
         s"get$prefix($index, ${dt.getPrecision}, ${dt.getScale})"
+      case dt: TimestampType =>
+        s"get$prefix($index, ${dt.getPrecision})"
       case _ =>
         s"get$prefix($index)"
     }
@@ -415,7 +417,7 @@ class SortCodeGenerator(
     case DECIMAL => "Decimal"
     case DATE => "Int"
     case TIME_WITHOUT_TIME_ZONE => "Int"
-    case TIMESTAMP_WITHOUT_TIME_ZONE => "Long"
+    case TIMESTAMP_WITHOUT_TIME_ZONE => "Timestamp"
     case INTERVAL_YEAR_MONTH => "Int"
     case INTERVAL_DAY_TIME => "Long"
     case _ => null
@@ -437,7 +439,9 @@ class SortCodeGenerator(
     t.getTypeRoot match {
       case _ if PlannerTypeUtils.isPrimitive(t) => true
       case VARCHAR | CHAR | VARBINARY | BINARY |
-           DATE | TIME_WITHOUT_TIME_ZONE | TIMESTAMP_WITHOUT_TIME_ZONE => true
+           DATE | TIME_WITHOUT_TIME_ZONE => true
+      case TIMESTAMP_WITHOUT_TIME_ZONE =>
+        SqlTimestamp.isCompact(t.asInstanceOf[TimestampType].getPrecision)
       case DECIMAL => Decimal.isCompact(t.asInstanceOf[DecimalType].getPrecision)
       case _ => false
     }
@@ -452,7 +456,8 @@ class SortCodeGenerator(
       case FLOAT => 4
       case DOUBLE => 8
       case BIGINT => 8
-      case TIMESTAMP_WITHOUT_TIME_ZONE => 8
+      case TIMESTAMP_WITHOUT_TIME_ZONE
+        if SqlTimestamp.isCompact(t.asInstanceOf[TimestampType].getPrecision) => 8
       case INTERVAL_YEAR_MONTH => 4
       case INTERVAL_DAY_TIME => 8
       case DATE => 4

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/sort/SortCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/sort/SortCodeGenerator.scala
@@ -441,6 +441,7 @@ class SortCodeGenerator(
       case VARCHAR | CHAR | VARBINARY | BINARY |
            DATE | TIME_WITHOUT_TIME_ZONE => true
       case TIMESTAMP_WITHOUT_TIME_ZONE =>
+        // TODO: support normalize key for non-compact timestamp
         SqlTimestamp.isCompact(t.asInstanceOf[TimestampType].getPrecision)
       case DECIMAL => Decimal.isCompact(t.asInstanceOf[DecimalType].getPrecision)
       case _ => false

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
@@ -748,12 +748,6 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
       }
     }
 
-    else if (hasRoot(logicalType, TIMESTAMP_WITHOUT_TIME_ZONE)) {
-      if (getPrecision(logicalType) <= 3) {
-        return Types.SQL_TIMESTAMP
-      }
-    }
-
     fromDataTypeToTypeInfo(literal.getOutputDataType)
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/UserDefinedFunctionUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/UserDefinedFunctionUtils.scala
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.functions.InvalidTypesException
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils._
 import org.apache.flink.table.api.{TableException, ValidationException}
-import org.apache.flink.table.dataformat.{BaseRow, BinaryString, Decimal}
+import org.apache.flink.table.dataformat.{BaseRow, BinaryString, Decimal, SqlTimestamp}
 import org.apache.flink.table.functions._
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.schema.DeferredTypeFlinkTableFunction
@@ -39,16 +39,15 @@ import org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataTy
 import org.apache.flink.table.typeutils.FieldInfoUtils
 import org.apache.flink.types.Row
 import org.apache.flink.util.InstantiationUtil
-
 import com.google.common.primitives.Primitives
 import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeFactory}
 import org.apache.calcite.rex.{RexLiteral, RexNode}
 import org.apache.calcite.sql.`type`.SqlTypeName
 import org.apache.calcite.sql.{SqlFunction, SqlOperatorBinding}
-
 import java.lang.reflect.{Method, Modifier}
 import java.lang.{Integer => JInt, Long => JLong}
 import java.sql.{Date, Time, Timestamp}
+import java.time.LocalDateTime
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable
@@ -728,10 +727,12 @@ object UserDefinedFunctionUtils {
         expected.isPrimitive && Primitives.wrap(expected) == candidate ||
         candidate == classOf[Date] && (expected == classOf[Int] || expected == classOf[JInt])  ||
         candidate == classOf[Time] && (expected == classOf[Int] || expected == classOf[JInt]) ||
-        candidate == classOf[Timestamp] && (expected == classOf[Long] ||
-            expected == classOf[JLong]) ||
         candidate == classOf[BinaryString] && expected == classOf[String] ||
         candidate == classOf[String] && expected == classOf[BinaryString] ||
+        candidate == classOf[SqlTimestamp] && expected == classOf[LocalDateTime] ||
+        candidate == classOf[Timestamp] && expected == classOf[SqlTimestamp] ||
+        candidate == classOf[SqlTimestamp] && expected == classOf[Timestamp] ||
+        candidate == classOf[LocalDateTime] && expected == classOf[SqlTimestamp] ||
         classOf[BaseRow].isAssignableFrom(candidate) && expected == classOf[Row] ||
         candidate == classOf[Row] && classOf[BaseRow].isAssignableFrom(expected) ||
         classOf[BaseRow].isAssignableFrom(candidate) && expected == classOf[BaseRow] ||

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecMatch.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecMatch.scala
@@ -295,10 +295,11 @@ class StreamExecMatch(
         // copy the rowtime field into the StreamRecord timestamp field
         val timeIdx = timeOrderField.getIndex
         val inputTypeInfo = inputTransform.getOutputType
+        val precision = timeOrderField.getType.getPrecision
         val transformation = new OneInputTransformation(
           inputTransform,
           s"rowtime field: ($timeOrderField)",
-          new ProcessOperator(new RowtimeProcessFunction(timeIdx, inputTypeInfo)),
+          new ProcessOperator(new RowtimeProcessFunction(timeIdx, inputTypeInfo, precision)),
           inputTypeInfo,
           inputTransform.getParallelism)
         if (inputsContainSingleton()) {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecTableSourceScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecTableSourceScan.scala
@@ -274,7 +274,7 @@ private class PeriodicWatermarkAssignerWrapper(
   override def getCurrentWatermark: Watermark = assigner.getWatermark
 
   override def extractTimestamp(row: BaseRow, previousElementTimestamp: Long): Long = {
-    val timestamp: Long = row.getLong(timeFieldIdx)
+    val timestamp: Long = row.getTimestamp(timeFieldIdx, 3).getMillisecond
     assigner.nextTimestamp(timestamp)
     0L
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/StreamLogicalWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/StreamLogicalWindowAggregateRule.scala
@@ -58,7 +58,8 @@ class StreamLogicalWindowAggregateRule
 
     rexBuilder.makeLiteral(
       0L,
-      rexBuilder.getTypeFactory.createSqlType(SqlTypeName.TIMESTAMP),
+      rexBuilder.getTypeFactory.createSqlType(
+        SqlTypeName.TIMESTAMP, windowExpression.getType.getPrecision),
       true)
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.utils
 import org.apache.flink.api.common.typeinfo.Types
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.api.{DataTypes, TableConfig, TableException}
-import org.apache.flink.table.dataformat.{BaseRow, BinaryString, Decimal}
+import org.apache.flink.table.dataformat.{BaseRow, BinaryString, Decimal, SqlTimestamp}
 import org.apache.flink.table.dataview.MapViewTypeInfo
 import org.apache.flink.table.expressions.ExpressionUtils.extractValue
 import org.apache.flink.table.expressions._
@@ -494,7 +494,9 @@ object AggregateUtil extends Enumeration {
 
       case DATE => DataTypes.INT
       case TIME_WITHOUT_TIME_ZONE => DataTypes.INT
-      case TIMESTAMP_WITHOUT_TIME_ZONE => DataTypes.BIGINT
+      case TIMESTAMP_WITHOUT_TIME_ZONE =>
+        val dt = argTypes(0).asInstanceOf[TimestampType]
+        DataTypes.TIMESTAMP(dt.getPrecision).bridgedTo(classOf[SqlTimestamp])
 
       case INTERVAL_YEAR_MONTH => DataTypes.INT
       case INTERVAL_DAY_TIME => DataTypes.BIGINT

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
@@ -342,8 +342,7 @@ class RexNodeToExpressionConverter(
         val v = literal.getValueAs(classOf[TimestampString])
         val millisecond = v.getMillisSinceEpoch
         val nanoOfMillisecond = SqlDateTimeUtils.getNanoOfMillisSinceEpoch(v.toString)
-        LocalDateTimeConverter.INSTANCE.toExternal(
-          SqlTimestamp.fromEpochMillis(millisecond, nanoOfMillisecond))
+        SqlTimestamp.fromEpochMillis(millisecond, nanoOfMillisecond).toLocalDateTime
 
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
         val v = literal.getValueAs(classOf[java.lang.Long])

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.plan.utils
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog, FunctionLookup, UnresolvedIdentifier}
 import org.apache.flink.table.dataformat.DataFormatConverters.{LocalDateConverter, LocalDateTimeConverter, LocalTimeConverter}
+import org.apache.flink.table.dataformat.SqlTimestamp
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.expressions.utils.ApiExpressionUtils._
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions.{AND, CAST, OR}
@@ -338,7 +339,7 @@ class RexNodeToExpressionConverter(
 
       case TIMESTAMP_WITHOUT_TIME_ZONE =>
         val v = literal.getValueAs(classOf[java.lang.Long])
-        LocalDateTimeConverter.INSTANCE.toExternal(v)
+        LocalDateTimeConverter.INSTANCE.toExternal(SqlTimestamp.fromEpochMillis(v))
 
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
         val v = literal.getValueAs(classOf[java.lang.Long])

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
@@ -36,10 +36,11 @@ import org.apache.calcite.plan.RelOptUtil
 import org.apache.calcite.rex._
 import org.apache.calcite.sql.fun.{SqlStdOperatorTable, SqlTrimFunction}
 import org.apache.calcite.sql.{SqlFunction, SqlPostfixOperator}
-import org.apache.calcite.util.Util
-
+import org.apache.calcite.util.{TimestampString, Util}
 import java.util
 import java.util.{TimeZone, List => JList}
+
+import org.apache.flink.table.runtime.functions.SqlDateTimeUtils
 
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
@@ -338,8 +339,11 @@ class RexNodeToExpressionConverter(
         LocalTimeConverter.INSTANCE.toExternal(v)
 
       case TIMESTAMP_WITHOUT_TIME_ZONE =>
-        val v = literal.getValueAs(classOf[java.lang.Long])
-        LocalDateTimeConverter.INSTANCE.toExternal(SqlTimestamp.fromEpochMillis(v))
+        val v = literal.getValueAs(classOf[TimestampString])
+        val millisecond = v.getMillisSinceEpoch
+        val nanoOfMillisecond = SqlDateTimeUtils.getNanoOfMillisSinceEpoch(v.toString)
+        LocalDateTimeConverter.INSTANCE.toExternal(
+          SqlTimestamp.fromEpochMillis(millisecond, nanoOfMillisecond))
 
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
         val v = literal.getValueAs(classOf[java.lang.Long])

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/typeutils/TypeInfoCheckUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/typeutils/TypeInfoCheckUtils.scala
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.typeutils.CompositeType
 import org.apache.flink.api.java.typeutils.{MapTypeInfo, ObjectArrayTypeInfo, PojoTypeInfo}
 import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.planner.validate._
-import org.apache.flink.table.runtime.typeutils.{BigDecimalTypeInfo, DecimalTypeInfo}
+import org.apache.flink.table.runtime.typeutils.{BigDecimalTypeInfo, DecimalTypeInfo, LegacyLocalDateTimeTypeInfo, LegacyTimestampTypeInfo}
 import org.apache.flink.table.typeutils.TimeIntervalTypeInfo.{INTERVAL_MILLIS, INTERVAL_MONTHS}
 import org.apache.flink.table.typeutils.{TimeIndicatorTypeInfo, TimeIntervalTypeInfo}
 
@@ -89,8 +89,12 @@ object TypeInfoCheckUtils {
   def isMap(dataType: TypeInformation[_]): Boolean =
     dataType.isInstanceOf[MapTypeInfo[_, _]]
 
-  def isComparable(dataType: TypeInformation[_]): Boolean =
-    classOf[Comparable[_]].isAssignableFrom(dataType.getTypeClass) && !isArray(dataType)
+  def isComparable(dataType: TypeInformation[_]): Boolean = dataType match {
+    case _: LegacyLocalDateTimeTypeInfo |
+         _: LegacyTimestampTypeInfo => true
+    case _ =>
+      classOf[Comparable[_]].isAssignableFrom(dataType.getTypeClass) && !isArray(dataType)
+  }
 
   /**
     * Types that can be easily converted into a string without ambiguity.

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -297,8 +297,8 @@ public class SqlToOperationConverterTest {
 			createTestItem("TIME(3)", DataTypes.TIME()),
 			// Expect to be TIME(3).
 			createTestItem("TIME(3) WITHOUT TIME ZONE", DataTypes.TIME()),
-			createTestItem("TIMESTAMP", DataTypes.TIMESTAMP(3)),
-			createTestItem("TIMESTAMP WITHOUT TIME ZONE", DataTypes.TIMESTAMP(3)),
+			createTestItem("TIMESTAMP", DataTypes.TIMESTAMP(6)),
+			createTestItem("TIMESTAMP WITHOUT TIME ZONE", DataTypes.TIMESTAMP(6)),
 			createTestItem("TIMESTAMP(3)", DataTypes.TIMESTAMP(3)),
 			createTestItem("TIMESTAMP(3) WITHOUT TIME ZONE", DataTypes.TIMESTAMP(3)),
 			createTestItem("TIMESTAMP WITH LOCAL TIME ZONE",

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
@@ -30,8 +30,6 @@ import org.apache.flink.table.functions.python.PythonEnv;
 import org.apache.flink.table.functions.python.PythonFunction;
 
 import java.sql.Timestamp;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Random;
 import java.util.TimeZone;

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.table.dataformat.SqlTimestamp;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.functions.FunctionContext;
 import org.apache.flink.table.functions.ScalarFunction;
@@ -29,6 +30,8 @@ import org.apache.flink.table.functions.python.PythonEnv;
 import org.apache.flink.table.functions.python.PythonFunction;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Random;
 import java.util.TimeZone;
@@ -82,8 +85,9 @@ public class JavaUserDefinedScalarFunctions {
 	 * Concatenate inputs as strings.
 	 */
 	public static class JavaFunc1 extends ScalarFunction {
-		public String eval(Integer a, int b,  Long c) {
-			return a + " and " + b + " and " + c;
+		public String eval(Integer a, int b,  SqlTimestamp c) {
+			Long ts = (c == null) ? null : c.getMillisecond();
+			return a + " and " + b + " and " + ts;
 		}
 	}
 
@@ -137,14 +141,14 @@ public class JavaUserDefinedScalarFunctions {
 			openCalled = true;
 		}
 
-		public Timestamp eval(Long l, Integer offset) {
+		public Timestamp eval(SqlTimestamp sqlTimestamp, Integer offset) {
 			if (!openCalled) {
 				fail("Open was not called before run.");
 			}
-			if (l == null || offset == null) {
+			if (sqlTimestamp == null || offset == null) {
 				return null;
 			} else {
-				long ts = l - offset;
+				long ts = sqlTimestamp.getMillisecond() - offset;
 				int tzOffset = TimeZone.getDefault().getOffset(ts);
 				return new Timestamp(ts - tzOffset);
 			}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedTableFunctions.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedTableFunctions.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.runtime.utils;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.table.dataformat.SqlTimestamp;
 import org.apache.flink.table.functions.TableFunction;
 
 import org.apache.commons.lang3.StringUtils;
@@ -36,10 +37,10 @@ public class JavaUserDefinedTableFunctions {
 	 * Emit inputs as long.
 	 */
 	public static class JavaTableFunc0 extends TableFunction<Long> {
-		public void eval(Integer a, Long b, Long c) {
+		public void eval(Integer a, Long b, SqlTimestamp c) {
 			collect(a.longValue());
 			collect(b);
-			collect(c);
+			collect(c.getMillisecond());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/RelTimeIndicatorConverterTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/RelTimeIndicatorConverterTest.xml
@@ -62,7 +62,7 @@ Calc(select=[EXPR$0])
   </TestCase>
   <TestCase name="testFilteringOnRowtime">
     <Resource name="sql">
-      <![CDATA[SELECT rowtime FROM MyTable1 WHERE rowtime > CAST('1990-12-02 12:11:11' AS TIMESTAMP)]]>
+      <![CDATA[SELECT rowtime FROM MyTable1 WHERE rowtime > CAST('1990-12-02 12:11:11' AS TIMESTAMP(3))]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
@@ -277,17 +277,17 @@ class CatalogTableITCase(isStreamingMode: Boolean) {
   def testInsertSourceTableWithFuncField(): Unit = {
     val sourceData = List(
       toRow(1, "1990-02-10 12:34:56"),
-      toRow(2, "2019-09-10 9:23:41"),
-      toRow(3, "2019-09-10 9:23:42"),
-      toRow(1, "2019-09-10 9:23:43"),
-      toRow(2, "2019-09-10 9:23:44")
+      toRow(2, "2019-09-10 09:23:41"),
+      toRow(3, "2019-09-10 09:23:42"),
+      toRow(1, "2019-09-10 09:23:43"),
+      toRow(2, "2019-09-10 09:23:44")
     )
     val expected = List(
       toRow(1, "1990-02-10 12:34:56", Timestamp.valueOf("1990-02-10 12:34:56")),
-      toRow(2, "2019-09-10 9:23:41", Timestamp.valueOf("2019-09-10 9:23:41")),
-      toRow(3, "2019-09-10 9:23:42", Timestamp.valueOf("2019-09-10 9:23:42")),
-      toRow(1, "2019-09-10 9:23:43", Timestamp.valueOf("2019-09-10 9:23:43")),
-      toRow(2, "2019-09-10 9:23:44", Timestamp.valueOf("2019-09-10 9:23:44"))
+      toRow(2, "2019-09-10 09:23:41", Timestamp.valueOf("2019-09-10 9:23:41")),
+      toRow(3, "2019-09-10 09:23:42", Timestamp.valueOf("2019-09-10 9:23:42")),
+      toRow(1, "2019-09-10 09:23:43", Timestamp.valueOf("2019-09-10 9:23:43")),
+      toRow(2, "2019-09-10 09:23:44", Timestamp.valueOf("2019-09-10 9:23:44"))
     )
     TestCollectionTableFactory.initData(sourceData)
     val sourceDDL =

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
@@ -305,7 +305,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) {
         |create table t2(
         |  a int,
         |  b varchar,
-        |  c timestamp
+        |  c timestamp(3)
         |) with (
         |  'connector' = 'COLLECTION'
         |)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/WatermarkGeneratorCodeGenTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/WatermarkGeneratorCodeGenTest.scala
@@ -22,7 +22,7 @@ import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.util.MockStreamingRuntimeContext
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog, GenericInMemoryCatalog, ObjectIdentifier}
-import org.apache.flink.table.dataformat.GenericRow
+import org.apache.flink.table.dataformat.{GenericRow, SqlTimestamp}
 import org.apache.flink.table.module.ModuleManager
 import org.apache.flink.table.planner.calcite.{FlinkPlannerImpl, FlinkTypeFactory}
 import org.apache.flink.table.planner.catalog.CatalogManagerCalciteSchema
@@ -59,12 +59,12 @@ class WatermarkGeneratorCodeGenTest {
     catalogManager.getCurrentDatabase)
 
   val data = List(
-    GenericRow.of(JLong.valueOf(1000L), JInt.valueOf(5)),
+    GenericRow.of(SqlTimestamp.fromEpochMillis(1000L), JInt.valueOf(5)),
     GenericRow.of(null, JInt.valueOf(4)),
-    GenericRow.of(JLong.valueOf(3000L), null),
-    GenericRow.of(JLong.valueOf(5000L), JInt.valueOf(3)),
-    GenericRow.of(JLong.valueOf(4000L), JInt.valueOf(10)),
-    GenericRow.of(JLong.valueOf(6000L), JInt.valueOf(8))
+    GenericRow.of(SqlTimestamp.fromEpochMillis(3000L), null),
+    GenericRow.of(SqlTimestamp.fromEpochMillis(5000L), JInt.valueOf(3)),
+    GenericRow.of(SqlTimestamp.fromEpochMillis(4000L), JInt.valueOf(10)),
+    GenericRow.of(SqlTimestamp.fromEpochMillis(6000L), JInt.valueOf(8))
   )
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ArrayTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ArrayTypeTest.scala
@@ -23,6 +23,8 @@ import org.apache.flink.table.api.scala._
 import org.apache.flink.table.planner.expressions.utils.ArrayTypeTestBase
 import org.apache.flink.table.planner.utils.DateTimeTestUtil.{localDate, localDateTime, localTime => gLocalTime}
 
+import java.time.{LocalDateTime => JLocalDateTime}
+
 import org.junit.Test
 
 class ArrayTypeTest extends ArrayTypeTestBase {
@@ -92,7 +94,49 @@ class ArrayTypeTest extends ArrayTypeTestBase {
       Array(localDateTime("1985-04-11 14:15:16"), localDateTime("2018-07-26 17:18:19")),
       "array('1985-04-11 14:15:16'.toTimestamp, '2018-07-26 17:18:19'.toTimestamp)",
       "ARRAY[TIMESTAMP '1985-04-11 14:15:16', TIMESTAMP '2018-07-26 17:18:19']",
-      "[1985-04-11 14:15:16.000, 2018-07-26 17:18:19.000]")
+      "[1985-04-11 14:15:16, 2018-07-26 17:18:19]")
+
+    // localDateTime use DateTimeUtils.timestampStringToUnixDate to parse a time string,
+    // which only support millisecond's precision.
+    testTableApi(
+      Array(
+        JLocalDateTime.of(1985, 4, 11, 14, 15, 16, 123456789),
+        JLocalDateTime.of(2018, 7, 26, 17, 18, 19, 123456789)),
+        "[1985-04-11 14:15:16.123456789, 2018-07-26 17:18:19.123456789]")
+
+    testTableApi(
+      Array(
+        JLocalDateTime.of(1985, 4, 11, 14, 15, 16, 123456700),
+        JLocalDateTime.of(2018, 7, 26, 17, 18, 19, 123456700)),
+      "[1985-04-11 14:15:16.1234567, 2018-07-26 17:18:19.1234567]")
+
+    testTableApi(
+      Array(
+        JLocalDateTime.of(1985, 4, 11, 14, 15, 16, 123456000),
+        JLocalDateTime.of(2018, 7, 26, 17, 18, 19, 123456000)),
+      "[1985-04-11 14:15:16.123456, 2018-07-26 17:18:19.123456]")
+
+    testTableApi(
+      Array(
+        JLocalDateTime.of(1985, 4, 11, 14, 15, 16, 123400000),
+        JLocalDateTime.of(2018, 7, 26, 17, 18, 19, 123400000)),
+      "[1985-04-11 14:15:16.1234, 2018-07-26 17:18:19.1234]")
+
+    testSqlApi(
+      "ARRAY[TIMESTAMP '1985-04-11 14:15:16.123456789', TIMESTAMP '2018-07-26 17:18:19.123456789']",
+      "[1985-04-11 14:15:16.123456789, 2018-07-26 17:18:19.123456789]")
+
+    testSqlApi(
+      "ARRAY[TIMESTAMP '1985-04-11 14:15:16.1234567', TIMESTAMP '2018-07-26 17:18:19.1234567']",
+      "[1985-04-11 14:15:16.1234567, 2018-07-26 17:18:19.1234567]")
+
+    testSqlApi(
+      "ARRAY[TIMESTAMP '1985-04-11 14:15:16.123456', TIMESTAMP '2018-07-26 17:18:19.123456']",
+      "[1985-04-11 14:15:16.123456, 2018-07-26 17:18:19.123456]")
+
+    testSqlApi(
+      "ARRAY[TIMESTAMP '1985-04-11 14:15:16.1234', TIMESTAMP '2018-07-26 17:18:19.1234']",
+      "[1985-04-11 14:15:16.1234, 2018-07-26 17:18:19.1234]")
 
     testAllApis(
       Array(BigDecimal(2.0002), BigDecimal(2.0003)),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/MapTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/MapTypeTest.scala
@@ -24,6 +24,8 @@ import org.apache.flink.table.expressions.utils.ApiExpressionUtils.valueLiteral
 import org.apache.flink.table.planner.expressions.utils.MapTypeTestBase
 import org.apache.flink.table.planner.utils.DateTimeTestUtil.{localDate, localDateTime, localTime => gLocalTime}
 
+import java.time.{LocalDateTime => JLocalTimestamp}
+
 import org.junit.Test
 
 class MapTypeTest extends MapTypeTestBase {
@@ -90,7 +92,30 @@ class MapTypeTest extends MapTypeTestBase {
           "'17:18:19'.toTime, '2018-07-26 17:18:19'.toTimestamp)",
       "MAP[TIME '14:15:16', TIMESTAMP '1985-04-11 14:15:16', " +
           "TIME '17:18:19', TIMESTAMP '2018-07-26 17:18:19']",
-      "{14:15:16=1985-04-11 14:15:16.000, 17:18:19=2018-07-26 17:18:19.000}")
+      "{14:15:16=1985-04-11 14:15:16, 17:18:19=2018-07-26 17:18:19}")
+
+    testAllApis(
+      map(valueLiteral(gLocalTime("14:15:16")),
+        valueLiteral(localDateTime("1985-04-11 14:15:16.123")),
+        valueLiteral(gLocalTime("17:18:19")),
+        valueLiteral(localDateTime("2018-07-26 17:18:19.123"))),
+      "map('14:15:16'.toTime, '1985-04-11 14:15:16.123'.toTimestamp, " +
+        "'17:18:19'.toTime, '2018-07-26 17:18:19.123'.toTimestamp)",
+      "MAP[TIME '14:15:16', TIMESTAMP '1985-04-11 14:15:16.123', " +
+        "TIME '17:18:19', TIMESTAMP '2018-07-26 17:18:19.123']",
+      "{14:15:16=1985-04-11 14:15:16.123, 17:18:19=2018-07-26 17:18:19.123}")
+
+    testTableApi(
+      map(valueLiteral(gLocalTime("14:15:16")),
+        valueLiteral(JLocalTimestamp.of(1985, 4, 11, 14, 15, 16, 123456000)),
+        valueLiteral(gLocalTime("17:18:19")),
+        valueLiteral(JLocalTimestamp.of(2018, 7, 26, 17, 18, 19, 123456000))),
+      "{14:15:16=1985-04-11 14:15:16.123456, 17:18:19=2018-07-26 17:18:19.123456}")
+
+    testSqlApi(
+      "MAP[TIME '14:15:16', TIMESTAMP '1985-04-11 14:15:16.123456', " +
+        "TIME '17:18:19', TIMESTAMP '2018-07-26 17:18:19.123456']",
+      "{14:15:16=1985-04-11 14:15:16.123456, 17:18:19=2018-07-26 17:18:19.123456}")
 
     testAllApis(
       map(BigDecimal(2.0002), BigDecimal(2.0003)),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/RowTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/RowTypeTest.scala
@@ -51,12 +51,17 @@ class RowTypeTest extends RowTypeTestBase {
           "0.1p, Array(1, 2, 3), Map('foo', 'bar'), row(1, true))",
       "ROW(DATE '1985-04-11', TIME '14:15:16', TIMESTAMP '1985-04-11 14:15:16', " +
           "CAST(0.1 AS DECIMAL(2, 1)), ARRAY[1, 2, 3], MAP['foo', 'bar'], row(1, true))",
-      "(1985-04-11,14:15:16,1985-04-11 14:15:16.000,0.1,[1, 2, 3],{foo=bar},(1,true))")
+      "(1985-04-11,14:15:16,1985-04-11 14:15:16,0.1,[1, 2, 3],{foo=bar},(1,true))")
 
     testSqlApi(
       "ROW(DATE '1985-04-11', TIME '14:15:16', TIMESTAMP '1985-04-11 14:15:16', " +
           "CAST(0.1 AS DECIMAL(2, 1)), ARRAY[1, 2, 3], MAP['foo', 'bar'], row(1, true))",
-      "(1985-04-11,14:15:16,1985-04-11 14:15:16.000,0.1,[1, 2, 3],{foo=bar},(1,true))")
+      "(1985-04-11,14:15:16,1985-04-11 14:15:16,0.1,[1, 2, 3],{foo=bar},(1,true))")
+
+    testSqlApi(
+      "ROW(DATE '1985-04-11', TIME '14:15:16', TIMESTAMP '1985-04-11 14:15:16.123456', " +
+        "CAST(0.1 AS DECIMAL(2, 1)), ARRAY[1, 2, 3], MAP['foo', 'bar'], row(1, true))",
+      "(1985-04-11,14:15:16,1985-04-11 14:15:16.123456,0.1,[1, 2, 3],{foo=bar},(1,true))")
 
     testAllApis(
       row(1 + 1, 2 * 3, nullOf(DataTypes.STRING())),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -3014,31 +3014,31 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       'f18.floor(TimeIntervalUnit.YEAR),
       "f18.floor(YEAR)",
       "FLOOR(f18 TO YEAR)",
-      "1996-01-01 00:00:00.000")
+      "1996-01-01 00:00:00")
 
     testAllApis(
       'f18.floor(TimeIntervalUnit.MONTH),
       "f18.floor(MONTH)",
       "FLOOR(f18 TO MONTH)",
-      "1996-11-01 00:00:00.000")
+      "1996-11-01 00:00:00")
 
     testAllApis(
       'f18.floor(TimeIntervalUnit.DAY),
       "f18.floor(DAY)",
       "FLOOR(f18 TO DAY)",
-      "1996-11-10 00:00:00.000")
+      "1996-11-10 00:00:00")
 
     testAllApis(
       'f18.floor(TimeIntervalUnit.MINUTE),
       "f18.floor(MINUTE)",
       "FLOOR(f18 TO MINUTE)",
-      "1996-11-10 06:55:00.000")
+      "1996-11-10 06:55:00")
 
     testAllApis(
       'f18.floor(TimeIntervalUnit.SECOND),
       "f18.floor(SECOND)",
       "FLOOR(f18 TO SECOND)",
-      "1996-11-10 06:55:44.000")
+      "1996-11-10 06:55:44")
 
     testAllApis(
       'f17.floor(TimeIntervalUnit.HOUR),
@@ -3074,31 +3074,31 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       'f18.ceil(TimeIntervalUnit.YEAR),
       "f18.ceil(YEAR)",
       "CEIL(f18 TO YEAR)",
-      "1997-01-01 00:00:00.000")
+      "1997-01-01 00:00:00")
 
     testAllApis(
       'f18.ceil(TimeIntervalUnit.MONTH),
       "f18.ceil(MONTH)",
       "CEIL(f18 TO MONTH)",
-      "1996-12-01 00:00:00.000")
+      "1996-12-01 00:00:00")
 
     testAllApis(
       'f18.ceil(TimeIntervalUnit.DAY),
       "f18.ceil(DAY)",
       "CEIL(f18 TO DAY)",
-      "1996-11-11 00:00:00.000")
+      "1996-11-11 00:00:00")
 
     testAllApis(
       'f18.ceil(TimeIntervalUnit.MINUTE),
       "f18.ceil(MINUTE)",
       "CEIL(f18 TO MINUTE)",
-      "1996-11-10 06:56:00.000")
+      "1996-11-10 06:56:00")
 
     testAllApis(
       'f18.ceil(TimeIntervalUnit.SECOND),
       "f18.ceil(SECOND)",
       "CEIL(f18 TO SECOND)",
-      "1996-11-10 06:55:45.000")
+      "1996-11-10 06:55:45")
 
     testAllApis(
       'f17.ceil(TimeIntervalUnit.HOUR),
@@ -3525,22 +3525,22 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
     testAllApis("2016-06-15".toTimestamp - 1.hour,
       "'2016-06-15'.toTimestamp - 1.hour",
       "timestampadd(HOUR, -1, date '2016-06-15')",
-      "2016-06-14 23:00:00.000")
+      "2016-06-14 23:00:00")
 
     testAllApis("2016-06-15".toTimestamp + 1.minute,
       "'2016-06-15'.toTimestamp + 1.minute",
       "timestampadd(MINUTE, 1, date '2016-06-15')",
-      "2016-06-15 00:01:00.000")
+      "2016-06-15 00:01:00")
 
     testAllApis("2016-06-15".toTimestamp - 1.second,
       "'2016-06-15'.toTimestamp - 1.second",
       "timestampadd(SQL_TSI_SECOND, -1, date '2016-06-15')",
-      "2016-06-14 23:59:59.000")
+      "2016-06-14 23:59:59")
 
     testAllApis("2016-06-15".toTimestamp + 1.second,
       "'2016-06-15'.toTimestamp + 1.second",
       "timestampadd(SECOND, 1, date '2016-06-15')",
-      "2016-06-15 00:00:01.000")
+      "2016-06-15 00:00:01")
 
     testAllApis(nullOf(Types.SQL_TIMESTAMP) + 1.second,
       "nullOf(SQL_TIMESTAMP) + 1.second",
@@ -3577,9 +3577,9 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
   @Test
   def testToTimestamp(): Unit = {
     testSqlApi("to_timestamp('abc')", "null")
-    testSqlApi("to_timestamp('2017-09-15 00:00:00')", "2017-09-15 00:00:00.000")
-    testSqlApi("to_timestamp('20170915000000', 'yyyyMMddHHmmss')", "2017-09-15 00:00:00.000")
-    testSqlApi("to_timestamp('2017-09-15', 'yyyy-MM-dd')", "2017-09-15 00:00:00.000")
+    testSqlApi("to_timestamp('2017-09-15 00:00:00')", "2017-09-15 00:00:00")
+    testSqlApi("to_timestamp('20170915000000', 'yyyyMMddHHmmss')", "2017-09-15 00:00:00")
+    testSqlApi("to_timestamp('2017-09-15', 'yyyy-MM-dd')", "2017-09-15 00:00:00")
     // test with null input
     testSqlApi("to_timestamp(cast(null as varchar))", "null")
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -3029,6 +3029,12 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "1996-11-10 00:00:00")
 
     testAllApis(
+      'f18.floor(TimeIntervalUnit.HOUR),
+      "f18.floor(HOUR)",
+      "FLOOR(f18 TO HOUR)",
+      "1996-11-10 06:00:00")
+
+    testAllApis(
       'f18.floor(TimeIntervalUnit.MINUTE),
       "f18.floor(MINUTE)",
       "FLOOR(f18 TO MINUTE)",
@@ -3087,6 +3093,12 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "f18.ceil(DAY)",
       "CEIL(f18 TO DAY)",
       "1996-11-11 00:00:00")
+
+    testAllApis(
+      'f18.ceil(TimeIntervalUnit.HOUR),
+      "f18.ceil(HOUR)",
+      "CEIL(f18 TO HOUR)",
+      "1996-11-10 07:00:00")
 
     testAllApis(
       'f18.ceil(TimeIntervalUnit.MINUTE),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -1000,6 +1000,10 @@ class TemporalTypesTest extends ExpressionTestBase {
       "TIMESTAMP '1970-01-01 00:00:00.123456788' < TIMESTAMP '1970-01-01 00:00:00.123456789'",
       "true")
 
+    // DATE_FORMAT() should support nanosecond
+    testSqlApi(
+      "DATE_FORMAT(TIMESTAMP '1970-01-01 00:00:00.123456789', 'yyyy/MM/dd HH:mm:ss.SSSSSSSSS')",
+      "1970/01/01 00:00:00.123456789")
   }
 
   // ----------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -82,13 +82,29 @@ class TemporalTypesTest extends ExpressionTestBase {
     testTableApi(
       localDateTime2Literal(localDateTime("2040-09-11 00:00:00.000")),
       "'2040-09-11 00:00:00.000'.toTimestamp",
-      "2040-09-11 00:00:00.000")
+      "2040-09-11 00:00:00")
 
     testAllApis(
       "1500-04-30 12:00:00".cast(DataTypes.TIMESTAMP(3)),
       "'1500-04-30 12:00:00'.cast(SQL_TIMESTAMP)",
-      "CAST('1500-04-30 12:00:00' AS TIMESTAMP)",
-      "1500-04-30 12:00:00.000")
+      "CAST('1500-04-30 12:00:00' AS TIMESTAMP(3))",
+      "1500-04-30 12:00:00")
+
+    testSqlApi(
+      "TIMESTAMP '1500-04-30 12:00:00.123456789'",
+    "1500-04-30 12:00:00.123456789")
+
+    testSqlApi(
+      "TIMESTAMP '1500-04-30 12:00:00.12345678'",
+      "1500-04-30 12:00:00.12345678")
+
+    testSqlApi(
+      "TIMESTAMP '1500-04-30 12:00:00.123456'",
+      "1500-04-30 12:00:00.123456")
+
+    testSqlApi(
+      "TIMESTAMP '1500-04-30 12:00:00.1234'",
+      "1500-04-30 12:00:00.1234")
   }
 
   @Test
@@ -178,13 +194,13 @@ class TemporalTypesTest extends ExpressionTestBase {
       'f0.cast(DataTypes.TIMESTAMP(3)),
       "f0.cast(SQL_TIMESTAMP)",
       "CAST(f0 AS TIMESTAMP)",
-      "1990-10-14 00:00:00.000")
+      "1990-10-14 00:00:00")
 
     testAllApis(
       'f1.cast(DataTypes.TIMESTAMP(3)),
       "f1.cast(SQL_TIMESTAMP)",
       "CAST(f1 AS TIMESTAMP)",
-      "1970-01-01 10:20:45.000")
+      "1970-01-01 10:20:45")
 
     testAllApis(
       'f2.cast(DataTypes.DATE),
@@ -227,12 +243,12 @@ class TemporalTypesTest extends ExpressionTestBase {
     testTableApi(
       'f15.cast(DataTypes.TIMESTAMP(3)),
       "f15.cast(SQL_TIMESTAMP)",
-      "2016-06-27 07:23:33.000")
+      "2016-06-27 07:23:33")
 
     testTableApi(
       'f15.toTimestamp,
       "f15.toTimestamp",
-      "2016-06-27 07:23:33.000")
+      "2016-06-27 07:23:33")
 
     testTableApi(
       'f8.cast(DataTypes.TIMESTAMP(3)).cast(DataTypes.BIGINT()),
@@ -276,13 +292,13 @@ class TemporalTypesTest extends ExpressionTestBase {
     testAllApis(
       'f0.cast(DataTypes.TIMESTAMP(3)) !== 'f2,
       "f0.cast(SQL_TIMESTAMP) !== f2",
-      "CAST(f0 AS TIMESTAMP) <> f2",
+      "CAST(f0 AS TIMESTAMP(3)) <> f2",
       "true")
 
     testAllApis(
       'f0.cast(DataTypes.TIMESTAMP(3)) === 'f6,
       "f0.cast(SQL_TIMESTAMP) === f6",
-      "CAST(f0 AS TIMESTAMP) = f6",
+      "CAST(f0 AS TIMESTAMP(3)) = f6",
       "true")
   }
 
@@ -680,21 +696,21 @@ class TemporalTypesTest extends ExpressionTestBase {
     testSqlApi("CEIL(TIME '12:44:31' TO MINUTE)", "12:45:00")
     testSqlApi("CEIL(TIME '12:44:31' TO HOUR)", "13:00:00")
 
-    testSqlApi("FLOOR(TIMESTAMP '2018-03-20 06:44:31' TO HOUR)", "2018-03-20 06:00:00.000")
-    testSqlApi("FLOOR(TIMESTAMP '2018-03-20 06:44:31' TO DAY)", "2018-03-20 00:00:00.000")
-    testSqlApi("FLOOR(TIMESTAMP '2018-03-20 00:00:00' TO DAY)", "2018-03-20 00:00:00.000")
-    testSqlApi("FLOOR(TIMESTAMP '2018-04-01 06:44:31' TO MONTH)", "2018-04-01 00:00:00.000")
-    testSqlApi("FLOOR(TIMESTAMP '2018-01-01 06:44:31' TO MONTH)", "2018-01-01 00:00:00.000")
-    testSqlApi("CEIL(TIMESTAMP '2018-03-20 06:44:31' TO HOUR)", "2018-03-20 07:00:00.000")
-    testSqlApi("CEIL(TIMESTAMP '2018-03-20 06:00:00' TO HOUR)", "2018-03-20 06:00:00.000")
-    testSqlApi("CEIL(TIMESTAMP '2018-03-20 06:44:31' TO DAY)", "2018-03-21 00:00:00.000")
-    testSqlApi("CEIL(TIMESTAMP '2018-03-01 00:00:00' TO DAY)", "2018-03-01 00:00:00.000")
-    testSqlApi("CEIL(TIMESTAMP '2018-03-31 00:00:01' TO DAY)", "2018-04-01 00:00:00.000")
-    testSqlApi("CEIL(TIMESTAMP '2018-03-01 21:00:01' TO MONTH)", "2018-03-01 00:00:00.000")
-    testSqlApi("CEIL(TIMESTAMP '2018-03-01 00:00:00' TO MONTH)", "2018-03-01 00:00:00.000")
-    testSqlApi("CEIL(TIMESTAMP '2018-12-02 00:00:00' TO MONTH)", "2019-01-01 00:00:00.000")
-    testSqlApi("CEIL(TIMESTAMP '2018-01-01 21:00:01' TO YEAR)", "2018-01-01 00:00:00.000")
-    testSqlApi("CEIL(TIMESTAMP '2018-01-02 21:00:01' TO YEAR)", "2019-01-01 00:00:00.000")
+    testSqlApi("FLOOR(TIMESTAMP '2018-03-20 06:44:31' TO HOUR)", "2018-03-20 06:00:00")
+    testSqlApi("FLOOR(TIMESTAMP '2018-03-20 06:44:31' TO DAY)", "2018-03-20 00:00:00")
+    testSqlApi("FLOOR(TIMESTAMP '2018-03-20 00:00:00' TO DAY)", "2018-03-20 00:00:00")
+    testSqlApi("FLOOR(TIMESTAMP '2018-04-01 06:44:31' TO MONTH)", "2018-04-01 00:00:00")
+    testSqlApi("FLOOR(TIMESTAMP '2018-01-01 06:44:31' TO MONTH)", "2018-01-01 00:00:00")
+    testSqlApi("CEIL(TIMESTAMP '2018-03-20 06:44:31' TO HOUR)", "2018-03-20 07:00:00")
+    testSqlApi("CEIL(TIMESTAMP '2018-03-20 06:00:00' TO HOUR)", "2018-03-20 06:00:00")
+    testSqlApi("CEIL(TIMESTAMP '2018-03-20 06:44:31' TO DAY)", "2018-03-21 00:00:00")
+    testSqlApi("CEIL(TIMESTAMP '2018-03-01 00:00:00' TO DAY)", "2018-03-01 00:00:00")
+    testSqlApi("CEIL(TIMESTAMP '2018-03-31 00:00:01' TO DAY)", "2018-04-01 00:00:00")
+    testSqlApi("CEIL(TIMESTAMP '2018-03-01 21:00:01' TO MONTH)", "2018-03-01 00:00:00")
+    testSqlApi("CEIL(TIMESTAMP '2018-03-01 00:00:00' TO MONTH)", "2018-03-01 00:00:00")
+    testSqlApi("CEIL(TIMESTAMP '2018-12-02 00:00:00' TO MONTH)", "2019-01-01 00:00:00")
+    testSqlApi("CEIL(TIMESTAMP '2018-01-01 21:00:01' TO YEAR)", "2018-01-01 00:00:00")
+    testSqlApi("CEIL(TIMESTAMP '2018-01-02 21:00:01' TO YEAR)", "2019-01-01 00:00:00")
 
     testSqlApi(s"FLOOR(${timestampTz("2018-03-20 06:44:31")} TO HOUR)", "2018-03-20 06:00:00.000")
     testSqlApi(s"FLOOR(${timestampTz("2018-03-20 06:44:31")} TO DAY)", "2018-03-20 00:00:00.000")

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -974,6 +974,32 @@ class TemporalTypesTest extends ExpressionTestBase {
       "CAST(TO_TIMESTAMP('1970-01-01 00:00:00.123456789') AS TIMESTAMP(0))",
       "1970-01-01 00:00:00")
 
+    // DATETIME +/- INTERVAL should support nanosecond
+    testSqlApi(
+      "TIMESTAMP '1970-02-01 00:00:00.123456789' - INTERVAL '1' MONTH",
+      "1970-01-01 00:00:00.123456789")
+
+    testSqlApi(
+      "TIMESTAMP '1970-02-01 00:00:00.123456789' + INTERVAL '1' MONTH",
+      "1970-03-01 00:00:00.123456789")
+
+    testSqlApi(
+      "TIMESTAMP '1970-02-01 00:00:00.123456789' - INTERVAL '1' SECOND",
+      "1970-01-31 23:59:59.123456789")
+
+    testSqlApi(
+      "TIMESTAMP '1970-02-01 00:00:00.123456789' + INTERVAL '1' SECOND",
+      "1970-02-01 00:00:01.123456789")
+
+    // TIMESTAMP compare should support nanosecond
+    testSqlApi(
+      "TIMESTAMP '1970-01-01 00:00:00.123456789' > TIMESTAMP '1970-01-01 00:00:00.123456788'",
+      "true")
+
+    testSqlApi(
+      "TIMESTAMP '1970-01-01 00:00:00.123456788' < TIMESTAMP '1970-01-01 00:00:00.123456789'",
+      "true")
+
   }
 
   // ----------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -909,6 +909,73 @@ class TemporalTypesTest extends ExpressionTestBase {
       "1437699600")
   }
 
+  @Test
+  def testHighPrecisionTimestamp(): Unit = {
+    // EXTRACT should support millisecond/microsecond/nanosecond
+    testSqlApi(
+      "EXTRACT(MILLISECOND FROM TIMESTAMP '1970-01-01 00:00:00.123456789')",
+      "123")
+    testSqlApi(
+      "EXTRACT(MICROSECOND FROM TIMESTAMP '1970-01-01 00:00:00.123456789')",
+      "123456")
+    testSqlApi(
+      "EXTRACT(NANOSECOND FROM TIMESTAMP '1970-01-01 00:00:00.123456789')",
+      "123456789")
+
+    // TIMESTAMPADD should support microsecond/nanosecond
+    // TODO:
+    //  (1970-01-01 00:00:00.123455789:TIMESTAMP(9), /INT(*(1:INTERVAL MICROSECOND, 1), 1000))
+    // testSqlApi(
+    //  "TIMESTAMPADD(MICROSECOND, 1, TIMESTAMP '1970-01-01 00:00:00.123455789')",
+    //  "1970-01-01 00:00:00.123456789"
+    //)
+
+    // TIMESTAMPDIFF should support microsecond/nanosecond
+    // TODO:
+    //  *(
+    //  CAST(
+    //    /INT(
+    //      Reinterpret(
+    //        -(1970-01-01 00:00:00.123455789:TIMESTAMP(9),
+    //          1970-01-01 00:00:00.123456789:TIMESTAMP(9))),
+    //      1000)
+    //  ):INTEGER NOT NULL,
+    //  1000000)
+    //testSqlApi(
+    //  "TIMESTAMPDIFF(MICROSECOND, TIMESTAMP '1970-01-01 00:00:00.123456789', " +
+    //    "TIMESTAMP '1970-01-01 00:00:00.123455789')",
+    //  "1")
+
+    // TO_TIMESTAMP should support up to nanosecond
+    testSqlApi(
+      "TO_TIMESTAMP('1970-01-01 00:00:00.123456789')",
+      "1970-01-01 00:00:00.123456789")
+
+    testSqlApi(
+      "TO_TIMESTAMP('1970-01-01 00:00:00.12345', 'yyyy-MM-dd HH:mm:ss.SSSSS')",
+      "1970-01-01 00:00:00.12345")
+
+    testSqlApi("TO_TIMESTAMP('abc')", "null")
+
+    // CAST between two TIMESTAMPs
+    testSqlApi(
+      "CAST(TIMESTAMP '1970-01-01 00:00:00.123456789' AS TIMESTAMP(6))",
+      "1970-01-01 00:00:00.123456")
+
+    testSqlApi(
+      "CAST(TIMESTAMP '1970-01-01 00:00:00.123456789' AS TIMESTAMP(9))",
+      "1970-01-01 00:00:00.123456789")
+
+    testSqlApi(
+      "CAST(TIMESTAMP '1970-01-01 00:00:00.123456789' AS TIMESTAMP)",
+      "1970-01-01 00:00:00.123456")
+
+    testSqlApi(
+      "CAST(TO_TIMESTAMP('1970-01-01 00:00:00.123456789') AS TIMESTAMP(0))",
+      "1970-01-01 00:00:00")
+
+  }
+
   // ----------------------------------------------------------------------------------------------
 
   override def testData: Row = {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -29,7 +29,6 @@ import org.apache.flink.table.planner.utils.DateTimeTestUtil._
 import org.apache.flink.table.typeutils.TimeIntervalTypeInfo
 import org.apache.flink.types.Row
 import org.junit.Test
-
 import java.sql.Timestamp
 import java.text.SimpleDateFormat
 import java.time.{Instant, ZoneId}
@@ -254,6 +253,43 @@ class TemporalTypesTest extends ExpressionTestBase {
       'f8.cast(DataTypes.TIMESTAMP(3)).cast(DataTypes.BIGINT()),
       "f8.cast(SQL_TIMESTAMP).cast(LONG)",
       "1467012213000")
+
+    testSqlApi(
+      "CAST(CAST('123' as DECIMAL(5, 2)) AS TIMESTAMP)",
+      "1970-01-01 00:02:03")
+
+    testSqlApi(
+      "CAST(TIMESTAMP '1970-01-01 00:02:03' AS DECIMAL(5, 2))",
+      "123.00")
+
+    testSqlApi(
+      "CAST(CAST('123' AS FLOAT) AS TIMESTAMP)",
+      "1970-01-01 00:02:03")
+
+    testSqlApi(
+      "CAST(TIMESTAMP '1970-01-01 00:02:03' AS FLOAT)",
+      "123.0")
+
+    testSqlApi(
+      "CAST(CAST('123' AS DOUBLE) AS TIMESTAMP)",
+      "1970-01-01 00:02:03")
+
+    testSqlApi(
+      "CAST(TIMESTAMP '1970-01-01 00:02:03' AS DOUBLE)",
+      "123.0")
+
+    testSqlApi(
+      "CAST(TIMESTAMP '1970-01-01 00:02:03' AS TINYINT)",
+      "123")
+
+    testSqlApi(
+      "CAST(TIMESTAMP '1970-01-01 00:02:03' AS SMALLINT)",
+      "123")
+
+    testSqlApi(
+      "CAST(TIMESTAMP '1970-01-01 00:02:03' AS INT)",
+      "123")
+
   }
 
   @Test
@@ -923,7 +959,7 @@ class TemporalTypesTest extends ExpressionTestBase {
       "123456789")
 
     // TIMESTAMPADD should support microsecond/nanosecond
-    // TODO:
+    // TODO: https://issues.apache.org/jira/browse/CALCITE-3530
     //  (1970-01-01 00:00:00.123455789:TIMESTAMP(9), /INT(*(1:INTERVAL MICROSECOND, 1), 1000))
     // testSqlApi(
     //  "TIMESTAMPADD(MICROSECOND, 1, TIMESTAMP '1970-01-01 00:00:00.123455789')",
@@ -931,7 +967,8 @@ class TemporalTypesTest extends ExpressionTestBase {
     //)
 
     // TIMESTAMPDIFF should support microsecond/nanosecond
-    // TODO:
+    // TODO: https://issues.apache.org/jira/browse/CALCITE-3530 and
+    //   https://issues.apache.org/jira/browse/CALCITE-3529
     //  *(
     //  CAST(
     //    /INT(
@@ -1009,7 +1046,7 @@ class TemporalTypesTest extends ExpressionTestBase {
   // ----------------------------------------------------------------------------------------------
 
   override def testData: Row = {
-    val testData = new Row(23)
+    val testData = new Row(24)
     testData.setField(0, localDate("1990-10-14"))
     testData.setField(1, DateTimeTestUtil.localTime("10:20:45"))
     testData.setField(2, localDateTime("1990-10-14 10:20:45.123"))

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -92,7 +92,7 @@ class TemporalTypesTest extends ExpressionTestBase {
 
     testSqlApi(
       "TIMESTAMP '1500-04-30 12:00:00.123456789'",
-    "1500-04-30 12:00:00.123456789")
+      "1500-04-30 12:00:00.123456789")
 
     testSqlApi(
       "TIMESTAMP '1500-04-30 12:00:00.12345678'",

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/UserDefinedScalarFunctionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/UserDefinedScalarFunctionTest.scala
@@ -250,6 +250,12 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       "Func10(f6)",
       "Func10(f6)",
       "1990-10-14 12:10:10")
+
+    testAllApis(
+      Func13('f6),
+      "Func13(f6)",
+      "Func13(f6)",
+      "1990-10-14 12:10:10")
   }
 
   @Test
@@ -477,6 +483,7 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
     "Func10" -> Func10,
     "Func11" -> Func11,
     "Func12" -> Func12,
+    "Func13" -> Func13,
     "Func14" -> Func14,
     "Func15" -> Func15,
     "Func16" -> Func16,

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/UserDefinedScalarFunctionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/UserDefinedScalarFunctionTest.scala
@@ -249,7 +249,7 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       Func10('f6),
       "Func10(f6)",
       "Func10(f6)",
-      "1990-10-14 12:10:10.000")
+      "1990-10-14 12:10:10")
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/UserDefinedScalarFunctionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/UserDefinedScalarFunctionTest.scala
@@ -35,6 +35,17 @@ import java.lang.{Boolean => JBoolean}
 class UserDefinedScalarFunctionTest extends ExpressionTestBase {
 
   @Test
+  def test(): Unit = {
+    val JavaFunc1 = new JavaFunc1()
+
+    testAllApis(
+      JavaFunc1(nullOf(DataTypes.TIME), 15, nullOf(DataTypes.TIMESTAMP(3))),
+      "JavaFunc1(Null(SQL_TIME), 15, Null(SQL_TIMESTAMP))",
+      "JavaFunc1(NULL, 15, NULL)",
+      "null and 15 and null")
+  }
+
+  @Test
   def testParameters(): Unit = {
     testAllApis(
       Func0('f0),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/ExpressionTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/ExpressionTestBase.scala
@@ -226,6 +226,12 @@ abstract class ExpressionTestBase {
     addTableApiTestExpr(exprString, expected)
   }
 
+  def testTableApi(
+      expr: Expression,
+      expected: String): Unit = {
+    addTableApiTestExpr(expr, expected)
+  }
+
   private def addTableApiTestExpr(tableApiString: String, expected: String): Unit = {
     addTableApiTestExpr(ExpressionParser.parseExpression(tableApiString), expected)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/userDefinedScalarFunctions.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/userDefinedScalarFunctions.scala
@@ -24,13 +24,13 @@ import org.apache.flink.table.api.Types
 import org.apache.flink.table.functions.{FunctionContext, ScalarFunction}
 import org.apache.flink.table.typeutils.TimeIntervalTypeInfo
 import org.apache.flink.types.Row
-
 import org.apache.commons.lang3.StringUtils
 import org.junit.Assert
-
 import java.lang.{Long => JLong}
 import java.sql.{Date, Time, Timestamp}
 import java.util.Random
+
+import org.apache.flink.table.dataformat.SqlTimestamp
 
 import scala.annotation.varargs
 import scala.collection.mutable
@@ -117,15 +117,20 @@ object Func8 extends ScalarFunction {
 
 @SerialVersionUID(1L)
 object Func9 extends ScalarFunction {
-  def eval(a: Int, b: Int, c: Long): String = {
-    s"$a and $b and $c"
+  def eval(a: Int, b: Int, c: SqlTimestamp): String = {
+    val ts = if (c == null) null else c.getMillisecond
+    s"$a and $b and $ts"
   }
 }
 
 @SerialVersionUID(1L)
 object Func10 extends ScalarFunction {
-  def eval(c: Long): Long = {
-    c
+  def eval(c: SqlTimestamp): Timestamp = {
+    if (c == null) {
+      null
+    } else {
+      c.toTimestamp
+    }
   }
 
   override def getResultType(signature: Array[Class[_]]): TypeInformation[_] =

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/userDefinedScalarFunctions.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/userDefinedScalarFunctions.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.expressions.utils
 
-import org.apache.flink.api.common.typeinfo.{SqlTimeTypeInfo, TypeInformation}
+import org.apache.flink.api.common.typeinfo.{LocalTimeTypeInfo, SqlTimeTypeInfo, TypeInformation}
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.functions.{FunctionContext, ScalarFunction}
@@ -28,6 +28,7 @@ import org.apache.commons.lang3.StringUtils
 import org.junit.Assert
 import java.lang.{Long => JLong}
 import java.sql.{Date, Time, Timestamp}
+import java.time.LocalDateTime
 import java.util.Random
 
 import org.apache.flink.table.dataformat.SqlTimestamp
@@ -153,6 +154,20 @@ object Func12 extends ScalarFunction {
   override def getResultType(signature: Array[Class[_]]): TypeInformation[_] = {
     TimeIntervalTypeInfo.INTERVAL_MILLIS
   }
+}
+
+@SerialVersionUID(1L)
+object Func13 extends ScalarFunction {
+  def eval(c: SqlTimestamp): LocalDateTime = {
+    if (c == null) {
+      null
+    } else {
+      c.toLocalDateTime
+    }
+  }
+
+  override def getResultType(signature: Array[Class[_]]): TypeInformation[_] =
+    LocalTimeTypeInfo.LOCAL_DATE_TIME
 }
 
 @SerialVersionUID(1L)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/RelTimeIndicatorConverterTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/RelTimeIndicatorConverterTest.scala
@@ -57,7 +57,7 @@ class RelTimeIndicatorConverterTest extends TableTestBase {
   @Test
   def testFilteringOnRowtime(): Unit = {
     val sqlQuery =
-      "SELECT rowtime FROM MyTable1 WHERE rowtime > CAST('1990-12-02 12:11:11' AS TIMESTAMP)"
+      "SELECT rowtime FROM MyTable1 WHERE rowtime > CAST('1990-12-02 12:11:11' AS TIMESTAMP(3))"
     util.verifyPlan(sqlQuery)
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/RelTimeIndicatorConverterTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/RelTimeIndicatorConverterTest.scala
@@ -23,10 +23,10 @@ import org.apache.flink.table.api.scala._
 import org.apache.flink.table.functions.TableFunction
 import org.apache.flink.table.planner.plan.stream.sql.RelTimeIndicatorConverterTest.TableFunc
 import org.apache.flink.table.planner.utils.TableTestBase
-
 import org.junit.Test
-
 import java.sql.Timestamp
+
+import org.apache.flink.table.dataformat.SqlTimestamp
 
 /**
   * Tests for [[org.apache.flink.table.planner.calcite.RelTimeIndicatorConverter]].
@@ -170,7 +170,7 @@ object RelTimeIndicatorConverterTest {
   class TableFunc extends TableFunction[String] {
     val t = new Timestamp(0L)
 
-    def eval(time1: Long, time2: Timestamp, string: String): Unit = {
+    def eval(time1: SqlTimestamp, time2: Timestamp, string: String): Unit = {
       collect(time1.toString + time2.after(t) + string)
     }
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
@@ -144,7 +144,7 @@ class LookupJoinTest extends TableTestBase with Serializable {
       "SELECT * FROM T AS T JOIN temporalTable2 " +
         "FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id AND T.b = D.name AND T.ts = D.ts",
       "Expected: eval(java.lang.Integer, org.apache.flink.table.dataformat.BinaryString, " +
-        "java.lang.Long) \n" +
+        "org.apache.flink.table.dataformat.SqlTimestamp) \n" +
         "Actual: eval(java.lang.Integer, java.lang.String, java.time.LocalDateTime)",
       classOf[TableException]
     )
@@ -178,7 +178,8 @@ class LookupJoinTest extends TableTestBase with Serializable {
       "SELECT * FROM T AS T JOIN temporalTable7 " +
         "FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id AND T.b = D.name AND T.ts = D.ts",
       "Expected: eval(java.util.concurrent.CompletableFuture, " +
-        "java.lang.Integer, org.apache.flink.table.dataformat.BinaryString, java.lang.Long) \n" +
+        "java.lang.Integer, org.apache.flink.table.dataformat.BinaryString, " +
+        "org.apache.flink.table.dataformat.SqlTimestamp) \n" +
         "Actual: eval(java.lang.Integer, org.apache.flink.table.dataformat.BinaryString, " +
         "java.time.LocalDateTime)",
       classOf[TableException]
@@ -190,7 +191,8 @@ class LookupJoinTest extends TableTestBase with Serializable {
       "SELECT * FROM T AS T JOIN temporalTable8 " +
         "FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id AND T.b = D.name AND T.ts = D.ts",
         "Expected: eval(java.util.concurrent.CompletableFuture, " +
-        "java.lang.Integer, org.apache.flink.table.dataformat.BinaryString, java.lang.Long) \n" +
+        "java.lang.Integer, org.apache.flink.table.dataformat.BinaryString, " +
+        "org.apache.flink.table.dataformat.SqlTimestamp) \n" +
         "Actual: eval(java.util.concurrent.CompletableFuture, " +
         "java.lang.Integer, java.lang.String, java.time.LocalDateTime)",
       classOf[TableException]
@@ -208,7 +210,8 @@ class LookupJoinTest extends TableTestBase with Serializable {
       "SELECT * FROM T AS T JOIN temporalTable10 " +
         "FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id AND T.b = D.name AND T.ts = D.ts",
       "Expected: eval(java.util.concurrent.CompletableFuture, " +
-        "java.lang.Integer, org.apache.flink.table.dataformat.BinaryString, java.lang.Long) \n" +
+        "java.lang.Integer, org.apache.flink.table.dataformat.BinaryString, " +
+        "org.apache.flink.table.dataformat.SqlTimestamp) \n" +
         "Actual: eval(org.apache.flink.streaming.api.functions.async.ResultFuture, " +
         "java.lang.Integer, org.apache.flink.table.dataformat.BinaryString, java.lang.Long)",
       classOf[TableException]

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/TableAggregateValidationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/TableAggregateValidationTest.scala
@@ -33,7 +33,8 @@ class TableAggregateValidationTest extends TableTestBase {
     expectedException.expect(classOf[ValidationException])
     expectedException.expectMessage("Given parameters do not match any signature. \n" +
       "Actual: (java.lang.Long, java.lang.Integer, java.lang.String) \n" +
-      "Expected: (int), (long, int), (long, java.sql.Timestamp)")
+      "Expected: (int), (java.sql.Timestamp, java.sql.Timestamp), " +
+      "(long, int), (long, java.sql.Timestamp)")
 
     val util = streamTestUtil()
     val table = util.addTableSource[(Long, Int, String)]('a, 'b, 'c)
@@ -51,7 +52,8 @@ class TableAggregateValidationTest extends TableTestBase {
     expectedException.expect(classOf[ValidationException])
     expectedException.expectMessage("Given parameters do not match any signature. \n" +
       "Actual: (java.lang.Long, java.lang.String) \n" +
-      "Expected: (int), (long, int), (long, java.sql.Timestamp)")
+      "Expected: (int), (java.sql.Timestamp, java.sql.Timestamp), " +
+      "(long, int), (long, java.sql.Timestamp)")
 
     val util = streamTestUtil()
     val table = util.addTableSource[(Long, Int, String)]('a, 'b, 'c)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractorTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractorTest.scala
@@ -439,14 +439,14 @@ class RexNodeExtractorTest extends RexNodeTestBase {
       relBuilder,
       functionCatalog)
 
-    val timestamp = DateTimeTestUtil.localDateTime("2017-09-10 14:23:01")
+    val datetime = DateTimeTestUtil.localDateTime("2017-09-10 14:23:01")
     val date = DateTimeTestUtil.localDate("2017-09-12")
     val time = DateTimeTestUtil.localTime("14:23:01")
 
     {
       val expected = Array[Expression](
         // timestamp_col = '2017-09-10 14:23:01'
-        unresolvedCall(EQUALS, unresolvedRef("timestamp_col"), valueLiteral(timestamp)),
+        unresolvedCall(EQUALS, unresolvedRef("timestamp_col"), valueLiteral(datetime)),
         // date_col = '2017-09-12'
         unresolvedCall(EQUALS, unresolvedRef("date_col"), valueLiteral(date)),
         // time_col = '14:23:01'
@@ -460,7 +460,7 @@ class RexNodeExtractorTest extends RexNodeTestBase {
       val expected = Array[Expression](
         EqualTo(
           UnresolvedFieldReference("timestamp_col"),
-          Literal(Timestamp.valueOf("2017-09-10 14:23:01"))
+          Literal(datetime)
         ),
         EqualTo(
           UnresolvedFieldReference("date_col"),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -1007,7 +1007,7 @@ class CalcITCase extends BatchTestBase {
     val table = parseQuery("SELECT CURRENT_TIMESTAMP FROM testTable WHERE a = TRUE")
     val result = executeQuery(table)
     val ts1 = LocalDateTimeConverter.INSTANCE.toInternal(
-      result.toList.head.getField(0).asInstanceOf[LocalDateTime])
+      result.toList.head.getField(0).asInstanceOf[LocalDateTime]).getMillisecond
 
     val ts2 = System.currentTimeMillis()
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -28,8 +28,8 @@ import org.apache.flink.api.java.typeutils._
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.api.config.ExecutionConfigOptions
-import org.apache.flink.table.dataformat.DataFormatConverters.{LocalDateConverter, LocalDateTimeConverter}
-import org.apache.flink.table.dataformat.Decimal
+import org.apache.flink.table.dataformat.DataFormatConverters.{LocalDateConverter}
+import org.apache.flink.table.dataformat.{Decimal, SqlTimestamp}
 import org.apache.flink.table.planner.expressions.utils.{RichFunc1, RichFunc2, RichFunc3, SplitUDF}
 import org.apache.flink.table.planner.plan.rules.physical.batch.BatchExecSortRule
 import org.apache.flink.table.planner.runtime.utils.BatchTableEnvUtil.parseFieldNames
@@ -41,10 +41,8 @@ import org.apache.flink.table.planner.utils.DateTimeTestUtil
 import org.apache.flink.table.planner.utils.DateTimeTestUtil._
 import org.apache.flink.table.runtime.functions.SqlDateTimeUtils.unixTimestampToLocalDateTime
 import org.apache.flink.types.Row
-
 import org.junit.Assert.assertEquals
 import org.junit._
-
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Time, Timestamp}
 import java.time.{LocalDate, LocalDateTime}
@@ -1006,7 +1004,7 @@ class CalcITCase extends BatchTestBase {
 
     val table = parseQuery("SELECT CURRENT_TIMESTAMP FROM testTable WHERE a = TRUE")
     val result = executeQuery(table)
-    val ts1 = LocalDateTimeConverter.INSTANCE.toInternal(
+    val ts1 = SqlTimestamp.fromLocalDateTime(
       result.toList.head.getField(0).asInstanceOf[LocalDateTime]).getMillisecond
 
     val ts2 = System.currentTimeMillis()

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -702,14 +702,14 @@ class CalcITCase extends BatchTestBase {
 
   @Test
   def testValueConstructor(): Unit = {
-    val data = Seq(row("foo", 12, localDateTime("1984-07-12 14:34:24")))
+    val data = Seq(row("foo", 12, localDateTime("1984-07-12 14:34:24.001")))
     BatchTableEnvUtil.registerCollection(
       tEnv, "MyTable", data,
       new RowTypeInfo(Types.STRING, Types.INT, Types.LOCAL_DATE_TIME),
       Some(parseFieldNames("a, b, c")), None, None)
 
     val table = parseQuery("SELECT ROW(a, b, c), ARRAY[12, b], MAP[a, c] FROM MyTable " +
-        "WHERE (a, b, c) = ('foo', 12, TIMESTAMP '1984-07-12 14:34:24')")
+        "WHERE (a, b, c) = ('foo', 12, TIMESTAMP '1984-07-12 14:34:24.001')")
     val result = executeQuery(table)
 
     val baseRow = result.head.getField(0).asInstanceOf[Row]

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSourceITCase.scala
@@ -27,11 +27,14 @@ import org.apache.flink.table.planner.runtime.utils.{BatchTestBase, TestData}
 import org.apache.flink.table.planner.utils.{TestDataTypeTableSource, TestFileInputFormatTableSource, TestFilterableTableSource, TestInputFormatTableSource, TestNestedProjectableTableSource, TestPartitionableSourceFactory, TestProjectableTableSource, TestTableSources}
 import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter
 import org.apache.flink.types.Row
-
 import org.junit.{Before, Test}
-
 import java.io.FileWriter
 import java.lang.{Boolean => JBool, Integer => JInt, Long => JLong}
+import java.math.{BigDecimal => JDecimal}
+import java.sql.Timestamp
+import java.time.LocalDateTime
+
+import scala.collection.mutable
 
 class TableSourceITCase extends BatchTestBase {
 
@@ -225,28 +228,56 @@ class TableSourceITCase extends BatchTestBase {
   }
 
   @Test
-  def testDecimalSource(): Unit = {
+  def testMultiTypeSource(): Unit = {
     val tableSchema = TableSchema.builder().fields(
-      Array("a", "b", "c", "d"),
+      Array("a", "b", "c", "d", "e", "f"),
       Array(
         DataTypes.INT(),
         DataTypes.DECIMAL(5, 2),
         DataTypes.VARCHAR(5),
-        DataTypes.CHAR(5))).build()
+        DataTypes.CHAR(5),
+        DataTypes.TIMESTAMP(9).bridgedTo(classOf[LocalDateTime]),
+        DataTypes.TIMESTAMP(9).bridgedTo(classOf[Timestamp])
+      )
+    ).build()
+
+    val ints = List(1, 2, 3, 4, null)
+    val decimals = List(
+      new JDecimal(5.1), new JDecimal(6.1), new JDecimal(7.1), new JDecimal(8.123), null)
+    val varchars = List("1", "12", "123", "1234", null)
+    val chars = List("1", "12", "123", "1234", null)
+    val datetimes = List(
+      LocalDateTime.of(1969, 1, 1, 0, 0, 0, 123456789),
+      LocalDateTime.of(1970, 1, 1, 0, 0, 0, 123456000),
+      LocalDateTime.of(1971, 1, 1, 0, 0, 0, 123000000),
+      LocalDateTime.of(1972, 1, 1, 0, 0, 0, 0),
+      null)
+    val timestamps = List(
+      Timestamp.valueOf("1969-01-01 00:00:00.123456789"),
+      Timestamp.valueOf("1970-01-01 00:00:00.123456"),
+      Timestamp.valueOf("1971-01-01 00:00:00.123"),
+      Timestamp.valueOf("1972-01-01 00:00:00"),
+      null
+    )
+
+    val data = new mutable.MutableList[Row]
+
+    for (i <- ints.indices) {
+      data += row(ints(i), decimals(i), varchars(i), chars(i), datetimes(i), timestamps(i))
+    }
+
     val tableSource = new TestDataTypeTableSource(
       tableSchema,
-      Seq(
-        row(1, new java.math.BigDecimal(5.1), "1", "1"),
-        row(2, new java.math.BigDecimal(6.1), "12", "12"),
-        row(3, new java.math.BigDecimal(7.1), "123", "123")
-      ))
+      data.seq)
     tEnv.registerTableSource("MyInputFormatTable", tableSource)
     checkResult(
-      "SELECT a, b, c, d FROM MyInputFormatTable",
+      "SELECT a, b, c, d, e, f FROM MyInputFormatTable",
       Seq(
-        row(1, "5.10", "1", "1"),
-        row(2, "6.10", "12", "12"),
-        row(3, "7.10", "123", "123"))
+        row(1, "5.10", "1", "1", "1969-01-01T00:00:00.123456789", "1969-01-01T00:00:00.123456789"),
+        row(2, "6.10", "12", "12", "1970-01-01T00:00:00.123456", "1970-01-01T00:00:00.123456"),
+        row(3, "7.10", "123", "123", "1971-01-01T00:00:00.123", "1971-01-01T00:00:00.123"),
+        row(4, "8.12", "1234", "1234", "1972-01-01T00:00", "1972-01-01T00:00"),
+        row(null, null, null, null, null, null))
     )
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TimestampITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TimestampITCase.scala
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.batch.sql
+
+import org.apache.flink.table.api.{DataTypes, TableSchema}
+import org.apache.flink.table.planner.runtime.utils.BatchTestBase
+import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
+import org.apache.flink.table.planner.utils.DateTimeTestUtil._
+import org.apache.flink.table.planner.utils.TestDataTypeTableSource
+import org.apache.flink.types.Row
+import org.junit.Test
+
+import java.sql.Timestamp
+import java.time.LocalDateTime
+
+import scala.collection.mutable
+
+class TimestampITCase extends BatchTestBase {
+
+  override def before(): Unit = {
+    super.before()
+
+    val tableSchema = TableSchema.builder().fields(
+      Array("a", "b", "c", "d"),
+      Array(
+        DataTypes.INT(),
+        DataTypes.BIGINT(),
+        DataTypes.TIMESTAMP(9).bridgedTo(classOf[LocalDateTime]),
+        DataTypes.TIMESTAMP(9).bridgedTo(classOf[Timestamp])
+      )
+    ).build()
+
+    val ints = List(1, 2, 3, 4, null)
+
+    val longs = List(1L, 2L, 2L, 4L, null)
+    
+    val datetimes = List(
+      localDateTime("1969-01-01 00:00:00.123456789"),
+      localDateTime("1970-01-01 00:00:00.123456"),
+      localDateTime("1970-01-01 00:00:00.123456"),
+      localDateTime("1970-01-01 00:00:00.123"),
+      null)
+
+    val timestamps = List(
+      Timestamp.valueOf("1969-01-01 00:00:00.123456789"),
+      Timestamp.valueOf("1970-01-01 00:00:00.123456"),
+      Timestamp.valueOf("1970-01-01 00:00:00.123"),
+      Timestamp.valueOf("1972-01-01 00:00:00"),
+      null
+    )
+
+    val data = new mutable.MutableList[Row]
+
+    for (i <- ints.indices) {
+      data += row(ints(i), longs(i), datetimes(i), timestamps(i))
+    }
+
+    val tableSource = new TestDataTypeTableSource(
+      tableSchema,
+      data.seq)
+    tEnv.registerTableSource("T", tableSource)
+  }
+
+  @Test
+  def testGroupBy(): Unit = {
+    checkResult(
+      "SELECT MAX(a), MIN(a), c FROM T GROUP BY c",
+      Seq(
+        row(1, 1, "1969-01-01T00:00:00.123456789"),
+        row(3, 2, "1970-01-01T00:00:00.123456"),
+        row(4, 4, "1970-01-01T00:00:00.123"),
+        row(null, null, null)))
+  }
+
+  @Test
+  def testMaxMinOn(): Unit = {
+    checkResult(
+      "SELECT MAX(d), MIN(d), b FROM T GROUP BY b",
+      Seq(
+        row("1969-01-01T00:00:00.123456789", "1969-01-01T00:00:00.123456789", 1),
+        row("1970-01-01T00:00:00.123456", "1970-01-01T00:00:00.123", 2),
+        row("1972-01-01T00:00", "1972-01-01T00:00", 4),
+        row(null, null, null)
+      ))
+  }
+
+  @Test
+  def testLeadLagOn(): Unit = {
+    checkResult(
+      "SELECT b, lag(d) OVER (PARTITION BY b ORDER BY d), " +
+        "LEAD(d, -1) OVER (PARTITION BY b ORDER BY d) FROM T",
+      Seq(
+        row(1,null, null),
+        row(2,"1970-01-01T00:00:00.123", "1970-01-01T00:00:00.123"),
+        row(2, null, null),
+        row(4, null, null),
+        row(null, null, null)
+      ))
+  }
+
+  @Test
+  def testJoinOn(): Unit = {
+    checkResult(
+      "SELECT * FROM T as T1 JOIN T as T2 ON T1.c = T2.d",
+      Seq(
+        row(1, 1, "1969-01-01T00:00:00.123456789", "1969-01-01T00:00:00.123456789",
+          1, 1, "1969-01-01T00:00:00.123456789", "1969-01-01T00:00:00.123456789"),
+        row(2, 2, "1970-01-01T00:00:00.123456", "1970-01-01T00:00:00.123456",
+          2, 2, "1970-01-01T00:00:00.123456", "1970-01-01T00:00:00.123456"),
+        row(3, 2, "1970-01-01T00:00:00.123456", "1970-01-01T00:00:00.123",
+          2, 2, "1970-01-01T00:00:00.123456", "1970-01-01T00:00:00.123456"),
+        row(4, 4, "1970-01-01T00:00:00.123", "1972-01-01T00:00",
+          3, 2, "1970-01-01T00:00:00.123456", "1970-01-01T00:00:00.123")
+      ))
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TimestampITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TimestampITCase.scala
@@ -103,14 +103,14 @@ class TimestampITCase extends BatchTestBase {
   @Test
   def testLeadLagOn(): Unit = {
     checkResult(
-      "SELECT b, lag(d) OVER (PARTITION BY b ORDER BY d), " +
-        "LEAD(d, -1) OVER (PARTITION BY b ORDER BY d) FROM T",
+      "SELECT b, d, lag(d) OVER (PARTITION BY b ORDER BY d), " +
+        "LEAD(d) OVER (PARTITION BY b ORDER BY d) FROM T",
       Seq(
-        row(1,null, null),
-        row(2,"1970-01-01T00:00:00.123", "1970-01-01T00:00:00.123"),
-        row(2, null, null),
-        row(4, null, null),
-        row(null, null, null)
+        row(1, "1969-01-01T00:00:00.123456789", null, null),
+        row(2, "1970-01-01T00:00:00.123", null, "1970-01-01T00:00:00.123456"),
+        row(2, "1970-01-01T00:00:00.123456", "1970-01-01T00:00:00.123", null),
+        row(4, "1972-01-01T00:00", null, null),
+        row(null, null, null, null)
       ))
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
@@ -517,10 +517,8 @@ class AggregateITCase(
       case (a, b, c, d, e) => (b, a, c, d, e)
     }).assignTimestampsAndWatermarks(
       new TimestampAndWatermarkWithOffset[(Long, Int, Int, String, Long)](0L))
-        .toTable(tEnv, 'rowtime, 'a, 'c, 'd, 'e)
+        .toTable(tEnv, 'rowtime.rowtime, 'a, 'c, 'd, 'e)
     tEnv.registerTable("MyTable", t)
-    val sourceTable = tEnv.scan("MyTable")
-    addTableWithWatermark("MyTable1", sourceTable, "rowtime", 0)
 
     val innerSql =
       """
@@ -528,7 +526,7 @@ class AggregateITCase(
         |   SUM(DISTINCT e) b,
         |   MIN(DISTINCT e) c,
         |   COUNT(DISTINCT e) d
-        |FROM MyTable1
+        |FROM MyTable
         |GROUP BY a, TUMBLE(rowtime, INTERVAL '0.005' SECOND)
       """.stripMargin
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TimestampITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TimestampITCase.scala
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.sql
+
+import java.sql.Timestamp
+import java.time.LocalDateTime
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.api.{DataTypes, TableSchema}
+import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
+import org.apache.flink.table.planner.runtime.utils.{StreamingTestBase, TestingRetractSink}
+import org.apache.flink.table.planner.utils.DateTimeTestUtil.localDateTime
+import org.apache.flink.table.planner.utils.TestDataTypeTableSourceWithTime
+import org.apache.flink.types.Row
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+import scala.collection.mutable
+
+class TimestampITCase extends StreamingTestBase{
+
+  override def before(): Unit = {
+    super.before()
+
+    val tableSchema = TableSchema.builder().fields(
+      Array("a", "b", "c", "d"),
+      Array(
+        DataTypes.INT(),
+        DataTypes.BIGINT(),
+        DataTypes.TIMESTAMP(9).bridgedTo(classOf[LocalDateTime]),
+        // TODO: support high precision TIMESTAMP as timeAttributes
+        //  LegacyTypeInfoDataTypeConverter does not support TIMESTAMP(p) where p > 3
+        //  see TableSourceValidation::validateTimestampExtractorArguments
+        DataTypes.TIMESTAMP(3).bridgedTo(classOf[Timestamp])
+      )
+    ).build()
+
+    val ints = List(1, 2, 3, 4, null)
+
+    val longs = List(1L, 2L, 2L, 4L, null)
+
+    val datetimes = List(
+      localDateTime("1969-01-01 00:00:00.123456789"),
+      localDateTime("1970-01-01 00:00:00.123456"),
+      localDateTime("1970-01-01 00:00:00.123456"),
+      localDateTime("1970-01-01 00:00:00.123"),
+      null)
+
+    val timestamps = List(
+      Timestamp.valueOf("1969-01-01 00:00:00.123456789"),
+      Timestamp.valueOf("1970-01-01 00:00:00.123456"),
+      Timestamp.valueOf("1970-01-01 00:00:00.123"),
+      Timestamp.valueOf("1972-01-01 00:00:00"),
+      Timestamp.valueOf("1973-01-01 00:00:00")
+    )
+
+    val data = new mutable.MutableList[Row]
+
+    for (i <- ints.indices) {
+      data += row(ints(i), longs(i), datetimes(i), timestamps(i))
+    }
+
+    val tableSource = new TestDataTypeTableSourceWithTime(
+      tableSchema,
+      data.seq,
+      "d")
+    tEnv.registerTableSource("T", tableSource)
+  }
+
+  @Test
+  def testGroupBy(): Unit = {
+    val sink = new TestingRetractSink()
+    tEnv.sqlQuery("SELECT COUNT(a), c FROM T GROUP BY c")
+      .toRetractStream[Row].addSink(sink)
+    env.execute()
+    val expected = Seq(
+      "0,null",
+      "1,1969-01-01T00:00:00.123456789",
+      "1,1970-01-01T00:00:00.123",
+      "2,1970-01-01T00:00:00.123456"
+    )
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testCountDistinctOn(): Unit = {
+    val sink = new TestingRetractSink()
+    tEnv.sqlQuery("SELECT COUNT(DISTINCT c), b FROM T GROUP BY b")
+      .toRetractStream[Row].addSink(sink)
+    env.execute()
+    val expected = Seq(
+      "0,null",
+      "1,1",
+      "1,2",
+      "1,4"
+    )
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testMaxMinOn(): Unit = {
+    val sink = new TestingRetractSink()
+    tEnv.sqlQuery("SELECT MAX(c), MIN(c), b FROM T GROUP BY b")
+      .toRetractStream[Row].addSink(sink)
+    env.execute()
+    val expected = Seq(
+      "1969-01-01T00:00:00.123456789,1969-01-01T00:00:00.123456789,1",
+      "null,null,null",
+      "1970-01-01T00:00:00.123456,1970-01-01T00:00:00.123456,2",
+      "1970-01-01T00:00:00.123,1970-01-01T00:00:00.123,4"
+    )
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingTestBase.scala
@@ -57,25 +57,4 @@ class StreamingTestBase extends AbstractTestBase {
     val setting = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build()
     this.tEnv = StreamTableEnvironment.create(env, setting)
   }
-
-  def addTableWithWatermark(
-      tableName: String,
-      sourceTable: Table,
-      rowtimeField: String,
-      offset: Long): Unit = {
-    val sourceRel = TableTestUtil.toRelNode(sourceTable)
-    val rowtimeFieldIdx = sourceRel.getRowType.getFieldNames.indexOf(rowtimeField)
-    if (rowtimeFieldIdx < 0) {
-      throw new TableException(s"$rowtimeField does not exist, please check it")
-    }
-    val watermarkAssigner = new LogicalWatermarkAssigner(
-      sourceRel.getCluster,
-      sourceRel.getTraitSet,
-      sourceRel,
-      Some(rowtimeFieldIdx),
-      Option(offset)
-    )
-    val queryOperation = new PlannerQueryOperation(watermarkAssigner)
-    tEnv.registerTable(tableName, TableTestUtil.createTable(tEnv, queryOperation))
-  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/DateTimeTestUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/DateTimeTestUtil.scala
@@ -18,8 +18,8 @@
 
 package org.apache.flink.table.planner.utils
 
-import org.apache.flink.table.dataformat.DataFormatConverters.{LocalDateConverter, LocalDateTimeConverter, LocalTimeConverter}
-import org.apache.flink.table.dataformat.SqlTimestamp
+import org.apache.flink.table.dataformat.DataFormatConverters.{LocalDateConverter, LocalTimeConverter}
+import org.apache.flink.table.runtime.functions.SqlDateTimeUtils
 import org.apache.calcite.avatica.util.DateTimeUtils
 import org.apache.calcite.avatica.util.DateTimeUtils.dateStringToUnixDate
 import java.time.{LocalDate, LocalDateTime, LocalTime}
@@ -46,8 +46,7 @@ object DateTimeTestUtil {
     if (s == null) {
       null
     } else {
-      LocalDateTimeConverter.INSTANCE.toExternal(
-        SqlTimestamp.fromEpochMillis(DateTimeUtils.timestampStringToUnixDate(s)))
+      SqlDateTimeUtils.toSqlTimestamp(s).toLocalDateTime
     }
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/DateTimeTestUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/DateTimeTestUtil.scala
@@ -19,10 +19,9 @@
 package org.apache.flink.table.planner.utils
 
 import org.apache.flink.table.dataformat.DataFormatConverters.{LocalDateConverter, LocalDateTimeConverter, LocalTimeConverter}
-
+import org.apache.flink.table.dataformat.SqlTimestamp
 import org.apache.calcite.avatica.util.DateTimeUtils
 import org.apache.calcite.avatica.util.DateTimeUtils.dateStringToUnixDate
-
 import java.time.{LocalDate, LocalDateTime, LocalTime}
 
 object DateTimeTestUtil {
@@ -47,7 +46,8 @@ object DateTimeTestUtil {
     if (s == null) {
       null
     } else {
-      LocalDateTimeConverter.INSTANCE.toExternal(DateTimeUtils.timestampStringToUnixDate(s))
+      LocalDateTimeConverter.INSTANCE.toExternal(
+        SqlTimestamp.fromEpochMillis(DateTimeUtils.timestampStringToUnixDate(s)))
     }
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedTableAggFunctions.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedTableAggFunctions.scala
@@ -276,6 +276,8 @@ class EmptyTableAggFuncWithoutEmit extends TableAggregateFunction[JTuple2[JInt, 
 
   override def createAccumulator(): Top3Accum = new Top3Accum
 
+  def accumulate(acc: Top3Accum, catagory: Timestamp, value: Timestamp): Unit = {}
+
   def accumulate(acc: Top3Accum, category: Long, value: Timestamp): Unit = {}
 
   def accumulate(acc: Top3Accum, category: Long, value: Int): Unit = {}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/AbstractBinaryWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/AbstractBinaryWriter.java
@@ -199,7 +199,7 @@ public abstract class AbstractBinaryWriter implements BinaryWriter {
 				setOffsetAndSize(pos, cursor, value.getNanoOfMillisecond());
 			}
 
-			cursor += 12;
+			cursor += 8;
 		}
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryRow.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.runtime.util.SegmentsUtil;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.TimestampType;
 
 import java.nio.ByteOrder;
 
@@ -80,7 +81,6 @@ public final class BinaryRow extends BinarySection implements BaseRow {
 			case TIME_WITHOUT_TIME_ZONE:
 			case INTERVAL_YEAR_MONTH:
 			case BIGINT:
-			case TIMESTAMP_WITHOUT_TIME_ZONE:
 			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
 			case INTERVAL_DAY_TIME:
 			case FLOAT:
@@ -88,6 +88,8 @@ public final class BinaryRow extends BinarySection implements BaseRow {
 				return true;
 			case DECIMAL:
 				return ((DecimalType) type).getPrecision() <= Decimal.MAX_COMPACT_PRECISION;
+			case TIMESTAMP_WITHOUT_TIME_ZONE:
+				return SqlTimestamp.isCompact(((TimestampType) type).getPrecision());
 			default:
 				return false;
 		}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryWriter.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.runtime.typeutils.BaseRowSerializer;
 import org.apache.flink.table.runtime.typeutils.BinaryGenericSerializer;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.TimestampType;
 
 /**
  * Writer to write a composite data format, like row, array.
@@ -96,8 +97,11 @@ public interface BinaryWriter {
 			case INTERVAL_YEAR_MONTH:
 				writer.writeInt(pos, (int) o);
 				break;
-			case BIGINT:
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
+				TimestampType timestampType = (TimestampType) type;
+				writer.writeTimestamp(pos, (SqlTimestamp) o, timestampType.getPrecision());
+				break;
+			case BIGINT:
 			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
 			case INTERVAL_DAY_TIME:
 				writer.writeLong(pos, (long) o);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
@@ -691,27 +691,31 @@ public class DataFormatConverters {
 	/**
 	 * Converter for LocalDateTime.
 	 */
-	public static final class LocalDateTimeConverter extends DataFormatConverter<Long, LocalDateTime> {
+	public static final class LocalDateTimeConverter extends DataFormatConverter<SqlTimestamp, LocalDateTime> {
 
 		private static final long serialVersionUID = 1L;
 
-		public static final LocalDateTimeConverter INSTANCE = new LocalDateTimeConverter();
+		public static final LocalDateTimeConverter INSTANCE = new LocalDateTimeConverter(3);
 
-		private LocalDateTimeConverter() {}
+		private final int precision;
 
-		@Override
-		Long toInternalImpl(LocalDateTime value) {
-			return SqlDateTimeUtils.localDateTimeToUnixTimestamp(value);
+		private LocalDateTimeConverter(int precision) {
+			this.precision = precision;
 		}
 
 		@Override
-		LocalDateTime toExternalImpl(Long value) {
-			return SqlDateTimeUtils.unixTimestampToLocalDateTime(value);
+		SqlTimestamp toInternalImpl(LocalDateTime value) {
+			return SqlTimestamp.fromLocalDateTime(value);
+		}
+
+		@Override
+		LocalDateTime toExternalImpl(SqlTimestamp value) {
+			return value.toLocalDateTime();
 		}
 
 		@Override
 		LocalDateTime toExternalImpl(BaseRow row, int column) {
-			return toExternalImpl(row.getLong(column));
+			return toExternalImpl(row.getTimestamp(column, precision));
 		}
 	}
 
@@ -799,27 +803,31 @@ public class DataFormatConverters {
 	/**
 	 * Converter for timestamp.
 	 */
-	public static final class TimestampConverter extends DataFormatConverter<Long, Timestamp> {
+	public static final class TimestampConverter extends DataFormatConverter<SqlTimestamp, Timestamp> {
 
 		private static final long serialVersionUID = -779956524906131757L;
 
-		public static final TimestampConverter INSTANCE = new TimestampConverter();
+		public static final TimestampConverter INSTANCE = new TimestampConverter(3);
 
-		private TimestampConverter() {}
+		private final int precision;
 
-		@Override
-		Long toInternalImpl(Timestamp value) {
-			return SqlDateTimeUtils.timestampToInternal(value);
+		private TimestampConverter(int precision) {
+			this.precision = precision;
 		}
 
 		@Override
-		Timestamp toExternalImpl(Long value) {
-			return SqlDateTimeUtils.internalToTimestamp(value);
+		SqlTimestamp toInternalImpl(Timestamp value) {
+			return SqlTimestamp.fromTimestamp(value);
+		}
+
+		@Override
+		Timestamp toExternalImpl(SqlTimestamp value) {
+			return value.toTimestamp();
 		}
 
 		@Override
 		Timestamp toExternalImpl(BaseRow row, int column) {
-			return toExternalImpl(row.getLong(column));
+			return toExternalImpl(row.getTimestamp(column, precision));
 		}
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
@@ -118,8 +118,8 @@ public class DataFormatConverters {
 		t2C.put(DataTypes.TIME().bridgedTo(Integer.class), IntConverter.INSTANCE);
 		t2C.put(DataTypes.TIME().bridgedTo(int.class), IntConverter.INSTANCE);
 
-		t2C.put(DataTypes.TIMESTAMP(3).bridgedTo(Timestamp.class), TimestampConverter.INSTANCE);
-		t2C.put(DataTypes.TIMESTAMP(3).bridgedTo(LocalDateTime.class), LocalDateTimeConverter.INSTANCE);
+		t2C.put(DataTypes.TIMESTAMP(3).bridgedTo(Timestamp.class), new TimestampConverter(3));
+		t2C.put(DataTypes.TIMESTAMP(3).bridgedTo(LocalDateTime.class), new LocalDateTimeConverter(3));
 
 		t2C.put(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).bridgedTo(Long.class), LongConverter.INSTANCE);
 		t2C.put(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).bridgedTo(Instant.class), InstantConverter.INSTANCE);
@@ -703,11 +703,9 @@ public class DataFormatConverters {
 
 		private static final long serialVersionUID = 1L;
 
-		public static final LocalDateTimeConverter INSTANCE = new LocalDateTimeConverter(3);
-
 		private final int precision;
 
-		private LocalDateTimeConverter(int precision) {
+		public LocalDateTimeConverter(int precision) {
 			this.precision = precision;
 		}
 
@@ -815,11 +813,9 @@ public class DataFormatConverters {
 
 		private static final long serialVersionUID = -779956524906131757L;
 
-		public static final TimestampConverter INSTANCE = new TimestampConverter(3);
-
 		private final int precision;
 
-		private TimestampConverter(int precision) {
+		public TimestampConverter(int precision) {
 			this.precision = precision;
 		}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
@@ -35,6 +35,8 @@ import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter;
 import org.apache.flink.table.runtime.typeutils.BigDecimalTypeInfo;
 import org.apache.flink.table.runtime.typeutils.BinaryStringTypeInfo;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
+import org.apache.flink.table.runtime.typeutils.LegacyLocalDateTimeTypeInfo;
+import org.apache.flink.table.runtime.typeutils.LegacyTimestampTypeInfo;
 import org.apache.flink.table.types.CollectionDataType;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.KeyValueDataType;
@@ -238,6 +240,12 @@ public class DataFormatConverters {
 				} else if (typeInfo instanceof BigDecimalTypeInfo) {
 					BigDecimalTypeInfo decimalType = (BigDecimalTypeInfo) typeInfo;
 					return new BigDecimalConverter(decimalType.precision(), decimalType.scale());
+				} else if (typeInfo instanceof LegacyLocalDateTimeTypeInfo) {
+					LegacyLocalDateTimeTypeInfo dateTimeType = (LegacyLocalDateTimeTypeInfo) typeInfo;
+					return new LocalDateTimeConverter(dateTimeType.getPrecision());
+				} else if (typeInfo instanceof LegacyTimestampTypeInfo) {
+					LegacyTimestampTypeInfo timestampType = (LegacyTimestampTypeInfo) typeInfo;
+					return new TimestampConverter(timestampType.getPrecision());
 				}
 
 				if (clazz == BinaryGeneric.class) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/SqlTimestamp.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/SqlTimestamp.java
@@ -120,6 +120,25 @@ public class SqlTimestamp implements Comparable<SqlTimestamp> {
 	}
 
 	/**
+	 * Obtains an instance of {@code SqlTimestamp} from a millisecond.
+	 *
+	 * <p>This returns a {@code SqlTimestamp} with the specified millisecond.
+	 * The nanoOfMillisecond field will be set to zero.
+	 *
+	 * @param millisecond the number of milliseconds since January 1, 1970, 00:00:00 GMT
+	 *                    A negative number is the number of milliseconds before
+	 *                    January 1, 1970, 00:00:00 GMT
+	 * @return an instance of {@code SqlTimestamp}
+	 */
+	public static SqlTimestamp fromEpochMillis(Long millisecond) {
+		if (millisecond == null) {
+			return null;
+		}
+		return new SqlTimestamp(millisecond, 0);
+	}
+
+
+	/**
 	 * Convert this {@code SqlTimestmap} object to a {@link Timestamp}.
 	 *
 	 * @return An instance of {@link Timestamp}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/SqlTimestamp.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/SqlTimestamp.java
@@ -120,25 +120,6 @@ public class SqlTimestamp implements Comparable<SqlTimestamp> {
 	}
 
 	/**
-	 * Obtains an instance of {@code SqlTimestamp} from a millisecond.
-	 *
-	 * <p>This returns a {@code SqlTimestamp} with the specified millisecond.
-	 * The nanoOfMillisecond field will be set to zero.
-	 *
-	 * @param millisecond the number of milliseconds since January 1, 1970, 00:00:00 GMT
-	 *                    A negative number is the number of milliseconds before
-	 *                    January 1, 1970, 00:00:00 GMT
-	 * @return an instance of {@code SqlTimestamp}
-	 */
-	public static SqlTimestamp fromEpochMillis(Long millisecond) {
-		if (millisecond == null) {
-			return null;
-		}
-		return new SqlTimestamp(millisecond, 0);
-	}
-
-
-	/**
 	 * Convert this {@code SqlTimestmap} object to a {@link Timestamp}.
 	 *
 	 * @return An instance of {@link Timestamp}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/TypeGetterSetters.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/TypeGetterSetters.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.dataformat;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimestampType;
 
 /**
  * Provide type specialized getters and setters to reduce if/else and eliminate box and unbox.
@@ -188,8 +189,10 @@ public interface TypeGetterSetters {
 			case TIME_WITHOUT_TIME_ZONE:
 			case INTERVAL_YEAR_MONTH:
 				return row.getInt(ordinal);
-			case BIGINT:
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
+				TimestampType timestampType = (TimestampType) type;
+				return row.getTimestamp(ordinal, timestampType.getPrecision());
+			case BIGINT:
 			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
 			case INTERVAL_DAY_TIME:
 				return row.getLong(ordinal);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
@@ -1363,6 +1363,17 @@ public class SqlDateTimeUtils {
 		buf.append((char) ('0' + i % 10));
 	}
 
+	public static int getNanoOfMillisSinceEpoch(final String v) {
+		switch (v.length()) {
+			case 19:
+			case 20:
+				return 0;
+			default:
+				return (Integer.valueOf(v.substring(20)) *
+					(int) Math.pow(10, 9 - (v.length() - 20))) % 1000000;
+		}
+	}
+
 	// TODO: remove if CALCITE-3199 fixed
 	//  https://issues.apache.org/jira/browse/CALCITE-3199
 	public static long unixDateCeil(TimeUnitRange range, long date) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
@@ -124,6 +124,18 @@ public class SqlDateTimeUtils {
 		};
 
 	/**
+	 * A ThreadLocal cache map for DateTimeFormatter.
+	 * (string_format) => formatter
+	 */
+	private static final ThreadLocalCache<String, DateTimeFormatter> DateTimeFormatter_CACHE =
+		new ThreadLocalCache<String, DateTimeFormatter>() {
+			@Override
+			public DateTimeFormatter getNewInstance(String key) {
+				return DateTimeFormatter.ofPattern(key);
+			}
+		};
+
+	/**
 	 * A ThreadLocal cache map for TimeZone.
 	 * (string_zone_id) => TimeZone
 	 */
@@ -229,7 +241,7 @@ public class SqlDateTimeUtils {
 	}
 
 	public static SqlTimestamp toSqlTimestamp(String dateStr, String format) {
-		DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format);
+		DateTimeFormatter formatter = DateTimeFormatter_CACHE.get(format);
 
 		try {
 			if (dateStr.length() == 10) {
@@ -342,7 +354,7 @@ public class SqlDateTimeUtils {
 	 * @param zoneId the ZoneId.
 	 */
 	public static String dateFormat(SqlTimestamp ts, String format, ZoneId zoneId) {
-		DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format);
+		DateTimeFormatter formatter = DateTimeFormatter_CACHE.get(format);
 		return ts.toLocalDateTime().atZone(zoneId).format(formatter);
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
@@ -127,7 +127,7 @@ public class SqlDateTimeUtils {
 	 * A ThreadLocal cache map for DateTimeFormatter.
 	 * (string_format) => formatter
 	 */
-	private static final ThreadLocalCache<String, DateTimeFormatter> DateTimeFormatter_CACHE =
+	private static final ThreadLocalCache<String, DateTimeFormatter> DATETIME_FORMATTER_CACHE =
 		new ThreadLocalCache<String, DateTimeFormatter>() {
 			@Override
 			public DateTimeFormatter getNewInstance(String key) {
@@ -241,7 +241,7 @@ public class SqlDateTimeUtils {
 	}
 
 	public static SqlTimestamp toSqlTimestamp(String dateStr, String format) {
-		DateTimeFormatter formatter = DateTimeFormatter_CACHE.get(format);
+		DateTimeFormatter formatter = DATETIME_FORMATTER_CACHE.get(format);
 
 		try {
 			if (dateStr.length() == 10) {
@@ -354,7 +354,7 @@ public class SqlDateTimeUtils {
 	 * @param zoneId the ZoneId.
 	 */
 	public static String dateFormat(SqlTimestamp ts, String format, ZoneId zoneId) {
-		DateTimeFormatter formatter = DateTimeFormatter_CACHE.get(format);
+		DateTimeFormatter formatter = DATETIME_FORMATTER_CACHE.get(format);
 		return ts.toLocalDateTime().atZone(zoneId).format(formatter);
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
@@ -337,6 +337,21 @@ public class SqlDateTimeUtils {
 
 	/**
 	 * Format a timestamp as specific.
+	 * @param ts the {@link SqlTimestamp} to format.
+	 * @param format the string formatter.
+	 * @param zoneId the ZoneId.
+	 */
+	public static String dateFormat(SqlTimestamp ts, String format, ZoneId zoneId) {
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format);
+		return ts.toLocalDateTime().atZone(zoneId).format(formatter);
+	}
+
+	public static String dateFormat(SqlTimestamp ts, String format) {
+		return dateFormat(ts, format, ZoneId.of("UTC"));
+	}
+
+	/**
+	 * Format a timestamp as specific.
 	 * @param ts the timestamp to format.
 	 * @param format the string formatter.
 	 * @param tz the time zone

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/match/RowtimeProcessFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/match/RowtimeProcessFunction.java
@@ -44,7 +44,7 @@ public class RowtimeProcessFunction
 
 	@Override
 	public void processElement(BaseRow value, Context ctx, Collector<BaseRow> out) throws Exception {
-		long timestamp = value.getLong(rowtimeIdx);
+		long timestamp = value.getTimestamp(rowtimeIdx, 3).getMillisecond();
 		((TimestampedCollector<BaseRow>) out).setAbsoluteTimestamp(timestamp);
 		out.collect(value);
 	}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/match/RowtimeProcessFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/match/RowtimeProcessFunction.java
@@ -35,16 +35,18 @@ public class RowtimeProcessFunction
 	private static final long serialVersionUID = 1L;
 
 	private final int rowtimeIdx;
+	private final int precision;
 	private transient TypeInformation<BaseRow> returnType;
 
-	public RowtimeProcessFunction(int rowtimeIdx, TypeInformation<BaseRow> returnType) {
+	public RowtimeProcessFunction(int rowtimeIdx, TypeInformation<BaseRow> returnType, int precision) {
 		this.rowtimeIdx = rowtimeIdx;
 		this.returnType = returnType;
+		this.precision = precision;
 	}
 
 	@Override
 	public void processElement(BaseRow value, Context ctx, Collector<BaseRow> out) throws Exception {
-		long timestamp = value.getTimestamp(rowtimeIdx, 3).getMillisecond();
+		long timestamp = value.getTimestamp(rowtimeIdx, precision).getMillisecond();
 		((TimestampedCollector<BaseRow>) out).setAbsoluteTimestamp(timestamp);
 		out.collect(value);
 	}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/SortUtil.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/SortUtil.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.typeutils.base.NormalizedKeyUtil;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.table.dataformat.BinaryString;
 import org.apache.flink.table.dataformat.Decimal;
+import org.apache.flink.table.dataformat.SqlTimestamp;
 
 import java.nio.ByteOrder;
 
@@ -133,6 +134,15 @@ public class SortUtil {
 		for (int i = offset; i < limit; i++) {
 			target.put(i, (byte) 0);
 		}
+	}
+
+	/**
+	 * Support the compact precision SqlTimestamp.
+	 */
+	public static void putTimestampNormalizedKey(
+			SqlTimestamp value, MemorySegment target, int offset, int numBytes) {
+		assert value.getNanoOfMillisecond() == 0;
+		putLongNormalizedKey(value.getMillisecond(), target, offset, numBytes);
 	}
 
 	public static int compareBinary(byte[] a, byte[] b) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/ClassLogicalTypeConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/ClassLogicalTypeConverter.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.BinaryGeneric;
 import org.apache.flink.table.dataformat.BinaryString;
 import org.apache.flink.table.dataformat.Decimal;
+import org.apache.flink.table.dataformat.SqlTimestamp;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.utils.TypeConversions;
 
@@ -53,8 +54,9 @@ public class ClassLogicalTypeConverter {
 			case TIME_WITHOUT_TIME_ZONE:
 			case INTERVAL_YEAR_MONTH:
 				return Integer.class;
-			case BIGINT:
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
+				return SqlTimestamp.class;
+			case BIGINT:
 			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
 			case INTERVAL_DAY_TIME:
 				return Long.class;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/InternalSerializers.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/InternalSerializers.java
@@ -34,6 +34,7 @@ import org.apache.flink.table.runtime.typeutils.BaseRowSerializer;
 import org.apache.flink.table.runtime.typeutils.BinaryGenericSerializer;
 import org.apache.flink.table.runtime.typeutils.BinaryStringSerializer;
 import org.apache.flink.table.runtime.typeutils.DecimalSerializer;
+import org.apache.flink.table.runtime.typeutils.SqlTimestampSerializer;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.IntType;
@@ -41,6 +42,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TypeInformationRawType;
 
 /**
@@ -61,8 +63,10 @@ public class InternalSerializers {
 			case TIME_WITHOUT_TIME_ZONE:
 			case INTERVAL_YEAR_MONTH:
 				return IntSerializer.INSTANCE;
-			case BIGINT:
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
+				TimestampType timestampType = (TimestampType) type;
+				return new SqlTimestampSerializer(timestampType.getPrecision());
+			case BIGINT:
 			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
 			case INTERVAL_DAY_TIME:
 				return LongSerializer.INSTANCE;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/LogicalTypeDataTypeConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/LogicalTypeDataTypeConverter.java
@@ -27,6 +27,8 @@ import org.apache.flink.table.dataformat.Decimal;
 import org.apache.flink.table.runtime.typeutils.BigDecimalTypeInfo;
 import org.apache.flink.table.runtime.typeutils.BinaryStringTypeInfo;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
+import org.apache.flink.table.runtime.typeutils.LegacyLocalDateTimeTypeInfo;
+import org.apache.flink.table.runtime.typeutils.LegacyTimestampTypeInfo;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.DecimalType;
@@ -35,6 +37,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TypeInformationRawType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeDefaultVisitor;
 import org.apache.flink.table.types.utils.TypeConversions;
@@ -98,6 +101,12 @@ public class LogicalTypeDataTypeConverter {
 				} else if (typeInfo instanceof BigDecimalTypeInfo) {
 					BigDecimalTypeInfo decimalType = (BigDecimalTypeInfo) typeInfo;
 					return new DecimalType(decimalType.precision(), decimalType.scale());
+				} else if (typeInfo instanceof LegacyLocalDateTimeTypeInfo) {
+					LegacyLocalDateTimeTypeInfo dateTimeType = (LegacyLocalDateTimeTypeInfo) typeInfo;
+					return new TimestampType(dateTimeType.getPrecision());
+				} else if (typeInfo instanceof LegacyTimestampTypeInfo) {
+					LegacyTimestampTypeInfo timstampType = (LegacyTimestampTypeInfo) typeInfo;
+					return new TimestampType(timstampType.getPrecision());
 				} else {
 					return new TypeInformationRawType<>(typeInfo);
 				}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/TypeInfoDataTypeConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/TypeInfoDataTypeConverter.java
@@ -37,6 +37,8 @@ import org.apache.flink.table.runtime.typeutils.BaseRowTypeInfo;
 import org.apache.flink.table.runtime.typeutils.BigDecimalTypeInfo;
 import org.apache.flink.table.runtime.typeutils.BinaryStringTypeInfo;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
+import org.apache.flink.table.runtime.typeutils.LegacyLocalDateTimeTypeInfo;
+import org.apache.flink.table.runtime.typeutils.LegacyTimestampTypeInfo;
 import org.apache.flink.table.runtime.typeutils.SqlTimestampTypeInfo;
 import org.apache.flink.table.types.CollectionDataType;
 import org.apache.flink.table.types.DataType;
@@ -105,11 +107,15 @@ public class TypeInfoDataTypeConverter {
 		switch (logicalType.getTypeRoot()) {
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
 				TimestampType timestampType = (TimestampType) logicalType;
+				int precision = timestampType.getPrecision();
 				if (timestampType.getKind() == TimestampKind.REGULAR) {
 					return clazz == SqlTimestamp.class ?
-						new SqlTimestampTypeInfo(timestampType.getPrecision()) :
+						new SqlTimestampTypeInfo(precision) :
 						(clazz == LocalDateTime.class ?
-							Types.LOCAL_DATE_TIME : Types.SQL_TIMESTAMP);
+							((3 == precision) ?
+								Types.LOCAL_DATE_TIME : new LegacyLocalDateTimeTypeInfo(precision)) :
+							((3 == precision) ?
+								Types.SQL_TIMESTAMP : new LegacyTimestampTypeInfo(precision)));
 				} else {
 					return TypeConversions.fromDataTypeToLegacyInfo(dataType);
 				}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/TypeInfoDataTypeConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/TypeInfoDataTypeConverter.java
@@ -29,6 +29,7 @@ import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.BinaryString;
 import org.apache.flink.table.dataformat.Decimal;
+import org.apache.flink.table.dataformat.SqlTimestamp;
 import org.apache.flink.table.dataview.MapViewTypeInfo;
 import org.apache.flink.table.functions.AggregateFunctionDefinition;
 import org.apache.flink.table.functions.TableFunctionDefinition;
@@ -36,6 +37,7 @@ import org.apache.flink.table.runtime.typeutils.BaseRowTypeInfo;
 import org.apache.flink.table.runtime.typeutils.BigDecimalTypeInfo;
 import org.apache.flink.table.runtime.typeutils.BinaryStringTypeInfo;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
+import org.apache.flink.table.runtime.typeutils.SqlTimestampTypeInfo;
 import org.apache.flink.table.types.CollectionDataType;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.FieldsDataType;
@@ -43,11 +45,14 @@ import org.apache.flink.table.types.KeyValueDataType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimestampKind;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.table.typeutils.TimeIntervalTypeInfo;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
 
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -98,6 +103,16 @@ public class TypeInfoDataTypeConverter {
 		}
 		LogicalType logicalType = fromDataTypeToLogicalType(dataType);
 		switch (logicalType.getTypeRoot()) {
+			case TIMESTAMP_WITHOUT_TIME_ZONE:
+				TimestampType timestampType = (TimestampType) logicalType;
+				if (timestampType.getKind() == TimestampKind.REGULAR) {
+					return clazz == SqlTimestamp.class ?
+						new SqlTimestampTypeInfo(timestampType.getPrecision()) :
+						(clazz == LocalDateTime.class ?
+							Types.LOCAL_DATE_TIME : Types.SQL_TIMESTAMP);
+				} else {
+					return TypeConversions.fromDataTypeToLegacyInfo(dataType);
+				}
 			case DECIMAL:
 				DecimalType decimalType = (DecimalType) logicalType;
 				return clazz == Decimal.class ?

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/LegacyLocalDateTimeTypeInfo.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/LegacyLocalDateTimeTypeInfo.java
@@ -65,7 +65,6 @@ public class LegacyLocalDateTimeTypeInfo extends LocalTimeTypeInfo<LocalDateTime
 		return Objects.hash(this.getClass().getCanonicalName(), precision);
 	}
 
-
 	public int getPrecision() {
 		return precision;
 	}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/LegacyLocalDateTimeTypeInfo.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/LegacyLocalDateTimeTypeInfo.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.typeutils.base.LocalDateTimeComparator;
 import org.apache.flink.api.common.typeutils.base.LocalDateTimeSerializer;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 /**
  * {@link TypeInformation} for {@link LocalDateTime}.
@@ -31,6 +32,7 @@ import java.time.LocalDateTime;
  * <p>The difference between Types.LOCAL_DATE_TIME is this TypeInformation holds a precision
  * Reminder: Conversion from DateType to TypeInformation (and back) exists in
  * TableSourceUtil.computeIndexMapping, which should be fixed after we remove Legacy TypeInformation
+ * TODO: https://issues.apache.org/jira/browse/FLINK-14927
  */
 public class LegacyLocalDateTimeTypeInfo extends LocalTimeTypeInfo<LocalDateTime> {
 
@@ -57,6 +59,12 @@ public class LegacyLocalDateTimeTypeInfo extends LocalTimeTypeInfo<LocalDateTime
 	public String toString() {
 		return String.format("Timestamp(%d)", precision);
 	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.getClass().getCanonicalName(), precision);
+	}
+
 
 	public int getPrecision() {
 		return precision;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/LegacyLocalDateTimeTypeInfo.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/LegacyLocalDateTimeTypeInfo.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils;
+
+import org.apache.flink.api.common.typeinfo.LocalTimeTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.base.LocalDateTimeComparator;
+import org.apache.flink.api.common.typeutils.base.LocalDateTimeSerializer;
+
+import java.time.LocalDateTime;
+
+/**
+ * {@link TypeInformation} for {@link LocalDateTime}.
+ *
+ * <p>The difference between Types.LOCAL_DATE_TIME is this TypeInformation holds a precision
+ * Reminder: Conversion from DateType to TypeInformation (and back) exists in
+ * TableSourceUtil.computeIndexMapping, which should be fixed after we remove Legacy TypeInformation
+ */
+public class LegacyLocalDateTimeTypeInfo extends LocalTimeTypeInfo<LocalDateTime> {
+
+	private final int precision;
+
+	public LegacyLocalDateTimeTypeInfo(int precision) {
+		super(
+			LocalDateTime.class,
+			LocalDateTimeSerializer.INSTANCE,
+			LocalDateTimeComparator.class);
+		this.precision = precision;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof LegacyLocalDateTimeTypeInfo)) {
+			return false;
+		}
+		LegacyLocalDateTimeTypeInfo that = (LegacyLocalDateTimeTypeInfo) obj;
+		return this.precision == that.precision;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("Timestamp(%d)", precision);
+	}
+
+	public int getPrecision() {
+		return precision;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/LegacyLocalDateTimeTypeInfo.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/LegacyLocalDateTimeTypeInfo.java
@@ -36,6 +36,8 @@ import java.util.Objects;
  */
 public class LegacyLocalDateTimeTypeInfo extends LocalTimeTypeInfo<LocalDateTime> {
 
+	private static final long serialVersionUID = 1L;
+
 	private final int precision;
 
 	public LegacyLocalDateTimeTypeInfo(int precision) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/LegacyTimestampTypeInfo.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/LegacyTimestampTypeInfo.java
@@ -36,6 +36,8 @@ import java.util.Objects;
  */
 public class LegacyTimestampTypeInfo extends SqlTimeTypeInfo<Timestamp> {
 
+	private static final long serialVersionUID = 1L;
+
 	private final int precision;
 
 	@SuppressWarnings("unchecked")

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/LegacyTimestampTypeInfo.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/LegacyTimestampTypeInfo.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils;
+
+import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.base.SqlTimestampComparator;
+
+import java.sql.Timestamp;
+
+/**
+ * {@link TypeInformation} for {@link Timestamp}.
+ *
+ * <p>The difference between Types.SQL_TIMESTAMP is this TypeInformation holds a precision
+ * Reminder: Conversion from DateType to TypeInformation (and back) exists in
+ * TableSourceUtil.computeIndexMapping, which should be fixed after we remove Legacy TypeInformation
+ */
+public class LegacyTimestampTypeInfo extends SqlTimeTypeInfo<Timestamp> {
+
+	private final int precision;
+
+	@SuppressWarnings("unchecked")
+	public LegacyTimestampTypeInfo(int precision) {
+		super(
+			Timestamp.class,
+			org.apache.flink.api.common.typeutils.base.SqlTimestampSerializer.INSTANCE,
+			(Class) SqlTimestampComparator.class);
+		this.precision = precision;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof LegacyTimestampTypeInfo)) {
+			return false;
+		}
+		LegacyTimestampTypeInfo that = (LegacyTimestampTypeInfo) obj;
+		return this.precision == that.precision;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("Timestamp(%d)", precision);
+	}
+
+	public int getPrecision() {
+		return precision;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/LegacyTimestampTypeInfo.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/LegacyTimestampTypeInfo.java
@@ -21,8 +21,10 @@ package org.apache.flink.table.runtime.typeutils;
 import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.base.SqlTimestampComparator;
+import org.apache.flink.api.common.typeutils.base.SqlTimestampSerializer;
 
 import java.sql.Timestamp;
+import java.util.Objects;
 
 /**
  * {@link TypeInformation} for {@link Timestamp}.
@@ -30,6 +32,7 @@ import java.sql.Timestamp;
  * <p>The difference between Types.SQL_TIMESTAMP is this TypeInformation holds a precision
  * Reminder: Conversion from DateType to TypeInformation (and back) exists in
  * TableSourceUtil.computeIndexMapping, which should be fixed after we remove Legacy TypeInformation
+ * TODO: https://issues.apache.org/jira/browse/FLINK-14927
  */
 public class LegacyTimestampTypeInfo extends SqlTimeTypeInfo<Timestamp> {
 
@@ -39,7 +42,7 @@ public class LegacyTimestampTypeInfo extends SqlTimeTypeInfo<Timestamp> {
 	public LegacyTimestampTypeInfo(int precision) {
 		super(
 			Timestamp.class,
-			org.apache.flink.api.common.typeutils.base.SqlTimestampSerializer.INSTANCE,
+			SqlTimestampSerializer.INSTANCE,
 			(Class) SqlTimestampComparator.class);
 		this.precision = precision;
 	}
@@ -56,6 +59,11 @@ public class LegacyTimestampTypeInfo extends SqlTimeTypeInfo<Timestamp> {
 	@Override
 	public String toString() {
 		return String.format("Timestamp(%d)", precision);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.getClass().getCanonicalName(), precision);
 	}
 
 	public int getPrecision() {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/SqlTimestampTypeInfo.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/SqlTimestampTypeInfo.java
@@ -30,6 +30,8 @@ import java.util.Objects;
  */
 public class SqlTimestampTypeInfo extends TypeInformation<SqlTimestamp> {
 
+	private static final long serialVersionUID = 1L;
+
 	private final int precision;
 
 	public SqlTimestampTypeInfo(int precision) {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/BinaryRowTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/BinaryRowTest.java
@@ -1030,6 +1030,10 @@ public class BinaryRowTest {
 			writer.writeTimestamp(1, null, precision);
 			writer.complete();
 
+			// the size of row should be 8 + (8 + 8) * 2
+			// (8 bytes nullBits, 8 bytes fixed-length part and 8 bytes variable-length part for each timestamp(9))
+			assertEquals(40, row.getSizeInBytes());
+
 			assertEquals("1969-01-01T00:00:00.123456789", row.getTimestamp(0, precision).toString());
 			assertTrue(row.isNullAt(1));
 			row.setTimestamp(0, sqlTimestamp2, precision);


### PR DESCRIPTION
## What is the purpose of the change

Since FLINK-14080 introduced an internal representation(SqlTimestamp) of TimestampType with precision. This subtask will replace current long with SqlTimestamp, and let blink planner support precision of TimestampType.

Note:

- Tables defined by DDL is not supported in this PR since de/serializing DataTypes lost precision information. Would open another ticket to cover.


## Brief change log

- 799b0be - fb77dd9 replace current long with SqlTimestamp, and Fix all existing failure cases
- ad19558 introduces LegacyTimestampTypeInfo and LegacyLocalDateTimeTypeInfo to represent Types.SQL_TIMESTAMP and Types.LOCAL_DATE_TIME with precision
- eb98df4 support precision of Timestamp type in table source
- eb574ab support precision of Timestamp type for timestamp literals
- 78cb2cf support precision of Timestamp type for builtin functions, such as extract/to_timestamp/cast
 - f41e0aa support precision of Timestamp type for timestamp +/- interval
 - 0c03e1a support precision of Timestamp type for date_format
 - 684c5a2 support precision of Timestamp type for lead/lag/max/min/singlevalue

## Verifying this change


This change is already covered by existing tests and added tests, such as *testHighPrecisionTimestamp* in *TemporalTypesTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
