### PR TITLE
[FLINK-14901] Throw Error in MemoryUtils if there is problem with using system classes over reflection

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemoryUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemoryUtils.java
@@ -19,7 +19,6 @@
 package org.apache.flink.core.memory;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.JavaGcCleanerWrapper;
 
 import java.lang.reflect.Constructor;
@@ -49,15 +48,15 @@ public class MemoryUtils {
 			unsafeField.setAccessible(true);
 			return (sun.misc.Unsafe) unsafeField.get(null);
 		} catch (SecurityException e) {
-			throw new RuntimeException("Could not access the sun.misc.Unsafe handle, permission denied by security manager.", e);
+			throw new Error("Could not access the sun.misc.Unsafe handle, permission denied by security manager.", e);
 		} catch (NoSuchFieldException e) {
-			throw new RuntimeException("The static handle field in sun.misc.Unsafe was not found.");
+			throw new Error("The static handle field in sun.misc.Unsafe was not found.");
 		} catch (IllegalArgumentException e) {
-			throw new RuntimeException("Bug: Illegal argument reflection access for static field.", e);
+			throw new Error("Bug: Illegal argument reflection access for static field.", e);
 		} catch (IllegalAccessException e) {
-			throw new RuntimeException("Access to sun.misc.Unsafe is forbidden by the runtime.", e);
+			throw new Error("Access to sun.misc.Unsafe is forbidden by the runtime.", e);
 		} catch (Throwable t) {
-			throw new RuntimeException("Unclassified error while trying to access the sun.misc.Unsafe handle.", t);
+			throw new Error("Unclassified error while trying to access the sun.misc.Unsafe handle.", t);
 		}
 	}
 
@@ -72,21 +71,20 @@ public class MemoryUtils {
 			constructor.setAccessible(true);
 			return constructor;
 		} catch (NoSuchMethodException e) {
-			ExceptionUtils.rethrow(
-				e,
-				"The private constructor java.nio.DirectByteBuffer.<init>(long, int) is not available.");
+			throw new Error(
+				"The private constructor java.nio.DirectByteBuffer.<init>(long, int) is not available.",
+				e);
 		} catch (SecurityException e) {
-			ExceptionUtils.rethrow(
-				e,
+			throw new Error(
 				"The private constructor java.nio.DirectByteBuffer.<init>(long, int) is not available, " +
-					"permission denied by security manager");
+					"permission denied by security manager",
+				e);
 		} catch (Throwable t) {
-			ExceptionUtils.rethrow(
-				t,
+			throw new Error(
 				"Unclassified error while trying to access private constructor " +
-					"java.nio.DirectByteBuffer.<init>(long, int).");
+					"java.nio.DirectByteBuffer.<init>(long, int).",
+				t);
 		}
-		throw new RuntimeException("unexpected to avoid returning null");
 	}
 
 	/**
@@ -130,8 +128,7 @@ public class MemoryUtils {
 		try {
 			return (ByteBuffer) DIRECT_BUFFER_CONSTRUCTOR.newInstance(address, size);
 		} catch (Throwable t) {
-			ExceptionUtils.rethrow(t, "Failed to wrap unsafe off-heap memory with ByteBuffer");
+			throw new Error("Failed to wrap unsafe off-heap memory with ByteBuffer", t);
 		}
-		throw new RuntimeException("unexpected to avoid returning null");
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/util/JavaGcCleanerWrapper.java
+++ b/flink-core/src/main/java/org/apache/flink/util/JavaGcCleanerWrapper.java
@@ -70,10 +70,12 @@ public enum JavaGcCleanerWrapper {
 		return CLEANER_FACTORY.create(owner, cleanOperation);
 	}
 
+	@FunctionalInterface
 	private interface CleanerProvider {
 		CleanerFactory createCleanerFactory() throws ClassNotFoundException;
 	}
 
+	@FunctionalInterface
 	private interface CleanerFactory {
 		Runnable create(Object owner, Runnable cleanOperation);
 	}

--- a/flink-core/src/main/java/org/apache/flink/util/JavaGcCleanerWrapper.java
+++ b/flink-core/src/main/java/org/apache/flink/util/JavaGcCleanerWrapper.java
@@ -50,6 +50,7 @@ public enum JavaGcCleanerWrapper {
 		CleanerFactory foundCleanerFactory = null;
 		Throwable t = null;
 		for (CleanerProvider cleanerProvider : CLEANER_PROVIDERS) {
+			//noinspection OverlyBroadCatchBlock
 			try {
 				foundCleanerFactory = cleanerProvider.createCleanerFactory();
 				break;
@@ -60,7 +61,7 @@ public enum JavaGcCleanerWrapper {
 
 		if (foundCleanerFactory == null) {
 			String errorMessage = String.format("Failed to find GC Cleaner among available providers: %s", CLEANER_PROVIDERS);
-			throw new FlinkRuntimeException(errorMessage, t);
+			throw new Error(errorMessage, t);
 		}
 		return foundCleanerFactory;
 	}
@@ -135,7 +136,7 @@ public enum JavaGcCleanerWrapper {
 			try {
 				cleaner = cleanerCreateMethod.invoke(null, owner, cleanupOperation);
 			} catch (IllegalAccessException | InvocationTargetException e) {
-				throw new FlinkRuntimeException("Failed to create a Java legacy Cleaner", e);
+				throw new Error("Failed to create a Java legacy Cleaner", e);
 			}
 			String ownerString = owner.toString(); // lambda should not capture the owner object
 			return () -> {
@@ -144,7 +145,7 @@ public enum JavaGcCleanerWrapper {
 				} catch (IllegalAccessException | InvocationTargetException e) {
 					String message = String.format("FATAL UNEXPECTED - Failed to invoke a Java legacy Cleaner for %s", ownerString);
 					LOG.error(message, e);
-					throw new FlinkRuntimeException(message, e);
+					throw new Error(message, e);
 				}
 			};
 		}
@@ -238,7 +239,7 @@ public enum JavaGcCleanerWrapper {
 			try {
 				cleanable = cleanerRegisterMethod.invoke(cleaner, owner, cleanupOperation);
 			} catch (IllegalAccessException | InvocationTargetException e) {
-				throw new FlinkRuntimeException("Failed to create a Java 9 Cleaner", e);
+				throw new Error("Failed to create a Java 9 Cleaner", e);
 			}
 			String ownerString = owner.toString(); // lambda should not capture the owner object
 			return () -> {
@@ -247,7 +248,7 @@ public enum JavaGcCleanerWrapper {
 				} catch (IllegalAccessException | InvocationTargetException e) {
 					String message = String.format("FATAL UNEXPECTED - Failed to invoke a Java 9 Cleaner$Cleanable for %s", ownerString);
 					LOG.error(message, e);
-					throw new FlinkRuntimeException(message, e);
+					throw new Error(message, e);
 				}
 			};
 		}


### PR DESCRIPTION
A follow-up hotfix for #9747 and #9997.
If something goes wrong using system classes over reflection n MemoryUtils or JavaGcCleanerWrapper, Flink cannot really recover from it. We should throw an Error in this case which should stay unhandled.