### PR TITLE
[FLINK-14913][table] refactor CatalogFunction to remove properties

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -970,8 +970,8 @@ public class HiveCatalog extends AbstractCatalog {
 
 		try {
 			CatalogFunction existingFunction = getFunction(functionPath);
-			boolean existingType = Boolean.valueOf(existingFunction.getProperties().get(CatalogConfig.IS_GENERIC));
-			boolean newType = Boolean.valueOf(newFunction.getProperties().get(CatalogConfig.IS_GENERIC));
+			boolean existingType = existingFunction.isGeneric();
+			boolean newType = newFunction.isGeneric();
 			if (existingType != newType) {
 				throw new CatalogException(
 					String.format("Function types don't match. Existing function %s generic, and new function %s generic.",
@@ -1045,20 +1045,9 @@ public class HiveCatalog extends AbstractCatalog {
 			Function function = client.getFunction(functionPath.getDatabaseName(), functionPath.getObjectName());
 
 			if (function.getClassName().startsWith(FLINK_FUNCTION_PREFIX)) {
-
-				return new CatalogFunctionImpl(
-					function.getClassName().substring(FLINK_FUNCTION_PREFIX.length()),
-					new HashMap<String, String>() {{
-						put(CatalogConfig.IS_GENERIC, String.valueOf(true));
-					}}
-				);
+				return new CatalogFunctionImpl(function.getClassName().substring(FLINK_FUNCTION_PREFIX.length()));
 			} else {
-				return new CatalogFunctionImpl(
-					function.getClassName(),
-					new HashMap<String, String>() {{
-						put(CatalogConfig.IS_GENERIC, String.valueOf(false));
-					}}
-				);
+				return new CatalogFunctionImpl(function.getClassName(), false);
 			}
 		} catch (NoSuchObjectException e) {
 			throw new FunctionNotExistException(getName(), functionPath, e);
@@ -1084,7 +1073,7 @@ public class HiveCatalog extends AbstractCatalog {
 
 	private static Function instantiateHiveFunction(ObjectPath functionPath, CatalogFunction function) {
 
-		boolean isGeneric = Boolean.valueOf(function.getProperties().get(CatalogConfig.IS_GENERIC));
+		boolean isGeneric = function.isGeneric();
 
 		// Hive Function does not have properties map
 		// thus, use a prefix in class name to distinguish Flink and Hive functions

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -1047,7 +1047,7 @@ public class HiveCatalog extends AbstractCatalog {
 			if (function.getClassName().startsWith(FLINK_FUNCTION_PREFIX)) {
 				return new CatalogFunctionImpl(function.getClassName().substring(FLINK_FUNCTION_PREFIX.length()));
 			} else {
-				return new CatalogFunctionImpl(function.getClassName(), false);
+				return new CatalogFunctionImpl(function.getClassName());
 			}
 		} catch (NoSuchObjectException e) {
 			throw new FunctionNotExistException(getName(), functionPath, e);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/factories/HiveFunctionDefinitionFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/factories/HiveFunctionDefinitionFactory.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.java.typeutils.GenericTypeInfo;
 import org.apache.flink.connectors.hive.HiveTableFactory;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.CatalogFunction;
-import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.catalog.hive.client.HiveShim;
 import org.apache.flink.table.factories.FunctionDefinitionFactory;
 import org.apache.flink.table.functions.AggregateFunctionDefinition;
@@ -63,7 +62,7 @@ public class HiveFunctionDefinitionFactory implements FunctionDefinitionFactory 
 
 	@Override
 	public FunctionDefinition createFunctionDefinition(String name, CatalogFunction catalogFunction) {
-		if (Boolean.valueOf(catalogFunction.getProperties().get(CatalogConfig.IS_GENERIC))) {
+		if (catalogFunction.isGeneric()) {
 			return FunctionDefinitionUtil.createFunctionDefinition(name, catalogFunction);
 		}
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTestBase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTestBase.java
@@ -18,8 +18,12 @@
 
 package org.apache.flink.table.catalog.hive;
 
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.CatalogFunctionImpl;
 import org.apache.flink.table.catalog.CatalogTestBase;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.functions.hive.HiveGenericUDF;
+import org.apache.flink.table.functions.hive.HiveSimpleUDF;
 
 import org.junit.Assume;
 import org.junit.Test;
@@ -52,5 +56,15 @@ public abstract class HiveCatalogTestBase extends CatalogTestBase {
 		catalog.getFunction(functionPath);
 
 		catalog.dropFunction(functionPath, false);
+	}
+
+	@Override
+	protected CatalogFunction createFunction() {
+		return new CatalogFunctionImpl(HiveSimpleUDF.class.getCanonicalName());
+	}
+
+	@Override
+	protected CatalogFunction createAnotherFunction() {
+		return new CatalogFunctionImpl(HiveGenericUDF.class.getCanonicalName());
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogUseBlinkITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogUseBlinkITCase.java
@@ -64,7 +64,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -131,19 +130,19 @@ public class HiveCatalogUseBlinkITCase extends AbstractTestBase {
 
 		hiveCatalog.createFunction(
 				new ObjectPath(HiveCatalog.DEFAULT_DB, "myudf"),
-				new CatalogFunctionImpl(TestHiveSimpleUDF.class.getCanonicalName(), new HashMap<>()),
+				new CatalogFunctionImpl(TestHiveSimpleUDF.class.getCanonicalName(), false),
 				false);
 		hiveCatalog.createFunction(
 				new ObjectPath(HiveCatalog.DEFAULT_DB, "mygenericudf"),
-				new CatalogFunctionImpl(TestHiveGenericUDF.class.getCanonicalName(), new HashMap<>()),
+				new CatalogFunctionImpl(TestHiveGenericUDF.class.getCanonicalName(), false),
 				false);
 		hiveCatalog.createFunction(
 				new ObjectPath(HiveCatalog.DEFAULT_DB, "myudtf"),
-				new CatalogFunctionImpl(TestHiveUDTF.class.getCanonicalName(), new HashMap<>()),
+				new CatalogFunctionImpl(TestHiveUDTF.class.getCanonicalName(), false),
 				false);
 		hiveCatalog.createFunction(
 				new ObjectPath(HiveCatalog.DEFAULT_DB, "myudaf"),
-				new CatalogFunctionImpl(GenericUDAFSum.class.getCanonicalName(), new HashMap<>()),
+				new CatalogFunctionImpl(GenericUDAFSum.class.getCanonicalName(), false),
 				false);
 
 		testUdf(true);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogUseBlinkITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogUseBlinkITCase.java
@@ -130,19 +130,19 @@ public class HiveCatalogUseBlinkITCase extends AbstractTestBase {
 
 		hiveCatalog.createFunction(
 				new ObjectPath(HiveCatalog.DEFAULT_DB, "myudf"),
-				new CatalogFunctionImpl(TestHiveSimpleUDF.class.getCanonicalName(), false),
+				new CatalogFunctionImpl(TestHiveSimpleUDF.class.getCanonicalName()),
 				false);
 		hiveCatalog.createFunction(
 				new ObjectPath(HiveCatalog.DEFAULT_DB, "mygenericudf"),
-				new CatalogFunctionImpl(TestHiveGenericUDF.class.getCanonicalName(), false),
+				new CatalogFunctionImpl(TestHiveGenericUDF.class.getCanonicalName()),
 				false);
 		hiveCatalog.createFunction(
 				new ObjectPath(HiveCatalog.DEFAULT_DB, "myudtf"),
-				new CatalogFunctionImpl(TestHiveUDTF.class.getCanonicalName(), false),
+				new CatalogFunctionImpl(TestHiveUDTF.class.getCanonicalName()),
 				false);
 		hiveCatalog.createFunction(
 				new ObjectPath(HiveCatalog.DEFAULT_DB, "myudaf"),
-				new CatalogFunctionImpl(GenericUDAFSum.class.getCanonicalName(), false),
+				new CatalogFunctionImpl(GenericUDAFSum.class.getCanonicalName()),
 				false);
 
 		testUdf(true);

--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -757,14 +757,6 @@ class CatalogFunction(object):
         """
         return self._j_catalog_function.getClassName()
 
-    def get_properties(self):
-        """
-        Get the properties of the function.
-
-        :return: The properties of the function.
-        """
-        return dict(self._j_catalog_function.getProperties())
-
     def copy(self):
         """
         Create a deep copy of the function.
@@ -796,6 +788,14 @@ class CatalogFunction(object):
             return detailed_description.get()
         else:
             return None
+
+    def is_generic(self):
+        """
+        Whether or not is the function a flink UDF.
+
+        :return: Whether is the function a flink UDF.
+        """
+        return self._j_catalog_function.isGeneric()
 
 
 class ObjectPath(object):

--- a/flink-python/pyflink/table/tests/test_catalog.py
+++ b/flink-python/pyflink/table/tests/test_catalog.py
@@ -67,7 +67,7 @@ class CatalogTestBase(PyFlinkTestCase):
 
     def check_catalog_function_equals(self, f1, f2):
         self.assertEqual(f1.get_class_name(), f2.get_class_name())
-        self.assertEqual(f1.get_properties(), f2.get_properties())
+        self.assertEqual(f1.is_generic(), f2.is_generic())
 
     def check_catalog_partition_equals(self, p1, p2):
         self.assertEqual(p1.get_properties(), p2.get_properties())
@@ -178,13 +178,13 @@ class CatalogTestBase(PyFlinkTestCase):
     @staticmethod
     def create_function():
         gateway = get_gateway()
-        j_function = gateway.jvm.CatalogFunctionImpl("MyFunction", {})
+        j_function = gateway.jvm.CatalogFunctionImpl("MyFunction")
         return CatalogFunction(j_function)
 
     @staticmethod
     def create_another_function():
         gateway = get_gateway()
-        j_function = gateway.jvm.CatalogFunctionImpl("MyAnotherFunction", {})
+        j_function = gateway.jvm.CatalogFunctionImpl("MyAnotherFunction")
         return CatalogFunction(j_function)
 
     @staticmethod

--- a/flink-python/pyflink/table/tests/test_catalog.py
+++ b/flink-python/pyflink/table/tests/test_catalog.py
@@ -178,13 +178,15 @@ class CatalogTestBase(PyFlinkTestCase):
     @staticmethod
     def create_function():
         gateway = get_gateway()
-        j_function = gateway.jvm.CatalogFunctionImpl("MyFunction")
+        j_function = gateway.jvm.CatalogFunctionImpl(
+            "org.apache.flink.table.functions.python.SimplePythonFunction")
         return CatalogFunction(j_function)
 
     @staticmethod
     def create_another_function():
         gateway = get_gateway()
-        j_function = gateway.jvm.CatalogFunctionImpl("MyAnotherFunction")
+        j_function = gateway.jvm.CatalogFunctionImpl(
+            "org.apache.flink.table.functions.ScalarFunction")
         return CatalogFunction(j_function)
 
     @staticmethod

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogFunctionImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogFunctionImpl.java
@@ -20,25 +20,25 @@ package org.apache.flink.table.catalog;
 
 import org.apache.flink.util.StringUtils;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
-import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A catalog function implementation.
  */
 public class CatalogFunctionImpl implements CatalogFunction {
 	private final String className; // Fully qualified class name of the function
-	private final Map<String, String> properties;
+	private final boolean isGeneric;
 
-	public CatalogFunctionImpl(String className, Map<String, String> properties) {
+	public CatalogFunctionImpl(String className) {
+		this(className, true);
+	}
+
+	public CatalogFunctionImpl(String className, boolean isGeneric) {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(className), "className cannot be null or empty");
-
 		this.className = className;
-		this.properties = checkNotNull(properties, "properties cannot be null");
+		this.isGeneric = isGeneric;
 	}
 
 	@Override
@@ -47,13 +47,8 @@ public class CatalogFunctionImpl implements CatalogFunction {
 	}
 
 	@Override
-	public Map<String, String> getProperties() {
-		return this.properties;
-	}
-
-	@Override
 	public CatalogFunction copy() {
-		return new CatalogFunctionImpl(getClassName(), new HashMap<>(getProperties()));
+		return new CatalogFunctionImpl(getClassName(), isGeneric);
 	}
 
 	@Override
@@ -67,10 +62,15 @@ public class CatalogFunctionImpl implements CatalogFunction {
 	}
 
 	@Override
+	public boolean isGeneric() {
+		return isGeneric;
+	}
+
+	@Override
 	public String toString() {
 		return "CatalogFunctionImpl{" +
-			", className='" + getClassName() + '\'' +
-			", properties=" + getProperties() +
-			'}';
+			"className='" + getClassName() +
+			", isGeneric='" + isGeneric +
+			"'}";
 	}
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
@@ -124,7 +124,7 @@ public abstract class CatalogTestBase extends CatalogTest {
 	protected CatalogFunction createFunction() {
 		return new CatalogFunctionImpl(
 			"test.class.name",
-			getGenericFlag(isGeneric())
+			isGeneric()
 		);
 	}
 
@@ -132,7 +132,7 @@ public abstract class CatalogTestBase extends CatalogTest {
 	protected CatalogFunction createAnotherFunction() {
 		return new CatalogFunctionImpl(
 			"test.another.class.name",
-			getGenericFlag(isGeneric())
+			isGeneric()
 		);
 	}
 

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
@@ -120,22 +120,6 @@ public abstract class CatalogTestBase extends CatalogTest {
 			"This is another view");
 	}
 
-	@Override
-	protected CatalogFunction createFunction() {
-		return new CatalogFunctionImpl(
-			"test.class.name",
-			isGeneric()
-		);
-	}
-
-	@Override
-	protected CatalogFunction createAnotherFunction() {
-		return new CatalogFunctionImpl(
-			"test.another.class.name",
-			isGeneric()
-		);
-	}
-
 	protected Map<String, String> getBatchTableProperties() {
 		return new HashMap<String, String>() {{
 			put(IS_STREAMING, "false");

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/FunctionCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/FunctionCatalogTest.java
@@ -91,7 +91,7 @@ public class FunctionCatalogTest {
 		// test catalog function is found
 		catalog.createFunction(
 			oi.toObjectPath(),
-			new CatalogFunctionImpl(TestFunction1.class.getName(), Collections.emptyMap()), false);
+			new CatalogFunctionImpl(TestFunction1.class.getName()), false);
 
 		FunctionLookup.Result result = functionCatalog.lookupFunction(identifier).get();
 
@@ -125,7 +125,7 @@ public class FunctionCatalogTest {
 		// test catalog function is found
 		catalog.createFunction(
 			oi.toObjectPath(),
-			new CatalogFunctionImpl(TestFunction1.class.getName(), Collections.emptyMap()), false);
+			new CatalogFunctionImpl(TestFunction1.class.getName()), false);
 
 		FunctionLookup.Result result = functionCatalog.lookupFunction(UnresolvedIdentifier.of(TEST_FUNCTION_NAME)).get();
 

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
@@ -28,6 +28,8 @@ import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataLong;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataString;
 import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
 import org.apache.flink.table.catalog.stats.Date;
+import org.apache.flink.table.functions.TestGenericUDF;
+import org.apache.flink.table.functions.TestSimpleUDF;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -151,5 +153,15 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 		colStatsMap.put("dd5", doubleColStats);
 		colStatsMap.put("bb6", binaryColStats);
 		return new CatalogColumnStatistics(colStatsMap);
+	}
+
+	@Override
+	protected CatalogFunction createFunction() {
+		return new CatalogFunctionImpl(TestGenericUDF.class.getCanonicalName());
+	}
+
+	@Override
+	protected CatalogFunction createAnotherFunction() {
+		return new CatalogFunctionImpl(TestSimpleUDF.class.getCanonicalName());
 	}
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/functions/FunctionDefinitionUtilTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/functions/FunctionDefinitionUtilTest.java
@@ -23,8 +23,6 @@ import org.apache.flink.table.catalog.CatalogFunctionImpl;
 
 import org.junit.Test;
 
-import java.util.Collections;
-
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -35,7 +33,7 @@ public class FunctionDefinitionUtilTest {
 	public void testScalarFunction() {
 		FunctionDefinition fd = FunctionDefinitionUtil.createFunctionDefinition(
 			"test",
-				new CatalogFunctionImpl(TestScalarFunction.class.getName(), Collections.emptyMap())
+				new CatalogFunctionImpl(TestScalarFunction.class.getName())
 		);
 
 		assertTrue(((ScalarFunctionDefinition) fd).getScalarFunction() instanceof TestScalarFunction);
@@ -45,7 +43,7 @@ public class FunctionDefinitionUtilTest {
 	public void testTableFunction() {
 		FunctionDefinition fd = FunctionDefinitionUtil.createFunctionDefinition(
 			"test",
-			new CatalogFunctionImpl(TestTableFunction.class.getName(), Collections.emptyMap())
+			new CatalogFunctionImpl(TestTableFunction.class.getName())
 		);
 
 		assertTrue(((TableFunctionDefinition) fd).getTableFunction() instanceof TestTableFunction);
@@ -55,7 +53,7 @@ public class FunctionDefinitionUtilTest {
 	public void testAggregateFunction() {
 		FunctionDefinition fd = FunctionDefinitionUtil.createFunctionDefinition(
 			"test",
-			new CatalogFunctionImpl(TestAggFunction.class.getName(), Collections.emptyMap())
+			new CatalogFunctionImpl(TestAggFunction.class.getName())
 		);
 
 		assertTrue(((AggregateFunctionDefinition) fd).getAggregateFunction() instanceof TestAggFunction);
@@ -65,7 +63,7 @@ public class FunctionDefinitionUtilTest {
 	public void testTableAggregateFunction() {
 		FunctionDefinition fd = FunctionDefinitionUtil.createFunctionDefinition(
 			"test",
-			new CatalogFunctionImpl(TestTableAggFunction.class.getName(), Collections.emptyMap())
+			new CatalogFunctionImpl(TestTableAggFunction.class.getName())
 		);
 
 		assertTrue(((TableAggregateFunctionDefinition) fd).getTableAggregateFunction() instanceof TestTableAggFunction);

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/functions/TestGenericUDF.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/functions/TestGenericUDF.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions;
+
+import java.util.Set;
+
+/**
+ * UDF definition for test function create, alert and drop in catalog.
+ */
+public class TestGenericUDF extends UserDefinedFunction {
+
+	@Override
+	public FunctionKind getKind() {
+		return FunctionKind.SCALAR;
+	}
+
+	@Override
+	public Set<FunctionRequirement> getRequirements() {
+		return null;
+	}
+
+	@Override
+	public boolean isDeterministic() {
+		return false;
+	}
+}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/functions/TestSimpleUDF.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/functions/TestSimpleUDF.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions;
+
+import java.util.Set;
+
+/**
+ * UDF definition for test function create, alert and drop in catalog.
+ */
+public class TestSimpleUDF extends UserDefinedFunction {
+
+	@Override
+	public FunctionKind getKind() {
+		return FunctionKind.SCALAR;
+	}
+
+	@Override
+	public Set<FunctionRequirement> getRequirements() {
+		return null;
+	}
+
+	@Override
+	public boolean isDeterministic() {
+		return false;
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogFunction.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.catalog;
 
-import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -32,13 +31,6 @@ public interface CatalogFunction {
 	 * @return the full name of the class
 	 */
 	String getClassName();
-
-	/**
-	 * Get the properties of the function.
-	 *
-	 * @return the properties of the function
-	 */
-	Map<String, String> getProperties();
 
 	/**
 	 * Create a deep copy of the function.
@@ -61,4 +53,10 @@ public interface CatalogFunction {
 	 */
 	Optional<String> getDetailedDescription();
 
+	/**
+	 * Distinguish if the function is a generic Flink function.
+	 *
+	 * @return whether the function is a generic Flink function
+	 */
+	boolean isGeneric();
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
@@ -1322,7 +1322,7 @@ public abstract class CatalogTest {
 
 	protected void checkEquals(CatalogFunction f1, CatalogFunction f2) {
 		assertEquals(f1.getClassName(), f2.getClassName());
-		assertEquals(f1.getProperties(), f2.getProperties());
+		assertEquals(f1.isGeneric(), f2.isGeneric());
 	}
 
 	protected void checkEquals(CatalogColumnStatistics cs1, CatalogColumnStatistics cs2) {

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -62,7 +62,6 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -210,8 +209,7 @@ public class SqlToOperationConverterTest {
 	@Test
 	public void testCreateTableWithWatermark() throws FunctionAlreadyExistException, DatabaseNotExistException {
 		CatalogFunction cf = new CatalogFunctionImpl(
-			JavaUserDefinedScalarFunctions.JavaFunc5.class.getName(),
-			Collections.emptyMap());
+			JavaUserDefinedScalarFunctions.JavaFunc5.class.getName());
 		catalog.createFunction(ObjectPath.fromString("default.myfunc"), cf, true);
 
 		final String sql = "create table source_table(\n" +

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
@@ -63,8 +63,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) {
     TestCollectionTableFactory.isStreaming = isStreamingMode
 
     val func = new CatalogFunctionImpl(
-      classOf[JavaFunc0].getName,
-      new util.HashMap[String, String]())
+      classOf[JavaFunc0].getName)
     tableEnv.getCatalog(tableEnv.getCurrentCatalog).get().createFunction(
       new ObjectPath(tableEnv.getCurrentDatabase, "myfunc"),
       func,


### PR DESCRIPTION


## What is the purpose of the change
Refactor CatalogFunction to remove properties


## Brief change log
  - Refactor CatalogFunction to remove properties and add generic as a flag in the interface.
  - Refactor HiveCatalog with the new interface

## Verifying this change

This change is already covered by existing tests, such as:
1) HiveCatalogHiveMetadataTest
2) CatalogManagerTest


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
