### PR TITLE
[FLINK-14733][runtime] Introduce a builder for flexible ResourceProfile building

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.MemorySize;
@@ -503,14 +502,14 @@ public class TaskManagerServices {
 	}
 
 	private static ResourceProfile computeSlotResourceProfile(int numOfSlots, Map<MemoryType, Long> memorySizeByType) {
-		return new ResourceProfile(
-			new CPUResource(Double.MAX_VALUE),
-			MemorySize.MAX_VALUE,
-			MemorySize.MAX_VALUE,
-			new MemorySize(memorySizeByType.getOrDefault(MemoryType.HEAP, 0L) / numOfSlots),
-			new MemorySize(memorySizeByType.getOrDefault(MemoryType.OFF_HEAP, 0L) / numOfSlots),
-			MemorySize.MAX_VALUE,
-			Collections.emptyMap());
+		return ResourceProfile.newBuilder()
+			.setCpuCores(Double.MAX_VALUE)
+			.setTaskHeapMemory(MemorySize.MAX_VALUE)
+			.setTaskOffHeapMemory(MemorySize.MAX_VALUE)
+			.setOnHeapManagedMemory(new MemorySize(memorySizeByType.getOrDefault(MemoryType.HEAP, 0L) / numOfSlots))
+			.setOffHeapManagedMemory(new MemorySize(memorySizeByType.getOrDefault(MemoryType.OFF_HEAP, 0L) / numOfSlots))
+			.setShuffleMemory(MemorySize.MAX_VALUE)
+			.build();
 	}
 
 	private static long bytesToMegabytes(long bytes) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/LocationPreferenceSlotSelectionStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/LocationPreferenceSlotSelectionStrategyTest.java
@@ -56,7 +56,7 @@ public class LocationPreferenceSlotSelectionStrategyTest extends SlotSelectionSt
 		Optional<SlotSelectionStrategy.SlotInfoAndLocality> match = runMatching(slotProfile);
 		Assert.assertTrue(match.get().getSlotInfo().getResourceProfile().isMatching(slotProfile.getPhysicalSlotResourceProfile()));
 
-		ResourceProfile evenBiggerResourceProfile = new ResourceProfile(
+		ResourceProfile evenBiggerResourceProfile = ResourceProfile.fromResources(
 			biggerResourceProfile.getCpuCores().getValue().doubleValue() + 1.0,
 			resourceProfile.getTaskHeapMemory().getMebiBytes());
 		slotProfile = SlotProfile.priorAllocation(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.core.testutils.CommonTestUtils;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -44,10 +43,30 @@ public class ResourceProfileTest {
 
 	@Test
 	public void testMatchRequirement() {
-		ResourceProfile rp1 = new ResourceProfile(1.0, 100, 100, 100, 0, 0, Collections.emptyMap());
-		ResourceProfile rp2 = new ResourceProfile(1.0, 200, 200, 200, 0, 0, Collections.emptyMap());
-		ResourceProfile rp3 = new ResourceProfile(2.0, 100, 100, 100, 0, 0, Collections.emptyMap());
-		ResourceProfile rp4 = new ResourceProfile(2.0, 200, 200, 200, 0, 0, Collections.emptyMap());
+		final ResourceProfile rp1 = ResourceProfile.newBuilder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setOnHeapManagedMemoryMB(100)
+			.build();
+		final ResourceProfile rp2 = ResourceProfile.newBuilder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(200)
+			.setTaskOffHeapMemoryMB(200)
+			.setOnHeapManagedMemoryMB(200)
+			.build();
+		final ResourceProfile rp3 = ResourceProfile.newBuilder()
+			.setCpuCores(2.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setOnHeapManagedMemoryMB(100)
+			.build();
+		final ResourceProfile rp4 = ResourceProfile.newBuilder()
+			.setCpuCores(2.0)
+			.setTaskHeapMemoryMB(200)
+			.setTaskOffHeapMemoryMB(200)
+			.setOnHeapManagedMemoryMB(200)
+			.build();
 
 		assertFalse(rp1.isMatching(rp2));
 		assertTrue(rp2.isMatching(rp1));
@@ -63,7 +82,14 @@ public class ResourceProfileTest {
 		assertTrue(rp4.isMatching(rp3));
 		assertTrue(rp4.isMatching(rp4));
 
-		ResourceProfile rp5 = new ResourceProfile(2.0, 100, 100, 100, 100, 100, null);
+		final ResourceProfile rp5 = ResourceProfile.newBuilder()
+			.setCpuCores(2.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setOnHeapManagedMemoryMB(100)
+			.setOffHeapManagedMemoryMB(100)
+			.setShuffleMemoryMB(100)
+			.build();
 		assertFalse(rp4.isMatching(rp5));
 
 		ResourceSpec rs1 = ResourceSpec.newBuilder(1.0, 100).
@@ -103,14 +129,70 @@ public class ResourceProfileTest {
 		MemorySize networkMemory = MemorySize.parse(100 + "m");
 		assertEquals(ResourceProfile.fromResourceSpec(rs3, networkMemory), ResourceProfile.fromResourceSpec(rs5, networkMemory));
 
-		ResourceProfile rp1 = new ResourceProfile(1.0, 100, 100, 100, 100, 100, Collections.emptyMap());
-		ResourceProfile rp2 = new ResourceProfile(1.1, 100, 100, 100, 100, 100, Collections.emptyMap());
-		ResourceProfile rp3 = new ResourceProfile(1.0, 110, 100, 100, 100, 100, Collections.emptyMap());
-		ResourceProfile rp4 = new ResourceProfile(1.0, 100, 110, 100, 100, 100, Collections.emptyMap());
-		ResourceProfile rp5 = new ResourceProfile(1.0, 100, 100, 110, 100, 100, Collections.emptyMap());
-		ResourceProfile rp6 = new ResourceProfile(1.0, 100, 100, 100, 110, 100, Collections.emptyMap());
-		ResourceProfile rp7 = new ResourceProfile(1.0, 100, 100, 100, 100, 110, Collections.emptyMap());
-		ResourceProfile rp8 = new ResourceProfile(1.0, 100, 100, 100, 100, 100, Collections.emptyMap());
+		final ResourceProfile rp1 = ResourceProfile.newBuilder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setOnHeapManagedMemoryMB(100)
+			.setOffHeapManagedMemoryMB(100)
+			.setShuffleMemoryMB(100)
+			.build();
+		final ResourceProfile rp2 = ResourceProfile.newBuilder()
+			.setCpuCores(1.1)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setOnHeapManagedMemoryMB(100)
+			.setOffHeapManagedMemoryMB(100)
+			.setShuffleMemoryMB(100)
+			.build();
+		final ResourceProfile rp3 = ResourceProfile.newBuilder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(110)
+			.setTaskOffHeapMemoryMB(100)
+			.setOnHeapManagedMemoryMB(100)
+			.setOffHeapManagedMemoryMB(100)
+			.setShuffleMemoryMB(100)
+			.build();
+		final ResourceProfile rp4 = ResourceProfile.newBuilder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(110)
+			.setOnHeapManagedMemoryMB(100)
+			.setOffHeapManagedMemoryMB(100)
+			.setShuffleMemoryMB(100)
+			.build();
+		final ResourceProfile rp5 = ResourceProfile.newBuilder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setOnHeapManagedMemoryMB(110)
+			.setOffHeapManagedMemoryMB(100)
+			.setShuffleMemoryMB(100)
+			.build();
+		final ResourceProfile rp6 = ResourceProfile.newBuilder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setOnHeapManagedMemoryMB(100)
+			.setOffHeapManagedMemoryMB(110)
+			.setShuffleMemoryMB(100)
+			.build();
+		final ResourceProfile rp7 = ResourceProfile.newBuilder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setOnHeapManagedMemoryMB(100)
+			.setOffHeapManagedMemoryMB(100)
+			.setShuffleMemoryMB(110)
+			.build();
+		final ResourceProfile rp8 = ResourceProfile.newBuilder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setOnHeapManagedMemoryMB(100)
+			.setOffHeapManagedMemoryMB(100)
+			.setShuffleMemoryMB(100)
+			.build();
 
 		assertNotEquals(rp1, rp2);
 		assertNotEquals(rp1, rp3);
@@ -136,16 +218,50 @@ public class ResourceProfileTest {
 
 	@Test
 	public void testMerge() {
-		ResourceProfile rp1 = new ResourceProfile(1.0, 100, 100, 100, 100, 100, Collections.emptyMap());
-		ResourceProfile rp2 = new ResourceProfile(2.0, 200, 200, 200, 200, 200,
-			Collections.singletonMap("gpu", new GPUResource(2.0)));
+		final ResourceProfile rp1 = ResourceProfile.newBuilder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setOnHeapManagedMemoryMB(100)
+			.setOffHeapManagedMemoryMB(100)
+			.setShuffleMemoryMB(100)
+			.build();
+		final ResourceProfile rp2 = ResourceProfile.newBuilder()
+			.setCpuCores(2.0)
+			.setTaskHeapMemoryMB(200)
+			.setTaskOffHeapMemoryMB(200)
+			.setOnHeapManagedMemoryMB(200)
+			.setOffHeapManagedMemoryMB(200)
+			.setShuffleMemoryMB(200)
+			.addExtendedResource("gpu", new GPUResource(2.0))
+			.build();
 
-		ResourceProfile rp1MergeRp1 = new ResourceProfile(2.0, 200, 200, 200, 200, 200,
-			Collections.emptyMap());
-		ResourceProfile rp1MergeRp2 = new ResourceProfile(3.0, 300, 300, 300, 300, 300,
-			Collections.singletonMap("gpu", new GPUResource(2.0)));
-		ResourceProfile rp2MergeRp2 = new ResourceProfile(4.0, 400, 400, 400, 400, 400,
-			Collections.singletonMap("gpu", new GPUResource(4.0)));
+		final ResourceProfile rp1MergeRp1 = ResourceProfile.newBuilder()
+			.setCpuCores(2.0)
+			.setTaskHeapMemoryMB(200)
+			.setTaskOffHeapMemoryMB(200)
+			.setOnHeapManagedMemoryMB(200)
+			.setOffHeapManagedMemoryMB(200)
+			.setShuffleMemoryMB(200)
+			.build();
+		final ResourceProfile rp1MergeRp2 = ResourceProfile.newBuilder()
+			.setCpuCores(3.0)
+			.setTaskHeapMemoryMB(300)
+			.setTaskOffHeapMemoryMB(300)
+			.setOnHeapManagedMemoryMB(300)
+			.setOffHeapManagedMemoryMB(300)
+			.setShuffleMemoryMB(300)
+			.addExtendedResource("gpu", new GPUResource(2.0))
+			.build();
+		final ResourceProfile rp2MergeRp2 = ResourceProfile.newBuilder()
+			.setCpuCores(4.0)
+			.setTaskHeapMemoryMB(400)
+			.setTaskOffHeapMemoryMB(400)
+			.setOnHeapManagedMemoryMB(400)
+			.setOffHeapManagedMemoryMB(400)
+			.setShuffleMemoryMB(400)
+			.addExtendedResource("gpu", new GPUResource(4.0))
+			.build();
 
 		assertEquals(rp1MergeRp1, rp1.merge(rp1));
 		assertEquals(rp1MergeRp2, rp1.merge(rp2));
@@ -165,8 +281,22 @@ public class ResourceProfileTest {
 		final CPUResource largeDouble = new CPUResource(Double.MAX_VALUE - 1.0);
 		final MemorySize largeMemory = MemorySize.MAX_VALUE.subtract(MemorySize.parse("100m"));
 
-		ResourceProfile rp1 = new ResourceProfile(3.0, 300, 300, 300, 300, 300, Collections.emptyMap());
-		ResourceProfile rp2 = new ResourceProfile(largeDouble, largeMemory, largeMemory, largeMemory, largeMemory, largeMemory, Collections.emptyMap());
+		final ResourceProfile rp1 = ResourceProfile.newBuilder()
+			.setCpuCores(3.0)
+			.setTaskHeapMemoryMB(300)
+			.setTaskOffHeapMemoryMB(300)
+			.setOnHeapManagedMemoryMB(300)
+			.setOffHeapManagedMemoryMB(300)
+			.setShuffleMemoryMB(300)
+			.build();
+		final ResourceProfile rp2 = ResourceProfile.newBuilder()
+			.setCpuCores(largeDouble)
+			.setTaskHeapMemory(largeMemory)
+			.setTaskOffHeapMemory(largeMemory)
+			.setOnHeapManagedMemory(largeMemory)
+			.setOffHeapManagedMemory(largeMemory)
+			.setShuffleMemory(largeMemory)
+			.build();
 
 		List<ArithmeticException> exceptions = new ArrayList<>();
 		try {
@@ -189,9 +319,30 @@ public class ResourceProfileTest {
 
 	@Test
 	public void testSubtract() {
-		ResourceProfile rp1 = new ResourceProfile(1.0, 100, 100, 100, 100, 100, Collections.emptyMap());
-		ResourceProfile rp2 = new ResourceProfile(2.0, 200, 200, 200, 200, 200, Collections.emptyMap());
-		ResourceProfile rp3 = new ResourceProfile(3.0, 300, 300, 300, 300, 300, Collections.emptyMap());
+		final ResourceProfile rp1 = ResourceProfile.newBuilder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setOnHeapManagedMemoryMB(100)
+			.setOffHeapManagedMemoryMB(100)
+			.setShuffleMemoryMB(100)
+			.build();
+		final ResourceProfile rp2 = ResourceProfile.newBuilder()
+			.setCpuCores(2.0)
+			.setTaskHeapMemoryMB(200)
+			.setTaskOffHeapMemoryMB(200)
+			.setOnHeapManagedMemoryMB(200)
+			.setOffHeapManagedMemoryMB(200)
+			.setShuffleMemoryMB(200)
+			.build();
+		final ResourceProfile rp3 = ResourceProfile.newBuilder()
+			.setCpuCores(3.0)
+			.setTaskHeapMemoryMB(300)
+			.setTaskOffHeapMemoryMB(300)
+			.setOnHeapManagedMemoryMB(300)
+			.setOffHeapManagedMemoryMB(300)
+			.setShuffleMemoryMB(300)
+			.build();
 
 		assertEquals(rp1, rp3.subtract(rp2));
 		assertEquals(rp1, rp2.subtract(rp1));
@@ -215,10 +366,23 @@ public class ResourceProfileTest {
 	@Test(expected = IllegalArgumentException.class)
 	public void testSubtractWithInfValues() {
 		// Does not equals to ANY since it has extended resources.
-		ResourceProfile rp1 = new ResourceProfile(Double.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE,
-			Integer.MAX_VALUE, Collections.singletonMap("gpu", new GPUResource(4.0)));
-		ResourceProfile rp2 = new ResourceProfile(2.0, 200, 200, 200, 200, 200,
-			Collections.emptyMap());
+		final ResourceProfile rp1 = ResourceProfile.newBuilder()
+			.setCpuCores(Double.MAX_VALUE)
+			.setTaskHeapMemoryMB(Integer.MAX_VALUE)
+			.setTaskOffHeapMemoryMB(Integer.MAX_VALUE)
+			.setOnHeapManagedMemoryMB(Integer.MAX_VALUE)
+			.setOffHeapManagedMemoryMB(Integer.MAX_VALUE)
+			.setShuffleMemoryMB(Integer.MAX_VALUE)
+			.addExtendedResource("gpu", new GPUResource(4.0))
+			.build();
+		final ResourceProfile rp2 = ResourceProfile.newBuilder()
+			.setCpuCores(2.0)
+			.setTaskHeapMemoryMB(200)
+			.setTaskOffHeapMemoryMB(200)
+			.setOnHeapManagedMemoryMB(200)
+			.setOffHeapManagedMemoryMB(200)
+			.setShuffleMemoryMB(200)
+			.build();
 
 		rp2.subtract(rp1);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotSelectionStrategyTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotSelectionStrategyTestBase.java
@@ -37,8 +37,8 @@ import java.util.Set;
  */
 public abstract class SlotSelectionStrategyTestBase extends TestLogger {
 
-	protected final ResourceProfile resourceProfile = new ResourceProfile(2, 1024);
-	protected final ResourceProfile biggerResourceProfile = new ResourceProfile(3, 1024);
+	protected final ResourceProfile resourceProfile = ResourceProfile.fromResources(2, 1024);
+	protected final ResourceProfile biggerResourceProfile = ResourceProfile.fromResources(3, 1024);
 
 	protected final AllocationID aid1 = new AllocationID();
 	protected final AllocationID aid2 = new AllocationID();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotSelectionStrategyTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotSelectionStrategyTestBase.java
@@ -32,6 +32,9 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
+/**
+ * Test base for {@link SlotSelectionStrategy}.
+ */
 public abstract class SlotSelectionStrategyTestBase extends TestLogger {
 
 	protected final ResourceProfile resourceProfile = new ResourceProfile(2, 1024);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerIsolatedTasksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerIsolatedTasksTest.java
@@ -246,8 +246,8 @@ public class SchedulerIsolatedTasksTest extends SchedulerTestBase {
 
 	@Test
 	public void testNewPhysicalSlotAllocation() {
-		final ResourceProfile taskResourceProfile = new ResourceProfile(0.5, 250);
-		final ResourceProfile physicalSlotResourceProfile = new ResourceProfile(1.0, 300);
+		final ResourceProfile taskResourceProfile = ResourceProfile.fromResources(0.5, 250);
+		final ResourceProfile physicalSlotResourceProfile = ResourceProfile.fromResources(1.0, 300);
 
 		testingSlotProvider.allocateSlot(
 			new SlotRequestId(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/AvailableSlotsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/AvailableSlotsTest.java
@@ -33,6 +33,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Tests for {@link SlotPoolImpl.AvailableSlots}.
+ */
 public class AvailableSlotsTest extends TestLogger {
 
 	static final ResourceProfile DEFAULT_TESTING_PROFILE = new ResourceProfile(1.0, 512);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/AvailableSlotsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/AvailableSlotsTest.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class AvailableSlotsTest extends TestLogger {
 
-	static final ResourceProfile DEFAULT_TESTING_PROFILE = new ResourceProfile(1.0, 512);
+	static final ResourceProfile DEFAULT_TESTING_PROFILE = ResourceProfile.fromResources(1.0, 512);
 
 	@Test
 	public void testAddAndRemove() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolBatchSlotRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolBatchSlotRequestTest.java
@@ -56,8 +56,8 @@ import static org.junit.Assert.fail;
  */
 public class SlotPoolBatchSlotRequestTest extends TestLogger {
 
-	private static final ResourceProfile resourceProfile = new ResourceProfile(1.0, 1024);
-	private static final ResourceProfile smallerResourceProfile = new ResourceProfile(0.5, 512);
+	private static final ResourceProfile resourceProfile = ResourceProfile.fromResources(1.0, 1024);
+	private static final ResourceProfile smallerResourceProfile = ResourceProfile.fromResources(0.5, 512);
 	public static final CompletableFuture[] COMPLETABLE_FUTURES_EMPTY_ARRAY = new CompletableFuture[0];
 	private static ScheduledExecutorService singleThreadScheduledExecutorService;
 	private static ComponentMainThreadExecutor mainThreadExecutor;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolSlotSharingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolSlotSharingTest.java
@@ -327,9 +327,9 @@ public class SlotPoolSlotSharingTest extends TestLogger {
 	 */
 	@Test
 	public void testSlotSharingRespectsRemainingResource() throws Exception {
-		final ResourceProfile allocatedSlotRp = new ResourceProfile(3.0, 300);
-		final ResourceProfile largeRequestResource = new ResourceProfile(2.0, 200);
-		final ResourceProfile smallRequestResource = new ResourceProfile(1.0, 100);
+		final ResourceProfile allocatedSlotRp = ResourceProfile.fromResources(3.0, 300);
+		final ResourceProfile largeRequestResource = ResourceProfile.fromResources(2.0, 200);
+		final ResourceProfile smallRequestResource = ResourceProfile.fromResources(1.0, 100);
 
 		final BlockingQueue<AllocationID> allocationIds = new ArrayBlockingQueue<>(2);
 		final TestingResourceManagerGateway testingResourceManagerGateway = slotPoolResource.getTestingResourceManagerGateway();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManagerTest.java
@@ -589,9 +589,32 @@ public class SlotSharingManagerTest extends TestLogger {
 
 	@Test
 	public void testResourceCalculationOnSlotAllocatingAndReleasing() {
-		ResourceProfile rp1 = new ResourceProfile(1.0, 100, 100, 100, 100, 100, Collections.emptyMap());
-		ResourceProfile rp2 = new ResourceProfile(2.0, 200, 200, 200, 200, 200, Collections.singletonMap("gpu", new GPUResource(2.0)));
-		ResourceProfile rp3 = new ResourceProfile(3.0, 300, 300, 300, 300, 300, Collections.singletonMap("gpu", new GPUResource(3.0)));
+		final ResourceProfile rp1 = ResourceProfile.newBuilder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setOnHeapManagedMemoryMB(100)
+			.setOffHeapManagedMemoryMB(100)
+			.setShuffleMemoryMB(100)
+			.build();
+		final ResourceProfile rp2 = ResourceProfile.newBuilder()
+			.setCpuCores(2.0)
+			.setTaskHeapMemoryMB(200)
+			.setTaskOffHeapMemoryMB(200)
+			.setOnHeapManagedMemoryMB(200)
+			.setOffHeapManagedMemoryMB(200)
+			.setShuffleMemoryMB(200)
+			.addExtendedResource("gpu", new GPUResource(2.0))
+			.build();
+		final ResourceProfile rp3 = ResourceProfile.newBuilder()
+			.setCpuCores(3.0)
+			.setTaskHeapMemoryMB(300)
+			.setTaskOffHeapMemoryMB(300)
+			.setOnHeapManagedMemoryMB(300)
+			.setOffHeapManagedMemoryMB(300)
+			.setShuffleMemoryMB(300)
+			.addExtendedResource("gpu", new GPUResource(3.0))
+			.build();
 
 		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
 
@@ -650,9 +673,9 @@ public class SlotSharingManagerTest extends TestLogger {
 
 	@Test
 	public void testGetResolvedSlotWithResourceConfigured() {
-		ResourceProfile rp1 = new ResourceProfile(1.0, 100);
-		ResourceProfile rp2 = new ResourceProfile(2.0, 200);
-		ResourceProfile allocatedSlotRp = new ResourceProfile(5.0, 500);
+		ResourceProfile rp1 = ResourceProfile.fromResources(1.0, 100);
+		ResourceProfile rp2 = ResourceProfile.fromResources(2.0, 200);
+		ResourceProfile allocatedSlotRp = ResourceProfile.fromResources(5.0, 500);
 
 		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
 
@@ -695,9 +718,9 @@ public class SlotSharingManagerTest extends TestLogger {
 
 	@Test
 	public void testHashEnoughResourceOfMultiTaskSlot() {
-		ResourceProfile rp1 = new ResourceProfile(1.0, 100);
-		ResourceProfile rp2 = new ResourceProfile(2.0, 200);
-		ResourceProfile allocatedSlotRp = new ResourceProfile(2.0, 200);
+		ResourceProfile rp1 = ResourceProfile.fromResources(1.0, 100);
+		ResourceProfile rp2 = ResourceProfile.fromResources(2.0, 200);
+		ResourceProfile allocatedSlotRp = ResourceProfile.fromResources(2.0, 200);
 
 		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
 
@@ -740,7 +763,7 @@ public class SlotSharingManagerTest extends TestLogger {
 
 	@Test
 	public void testSlotAllocatedWithEnoughResource() {
-		SlotSharingResourceTestContext context = createResourceTestContext(new ResourceProfile(16.0, 1600));
+		SlotSharingResourceTestContext context = createResourceTestContext(ResourceProfile.fromResources(16.0, 1600));
 
 		// With enough resources, all the requests should be fulfilled.
 		for (SlotSharingManager.SingleTaskSlot singleTaskSlot : context.singleTaskSlotsInOrder) {
@@ -754,7 +777,7 @@ public class SlotSharingManagerTest extends TestLogger {
 
 	@Test
 	public void testSlotOverAllocatedAndTaskSlotsReleased() {
-		SlotSharingResourceTestContext context = createResourceTestContext(new ResourceProfile(7.0, 700));
+		SlotSharingResourceTestContext context = createResourceTestContext(ResourceProfile.fromResources(7.0, 700));
 
 		for (int i = 0; i < context.singleTaskSlotsInOrder.size(); ++i) {
 			SlotSharingManager.SingleTaskSlot singleTaskSlot = context.singleTaskSlotsInOrder.get(i);
@@ -771,9 +794,9 @@ public class SlotSharingManagerTest extends TestLogger {
 	}
 
 	private SlotSharingResourceTestContext createResourceTestContext(ResourceProfile allocatedResourceProfile) {
-		ResourceProfile coLocationTaskRp = new ResourceProfile(2.0, 200);
-		ResourceProfile thirdChildRp = new ResourceProfile(3.0, 300);
-		ResourceProfile forthChildRp = new ResourceProfile(9.0, 900);
+		ResourceProfile coLocationTaskRp = ResourceProfile.fromResources(2.0, 200);
+		ResourceProfile thirdChildRp = ResourceProfile.fromResources(3.0, 300);
+		ResourceProfile forthChildRp = ResourceProfile.fromResources(9.0, 900);
 
 		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/AnyMatchingSlotMatchingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/AnyMatchingSlotMatchingStrategyTest.java
@@ -47,8 +47,8 @@ public class AnyMatchingSlotMatchingStrategyTest extends TestLogger {
 
 	@Before
 	public void setup() {
-		final ResourceProfile largeResourceProfile = new ResourceProfile(10.2 , 42);
-		final ResourceProfile smallResourceProfile = new ResourceProfile(1 , 1);
+		final ResourceProfile largeResourceProfile = ResourceProfile.fromResources(10.2 , 42);
+		final ResourceProfile smallResourceProfile = ResourceProfile.fromResources(1 , 1);
 
 		largeTaskManagerSlotInformation = TestingTaskManagerSlotInformation.newBuilder()
 			.setInstanceId(instanceId)
@@ -77,7 +77,7 @@ public class AnyMatchingSlotMatchingStrategyTest extends TestLogger {
 	@Test
 	public void findMatchingSlot_withUnfulfillableRequest_returnsEmptyResult() {
 		final Optional<TestingTaskManagerSlotInformation> optionalMatchingSlot = AnyMatchingSlotMatchingStrategy.INSTANCE.findMatchingSlot(
-			new ResourceProfile(Double.MAX_VALUE, Integer.MAX_VALUE),
+			ResourceProfile.fromResources(Double.MAX_VALUE, Integer.MAX_VALUE),
 			freeSlots,
 			countSlotsPerInstance(freeSlots));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/LeastUtilizationSlotMatchingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/LeastUtilizationSlotMatchingStrategyTest.java
@@ -43,13 +43,13 @@ public class LeastUtilizationSlotMatchingStrategyTest extends TestLogger {
 
 	@Test
 	public void findMatchingSlot_multipleMatchingSlots_returnsSlotWithLeastUtilization() {
-		final ResourceProfile requestedResourceProfile = new ResourceProfile(2.0, 2);
+		final ResourceProfile requestedResourceProfile = ResourceProfile.fromResources(2.0, 2);
 
 		final TestingTaskManagerSlotInformation leastUtilizedSlot = TestingTaskManagerSlotInformation.newBuilder()
 			.setResourceProfile(requestedResourceProfile)
 			.build();
 		final TestingTaskManagerSlotInformation tooSmallSlot = TestingTaskManagerSlotInformation.newBuilder()
-			.setResourceProfile(new ResourceProfile(1.0, 10))
+			.setResourceProfile(ResourceProfile.fromResources(1.0, 10))
 			.build();
 		final TestingTaskManagerSlotInformation alternativeSlot = TestingTaskManagerSlotInformation.newBuilder()
 			.setResourceProfile(requestedResourceProfile)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerFailUnfulfillableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerFailUnfulfillableTest.java
@@ -55,8 +55,8 @@ public class SlotManagerFailUnfulfillableTest extends TestLogger {
 	@Test
 	public void testTurnOnKeepsPendingFulfillableRequests() throws Exception {
 		// setup
-		final ResourceProfile availableProfile = new ResourceProfile(2.0, 100);
-		final ResourceProfile fulfillableProfile = new ResourceProfile(1.0, 100);
+		final ResourceProfile availableProfile = ResourceProfile.fromResources(2.0, 100);
+		final ResourceProfile fulfillableProfile = ResourceProfile.fromResources(1.0, 100);
 
 		final SlotManager slotManager = createSlotManagerNotStartingNewTMs();
 		slotManager.setFailUnfulfillableRequest(false);
@@ -75,8 +75,8 @@ public class SlotManagerFailUnfulfillableTest extends TestLogger {
 	@Test
 	public void testTurnOnCancelsPendingUnFulfillableRequests() throws Exception {
 		// setup
-		final ResourceProfile availableProfile = new ResourceProfile(2.0, 100);
-		final ResourceProfile unfulfillableProfile = new ResourceProfile(1.0, 200);
+		final ResourceProfile availableProfile = ResourceProfile.fromResources(2.0, 100);
+		final ResourceProfile unfulfillableProfile = ResourceProfile.fromResources(1.0, 200);
 
 		final List<Tuple3<JobID, AllocationID, Exception>> allocationFailures = new ArrayList<>();
 		final SlotManager slotManager = createSlotManagerNotStartingNewTMs(allocationFailures);
@@ -98,8 +98,8 @@ public class SlotManagerFailUnfulfillableTest extends TestLogger {
 	@Test
 	public void testTurnOnKeepsRequestsWithStartingTMs() throws Exception {
 		// setup
-		final ResourceProfile availableProfile = new ResourceProfile(2.0, 100);
-		final ResourceProfile newTmProfile = new ResourceProfile(2.0, 200);
+		final ResourceProfile availableProfile = ResourceProfile.fromResources(2.0, 100);
+		final ResourceProfile newTmProfile = ResourceProfile.fromResources(2.0, 200);
 
 		final SlotManager slotManager = createSlotManagerStartingNewTMs();
 		slotManager.setFailUnfulfillableRequest(false);
@@ -116,7 +116,7 @@ public class SlotManagerFailUnfulfillableTest extends TestLogger {
 	@Test
 	public void testFulfillableRequestsKeepPendingWhenOn() throws Exception {
 		// setup
-		final ResourceProfile availableProfile = new ResourceProfile(2.0, 100);
+		final ResourceProfile availableProfile = ResourceProfile.fromResources(2.0, 100);
 
 		final SlotManager slotManager = createSlotManagerNotStartingNewTMs();
 		registerFreeSlot(slotManager, availableProfile);
@@ -132,8 +132,8 @@ public class SlotManagerFailUnfulfillableTest extends TestLogger {
 	@Test
 	public void testUnfulfillableRequestsFailWhenOn() {
 		// setup
-		final ResourceProfile availableProfile = new ResourceProfile(2.0, 100);
-		final ResourceProfile unfulfillableProfile = new ResourceProfile(2.0, 200);
+		final ResourceProfile availableProfile = ResourceProfile.fromResources(2.0, 100);
+		final ResourceProfile unfulfillableProfile = ResourceProfile.fromResources(2.0, 200);
 
 		final List<Tuple3<JobID, AllocationID, Exception>> notifiedAllocationFailures = new ArrayList<>();
 		final SlotManager slotManager = createSlotManagerNotStartingNewTMs(notifiedAllocationFailures);
@@ -155,8 +155,8 @@ public class SlotManagerFailUnfulfillableTest extends TestLogger {
 	@Test
 	public void testStartingTmKeepsSlotPendingWhenOn() throws Exception {
 		// setup
-		final ResourceProfile availableProfile = new ResourceProfile(2.0, 100);
-		final ResourceProfile newTmProfile = new ResourceProfile(2.0, 200);
+		final ResourceProfile availableProfile = ResourceProfile.fromResources(2.0, 100);
+		final ResourceProfile newTmProfile = ResourceProfile.fromResources(2.0, 200);
 
 		final SlotManager slotManager = createSlotManagerStartingNewTMs();
 		registerFreeSlot(slotManager, availableProfile);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
@@ -111,7 +111,7 @@ public class SlotManagerImplTest extends TestLogger {
 
 		final SlotID slotId1 = new SlotID(resourceId, 0);
 		final SlotID slotId2 = new SlotID(resourceId, 1);
-		final ResourceProfile resourceProfile = new ResourceProfile(42.0, 1337);
+		final ResourceProfile resourceProfile = ResourceProfile.fromResources(42.0, 1337);
 		final SlotStatus slotStatus1 = new SlotStatus(slotId1, resourceProfile);
 		final SlotStatus slotStatus2 = new SlotStatus(slotId2, resourceProfile);
 		final SlotReport slotReport = new SlotReport(Arrays.asList(slotStatus1, slotStatus2));
@@ -149,7 +149,7 @@ public class SlotManagerImplTest extends TestLogger {
 		final SlotID slotId2 = new SlotID(resourceId, 1);
 		final AllocationID allocationId1 = new AllocationID();
 		final AllocationID allocationId2 = new AllocationID();
-		final ResourceProfile resourceProfile = new ResourceProfile(42.0, 1337);
+		final ResourceProfile resourceProfile = ResourceProfile.fromResources(42.0, 1337);
 		final SlotStatus slotStatus1 = new SlotStatus(slotId1, resourceProfile, jobId, allocationId1);
 		final SlotStatus slotStatus2 = new SlotStatus(slotId2, resourceProfile);
 		final SlotReport slotReport = new SlotReport(Arrays.asList(slotStatus1, slotStatus2));
@@ -193,7 +193,7 @@ public class SlotManagerImplTest extends TestLogger {
 	@Test
 	public void testSlotRequestWithoutFreeSlots() throws Exception {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-		final ResourceProfile resourceProfile = new ResourceProfile(42.0, 1337);
+		final ResourceProfile resourceProfile = ResourceProfile.fromResources(42.0, 1337);
 		final SlotRequest slotRequest = new SlotRequest(
 			new JobID(),
 			new AllocationID(),
@@ -219,7 +219,7 @@ public class SlotManagerImplTest extends TestLogger {
 	@Test
 	public void testSlotRequestWithResourceAllocationFailure() throws Exception {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-		final ResourceProfile resourceProfile = new ResourceProfile(42.0, 1337);
+		final ResourceProfile resourceProfile = ResourceProfile.fromResources(42.0, 1337);
 		final SlotRequest slotRequest = new SlotRequest(
 			new JobID(),
 			new AllocationID(),
@@ -254,7 +254,7 @@ public class SlotManagerImplTest extends TestLogger {
 		final SlotID slotId = new SlotID(resourceID, 0);
 		final String targetAddress = "localhost";
 		final AllocationID allocationId = new AllocationID();
-		final ResourceProfile resourceProfile = new ResourceProfile(42.0, 1337);
+		final ResourceProfile resourceProfile = ResourceProfile.fromResources(42.0, 1337);
 		final SlotRequest slotRequest = new SlotRequest(
 			jobId,
 			allocationId,
@@ -308,7 +308,7 @@ public class SlotManagerImplTest extends TestLogger {
 			.setRequestSlotFunction(slotIDJobIDAllocationIDStringResourceManagerIdTuple5 -> new CompletableFuture<>())
 			.createTestingTaskExecutorGateway();
 
-		final ResourceProfile resourceProfile = new ResourceProfile(1.0, 1);
+		final ResourceProfile resourceProfile = ResourceProfile.fromResources(1.0, 1);
 		final SlotStatus slotStatus = new SlotStatus(slotId, resourceProfile);
 		final SlotReport slotReport = new SlotReport(slotStatus);
 
@@ -347,7 +347,7 @@ public class SlotManagerImplTest extends TestLogger {
 		final SlotID slotId = new SlotID(resourceID, 0);
 		final String targetAddress = "localhost";
 		final AllocationID allocationId = new AllocationID();
-		final ResourceProfile resourceProfile = new ResourceProfile(42.0, 1337);
+		final ResourceProfile resourceProfile = ResourceProfile.fromResources(42.0, 1337);
 		final SlotRequest slotRequest = new SlotRequest(
 			jobId,
 			allocationId,
@@ -405,7 +405,7 @@ public class SlotManagerImplTest extends TestLogger {
 		final ResourceID resourceID = taskExecutorConnection.getResourceID();
 		final SlotID slotId = new SlotID(resourceID, 0);
 		final AllocationID allocationId = new AllocationID();
-		final ResourceProfile resourceProfile = new ResourceProfile(42.0, 1337);
+		final ResourceProfile resourceProfile = ResourceProfile.fromResources(42.0, 1337);
 
 		final SlotStatus slotStatus = new SlotStatus(slotId, resourceProfile, jobId, allocationId);
 		final SlotReport slotReport = new SlotReport(slotStatus);
@@ -445,8 +445,8 @@ public class SlotManagerImplTest extends TestLogger {
 			.setAllocateResourceConsumer(resourceProfile -> numberAllocateResourceFunctionCalls.incrementAndGet())
 			.build();
 		final AllocationID allocationId = new AllocationID();
-		final ResourceProfile resourceProfile1 = new ResourceProfile(1.0, 2);
-		final ResourceProfile resourceProfile2 = new ResourceProfile(2.0, 1);
+		final ResourceProfile resourceProfile1 = ResourceProfile.fromResources(1.0, 2);
+		final ResourceProfile resourceProfile2 = ResourceProfile.fromResources(2.0, 1);
 		final SlotRequest slotRequest1 = new SlotRequest(new JobID(), allocationId, resourceProfile1, "foobar");
 		final SlotRequest slotRequest2 = new SlotRequest(new JobID(), allocationId, resourceProfile2, "barfoo");
 
@@ -474,7 +474,7 @@ public class SlotManagerImplTest extends TestLogger {
 
 		final JobID jobId = new JobID();
 		final AllocationID allocationId = new AllocationID();
-		final ResourceProfile resourceProfile = new ResourceProfile(1.0, 1);
+		final ResourceProfile resourceProfile = ResourceProfile.fromResources(1.0, 1);
 		final SlotID slotId = new SlotID(resourceID, 0);
 		final SlotStatus slotStatus = new SlotStatus(slotId, resourceProfile, jobId, allocationId);
 		final SlotReport slotReport = new SlotReport(slotStatus);
@@ -500,8 +500,8 @@ public class SlotManagerImplTest extends TestLogger {
 			.setAllocateResourceConsumer(resourceProfile -> allocateResourceCalls.incrementAndGet())
 			.build();
 		final AllocationID allocationId = new AllocationID();
-		final ResourceProfile resourceProfile1 = new ResourceProfile(1.0, 2);
-		final ResourceProfile resourceProfile2 = new ResourceProfile(2.0, 1);
+		final ResourceProfile resourceProfile1 = ResourceProfile.fromResources(1.0, 2);
+		final ResourceProfile resourceProfile2 = ResourceProfile.fromResources(2.0, 1);
 		final SlotRequest slotRequest1 = new SlotRequest(new JobID(), allocationId, resourceProfile1, "foobar");
 		final SlotRequest slotRequest2 = new SlotRequest(new JobID(), allocationId, resourceProfile2, "barfoo");
 
@@ -543,8 +543,8 @@ public class SlotManagerImplTest extends TestLogger {
 			.setAllocateResourceConsumer(resourceProfile -> allocateResourceCalls.incrementAndGet())
 			.build();
 		final AllocationID allocationId = new AllocationID();
-		final ResourceProfile resourceProfile1 = new ResourceProfile(1.0, 2);
-		final ResourceProfile resourceProfile2 = new ResourceProfile(2.0, 1);
+		final ResourceProfile resourceProfile1 = ResourceProfile.fromResources(1.0, 2);
+		final ResourceProfile resourceProfile2 = ResourceProfile.fromResources(2.0, 1);
 		final SlotRequest slotRequest1 = new SlotRequest(new JobID(), allocationId, resourceProfile1, "foobar");
 		final SlotRequest slotRequest2 = new SlotRequest(new JobID(), allocationId, resourceProfile2, "barfoo");
 
@@ -554,7 +554,7 @@ public class SlotManagerImplTest extends TestLogger {
 		final TaskExecutorConnection taskManagerConnection = new TaskExecutorConnection(resourceID, taskExecutorGateway);
 
 		final SlotID slotId = new SlotID(resourceID, 0);
-		final SlotStatus slotStatus = new SlotStatus(slotId, new ResourceProfile(2.0, 2));
+		final SlotStatus slotStatus = new SlotStatus(slotId, ResourceProfile.fromResources(2.0, 2));
 		final SlotReport slotReport = new SlotReport(slotStatus);
 
 		try (SlotManagerImpl slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
@@ -592,7 +592,7 @@ public class SlotManagerImplTest extends TestLogger {
 
 		final InstanceID unknownInstanceID = new InstanceID();
 		final SlotID unknownSlotId = new SlotID(ResourceID.generate(), 0);
-		final ResourceProfile unknownResourceProfile = new ResourceProfile(1.0, 1);
+		final ResourceProfile unknownResourceProfile = ResourceProfile.fromResources(1.0, 1);
 		final SlotStatus unknownSlotStatus = new SlotStatus(unknownSlotId, unknownResourceProfile);
 		final SlotReport unknownSlotReport = new SlotReport(unknownSlotStatus);
 
@@ -625,7 +625,7 @@ public class SlotManagerImplTest extends TestLogger {
 		final SlotID slotId1 = new SlotID(resourceId, 0);
 		final SlotID slotId2 = new SlotID(resourceId, 1);
 
-		final ResourceProfile resourceProfile = new ResourceProfile(1.0, 1);
+		final ResourceProfile resourceProfile = ResourceProfile.fromResources(1.0, 1);
 		final SlotStatus slotStatus1 = new SlotStatus(slotId1, resourceProfile);
 		final SlotStatus slotStatus2 = new SlotStatus(slotId2, resourceProfile);
 
@@ -677,7 +677,7 @@ public class SlotManagerImplTest extends TestLogger {
 		final JobID jobId = new JobID();
 		final AllocationID allocationId = new AllocationID();
 
-		final ResourceProfile resourceProfile = new ResourceProfile(1.0, 1);
+		final ResourceProfile resourceProfile = ResourceProfile.fromResources(1.0, 1);
 		final SlotRequest slotRequest = new SlotRequest(jobId, allocationId, resourceProfile, "foobar");
 
 		final Executor mainThreadExecutor = TestingUtils.defaultExecutor();
@@ -716,7 +716,7 @@ public class SlotManagerImplTest extends TestLogger {
 
 		final JobID jobId = new JobID();
 		final AllocationID allocationId = new AllocationID();
-		final ResourceProfile resourceProfile = new ResourceProfile(42.0, 1337);
+		final ResourceProfile resourceProfile = ResourceProfile.fromResources(42.0, 1337);
 		final SlotRequest slotRequest = new SlotRequest(jobId, allocationId, resourceProfile, "foobar");
 		final CompletableFuture<Acknowledge> slotRequestFuture1 = new CompletableFuture<>();
 		final CompletableFuture<Acknowledge> slotRequestFuture2 = new CompletableFuture<>();
@@ -782,7 +782,7 @@ public class SlotManagerImplTest extends TestLogger {
 
 		final JobID jobId = new JobID();
 		final AllocationID allocationId = new AllocationID();
-		final ResourceProfile resourceProfile = new ResourceProfile(42.0, 1337);
+		final ResourceProfile resourceProfile = ResourceProfile.fromResources(42.0, 1337);
 		final SlotRequest slotRequest = new SlotRequest(jobId, allocationId, resourceProfile, "foobar");
 		final CompletableFuture<Acknowledge> slotRequestFuture1 = new CompletableFuture<>();
 
@@ -881,7 +881,7 @@ public class SlotManagerImplTest extends TestLogger {
 
 		final JobID jobId = new JobID();
 		final AllocationID allocationId = new AllocationID();
-		final ResourceProfile resourceProfile = new ResourceProfile(1.0, 1);
+		final ResourceProfile resourceProfile = ResourceProfile.fromResources(1.0, 1);
 		final SlotRequest slotRequest = new SlotRequest(jobId, allocationId, resourceProfile, "foobar");
 
 		final CompletableFuture<SlotID> requestedSlotFuture = new CompletableFuture<>();
@@ -967,7 +967,7 @@ public class SlotManagerImplTest extends TestLogger {
 		final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway();
 
 		final TaskExecutorConnection taskExecutorConnection = new TaskExecutorConnection(resourceID, taskExecutorGateway);
-		final SlotStatus slotStatus = createEmptySlotStatus(new SlotID(resourceID, 0), new ResourceProfile(1.0, 1));
+		final SlotStatus slotStatus = createEmptySlotStatus(new SlotID(resourceID, 0), ResourceProfile.fromResources(1.0, 1));
 		final SlotReport initialSlotReport = new SlotReport(slotStatus);
 
 		try (final SlotManager slotManager = SlotManagerBuilder.newBuilder()
@@ -1368,7 +1368,7 @@ public class SlotManagerImplTest extends TestLogger {
 		final TestingResourceActions resourceActions = new TestingResourceActionsBuilder()
 			.setAllocateResourceFunction(convert(value -> numberSlots))
 			.build();
-		final ResourceProfile resourceProfile = new ResourceProfile(1.0, 100);
+		final ResourceProfile resourceProfile = ResourceProfile.fromResources(1.0, 100);
 
 		try (final SlotManagerImpl slotManager = createSlotManager(ResourceManagerId.generate(), resourceActions)) {
 			final JobID jobId = new JobID();
@@ -1412,7 +1412,7 @@ public class SlotManagerImplTest extends TestLogger {
 
 		try (final SlotManagerImpl slotManager = createSlotManager(ResourceManagerId.generate(), resourceActions)) {
 			final JobID jobId = new JobID();
-			final ResourceProfile requestedSlotProfile = new ResourceProfile(1.0, 1);
+			final ResourceProfile requestedSlotProfile = ResourceProfile.fromResources(1.0, 1);
 
 			assertThat(slotManager.registerSlotRequest(createSlotRequest(jobId, requestedSlotProfile)), is(true));
 
@@ -1420,7 +1420,7 @@ public class SlotManagerImplTest extends TestLogger {
 
 			final int numberOfferedSlots = 1;
 			final TaskExecutorConnection taskExecutorConnection = createTaskExecutorConnection();
-			final ResourceProfile offeredSlotProfile = new ResourceProfile(2.0, 2);
+			final ResourceProfile offeredSlotProfile = ResourceProfile.fromResources(2.0, 2);
 			final SlotReport slotReport = createSlotReport(
 				taskExecutorConnection.getResourceID(),
 				numberOfferedSlots,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotProtocolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotProtocolTest.java
@@ -71,9 +71,9 @@ public class SlotProtocolTest extends TestLogger {
 
 	/**
 	 * Tests whether
-	 * 1) SlotManager accepts a slot request
-	 * 2) SlotRequest leads to a container allocation
-	 * 3) Slot becomes available and TaskExecutor gets a SlotRequest
+	 * 1) SlotManager accepts a slot request.
+	 * 2) SlotRequest leads to a container allocation.
+	 * 3) Slot becomes available and TaskExecutor gets a SlotRequest.
 	 */
 	@Test
 	public void testSlotsUnavailableRequest() throws Exception {
@@ -128,10 +128,10 @@ public class SlotProtocolTest extends TestLogger {
 
 	/**
 	 * Tests whether
-	 * 1) a SlotRequest is routed to the SlotManager
-	 * 2) a SlotRequest is confirmed
-	 * 3) a SlotRequest leads to an allocation of a registered slot
-	 * 4) a SlotRequest is routed to the TaskExecutor
+	 * 1) a SlotRequest is routed to the SlotManager.
+	 * 2) a SlotRequest is confirmed.
+	 * 3) a SlotRequest leads to an allocation of a registered slot.
+	 * 4) a SlotRequest is routed to the TaskExecutor.
 	 */
 	@Test
 	public void testSlotAvailableRequest() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotProtocolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotProtocolTest.java
@@ -93,7 +93,7 @@ public class SlotProtocolTest extends TestLogger {
 			slotManager.start(rmLeaderID, Executors.directExecutor(), resourceManagerActions);
 
 			final AllocationID allocationID = new AllocationID();
-			final ResourceProfile resourceProfile = new ResourceProfile(1.0, 100);
+			final ResourceProfile resourceProfile = ResourceProfile.fromResources(1.0, 100);
 			final String targetAddress = "foobar";
 
 			SlotRequest slotRequest = new SlotRequest(jobID, allocationID, resourceProfile, targetAddress);
@@ -157,7 +157,7 @@ public class SlotProtocolTest extends TestLogger {
 
 			final ResourceID resourceID = ResourceID.generate();
 			final AllocationID allocationID = new AllocationID();
-			final ResourceProfile resourceProfile = new ResourceProfile(1.0, 100);
+			final ResourceProfile resourceProfile = ResourceProfile.fromResources(1.0, 100);
 			final SlotID slotID = new SlotID(resourceID, 0);
 
 			final SlotStatus slotStatus =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerReleaseInSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerReleaseInSlotManagerTest.java
@@ -55,7 +55,7 @@ public class TaskManagerReleaseInSlotManagerTest extends TestLogger {
 	private static final ResourceID resourceID = ResourceID.generate();
 	private static final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 	private static final SlotID slotId = new SlotID(resourceID, 0);
-	private static final ResourceProfile resourceProfile = new ResourceProfile(1.0, 1);
+	private static final ResourceProfile resourceProfile = ResourceProfile.fromResources(1.0, 1);
 	private static final SlotStatus slotStatus = new SlotStatus(slotId, resourceProfile);
 	private static final SlotReport slotReport = new SlotReport(slotStatus);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerReleaseInSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerReleaseInSlotManagerTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.RunnableWithException;
+
 import org.junit.Before;
 import org.junit.Test;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocatorTest.java
@@ -118,8 +118,8 @@ public class DefaultExecutionSlotAllocatorTest extends TestLogger {
 		final ExecutionVertexID executionVertexId = new ExecutionVertexID(new JobVertexID(), 0);
 		final AllocationID allocationId = new AllocationID();
 		final SlotSharingGroupId sharingGroupId = new SlotSharingGroupId();
-		final ResourceProfile taskResourceProfile = new ResourceProfile(0.5, 250);
-		final ResourceProfile physicalSlotResourceProfile = new ResourceProfile(1.0, 300);
+		final ResourceProfile taskResourceProfile = ResourceProfile.fromResources(0.5, 250);
+		final ResourceProfile physicalSlotResourceProfile = ResourceProfile.fromResources(1.0, 300);
 		final CoLocationConstraint coLocationConstraint = new CoLocationGroup().getLocationConstraint(0);
 		final Collection<TaskManagerLocation> taskManagerLocations = Collections.singleton(new LocalTaskManagerLocation());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -476,7 +476,7 @@ public class TaskExecutorTest extends TestLogger {
 		rpc.registerGateway(rmAddress, rmGateway);
 
 		final SlotID slotId = new SlotID(taskManagerLocation.getResourceID(), 0);
-		final ResourceProfile resourceProfile = new ResourceProfile(1.0, 1);
+		final ResourceProfile resourceProfile = ResourceProfile.fromResources(1.0, 1);
 		final SlotReport slotReport1 = new SlotReport(
 			new SlotStatus(
 				slotId,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotUtils.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.taskexecutor.slot;
 
-import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -26,7 +25,6 @@ import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -37,15 +35,14 @@ public enum TaskSlotUtils {
 
 	private static final long DEFAULT_SLOT_TIMEOUT = 10000L;
 
-	private static final ResourceProfile DEFAULT_RESOURCE_PROFILE =
-		new ResourceProfile(
-			new CPUResource(Double.MAX_VALUE),
-			MemorySize.MAX_VALUE,
-			MemorySize.MAX_VALUE,
-			new MemorySize(10 * MemoryManager.MIN_PAGE_SIZE),
-			new MemorySize(0),
-			MemorySize.MAX_VALUE,
-			Collections.emptyMap());
+	private static final ResourceProfile DEFAULT_RESOURCE_PROFILE = ResourceProfile.newBuilder()
+		.setCpuCores(Double.MAX_VALUE)
+		.setTaskHeapMemory(MemorySize.MAX_VALUE)
+		.setTaskOffHeapMemory(MemorySize.MAX_VALUE)
+		.setOnHeapManagedMemory(new MemorySize(10 * MemoryManager.MIN_PAGE_SIZE))
+		.setOffHeapManagedMemory(MemorySize.ZERO)
+		.setShuffleMemory(MemorySize.MAX_VALUE)
+		.build();
 
 	public static TaskSlotTable createTaskSlotTable(int numberOfSlots) {
 		return createTaskSlotTable(

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -394,10 +394,16 @@ public class YarnResourceManagerTest extends TestLogger {
 				final ResourceManagerGateway rmGateway = resourceManager.getSelfGateway(ResourceManagerGateway.class);
 
 				final ResourceID taskManagerResourceId = new ResourceID(testingContainer.getId().toString());
+				final ResourceProfile resourceProfile = ResourceProfile.newBuilder()
+					.setCpuCores(10.0)
+					.setTaskHeapMemoryMB(1)
+					.setTaskOffHeapMemoryMB(1)
+					.setOnHeapManagedMemoryMB(1)
+					.setOffHeapManagedMemoryMB(0)
+					.setShuffleMemoryMB(0)
+					.build();
 				final SlotReport slotReport = new SlotReport(
-					new SlotStatus(
-						new SlotID(taskManagerResourceId, 1),
-						new ResourceProfile(10, 1, 1, 1, 0, 0, Collections.emptyMap())));
+					new SlotStatus(new SlotID(taskManagerResourceId, 1), resourceProfile));
 
 				CompletableFuture<Integer> numberRegisteredSlotsFuture = rmGateway
 					.registerTaskExecutor(


### PR DESCRIPTION

## What is the purpose of the change

The ResourceProfile constructors may accept values in raw types (double/int) or advanced types(CPUResource/MemorySize). Thus it had to maintain different kinds of constructors for the combinations. Or one may need to build advanced values types from raw types to use construct ResourceProfile.
Using the constructor with many fields of the same types also makes it not clear to see what resource is set.

This PR is to introduce a builder to enable flexible building of ResourceProfile. It allows setting a resource with advanced value types as well as raw value types.

The change is based on #10232 to avoid conflicts.

## Brief change log

  - *Introduced ResourceProfile#Builder and related factory methods*
  - *Make ResourceProfile constructors to be private*
  - *Refactored usages of ResourceProfile constructors*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
