### PR TITLE
[FLINK-14735][scheduler] Improve scheduling of all-to-all partitions with ALL input constraint for legacy scheduler

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexInputConstraintTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexInputConstraintTest.java
@@ -29,12 +29,15 @@ import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
+import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
@@ -42,7 +45,9 @@ import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.is
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.waitForAllExecutionsPredicate;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.waitUntilExecutionVertexState;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.waitUntilJobStatus;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -106,7 +111,6 @@ public class ExecutionVertexInputConstraintTest extends TestLogger {
 		eg.start(mainThreadExecutor);
 		eg.scheduleForExecution();
 
-
 		// Inputs constraint not satisfied on init
 		assertFalse(ev31.checkInputDependencyConstraints());
 
@@ -119,9 +123,7 @@ public class ExecutionVertexInputConstraintTest extends TestLogger {
 		// Inputs constraint not satisfied after failover
 		ev11.fail(new Exception());
 
-
 		waitUntilJobRestarted(eg);
-
 
 		assertFalse(ev31.checkInputDependencyConstraints());
 
@@ -146,7 +148,6 @@ public class ExecutionVertexInputConstraintTest extends TestLogger {
 		eg.start(mainThreadExecutor);
 		eg.scheduleForExecution();
 
-
 		// Inputs constraint not satisfied on init
 		assertFalse(ev31.checkInputDependencyConstraints());
 
@@ -164,10 +165,54 @@ public class ExecutionVertexInputConstraintTest extends TestLogger {
 		// Inputs constraint not satisfied after failover
 		ev11.fail(new Exception());
 
-
 		waitUntilJobRestarted(eg);
 
 		assertFalse(ev31.checkInputDependencyConstraints());
+	}
+
+	@Test
+	public void testInputConstraintALLPerformance() throws Exception {
+		final int parallelism = 1000;
+		final JobVertex v1 = createVertexWithAllInputConstraints("vertex1", parallelism);
+		final JobVertex v2 = createVertexWithAllInputConstraints("vertex2", parallelism);
+		final JobVertex v3 = createVertexWithAllInputConstraints("vertex3", parallelism);
+		v2.connectNewDataSetAsInput(v1, DistributionPattern.ALL_TO_ALL, ResultPartitionType.BLOCKING);
+		v2.connectNewDataSetAsInput(v3, DistributionPattern.ALL_TO_ALL, ResultPartitionType.BLOCKING);
+
+		final ExecutionGraph eg = createExecutionGraph(Arrays.asList(v1, v2, v3), InputDependencyConstraint.ALL, 3000);
+
+		eg.start(mainThreadExecutor);
+		eg.scheduleForExecution();
+
+		for (int i = 0; i < parallelism - 1; i++) {
+			finishSubtask(eg, v1.getID(), i);
+		}
+
+		final long startTime = System.nanoTime();
+		finishSubtask(eg, v1.getID(), parallelism - 1);
+
+		final Duration duration = Duration.ofNanos(System.nanoTime() - startTime);
+		final Duration timeout = Duration.ofSeconds(5);
+
+		assertThat(duration, lessThan(timeout));
+	}
+
+	private static JobVertex createVertexWithAllInputConstraints(String name, int parallelism) {
+		final JobVertex v = new JobVertex(name);
+		v.setParallelism(parallelism);
+		v.setInvokableClass(AbstractInvokable.class);
+		v.setInputDependencyConstraint(InputDependencyConstraint.ALL);
+		return v;
+	}
+
+	private static void finishSubtask(ExecutionGraph graph, JobVertexID jvId, int subtask) {
+		final ExecutionVertex[] vertices = graph.getJobVertex(jvId).getTaskVertices();
+
+		graph.updateState(
+				new TaskExecutionState(
+					graph.getJobID(),
+					vertices[subtask].getCurrentExecutionAttempt().getAttemptId(),
+					ExecutionState.FINISHED));
 	}
 
 	private static List<JobVertex> createOrderedVertices() {
@@ -188,12 +233,21 @@ public class ExecutionVertexInputConstraintTest extends TestLogger {
 	private static ExecutionGraph createExecutionGraph(
 			List<JobVertex> orderedVertices,
 			InputDependencyConstraint inputDependencyConstraint) throws Exception {
+
+		return createExecutionGraph(orderedVertices, inputDependencyConstraint, 20);
+	}
+
+	private static ExecutionGraph createExecutionGraph(
+			List<JobVertex> orderedVertices,
+			InputDependencyConstraint inputDependencyConstraint,
+			int numSlots) throws Exception {
+
 		for (JobVertex vertex : orderedVertices) {
 			vertex.setInputDependencyConstraint(inputDependencyConstraint);
 		}
 
 		final JobGraph jobGraph = new JobGraph(orderedVertices.toArray(new JobVertex[0]));
-		final SlotProvider slotProvider = new SimpleSlotProvider(jobGraph.getJobID(), 20);
+		final SlotProvider slotProvider = new SimpleSlotProvider(jobGraph.getJobID(), numSlots);
 
 		return TestingExecutionGraphBuilder
 			.newBuilder()


### PR DESCRIPTION
## What is the purpose of the change

Avoid explosion in the number of input checks when scheduling a downstream vertex in a all-to-all blocking shuffle.

This code is based on the discussion in [FLINK-14735](https://issues.apache.org/jira/browse/FLINK-14735) and is a modified version of @zhuzhurk's original patch.

## Brief change log

  - In the `ExecutionGraph`/ `Execution`, when scheduling downstream consumers, now collects all scheduling candidates in a set before checking their inputs and scheduling them. This avoid double checking of vertices.

## Verifying this change

  - This adds a unit test to validate the performance fix

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **yes**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
