### PR TITLE
[FLINK-14873][client] Make PackagedProgram#savepointSettings final

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -804,17 +804,14 @@ public class CliFrontend {
 			jarFile = getJarFile(jarFilePath);
 		}
 
-		PackagedProgram program = PackagedProgram.newBuilder()
+		return PackagedProgram.newBuilder()
 			.setJarFile(jarFile)
 			.setUserClassPaths(classpaths)
 			.setEntryPointClassName(entryPointClass)
 			.setConfiguration(configuration)
+			.setSavepointRestoreSettings(runOptions.getSavepointRestoreSettings())
 			.setArguments(programArgs)
 			.build();
-
-		program.setSavepointRestoreSettings(runOptions.getSavepointRestoreSettings());
-
-		return program;
 	}
 
 	/**

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -142,11 +142,6 @@ public class PackagedProgram {
 
 		this.jarFile = jarFileUrl;
 
-		// if no entryPointClassName name was given, we try and look one up through the manifest
-		if (entryPointClassName == null) {
-			entryPointClassName = getEntryPointClassNameFromJar(jarFileUrl);
-		}
-
 		// now that we have an entry point, we can extract the nested jar files (if any)
 		this.extractedTempLibraries = jarFileUrl == null ? Collections.emptyList() : extractContainedLibraries(jarFileUrl);
 		this.userCodeClassLoader = ClientUtils.buildUserCodeClassLoader(
@@ -156,7 +151,10 @@ public class PackagedProgram {
 			configuration);
 
 		// load the entry point class
-		this.mainClass = loadMainClass(entryPointClassName, userCodeClassLoader);
+		this.mainClass = loadMainClass(
+			// if no entryPointClassName name was given, we try and look one up through the manifest
+			entryPointClassName != null ? entryPointClassName : getEntryPointClassNameFromJar(jarFileUrl),
+			userCodeClassLoader);
 
 		if (!hasMainMethod(mainClass)) {
 			throw new ProgramInvocationException("The given program class does not have a main(String[]) method.");

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendPackageProgramTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendPackageProgramTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.optimizer.DataStatistics;
 import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.costs.DefaultCostEstimator;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.commons.cli.CommandLine;
@@ -96,12 +97,12 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 		ProgramOptions programOptions = mock(ProgramOptions.class);
 		when(programOptions.getJarFilePath()).thenReturn(getNonJarFilePath());
 		when(programOptions.getProgramArgs()).thenReturn(new String[0]);
+		when(programOptions.getSavepointRestoreSettings()).thenReturn(SavepointRestoreSettings.none());
 
 		try {
 			frontend.buildProgram(programOptions);
 			fail("should throw an exception");
-		}
-		catch (ProgramInvocationException e) {
+		} catch (ProgramInvocationException e) {
 			// that's what we want
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

This field is logically final and with we move the initialization into Builder we can make it final.

## Brief change log

- Make PackagedProgram#savepointSettings final
- Make parameter `entryPointClassName` of PackagedProgram#<init> final
- Extract loadJarFile from PackageProgram#<init>


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
