### PR TITLE
[FLINK-14924][table sql / api] CsvTableSource can not config empty column as null

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/CsvTableSource.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/CsvTableSource.java
@@ -544,21 +544,22 @@ public class CsvTableSource
 			}
 			CsvInputFormatConfig that = (CsvInputFormatConfig) o;
 			return ignoreFirstLine == that.ignoreFirstLine &&
-				lenient == that.lenient &&
-				Objects.equals(path, that.path) &&
-				Arrays.equals(fieldNames, that.fieldNames) &&
-				Arrays.equals(fieldTypes, that.fieldTypes) &&
-				Arrays.equals(selectedFields, that.selectedFields) &&
-				Objects.equals(fieldDelim, that.fieldDelim) &&
-				Objects.equals(lineDelim, that.lineDelim) &&
-				Objects.equals(quoteCharacter, that.quoteCharacter) &&
-				Objects.equals(ignoreComments, that.ignoreComments);
+					lenient == that.lenient &&
+					Objects.equals(path, that.path) &&
+					Arrays.equals(fieldNames, that.fieldNames) &&
+					Arrays.equals(fieldTypes, that.fieldTypes) &&
+					Arrays.equals(selectedFields, that.selectedFields) &&
+					Objects.equals(fieldDelim, that.fieldDelim) &&
+					Objects.equals(lineDelim, that.lineDelim) &&
+					Objects.equals(quoteCharacter, that.quoteCharacter) &&
+					Objects.equals(ignoreComments, that.ignoreComments) &&
+					Objects.equals(emptyColumnAsNull, that.emptyColumnAsNull);
 		}
 
 		@Override
 		public int hashCode() {
 			int result = Objects.hash(path, fieldDelim, lineDelim, quoteCharacter, ignoreFirstLine,
-				ignoreComments, lenient);
+					ignoreComments, lenient, emptyColumnAsNull);
 			result = 31 * result + Arrays.hashCode(fieldNames);
 			result = 31 * result + Arrays.hashCode(fieldTypes);
 			result = 31 * result + Arrays.hashCode(selectedFields);

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/CsvTableSource.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/CsvTableSource.java
@@ -64,9 +64,9 @@ public class CsvTableSource
 	 */
 	public CsvTableSource(String path, String[] fieldNames, TypeInformation<?>[] fieldTypes) {
 		this(path, fieldNames, fieldTypes,
-			IntStream.range(0, fieldNames.length).toArray(),
-			CsvInputFormat.DEFAULT_FIELD_DELIMITER, CsvInputFormat.DEFAULT_LINE_DELIMITER,
-			null, false, null, false);
+				IntStream.range(0, fieldNames.length).toArray(),
+				CsvInputFormat.DEFAULT_FIELD_DELIMITER, CsvInputFormat.DEFAULT_LINE_DELIMITER,
+				null, false, null, false);
 	}
 
 	/**
@@ -85,54 +85,19 @@ public class CsvTableSource
 	 *                        default.
 	 */
 	public CsvTableSource(
-		String path,
-		String[] fieldNames,
-		TypeInformation<?>[] fieldTypes,
-		String fieldDelim,
-		String lineDelim,
-		Character quoteCharacter,
-		boolean ignoreFirstLine,
-		String ignoreComments,
-		boolean lenient) {
-
+			String path,
+			String[] fieldNames,
+			TypeInformation<?>[] fieldTypes,
+			String fieldDelim,
+			String lineDelim,
+			Character quoteCharacter,
+			boolean ignoreFirstLine,
+			String ignoreComments,
+			boolean lenient) {
 		this(path, fieldNames, fieldTypes,
-			IntStream.range(0, fieldNames.length).toArray(),
-			fieldDelim, lineDelim,
-			quoteCharacter, ignoreFirstLine, ignoreComments, lenient);
-	}
-
-	/**
-	 * A {@link InputFormatTableSource} and {@link LookupableTableSource} for simple CSV files with
-	 * a (logically) unlimited number of fields.
-	 *
-	 * @param path            	The path to the CSV file.
-	 * @param fieldNames      	The names of the table fields.
-	 * @param fieldTypes      	The types of the table fields.
-	 * @param fieldDelim      	The field delimiter, "," by default.
-	 * @param lineDelim       	The row delimiter, "\n" by default.
-	 * @param quoteCharacter  	An optional quote character for String values, null by default.
-	 * @param ignoreFirstLine 	Flag to ignore the first line, false by default.
-	 * @param ignoreComments  	An optional prefix to indicate comments, null by default.
-	 * @param lenient         	Flag to skip records with parse error instead to fail, false by
-	 *                        	default.
-	 * @param emptyColumnAsNull	Flag to treat empty column as null.
-	 */
-	public CsvTableSource(
-		String path,
-		String[] fieldNames,
-		TypeInformation<?>[] fieldTypes,
-		String fieldDelim,
-		String lineDelim,
-		Character quoteCharacter,
-		boolean ignoreFirstLine,
-		String ignoreComments,
-		boolean lenient,
-		boolean emptyColumnAsNull) {
-
-		this(path, fieldNames, fieldTypes,
-			IntStream.range(0, fieldNames.length).toArray(),
-			fieldDelim, lineDelim,
-			quoteCharacter, ignoreFirstLine, ignoreComments, lenient, emptyColumnAsNull);
+				IntStream.range(0, fieldNames.length).toArray(),
+				fieldDelim, lineDelim, quoteCharacter,
+				ignoreFirstLine, ignoreComments, lenient);
 	}
 
 	/**
@@ -153,53 +118,20 @@ public class CsvTableSource
 	 *                        default.
 	 */
 	public CsvTableSource(
-		String path,
-		String[] fieldNames,
-		TypeInformation<?>[] fieldTypes,
-		int[] selectedFields,
-		String fieldDelim,
-		String lineDelim,
-		Character quoteCharacter,
-		boolean ignoreFirstLine,
-		String ignoreComments,
-		boolean lenient) {
-		this(path, fieldNames, fieldTypes, selectedFields,
-			fieldDelim, lineDelim, quoteCharacter, ignoreFirstLine,
-			ignoreComments, lenient, false);
-	}
-
-	/**
-	 * A {@link InputFormatTableSource} and {@link LookupableTableSource} for simple CSV files with
-	 * a (logically) unlimited number of fields.
-	 *
-	 * @param path            	The path to the CSV file.
-	 * @param fieldNames      	The names of the table fields.
-	 * @param fieldTypes      	The types of the table fields.
-	 * @param selectedFields  	The fields which will be read and returned by the table source. If
-	 *                        	None, all fields are returned.
-	 * @param fieldDelim      	The field delimiter, "," by default.
-	 * @param lineDelim     	The row delimiter, "\n" by default.
-	 * @param quoteCharacter  	An optional quote character for String values, null by default.
-	 * @param ignoreFirstLine 	Flag to ignore the first line, false by default.
-	 * @param ignoreComments  	An optional prefix to indicate comments, null by default.
-	 * @param lenient         	Flag to skip records with parse error instead to fail, false by
-	 *                        	default.
-	 * @param emptyColumnAsNull	Flag to treat empty column as null.
-	 */
-	public CsvTableSource(
-		String path,
-		String[] fieldNames,
-		TypeInformation<?>[] fieldTypes,
-		int[] selectedFields,
-		String fieldDelim,
-		String lineDelim,
-		Character quoteCharacter,
-		boolean ignoreFirstLine,
-		String ignoreComments,
-		boolean lenient,
-		boolean emptyColumnAsNull) {
-		this(new CsvInputFormatConfig(path, fieldNames, fieldTypes, selectedFields, fieldDelim,
-			lineDelim, quoteCharacter, ignoreFirstLine, ignoreComments, lenient, emptyColumnAsNull));
+			String path,
+			String[] fieldNames,
+			TypeInformation<?>[] fieldTypes,
+			int[] selectedFields,
+			String fieldDelim,
+			String lineDelim,
+			Character quoteCharacter,
+			boolean ignoreFirstLine,
+			String ignoreComments,
+			boolean lenient) {
+		this(new CsvInputFormatConfig(
+				path, fieldNames, fieldTypes, selectedFields,
+				fieldDelim, lineDelim, quoteCharacter, ignoreFirstLine,
+				ignoreComments, lenient, false));
 	}
 
 	private CsvTableSource(CsvInputFormatConfig config) {
@@ -409,17 +341,19 @@ public class CsvTableSource
 			if (schema.isEmpty()) {
 				throw new IllegalArgumentException("Fields can not be empty.");
 			}
-			return new CsvTableSource(
-				path,
-				schema.keySet().toArray(new String[0]),
-				schema.values().toArray(new TypeInformation<?>[0]),
-				fieldDelim,
-				lineDelim,
-				quoteCharacter,
-				isIgnoreFirstLine,
-				commentPrefix,
-				lenient,
-				emptyColumnAsNull);
+
+			return new CsvTableSource(new CsvInputFormatConfig(
+					path,
+					schema.keySet().toArray(new String[0]),
+					schema.values().toArray(new TypeInformation<?>[0]),
+					IntStream.range(0, schema.values().size()).toArray(),
+					fieldDelim,
+					lineDelim,
+					quoteCharacter,
+					isIgnoreFirstLine,
+					commentPrefix,
+					lenient,
+					emptyColumnAsNull));
 		}
 	}
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/TableSourceITCase.scala
@@ -59,6 +59,25 @@ class TableSourceITCase(
   }
 
   @Test
+  def testCsvTableSourceWithEmptyColumn(): Unit = {
+
+    val csvTable = CommonTestData.getCsvTableSourceWithEmptyColumn
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = BatchTableEnvironment.create(env, config)
+
+    tEnv.registerTableSource("csvTable", csvTable)
+    val results = tEnv.sqlQuery(
+      "SELECT id, `first`, `last`, score FROM csvTable").collect()
+
+    val expected = Seq(
+      "1,Mike,Smith,12.3",
+      "2,Bob,Taylor,null",
+      "null,Leonard,null,null").mkString("\n")
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
+  @Test
   def testNested(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tableEnv = BatchTableEnvironment.create(env, config)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/utils/CommonTestData.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/utils/CommonTestData.scala
@@ -59,6 +59,30 @@ object CommonTestData {
       .build()
   }
 
+  def getCsvTableSourceWithEmptyColumn: CsvTableSource = {
+    val csvRecords = Seq(
+      "First#Id#Score#Last",
+      "Mike#1#12.3#Smith",
+      "Bob#2##Taylor",
+      "% Just a comment",
+      "Leonard###"
+    )
+
+    val tempFilePath = writeToTempFile(csvRecords.mkString("$"), "csv-null-test", "tmp")
+    CsvTableSource.builder()
+      .path(tempFilePath)
+      .field("first",Types.STRING)
+      .field("id",Types.INT)
+      .field("score",Types.DOUBLE)
+      .field("last",Types.STRING)
+      .fieldDelimiter("#")
+      .lineDelimiter("$")
+      .ignoreFirstLine()
+      .commentPrefix("%")
+      .emptyColumnAsNull()
+      .build()
+  }
+
   private def writeToTempFile(
       contents: String,
       filePrefix: String,


### PR DESCRIPTION
CsvTableSource can not config empty column as null.
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*This pull request add option of treating empty column as null for CsvTableSource.*


## Brief change log
  - *update file org.apache.flink.table.sources.CsvTableSource.java*

## Verifying this change
    Add ITCase to to test CsvTableSource:
  - *org.apache.flink.table.runtime.batch.sql.TableSourceITCase.scala*
  - *org.apache.flink.table.runtime.utils.CommonTestData.scala*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

 - Does this pull request introduce a new feature? (no)
 - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
