### PR TITLE
[FLINK-14672][sql-client] Make Executor stateful in sql client

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliChangelogResultView.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliChangelogResultView.java
@@ -106,7 +106,7 @@ public class CliChangelogResultView extends CliResultView<CliChangelogResultView
 		// retrieve change record
 		final TypedResult<List<Tuple2<Boolean, Row>>> result;
 		try {
-			result = client.getExecutor().retrieveResultChanges(client.getContext(), resultDescriptor.getResultId());
+			result = client.getExecutor().retrieveResultChanges(client.getSessionId(), resultDescriptor.getResultId());
 		} catch (SqlExecutionException e) {
 			close(e);
 			return;

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -26,7 +26,6 @@ import org.apache.flink.table.client.config.entries.ViewEntry;
 import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.ProgramTargetDescriptor;
 import org.apache.flink.table.client.gateway.ResultDescriptor;
-import org.apache.flink.table.client.gateway.SessionContext;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 
 import org.jline.reader.EndOfFileException;
@@ -63,7 +62,7 @@ public class CliClient {
 
 	private final Executor executor;
 
-	private final SessionContext context;
+	private final String sessionId;
 
 	private final Terminal terminal;
 
@@ -84,9 +83,9 @@ public class CliClient {
 	 * afterwards using {@link #close()}.
 	 */
 	@VisibleForTesting
-	public CliClient(Terminal terminal, SessionContext context, Executor executor) {
+	public CliClient(Terminal terminal, String sessionId, Executor executor) {
 		this.terminal = terminal;
-		this.context = context;
+		this.sessionId = sessionId;
 		this.executor = executor;
 
 		// make space from previous output and test the writer
@@ -98,7 +97,7 @@ public class CliClient {
 			.terminal(terminal)
 			.appName(CliStrings.CLI_NAME)
 			.parser(new SqlMultiLineParser())
-			.completer(new SqlCompleter(context, executor))
+			.completer(new SqlCompleter(sessionId, executor))
 			.build();
 		// this option is disabled for now for correct backslash escaping
 		// a "SELECT '\'" query should return a string with a backslash
@@ -121,16 +120,16 @@ public class CliClient {
 	 * Creates a CLI instance with a prepared terminal. Make sure to close the CLI instance
 	 * afterwards using {@link #close()}.
 	 */
-	public CliClient(SessionContext context, Executor executor) {
-		this(createDefaultTerminal(), context, executor);
+	public CliClient(String sessionId, Executor executor) {
+		this(createDefaultTerminal(), sessionId, executor);
 	}
 
 	public Terminal getTerminal() {
 		return terminal;
 	}
 
-	public SessionContext getContext() {
-		return context;
+	public String getSessionId() {
+		return this.sessionId;
 	}
 
 	public void clearTerminal() {
@@ -321,7 +320,7 @@ public class CliClient {
 	}
 
 	private void callReset() {
-		context.resetSessionProperties();
+		executor.resetSessionProperties(sessionId);
 		printInfo(CliStrings.MESSAGE_RESET);
 	}
 
@@ -330,7 +329,7 @@ public class CliClient {
 		if (cmdCall.operands.length == 0) {
 			final Map<String, String> properties;
 			try {
-				properties = executor.getSessionProperties(context);
+				properties = executor.getSessionProperties(sessionId);
 			} catch (SqlExecutionException e) {
 				printExecutionException(e);
 				return;
@@ -348,7 +347,7 @@ public class CliClient {
 		}
 		// set a property
 		else {
-			context.setSessionProperty(cmdCall.operands[0], cmdCall.operands[1]);
+			executor.setSessionProperty(sessionId, cmdCall.operands[0], cmdCall.operands[1]);
 			terminal.writer().println(CliStrings.messageInfo(CliStrings.MESSAGE_SET).toAnsi());
 		}
 		terminal.flush();
@@ -362,7 +361,7 @@ public class CliClient {
 	private void callShowCatalogs() {
 		final List<String> catalogs;
 		try {
-			catalogs = executor.listCatalogs(context);
+			catalogs = executor.listCatalogs(sessionId);
 		} catch (SqlExecutionException e) {
 			printExecutionException(e);
 			return;
@@ -378,7 +377,7 @@ public class CliClient {
 	private void callShowDatabases() {
 		final List<String> dbs;
 		try {
-			dbs = executor.listDatabases(context);
+			dbs = executor.listDatabases(sessionId);
 		} catch (SqlExecutionException e) {
 			printExecutionException(e);
 			return;
@@ -394,7 +393,7 @@ public class CliClient {
 	private void callShowTables() {
 		final List<String> tables;
 		try {
-			tables = executor.listTables(context);
+			tables = executor.listTables(sessionId);
 		} catch (SqlExecutionException e) {
 			printExecutionException(e);
 			return;
@@ -410,7 +409,7 @@ public class CliClient {
 	private void callShowFunctions() {
 		final List<String> functions;
 		try {
-			functions = executor.listFunctions(context);
+			functions = executor.listFunctions(sessionId);
 		} catch (SqlExecutionException e) {
 			printExecutionException(e);
 			return;
@@ -427,7 +426,7 @@ public class CliClient {
 	private void callShowModules() {
 		final List<String> modules;
 		try {
-			modules = executor.listModules(context);
+			modules = executor.listModules(sessionId);
 		} catch (SqlExecutionException e) {
 			printExecutionException(e);
 			return;
@@ -443,7 +442,7 @@ public class CliClient {
 
 	private void callUseCatalog(SqlCommandCall cmdCall) {
 		try {
-			executor.useCatalog(context, cmdCall.operands[0]);
+			executor.useCatalog(sessionId, cmdCall.operands[0]);
 		} catch (SqlExecutionException e) {
 			printExecutionException(e);
 			return;
@@ -453,7 +452,7 @@ public class CliClient {
 
 	private void callUseDatabase(SqlCommandCall cmdCall) {
 		try {
-			executor.useDatabase(context, cmdCall.operands[0]);
+			executor.useDatabase(sessionId, cmdCall.operands[0]);
 		} catch (SqlExecutionException e) {
 			printExecutionException(e);
 			return;
@@ -464,7 +463,7 @@ public class CliClient {
 	private void callDescribe(SqlCommandCall cmdCall) {
 		final TableSchema schema;
 		try {
-			schema = executor.getTableSchema(context, cmdCall.operands[0]);
+			schema = executor.getTableSchema(sessionId, cmdCall.operands[0]);
 		} catch (SqlExecutionException e) {
 			printExecutionException(e);
 			return;
@@ -476,7 +475,7 @@ public class CliClient {
 	private void callExplain(SqlCommandCall cmdCall) {
 		final String explanation;
 		try {
-			explanation = executor.explainStatement(context, cmdCall.operands[0]);
+			explanation = executor.explainStatement(sessionId, cmdCall.operands[0]);
 		} catch (SqlExecutionException e) {
 			printExecutionException(e);
 			return;
@@ -488,7 +487,7 @@ public class CliClient {
 	private void callSelect(SqlCommandCall cmdCall) {
 		final ResultDescriptor resultDesc;
 		try {
-			resultDesc = executor.executeQuery(context, cmdCall.operands[0]);
+			resultDesc = executor.executeQuery(sessionId, cmdCall.operands[0]);
 		} catch (SqlExecutionException e) {
 			printExecutionException(e);
 			return;
@@ -515,7 +514,7 @@ public class CliClient {
 		printInfo(CliStrings.MESSAGE_SUBMITTING_STATEMENT);
 
 		try {
-			final ProgramTargetDescriptor programTarget = executor.executeUpdate(context, cmdCall.operands[0]);
+			final ProgramTargetDescriptor programTarget = executor.executeUpdate(sessionId, cmdCall.operands[0]);
 			terminal.writer().println(CliStrings.messageInfo(CliStrings.MESSAGE_STATEMENT_SUBMITTED).toAnsi());
 			terminal.writer().println(programTarget.toString());
 			terminal.flush();
@@ -530,7 +529,7 @@ public class CliClient {
 		final String name = cmdCall.operands[0];
 		final String query = cmdCall.operands[1];
 
-		final ViewEntry previousView = context.getViews().get(name);
+		final ViewEntry previousView = executor.listViews(sessionId).get(name);
 		if (previousView != null) {
 			printExecutionError(CliStrings.MESSAGE_VIEW_ALREADY_EXISTS);
 			return;
@@ -538,20 +537,19 @@ public class CliClient {
 
 		try {
 			// perform and validate change
-			context.addView(ViewEntry.create(name, query));
-			executor.validateSession(context);
+			executor.addView(sessionId, name, query);
+			executor.validateSession(sessionId);
 			printInfo(CliStrings.MESSAGE_VIEW_CREATED);
 		} catch (SqlExecutionException e) {
 			// rollback change
-			context.removeView(name);
+			executor.removeView(sessionId, name);
 			printExecutionException(e);
 		}
 	}
 
 	private void callDropView(SqlCommandCall cmdCall) {
 		final String name = cmdCall.operands[0];
-		final ViewEntry view = context.getViews().get(name);
-
+		final ViewEntry view = executor.listViews(sessionId).get(name);
 		if (view == null) {
 			printExecutionError(CliStrings.MESSAGE_VIEW_NOT_FOUND);
 			return;
@@ -559,12 +557,12 @@ public class CliClient {
 
 		try {
 			// perform and validate change
-			context.removeView(name);
-			executor.validateSession(context);
+			executor.removeView(sessionId, name);
+			executor.validateSession(sessionId);
 			printInfo(CliStrings.MESSAGE_VIEW_REMOVED);
 		} catch (SqlExecutionException e) {
 			// rollback change
-			context.addView(view);
+			executor.addView(sessionId, view.getName(), view.getQuery());
 			printExecutionException(CliStrings.MESSAGE_VIEW_NOT_REMOVED, e);
 		}
 	}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -538,7 +538,6 @@ public class CliClient {
 		try {
 			// perform and validate change
 			executor.addView(sessionId, name, query);
-			executor.validateSession(sessionId);
 			printInfo(CliStrings.MESSAGE_VIEW_CREATED);
 		} catch (SqlExecutionException e) {
 			// rollback change
@@ -558,7 +557,6 @@ public class CliClient {
 		try {
 			// perform and validate change
 			executor.removeView(sessionId, name);
-			executor.validateSession(sessionId);
 			printInfo(CliStrings.MESSAGE_VIEW_REMOVED);
 		} catch (SqlExecutionException e) {
 			// rollback change

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliResultView.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliResultView.java
@@ -286,7 +286,7 @@ public abstract class CliResultView<O extends Enum<O>> extends CliView<O, Void> 
 				try {
 					// the cancellation happens in the refresh thread in order to keep the main thread
 					// responsive at all times; esp. if the cluster is not available
-					client.getExecutor().cancelQuery(client.getContext(), resultDescriptor.getResultId());
+					client.getExecutor().cancelQuery(client.getSessionId(), resultDescriptor.getResultId());
 				} catch (SqlExecutionException e) {
 					// ignore further exceptions
 				}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliTableResultView.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliTableResultView.java
@@ -88,7 +88,7 @@ public class CliTableResultView extends CliResultView<CliTableResultView.ResultT
 		// take snapshot
 		TypedResult<Integer> result;
 		try {
-			result = client.getExecutor().snapshotResult(client.getContext(), resultDescriptor.getResultId(), getVisibleMainHeight());
+			result = client.getExecutor().snapshotResult(client.getSessionId(), resultDescriptor.getResultId(), getVisibleMainHeight());
 		} catch (SqlExecutionException e) {
 			close(e);
 			return;

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCompleter.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCompleter.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.client.cli;
 
 import org.apache.flink.table.client.gateway.Executor;
-import org.apache.flink.table.client.gateway.SessionContext;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 
 import org.jline.reader.Candidate;
@@ -41,12 +40,12 @@ public class SqlCompleter implements Completer {
 
 	public static final String[] COMMAND_HINTS = getCommandHints();
 
-	private SessionContext context;
+	private String sessionId;
 
 	private Executor executor;
 
-	public SqlCompleter(SessionContext context, Executor executor) {
-		this.context = context;
+	public SqlCompleter(String sessionId, Executor executor) {
+		this.sessionId = sessionId;
 		this.executor = executor;
 	}
 
@@ -68,7 +67,7 @@ public class SqlCompleter implements Completer {
 
 		// fallback to Table API hinting
 		try {
-			executor.completeStatement(context, statement, line.cursor())
+			executor.completeStatement(sessionId, statement, line.cursor())
 				.forEach(hint -> candidates.add(createCandidate(hint)));
 		} catch (SqlExecutionException e) {
 			LOG.debug("Could not complete statement at " + line.cursor() + ":" + statement, e);

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Environment.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Environment.java
@@ -266,6 +266,10 @@ public class Environment {
 		return mergedEnv;
 	}
 
+	public Environment clone() {
+		return enrich(this, Collections.emptyMap(), Collections.emptyMap());
+	}
+
 	/**
 	 * Enriches an environment with new/modified properties or views and returns the new instance.
 	 */

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -194,9 +194,4 @@ public interface Executor {
 	 * @return information about the target of the submitted Flink job
 	 */
 	ProgramTargetDescriptor executeUpdate(String sessionId, String statement) throws SqlExecutionException;
-
-	/**
-	 * Validates the current session. For example, it checks whether all views are still valid.
-	 */
-	void validateSession(String sessionId) throws SqlExecutionException;
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.client.gateway;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.client.config.entries.ViewEntry;
 import org.apache.flink.types.Row;
 
 import java.util.List;
@@ -36,81 +37,143 @@ public interface Executor {
 	void start() throws SqlExecutionException;
 
 	/**
+	 * Open a new session by using the given {@link SessionContext}.
+	 *
+	 * @param session context to create new session.
+	 * @return session identifier to track the session.
+	 * @throws SqlExecutionException if any error happen
+	 */
+	String openSession(SessionContext session) throws SqlExecutionException;
+
+	/**
+	 * Close the resources of session for given session id.
+	 *
+	 * @param sessionId session identifier
+	 * @throws SqlExecutionException if any error happen
+	 */
+	void closeSession(String sessionId) throws SqlExecutionException;
+
+	/**
 	 * Lists all session properties that are defined by the executor and the session.
 	 */
-	Map<String, String> getSessionProperties(SessionContext session) throws SqlExecutionException;
+	Map<String, String> getSessionProperties(String sessionId) throws SqlExecutionException;
+
+	/**
+	 * Reset all the properties for the given session identifier.
+	 *
+	 * @param sessionId to identifier the session
+	 * @throws SqlExecutionException if any error happen.
+	 */
+	void resetSessionProperties(String sessionId) throws SqlExecutionException;
+
+	/**
+	 * Set given key's session property to the specific value.
+	 *
+	 * @param key   of the session property
+	 * @param value of the session property
+	 * @throws SqlExecutionException if any error happen.
+	 */
+	void setSessionProperty(String sessionId, String key, String value) throws SqlExecutionException;
+
+	/**
+	 * Add a new view to the given session.
+	 *
+	 * @param sessionId to identify the session.
+	 * @param name      of the view.
+	 * @param query     to represent the view.
+	 * @throws SqlExecutionException
+	 */
+	void addView(String sessionId, String name, String query) throws SqlExecutionException;
+
+	/**
+	 * Remove the view with given name for the given session.
+	 *
+	 * @param sessionId to identify the session.
+	 * @param name      of the view.
+	 * @throws SqlExecutionException
+	 */
+	void removeView(String sessionId, String name) throws SqlExecutionException;
+
+	/**
+	 * Lists all registered views for the given session.
+	 *
+	 * @param sessionId to identify the session.
+	 * @return list of view in the given session.
+	 * @throws SqlExecutionException
+	 */
+	Map<String, ViewEntry> listViews(String sessionId) throws SqlExecutionException;
 
 	/**
 	 * Lists all registered catalogs.
 	 */
-	List<String> listCatalogs(SessionContext session) throws SqlExecutionException;
+	List<String> listCatalogs(String sessionid) throws SqlExecutionException;
 
 	/**
 	 * Lists all databases in the current catalog.
 	 */
-	List<String> listDatabases(SessionContext session) throws SqlExecutionException;
+	List<String> listDatabases(String sessionId) throws SqlExecutionException;
 
 	/**
 	 * Lists all tables in the current database of the current catalog.
 	 */
-	List<String> listTables(SessionContext session) throws SqlExecutionException;
+	List<String> listTables(String sessionId) throws SqlExecutionException;
 
 	/**
 	 * Lists all user-defined functions known to the executor.
 	 */
-	List<String> listUserDefinedFunctions(SessionContext session) throws SqlExecutionException;
+	List<String> listUserDefinedFunctions(String sessionId) throws SqlExecutionException;
 
 	/**
 	 * Lists all functions known to the executor.
 	 */
-	List<String> listFunctions(SessionContext session) throws SqlExecutionException;
+	List<String> listFunctions(String sessionId) throws SqlExecutionException;
 
 	/**
 	 * Lists all modules known to the executor in their loaded order.
 	 */
-	List<String> listModules(SessionContext session) throws SqlExecutionException;
+	List<String> listModules(String sessionId) throws SqlExecutionException;
 
 	/**
 	 * Sets a catalog with given name as the current catalog.
 	 */
-	void useCatalog(SessionContext session, String catalogName) throws SqlExecutionException;
+	void useCatalog(String sessionId, String catalogName) throws SqlExecutionException;
 
 	/**
 	 * Sets a database with given name as the current database of the current catalog.
 	 */
-	void useDatabase(SessionContext session, String databaseName) throws SqlExecutionException;
+	void useDatabase(String sessionId, String databaseName) throws SqlExecutionException;
 
 	/**
 	 * Returns the schema of a table. Throws an exception if the table could not be found. The
 	 * schema might contain time attribute types for helping the user during debugging a query.
 	 */
-	TableSchema getTableSchema(SessionContext session, String name) throws SqlExecutionException;
+	TableSchema getTableSchema(String sessionId, String name) throws SqlExecutionException;
 
 	/**
 	 * Returns a string-based explanation about AST and execution plan of the given statement.
 	 */
-	String explainStatement(SessionContext session, String statement) throws SqlExecutionException;
+	String explainStatement(String sessionId, String statement) throws SqlExecutionException;
 
 	/**
 	 * Returns a list of completion hints for the given statement at the given position.
 	 */
-	List<String> completeStatement(SessionContext session, String statement, int position);
+	List<String> completeStatement(String sessionId, String statement, int position);
 
 	/**
 	 * Submits a Flink SQL query job (detached) and returns the result descriptor.
 	 */
-	ResultDescriptor executeQuery(SessionContext session, String query) throws SqlExecutionException;
+	ResultDescriptor executeQuery(String sessionId, String query) throws SqlExecutionException;
 
 	/**
 	 * Asks for the next changelog results (non-blocking).
 	 */
-	TypedResult<List<Tuple2<Boolean, Row>>> retrieveResultChanges(SessionContext session, String resultId) throws SqlExecutionException;
+	TypedResult<List<Tuple2<Boolean, Row>>> retrieveResultChanges(String sessionId, String resultId) throws SqlExecutionException;
 
 	/**
 	 * Creates an immutable result snapshot of the running Flink job. Throws an exception if no Flink job can be found.
 	 * Returns the number of pages.
 	 */
-	TypedResult<Integer> snapshotResult(SessionContext session, String resultId, int pageSize) throws SqlExecutionException;
+	TypedResult<Integer> snapshotResult(String sessionId, String resultId, int pageSize) throws SqlExecutionException;
 
 	/**
 	 * Returns the rows that are part of the current page or throws an exception if the snapshot has been expired.
@@ -121,24 +184,19 @@ public interface Executor {
 	 * Cancels a table program and stops the result retrieval. Blocking until cancellation command has
 	 * been sent to cluster.
 	 */
-	void cancelQuery(SessionContext session, String resultId) throws SqlExecutionException;
+	void cancelQuery(String sessionId, String resultId) throws SqlExecutionException;
 
 	/**
 	 * Submits a Flink SQL update statement such as INSERT INTO.
 	 *
-	 * @param session context in with the statement is executed
+	 * @param sessionId to identify the user session.
 	 * @param statement SQL update statement (currently only INSERT INTO is supported)
 	 * @return information about the target of the submitted Flink job
 	 */
-	ProgramTargetDescriptor executeUpdate(SessionContext session, String statement) throws SqlExecutionException;
+	ProgramTargetDescriptor executeUpdate(String sessionId, String statement) throws SqlExecutionException;
 
 	/**
 	 * Validates the current session. For example, it checks whether all views are still valid.
 	 */
-	void validateSession(SessionContext session) throws SqlExecutionException;
-
-	/**
-	 * Stops the executor.
-	 */
-	void stop(SessionContext session);
+	void validateSession(String sessionId) throws SqlExecutionException;
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/SessionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/SessionContext.java
@@ -37,7 +37,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  */
 public class SessionContext {
 
-	private final String name;
+	private final String sessionId;
 
 	private final Environment defaultEnvironment;
 
@@ -45,8 +45,8 @@ public class SessionContext {
 
 	private final Map<String, ViewEntry> views;
 
-	public SessionContext(String name, Environment defaultEnvironment) {
-		this.name = name;
+	public SessionContext(String sessionId, Environment defaultEnvironment) {
+		this.sessionId = sessionId;
 		this.defaultEnvironment = defaultEnvironment;
 		this.sessionProperties = new HashMap<>();
 		// the order of how views are registered matters because
@@ -74,8 +74,8 @@ public class SessionContext {
 		return Collections.unmodifiableMap(views);
 	}
 
-	public String getName() {
-		return name;
+	public String getSessionId() {
+		return this.sessionId;
 	}
 
 	public Optional<String> getCurrentCatalog() {
@@ -106,7 +106,7 @@ public class SessionContext {
 	}
 
 	public SessionContext copy() {
-		final SessionContext session = new SessionContext(name, defaultEnvironment);
+		final SessionContext session = new SessionContext(sessionId, defaultEnvironment);
 		session.sessionProperties.putAll(sessionProperties);
 		session.views.putAll(views);
 		return session;
@@ -121,7 +121,7 @@ public class SessionContext {
 			return false;
 		}
 		SessionContext context = (SessionContext) o;
-		return Objects.equals(name, context.name) &&
+		return Objects.equals(sessionId, context.sessionId) &&
 			Objects.equals(defaultEnvironment, context.defaultEnvironment) &&
 			Objects.equals(sessionProperties, context.sessionProperties) &&
 			Objects.equals(views, context.views);
@@ -130,7 +130,7 @@ public class SessionContext {
 	@Override
 	public int hashCode() {
 		return Objects.hash(
-			name,
+			sessionId,
 			defaultEnvironment,
 			sessionProperties,
 			views);

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/SessionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/SessionContext.java
@@ -19,97 +19,30 @@
 package org.apache.flink.table.client.gateway;
 
 import org.apache.flink.table.client.config.Environment;
-import org.apache.flink.table.client.config.entries.ExecutionEntry;
-import org.apache.flink.table.client.config.entries.ViewEntry;
-import org.apache.flink.util.StringUtils;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
-
-import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
- * Context describing a session.
+ * Context describing a session, it's mainly used for user to open a new session in the backend. If client request to
+ * open a new session, the backend {@link Executor} will maintain a {@link org.apache.flink.table.client.gateway.local.ExecutionContext}
+ * for it, and each interaction the client need to attach the session id.
  */
 public class SessionContext {
 
 	private final String sessionId;
+	private final Environment sessionEnv;
 
-	private final Environment defaultEnvironment;
-
-	private final Map<String, String> sessionProperties;
-
-	private final Map<String, ViewEntry> views;
-
-	public SessionContext(String sessionId, Environment defaultEnvironment) {
+	public SessionContext(String sessionId, Environment sessionEnv) {
 		this.sessionId = sessionId;
-		this.defaultEnvironment = defaultEnvironment;
-		this.sessionProperties = new HashMap<>();
-		// the order of how views are registered matters because
-		// they might reference each other
-		this.views = new LinkedHashMap<>();
-	}
-
-	public void setSessionProperty(String key, String value) {
-		sessionProperties.put(key, value);
-	}
-
-	public void resetSessionProperties() {
-		sessionProperties.clear();
-	}
-
-	public void addView(ViewEntry viewEntry) {
-		views.put(viewEntry.getName(), viewEntry);
-	}
-
-	public void removeView(String name) {
-		views.remove(name);
-	}
-
-	public Map<String, ViewEntry> getViews() {
-		return Collections.unmodifiableMap(views);
+		this.sessionEnv = sessionEnv;
 	}
 
 	public String getSessionId() {
 		return this.sessionId;
 	}
 
-	public Optional<String> getCurrentCatalog() {
-		return Optional.ofNullable(sessionProperties.get(ExecutionEntry.EXECUTION_CURRENT_CATALOG));
-	}
-
-	public void setCurrentCatalog(String currentCatalog) {
-		checkArgument(!StringUtils.isNullOrWhitespaceOnly(currentCatalog));
-
-		sessionProperties.put(ExecutionEntry.EXECUTION_CURRENT_CATALOG, currentCatalog);
-	}
-
-	public Optional<String> getCurrentDatabase() {
-		return Optional.ofNullable(sessionProperties.get(ExecutionEntry.EXECUTION_CURRENT_DATABASE));
-	}
-
-	public void setCurrentDatabase(String currentDatabase) {
-		checkArgument(!StringUtils.isNullOrWhitespaceOnly(currentDatabase));
-
-		sessionProperties.put(ExecutionEntry.EXECUTION_CURRENT_DATABASE, currentDatabase);
-	}
-
-	public Environment getEnvironment() {
-		return Environment.enrich(
-			defaultEnvironment,
-			sessionProperties,
-			views);
-	}
-
-	public SessionContext copy() {
-		final SessionContext session = new SessionContext(sessionId, defaultEnvironment);
-		session.sessionProperties.putAll(sessionProperties);
-		session.views.putAll(views);
-		return session;
+	public Environment getSessionEnv() {
+		return this.sessionEnv;
 	}
 
 	@Override
@@ -122,17 +55,11 @@ public class SessionContext {
 		}
 		SessionContext context = (SessionContext) o;
 		return Objects.equals(sessionId, context.sessionId) &&
-			Objects.equals(defaultEnvironment, context.defaultEnvironment) &&
-			Objects.equals(sessionProperties, context.sessionProperties) &&
-			Objects.equals(views, context.views);
+			Objects.equals(sessionEnv, context.sessionEnv);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(
-			sessionId,
-			defaultEnvironment,
-			sessionProperties,
-			views);
+		return Objects.hash(sessionId, sessionEnv);
 	}
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.client.gateway.local;
 
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.api.java.ExecutionEnvironment;
@@ -62,7 +61,6 @@ import org.apache.flink.table.client.config.entries.SourceSinkTableEntry;
 import org.apache.flink.table.client.config.entries.SourceTableEntry;
 import org.apache.flink.table.client.config.entries.TemporalTableEntry;
 import org.apache.flink.table.client.config.entries.ViewEntry;
-import org.apache.flink.table.client.gateway.SessionContext;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.delegation.Executor;
 import org.apache.flink.table.delegation.ExecutorFactory;
@@ -78,6 +76,7 @@ import org.apache.flink.table.factories.TableFactoryService;
 import org.apache.flink.table.factories.TableSinkFactory;
 import org.apache.flink.table.factories.TableSourceFactory;
 import org.apache.flink.table.functions.AggregateFunction;
+import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.functions.FunctionService;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.TableFunction;
@@ -94,9 +93,11 @@ import org.apache.commons.cli.Options;
 
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -111,14 +112,9 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 public class ExecutionContext<ClusterID> {
 
-	private final SessionContext sessionContext;
-	private final Environment mergedEnv;
+	private final Environment environment;
 	private final ClassLoader classLoader;
-	private final Map<String, Module> modules;
-	private final Map<String, Catalog> catalogs;
-	private final Map<String, TableSource<?>> tableSources;
-	private final Map<String, TableSink<?>> tableSinks;
-	private final Map<String, UserDefinedFunction> functions;
+
 	private final Configuration flinkConfig;
 	private final Configuration executorConfig;
 	private final ClusterClientFactory<ClusterID> clusterClientFactory;
@@ -126,15 +122,33 @@ public class ExecutionContext<ClusterID> {
 	private final ClusterID clusterId;
 	private final ClusterSpecification clusterSpec;
 
-	public ExecutionContext(Environment defaultEnvironment, SessionContext sessionContext, List<URL> dependencies,
-				Configuration flinkConfig, Options commandLineOptions, List<CustomCommandLine> availableCommandLines) throws FlinkException {
-		this(defaultEnvironment, sessionContext, dependencies, flinkConfig, new DefaultClusterClientServiceLoader(), commandLineOptions, availableCommandLines);
+	private TableEnvironment tableEnv;
+	private ExecutionEnvironment execEnv;
+	private StreamExecutionEnvironment streamExecEnv;
+	private Executor executor;
+
+	public ExecutionContext(
+		Environment environment,
+		List<URL> dependencies,
+		Configuration flinkConfig,
+		Options commandLineOptions,
+		List<CustomCommandLine> availableCommandLines) throws FlinkException {
+		this(environment,
+			dependencies,
+			flinkConfig,
+			new DefaultClusterClientServiceLoader(),
+			commandLineOptions,
+			availableCommandLines);
 	}
 
-	public ExecutionContext(Environment defaultEnvironment, SessionContext sessionContext, List<URL> dependencies,
-			Configuration flinkConfig, ClusterClientServiceLoader clusterClientServiceLoader, Options commandLineOptions, List<CustomCommandLine> availableCommandLines) throws FlinkException {
-		this.sessionContext = sessionContext.copy(); // create internal copy because session context is mutable
-		this.mergedEnv = Environment.merge(defaultEnvironment, sessionContext.getEnvironment());
+	public ExecutionContext(
+		Environment environment,
+		List<URL> dependencies,
+		Configuration flinkConfig,
+		ClusterClientServiceLoader clusterClientServiceLoader,
+		Options commandLineOptions,
+		List<CustomCommandLine> availableCommandLines) throws FlinkException {
+		this.environment = environment;
 		this.flinkConfig = flinkConfig;
 
 		// create class loader
@@ -142,40 +156,12 @@ public class ExecutionContext<ClusterID> {
 			dependencies.toArray(new URL[dependencies.size()]),
 			this.getClass().getClassLoader());
 
-		// create modules
-		modules = new LinkedHashMap<>();
-		mergedEnv.getModules().forEach((name, entry) ->
-			modules.put(name, createModule(entry.asMap(), classLoader))
-		);
-
-		// create catalogs
-		catalogs = new LinkedHashMap<>();
-		mergedEnv.getCatalogs().forEach((name, entry) ->
-			catalogs.put(name, createCatalog(name, entry.asMap(), classLoader))
-		);
-
-		// create table sources & sinks.
-		tableSources = new LinkedHashMap<>();
-		tableSinks = new LinkedHashMap<>();
-		mergedEnv.getTables().forEach((name, entry) -> {
-			if (entry instanceof SourceTableEntry || entry instanceof SourceSinkTableEntry) {
-				tableSources.put(name, createTableSource(mergedEnv.getExecution(), entry.asMap(), classLoader));
-			}
-			if (entry instanceof SinkTableEntry || entry instanceof SourceSinkTableEntry) {
-				tableSinks.put(name, createTableSink(mergedEnv.getExecution(), entry.asMap(), classLoader));
-			}
-		});
-
-		// create user-defined functions
-		functions = new LinkedHashMap<>();
-		mergedEnv.getFunctions().forEach((name, entry) -> {
-			final UserDefinedFunction function = FunctionService.createFunction(entry.getDescriptor(), classLoader, false);
-			functions.put(name, function);
-		});
+		// Initialize the TableEnvironment.
+		initializeTableEnvironment();
 
 		// convert deployment options into command line options that describe a cluster
 		final ClusterClientServiceLoader serviceLoader = checkNotNull(clusterClientServiceLoader);
-		final CommandLine commandLine = createCommandLine(mergedEnv.getDeployment(), commandLineOptions);
+		final CommandLine commandLine = createCommandLine(environment.getDeployment(), commandLineOptions);
 		final CustomCommandLine activeCommandLine = findActiveCommandLine(availableCommandLines, commandLine);
 
 		executorConfig = activeCommandLine.applyCommandLineOptionsToConfiguration(commandLine);
@@ -187,16 +173,12 @@ public class ExecutionContext<ClusterID> {
 		clusterSpec = clusterClientFactory.getClusterSpecification(executorConfig);
 	}
 
-	public SessionContext getSessionContext() {
-		return sessionContext;
-	}
-
 	public ClassLoader getClassLoader() {
 		return classLoader;
 	}
 
-	public Environment getMergedEnvironment() {
-		return mergedEnv;
+	public Environment getEnvironment() {
+		return environment;
 	}
 
 	public ClusterSpecification getClusterSpec() {
@@ -211,25 +193,12 @@ public class ExecutionContext<ClusterID> {
 		return clusterClientFactory.createClusterDescriptor(executorConfig);
 	}
 
-	public EnvironmentInstance createEnvironmentInstance() {
-		try {
-			return wrapClassLoader(EnvironmentInstance::new);
-		} catch (Throwable t) {
-			// catch everything such that a wrong environment does not affect invocations
-			throw new SqlExecutionException("Could not create environment instance.", t);
-		}
-	}
-
 	public Map<String, Catalog> getCatalogs() {
+		Map<String, Catalog> catalogs = new HashMap<>();
+		for (String name : tableEnv.listCatalogs()) {
+			tableEnv.getCatalog(name).ifPresent(c -> catalogs.put(name, c));
+		}
 		return catalogs;
-	}
-
-	public Map<String, TableSource<?>> getTableSources() {
-		return tableSources;
-	}
-
-	public Map<String, TableSink<?>> getTableSinks() {
-		return tableSinks;
 	}
 
 	/**
@@ -241,7 +210,56 @@ public class ExecutionContext<ClusterID> {
 		}
 	}
 
-	// --------------------------------------------------------------------------------------------
+	public QueryConfig getQueryConfig() {
+		if (streamExecEnv != null) {
+			final StreamQueryConfig config = new StreamQueryConfig();
+			final long minRetention = environment.getExecution().getMinStateRetention();
+			final long maxRetention = environment.getExecution().getMaxStateRetention();
+			config.withIdleStateRetentionTime(Time.milliseconds(minRetention), Time.milliseconds(maxRetention));
+			return config;
+		} else {
+			return new BatchQueryConfig();
+		}
+	}
+
+	public TableEnvironment getTableEnvironment() {
+		return tableEnv;
+	}
+
+	public ExecutionConfig getExecutionConfig() {
+		if (streamExecEnv != null) {
+			return streamExecEnv.getConfig();
+		} else {
+			return execEnv.getConfig();
+		}
+	}
+
+	public JobGraph createJobGraph(String name) {
+		final Pipeline pipeline = createPipeline(name);
+
+		int parallelism;
+		if (execEnv != null) {
+			parallelism = execEnv.getParallelism();
+		} else if (streamExecEnv != null) {
+			parallelism = streamExecEnv.getParallelism();
+		} else {
+			throw new RuntimeException("No execution environment defined.");
+		}
+		JobGraph jobGraph = FlinkPipelineTranslationUtil.getJobGraph(
+			pipeline,
+			flinkConfig,
+			parallelism);
+
+		jobGraph.addJars(executionParameters.getJars());
+		jobGraph.setClasspaths(executionParameters.getClasspaths());
+		jobGraph.setSavepointRestoreSettings(executionParameters.getSavepointRestoreSettings());
+
+		return jobGraph;
+	}
+
+	//------------------------------------------------------------------------------------------------------------------
+	// Non-public methods
+	//------------------------------------------------------------------------------------------------------------------
 
 	private static CommandLine createCommandLine(DeploymentEntry deployment, Options commandLineOptions) {
 		try {
@@ -355,246 +373,197 @@ public class ExecutionContext<ClusterID> {
 		}
 	}
 
-	// --------------------------------------------------------------------------------------------
+	private void initializeTableEnvironment() {
+		//--------------------------------------------------------------------------------------------------------------
+		// Step.1 Create environments
+		//--------------------------------------------------------------------------------------------------------------
+		if (environment.getExecution().isStreamingPlanner()) {
+			streamExecEnv = createStreamExecutionEnvironment();
+			execEnv = null;
 
-	/**
-	 * {@link ExecutionEnvironment} and {@link StreamExecutionEnvironment} cannot be reused
-	 * across multiple queries because they are stateful. This class abstracts execution
-	 * environments and table environments.
-	 */
-	public class EnvironmentInstance {
+			final EnvironmentSettings settings = environment.getExecution().getEnvironmentSettings();
+			final Map<String, String> executorProperties = settings.toExecutorProperties();
+			executor = lookupExecutor(executorProperties, streamExecEnv);
+			tableEnv = createStreamTableEnvironment(streamExecEnv, settings, executor);
+		} else if (environment.getExecution().isBatchPlanner()) {
+			streamExecEnv = null;
+			execEnv = createExecutionEnvironment();
+			executor = null;
+			tableEnv = BatchTableEnvironment.create(execEnv);
+		} else {
+			throw new SqlExecutionException("Unsupported execution type specified.");
+		}
+		// set table configuration
+		environment.getConfiguration().asMap().forEach((k, v) ->
+			tableEnv.getConfig().getConfiguration().setString(k, v));
 
-		private final QueryConfig queryConfig;
-		private final ExecutionEnvironment execEnv;
-		private final StreamExecutionEnvironment streamExecEnv;
-		private final Executor executor;
-		private final TableEnvironment tableEnv;
+		//--------------------------------------------------------------------------------------------------------------
+		// Step.2 Create modules and load them into the TableEnvironment.
+		//--------------------------------------------------------------------------------------------------------------
+		Map<String, Module> modules = new LinkedHashMap<>();
+		environment.getModules().forEach((name, entry) ->
+			modules.put(name, createModule(entry.asMap(), classLoader))
+		);
+		if (!modules.isEmpty()) {
+			// unload core module first to respect whatever users configure
+			tableEnv.unloadModule(CoreModuleDescriptorValidator.MODULE_TYPE_CORE);
+			modules.forEach(tableEnv::loadModule);
+		}
 
-		private EnvironmentInstance() {
-			// create settings
-			final EnvironmentSettings settings = mergedEnv.getExecution().getEnvironmentSettings();
+		//--------------------------------------------------------------------------------------------------------------
+		// Step.3 Create catalogs and register them.
+		//--------------------------------------------------------------------------------------------------------------
+		Map<String, Catalog> catalogs = new LinkedHashMap<>();
+		environment.getCatalogs().forEach((name, entry) ->
+			catalogs.put(name, createCatalog(name, entry.asMap(), classLoader))
+		);
+		// register catalogs
+		catalogs.forEach(tableEnv::registerCatalog);
 
-			// create environments
-			if (mergedEnv.getExecution().isStreamingPlanner()) {
-				streamExecEnv = createStreamExecutionEnvironment();
-				execEnv = null;
-
-				final Map<String, String> executorProperties = settings.toExecutorProperties();
-				executor = lookupExecutor(executorProperties, streamExecEnv);
-				tableEnv = createStreamTableEnvironment(streamExecEnv, settings, executor);
-			} else if (mergedEnv.getExecution().isBatchPlanner()) {
-				streamExecEnv = null;
-				execEnv = createExecutionEnvironment();
-				executor = null;
-				tableEnv = BatchTableEnvironment.create(execEnv);
-			} else {
-				throw new SqlExecutionException("Unsupported execution type specified.");
+		//--------------------------------------------------------------------------------------------------------------
+		// Step.4 create table sources & sinks, and register them.
+		//--------------------------------------------------------------------------------------------------------------
+		Map<String, TableSource<?>> tableSources = new HashMap<>();
+		Map<String, TableSink<?>> tableSinks = new HashMap<>();
+		environment.getTables().forEach((name, entry) -> {
+			if (entry instanceof SourceTableEntry || entry instanceof SourceSinkTableEntry) {
+				tableSources.put(name, createTableSource(environment.getExecution(), entry.asMap(), classLoader));
 			}
-
-			// set table configuration
-			mergedEnv.getConfiguration().asMap().forEach((k, v) ->
-				tableEnv.getConfig().getConfiguration().setString(k, v));
-
-			// load modules
-			if (!modules.isEmpty()) {
-				// unload core module first to respect whatever users configure
-				tableEnv.unloadModule(CoreModuleDescriptorValidator.MODULE_TYPE_CORE);
-				modules.forEach(tableEnv::loadModule);
+			if (entry instanceof SinkTableEntry || entry instanceof SourceSinkTableEntry) {
+				tableSinks.put(name, createTableSink(environment.getExecution(), entry.asMap(), classLoader));
 			}
+		});
+		// register table sources
+		tableSources.forEach(tableEnv::registerTableSource);
+		// register table sinks
+		tableSinks.forEach(tableEnv::registerTableSink);
 
-			// register catalogs
-			catalogs.forEach(tableEnv::registerCatalog);
+		//--------------------------------------------------------------------------------------------------------------
+		// Step.5 create user-defined functions and register them.
+		//--------------------------------------------------------------------------------------------------------------
+		Map<String, FunctionDefinition> functions = new LinkedHashMap<>();
+		environment.getFunctions().forEach((name, entry) -> {
+			final UserDefinedFunction function = FunctionService.createFunction(entry.getDescriptor(), classLoader, false);
+			functions.put(name, function);
+		});
+		registerFunctions(functions);
 
-			// create query config
-			queryConfig = createQueryConfig();
+		//--------------------------------------------------------------------------------------------------------------
+		// Step.5 Register views and temporal tables in specified order.
+		//--------------------------------------------------------------------------------------------------------------
+		environment.getTables().forEach((name, entry) -> {
+			// if registering a view fails at this point,
+			// it means that it accesses tables that are not available anymore
+			if (entry instanceof ViewEntry) {
+				final ViewEntry viewEntry = (ViewEntry) entry;
+				registerView(viewEntry);
+			} else if (entry instanceof TemporalTableEntry) {
+				final TemporalTableEntry temporalTableEntry = (TemporalTableEntry) entry;
+				registerTemporalTable(temporalTableEntry);
+			}
+		});
 
-			// register table sources
-			tableSources.forEach(tableEnv::registerTableSource);
+		//--------------------------------------------------------------------------------------------------------------
+		// Step.6 Set current catalog and database.
+		//--------------------------------------------------------------------------------------------------------------
+		// Switch to the current catalog.
+		Optional<String> catalog = environment.getExecution().getCurrentCatalog();
+		catalog.ifPresent(tableEnv::useCatalog);
 
-			// register table sinks
-			tableSinks.forEach(tableEnv::registerTableSink);
+		// Switch to the current database.
+		Optional<String> database = environment.getExecution().getCurrentDatabase();
+		database.ifPresent(tableEnv::useDatabase);
+	}
 
-			// register user-defined functions
-			registerFunctions();
+	private ExecutionEnvironment createExecutionEnvironment() {
+		final ExecutionEnvironment execEnv = ExecutionEnvironment.getExecutionEnvironment();
+		execEnv.setRestartStrategy(environment.getExecution().getRestartStrategy());
+		execEnv.setParallelism(environment.getExecution().getParallelism());
+		return execEnv;
+	}
 
-			// register views and temporal tables in specified order
-			mergedEnv.getTables().forEach((name, entry) -> {
-				// if registering a view fails at this point,
-				// it means that it accesses tables that are not available anymore
-				if (entry instanceof ViewEntry) {
-					final ViewEntry viewEntry = (ViewEntry) entry;
-					registerView(viewEntry);
-				} else if (entry instanceof TemporalTableEntry) {
-					final TemporalTableEntry temporalTableEntry = (TemporalTableEntry) entry;
-					registerTemporalTable(temporalTableEntry);
+	private StreamExecutionEnvironment createStreamExecutionEnvironment() {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setRestartStrategy(environment.getExecution().getRestartStrategy());
+		env.setParallelism(environment.getExecution().getParallelism());
+		env.setMaxParallelism(environment.getExecution().getMaxParallelism());
+		env.setStreamTimeCharacteristic(environment.getExecution().getTimeCharacteristic());
+		if (env.getStreamTimeCharacteristic() == TimeCharacteristic.EventTime) {
+			env.getConfig().setAutoWatermarkInterval(environment.getExecution().getPeriodicWatermarksInterval());
+		}
+		return env;
+	}
+
+	private void registerFunctions(Map<String, FunctionDefinition> functions) {
+		if (tableEnv instanceof StreamTableEnvironment) {
+			StreamTableEnvironment streamTableEnvironment = (StreamTableEnvironment) tableEnv;
+			functions.forEach((k, v) -> {
+				if (v instanceof ScalarFunction) {
+					streamTableEnvironment.registerFunction(k, (ScalarFunction) v);
+				} else if (v instanceof AggregateFunction) {
+					streamTableEnvironment.registerFunction(k, (AggregateFunction<?, ?>) v);
+				} else if (v instanceof TableFunction) {
+					streamTableEnvironment.registerFunction(k, (TableFunction<?>) v);
+				} else {
+					throw new SqlExecutionException("Unsupported function type: " + v.getClass().getName());
 				}
 			});
-
-			// set current catalog
-			if (sessionContext.getCurrentCatalog().isPresent()) {
-				tableEnv.useCatalog(sessionContext.getCurrentCatalog().get());
-			} else if (mergedEnv.getExecution().getCurrentCatalog().isPresent()) {
-				tableEnv.useCatalog(mergedEnv.getExecution().getCurrentCatalog().get());
-			}
-
-			// set current database
-			if (sessionContext.getCurrentDatabase().isPresent()) {
-				tableEnv.useDatabase(sessionContext.getCurrentDatabase().get());
-			} else if (mergedEnv.getExecution().getCurrentDatabase().isPresent()) {
-				tableEnv.useDatabase(mergedEnv.getExecution().getCurrentDatabase().get());
-			}
-		}
-
-		public QueryConfig getQueryConfig() {
-			return queryConfig;
-		}
-
-		public ExecutionEnvironment getExecutionEnvironment() {
-			return execEnv;
-		}
-
-		public StreamExecutionEnvironment getStreamExecutionEnvironment() {
-			return streamExecEnv;
-		}
-
-		public TableEnvironment getTableEnvironment() {
-			return tableEnv;
-		}
-
-		public ExecutionConfig getExecutionConfig() {
-			if (streamExecEnv != null) {
-				return streamExecEnv.getConfig();
-			} else {
-				return execEnv.getConfig();
-			}
-		}
-
-		public JobGraph createJobGraph(String name) {
-			final Pipeline pipeline = createPipeline(name, flinkConfig);
-
-			int parallelism;
-			if (execEnv != null) {
-				parallelism = execEnv.getParallelism();
-			} else if (streamExecEnv != null) {
-				parallelism = streamExecEnv.getParallelism();
-			} else {
-				throw new RuntimeException("No execution environment defined.");
-			}
-			JobGraph jobGraph = FlinkPipelineTranslationUtil.getJobGraph(
-					pipeline,
-					flinkConfig,
-					parallelism);
-
-			jobGraph.addJars(executionParameters.getJars());
-			jobGraph.setClasspaths(executionParameters.getClasspaths());
-			jobGraph.setSavepointRestoreSettings(executionParameters.getSavepointRestoreSettings());
-
-			return jobGraph;
-		}
-
-		private Pipeline createPipeline(String name, Configuration flinkConfig) {
-			if (streamExecEnv != null) {
-				// special case for Blink planner to apply batch optimizations
-				// note: it also modifies the ExecutionConfig!
-				if (executor instanceof ExecutorBase) {
-					return ((ExecutorBase) executor).getStreamGraph(name);
+		} else {
+			BatchTableEnvironment batchTableEnvironment = (BatchTableEnvironment) tableEnv;
+			functions.forEach((k, v) -> {
+				if (v instanceof ScalarFunction) {
+					batchTableEnvironment.registerFunction(k, (ScalarFunction) v);
+				} else if (v instanceof AggregateFunction) {
+					batchTableEnvironment.registerFunction(k, (AggregateFunction<?, ?>) v);
+				} else if (v instanceof TableFunction) {
+					batchTableEnvironment.registerFunction(k, (TableFunction<?>) v);
+				} else {
+					throw new SqlExecutionException("Unsupported function type: " + v.getClass().getName());
 				}
-				return streamExecEnv.getStreamGraph(name);
-			} else {
-				final int parallelism = execEnv.getParallelism();
-				return execEnv.createProgramPlan(name);
-			}
+			});
 		}
+	}
 
-		private ExecutionEnvironment createExecutionEnvironment() {
-			final ExecutionEnvironment execEnv = ExecutionEnvironment.getExecutionEnvironment();
-			execEnv.setRestartStrategy(mergedEnv.getExecution().getRestartStrategy());
-			execEnv.setParallelism(mergedEnv.getExecution().getParallelism());
-			return execEnv;
+	private void registerView(ViewEntry viewEntry) {
+		try {
+			tableEnv.registerTable(viewEntry.getName(), tableEnv.sqlQuery(viewEntry.getQuery()));
+		} catch (Exception e) {
+			throw new SqlExecutionException(
+				"Invalid view '" + viewEntry.getName() + "' with query:\n" + viewEntry.getQuery()
+					+ "\nCause: " + e.getMessage());
 		}
+	}
 
-		private StreamExecutionEnvironment createStreamExecutionEnvironment() {
-			final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-			env.setRestartStrategy(mergedEnv.getExecution().getRestartStrategy());
-			env.setParallelism(mergedEnv.getExecution().getParallelism());
-			env.setMaxParallelism(mergedEnv.getExecution().getMaxParallelism());
-			env.setStreamTimeCharacteristic(mergedEnv.getExecution().getTimeCharacteristic());
-			if (env.getStreamTimeCharacteristic() == TimeCharacteristic.EventTime) {
-				env.getConfig().setAutoWatermarkInterval(mergedEnv.getExecution().getPeriodicWatermarksInterval());
-			}
-			return env;
-		}
-
-		private QueryConfig createQueryConfig() {
-			if (streamExecEnv != null) {
-				final StreamQueryConfig config = new StreamQueryConfig();
-				final long minRetention = mergedEnv.getExecution().getMinStateRetention();
-				final long maxRetention = mergedEnv.getExecution().getMaxStateRetention();
-				config.withIdleStateRetentionTime(Time.milliseconds(minRetention), Time.milliseconds(maxRetention));
-				return config;
-			} else {
-				return new BatchQueryConfig();
-			}
-		}
-
-		private void registerFunctions() {
+	private void registerTemporalTable(TemporalTableEntry temporalTableEntry) {
+		try {
+			final Table table = tableEnv.scan(temporalTableEntry.getHistoryTable());
+			final TableFunction<?> function = table.createTemporalTableFunction(
+				temporalTableEntry.getTimeAttribute(),
+				String.join(",", temporalTableEntry.getPrimaryKeyFields()));
 			if (tableEnv instanceof StreamTableEnvironment) {
 				StreamTableEnvironment streamTableEnvironment = (StreamTableEnvironment) tableEnv;
-				functions.forEach((k, v) -> {
-					if (v instanceof ScalarFunction) {
-						streamTableEnvironment.registerFunction(k, (ScalarFunction) v);
-					} else if (v instanceof AggregateFunction) {
-						streamTableEnvironment.registerFunction(k, (AggregateFunction<?, ?>) v);
-					} else if (v instanceof TableFunction) {
-						streamTableEnvironment.registerFunction(k, (TableFunction<?>) v);
-					} else {
-						throw new SqlExecutionException("Unsupported function type: " + v.getClass().getName());
-					}
-				});
+				streamTableEnvironment.registerFunction(temporalTableEntry.getName(), function);
 			} else {
 				BatchTableEnvironment batchTableEnvironment = (BatchTableEnvironment) tableEnv;
-				functions.forEach((k, v) -> {
-					if (v instanceof ScalarFunction) {
-						batchTableEnvironment.registerFunction(k, (ScalarFunction) v);
-					} else if (v instanceof AggregateFunction) {
-						batchTableEnvironment.registerFunction(k, (AggregateFunction<?, ?>) v);
-					} else if (v instanceof TableFunction) {
-						batchTableEnvironment.registerFunction(k, (TableFunction<?>) v);
-					} else {
-						throw new SqlExecutionException("Unsupported function type: " + v.getClass().getName());
-					}
-				});
+				batchTableEnvironment.registerFunction(temporalTableEntry.getName(), function);
 			}
+		} catch (Exception e) {
+			throw new SqlExecutionException(
+				"Invalid temporal table '" + temporalTableEntry.getName() + "' over table '" +
+					temporalTableEntry.getHistoryTable() + ".\nCause: " + e.getMessage());
 		}
+	}
 
-		private void registerView(ViewEntry viewEntry) {
-			try {
-				tableEnv.registerTable(viewEntry.getName(), tableEnv.sqlQuery(viewEntry.getQuery()));
-			} catch (Exception e) {
-				throw new SqlExecutionException(
-					"Invalid view '" + viewEntry.getName() + "' with query:\n" + viewEntry.getQuery()
-						+ "\nCause: " + e.getMessage());
+	private Pipeline createPipeline(String name) {
+		if (streamExecEnv != null) {
+			// special case for Blink planner to apply batch optimizations
+			// note: it also modifies the ExecutionConfig!
+			if (executor instanceof ExecutorBase) {
+				return ((ExecutorBase) executor).getStreamGraph(name);
 			}
-		}
-
-		private void registerTemporalTable(TemporalTableEntry temporalTableEntry) {
-			try {
-				final Table table = tableEnv.scan(temporalTableEntry.getHistoryTable());
-				final TableFunction<?> function = table.createTemporalTableFunction(
-					temporalTableEntry.getTimeAttribute(),
-					String.join(",", temporalTableEntry.getPrimaryKeyFields()));
-				if (tableEnv instanceof StreamTableEnvironment) {
-					StreamTableEnvironment streamTableEnvironment = (StreamTableEnvironment) tableEnv;
-					streamTableEnvironment.registerFunction(temporalTableEntry.getName(), function);
-				} else {
-					BatchTableEnvironment batchTableEnvironment = (BatchTableEnvironment) tableEnv;
-					batchTableEnvironment.registerFunction(temporalTableEntry.getName(), function);
-				}
-			} catch (Exception e) {
-				throw new SqlExecutionException(
-					"Invalid temporal table '" + temporalTableEntry.getName() + "' over table '" +
-						temporalTableEntry.getHistoryTable() + ".\nCause: " + e.getMessage());
-			}
+			return streamExecEnv.getStreamGraph(name);
+		} else {
+			return execEnv.createProgramPlan(name);
 		}
 	}
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ProgramDeployer.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ProgramDeployer.java
@@ -73,7 +73,7 @@ public class ProgramDeployer<C> implements Runnable {
 		LOG.info("Submitting job {} for query {}`", jobGraph.getJobID(), jobName);
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("Submitting job {} with the following environment: \n{}",
-					jobGraph.getJobID(), context.getMergedEnvironment());
+					jobGraph.getJobID(), context.getEnvironment());
 		}
 		deployJob(context, jobGraph, result);
 	}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
@@ -63,7 +63,7 @@ public class ResultStore {
 
 		if (env.getExecution().inStreamingMode()) {
 			// determine gateway address (and port if possible)
-			final InetAddress gatewayAddress = getGatewayAddress(env.getDeployment());
+			InetAddress gatewayAddress = getGatewayAddress(env.getDeployment());
 			final int gatewayPort = getGatewayPort(env.getDeployment());
 
 			if (env.getExecution().isChangelogMode()) {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
@@ -63,19 +63,19 @@ public class ResultStore {
 
 		if (env.getExecution().inStreamingMode()) {
 			// determine gateway address (and port if possible)
-			InetAddress gatewayAddress = getGatewayAddress(env.getDeployment());
+			final InetAddress gatewayAddress = getGatewayAddress(env.getDeployment());
 			final int gatewayPort = getGatewayPort(env.getDeployment());
 
 			if (env.getExecution().isChangelogMode()) {
 				return new ChangelogCollectStreamResult<>(outputType, schema, config, gatewayAddress, gatewayPort);
 			} else {
 				return new MaterializedCollectStreamResult<>(
-					outputType,
-					schema,
-					config,
-					gatewayAddress,
-					gatewayPort,
-					env.getExecution().getMaxTableResultRows());
+						outputType,
+						schema,
+						config,
+						gatewayAddress,
+						gatewayPort,
+						env.getExecution().getMaxTableResultRows());
 			}
 
 		} else {
@@ -130,19 +130,19 @@ public class ResultStore {
 			if (jobManagerAddress != null && !jobManagerAddress.isEmpty()) {
 				try {
 					return ConnectionUtils.findConnectingAddress(
-						new InetSocketAddress(jobManagerAddress, jobManagerPort),
-						deploy.getResponseTimeout(),
-						400);
+							new InetSocketAddress(jobManagerAddress, jobManagerPort),
+							deploy.getResponseTimeout(),
+							400);
 				} catch (Exception e) {
 					throw new SqlClientException("Could not determine address of the gateway for result retrieval " +
-						"by connecting to the job manager. Please specify the gateway address manually.", e);
+							"by connecting to the job manager. Please specify the gateway address manually.", e);
 				}
 			} else {
 				try {
 					return InetAddress.getLocalHost();
 				} catch (UnknownHostException e) {
 					throw new SqlClientException("Could not determine address of the gateway for result retrieval. " +
-						"Please specify the gateway address manually.", e);
+							"Please specify the gateway address manually.", e);
 				}
 			}
 		}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -353,10 +353,5 @@ public class CliClientTest extends TestLogger {
 			}
 			return new ProgramTargetDescriptor("testClusterId", "testJobId", "http://testcluster:1234");
 		}
-
-		@Override
-		public void validateSession(String sessionId) throws SqlExecutionException {
-			// nothing to do
-		}
 	}
 }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.client.cli.utils.TerminalUtils;
 import org.apache.flink.table.client.config.Environment;
+import org.apache.flink.table.client.config.entries.ViewEntry;
 import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.ProgramTargetDescriptor;
 import org.apache.flink.table.client.gateway.ResultDescriptor;
@@ -47,8 +48,10 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -103,9 +106,12 @@ public class CliClientTest extends TestLogger {
 			public void write(int b) throws IOException {
 			}
 		};
+		SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+
 		CliClient cliClient = null;
 		try (Terminal terminal = new DumbTerminal(inputStream, outputStream)) {
-			cliClient = new CliClient(terminal, new SessionContext("test-session", new Environment()), executor);
+			cliClient = new CliClient(terminal, sessionId, executor);
 			cliClient.open();
 			verify(executor).useDatabase(any(), any());
 		} finally {
@@ -127,8 +133,11 @@ public class CliClientTest extends TestLogger {
 			}
 		};
 		CliClient cliClient = null;
+		SessionContext sessionContext = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(sessionContext);
+
 		try (Terminal terminal = new DumbTerminal(inputStream, outputStream)) {
-			cliClient = new CliClient(terminal, new SessionContext("test-session", new Environment()), executor);
+			cliClient = new CliClient(terminal, sessionId, executor);
 			cliClient.open();
 			verify(executor).useCatalog(any(), any());
 		} finally {
@@ -144,11 +153,12 @@ public class CliClientTest extends TestLogger {
 		final SessionContext context = new SessionContext("test-session", new Environment());
 
 		final MockExecutor mockExecutor = new MockExecutor();
+		String sessionId = mockExecutor.openSession(context);
 		mockExecutor.failExecution = failExecution;
 
 		CliClient cli = null;
 		try {
-			cli = new CliClient(TerminalUtils.createDummyTerminal(), context, mockExecutor);
+			cli = new CliClient(TerminalUtils.createDummyTerminal(), sessionId, mockExecutor);
 			if (testFailure) {
 				assertFalse(cli.submitUpdate(statement));
 			} else {
@@ -166,8 +176,9 @@ public class CliClientTest extends TestLogger {
 	private void verifySqlCompletion(String statement, int position, List<String> expectedHints, List<String> notExpectedHints) throws IOException {
 		final SessionContext context = new SessionContext("test-session", new Environment());
 		final MockExecutor mockExecutor = new MockExecutor();
+		String sessionId = mockExecutor.openSession(context);
 
-		final SqlCompleter completer = new SqlCompleter(context, mockExecutor);
+		final SqlCompleter completer = new SqlCompleter(sessionId, mockExecutor);
 		final SqlMultiLineParser parser = new SqlMultiLineParser();
 
 		try (Terminal terminal = TerminalUtils.createDummyTerminal()) {
@@ -201,6 +212,7 @@ public class CliClientTest extends TestLogger {
 		public SessionContext receivedContext;
 		public String receivedStatement;
 		public int receivedPosition;
+		private final Map<String, SessionContext> sessionMap = new HashMap<>();
 
 		@Override
 		public void start() throws SqlExecutionException {
@@ -208,80 +220,117 @@ public class CliClientTest extends TestLogger {
 		}
 
 		@Override
-		public Map<String, String> getSessionProperties(SessionContext session) throws SqlExecutionException {
+		public String openSession(SessionContext session) throws SqlExecutionException {
+			String sessionId = UUID.randomUUID().toString();
+			sessionMap.put(sessionId, session);
+			return sessionId;
+		}
+
+		@Override
+		public void closeSession(String sessionId) throws SqlExecutionException {
+
+		}
+
+		@Override
+		public Map<String, String> getSessionProperties(String sessionId) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public List<String> listCatalogs(SessionContext session) throws SqlExecutionException {
+		public void resetSessionProperties(String sessionId) throws SqlExecutionException {
+
+		}
+
+		@Override
+		public void setSessionProperty(String sessionId, String key, String value) throws SqlExecutionException {
+
+		}
+
+		@Override
+		public void addView(String sessionId, String name, String query) throws SqlExecutionException {
+
+		}
+
+		@Override
+		public void removeView(String sessionId, String name) throws SqlExecutionException {
+
+		}
+
+		@Override
+		public Map<String, ViewEntry> listViews(String sessionId) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public List<String> listDatabases(SessionContext session) throws SqlExecutionException {
+		public List<String> listCatalogs(String sessionId) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public List<String> listTables(SessionContext session) throws SqlExecutionException {
+		public List<String> listDatabases(String sessionId) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public List<String> listUserDefinedFunctions(SessionContext session) throws SqlExecutionException {
+		public List<String> listTables(String sessionId) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public List<String> listFunctions(SessionContext session) throws SqlExecutionException {
+		public List<String> listUserDefinedFunctions(String sessionId) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public List<String> listModules(SessionContext session) throws SqlExecutionException {
+		public List<String> listFunctions(String sessionId) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public void useCatalog(SessionContext session, String catalogName) throws SqlExecutionException {
-
-		}
-
-		@Override
-		public void useDatabase(SessionContext session, String databaseName) throws SqlExecutionException {
-
-		}
-
-		@Override
-		public TableSchema getTableSchema(SessionContext session, String name) throws SqlExecutionException {
+		public List<String> listModules(String sessionId) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public String explainStatement(SessionContext session, String statement) throws SqlExecutionException {
+		public void useCatalog(String sessionId, String catalogName) throws SqlExecutionException {
+
+		}
+
+		@Override
+		public void useDatabase(String sessionId, String databaseName) throws SqlExecutionException {
+
+		}
+
+		@Override
+		public TableSchema getTableSchema(String sessionId, String name) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public List<String> completeStatement(SessionContext session, String statement, int position) {
-			receivedContext = session;
+		public String explainStatement(String sessionId, String statement) throws SqlExecutionException {
+			return null;
+		}
+
+		@Override
+		public List<String> completeStatement(String sessionId, String statement, int position) {
+			receivedContext = sessionMap.get(sessionId);
 			receivedStatement = statement;
 			receivedPosition = position;
 			return Arrays.asList("HintA", "Hint B");
 		}
 
 		@Override
-		public ResultDescriptor executeQuery(SessionContext session, String query) throws SqlExecutionException {
+		public ResultDescriptor executeQuery(String sessionId, String query) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public TypedResult<List<Tuple2<Boolean, Row>>> retrieveResultChanges(SessionContext session, String resultId) throws SqlExecutionException {
+		public TypedResult<List<Tuple2<Boolean, Row>>> retrieveResultChanges(String sessionId, String resultId) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public TypedResult<Integer> snapshotResult(SessionContext session, String resultId, int pageSize) throws SqlExecutionException {
+		public TypedResult<Integer> snapshotResult(String sessionId, String resultId, int pageSize) throws SqlExecutionException {
 			return null;
 		}
 
@@ -291,13 +340,13 @@ public class CliClientTest extends TestLogger {
 		}
 
 		@Override
-		public void cancelQuery(SessionContext session, String resultId) throws SqlExecutionException {
+		public void cancelQuery(String sessionId, String resultId) throws SqlExecutionException {
 			// nothing to do
 		}
 
 		@Override
-		public ProgramTargetDescriptor executeUpdate(SessionContext session, String statement) throws SqlExecutionException {
-			receivedContext = session;
+		public ProgramTargetDescriptor executeUpdate(String sessionId, String statement) throws SqlExecutionException {
+			receivedContext = sessionMap.get(sessionId);
 			receivedStatement = statement;
 			if (failExecution) {
 				throw new SqlExecutionException("Fail execution.");
@@ -306,12 +355,7 @@ public class CliClientTest extends TestLogger {
 		}
 
 		@Override
-		public void validateSession(SessionContext session) throws SqlExecutionException {
-			// nothing to do
-		}
-
-		@Override
-		public void stop(SessionContext session) {
+		public void validateSession(String sessionId) throws SqlExecutionException {
 			// nothing to do
 		}
 	}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
@@ -249,11 +249,6 @@ public class CliResultViewTest {
 		public ProgramTargetDescriptor executeUpdate(String sessionId, String statement) throws SqlExecutionException {
 			return null;
 		}
-
-		@Override
-		public void validateSession(String sessionId) throws SqlExecutionException {
-			// do nothing
-		}
 	}
 
 	private static final class TestingCliResultView implements Runnable {

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.Types;
 import org.apache.flink.table.client.cli.utils.TerminalUtils;
 import org.apache.flink.table.client.config.Environment;
+import org.apache.flink.table.client.config.entries.ViewEntry;
 import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.ProgramTargetDescriptor;
 import org.apache.flink.table.client.gateway.ResultDescriptor;
@@ -36,6 +37,7 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -80,6 +82,7 @@ public class CliResultViewTest {
 		final CountDownLatch cancellationCounterLatch = new CountDownLatch(expectedCancellationCount);
 		final SessionContext session = new SessionContext("test-session", new Environment());
 		final MockExecutor executor = new MockExecutor(typedResult, cancellationCounterLatch);
+		String sessionId = executor.openSession(session);
 		final ResultDescriptor descriptor = new ResultDescriptor(
 			"result-id",
 			TableSchema.builder().field("Null Field", Types.STRING()).build(),
@@ -88,7 +91,7 @@ public class CliResultViewTest {
 		Thread resultViewRunner = null;
 		CliClient cli = null;
 		try {
-			cli = new CliClient(TerminalUtils.createDummyTerminal(), session, executor);
+			cli = new CliClient(TerminalUtils.createDummyTerminal(), sessionId, executor);
 			resultViewRunner = new Thread(new TestingCliResultView(cli, descriptor, isTableMode));
 			resultViewRunner.start();
 		} finally {
@@ -121,79 +124,114 @@ public class CliResultViewTest {
 		}
 
 		@Override
-		public Map<String, String> getSessionProperties(SessionContext session) throws SqlExecutionException {
+		public String openSession(SessionContext session) throws SqlExecutionException {
+			return UUID.randomUUID().toString();
+		}
+
+		@Override
+		public void closeSession(String sessionId) throws SqlExecutionException {
+			// do nothing
+		}
+
+		@Override
+		public Map<String, String> getSessionProperties(String sessionId) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public List<String> listCatalogs(SessionContext session) throws SqlExecutionException {
+		public void resetSessionProperties(String sessionId) throws SqlExecutionException {
+
+		}
+
+		@Override
+		public void setSessionProperty(String sessionId, String key, String value) throws SqlExecutionException {
+
+		}
+
+		@Override
+		public void addView(String sessionId, String name, String query) throws SqlExecutionException {
+
+		}
+
+		@Override
+		public void removeView(String sessionId, String name) throws SqlExecutionException {
+
+		}
+
+		@Override
+		public Map<String, ViewEntry> listViews(String sessionId) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public List<String> listDatabases(SessionContext session) throws SqlExecutionException {
+		public List<String> listCatalogs(String sessionId) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public List<String> listTables(SessionContext session) throws SqlExecutionException {
+		public List<String> listDatabases(String sessionId) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public List<String> listUserDefinedFunctions(SessionContext session) throws SqlExecutionException {
+		public List<String> listTables(String sessionId) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public List<String> listFunctions(SessionContext session) throws SqlExecutionException {
+		public List<String> listUserDefinedFunctions(String sessionId) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public List<String> listModules(SessionContext session) throws SqlExecutionException {
+		public List<String> listFunctions(String sessionId) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public void useCatalog(SessionContext session, String catalogName) throws SqlExecutionException {
-
-		}
-
-		@Override
-		public void useDatabase(SessionContext session, String databaseName) throws SqlExecutionException {
-
-		}
-
-		@Override
-		public TableSchema getTableSchema(SessionContext session, String name) throws SqlExecutionException {
+		public List<String> listModules(String sessionId) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public String explainStatement(SessionContext session, String statement) throws SqlExecutionException {
+		public void useCatalog(String sessionId, String catalogName) throws SqlExecutionException {
+
+		}
+
+		@Override
+		public void useDatabase(String sessionId, String databaseName) throws SqlExecutionException {
+
+		}
+
+		@Override
+		public TableSchema getTableSchema(String sessionId, String name) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public List<String> completeStatement(SessionContext session, String statement, int position) {
+		public String explainStatement(String sessionId, String statement) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public ResultDescriptor executeQuery(SessionContext session, String query) throws SqlExecutionException {
+		public List<String> completeStatement(String sessionId, String statement, int position) {
+			return null;
+		}
+
+		@Override
+		public ResultDescriptor executeQuery(String sessionId, String query) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
 		@SuppressWarnings("unchecked")
-		public TypedResult<List<Tuple2<Boolean, Row>>> retrieveResultChanges(SessionContext session, String resultId) throws SqlExecutionException {
+		public TypedResult<List<Tuple2<Boolean, Row>>> retrieveResultChanges(String sessionId, String resultId) throws SqlExecutionException {
 			return (TypedResult<List<Tuple2<Boolean, Row>>>) typedResult;
 		}
 
 		@Override
 		@SuppressWarnings("unchecked")
-		public TypedResult<Integer> snapshotResult(SessionContext session, String resultId, int pageSize) throws SqlExecutionException {
+		public TypedResult<Integer> snapshotResult(String sessionId, String resultId, int pageSize) throws SqlExecutionException {
 			return (TypedResult<Integer>) typedResult;
 		}
 
@@ -203,22 +241,17 @@ public class CliResultViewTest {
 		}
 
 		@Override
-		public void cancelQuery(SessionContext session, String resultId) throws SqlExecutionException {
+		public void cancelQuery(String sessionId, String resultId) throws SqlExecutionException {
 			cancellationCounter.countDown();
 		}
 
 		@Override
-		public ProgramTargetDescriptor executeUpdate(SessionContext session, String statement) throws SqlExecutionException {
+		public ProgramTargetDescriptor executeUpdate(String sessionId, String statement) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public void validateSession(SessionContext session) throws SqlExecutionException {
-			// do nothing
-		}
-
-		@Override
-		public void stop(SessionContext session) {
+		public void validateSession(String sessionId) throws SqlExecutionException {
 			// do nothing
 		}
 	}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
@@ -100,8 +100,9 @@ public class DependencyTest {
 			new DefaultClusterClientServiceLoader());
 
 		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
 
-		final TableSchema result = executor.getTableSchema(session, "TableNumber1");
+		final TableSchema result = executor.getTableSchema(sessionId, "TableNumber1");
 		final TableSchema expected = TableSchema.builder()
 			.field("IntegerField1", Types.INT())
 			.field("StringField1", Types.STRING())

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.client.config.Environment;
+import org.apache.flink.table.client.gateway.SessionContext;
 import org.apache.flink.table.client.gateway.utils.DummyTableSourceFactory;
 import org.apache.flink.table.client.gateway.utils.EnvironmentFileUtil;
 import org.apache.flink.util.StringUtils;
@@ -249,6 +250,7 @@ public class ExecutionContextTest {
 		final Configuration flinkConfig = new Configuration();
 		return new ExecutionContext<>(
 			env,
+			new SessionContext("test-session", new Environment()),
 			Collections.emptyList(),
 			flinkConfig,
 			new Options(),

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -139,11 +139,8 @@ public class LocalExecutorITCase extends TestLogger {
 		String sessionId = executor.openSession(session);
 		assertEquals("test-session", sessionId);
 
-		executor.validateSession(sessionId);
-
 		executor.addView(sessionId, "AdditionalView1", "SELECT 1");
 		executor.addView(sessionId, "AdditionalView2", "SELECT * FROM AdditionalView1");
-		executor.validateSession(sessionId);
 
 		List<String> actualTables = executor.listTables(sessionId);
 		List<String> expectedTables = Arrays.asList(
@@ -156,16 +153,16 @@ public class LocalExecutorITCase extends TestLogger {
 			"TestView2");
 		assertEquals(expectedTables, actualTables);
 
-		executor.removeView(sessionId, "AdditionalView1");
 		try {
-			executor.validateSession(sessionId);
+			executor.removeView(sessionId, "AdditionalView1");
 			fail();
 		} catch (SqlExecutionException e) {
 			// AdditionalView2 needs AdditionalView1
 		}
 
 		executor.removeView(sessionId, "AdditionalView2");
-		executor.validateSession(sessionId);
+
+		executor.removeView(sessionId, "AdditionalView1");
 
 		actualTables = executor.listTables(sessionId);
 		expectedTables = Arrays.asList(
@@ -250,11 +247,11 @@ public class LocalExecutorITCase extends TestLogger {
 	public void testGetSessionProperties() throws Exception {
 		final Executor executor = createDefaultExecutor(clusterClient);
 		final SessionContext session = new SessionContext("test-session", new Environment());
-		session.setSessionProperty("execution.result-mode", "changelog");
-
 		// Open the session and get the sessionId.
 		String sessionId = executor.openSession(session);
 		assertEquals("test-session", sessionId);
+		executor.setSessionProperty(sessionId, "execution.result-mode", "changelog");
+		assertEquals(executor.getSessionProperties(sessionId).get("execution.result-mode"), "changelog");
 
 		// modify defaults
 		executor.setSessionProperty(sessionId, "execution.result-mode", "table");

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -36,7 +36,6 @@ import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.config.entries.ExecutionEntry;
-import org.apache.flink.table.client.config.entries.ViewEntry;
 import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.ProgramTargetDescriptor;
 import org.apache.flink.table.client.gateway.ResultDescriptor;
@@ -137,14 +136,16 @@ public class LocalExecutorITCase extends TestLogger {
 	public void testValidateSession() throws Exception {
 		final Executor executor = createDefaultExecutor(clusterClient);
 		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+		assertEquals("test-session", sessionId);
 
-		executor.validateSession(session);
+		executor.validateSession(sessionId);
 
-		session.addView(ViewEntry.create("AdditionalView1", "SELECT 1"));
-		session.addView(ViewEntry.create("AdditionalView2", "SELECT * FROM AdditionalView1"));
-		executor.validateSession(session);
+		executor.addView(sessionId, "AdditionalView1", "SELECT 1");
+		executor.addView(sessionId, "AdditionalView2", "SELECT * FROM AdditionalView1");
+		executor.validateSession(sessionId);
 
-		List<String> actualTables = executor.listTables(session);
+		List<String> actualTables = executor.listTables(sessionId);
 		List<String> expectedTables = Arrays.asList(
 			"AdditionalView1",
 			"AdditionalView2",
@@ -155,18 +156,18 @@ public class LocalExecutorITCase extends TestLogger {
 			"TestView2");
 		assertEquals(expectedTables, actualTables);
 
-		session.removeView("AdditionalView1");
+		executor.removeView(sessionId, "AdditionalView1");
 		try {
-			executor.validateSession(session);
+			executor.validateSession(sessionId);
 			fail();
 		} catch (SqlExecutionException e) {
 			// AdditionalView2 needs AdditionalView1
 		}
 
-		session.removeView("AdditionalView2");
-		executor.validateSession(session);
+		executor.removeView(sessionId, "AdditionalView2");
+		executor.validateSession(sessionId);
 
-		actualTables = executor.listTables(session);
+		actualTables = executor.listTables(sessionId);
 		expectedTables = Arrays.asList(
 			"TableNumber1",
 			"TableNumber2",
@@ -174,39 +175,51 @@ public class LocalExecutorITCase extends TestLogger {
 			"TestView1",
 			"TestView2");
 		assertEquals(expectedTables, actualTables);
+
+		executor.closeSession(sessionId);
 	}
 
 	@Test
 	public void testListCatalogs() throws Exception {
 		final Executor executor = createDefaultExecutor(clusterClient);
 		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+		assertEquals("test-session", sessionId);
 
-		final List<String> actualCatalogs = executor.listCatalogs(session);
+		final List<String> actualCatalogs = executor.listCatalogs(sessionId);
 
 		final List<String> expectedCatalogs = Arrays.asList(
 			"catalog1",
 			"default_catalog",
 			"simple-catalog");
 		assertEquals(expectedCatalogs, actualCatalogs);
+
+		executor.closeSession(sessionId);
 	}
 
 	@Test
 	public void testListDatabases() throws Exception {
 		final Executor executor = createDefaultExecutor(clusterClient);
 		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+		assertEquals("test-session", sessionId);
 
-		final List<String> actualDatabases = executor.listDatabases(session);
+		final List<String> actualDatabases = executor.listDatabases(sessionId);
 
 		final List<String> expectedDatabases = Collections.singletonList("default_database");
 		assertEquals(expectedDatabases, actualDatabases);
+
+		executor.closeSession(sessionId);
 	}
 
 	@Test
 	public void testListTables() throws Exception {
 		final Executor executor = createDefaultExecutor(clusterClient);
 		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+		assertEquals("test-session", sessionId);
 
-		final List<String> actualTables = executor.listTables(session);
+		final List<String> actualTables = executor.listTables(sessionId);
 
 		final List<String> expectedTables = Arrays.asList(
 			"TableNumber1",
@@ -215,32 +228,38 @@ public class LocalExecutorITCase extends TestLogger {
 			"TestView1",
 			"TestView2");
 		assertEquals(expectedTables, actualTables);
+		executor.closeSession(sessionId);
 	}
 
 	@Test
 	public void testListUserDefinedFunctions() throws Exception {
 		final Executor executor = createDefaultExecutor(clusterClient);
 		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+		assertEquals("test-session", sessionId);
 
-		final List<String> actualTables = executor.listUserDefinedFunctions(session);
+		final List<String> actualTables = executor.listUserDefinedFunctions(sessionId);
 
 		final List<String> expectedTables = Arrays.asList("aggregateudf", "tableudf", "scalarudf");
 		assertEquals(expectedTables, actualTables);
+
+		executor.closeSession(sessionId);
 	}
 
 	@Test
 	public void testGetSessionProperties() throws Exception {
 		final Executor executor = createDefaultExecutor(clusterClient);
 		final SessionContext session = new SessionContext("test-session", new Environment());
-
 		session.setSessionProperty("execution.result-mode", "changelog");
 
-		executor.getSessionProperties(session);
+		// Open the session and get the sessionId.
+		String sessionId = executor.openSession(session);
+		assertEquals("test-session", sessionId);
 
 		// modify defaults
-		session.setSessionProperty("execution.result-mode", "table");
+		executor.setSessionProperty(sessionId, "execution.result-mode", "table");
 
-		final Map<String, String> actualProperties = executor.getSessionProperties(session);
+		final Map<String, String> actualProperties = executor.getSessionProperties(sessionId);
 
 		final Map<String, String> expectedProperties = new HashMap<>();
 		expectedProperties.put("execution.planner", planner);
@@ -261,38 +280,46 @@ public class LocalExecutorITCase extends TestLogger {
 		expectedProperties.put("deployment.response-timeout", "5000");
 
 		assertEquals(expectedProperties, actualProperties);
+
+		executor.closeSession(sessionId);
 	}
 
 	@Test
 	public void testTableSchema() throws Exception {
 		final Executor executor = createDefaultExecutor(clusterClient);
 		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+		assertEquals("test-session", sessionId);
 
-		final TableSchema actualTableSchema = executor.getTableSchema(session, "TableNumber2");
+		final TableSchema actualTableSchema = executor.getTableSchema(sessionId, "TableNumber2");
 
 		final TableSchema expectedTableSchema = new TableSchema(
-			new String[] {"IntegerField2", "StringField2"},
-			new TypeInformation[] {Types.INT, Types.STRING});
+			new String[]{"IntegerField2", "StringField2"},
+			new TypeInformation[]{Types.INT, Types.STRING});
 
 		assertEquals(expectedTableSchema, actualTableSchema);
+		executor.closeSession(sessionId);
 	}
 
 	@Test
 	public void testCompleteStatement() throws Exception {
 		final Executor executor = createDefaultExecutor(clusterClient);
 		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+		assertEquals("test-session", sessionId);
 
 		final List<String> expectedTableHints = Arrays.asList(
 			"default_catalog.default_database.TableNumber1",
 			"default_catalog.default_database.TableNumber2",
 			"default_catalog.default_database.TableSourceSink");
-		assertEquals(expectedTableHints, executor.completeStatement(session, "SELECT * FROM Ta", 16));
+		assertEquals(expectedTableHints, executor.completeStatement(sessionId, "SELECT * FROM Ta", 16));
 
 		final List<String> expectedClause = Collections.singletonList("WHERE");
-		assertEquals(expectedClause, executor.completeStatement(session, "SELECT * FROM TableNumber2 WH", 29));
+		assertEquals(expectedClause, executor.completeStatement(sessionId, "SELECT * FROM TableNumber2 WH", 29));
 
 		final List<String> expectedField = Arrays.asList("IntegerField1");
-		assertEquals(expectedField, executor.completeStatement(session, "SELECT * FROM TableNumber1 WHERE Inte", 37));
+		assertEquals(expectedField, executor.completeStatement(sessionId, "SELECT * FROM TableNumber1 WHERE Inte", 37));
+		executor.closeSession(sessionId);
 	}
 
 	@Test(timeout = 30_000L)
@@ -309,17 +336,19 @@ public class LocalExecutorITCase extends TestLogger {
 
 		final Executor executor = createModifiedExecutor(clusterClient, replaceVars);
 		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+		assertEquals("test-session", sessionId);
 
 		try {
 			// start job and retrieval
 			final ResultDescriptor desc = executor.executeQuery(
-				session,
+				sessionId,
 				"SELECT scalarUDF(IntegerField1), StringField1 FROM TableNumber1");
 
 			assertFalse(desc.isMaterialized());
 
 			final List<String> actualResults =
-					retrieveChangelogResult(executor, session, desc.getResultId());
+				retrieveChangelogResult(executor, sessionId, desc.getResultId());
 
 			final List<String> expectedResults = new ArrayList<>();
 			expectedResults.add("(true,47,Hello World)");
@@ -331,7 +360,7 @@ public class LocalExecutorITCase extends TestLogger {
 
 			TestBaseUtils.compareResultCollections(expectedResults, actualResults, Comparator.naturalOrder());
 		} finally {
-			executor.stop(session);
+			executor.closeSession(sessionId);
 		}
 	}
 
@@ -396,13 +425,15 @@ public class LocalExecutorITCase extends TestLogger {
 
 		final Executor executor = createModifiedExecutor(clusterClient, replaceVars);
 		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+		assertEquals("test-session", sessionId);
 
 		try {
-			final ResultDescriptor desc = executor.executeQuery(session, "SELECT * FROM TestView1");
+			final ResultDescriptor desc = executor.executeQuery(sessionId, "SELECT * FROM TestView1");
 
 			assertTrue(desc.isMaterialized());
 
-			final List<String> actualResults = retrieveTableResult(executor, session, desc.getResultId());
+			final List<String> actualResults = retrieveTableResult(executor, sessionId, desc.getResultId());
 
 			final List<String> expectedResults = new ArrayList<>();
 			expectedResults.add("47");
@@ -414,7 +445,7 @@ public class LocalExecutorITCase extends TestLogger {
 
 			TestBaseUtils.compareResultCollections(expectedResults, actualResults, Comparator.naturalOrder());
 		} finally {
-			executor.stop(session);
+			executor.closeSession(sessionId);
 		}
 	}
 
@@ -433,11 +464,13 @@ public class LocalExecutorITCase extends TestLogger {
 
 		final Executor executor = createModifiedExecutor(clusterClient, replaceVars);
 		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+		assertEquals("test-session", sessionId);
 
 		try {
 			// Case 1: Registered sink
 			final ProgramTargetDescriptor targetDescriptor = executor.executeUpdate(
-				session,
+				sessionId,
 				"INSERT INTO TableSourceSink SELECT IntegerField1 = 42, StringField1 FROM TableNumber1");
 
 			// wait for job completion and verify result
@@ -459,14 +492,14 @@ public class LocalExecutorITCase extends TestLogger {
 			}
 
 			// Case 2: Temporary sink
-			session.setCurrentCatalog("simple-catalog");
-			session.setCurrentDatabase("default_database");
+			executor.useCatalog(sessionId, "simple-catalog");
+			executor.useDatabase(sessionId, "default_database");
 			// all queries are pipelined to an in-memory sink, check it is properly registered
-			final ResultDescriptor otherCatalogDesc = executor.executeQuery(session, "SELECT * FROM `test-table`");
+			final ResultDescriptor otherCatalogDesc = executor.executeQuery(sessionId, "SELECT * FROM `test-table`");
 
 			final List<String> otherCatalogResults = retrieveTableResult(
 				executor,
-				session,
+				sessionId,
 				otherCatalogDesc.getResultId());
 
 			TestBaseUtils.compareResultCollections(
@@ -474,7 +507,7 @@ public class LocalExecutorITCase extends TestLogger {
 				otherCatalogResults,
 				Comparator.naturalOrder());
 		} finally {
-			executor.stop(session);
+			executor.closeSession(sessionId);
 		}
 	}
 
@@ -496,24 +529,26 @@ public class LocalExecutorITCase extends TestLogger {
 
 		final Executor executor = createModifiedExecutor(CATALOGS_ENVIRONMENT_FILE, clusterClient, replaceVars);
 		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+		assertEquals("test-session", sessionId);
 
 		try {
-			assertEquals(Arrays.asList("mydatabase"), executor.listDatabases(session));
+			assertEquals(Arrays.asList("mydatabase"), executor.listDatabases(sessionId));
 
-			executor.useCatalog(session, "hivecatalog");
+			executor.useCatalog(sessionId, "hivecatalog");
 
 			assertEquals(
 				Arrays.asList(DependencyTest.TestHiveCatalogFactory.ADDITIONAL_TEST_DATABASE, HiveCatalog.DEFAULT_DB),
-				executor.listDatabases(session));
+				executor.listDatabases(sessionId));
 
 			assertEquals(Collections.singletonList(DependencyTest.TestHiveCatalogFactory.TABLE_WITH_PARAMETERIZED_TYPES),
-					executor.listTables(session));
+				executor.listTables(sessionId));
 
-			executor.useDatabase(session, DependencyTest.TestHiveCatalogFactory.ADDITIONAL_TEST_DATABASE);
+			executor.useDatabase(sessionId, DependencyTest.TestHiveCatalogFactory.ADDITIONAL_TEST_DATABASE);
 
-			assertEquals(Arrays.asList(DependencyTest.TestHiveCatalogFactory.TEST_TABLE), executor.listTables(session));
+			assertEquals(Arrays.asList(DependencyTest.TestHiveCatalogFactory.TEST_TABLE), executor.listTables(sessionId));
 		} finally {
-			executor.stop(session);
+			executor.closeSession(sessionId);
 		}
 	}
 
@@ -521,18 +556,23 @@ public class LocalExecutorITCase extends TestLogger {
 	public void testUseNonExistingDatabase() throws Exception {
 		final Executor executor = createDefaultExecutor(clusterClient);
 		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+		assertEquals("test-session", sessionId);
 
 		exception.expect(SqlExecutionException.class);
-		executor.useDatabase(session, "nonexistingdb");
+		executor.useDatabase(sessionId, "nonexistingdb");
 	}
 
 	@Test
 	public void testUseNonExistingCatalog() throws Exception {
 		final Executor executor = createDefaultExecutor(clusterClient);
 		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+		assertEquals("test-session", sessionId);
 
 		exception.expect(SqlExecutionException.class);
-		executor.useCatalog(session, "nonexistingcatalog");
+		executor.useCatalog(sessionId, "nonexistingcatalog");
+		executor.closeSession(sessionId);
 	}
 
 	@Test
@@ -554,15 +594,19 @@ public class LocalExecutorITCase extends TestLogger {
 
 		final Executor executor = createModifiedExecutor(CATALOGS_ENVIRONMENT_FILE, clusterClient, replaceVars);
 		final SessionContext session = new SessionContext("test-session", new Environment());
-		executor.useCatalog(session, "hivecatalog");
-		String resultID = executor.executeQuery(session,
-				"select * from " + DependencyTest.TestHiveCatalogFactory.TABLE_WITH_PARAMETERIZED_TYPES).getResultId();
-		retrieveTableResult(executor, session, resultID);
+		String sessionId = executor.openSession(session);
+		assertEquals("test-session", sessionId);
+
+		executor.useCatalog(sessionId, "hivecatalog");
+		String resultID = executor.executeQuery(sessionId,
+			"select * from " + DependencyTest.TestHiveCatalogFactory.TABLE_WITH_PARAMETERIZED_TYPES).getResultId();
+		retrieveTableResult(executor, sessionId, resultID);
 
 		// make sure legacy types still work
-		executor.useCatalog(session, "default_catalog");
-		resultID = executor.executeQuery(session, "select * from TableNumber3").getResultId();
-		retrieveTableResult(executor, session, resultID);
+		executor.useCatalog(sessionId, "default_catalog");
+		resultID = executor.executeQuery(sessionId, "select * from TableNumber3").getResultId();
+		retrieveTableResult(executor, sessionId, resultID);
+		executor.closeSession(sessionId);
 	}
 
 	private void executeStreamQueryTable(
@@ -572,18 +616,20 @@ public class LocalExecutorITCase extends TestLogger {
 
 		final Executor executor = createModifiedExecutor(clusterClient, replaceVars);
 		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+		assertEquals("test-session", sessionId);
 
 		try {
 			// start job and retrieval
-			final ResultDescriptor desc = executor.executeQuery(session, query);
+			final ResultDescriptor desc = executor.executeQuery(sessionId, query);
 
 			assertTrue(desc.isMaterialized());
 
-			final List<String> actualResults = retrieveTableResult(executor, session, desc.getResultId());
+			final List<String> actualResults = retrieveTableResult(executor, sessionId, desc.getResultId());
 
 			TestBaseUtils.compareResultCollections(expectedResults, actualResults, Comparator.naturalOrder());
 		} finally {
-			executor.stop(session);
+			executor.closeSession(sessionId);
 		}
 	}
 
@@ -635,13 +681,13 @@ public class LocalExecutorITCase extends TestLogger {
 
 	private List<String> retrieveTableResult(
 			Executor executor,
-			SessionContext session,
+			String sessionId,
 			String resultID) throws InterruptedException {
 
 		final List<String> actualResults = new ArrayList<>();
 		while (true) {
 			Thread.sleep(50); // slow the processing down
-			final TypedResult<Integer> result = executor.snapshotResult(session, resultID, 2);
+			final TypedResult<Integer> result = executor.snapshotResult(sessionId, resultID, 2);
 			if (result.getType() == TypedResult.ResultType.PAYLOAD) {
 				actualResults.clear();
 				IntStream.rangeClosed(1, result.getPayload()).forEach((page) -> {
@@ -659,14 +705,14 @@ public class LocalExecutorITCase extends TestLogger {
 
 	private List<String> retrieveChangelogResult(
 			Executor executor,
-			SessionContext session,
+			String sessionId,
 			String resultID) throws InterruptedException {
 
 		final List<String> actualResults = new ArrayList<>();
 		while (true) {
 			Thread.sleep(50); // slow the processing down
 			final TypedResult<List<Tuple2<Boolean, Row>>> result =
-					executor.retrieveResultChanges(session, resultID);
+				executor.retrieveResultChanges(sessionId, resultID);
 			if (result.getType() == TypedResult.ResultType.PAYLOAD) {
 				for (Tuple2<Boolean, Row> change : result.getPayload()) {
 					actualResults.add(change.toString());

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -135,7 +135,7 @@ public class LocalExecutorITCase extends TestLogger {
 	public ExpectedException exception = ExpectedException.none();
 
 	@Test
-	public void testValidateSession() throws Exception {
+	public void testViews() throws Exception {
 		final Executor executor = createDefaultExecutor(clusterClient);
 		final SessionContext session = new SessionContext("test-session", new Environment());
 		String sessionId = executor.openSession(session);
@@ -146,13 +146,13 @@ public class LocalExecutorITCase extends TestLogger {
 
 		List<String> actualTables = executor.listTables(sessionId);
 		List<String> expectedTables = Arrays.asList(
-			"AdditionalView1",
-			"AdditionalView2",
-			"TableNumber1",
-			"TableNumber2",
-			"TableSourceSink",
-			"TestView1",
-			"TestView2");
+				"AdditionalView1",
+				"AdditionalView2",
+				"TableNumber1",
+				"TableNumber2",
+				"TableSourceSink",
+				"TestView1",
+				"TestView2");
 		assertEquals(expectedTables, actualTables);
 
 		try {
@@ -168,11 +168,11 @@ public class LocalExecutorITCase extends TestLogger {
 
 		actualTables = executor.listTables(sessionId);
 		expectedTables = Arrays.asList(
-			"TableNumber1",
-			"TableNumber2",
-			"TableSourceSink",
-			"TestView1",
-			"TestView2");
+				"TableNumber1",
+				"TableNumber2",
+				"TableSourceSink",
+				"TestView1",
+				"TestView2");
 		assertEquals(expectedTables, actualTables);
 
 		executor.closeSession(sessionId);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -237,7 +237,7 @@ public class TableEnvironmentImpl implements TableEnvironment {
 	private void createTemporaryView(UnresolvedIdentifier identifier, Table view) {
 		if (((TableImpl) view).getTableEnvironment() != this) {
 			throw new TableException(
-				"Only table API objects that belong to this TableEnvironment can be registered.");
+					"Only table API objects that belong to this TableEnvironment can be registered.");
 		}
 
 		ObjectIdentifier tableIdentifier = catalogManager.qualifyIdentifier(identifier);


### PR DESCRIPTION
## What is the purpose of the change

Now we only have the embedded mode SQL to interact with Flink cluster, will support the multi-statement and DDL such create table, which means we need to store some state for the same session. On the other hande, it will support the gateway mode in future, means it will maitain multi-sessions at the server side. 

So it's necessary to be stateful for the Executor (both LocalExecutor and GatewayExecutor). 


The pull request provide two extra API in Executor interface to manage session life-cycle:  
1. String openSession(SessionContext context);  it will create a new session based on the passed session context, the session will have the ExecutionContext/TableEnviroment/UDF informations (etc).  and the openSession will return a uuid string which represent the session identification, the following operations of this session will attach the sessionId to request the Executor (both local and gateway). 
2. String closeSession(String sessionId);   it will close the session(clear the session related resources) with given session identify.

For each session, we will openSesion firstly, then execute some DDL or DML, and closeSession finally. When executing the DDL or DML, it will share the same session context and execution context for the same session identifier.

## Brief change log

- 4b5c6f4491 [FLINK-14672][sql-client] Make Executor stateful in sql client 
- e60ea8bf25 [FLINK-14672][sql-client] Simplify the executor backend state for each session: The SessionContext is only used for frontend user to open session, all the backend informations are maintained in ExecutionContext.

## Verifying this change

The LocalExecutorITCase addressed all the cases.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)