### PR TITLE
[FLINK-14898] Enable background cleanup of state with TTL by default

### DIFF
--- a/docs/dev/stream/state/state.md
+++ b/docs/dev/stream/state/state.md
@@ -356,11 +356,32 @@ If the serializer does not support null values, it can be wrapped with `Nullable
 
 #### Cleanup of Expired State
 
-By default, expired values are only removed when they are read out explicitly, 
-e.g. by calling `ValueState.value()`.
+By default, expired values are explicitly removed on read, such as `ValueState#value`, and periodically garbage collected
+in the background if supported by the configured state backend. Background cleanup can be disabled in the `StateTtlConfig`:
 
-<span class="label label-danger">Attention</span> This means that by default if expired state is not read, 
-it won't be removed, possibly leading to ever growing state. This might change in future releases. 
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+import org.apache.flink.api.common.state.StateTtlConfig;
+StateTtlConfig ttlConfig = StateTtlConfig
+    .newBuilder(Time.seconds(1))
+    .disableCleanupInBackground()
+    .build();
+{% endhighlight %}
+</div>
+ <div data-lang="scala" markdown="1">
+{% highlight scala %}
+import org.apache.flink.api.common.state.StateTtlConfig
+val ttlConfig = StateTtlConfig
+    .newBuilder(Time.seconds(1))
+    .disableCleanupInBackground
+    .build
+{% endhighlight %}
+</div>
+</div>
+
+For more fine-grained control over some special cleanup in background, you can configure it separately as described below.
+Currently, heap state backend relies on incremental cleanup and RocksDB backend uses compaction filter for background cleanup.
 
 ##### Cleanup in full snapshot
 
@@ -400,35 +421,6 @@ This option is not applicable for the incremental checkpointing in the RocksDB s
 **Notes:** 
 - For existing jobs, this cleanup strategy can be activated or deactivated anytime in `StateTtlConfig`, 
 e.g. after restart from savepoint.
-
-#### Cleanup in background
-
-Besides cleanup in full snapshot, you can also activate the cleanup in background. The following option 
-will activate a default background cleanup in StateTtlConfig if it is supported for the used backend:
-
-<div class="codetabs" markdown="1">
-<div data-lang="java" markdown="1">
-{% highlight java %}
-import org.apache.flink.api.common.state.StateTtlConfig;
-StateTtlConfig ttlConfig = StateTtlConfig
-    .newBuilder(Time.seconds(1))
-    .cleanupInBackground()
-    .build();
-{% endhighlight %}
-</div>
- <div data-lang="scala" markdown="1">
-{% highlight scala %}
-import org.apache.flink.api.common.state.StateTtlConfig
-val ttlConfig = StateTtlConfig
-    .newBuilder(Time.seconds(1))
-    .cleanupInBackground
-    .build
-{% endhighlight %}
-</div>
-</div>
-
-For more fine-grained control over some special cleanup in background, you can configure it separately as described below.
-Currently, heap state backend relies on incremental cleanup and RocksDB backend uses compaction filter for background cleanup.
 
 ##### Incremental cleanup
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
@@ -169,7 +169,7 @@ public class StateTtlConfig implements Serializable {
 		private StateVisibility stateVisibility = NeverReturnExpired;
 		private TtlTimeCharacteristic ttlTimeCharacteristic = ProcessingTime;
 		private Time ttl;
-		private boolean isCleanupInBackground = false;
+		private boolean isCleanupInBackground = true;
 		private final EnumMap<CleanupStrategies.Strategies, CleanupStrategies.CleanupStrategy> strategies =
 			new EnumMap<>(CleanupStrategies.Strategies.class);
 
@@ -336,13 +336,27 @@ public class StateTtlConfig implements Serializable {
 		}
 
 		/**
-		 * Enable cleanup of expired state in background.
+		 * Enable default cleanup of expired state in background (enabled by default).
 		 *
-		 * <p>Depending on actually used backend, the corresponding cleanup will kick in if supported.
+		 * <p>Depending on actually used backend, the corresponding default cleanup will kick in if supported.
+		 * If some specific cleanup is also configured, e.g. {@link #cleanupIncrementally(int, boolean)} or
+		 * {@link #cleanupInRocksdbCompactFilter()}, then the specific one will kick in instead of default.
 		 */
 		@Nonnull
 		public Builder cleanupInBackground() {
 			isCleanupInBackground = true;
+			return this;
+		}
+
+		/**
+		 * Disable default cleanup of expired state in background (enabled by default).
+		 *
+		 * <p>If some specific cleanup is configured, e.g. {@link #cleanupIncrementally(int, boolean)} or
+		 * {@link #cleanupInRocksdbCompactFilter()}, this setting does not disable it.
+		 */
+		@Nonnull
+		public Builder disableCleanupInBackground() {
+			isCleanupInBackground = false;
 			return this;
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestBase.java
@@ -120,6 +120,7 @@ public abstract class TtlStateTestBase {
 		initTest(getConfBuilder(ttl)
 			.setUpdateType(updateType)
 			.setStateVisibility(visibility)
+			.disableCleanupInBackground()
 			.build());
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

So far, we were conservative about enabling background cleanup strategies for state with TTL. In general, if state is configured to have TTL, most users would expect the background cleanup to kick in. As there were no reported issues so far since the release of backend specific cleanups and that should not affect any state without TTL, this issue suggests to enable default background cleanup for backends.

## Brief change log

  - change initial value for `StateTtlConfig.Builder.isCleanupInBackground` to true
  - add `StateTtlConfig.Builder#disableCleanupInBackground`
  - add test for `StateTtlConfig.Builder#disableCleanupInBackground`

## Verifying this change

Unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs / JavaDocs)
