### PR TITLE
[FLINK-14891][python] Set the default chaining strategy to ALWAYS for Python operators

### DIFF
--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -149,6 +149,14 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils-junit</artifactId>
 		</dependency>
 

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractPythonFunctionOperator.java
@@ -23,6 +23,7 @@ import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.python.PythonOptions;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -80,6 +81,10 @@ public abstract class AbstractPythonFunctionOperator<IN, OUT>
 	 * Callback to be executed after the current bundle was finished.
 	 */
 	private transient Runnable bundleFinishedCallback;
+
+	public AbstractPythonFunctionOperator() {
+		this.chainingStrategy = ChainingStrategy.ALWAYS;
+	}
 
 	@Override
 	public void open() throws Exception {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/AbstractPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/AbstractPythonScalarFunctionOperator.java
@@ -118,6 +118,7 @@ public abstract class AbstractPythonScalarFunctionOperator<IN, OUT, UDFIN, UDFOU
 		RowType outputType,
 		int[] udfInputOffsets,
 		int[] forwardedFields) {
+		super();
 		this.scalarFunctions = Preconditions.checkNotNull(scalarFunctions);
 		this.inputType = Preconditions.checkNotNull(inputType);
 		this.outputType = Preconditions.checkNotNull(outputType);

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonScalarFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonScalarFunctionOperatorTest.java
@@ -21,6 +21,9 @@ package org.apache.flink.table.runtime.operators.python;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.python.PythonFunctionRunner;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.util.BaseRowUtil;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
@@ -74,6 +77,12 @@ public class BaseRowPythonScalarFunctionOperatorTest
 	@Override
 	public void assertOutputEquals(String message, Collection<Object> expected, Collection<Object> actual) {
 		assertor.assertOutputEquals(message, expected, actual);
+	}
+
+	@Override
+	public StreamTableEnvironment createTableEnvironment(StreamExecutionEnvironment env) {
+		return StreamTableEnvironment.create(
+			env, EnvironmentSettings.newInstance().inStreamingMode().useBlinkPlanner().build());
 	}
 
 	private static class PassThroughPythonScalarFunctionOperator extends BaseRowPythonScalarFunctionOperator {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperatorTest.java
@@ -19,7 +19,9 @@
 package org.apache.flink.table.runtime.operators.python;
 
 import org.apache.flink.python.PythonFunctionRunner;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.util.TestHarnessUtil;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.runtime.types.CRow;
 import org.apache.flink.table.types.logical.RowType;
@@ -54,6 +56,11 @@ public class PythonScalarFunctionOperatorTest extends PythonScalarFunctionOperat
 	@Override
 	public void assertOutputEquals(String message, Collection<Object> expected, Collection<Object> actual) {
 		TestHarnessUtil.assertOutputEquals(message, (Queue<Object>) expected, (Queue<Object>) actual);
+	}
+
+	@Override
+	public StreamTableEnvironment createTableEnvironment(StreamExecutionEnvironment env) {
+		return StreamTableEnvironment.create(env);
 	}
 
 	private static class PassThroughPythonScalarFunctionOperator extends PythonScalarFunctionOperator {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperatorTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperatorTestBase.java
@@ -18,21 +18,32 @@
 
 package org.apache.flink.table.runtime.operators.python;
 
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.python.PythonOptions;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.functions.python.AbstractPythonScalarFunctionRunnerTest;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.PythonScalarFunction;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
@@ -190,6 +201,21 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN, UDFOU
 		testHarness.close();
 	}
 
+	@Test
+	public void testPythonScalarFunctionOperatorIsChainedByDefault() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+		StreamTableEnvironment tEnv = createTableEnvironment(env);
+		tEnv.registerFunction("pyFunc", new PythonScalarFunction("pyFunc"));
+		DataStream<Tuple2<Integer, Integer>> ds = env.fromElements(new Tuple2<>(1, 2));
+		Table t = tEnv.fromDataStream(ds, "a, b").select("pyFunc(a, b)");
+		// force generating the physical plan for the given table
+		tEnv.toAppendStream(t, BasicTypeInfo.INT_TYPE_INFO);
+		JobGraph jobGraph = env.getStreamGraph().getJobGraph();
+		List<JobVertex> vertices = jobGraph.getVerticesSortedTopologicallyFromSources();
+		Assert.assertEquals(1, vertices.size());
+	}
+
 	private OneInputStreamOperatorTestHarness<IN, OUT> getTestHarness() throws Exception {
 		RowType dataType = new RowType(Arrays.asList(
 			new RowType.RowField("f1", new VarCharType()),
@@ -220,4 +246,6 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN, UDFOU
 	public abstract IN newRow(boolean accumulateMsg, Object... fields);
 
 	public abstract void assertOutputEquals(String message, Collection<Object> expected, Collection<Object> actual);
+
+	public abstract StreamTableEnvironment createTableEnvironment(StreamExecutionEnvironment env);
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
@@ -233,7 +233,7 @@ public class JavaUserDefinedScalarFunctions {
 
 		@Override
 		public PythonEnv getPythonEnv() {
-			return null;
+			return new PythonEnv(PythonEnv.ExecType.PROCESS);
 		}
 	}
 


### PR DESCRIPTION

## What is the purpose of the change

*This pull request set the default chaining strategy to ALWAYS for Python operators.*

## Brief change log

  - *Set the default chaining strategy to ALWAYS for Python operators.*

## Verifying this change
This change added tests and can be verified as follows:

  - *Added tests PythonScalarFunctionOperatorTestBase#testPythonScalarFunctionOperatorIsChainedByDefault*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
