### PR TITLE
[FLINK-14899] [table-planner-blink] Fix unexpected plan when PROCTIME() is defined in query

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/RelTimeIndicatorConverter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/RelTimeIndicatorConverter.scala
@@ -642,7 +642,7 @@ class RexTimeIndicatorMaterializer(
 
       // materialize function's result and operands
       case _ if isTimeIndicatorType(updatedCall.getType) =>
-        if (updatedCall.getOperator == FlinkSqlOperatorTable.PROCTIME_MATERIALIZE) {
+        if (updatedCall.getOperator == FlinkSqlOperatorTable.PROCTIME) {
           updatedCall
         } else {
           updatedCall.clone(timestamp(updatedCall.getType.isNullable), materializedOperands)

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/DeduplicateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/DeduplicateTest.xml
@@ -1,0 +1,250 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testInvalidRowNumberConditionOnProctime">
+    <Resource name="sql">
+      <![CDATA[
+SELECT *
+FROM (
+  SELECT a, ROW_NUMBER() OVER (PARTITION BY b ORDER BY proctime DESC) as rank_num
+  FROM MyTable)
+WHERE rank_num = 2
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], rank_num=[$1])
++- LogicalFilter(condition=[=($1, 2)])
+   +- LogicalProject(a=[$0], rank_num=[ROW_NUMBER() OVER (PARTITION BY $1 ORDER BY $3 DESC NULLS LAST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, 2:BIGINT AS rank_num])
++- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=2, rankEnd=2], partitionBy=[b], orderBy=[proctime DESC], select=[a, b, proctime])
+   +- Exchange(distribution=[hash[b]])
+      +- Calc(select=[a, b, proctime])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInvalidRowNumberConditionOnRowtime">
+    <Resource name="sql">
+      <![CDATA[
+SELECT *
+FROM (
+  SELECT a, ROW_NUMBER() OVER (PARTITION BY b ORDER BY rowtime DESC) as rank_num
+  FROM MyTable)
+WHERE rank_num = 3
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], rank_num=[$1])
++- LogicalFilter(condition=[=($1, 3)])
+   +- LogicalProject(a=[$0], rank_num=[ROW_NUMBER() OVER (PARTITION BY $1 ORDER BY $4 DESC NULLS LAST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, 3:BIGINT AS rank_num])
++- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=3, rankEnd=3], partitionBy=[b], orderBy=[rowtime DESC], select=[a, b, rowtime])
+   +- Exchange(distribution=[hash[b]])
+      +- Calc(select=[a, b, rowtime])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSimpleFirstRowOnBuiltinProctime">
+    <Resource name="sql">
+      <![CDATA[
+SELECT *
+FROM (
+  SELECT *,
+    ROW_NUMBER() OVER (PARTITION BY a ORDER BY PROCTIME() ASC) as rowNum
+  FROM MyTable
+)
+WHERE rowNum = 1
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], rowNum=[$5])
++- LogicalFilter(condition=[=($5, 1)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], rowNum=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY PROCTIME() NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, 1:BIGINT AS rowNum])
++- Deduplicate(keep=[FirstRow], key=[a], order=[PROCTIME])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c, proctime, rowtime, PROCTIME() AS $5])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSimpleFirstRowOnProctime">
+    <Resource name="sql">
+      <![CDATA[
+SELECT a, b, c
+FROM (
+  SELECT *,
+      ROW_NUMBER() OVER (PARTITION BY a ORDER BY proctime ASC) as rank_num
+  FROM MyTable)
+WHERE rank_num = 1
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[=($5, 1)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], rank_num=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $3 NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c])
++- Deduplicate(keep=[FirstRow], key=[a], order=[PROCTIME])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c, proctime])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSimpleFirstRowOnRowtime">
+    <Resource name="sql">
+      <![CDATA[
+SELECT a, b, c
+FROM (
+  SELECT *,
+      ROW_NUMBER() OVER (PARTITION BY a ORDER BY rowtime ASC) as rank_num
+  FROM MyTable)
+WHERE rank_num <= 1
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[<=($5, 1)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], rank_num=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $4 NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c])
++- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=1], partitionBy=[a], orderBy=[rowtime ASC], select=[a, b, c, rowtime])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c, rowtime])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSimpleLastRowOnBuiltinProctime">
+    <Resource name="sql">
+      <![CDATA[
+SELECT *
+FROM (
+  SELECT *,
+    ROW_NUMBER() OVER (ORDER BY PROCTIME() DESC) as rowNum
+  FROM MyTable
+)
+WHERE rowNum = 1
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], rowNum=[$5])
++- LogicalFilter(condition=[=($5, 1)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], rowNum=[ROW_NUMBER() OVER (ORDER BY PROCTIME() DESC NULLS LAST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, 1:BIGINT AS rowNum])
++- Deduplicate(keep=[LastRow], key=[], order=[PROCTIME])
+   +- Exchange(distribution=[single])
+      +- Calc(select=[a, b, c, proctime, rowtime, PROCTIME() AS $5])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSimpleLastRowOnRowtime">
+    <Resource name="sql">
+      <![CDATA[
+SELECT a, b, c
+FROM (
+  SELECT *,
+      ROW_NUMBER() OVER (PARTITION BY a ORDER BY rowtime DESC) as rank_num
+  FROM MyTable)
+WHERE rank_num = 1
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[=($5, 1)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], rank_num=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $4 DESC NULLS LAST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c])
++- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=1], partitionBy=[a], orderBy=[rowtime DESC], select=[a, b, c, rowtime])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c, rowtime])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSimpleLastRowOnProctime">
+    <Resource name="sql">
+      <![CDATA[
+SELECT *
+FROM (
+  SELECT *,
+      ROW_NUMBER() OVER (PARTITION BY a ORDER BY proctime DESC) as rank_num
+  FROM MyTable)
+WHERE rank_num = 1
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], rank_num=[$5])
++- LogicalFilter(condition=[=($5, 1)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], rank_num=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $3 DESC NULLS LAST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, 1:BIGINT AS rank_num])
++- Deduplicate(keep=[LastRow], key=[a], order=[PROCTIME])
+   +- Exchange(distribution=[hash[a]])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/RankTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/RankTest.xml
@@ -529,42 +529,6 @@ GroupAggregate(select=[MAX_RETRACT(a) AS EXPR$0], updateAsRetraction=[false], ac
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testTopNOrderByIncrSum">
-    <Resource name="sql">
-      <![CDATA[
-SELECT *
-FROM (
-  SELECT a, b, sum_c,
-      ROW_NUMBER() OVER (PARTITION BY b ORDER BY sum_c DESC) AS row_num
-  FROM (
-SELECT a, b, incr_sum(c) as sum_c
-FROM MyTable
-GROUP BY a, b
-      ))
-WHERE row_num <= 10
-      ]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(a=[$0], b=[$1], sum_c=[$2], row_num=[$3])
-+- LogicalFilter(condition=[<=($3, 10)])
-   +- LogicalProject(a=[$0], b=[$1], sum_c=[$2], row_num=[ROW_NUMBER() OVER (PARTITION BY $1 ORDER BY $2 DESC NULLS LAST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)])
-      +- LogicalAggregate(group=[{0, 1}], sum_c=[INCR_SUM($2)])
-         +- LogicalProject(a=[$0], b=[$1], c=[$2])
-            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-Rank(strategy=[UpdateFastStrategy[0,1]], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=10], partitionBy=[b], orderBy=[sum_c DESC], select=[a, b, sum_c, w0$o0], updateAsRetraction=[false], accMode=[Acc])
-+- Exchange(distribution=[hash[b]], updateAsRetraction=[false], accMode=[Acc])
-   +- GroupAggregate(groupBy=[a, b], select=[a, b, INCR_SUM(c) AS sum_c], updateAsRetraction=[false], accMode=[Acc])
-      +- Exchange(distribution=[hash[a, b]], updateAsRetraction=[true], accMode=[Acc])
-         +- Calc(select=[a, b, c], updateAsRetraction=[true], accMode=[Acc])
-            +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime], updateAsRetraction=[true], accMode=[Acc])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testTopNOrderBySumWithCaseWhen">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/OverAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/OverAggregateTest.xml
@@ -173,6 +173,27 @@ Calc(select=[c, w0$o0 AS cnt1, CASE(>(w0$o0, 0:BIGINT), w0$o1, null:INTEGER) AS 
       +- Calc(select=[a, c, proctime])
          +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
+
+    </Resource>
+  </TestCase>
+  <TestCase name="testProcTimeBoundedPartitionedRowsOverWithBuiltinProctime">
+    <Resource name="sql">
+      <![CDATA[SELECT a,   SUM(c) OVER (    PARTITION BY a ORDER BY proctime() ROWS BETWEEN 4 PRECEDING AND CURRENT ROW),   MIN(c) OVER (    PARTITION BY a ORDER BY proctime() ROWS BETWEEN 4 PRECEDING AND CURRENT ROW) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], EXPR$1=[CASE(>(COUNT($2) OVER (PARTITION BY $0 ORDER BY PROCTIME() NULLS FIRST ROWS BETWEEN 4 PRECEDING AND CURRENT ROW), 0), $SUM0($2) OVER (PARTITION BY $0 ORDER BY PROCTIME() NULLS FIRST ROWS BETWEEN 4 PRECEDING AND CURRENT ROW), null:BIGINT)], EXPR$2=[MIN($2) OVER (PARTITION BY $0 ORDER BY PROCTIME() NULLS FIRST ROWS BETWEEN 4 PRECEDING AND CURRENT ROW)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, CASE(>(w0$o0, 0:BIGINT), w0$o1, null:BIGINT) AS EXPR$1, w0$o2 AS EXPR$2])
++- OverAggregate(partitionBy=[a], orderBy=[$2 ASC], window=[ ROWS BETWEEN 4 PRECEDING AND CURRENT ROW], select=[a, c, $2, COUNT(c) AS w0$o0, $SUM0(c) AS w0$o1, MIN(c) AS w0$o2])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, c, PROCTIME() AS $2])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
     </Resource>
   </TestCase>
   <TestCase name="testProcTimeUnboundedNonPartitionedRangeOver">

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/DeduplicateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/DeduplicateTest.scala
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.stream.sql
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.TableException
+import org.apache.flink.table.api.config.ExecutionConfigOptions
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.planner.utils.{StreamTableTestUtil, TableTestBase}
+
+import org.junit.{Before, Test}
+
+class DeduplicateTest extends TableTestBase {
+
+  var util: StreamTableTestUtil = _
+
+  @Before
+  def setUp(): Unit = {
+    util = streamTestUtil()
+    util.addDataStream[(Int, String, Long)](
+      "MyTable", 'a, 'b, 'c, 'proctime.proctime, 'rowtime.rowtime)
+  }
+
+  @Test
+  def testInvalidRowNumberConditionOnProctime(): Unit = {
+    val sql =
+      """
+        |SELECT *
+        |FROM (
+        |  SELECT a, ROW_NUMBER() OVER (PARTITION BY b ORDER BY proctime DESC) as rank_num
+        |  FROM MyTable)
+        |WHERE rank_num = 2
+      """.stripMargin
+
+    // the rank condition is not 1, so it will not be translate to LastRow, but Rank
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testInvalidRowNumberConditionOnRowtime(): Unit = {
+    val sql =
+      """
+        |SELECT *
+        |FROM (
+        |  SELECT a, ROW_NUMBER() OVER (PARTITION BY b ORDER BY rowtime DESC) as rank_num
+        |  FROM MyTable)
+        |WHERE rank_num = 3
+      """.stripMargin
+
+    // the rank condition is not 1, so it will not be translate to LastRow, but Rank
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testLastRowWithWindowOnRowtime(): Unit = {
+    // lastRow on rowtime followed by group window is not supported now.
+    util.tableEnv.getConfig.getConfiguration
+      .setString(ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_ALLOW_LATENCY, "500 ms")
+    util.addTable(
+      """
+        |CREATE TABLE T (
+        | `a` INT,
+        | `b` STRING,
+        | `ts` TIMESTAMP(3),
+        | WATERMARK FOR `ts` AS `ts`
+        |) WITH (
+        | 'connector' = 'COLLECTION',
+        | 'is-bounded' = 'false'
+        |)
+      """.stripMargin
+    )
+
+    val deduplicateSQl =
+      """
+        |(
+        |SELECT a, b, ts
+        |FROM (
+        |  SELECT *,
+        |    ROW_NUMBER() OVER (PARTITION BY a ORDER BY ts DESC) as rowNum
+        |  FROM T
+        |)
+        |WHERE rowNum = 1
+        |)
+      """.stripMargin
+    val windowSql =
+      s"""
+         |select b, sum(a), TUMBLE_START(ts, INTERVAL '0.004' SECOND)
+         |FROM $deduplicateSQl
+         |GROUP BY b, TUMBLE(ts, INTERVAL '0.004' SECOND)
+      """.stripMargin
+
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Retraction on windowed GroupBy Aggregate is not supported yet")
+    util.verifyExplain(windowSql)
+  }
+
+  @Test
+  def testSimpleFirstRowOnRowtime(): Unit = {
+    // Deduplicate does not support sort on rowtime now, so it is translated to Rank currently
+    val sql =
+      """
+        |SELECT a, b, c
+        |FROM (
+        |  SELECT *,
+        |      ROW_NUMBER() OVER (PARTITION BY a ORDER BY rowtime ASC) as rank_num
+        |  FROM MyTable)
+        |WHERE rank_num <= 1
+      """.stripMargin
+
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testSimpleLastRowOnRowtime(): Unit = {
+    // Deduplicate does not support sort on rowtime now, so it is translated to Rank currently
+    val sql =
+      """
+        |SELECT a, b, c
+        |FROM (
+        |  SELECT *,
+        |      ROW_NUMBER() OVER (PARTITION BY a ORDER BY rowtime DESC) as rank_num
+        |  FROM MyTable)
+        |WHERE rank_num = 1
+      """.stripMargin
+
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testSimpleLastRowOnProctime(): Unit = {
+    val sql =
+      """
+        |SELECT *
+        |FROM (
+        |  SELECT *,
+        |      ROW_NUMBER() OVER (PARTITION BY a ORDER BY proctime DESC) as rank_num
+        |  FROM MyTable)
+        |WHERE rank_num = 1
+      """.stripMargin
+
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testSimpleLastRowOnBuiltinProctime(): Unit = {
+    val sqlQuery =
+      """
+        |SELECT *
+        |FROM (
+        |  SELECT *,
+        |    ROW_NUMBER() OVER (ORDER BY PROCTIME() DESC) as rowNum
+        |  FROM MyTable
+        |)
+        |WHERE rowNum = 1
+      """.stripMargin
+
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testSimpleFirstRowOnProctime(): Unit = {
+    val sql =
+      """
+        |SELECT a, b, c
+        |FROM (
+        |  SELECT *,
+        |      ROW_NUMBER() OVER (PARTITION BY a ORDER BY proctime ASC) as rank_num
+        |  FROM MyTable)
+        |WHERE rank_num = 1
+      """.stripMargin
+
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testSimpleFirstRowOnBuiltinProctime(): Unit = {
+    val sqlQuery =
+      """
+        |SELECT *
+        |FROM (
+        |  SELECT *,
+        |    ROW_NUMBER() OVER (PARTITION BY a ORDER BY PROCTIME() ASC) as rowNum
+        |  FROM MyTable
+        |)
+        |WHERE rowNum = 1
+      """.stripMargin
+
+    util.verifyPlan(sqlQuery)
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/OverAggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/OverAggregateTest.scala
@@ -430,4 +430,16 @@ class OverAggregateTest extends TableTestBase {
     verifyPlanIdentical(sql, sql2)
     util.verifyPlan(sql)
   }
+
+  @Test
+  def testProcTimeBoundedPartitionedRowsOverWithBuiltinProctime(): Unit = {
+    val sqlQuery = "SELECT a, " +
+      "  SUM(c) OVER (" +
+      "    PARTITION BY a ORDER BY proctime() ROWS BETWEEN 4 PRECEDING AND CURRENT ROW), " +
+      "  MIN(c) OVER (" +
+      "    PARTITION BY a ORDER BY proctime() ROWS BETWEEN 4 PRECEDING AND CURRENT ROW) " +
+      "FROM MyTable"
+
+    util.verifyPlan(sqlQuery)
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/OverWindowITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/OverWindowITCase.scala
@@ -84,16 +84,15 @@ class OverWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
   }
 
   @Test
-  def testProcTimeBoundedPartitionedRowsOverWithBultinProctime(): Unit = {
-    val t = failingDataSource(TestData.tupleData5)
-      .toTable(tEnv, 'a, 'b, 'c, 'd, 'e, 'proctime.proctime)
+  def testProcTimeBoundedPartitionedRowsOverWithBulitinProctime(): Unit = {
+    val t = failingDataSource(TestData.tupleData5).toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
     tEnv.registerTable("MyTable", t)
 
     val sqlQuery = "SELECT a, " +
       "  SUM(c) OVER (" +
-      "    PARTITION BY a ORDER BY proctime ROWS BETWEEN 4 PRECEDING AND CURRENT ROW), " +
+      "    PARTITION BY a ORDER BY proctime() ROWS BETWEEN 4 PRECEDING AND CURRENT ROW), " +
       "  MIN(c) OVER (" +
-      "    PARTITION BY a ORDER BY proctime ROWS BETWEEN 4 PRECEDING AND CURRENT ROW) " +
+      "    PARTITION BY a ORDER BY proctime() ROWS BETWEEN 4 PRECEDING AND CURRENT ROW) " +
       "FROM MyTable"
 
     val sink = new TestingAppendSink
@@ -121,15 +120,14 @@ class OverWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
 
   @Test
   def testProcTimeBoundedPartitionedRowsOverWithBuiltinProctime(): Unit = {
-    val t = failingDataSource(TestData.tupleData5)
-      .toTable(tEnv, 'a, 'b, 'c, 'd, 'e, 'proctime.proctime)
+    val t = failingDataSource(TestData.tupleData5).toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
     tEnv.registerTable("MyTable", t)
 
     val sqlQuery = "SELECT a, " +
       "  SUM(c) OVER (" +
-      "    PARTITION BY a ORDER BY proctime ROWS BETWEEN 4 PRECEDING AND CURRENT ROW), " +
+      "    PARTITION BY a ORDER BY proctime() ROWS BETWEEN 4 PRECEDING AND CURRENT ROW), " +
       "  MIN(c) OVER (" +
-      "    PARTITION BY a ORDER BY proctime ROWS BETWEEN 4 PRECEDING AND CURRENT ROW) " +
+      "    PARTITION BY a ORDER BY proctime() ROWS BETWEEN 4 PRECEDING AND CURRENT ROW) " +
       "FROM MyTable"
 
     val sink = new TestingAppendSink


### PR DESCRIPTION
## What is the purpose of the change

*currently,  `SELECT * (SELECT *, ROW_NUMBER() OVER (ORDER BY PROCTIME() ASC) as rowNum FROM MyTable) WHERE rowNum = 1` will be translated to StreamExecRank, while StreamExecDeduplicate is the expected operator. The reason is: PROCTIME type is materialized to Timestamp type in RelTimeIndicatorConverter. The solution is: returns original call when meeting PROCTIME instead of PROCTIME_MATERIALIZE in RelTimeIndicatorConverter#RexTimeIndicatorMaterializer.*


## Brief change log

  - *return original call when meeting PROCTIME instead of PROCTIME_MATERIALIZE in RelTimeIndicatorConverter#RexTimeIndicatorMaterializer*
  - *add related tests*


## Verifying this change


This change added tests and can be verified as follows:

  - *Added related tests to verify the fix*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no)**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no)**
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no)**
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
