### PR TITLE
[FLINK-14930] fix FLINK_SHADING_PREFIX in OSSFileSystemFactory

### DIFF
--- a/docs/ops/filesystems/oss.md
+++ b/docs/ops/filesystems/oss.md
@@ -77,4 +77,13 @@ fs.oss.accessKeyId: Aliyun access key ID
 fs.oss.accessKeySecret: Aliyun access key secret
 {% endhighlight %}
 
+An alternative `CredentialsProvider` can also be configured in the `flink-conf.yaml`, e.g. 
+{% highlight yaml %}
+# Read Credentials from OSS_ACCESS_KEY_ID and OSS_ACCESS_KEY_SECRET
+fs.oss.credentials.provider: com.aliyun.oss.common.auth.EnvironmentVariableCredentialsProvider
+{% endhighlight %}
+Other credential providers can be found under https://github.com/aliyun/aliyun-oss-java-sdk/tree/master/src/main/java/com/aliyun/oss/common/auth. 
+
+ 
+
 {% top %}

--- a/flink-filesystems/flink-oss-fs-hadoop/src/main/java/org/apache/flink/fs/osshadoop/OSSFileSystemFactory.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/main/java/org/apache/flink/fs/osshadoop/OSSFileSystemFactory.java
@@ -45,7 +45,7 @@ public class OSSFileSystemFactory implements FileSystemFactory {
 
 	private static final Set<String> CONFIG_KEYS_TO_SHADE = Collections.singleton("fs.oss.credentials.provider");
 
-	private static final String FLINK_SHADING_PREFIX = "org.apache.flink.fs.shaded.hadoop3.";
+	private static final String FLINK_SHADING_PREFIX = "org.apache.flink.fs.osshadoop.shaded.";
 
 	/**
 	 * In order to simplify, we make flink oss configuration keys same with hadoop oss module.

--- a/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/HadoopOSSFileSystemITCase.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/HadoopOSSFileSystemITCase.java
@@ -66,7 +66,7 @@ public class HadoopOSSFileSystemITCase extends AbstractHadoopFileSystemITTest {
 		ossfsFactory.configure(conf);
 		org.apache.hadoop.conf.Configuration configuration = ossfsFactory.getHadoopConfiguration();
 		// shaded
-		assertEquals("org.apache.flink.fs.shaded.hadoop3.org.apache.hadoop.fs.aliyun.oss.AliyunCredentialsProvider",
+		assertEquals("org.apache.flink.fs.osshadoop.shaded.org.apache.hadoop.fs.aliyun.oss.AliyunCredentialsProvider",
 			configuration.get("fs.oss.credentials.provider"));
 		// should not shaded
 		assertEquals(OSSTestCredentials.getOSSEndpoint(), configuration.get("fs.oss.endpoint"));


### PR DESCRIPTION
## What is the purpose of the change

Fix the shading prefix in OSS Filesystem to enable configuration of custom CredentialsProviders

## Brief change log

  - Fix the shading prefix in OSS Filesystem to enable configuration of custom CredentialsProviders

## Verifying this change

Build Flink and Run the Job with Checkpointing to OSS with a custom CredentialsProvider: 

flink-conf.yaml

fs.oss.credentials.provider: com.aliyun.oss.common.auth.EnvironmentVariableCredentialsProvider
fs.oss.endpoint: https://oss-eu-central-1.aliyuncs.com

state.checkpoints.dir: oss:/...
state.savepoints.dir: oss://...

Environment:

export OSS_ACCESS_KEY_SECRET=...
export OSS_ACCESS_KEY_ID=....  

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation
  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?  docs 
