### PR TITLE
[FLINK-14691][table]Add use/create/drop/alter database operation and support it in flink/blink planner

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -301,10 +301,10 @@ public class HiveCatalog extends AbstractCatalog {
 	}
 
 	@Override
-	public void dropDatabase(String name, boolean ignoreIfNotExists, boolean restrict)
+	public void dropDatabase(String name, boolean ignoreIfNotExists, boolean cascade)
 			throws DatabaseNotExistException, DatabaseNotEmptyException, CatalogException {
 		try {
-			client.dropDatabase(name, true, ignoreIfNotExists, !restrict);
+			client.dropDatabase(name, true, ignoreIfNotExists, cascade);
 		} catch (NoSuchObjectException e) {
 			if (!ignoreIfNotExists) {
 				throw new DatabaseNotExistException(getName(), name);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -301,14 +301,16 @@ public class HiveCatalog extends AbstractCatalog {
 	}
 
 	@Override
+	public void dropDatabase(String name, boolean ignoreIfNotExists)
+			throws DatabaseNotExistException, DatabaseNotEmptyException, CatalogException {
+		dropDatabase(name, ignoreIfNotExists, true);
+	}
+
+	@Override
 	public void dropDatabase(String name, boolean ignoreIfNotExists, boolean isRestrict)
 			throws DatabaseNotExistException, DatabaseNotEmptyException, CatalogException {
 		try {
-			if (isRestrict) {
-				client.dropDatabase(name, true, ignoreIfNotExists);
-			} else {
-				client.dropDatabase(name, true, ignoreIfNotExists, true);
-			}
+			client.dropDatabase(name, true, ignoreIfNotExists, !isRestrict);
 		} catch (NoSuchObjectException e) {
 			if (!ignoreIfNotExists) {
 				throw new DatabaseNotExistException(getName(), name);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -301,10 +301,14 @@ public class HiveCatalog extends AbstractCatalog {
 	}
 
 	@Override
-	public void dropDatabase(String name, boolean ignoreIfNotExists) throws DatabaseNotExistException,
-			DatabaseNotEmptyException, CatalogException {
+	public void dropDatabase(String name, boolean ignoreIfNotExists, boolean isRestrict)
+			throws DatabaseNotExistException, DatabaseNotEmptyException, CatalogException {
 		try {
-			client.dropDatabase(name, true, ignoreIfNotExists);
+			if (isRestrict) {
+				client.dropDatabase(name, true, ignoreIfNotExists);
+			} else {
+				client.dropDatabase(name, true, ignoreIfNotExists, true);
+			}
 		} catch (NoSuchObjectException e) {
 			if (!ignoreIfNotExists) {
 				throw new DatabaseNotExistException(getName(), name);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -301,16 +301,10 @@ public class HiveCatalog extends AbstractCatalog {
 	}
 
 	@Override
-	public void dropDatabase(String name, boolean ignoreIfNotExists)
-			throws DatabaseNotExistException, DatabaseNotEmptyException, CatalogException {
-		dropDatabase(name, ignoreIfNotExists, true);
-	}
-
-	@Override
-	public void dropDatabase(String name, boolean ignoreIfNotExists, boolean isRestrict)
+	public void dropDatabase(String name, boolean ignoreIfNotExists, boolean restrict)
 			throws DatabaseNotExistException, DatabaseNotEmptyException, CatalogException {
 		try {
-			client.dropDatabase(name, true, ignoreIfNotExists, !isRestrict);
+			client.dropDatabase(name, true, ignoreIfNotExists, !restrict);
 		} catch (NoSuchObjectException e) {
 			if (!ignoreIfNotExists) {
 				throw new DatabaseNotExistException(getName(), name);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveMetastoreClientWrapper.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveMetastoreClientWrapper.java
@@ -149,6 +149,11 @@ public class HiveMetastoreClientWrapper implements AutoCloseable {
 		client.dropDatabase(name, deleteData, ignoreIfNotExists);
 	}
 
+	public void dropDatabase(String name, boolean deleteData, boolean ignoreIfNotExists, boolean cascade)
+			throws NoSuchObjectException, InvalidOperationException, MetaException, TException {
+		client.dropDatabase(name, deleteData, ignoreIfNotExists, cascade);
+	}
+
 	public void alterDatabase(String name, Database database) throws NoSuchObjectException, MetaException, TException {
 		client.alterDatabase(name, database);
 	}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogDataTypeTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogDataTypeTest.java
@@ -83,10 +83,10 @@ public class HiveCatalogDataTypeTest {
 			catalog.dropFunction(path1, true);
 		}
 		if (catalog.databaseExists(db1)) {
-			catalog.dropDatabase(db1, true);
+			catalog.dropDatabase(db1, true, true);
 		}
 		if (catalog.databaseExists(db2)) {
-			catalog.dropDatabase(db2, true);
+			catalog.dropDatabase(db2, true, true);
 		}
 	}
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogDataTypeTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogDataTypeTest.java
@@ -83,10 +83,10 @@ public class HiveCatalogDataTypeTest {
 			catalog.dropFunction(path1, true);
 		}
 		if (catalog.databaseExists(db1)) {
-			catalog.dropDatabase(db1, true, true);
+			catalog.dropDatabase(db1, true);
 		}
 		if (catalog.databaseExists(db2)) {
-			catalog.dropDatabase(db2, true, true);
+			catalog.dropDatabase(db2, true);
 		}
 	}
 

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -138,7 +138,7 @@ SqlDrop SqlDropDatabase(Span s, boolean replace) :
 {
     SqlIdentifier databaseName = null;
     boolean ifExists = false;
-    boolean isRestrict = true;
+    boolean cascade = false;
 }
 {
     <DATABASE>
@@ -151,13 +151,13 @@ SqlDrop SqlDropDatabase(Span s, boolean replace) :
 
     databaseName = CompoundIdentifier()
     [
-                <RESTRICT> { isRestrict = true; }
+                <RESTRICT> { cascade = false; }
         |
-                <CASCADE>  { isRestrict = false; }
+                <CASCADE>  { cascade = true; }
     ]
 
     {
-         return new SqlDropDatabase(s.pos(), databaseName, ifExists, isRestrict);
+         return new SqlDropDatabase(s.pos(), databaseName, ifExists, cascade);
     }
 }
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterDatabase.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterDatabase.java
@@ -38,7 +38,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class SqlAlterDatabase extends SqlCall {
 
-	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("ALTER DATABASE", SqlKind.OTHER);
+	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("ALTER DATABASE", SqlKind.OTHER_DDL);
 
 	private final SqlIdentifier databaseName;
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateDatabase.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateDatabase.java
@@ -45,7 +45,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class SqlCreateDatabase extends SqlCreate implements ExtendedSqlNode {
 
-	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("CREATE DATABASE", SqlKind.OTHER);
+	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("CREATE DATABASE", SqlKind.OTHER_DDL);
 
 	private final SqlIdentifier databaseName;
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropDatabase.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropDatabase.java
@@ -37,7 +37,7 @@ import java.util.List;
  */
 public class SqlDropDatabase extends SqlDrop implements ExtendedSqlNode {
 	private static final SqlOperator OPERATOR =
-		new SqlSpecialOperator("DROP DATABASE", SqlKind.OTHER);
+		new SqlSpecialOperator("DROP DATABASE", SqlKind.OTHER_DDL);
 
 	private SqlIdentifier databaseName;
 	private boolean ifExists;
@@ -62,16 +62,12 @@ public class SqlDropDatabase extends SqlDrop implements ExtendedSqlNode {
 		return databaseName;
 	}
 
-	public void setDatabaseName(SqlIdentifier viewName) {
-		this.databaseName = viewName;
-	}
-
 	public boolean getIfExists() {
 		return this.ifExists;
 	}
 
-	public void setIfExists(boolean ifExists) {
-		this.ifExists = ifExists;
+	public boolean isRestrict() {
+		return isRestrict;
 	}
 
 	@Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropDatabase.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropDatabase.java
@@ -41,16 +41,16 @@ public class SqlDropDatabase extends SqlDrop implements ExtendedSqlNode {
 
 	private final SqlIdentifier databaseName;
 	private final boolean ifExists;
-	private final boolean isRestrict;
+	private final boolean isCascade;
 
 	public SqlDropDatabase(SqlParserPos pos,
 			SqlIdentifier databaseName,
 			boolean ifExists,
-			boolean isRestrict) {
+			boolean isCascade) {
 		super(OPERATOR, pos, ifExists);
 		this.databaseName = databaseName;
 		this.ifExists = ifExists;
-		this.isRestrict = isRestrict;
+		this.isCascade = isCascade;
 	}
 
 	@Override
@@ -66,8 +66,8 @@ public class SqlDropDatabase extends SqlDrop implements ExtendedSqlNode {
 		return this.ifExists;
 	}
 
-	public boolean isRestrict() {
-		return isRestrict;
+	public boolean isCascade() {
+		return isCascade;
 	}
 
 	@Override
@@ -78,10 +78,10 @@ public class SqlDropDatabase extends SqlDrop implements ExtendedSqlNode {
 			writer.keyword("IF EXISTS");
 		}
 		databaseName.unparse(writer, leftPrec, rightPrec);
-		if (isRestrict) {
-			writer.keyword("RESTRICT");
-		} else {
+		if (isCascade) {
 			writer.keyword("CASCADE");
+		} else {
+			writer.keyword("RESTRICT");
 		}
 	}
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropDatabase.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropDatabase.java
@@ -39,9 +39,9 @@ public class SqlDropDatabase extends SqlDrop implements ExtendedSqlNode {
 	private static final SqlOperator OPERATOR =
 		new SqlSpecialOperator("DROP DATABASE", SqlKind.OTHER_DDL);
 
-	private SqlIdentifier databaseName;
-	private boolean ifExists;
-	private boolean isRestrict = true;
+	private final SqlIdentifier databaseName;
+	private final boolean ifExists;
+	private final boolean isRestrict;
 
 	public SqlDropDatabase(SqlParserPos pos,
 			SqlIdentifier databaseName,

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlUseDatabase.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlUseDatabase.java
@@ -35,13 +35,12 @@ import java.util.List;
  */
 public class SqlUseDatabase extends SqlCall {
 
-	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("USE DATABASE", SqlKind.OTHER);
+	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("USE DATABASE", SqlKind.OTHER_DDL);
 	private final SqlIdentifier databaseName;
 
 	public SqlUseDatabase(SqlParserPos pos, SqlIdentifier databaseName) {
 		super(pos);
 		this.databaseName = databaseName;
-
 	}
 
 	@Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -477,11 +477,12 @@ public class TableEnvironmentImpl implements TableEnvironment {
 				createTableOperation.isIgnoreIfExists());
 		} else if (operation instanceof CreateDatabaseOperation) {
 			CreateDatabaseOperation createDatabaseOperation = (CreateDatabaseOperation) operation;
-			catalogManager.createDatabase(createDatabaseOperation.getCatalogName(),
-										createDatabaseOperation.getDatabaseName(),
-										createDatabaseOperation.getCatalogDatabase(),
-										createDatabaseOperation.isIgnoreIfExists(),
-										false);
+			catalogManager.createDatabase(
+					createDatabaseOperation.getCatalogName(),
+					createDatabaseOperation.getDatabaseName(),
+					createDatabaseOperation.getCatalogDatabase(),
+					createDatabaseOperation.isIgnoreIfExists(),
+					false);
 		} else if (operation instanceof DropTableOperation) {
 			DropTableOperation dropTableOperation = (DropTableOperation) operation;
 			catalogManager.dropTable(

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -506,7 +506,7 @@ public class TableEnvironmentImpl implements TableEnvironment {
 				catalog.dropDatabase(
 						dropDatabaseOperation.getDatabaseName(),
 						dropDatabaseOperation.isIfExists(),
-						dropDatabaseOperation.isRestrict());
+						dropDatabaseOperation.isCascade());
 			} catch (DatabaseNotExistException | DatabaseNotEmptyException e) {
 				throw new ValidationException(exMsg, e);
 			} catch (Exception e) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -63,6 +63,7 @@ import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.UseOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
+import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
 import org.apache.flink.table.operations.ddl.DropTableOperation;
 import org.apache.flink.table.operations.utils.OperationTreeBuilder;
 import org.apache.flink.table.sinks.TableSink;
@@ -484,6 +485,14 @@ public class TableEnvironmentImpl implements TableEnvironment {
 			catalogManager.dropTable(
 				dropTableOperation.getTableIdentifier(),
 				dropTableOperation.isIfExists());
+		} else if (operation instanceof DropDatabaseOperation) {
+			DropDatabaseOperation dropDatabaseOperation = (DropDatabaseOperation) operation;
+			catalogManager.dropDatabase(
+					dropDatabaseOperation.getCatalogName(),
+					dropDatabaseOperation.getDatabaseName(),
+					dropDatabaseOperation.isIfExists(),
+					dropDatabaseOperation.isRestrict(),
+					false);
 		} else if (operation instanceof UseOperation) {
 			applyUseOperation((UseOperation) operation);
 		} else {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -61,6 +61,7 @@ import org.apache.flink.table.operations.TableSourceQueryOperation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.UseOperation;
+import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
@@ -455,7 +456,8 @@ public class TableEnvironmentImpl implements TableEnvironment {
 		if (operations.size() != 1) {
 			throw new TableException(
 				"Unsupported SQL query! sqlUpdate() only accepts a single SQL statement of type " +
-					"INSERT, CREATE TABLE, DROP TABLE, USE CATALOG, USE [catalog.]database, CREATE DATABASE");
+					"INSERT, CREATE TABLE, DROP TABLE, USE CATALOG, USE [catalog.]database, " +
+					"CREATE DATABASE, DROP DATABASE, ALTER DATABASE");
 		}
 
 		Operation operation = operations.get(0);
@@ -493,12 +495,20 @@ public class TableEnvironmentImpl implements TableEnvironment {
 					dropDatabaseOperation.isIfExists(),
 					dropDatabaseOperation.isRestrict(),
 					false);
+		} else if (operation instanceof AlterDatabaseOperation) {
+			AlterDatabaseOperation alterDatabaseOperation = (AlterDatabaseOperation) operation;
+			catalogManager.alterDatabase(
+					alterDatabaseOperation.getCatalogName(),
+					alterDatabaseOperation.getDatabaseName(),
+					alterDatabaseOperation.getCatalogDatabase(),
+					false);
 		} else if (operation instanceof UseOperation) {
 			applyUseOperation((UseOperation) operation);
 		} else {
 			throw new TableException(
 				"Unsupported SQL query! sqlUpdate() only accepts a single SQL statements of " +
-					"type INSERT, CREATE TABLE, DROP TABLE, USE CATALOG, USE [catalog.]database, CREATE DATABASE");
+					"type INSERT, CREATE TABLE, DROP TABLE, USE CATALOG, USE [catalog.]database, " +
+					"CREATE DATABASE, DROP DATABASE, ALTER DATABASE");
 		}
 	}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -61,6 +61,7 @@ import org.apache.flink.table.operations.TableSourceQueryOperation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.UseOperation;
+import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.DropTableOperation;
 import org.apache.flink.table.operations.utils.OperationTreeBuilder;
@@ -453,7 +454,7 @@ public class TableEnvironmentImpl implements TableEnvironment {
 		if (operations.size() != 1) {
 			throw new TableException(
 				"Unsupported SQL query! sqlUpdate() only accepts a single SQL statement of type " +
-					"INSERT, CREATE TABLE, DROP TABLE, USE CATALOG, USE [catalog.]database");
+					"INSERT, CREATE TABLE, DROP TABLE, USE CATALOG, USE [catalog.]database, CREATE DATABASE");
 		}
 
 		Operation operation = operations.get(0);
@@ -471,6 +472,13 @@ public class TableEnvironmentImpl implements TableEnvironment {
 				createTableOperation.getCatalogTable(),
 				createTableOperation.getTableIdentifier(),
 				createTableOperation.isIgnoreIfExists());
+		} else if (operation instanceof CreateDatabaseOperation) {
+			CreateDatabaseOperation createDatabaseOperation = (CreateDatabaseOperation) operation;
+			catalogManager.createDatabase(createDatabaseOperation.getCatalogName(),
+										createDatabaseOperation.getDatabaseName(),
+										createDatabaseOperation.getCatalogDatabase(),
+										createDatabaseOperation.isIgnoreIfExists(),
+										false);
 		} else if (operation instanceof DropTableOperation) {
 			DropTableOperation dropTableOperation = (DropTableOperation) operation;
 			catalogManager.dropTable(
@@ -481,7 +489,7 @@ public class TableEnvironmentImpl implements TableEnvironment {
 		} else {
 			throw new TableException(
 				"Unsupported SQL query! sqlUpdate() only accepts a single SQL statements of " +
-					"type INSERT, CREATE TABLE, DROP TABLE, USE CATALOG, USE [catalog.]database");
+					"type INSERT, CREATE TABLE, DROP TABLE, USE CATALOG, USE [catalog.]database, CREATE DATABASE");
 		}
 	}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -481,11 +481,8 @@ public class TableEnvironmentImpl implements TableEnvironment {
 				createTableOperation.isIgnoreIfExists());
 		} else if (operation instanceof CreateDatabaseOperation) {
 			CreateDatabaseOperation createDatabaseOperation = (CreateDatabaseOperation) operation;
-			Catalog catalog = getCatalog(createDatabaseOperation.getCatalogName())
-					.orElseThrow(() -> new ValidationException(
-							String.format("Catalog %s does not exist.", createDatabaseOperation.getCatalogName())));
-			String exMsg = String.format("Could not execute %s in path %s", "CREATE DATABASE",
-										createDatabaseOperation.getCatalogName());
+			Catalog catalog = getCatalogOrThrowException(createDatabaseOperation.getCatalogName());
+			String exMsg = getDDLOpExecuteErrorMsg("CREATE DATABASE", createDatabaseOperation.getCatalogName());
 			try {
 				catalog.createDatabase(
 						createDatabaseOperation.getDatabaseName(),
@@ -503,11 +500,8 @@ public class TableEnvironmentImpl implements TableEnvironment {
 				dropTableOperation.isIfExists());
 		} else if (operation instanceof DropDatabaseOperation) {
 			DropDatabaseOperation dropDatabaseOperation = (DropDatabaseOperation) operation;
-			Catalog catalog = getCatalog(dropDatabaseOperation.getCatalogName())
-					.orElseThrow(() -> new ValidationException(
-							String.format("Catalog %s does not exist.", dropDatabaseOperation.getCatalogName())));
-			String exMsg = String.format("Could not execute %s in path %s", "DROP DATABASE",
-										dropDatabaseOperation.getCatalogName());
+			Catalog catalog = getCatalogOrThrowException(dropDatabaseOperation.getCatalogName());
+			String exMsg = getDDLOpExecuteErrorMsg("DROP DATABASE", dropDatabaseOperation.getCatalogName());
 			try {
 				catalog.dropDatabase(
 						dropDatabaseOperation.getDatabaseName(),
@@ -520,11 +514,8 @@ public class TableEnvironmentImpl implements TableEnvironment {
 			}
 		} else if (operation instanceof AlterDatabaseOperation) {
 			AlterDatabaseOperation alterDatabaseOperation = (AlterDatabaseOperation) operation;
-			Catalog catalog = getCatalog(alterDatabaseOperation.getCatalogName())
-					.orElseThrow(() -> new ValidationException(
-							String.format("Catalog %s does not exist.", alterDatabaseOperation.getCatalogName())));
-			String exMsg = String.format("Could not execute %s in path %s", "ALTER DATABASE",
-										alterDatabaseOperation.getCatalogName());
+			Catalog catalog = getCatalogOrThrowException(alterDatabaseOperation.getCatalogName());
+			String exMsg = getDDLOpExecuteErrorMsg("ALTER DATABASE", alterDatabaseOperation.getCatalogName());
 			try {
 				catalog.alterDatabase(
 						alterDatabaseOperation.getDatabaseName(),
@@ -554,6 +545,16 @@ public class TableEnvironmentImpl implements TableEnvironment {
 		} else {
 			throw new TableException(UNSUPPORTED_QUERY_IN_SQL_UPDATE_MSG);
 		}
+	}
+
+	/** Get catalog from catalogName or throw a ValidationException if the catalog not exists. */
+	private Catalog getCatalogOrThrowException(String catalogName) {
+		return getCatalog(catalogName)
+				.orElseThrow(() -> new ValidationException(String.format("Catalog %s does not exist.", catalogName)));
+	}
+
+	private String getDDLOpExecuteErrorMsg(String action, String path) {
+		return String.format("Could not execute %s in path %s", action, path);
 	}
 
 	@Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -63,7 +63,6 @@ import org.apache.flink.table.operations.QueryOperation;
 import org.apache.flink.table.operations.TableSourceQueryOperation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
-import org.apache.flink.table.operations.UseOperation;
 import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
@@ -526,15 +525,13 @@ public class TableEnvironmentImpl implements TableEnvironment {
 			} catch (Exception e) {
 				throw new TableException(exMsg, e);
 			}
-		} else if (operation instanceof UseOperation) {
-			if (operation instanceof UseCatalogOperation) {
-				UseCatalogOperation useCatalogOperation = (UseCatalogOperation) operation;
-				catalogManager.setCurrentCatalog(useCatalogOperation.getCatalogName());
-			} else if (operation instanceof UseDatabaseOperation) {
-				UseDatabaseOperation useDatabaseOperation = (UseDatabaseOperation) operation;
-				catalogManager.setCurrentCatalog(useDatabaseOperation.getCatalogName());
-				catalogManager.setCurrentDatabase(useDatabaseOperation.getDatabaseName());
-			}
+		} else if (operation instanceof UseCatalogOperation) {
+			UseCatalogOperation useCatalogOperation = (UseCatalogOperation) operation;
+			catalogManager.setCurrentCatalog(useCatalogOperation.getCatalogName());
+		} else if (operation instanceof UseDatabaseOperation) {
+			UseDatabaseOperation useDatabaseOperation = (UseDatabaseOperation) operation;
+			catalogManager.setCurrentCatalog(useDatabaseOperation.getCatalogName());
+			catalogManager.setCurrentDatabase(useDatabaseOperation.getDatabaseName());
 		} else {
 			throw new TableException(UNSUPPORTED_QUERY_IN_SQL_UPDATE_MSG);
 		}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -519,13 +519,8 @@ public class TableEnvironmentImpl implements TableEnvironment {
 			catalogManager.setCurrentCatalog(useCatalogOperation.getCatalogName());
 		} else if (operation instanceof UseDatabaseOperation) {
 			UseDatabaseOperation useDatabaseOperation = (UseDatabaseOperation) operation;
-			String[] fullDatabaseName = useDatabaseOperation.getFullDatabaseName();
-			if (fullDatabaseName.length == 2) {
-				catalogManager.setCurrentCatalog(fullDatabaseName[0]);
-				catalogManager.setCurrentDatabase(fullDatabaseName[1]);
-			} else {
-				catalogManager.setCurrentDatabase(fullDatabaseName[0]);
-			}
+			catalogManager.setCurrentCatalog(useDatabaseOperation.getCatalogName());
+			catalogManager.setCurrentDatabase(useDatabaseOperation.getDatabaseName());
 		}
 	}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -511,7 +511,38 @@ public class CatalogManager {
 		} else if (!ignoreNoCatalog) {
 			throw new ValidationException(String.format("Catalog %s does not exist.", catalogName));
 		}
+	}
 
+	/**
+	 * Drop a database in a given path.
+	 * @param catalogName
+	 * @param databaseName
+	 * @param catalogDatabase new catalogDatabase.
+	 */
+	public void alterDatabase(String catalogName,
+							String databaseName,
+							CatalogDatabase catalogDatabase,
+							boolean ignoreNoCatalog) {
+		Optional<Catalog> catalog = getCatalog(catalogName);
+		if (catalog.isPresent()) {
+			try {
+				CatalogDatabase originDatabase = catalog.get().getDatabase(databaseName);
+				Map<String, String> properties = new HashMap<>(originDatabase.getProperties());
+				properties.putAll(catalogDatabase.getProperties());
+				catalog.get().alterDatabase(
+						databaseName,
+						new CatalogDatabaseImpl(properties, originDatabase.getComment()),
+						false);
+			} catch (DatabaseNotExistException e) {
+				throw new ValidationException(
+						String.format("Could not execute %s in path %s", "ALTER DATABASE", catalogName), e);
+			} catch (Exception e) {
+				throw new TableException(
+						String.format("Could not execute %s in path %s", "ALTER DATABASE", catalogName), e);
+			}
+		} else if (!ignoreNoCatalog) {
+			throw new ValidationException(String.format("Catalog %s does not exist.", catalogName));
+		}
 	}
 
 	/**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -23,8 +23,6 @@ import org.apache.flink.table.api.CatalogNotExistException;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
-import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
-import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
@@ -455,93 +453,6 @@ public class CatalogManager {
 			objectIdentifier,
 			false,
 			"CreateTable");
-	}
-
-	/**
-	 * Creates a database in a given fully qualified path.
-	 *
-	 * @param catalogName The catalog where database will be created.S
-	 * @param databaseName Name of database to be created.
-	 * @param database The database to be created.
-	 * @param ignoreIfExists If false exception will be thrown if a database exists in the given path.
-	 */
-	public void createDatabase(String catalogName,
-					String databaseName,
-					CatalogDatabase database,
-					boolean ignoreIfExists,
-					boolean ignoreNoCatalog) {
-		Optional<Catalog> catalog = getCatalog(catalogName);
-		if (catalog.isPresent()) {
-			try {
-				catalog.get().createDatabase(databaseName, database, ignoreIfExists);
-			} catch (DatabaseAlreadyExistException e) {
-				throw new ValidationException(
-						String.format("Could not execute %s in path %s", "CREATE DATABASE", catalogName), e);
-			} catch (Exception e) {
-				throw new TableException(
-						String.format("Could not execute %s in path %s", "CREATE DATABASE", catalogName), e);
-			}
-		} else if (!ignoreNoCatalog) {
-			throw new ValidationException(String.format("Catalog %s does not exist.", catalogName));
-		}
-	}
-
-	/**
-	 * Drop a database in a given path.
-	 *
-	 * @param catalogName        The catalog where database will be deleted.
-	 * @param databaseName       Name of database to be deleted.
-	 * @param ignoreIfNotExists  If false exception will be thrown if a database not exists in the given path.
-	 * @param isRestrict         Flag to specify behavior when the database contains table:
-	 *                              if set to false, delete all tables in the database and then delete the database,
-	 *                              if set to true, throw an exception.
-	 */
-	public void dropDatabase(String catalogName,
-					String databaseName,
-					boolean ignoreIfNotExists,
-					boolean isRestrict,
-					boolean ignoreNoCatalog) {
-		Optional<Catalog> catalog = getCatalog(catalogName);
-		if (catalog.isPresent()) {
-			try {
-				catalog.get().dropDatabase(databaseName, ignoreIfNotExists, isRestrict);
-			} catch (DatabaseNotExistException | DatabaseNotEmptyException e) {
-				throw new ValidationException(
-						String.format("Could not execute %s in path %s", "DROP DATABASE", catalogName), e);
-			} catch (Exception e) {
-				throw new TableException(
-						String.format("Could not execute %s in path %s", "DROP DATABASE", catalogName), e);
-			}
-		} else if (!ignoreNoCatalog) {
-			throw new ValidationException(String.format("Catalog %s does not exist.", catalogName));
-		}
-	}
-
-	/**
-	 * Alter a database in a given path.
-	 *
-	 * @param catalogName     The catalog where database will be deleted.
-	 * @param databaseName    Name of database to be deleted.
-	 * @param catalogDatabase New catalogDatabase.
-	 */
-	public void alterDatabase(String catalogName,
-							String databaseName,
-							CatalogDatabase catalogDatabase,
-							boolean ignoreNoCatalog) {
-		Optional<Catalog> catalog = getCatalog(catalogName);
-		if (catalog.isPresent()) {
-			try {
-				catalog.get().alterDatabase(databaseName, catalogDatabase, false);
-			} catch (DatabaseNotExistException e) {
-				throw new ValidationException(
-						String.format("Could not execute %s in path %s", "ALTER DATABASE", catalogName), e);
-			} catch (Exception e) {
-				throw new TableException(
-						String.format("Could not execute %s in path %s", "ALTER DATABASE", catalogName), e);
-			}
-		} else if (!ignoreNoCatalog) {
-			throw new ValidationException(String.format("Catalog %s does not exist.", catalogName));
-		}
 	}
 
 	/**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -531,13 +531,7 @@ public class CatalogManager {
 		Optional<Catalog> catalog = getCatalog(catalogName);
 		if (catalog.isPresent()) {
 			try {
-				CatalogDatabase originDatabase = catalog.get().getDatabase(databaseName);
-				Map<String, String> properties = new HashMap<>(originDatabase.getProperties());
-				properties.putAll(catalogDatabase.getProperties());
-				catalog.get().alterDatabase(
-						databaseName,
-						new CatalogDatabaseImpl(properties, originDatabase.getComment()),
-						false);
+				catalog.get().alterDatabase(databaseName, catalogDatabase, false);
 			} catch (DatabaseNotExistException e) {
 				throw new ValidationException(
 						String.format("Could not execute %s in path %s", "ALTER DATABASE", catalogName), e);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -459,9 +459,10 @@ public class CatalogManager {
 
 	/**
 	 * Creates a database in a given fully qualified path.
-	 * @param catalogName
-	 * @param databaseName
-	 * @param database
+	 *
+	 * @param catalogName The catalog where database will be created.S
+	 * @param databaseName Name of database to be created.
+	 * @param database The database to be created.
 	 * @param ignoreIfExists If false exception will be thrown if a database exists in the given path.
 	 */
 	public void createDatabase(String catalogName,
@@ -487,10 +488,13 @@ public class CatalogManager {
 
 	/**
 	 * Drop a database in a given path.
-	 * @param catalogName
-	 * @param databaseName
+	 *
+	 * @param catalogName        The catalog where database will be deleted.
+	 * @param databaseName       Name of database to be deleted.
 	 * @param ignoreIfNotExists  If false exception will be thrown if a database not exists in the given path.
-	 * @param isRestrict
+	 * @param isRestrict         Flag to specify behavior when the database contains table:
+	 *                              if set to false, delete all tables in the database and then delete the database,
+	 *                              if set to true, throw an exception.
 	 */
 	public void dropDatabase(String catalogName,
 					String databaseName,
@@ -514,10 +518,11 @@ public class CatalogManager {
 	}
 
 	/**
-	 * Drop a database in a given path.
-	 * @param catalogName
-	 * @param databaseName
-	 * @param catalogDatabase new catalogDatabase.
+	 * Alter a database in a given path.
+	 *
+	 * @param catalogName     The catalog where database will be deleted.
+	 * @param databaseName    Name of database to be deleted.
+	 * @param catalogDatabase New catalogDatabase.
 	 */
 	public void alterDatabase(String catalogName,
 							String databaseName,

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
@@ -482,6 +483,35 @@ public class CatalogManager {
 		} else if (!ignoreNoCatalog) {
 			throw new ValidationException(String.format("Catalog %s does not exist.", catalogName));
 		}
+	}
+
+	/**
+	 * Drop a database in a given path.
+	 * @param catalogName
+	 * @param databaseName
+	 * @param ignoreIfNotExists  If false exception will be thrown if a database not exists in the given path.
+	 * @param isRestrict
+	 */
+	public void dropDatabase(String catalogName,
+					String databaseName,
+					boolean ignoreIfNotExists,
+					boolean isRestrict,
+					boolean ignoreNoCatalog) {
+		Optional<Catalog> catalog = getCatalog(catalogName);
+		if (catalog.isPresent()) {
+			try {
+				catalog.get().dropDatabase(databaseName, ignoreIfNotExists, isRestrict);
+			} catch (DatabaseNotExistException | DatabaseNotEmptyException e) {
+				throw new ValidationException(
+						String.format("Could not execute %s in path %s", "DROP DATABASE", catalogName), e);
+			} catch (Exception e) {
+				throw new TableException(
+						String.format("Could not execute %s in path %s", "DROP DATABASE", catalogName), e);
+			}
+		} else if (!ignoreNoCatalog) {
+			throw new ValidationException(String.format("Catalog %s does not exist.", catalogName));
+		}
+
 	}
 
 	/**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -107,7 +107,7 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
 	}
 
 	@Override
-	public void dropDatabase(String databaseName, boolean ignoreIfNotExists, boolean restrict)
+	public void dropDatabase(String databaseName, boolean ignoreIfNotExists, boolean cascade)
 			throws DatabaseNotExistException, DatabaseNotEmptyException {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(databaseName));
 
@@ -116,7 +116,7 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
 			// Make sure the database is empty
 			if (isDatabaseEmpty(databaseName)) {
 				databases.remove(databaseName);
-			} else if (!restrict) {
+			} else if (cascade) {
 				// delete all tables in this database and then delete the database.
 				List<ObjectPath> deleteTablePaths = tables.keySet().stream()
 														.filter(op -> op.getDatabaseName().equals(databaseName))
@@ -128,10 +128,10 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
 							//ignore
 						}
 					});
-				List<ObjectPath> deleteFuntcionPaths = functions.keySet().stream()
+				List<ObjectPath> deleteFunctionPaths = functions.keySet().stream()
 															.filter(op -> op.getDatabaseName().equals(databaseName))
 															.collect(Collectors.toList());
-				deleteFuntcionPaths.forEach(objectPath -> {
+				deleteFunctionPaths.forEach(objectPath -> {
 						try {
 							dropFunction(objectPath, true);
 						} catch (FunctionNotExistException e) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -107,7 +107,7 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
 	}
 
 	@Override
-	public void dropDatabase(String databaseName, boolean ignoreIfNotExists)
+	public void dropDatabase(String databaseName, boolean ignoreIfNotExists, boolean isRestrict)
 			throws DatabaseNotExistException, DatabaseNotEmptyException {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(databaseName));
 
@@ -115,6 +115,29 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
 
 			// Make sure the database is empty
 			if (isDatabaseEmpty(databaseName)) {
+				databases.remove(databaseName);
+			} else if (!isRestrict) {
+				// delete all tables in this database and then delete the database.
+				List<ObjectPath> deleteTablePaths = tables.keySet().stream()
+														.filter(op -> op.getDatabaseName().equals(databaseName))
+														.collect(Collectors.toList());
+				deleteTablePaths.forEach(objectPath -> {
+						try {
+							dropTable(objectPath, true);
+						} catch (TableNotExistException e) {
+							//ignore
+						}
+					});
+				List<ObjectPath> deleteFuntcionPaths = functions.keySet().stream()
+															.filter(op -> op.getDatabaseName().equals(databaseName))
+															.collect(Collectors.toList());
+				deleteFuntcionPaths.forEach(objectPath -> {
+						try {
+							dropFunction(objectPath, true);
+						} catch (FunctionNotExistException e) {
+							//ignore
+						}
+					});
 				databases.remove(databaseName);
 			} else {
 				throw new DatabaseNotEmptyException(getName(), databaseName);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -107,13 +107,7 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
 	}
 
 	@Override
-	public void dropDatabase(String name, boolean ignoreIfNotExists)
-			throws DatabaseNotExistException, DatabaseNotEmptyException, CatalogException {
-		dropDatabase(name, ignoreIfNotExists, true);
-	}
-
-	@Override
-	public void dropDatabase(String databaseName, boolean ignoreIfNotExists, boolean isRestrict)
+	public void dropDatabase(String databaseName, boolean ignoreIfNotExists, boolean restrict)
 			throws DatabaseNotExistException, DatabaseNotEmptyException {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(databaseName));
 
@@ -122,7 +116,7 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
 			// Make sure the database is empty
 			if (isDatabaseEmpty(databaseName)) {
 				databases.remove(databaseName);
-			} else if (!isRestrict) {
+			} else if (!restrict) {
 				// delete all tables in this database and then delete the database.
 				List<ObjectPath> deleteTablePaths = tables.keySet().stream()
 														.filter(op -> op.getDatabaseName().equals(databaseName))

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -119,8 +119,7 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
 			} else if (cascade) {
 				// delete all tables in this database and then delete the database.
 				List<ObjectPath> deleteTablePaths = tables.keySet().stream()
-														.filter(op -> op.getDatabaseName().equals(databaseName))
-														.collect(Collectors.toList());
+						.filter(op -> op.getDatabaseName().equals(databaseName)).collect(Collectors.toList());
 				deleteTablePaths.forEach(objectPath -> {
 						try {
 							dropTable(objectPath, true);
@@ -129,8 +128,7 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
 						}
 					});
 				List<ObjectPath> deleteFunctionPaths = functions.keySet().stream()
-															.filter(op -> op.getDatabaseName().equals(databaseName))
-															.collect(Collectors.toList());
+						.filter(op -> op.getDatabaseName().equals(databaseName)).collect(Collectors.toList());
 				deleteFunctionPaths.forEach(objectPath -> {
 						try {
 							dropFunction(objectPath, true);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -107,6 +107,12 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
 	}
 
 	@Override
+	public void dropDatabase(String name, boolean ignoreIfNotExists)
+			throws DatabaseNotExistException, DatabaseNotEmptyException, CatalogException {
+		dropDatabase(name, ignoreIfNotExists, true);
+	}
+
+	@Override
 	public void dropDatabase(String databaseName, boolean ignoreIfNotExists, boolean isRestrict)
 			throws DatabaseNotExistException, DatabaseNotEmptyException {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(databaseName));

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/UseDatabaseOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/UseDatabaseOperation.java
@@ -18,33 +18,29 @@
 
 package org.apache.flink.table.operations;
 
-import static org.apache.flink.util.Preconditions.checkArgument;
-import static org.apache.flink.util.Preconditions.checkNotNull;
-
 /**
  * Operation to describe a USE [catalogName.]dataBaseName statement.
  */
 public class UseDatabaseOperation implements UseOperation {
 
-	private String[] fullDatabaseName;
+	private final String catalogName;
+	private final String databaseName;
 
-	public UseDatabaseOperation(String[] fullDatabaseName) {
-		checkNotNull(fullDatabaseName);
-		checkArgument(fullDatabaseName.length > 0 && fullDatabaseName.length <= 2,
-					"database full path length can not be zero or greater than 2");
-		this.fullDatabaseName = fullDatabaseName;
+	public UseDatabaseOperation(String catalogName, String databaseName) {
+		this.catalogName = catalogName;
+		this.databaseName = databaseName;
 	}
 
-	public String[] getFullDatabaseName() {
-		return fullDatabaseName;
+	public String getCatalogName() {
+		return catalogName;
+	}
+
+	public String getDatabaseName() {
+		return databaseName;
 	}
 
 	@Override
 	public String asSummaryString() {
-		if (fullDatabaseName.length == 1) {
-			return String.format("USE %s", fullDatabaseName[0]);
-		} else {
-			return String.format("USE %s.%s", fullDatabaseName[0], fullDatabaseName[1]);
-		}
+		return String.format("USE %s.%s", catalogName, databaseName);
 	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/UseDatabaseOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/UseDatabaseOperation.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Operation to describe a USE [catalogName.]dataBaseName statement.
+ */
+public class UseDatabaseOperation implements UseOperation {
+
+	private String[] fullDatabaseName;
+
+	public UseDatabaseOperation(String[] fullDatabaseName) {
+		checkNotNull(fullDatabaseName);
+		checkArgument(fullDatabaseName.length > 0 && fullDatabaseName.length <= 2,
+					"database full path length can not be zero or greater than 2");
+		this.fullDatabaseName = fullDatabaseName;
+	}
+
+	public String[] getFullDatabaseName() {
+		return fullDatabaseName;
+	}
+
+	@Override
+	public String asSummaryString() {
+		if (fullDatabaseName.length == 1) {
+			return String.format("USE %s", fullDatabaseName[0]);
+		} else {
+			return String.format("USE %s.%s", fullDatabaseName[0], fullDatabaseName[1]);
+		}
+	}
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterDatabaseOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterDatabaseOperation.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.ddl;
+
+import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.OperationUtils;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Operation to describe a ALTER DATABASE statement.
+ */
+public class AlterDatabaseOperation implements AlterOperation {
+	private final String catalogName;
+	private final String databaseName;
+	private final CatalogDatabase catalogDatabase;
+
+	public AlterDatabaseOperation(
+			String catalogName,
+			String databaseName,
+			CatalogDatabase catalogDatabase) {
+		this.catalogName = catalogName;
+		this.databaseName = databaseName;
+		this.catalogDatabase = catalogDatabase;
+	}
+
+	public String getCatalogName() {
+		return catalogName;
+	}
+
+	public String getDatabaseName() {
+		return databaseName;
+	}
+
+	public CatalogDatabase getCatalogDatabase() {
+		return catalogDatabase;
+	}
+
+	@Override
+	public String asSummaryString() {
+		Map<String, Object> params = new LinkedHashMap<>();
+		params.put("alterDatabase", catalogDatabase.getProperties());
+		params.put("catalogName", catalogName);
+		params.put("databaseName", databaseName);
+
+		return OperationUtils.formatWithChildren(
+			"ALTER DATABASE",
+			params,
+			Collections.emptyList(),
+			Operation::asSummaryString);
+	}
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterOperation.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.ddl;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.operations.Operation;
+
+/**
+ * A {@link Operation} that describes the DDL statements, e.g. ALTER TABLE or ALTER DATABASE.
+ *
+ * <p>Different sub operations can have their special instances. For example, a
+ * alter table operation will have a {@link org.apache.flink.table.catalog.CatalogTable} instance,
+ * while a alter database operation will have a
+ * {@link org.apache.flink.table.catalog.CatalogDatabase} instance.
+ */
+@Internal
+public interface AlterOperation extends Operation {
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterOperation.java
@@ -24,10 +24,8 @@ import org.apache.flink.table.operations.Operation;
 /**
  * A {@link Operation} that describes the DDL statements, e.g. ALTER TABLE or ALTER DATABASE.
  *
- * <p>Different sub operations can have their special instances. For example, a
- * alter table operation will have a {@link org.apache.flink.table.catalog.CatalogTable} instance,
- * while a alter database operation will have a
- * {@link org.apache.flink.table.catalog.CatalogDatabase} instance.
+ * <p>Different sub operations can have their special target name. For example, a alter table
+ * operation may have a target table name and a flag to describe if is exists.
  */
 @Internal
 public interface AlterOperation extends Operation {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateDatabaseOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateDatabaseOperation.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.ddl;
+
+import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.OperationUtils;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Operation to describe a CREATE DATABASE statement.
+ */
+public class CreateDatabaseOperation implements CreateOperation {
+	private final String catalogName;
+	private final String databaseName;
+	private CatalogDatabase catalogDatabase;
+	private boolean ignoreIfExists;
+
+	public CreateDatabaseOperation(
+			String catalogName,
+			String databaseName,
+			CatalogDatabase catalogDatabase, boolean ignoreIfExists) {
+		this.catalogName = catalogName;
+		this.databaseName = databaseName;
+		this.catalogDatabase = catalogDatabase;
+		this.ignoreIfExists = ignoreIfExists;
+	}
+
+	public String getCatalogName() {
+		return catalogName;
+	}
+
+	public String getDatabaseName() {
+		return databaseName;
+	}
+
+	public CatalogDatabase getCatalogDatabase() {
+		return catalogDatabase;
+	}
+
+	public boolean isIgnoreIfExists() {
+		return ignoreIfExists;
+	}
+
+	@Override
+	public String asSummaryString() {
+		Map<String, Object> params = new LinkedHashMap<>();
+		params.put("catalogDatabase", catalogDatabase.getProperties());
+		params.put("catalogName", catalogName);
+		params.put("databaseName", databaseName);
+		params.put("ignoreIfExists", ignoreIfExists);
+
+		return OperationUtils.formatWithChildren(
+			"CREATE DATABASE",
+			params,
+			Collections.emptyList(),
+			Operation::asSummaryString);
+	}
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateDatabaseOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateDatabaseOperation.java
@@ -32,8 +32,8 @@ import java.util.Map;
 public class CreateDatabaseOperation implements CreateOperation {
 	private final String catalogName;
 	private final String databaseName;
-	private CatalogDatabase catalogDatabase;
-	private boolean ignoreIfExists;
+	private final CatalogDatabase catalogDatabase;
+	private final boolean ignoreIfExists;
 
 	public CreateDatabaseOperation(
 			String catalogName,

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropDatabaseOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropDatabaseOperation.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.ddl;
+
+/**
+ * Operation to describe a DROP DATABASE statement.
+ */
+public class DropDatabaseOperation implements DropOperation {
+	private final String catalogName;
+	private final String databaseName;
+	private final boolean ifExists;
+	private final boolean isRestrict;
+
+	public DropDatabaseOperation(String catalogName, String databaseName, boolean ifExists, boolean isRestrict) {
+		this.catalogName = catalogName;
+		this.databaseName = databaseName;
+		this.ifExists = ifExists;
+		this.isRestrict = isRestrict;
+	}
+
+	public String getCatalogName() {
+		return catalogName;
+	}
+
+	public String getDatabaseName() {
+		return databaseName;
+	}
+
+	public boolean isRestrict() {
+		return isRestrict;
+	}
+
+	public boolean isIfExists() {
+		return ifExists;
+	}
+
+	@Override
+	public String asSummaryString() {
+		StringBuilder summaryString = new StringBuilder("DROP DATABASE");
+		summaryString.append(ifExists ? " IF EXISTS " : "");
+		summaryString.append(" " + catalogName + "." + databaseName);
+		summaryString.append(isRestrict ? " RESTRICT" : "CASCADE");
+		return summaryString.toString();
+	}
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropDatabaseOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropDatabaseOperation.java
@@ -25,13 +25,13 @@ public class DropDatabaseOperation implements DropOperation {
 	private final String catalogName;
 	private final String databaseName;
 	private final boolean ifExists;
-	private final boolean isRestrict;
+	private final boolean cascade;
 
-	public DropDatabaseOperation(String catalogName, String databaseName, boolean ifExists, boolean isRestrict) {
+	public DropDatabaseOperation(String catalogName, String databaseName, boolean ifExists, boolean cascade) {
 		this.catalogName = catalogName;
 		this.databaseName = databaseName;
 		this.ifExists = ifExists;
-		this.isRestrict = isRestrict;
+		this.cascade = cascade;
 	}
 
 	public String getCatalogName() {
@@ -42,8 +42,8 @@ public class DropDatabaseOperation implements DropOperation {
 		return databaseName;
 	}
 
-	public boolean isRestrict() {
-		return isRestrict;
+	public boolean isCascade() {
+		return cascade;
 	}
 
 	public boolean isIfExists() {
@@ -55,7 +55,7 @@ public class DropDatabaseOperation implements DropOperation {
 		StringBuilder summaryString = new StringBuilder("DROP DATABASE");
 		summaryString.append(ifExists ? " IF EXISTS " : "");
 		summaryString.append(" " + catalogName + "." + databaseName);
-		summaryString.append(isRestrict ? " RESTRICT" : "CASCADE");
+		summaryString.append(cascade ?  " CASCADE" : " RESTRICT");
 		return summaryString.toString();
 	}
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
@@ -125,9 +125,9 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 
 		// Clean up
 		catalog.dropTable(path1, false);
-		catalog.dropDatabase(db1, false, true);
+		catalog.dropDatabase(db1, false, false);
 		catalog.dropTable(path2, false);
-		catalog.dropDatabase(db2, false, true);
+		catalog.dropDatabase(db2, false, false);
 	}
 
 	// ------ utilities ------

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
@@ -125,9 +125,9 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 
 		// Clean up
 		catalog.dropTable(path1, false);
-		catalog.dropDatabase(db1, false);
+		catalog.dropDatabase(db1, false, true);
 		catalog.dropTable(path2, false);
-		catalog.dropDatabase(db2, false);
+		catalog.dropDatabase(db2, false, true);
 	}
 
 	// ------ utilities ------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -141,6 +141,19 @@ public interface Catalog {
 	 * @param ignoreIfNotExists Flag to specify behavior when the database does not exist:
 	 *                          if set to false, throw an exception,
 	 *                          if set to true, do nothing.
+	 * @throws DatabaseNotExistException if the given database does not exist
+	 * @throws CatalogException in case of any runtime exception
+	 */
+	void dropDatabase(String name, boolean ignoreIfNotExists) throws DatabaseNotExistException,
+			DatabaseNotEmptyException, CatalogException;
+
+	/**
+	 * Drop a database.
+	 *
+	 * @param name              Name of the database to be dropped.
+	 * @param ignoreIfNotExists Flag to specify behavior when the database does not exist:
+	 *                          if set to false, throw an exception,
+	 *                          if set to true, do nothing.
 	 * @param isRestrict        Flag to specify behavior when the database contains table:
 	 *                          if set to false, delete all tables in the database and then delete the database,
 	 *                          if set to true, throw an exception.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -141,10 +141,14 @@ public interface Catalog {
 	 * @param ignoreIfNotExists Flag to specify behavior when the database does not exist:
 	 *                          if set to false, throw an exception,
 	 *                          if set to true, do nothing.
+	 * @param isRestrict        Flag to specify behavior when the database contains table:
+	 *                          if set to false, delete all tables in the database and then delete the database,
+	 *                          if set to true, throw an exception.
 	 * @throws DatabaseNotExistException if the given database does not exist
+	 * @throws DatabaseNotEmptyException if the given database is not empty
 	 * @throws CatalogException in case of any runtime exception
 	 */
-	void dropDatabase(String name, boolean ignoreIfNotExists) throws DatabaseNotExistException,
+	void dropDatabase(String name, boolean ignoreIfNotExists, boolean isRestrict) throws DatabaseNotExistException,
 		DatabaseNotEmptyException, CatalogException;
 
 	/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -146,7 +146,7 @@ public interface Catalog {
 	 */
 	default void dropDatabase(String name, boolean ignoreIfNotExists) throws DatabaseNotExistException,
 			DatabaseNotEmptyException, CatalogException{
-		dropDatabase(name, ignoreIfNotExists, true);
+		dropDatabase(name, ignoreIfNotExists, false);
 	}
 
 	/**
@@ -154,16 +154,17 @@ public interface Catalog {
 	 *
 	 * @param name              Name of the database to be dropped.
 	 * @param ignoreIfNotExists Flag to specify behavior when the database does not exist:
-	 *                          if set to false, throw an exception,
-	 *                          if set to true, do nothing.
-	 * @param restrict         Flag to specify behavior when the database contains table:
-	 *                          if set to false, delete all tables in the database and then delete the database,
-	 *                          if set to true, throw an exception.
+	 *                           if set to false, throw an exception,
+	 *                           if set to true, do nothing.
+	 * @param cascade          Flag to specify behavior when the database contains table or function:
+	 *                           if set to true, delete all tables and functions in the database and then delete the
+	 *                             database,
+	 *                           if set to false, throw an exception.
 	 * @throws DatabaseNotExistException if the given database does not exist
 	 * @throws DatabaseNotEmptyException if the given database is not empty and isRestrict is true
 	 * @throws CatalogException in case of any runtime exception
 	 */
-	void dropDatabase(String name, boolean ignoreIfNotExists, boolean restrict) throws DatabaseNotExistException,
+	void dropDatabase(String name, boolean ignoreIfNotExists, boolean cascade) throws DatabaseNotExistException,
 		DatabaseNotEmptyException, CatalogException;
 
 	/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -144,8 +144,10 @@ public interface Catalog {
 	 * @throws DatabaseNotExistException if the given database does not exist
 	 * @throws CatalogException in case of any runtime exception
 	 */
-	void dropDatabase(String name, boolean ignoreIfNotExists) throws DatabaseNotExistException,
-			DatabaseNotEmptyException, CatalogException;
+	default void dropDatabase(String name, boolean ignoreIfNotExists) throws DatabaseNotExistException,
+			DatabaseNotEmptyException, CatalogException{
+		dropDatabase(name, ignoreIfNotExists, true);
+	}
 
 	/**
 	 * Drop a database.
@@ -154,14 +156,14 @@ public interface Catalog {
 	 * @param ignoreIfNotExists Flag to specify behavior when the database does not exist:
 	 *                          if set to false, throw an exception,
 	 *                          if set to true, do nothing.
-	 * @param isRestrict        Flag to specify behavior when the database contains table:
+	 * @param restrict         Flag to specify behavior when the database contains table:
 	 *                          if set to false, delete all tables in the database and then delete the database,
 	 *                          if set to true, throw an exception.
 	 * @throws DatabaseNotExistException if the given database does not exist
-	 * @throws DatabaseNotEmptyException if the given database is not empty
+	 * @throws DatabaseNotEmptyException if the given database is not empty and isRestrict is true
 	 * @throws CatalogException in case of any runtime exception
 	 */
-	void dropDatabase(String name, boolean ignoreIfNotExists, boolean isRestrict) throws DatabaseNotExistException,
+	void dropDatabase(String name, boolean ignoreIfNotExists, boolean restrict) throws DatabaseNotExistException,
 		DatabaseNotEmptyException, CatalogException;
 
 	/**

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
@@ -101,10 +101,10 @@ public abstract class CatalogTest {
 			catalog.dropFunction(path1, true);
 		}
 		if (catalog.databaseExists(db1)) {
-			catalog.dropDatabase(db1, true);
+			catalog.dropDatabase(db1, true, true);
 		}
 		if (catalog.databaseExists(db2)) {
-			catalog.dropDatabase(db2, true);
+			catalog.dropDatabase(db2, true, true);
 		}
 	}
 
@@ -167,7 +167,7 @@ public abstract class CatalogTest {
 
 		assertTrue(catalog.databaseExists(db1));
 
-		catalog.dropDatabase(db1, false);
+		catalog.dropDatabase(db1, false, false);
 
 		assertFalse(catalog.databaseExists(db1));
 	}
@@ -176,12 +176,12 @@ public abstract class CatalogTest {
 	public void testDropDb_DatabaseNotExistException() throws Exception {
 		exception.expect(DatabaseNotExistException.class);
 		exception.expectMessage("Database db1 does not exist in Catalog");
-		catalog.dropDatabase(db1, false);
+		catalog.dropDatabase(db1, false, true);
 	}
 
 	@Test
 	public void testDropDb_DatabaseNotExist_Ignore() throws Exception {
-		catalog.dropDatabase(db1, true);
+		catalog.dropDatabase(db1, true, true);
 	}
 
 	@Test
@@ -191,7 +191,7 @@ public abstract class CatalogTest {
 
 		exception.expect(DatabaseNotEmptyException.class);
 		exception.expectMessage("Database db1 in catalog test-catalog is not empty");
-		catalog.dropDatabase(db1, true);
+		catalog.dropDatabase(db1, true, true);
 	}
 
 	@Test
@@ -729,7 +729,7 @@ public abstract class CatalogTest {
 	public void testDropFunction_FunctionNotExist_ignored() throws Exception {
 		catalog.createDatabase(db1, createDb(), false);
 		catalog.dropFunction(nonExistObjectPath, true);
-		catalog.dropDatabase(db1, false);
+		catalog.dropDatabase(db1, false, true);
 	}
 
 	// ------ partitions ------

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
@@ -101,10 +101,10 @@ public abstract class CatalogTest {
 			catalog.dropFunction(path1, true);
 		}
 		if (catalog.databaseExists(db1)) {
-			catalog.dropDatabase(db1, true, true);
+			catalog.dropDatabase(db1, true, false);
 		}
 		if (catalog.databaseExists(db2)) {
-			catalog.dropDatabase(db2, true, true);
+			catalog.dropDatabase(db2, true, false);
 		}
 	}
 
@@ -167,7 +167,7 @@ public abstract class CatalogTest {
 
 		assertTrue(catalog.databaseExists(db1));
 
-		catalog.dropDatabase(db1, false, false);
+		catalog.dropDatabase(db1, false, true);
 
 		assertFalse(catalog.databaseExists(db1));
 	}
@@ -176,12 +176,12 @@ public abstract class CatalogTest {
 	public void testDropDb_DatabaseNotExistException() throws Exception {
 		exception.expect(DatabaseNotExistException.class);
 		exception.expectMessage("Database db1 does not exist in Catalog");
-		catalog.dropDatabase(db1, false, true);
+		catalog.dropDatabase(db1, false, false);
 	}
 
 	@Test
 	public void testDropDb_DatabaseNotExist_Ignore() throws Exception {
-		catalog.dropDatabase(db1, true, true);
+		catalog.dropDatabase(db1, true, false);
 	}
 
 	@Test
@@ -191,7 +191,7 @@ public abstract class CatalogTest {
 
 		exception.expect(DatabaseNotEmptyException.class);
 		exception.expectMessage("Database db1 in catalog test-catalog is not empty");
-		catalog.dropDatabase(db1, true, true);
+		catalog.dropDatabase(db1, true, false);
 	}
 
 	@Test
@@ -729,7 +729,7 @@ public abstract class CatalogTest {
 	public void testDropFunction_FunctionNotExist_ignored() throws Exception {
 		catalog.createDatabase(db1, createDb(), false);
 		catalog.dropFunction(nonExistObjectPath, true);
-		catalog.dropDatabase(db1, false, true);
+		catalog.dropDatabase(db1, false, false);
 	}
 
 	// ------ partitions ------

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -206,7 +206,13 @@ public class SqlToOperationConverter {
 
 	/** Convert use database statement. */
 	private Operation convertUseDatabase(SqlUseDatabase useDatabase) {
-		return new UseDatabaseOperation(useDatabase.fullDatabaseName());
+		String[] fullDatabaseName = useDatabase.fullDatabaseName();
+		if (fullDatabaseName.length > 2) {
+			throw new SqlConversionException("use database identifier format error");
+		}
+		String catalogName = fullDatabaseName.length == 2 ? fullDatabaseName[0] : catalogManager.getCurrentCatalog();
+		String databaseName = fullDatabaseName.length == 2 ? fullDatabaseName[1] : fullDatabaseName[0];
+		return new UseDatabaseOperation(catalogName, databaseName);
 	}
 
 	/** Convert CREATE DATABASE statement. */

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -249,7 +249,7 @@ public class SqlToOperationConverter {
 				catalogName,
 				databaseName,
 				sqlDropDatabase.getIfExists(),
-				sqlDropDatabase.isRestrict());
+				sqlDropDatabase.isCascade());
 	}
 
 	/** Convert ALTER DATABASE statement. */

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -275,8 +275,7 @@ public class SqlToOperationConverter {
 		}
 		// set with properties
 		sqlAlterDatabase.getPropertyList().getList().forEach(p ->
-																	 properties.put(((SqlTableOption) p).getKeyString().toLowerCase(),
-																					((SqlTableOption) p).getValueString()));
+			properties.put(((SqlTableOption) p).getKeyString().toLowerCase(), ((SqlTableOption) p).getValueString()));
 		CatalogDatabase catalogDatabase = new CatalogDatabaseImpl(properties, originCatalogDatabase.getComment());
 		return new AlterDatabaseOperation(catalogName, databaseName, catalogDatabase);
 	}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -23,6 +23,7 @@ import org.apache.flink.sql.parser.ddl.SqlDropTable;
 import org.apache.flink.sql.parser.ddl.SqlTableColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableOption;
 import org.apache.flink.sql.parser.ddl.SqlUseCatalog;
+import org.apache.flink.sql.parser.ddl.SqlUseDatabase;
 import org.apache.flink.sql.parser.dml.RichSqlInsert;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
@@ -34,6 +35,7 @@ import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.operations.CatalogSinkModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.UseCatalogOperation;
+import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.DropTableOperation;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
@@ -104,6 +106,8 @@ public class SqlToOperationConverter {
 			return Optional.of(converter.convertSqlInsert((RichSqlInsert) validated));
 		} else if (validated instanceof SqlUseCatalog) {
 			return Optional.of(converter.convertUseCatalog((SqlUseCatalog) validated));
+		} else if (validated instanceof SqlUseDatabase) {
+			return Optional.of(converter.convertUseDatabase((SqlUseDatabase) validated));
 		} else if (validated.getKind().belongsTo(SqlKind.QUERY)) {
 			return Optional.of(converter.convertSqlQuery(validated));
 		} else {
@@ -184,6 +188,11 @@ public class SqlToOperationConverter {
 	/** Convert use catalog statement. */
 	private Operation convertUseCatalog(SqlUseCatalog useCatalog) {
 		return new UseCatalogOperation(useCatalog.getCatalogName());
+	}
+
+	/** Convert use database statement. */
+	private Operation convertUseDatabase(SqlUseDatabase useDatabase) {
+		return new UseDatabaseOperation(useDatabase.fullDatabaseName());
 	}
 
 	/** Fallback method for sql query. */

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.operations;
 
+import org.apache.flink.sql.parser.ddl.SqlCreateDatabase;
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
 import org.apache.flink.sql.parser.ddl.SqlDropTable;
 import org.apache.flink.sql.parser.ddl.SqlTableColumn;
@@ -27,6 +28,8 @@ import org.apache.flink.sql.parser.ddl.SqlUseDatabase;
 import org.apache.flink.sql.parser.dml.RichSqlInsert;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.catalog.CatalogDatabaseImpl;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
@@ -36,6 +39,7 @@ import org.apache.flink.table.operations.CatalogSinkModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
+import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.DropTableOperation;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
@@ -108,6 +112,8 @@ public class SqlToOperationConverter {
 			return Optional.of(converter.convertUseCatalog((SqlUseCatalog) validated));
 		} else if (validated instanceof SqlUseDatabase) {
 			return Optional.of(converter.convertUseDatabase((SqlUseDatabase) validated));
+		} else if (validated instanceof SqlCreateDatabase) {
+			return Optional.of(converter.convertCreateDatabase((SqlCreateDatabase) validated));
 		} else if (validated.getKind().belongsTo(SqlKind.QUERY)) {
 			return Optional.of(converter.convertSqlQuery(validated));
 		} else {
@@ -193,6 +199,32 @@ public class SqlToOperationConverter {
 	/** Convert use database statement. */
 	private Operation convertUseDatabase(SqlUseDatabase useDatabase) {
 		return new UseDatabaseOperation(useDatabase.fullDatabaseName());
+	}
+
+	/** Convert CREATE DATABASE statement. */
+	private Operation convertCreateDatabase(SqlCreateDatabase sqlCreateDatabase) {
+		String[] fullDatabaseName = sqlCreateDatabase.fullDatabaseName();
+		if (fullDatabaseName.length > 2) {
+			throw new SqlConversionException("create database identifier format error");
+		}
+		String catalogName = catalogManager.getCurrentCatalog();
+		String databaseName = null;
+		if (fullDatabaseName.length == 1) {
+			databaseName = fullDatabaseName[0];
+		} else {
+			catalogName = fullDatabaseName[0];
+			databaseName = fullDatabaseName[1];
+		}
+		boolean ignoreIfExists = sqlCreateDatabase.isIfNotExists();
+		String databaseComment = sqlCreateDatabase.getComment()
+								.map(comment -> comment.getNlsString().getValue()).orElse(null);
+		// set with properties
+		Map<String, String> properties = new HashMap<>();
+		sqlCreateDatabase.getPropertyList().getList().forEach(p ->
+			properties.put(((SqlTableOption) p).getKeyString().toLowerCase(),
+				((SqlTableOption) p).getValueString()));
+		CatalogDatabase catalogDatabase = new CatalogDatabaseImpl(properties, databaseComment);
+		return new CreateDatabaseOperation(catalogName, databaseName, catalogDatabase, ignoreIfExists);
 	}
 
 	/** Fallback method for sql query. */

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -30,6 +30,7 @@ import org.apache.flink.sql.parser.ddl.SqlUseDatabase;
 import org.apache.flink.sql.parser.dml.RichSqlInsert;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.CatalogDatabaseImpl;
 import org.apache.flink.table.catalog.CatalogManager;
@@ -37,6 +38,7 @@ import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.operations.CatalogSinkModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.UseCatalogOperation;
@@ -258,13 +260,24 @@ public class SqlToOperationConverter {
 		}
 		String catalogName = (fullDatabaseName.length == 1) ? catalogManager.getCurrentCatalog() : fullDatabaseName[0];
 		String databaseName = (fullDatabaseName.length == 1) ? fullDatabaseName[0] : fullDatabaseName[1];
-
-		// set with properties
 		Map<String, String> properties = new HashMap<>();
+		CatalogDatabase originCatalogDatabase;
+		Optional<Catalog> catalog = catalogManager.getCatalog(catalogName);
+		if (catalog.isPresent()) {
+			try {
+				originCatalogDatabase = catalog.get().getDatabase(databaseName);
+				properties.putAll(originCatalogDatabase.getProperties());
+			} catch (DatabaseNotExistException e) {
+				throw new SqlConversionException(String.format("Database %s not exists", databaseName), e);
+			}
+		} else {
+			throw new SqlConversionException(String.format("Catalog %s not exists", catalogName));
+		}
+		// set with properties
 		sqlAlterDatabase.getPropertyList().getList().forEach(p ->
-						properties.put(((SqlTableOption) p).getKeyString().toLowerCase(),
-						((SqlTableOption) p).getValueString()));
-		CatalogDatabase catalogDatabase = new CatalogDatabaseImpl(properties, null);
+																	 properties.put(((SqlTableOption) p).getKeyString().toLowerCase(),
+																					((SqlTableOption) p).getValueString()));
+		CatalogDatabase catalogDatabase = new CatalogDatabaseImpl(properties, originCatalogDatabase.getComment());
 		return new AlterDatabaseOperation(catalogName, databaseName, catalogDatabase);
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -200,14 +200,13 @@ public class SqlToOperationConverterTest {
 	}
 
 	@Test
-	public void testAlterDatabase() {
+	public void testAlterDatabase() throws Exception {
 		catalogManager.registerCatalog("cat1",
 									new GenericInMemoryCatalog("default", "default"));
-		catalogManager.createDatabase("cat1",
-									"db1",
-									new CatalogDatabaseImpl(new HashMap<>(), "db1_comment"),
-									true,
-									true);
+		catalogManager.getCatalog("cat1").get()
+						.createDatabase("db1",
+										new CatalogDatabaseImpl(new HashMap<>(), "db1_comment"),
+										true);
 		final String sql = "alter database cat1.db1 set ('k1'='a')";
 		Operation operation = parse(sql, SqlDialect.DEFAULT);
 		assert operation instanceof AlterDatabaseOperation;

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -45,6 +45,7 @@ import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
+import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
 import org.apache.flink.table.planner.calcite.CalciteParser;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.planner.catalog.CatalogManagerCalciteSchema;
@@ -167,6 +168,30 @@ public class SqlToOperationConverterTest {
 			assertEquals(expectedComments[i], createDatabaseOperation.getCatalogDatabase().getComment());
 			assertEquals(expectedIgnoreIfExists[i], createDatabaseOperation.isIgnoreIfExists());
 			assertEquals(expectedPropertySize[i], createDatabaseOperation.getCatalogDatabase().getProperties().size());
+		}
+	}
+
+	@Test
+	public void testDropDatabase() {
+		final String[] dropDatabaseSqls = new String[] {
+				"drop database db1",
+				"drop database if exists db1",
+				"drop database if exists cat1.db1 CASCADE",
+				"drop database if exists cat1.db1 RESTRICT"
+		};
+		final String[] expectedCatalogs = new String[] {"builtin", "builtin", "cat1", "cat1"};
+		final String expectedDatabase = "db1";
+		final boolean[] expectedIfExists = new boolean[] {false, true, true, true};
+		final boolean[] expectedIsRestricts = new boolean[] {true, true, false, true};
+
+		for (int i = 0; i < dropDatabaseSqls.length; i++) {
+			Operation operation = parse(dropDatabaseSqls[i], SqlDialect.DEFAULT);
+			assert operation instanceof DropDatabaseOperation;
+			final DropDatabaseOperation dropDatabaseOperation = (DropDatabaseOperation) operation;
+			assertEquals(expectedCatalogs[i], dropDatabaseOperation.getCatalogName());
+			assertEquals(expectedDatabase, dropDatabaseOperation.getDatabaseName());
+			assertEquals(expectedIfExists[i], dropDatabaseOperation.isIfExists());
+			assertEquals(expectedIsRestricts[i], dropDatabaseOperation.isRestrict());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -186,7 +186,7 @@ public class SqlToOperationConverterTest {
 		final String[] expectedCatalogs = new String[] {"builtin", "builtin", "cat1", "cat1"};
 		final String expectedDatabase = "db1";
 		final boolean[] expectedIfExists = new boolean[] {false, true, true, true};
-		final boolean[] expectedIsRestricts = new boolean[] {true, true, false, true};
+		final boolean[] expectedIsCascades = new boolean[] {false, false, true, false};
 
 		for (int i = 0; i < dropDatabaseSqls.length; i++) {
 			Operation operation = parse(dropDatabaseSqls[i], SqlDialect.DEFAULT);
@@ -195,7 +195,7 @@ public class SqlToOperationConverterTest {
 			assertEquals(expectedCatalogs[i], dropDatabaseOperation.getCatalogName());
 			assertEquals(expectedDatabase, dropDatabaseOperation.getDatabaseName());
 			assertEquals(expectedIfExists[i], dropDatabaseOperation.isIfExists());
-			assertEquals(expectedIsRestricts[i], dropDatabaseOperation.isRestrict());
+			assertEquals(expectedIsCascades[i], dropDatabaseOperation.isCascade());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -205,7 +205,7 @@ public class SqlToOperationConverterTest {
 									new GenericInMemoryCatalog("default", "default"));
 		catalogManager.createDatabase("cat1",
 									"db1",
-									new CatalogDatabaseImpl(new HashMap<>(), null),
+									new CatalogDatabaseImpl(new HashMap<>(), "db1_comment"),
 									true,
 									true);
 		final String sql = "alter database cat1.db1 set ('k1'='a')";
@@ -213,6 +213,7 @@ public class SqlToOperationConverterTest {
 		assert operation instanceof AlterDatabaseOperation;
 		assertEquals("db1", ((AlterDatabaseOperation) operation).getDatabaseName());
 		assertEquals("cat1", ((AlterDatabaseOperation) operation).getCatalogName());
+		assertEquals("db1_comment", ((AlterDatabaseOperation) operation).getCatalogDatabase().getComment());
 	}
 
 	@Test

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -43,6 +43,7 @@ import org.apache.flink.table.operations.CatalogSinkModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
+import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
@@ -193,6 +194,15 @@ public class SqlToOperationConverterTest {
 			assertEquals(expectedIfExists[i], dropDatabaseOperation.isIfExists());
 			assertEquals(expectedIsRestricts[i], dropDatabaseOperation.isRestrict());
 		}
+	}
+
+	@Test
+	public void testAlterDatabase() {
+		final String sql = "alter database cat1.db1 set ('k1'='a')";
+		Operation operation = parse(sql, SqlDialect.DEFAULT);
+		assert operation instanceof AlterDatabaseOperation;
+		assertEquals("db1", ((AlterDatabaseOperation) operation).getDatabaseName());
+		assertEquals("cat1", ((AlterDatabaseOperation) operation).getCatalogName());
 	}
 
 	@Test

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -132,15 +132,17 @@ public class SqlToOperationConverterTest {
 		final String sql1 = "USE db1";
 		Operation operation1 = parse(sql1, SqlDialect.DEFAULT);
 		assert operation1 instanceof UseDatabaseOperation;
-		assertArrayEquals(new String[]{"db1"}, ((UseDatabaseOperation) operation1).getFullDatabaseName());
+		assertEquals("builtin", ((UseDatabaseOperation) operation1).getCatalogName());
+		assertEquals("db1", ((UseDatabaseOperation) operation1).getDatabaseName());
 
 		final String sql2 = "USE cat1.db1";
 		Operation operation2 = parse(sql2, SqlDialect.DEFAULT);
 		assert operation2 instanceof UseDatabaseOperation;
-		assertArrayEquals(new String[]{"cat1", "db1"}, ((UseDatabaseOperation) operation2).getFullDatabaseName());
+		assertEquals("cat1", ((UseDatabaseOperation) operation2).getCatalogName());
+		assertEquals("db1", ((UseDatabaseOperation) operation2).getDatabaseName());
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = SqlConversionException.class)
 	public void testUseDatabaseWithException() {
 		final String sql = "USE cat1.db1.tbl1";
 		Operation operation = parse(sql, SqlDialect.DEFAULT);

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -42,6 +42,7 @@ import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.operations.CatalogSinkModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.UseCatalogOperation;
+import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.planner.calcite.CalciteParser;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
@@ -118,11 +119,28 @@ public class SqlToOperationConverterTest {
 	@Test
 	public void testUseCatalog() {
 		final String sql = "USE CATALOG cat1";
-		FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
-		final CalciteParser parser = getParserBySqlDialect(SqlDialect.DEFAULT);
-		Operation operation = parse(sql, planner, parser);
+		Operation operation = parse(sql, SqlDialect.DEFAULT);
 		assert operation instanceof UseCatalogOperation;
 		assertEquals("cat1", ((UseCatalogOperation) operation).getCatalogName());
+	}
+
+	@Test
+	public void testUseDatabase() {
+		final String sql1 = "USE db1";
+		Operation operation1 = parse(sql1, SqlDialect.DEFAULT);
+		assert operation1 instanceof UseDatabaseOperation;
+		assertArrayEquals(new String[]{"db1"}, ((UseDatabaseOperation) operation1).getFullDatabaseName());
+
+		final String sql2 = "USE cat1.db1";
+		Operation operation2 = parse(sql2, SqlDialect.DEFAULT);
+		assert operation2 instanceof UseDatabaseOperation;
+		assertArrayEquals(new String[]{"cat1", "db1"}, ((UseDatabaseOperation) operation2).getFullDatabaseName());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testUseDatabaseWithException() {
+		final String sql = "USE cat1.db1.tbl1";
+		Operation operation = parse(sql, SqlDialect.DEFAULT);
 	}
 
 	@Test
@@ -468,6 +486,13 @@ public class SqlToOperationConverterTest {
 	}
 
 	private Operation parse(String sql, FlinkPlannerImpl planner, CalciteParser parser) {
+		SqlNode node = parser.parse(sql);
+		return SqlToOperationConverter.convert(planner, catalogManager, node).get();
+	}
+
+	private Operation parse(String sql, SqlDialect sqlDialect) {
+		FlinkPlannerImpl planner = getPlannerBySqlDialect(sqlDialect);
+		final CalciteParser parser = getParserBySqlDialect(sqlDialect);
 		SqlNode node = parser.parse(sql);
 		return SqlToOperationConverter.convert(planner, catalogManager, node).get();
 	}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.api.TableColumn;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CatalogDatabaseImpl;
 import org.apache.flink.table.catalog.CatalogFunction;
 import org.apache.flink.table.catalog.CatalogFunctionImpl;
 import org.apache.flink.table.catalog.CatalogManager;
@@ -200,6 +201,13 @@ public class SqlToOperationConverterTest {
 
 	@Test
 	public void testAlterDatabase() {
+		catalogManager.registerCatalog("cat1",
+									new GenericInMemoryCatalog("default", "default"));
+		catalogManager.createDatabase("cat1",
+									"db1",
+									new CatalogDatabaseImpl(new HashMap<>(), null),
+									true,
+									true);
 		final String sql = "alter database cat1.db1 set ('k1'='a')";
 		Operation operation = parse(sql, SqlDialect.DEFAULT);
 		assert operation instanceof AlterDatabaseOperation;

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -43,6 +43,7 @@ import org.apache.flink.table.operations.CatalogSinkModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
+import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.planner.calcite.CalciteParser;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
@@ -141,6 +142,32 @@ public class SqlToOperationConverterTest {
 	public void testUseDatabaseWithException() {
 		final String sql = "USE cat1.db1.tbl1";
 		Operation operation = parse(sql, SqlDialect.DEFAULT);
+	}
+
+	@Test
+	public void testCreateDatabase() {
+		final String[] createDatabaseSqls = new String[] {
+				"create database db1",
+				"create database if not exists cat1.db1",
+				"create database cat1.db1 comment 'db1_comment'",
+				"create database cat1.db1 comment 'db1_comment' with ('k1' = 'v1', 'k2' = 'v2')"
+		};
+		final String[] expectedCatalogs = new String[] {"builtin", "cat1", "cat1", "cat1"};
+		final String expectedDatabase = "db1";
+		final String[] expectedComments = new String[] {null, null, "db1_comment", "db1_comment"};
+		final boolean[] expectedIgnoreIfExists = new boolean[] {false, true, false, false};
+		final int[] expectedPropertySize = new int[] {0, 0, 0, 2};
+
+		for (int i = 0; i < createDatabaseSqls.length; i++) {
+			Operation operation = parse(createDatabaseSqls[i], SqlDialect.DEFAULT);
+			assert operation instanceof CreateDatabaseOperation;
+			final CreateDatabaseOperation createDatabaseOperation = (CreateDatabaseOperation) operation;
+			assertEquals(expectedCatalogs[i], createDatabaseOperation.getCatalogName());
+			assertEquals(expectedDatabase, createDatabaseOperation.getDatabaseName());
+			assertEquals(expectedComments[i], createDatabaseOperation.getCatalogDatabase().getComment());
+			assertEquals(expectedIgnoreIfExists[i], createDatabaseOperation.isIgnoreIfExists());
+			assertEquals(expectedPropertySize[i], createDatabaseOperation.getCatalogDatabase().getProperties().size());
+		}
 	}
 
 	@Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
@@ -919,6 +919,21 @@ class CatalogTableITCase(isStreamingMode: Boolean) {
     }
     tableEnv.sqlUpdate("drop database db1 cascade")
   }
+
+  @Test
+  def testAlterDatabase: Unit = {
+    tableEnv.registerCatalog("cat1", new GenericInMemoryCatalog("default"))
+    tableEnv.sqlUpdate("use catalog cat1")
+    tableEnv.sqlUpdate("create database db1 comment 'db1_comment' with ('k1' = 'v1')")
+    tableEnv.sqlUpdate("alter database db1 set ('k1' = 'a', 'k2' = 'b')")
+    val database = tableEnv.getCatalog("cat1").get().getDatabase("db1")
+    assertEquals("db1_comment", database.getComment)
+    assertEquals(2, database.getProperties.size())
+    val expectedProperty = new util.HashMap[String, String]()
+    expectedProperty.put("k1", "a")
+    expectedProperty.put("k2", "b")
+    assertEquals(expectedProperty, database.getProperties)
+  }
 }
 
 object CatalogTableITCase {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
@@ -873,6 +873,52 @@ class CatalogTableITCase(isStreamingMode: Boolean) {
     expectedProperty.put("k2", "v2")
     assertEquals(expectedProperty, database.getProperties)
   }
+
+  @Test
+  def testDropDatabase: Unit = {
+    tableEnv.registerCatalog("cat1", new GenericInMemoryCatalog("default"))
+    tableEnv.sqlUpdate("use catalog cat1")
+    tableEnv.sqlUpdate("create database db1")
+    tableEnv.sqlUpdate("drop database db1")
+    tableEnv.sqlUpdate("drop database if exists db1")
+    try {
+      tableEnv.sqlUpdate("drop database db1")
+      fail("ValidationException expected")
+    } catch {
+      case _: ValidationException => //ignore
+    }
+    tableEnv.sqlUpdate("create database db1")
+    tableEnv.sqlUpdate("use db1")
+    val ddl1 =
+      """
+        |create table t1(
+        |  a bigint,
+        |  b bigint,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION'
+        |)
+      """.stripMargin
+    tableEnv.sqlUpdate(ddl1)
+    val ddl2 =
+      """
+        |create table t2(
+        |  a bigint,
+        |  b bigint,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION'
+        |)
+      """.stripMargin
+    tableEnv.sqlUpdate(ddl2)
+    try {
+      tableEnv.sqlUpdate("drop database db1")
+      fail("ValidationException expected")
+    } catch {
+      case _: ValidationException => //ignore
+    }
+    tableEnv.sqlUpdate("drop database db1 cascade")
+  }
 }
 
 object CatalogTableITCase {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.planner.catalog
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.api.internal.TableEnvironmentImpl
 import org.apache.flink.table.api.{EnvironmentSettings, TableEnvironment, ValidationException}
-import org.apache.flink.table.catalog.{CatalogFunctionImpl, GenericInMemoryCatalog, ObjectPath}
+import org.apache.flink.table.catalog.{CatalogDatabaseImpl, CatalogFunctionImpl, GenericInMemoryCatalog, ObjectPath}
 import org.apache.flink.table.planner.expressions.utils.Func0
 import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.JavaFunc0
@@ -834,6 +834,20 @@ class CatalogTableITCase(isStreamingMode: Boolean) {
     assertEquals("cat1", tableEnv.getCurrentCatalog)
     tableEnv.sqlUpdate("use catalog cat2")
     assertEquals("cat2", tableEnv.getCurrentCatalog)
+  }
+
+  @Test
+  def testUseDatabase(): Unit = {
+    val catalog = new GenericInMemoryCatalog("cat1")
+    tableEnv.registerCatalog("cat1", catalog)
+    val catalogDB1 = new CatalogDatabaseImpl(new util.HashMap[String, String](), "db1")
+    val catalogDB2 = new CatalogDatabaseImpl(new util.HashMap[String, String](), "db2")
+    catalog.createDatabase("db1", catalogDB1, true)
+    catalog.createDatabase("db2", catalogDB2, true)
+    tableEnv.sqlUpdate("use cat1.db1")
+    assertEquals("db1", tableEnv.getCurrentDatabase)
+    tableEnv.sqlUpdate("use db2")
+    assertEquals("db2", tableEnv.getCurrentDatabase)
   }
 }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.sqlexec;
 
+import org.apache.flink.sql.parser.ddl.SqlAlterDatabase;
 import org.apache.flink.sql.parser.ddl.SqlCreateDatabase;
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
 import org.apache.flink.sql.parser.ddl.SqlDropDatabase;
@@ -44,6 +45,7 @@ import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.PlannerQueryOperation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
+import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
@@ -120,6 +122,8 @@ public class SqlToOperationConverter {
 			return Optional.of(converter.convertCreateDatabase((SqlCreateDatabase) validated));
 		} else if (validated instanceof SqlDropDatabase) {
 			return Optional.of(converter.convertDropDatabase((SqlDropDatabase) validated));
+		} else if (validated instanceof SqlAlterDatabase) {
+			return Optional.of(converter.convertAlterDatabase((SqlAlterDatabase) validated));
 		} else if (validated.getKind().belongsTo(SqlKind.QUERY)) {
 			return Optional.of(converter.convertSqlQuery(validated));
 		} else {
@@ -223,14 +227,8 @@ public class SqlToOperationConverter {
 		if (fullDatabaseName.length > 2) {
 			throw new SqlConversionException("create database identifier format error");
 		}
-		String catalogName = catalogManager.getCurrentCatalog();
-		String databaseName = null;
-		if (fullDatabaseName.length == 1) {
-			databaseName = fullDatabaseName[0];
-		} else {
-			catalogName = fullDatabaseName[0];
-			databaseName = fullDatabaseName[1];
-		}
+		String catalogName = (fullDatabaseName.length == 1) ? catalogManager.getCurrentCatalog() : fullDatabaseName[0];
+		String databaseName = (fullDatabaseName.length == 1) ? fullDatabaseName[0] : fullDatabaseName[1];
 		boolean ignoreIfExists = sqlCreateDatabase.isIfNotExists();
 		String databaseComment = sqlCreateDatabase.getComment()
 												.map(comment -> comment.getNlsString().getValue()).orElse(null);
@@ -249,19 +247,31 @@ public class SqlToOperationConverter {
 		if (fullDatabaseName.length > 2) {
 			throw new SqlConversionException("drop database identifier format error");
 		}
-		String catalogName = catalogManager.getCurrentCatalog();
-		String databaseName = null;
-		if (fullDatabaseName.length == 1) {
-			databaseName = fullDatabaseName[0];
-		} else {
-			catalogName = fullDatabaseName[0];
-			databaseName = fullDatabaseName[1];
-		}
+		String catalogName = (fullDatabaseName.length == 1) ? catalogManager.getCurrentCatalog() : fullDatabaseName[0];
+		String databaseName = (fullDatabaseName.length == 1) ? fullDatabaseName[0] : fullDatabaseName[1];
 		return new DropDatabaseOperation(
 				catalogName,
 				databaseName,
 				sqlDropDatabase.getIfExists(),
 				sqlDropDatabase.isRestrict());
+	}
+
+	/** Convert ALTER DATABASE statement. */
+	private Operation convertAlterDatabase(SqlAlterDatabase sqlAlterDatabase) {
+		String[] fullDatabaseName = sqlAlterDatabase.fullDatabaseName();
+		if (fullDatabaseName.length > 2) {
+			throw new SqlConversionException("alter database identifier format error");
+		}
+		String catalogName = (fullDatabaseName.length == 1) ? catalogManager.getCurrentCatalog() : fullDatabaseName[0];
+		String databaseName = (fullDatabaseName.length == 1) ? fullDatabaseName[0] : fullDatabaseName[1];
+
+		// set with properties
+		Map<String, String> properties = new HashMap<>();
+		sqlAlterDatabase.getPropertyList().getList().forEach(p ->
+						properties.put(((SqlTableOption) p).getKeyString().toLowerCase(),
+						((SqlTableOption) p).getValueString()));
+		CatalogDatabase catalogDatabase = new CatalogDatabaseImpl(properties, null);
+		return new AlterDatabaseOperation(catalogName, databaseName, catalogDatabase);
 	}
 
 	//~ Tools ------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -261,7 +261,7 @@ public class SqlToOperationConverter {
 				catalogName,
 				databaseName,
 				sqlDropDatabase.getIfExists(),
-				sqlDropDatabase.isRestrict());
+				sqlDropDatabase.isCascade());
 	}
 
 	/** Convert ALTER DATABASE statement. */

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -23,6 +23,7 @@ import org.apache.flink.sql.parser.ddl.SqlDropTable;
 import org.apache.flink.sql.parser.ddl.SqlTableColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableOption;
 import org.apache.flink.sql.parser.ddl.SqlUseCatalog;
+import org.apache.flink.sql.parser.ddl.SqlUseDatabase;
 import org.apache.flink.sql.parser.dml.RichSqlInsert;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
@@ -38,6 +39,7 @@ import org.apache.flink.table.operations.CatalogSinkModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.PlannerQueryOperation;
 import org.apache.flink.table.operations.UseCatalogOperation;
+import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.DropTableOperation;
 import org.apache.flink.table.types.utils.TypeConversions;
@@ -106,7 +108,9 @@ public class SqlToOperationConverter {
 			return Optional.of(converter.convertSqlInsert((RichSqlInsert) validated));
 		} else if (validated instanceof SqlUseCatalog) {
 			return Optional.of(converter.convertUseCatalog((SqlUseCatalog) validated));
-		} else if (validated.getKind().belongsTo(SqlKind.QUERY)) {
+		} else if (validated instanceof SqlUseDatabase) {
+			return Optional.of(converter.convertUseDatabase((SqlUseDatabase) validated));
+		}  else if (validated.getKind().belongsTo(SqlKind.QUERY)) {
 			return Optional.of(converter.convertSqlQuery(validated));
 		} else {
 			return Optional.empty();
@@ -196,6 +200,11 @@ public class SqlToOperationConverter {
 	/** Convert use catalog statement. */
 	private Operation convertUseCatalog(SqlUseCatalog useCatalog) {
 		return new UseCatalogOperation(useCatalog.getCatalogName());
+	}
+
+	/** Convert use database statement. */
+	private Operation convertUseDatabase(SqlUseDatabase useDatabase) {
+		return new UseDatabaseOperation(useDatabase.fullDatabaseName());
 	}
 
 	//~ Tools ------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -218,7 +218,13 @@ public class SqlToOperationConverter {
 
 	/** Convert use database statement. */
 	private Operation convertUseDatabase(SqlUseDatabase useDatabase) {
-		return new UseDatabaseOperation(useDatabase.fullDatabaseName());
+		String[] fullDatabaseName = useDatabase.fullDatabaseName();
+		if (fullDatabaseName.length > 2) {
+			throw new SqlConversionException("use database identifier format error");
+		}
+		String catalogName = fullDatabaseName.length == 2 ? fullDatabaseName[0] : catalogManager.getCurrentCatalog();
+		String databaseName = fullDatabaseName.length == 2 ? fullDatabaseName[1] : fullDatabaseName[0];
+		return new UseDatabaseOperation(catalogName, databaseName);
 	}
 
 	/** Convert CREATE DATABASE statement. */

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.sqlexec;
 
 import org.apache.flink.sql.parser.ddl.SqlCreateDatabase;
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
+import org.apache.flink.sql.parser.ddl.SqlDropDatabase;
 import org.apache.flink.sql.parser.ddl.SqlDropTable;
 import org.apache.flink.sql.parser.ddl.SqlTableColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableOption;
@@ -45,6 +46,7 @@ import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
+import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
 import org.apache.flink.table.operations.ddl.DropTableOperation;
 import org.apache.flink.table.types.utils.TypeConversions;
 
@@ -116,7 +118,9 @@ public class SqlToOperationConverter {
 			return Optional.of(converter.convertUseDatabase((SqlUseDatabase) validated));
 		} else if (validated instanceof SqlCreateDatabase) {
 			return Optional.of(converter.convertCreateDatabase((SqlCreateDatabase) validated));
-		}  else if (validated.getKind().belongsTo(SqlKind.QUERY)) {
+		} else if (validated instanceof SqlDropDatabase) {
+			return Optional.of(converter.convertDropDatabase((SqlDropDatabase) validated));
+		} else if (validated.getKind().belongsTo(SqlKind.QUERY)) {
 			return Optional.of(converter.convertSqlQuery(validated));
 		} else {
 			return Optional.empty();
@@ -237,6 +241,27 @@ public class SqlToOperationConverter {
 				((SqlTableOption) p).getValueString()));
 		CatalogDatabase catalogDatabase = new CatalogDatabaseImpl(properties, databaseComment);
 		return new CreateDatabaseOperation(catalogName, databaseName, catalogDatabase, ignoreIfExists);
+	}
+
+	/** Convert DROP DATABASE statement. */
+	private Operation convertDropDatabase(SqlDropDatabase sqlDropDatabase) {
+		String[] fullDatabaseName = sqlDropDatabase.fullDatabaseName();
+		if (fullDatabaseName.length > 2) {
+			throw new SqlConversionException("drop database identifier format error");
+		}
+		String catalogName = catalogManager.getCurrentCatalog();
+		String databaseName = null;
+		if (fullDatabaseName.length == 1) {
+			databaseName = fullDatabaseName[0];
+		} else {
+			catalogName = fullDatabaseName[0];
+			databaseName = fullDatabaseName[1];
+		}
+		return new DropDatabaseOperation(
+				catalogName,
+				databaseName,
+				sqlDropDatabase.getIfExists(),
+				sqlDropDatabase.isRestrict());
 	}
 
 	//~ Tools ------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -491,6 +491,13 @@ abstract class TableEnvImpl(
         catalogManager.dropTable(
           dropTableOperation.getTableIdentifier,
           dropTableOperation.isIfExists)
+      case dropDatabaseOperation: DropDatabaseOperation =>
+        catalogManager.dropDatabase(
+          dropDatabaseOperation.getCatalogName,
+          dropDatabaseOperation.getDatabaseName,
+          dropDatabaseOperation.isIfExists,
+          dropDatabaseOperation.isRestrict,
+          false)
       case useOperation: UseOperation => applyUseOperation(useOperation)
       case _ => throw new TableException(
         "Unsupported SQL query! sqlUpdate() only accepts a single SQL statements of " +

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -30,17 +30,16 @@ import org.apache.flink.table.factories.{TableFactoryService, TableFactoryUtil, 
 import org.apache.flink.table.functions.{AggregateFunction, ScalarFunction, TableFunction, UserDefinedAggregateFunction, _}
 import org.apache.flink.table.module.{Module, ModuleManager}
 import org.apache.flink.table.operations.ddl.{CreateTableOperation, DropTableOperation}
+import org.apache.flink.table.operations.ddl._
 import org.apache.flink.table.operations.utils.OperationTreeBuilder
 import org.apache.flink.table.operations.{CatalogQueryOperation, TableSourceQueryOperation, _}
 import org.apache.flink.table.planner.{ParserImpl, PlanningConfigurationBuilder}
 import org.apache.flink.table.sinks.{OverwritableTableSink, PartitionableTableSink, TableSink, TableSinkUtils}
 import org.apache.flink.table.sources.TableSource
 import org.apache.flink.table.util.JavaScalaConversionUtil
-
 import org.apache.calcite.jdbc.CalciteSchemaBuilder.asRootSchema
 import org.apache.calcite.sql.parser.SqlParser
 import org.apache.calcite.tools.FrameworkConfig
-
 import _root_.java.util.function.{Supplier => JSupplier}
 import _root_.java.util.{Optional, HashMap => JHashMap, Map => JMap}
 
@@ -468,7 +467,7 @@ abstract class TableEnvImpl(
 
     if (operations.size != 1) throw new TableException(
       "Unsupported SQL query! sqlUpdate() only accepts a single SQL statement of type " +
-        "INSERT, CREATE TABLE, DROP TABLE, USE CATALOG")
+        "INSERT, CREATE TABLE, DROP TABLE, USE CATALOG, USE [catalog.]database")
 
     operations.get(0) match {
       case op: CatalogSinkModifyOperation =>
@@ -485,12 +484,26 @@ abstract class TableEnvImpl(
         catalogManager.dropTable(
           dropTableOperation.getTableIdentifier,
           dropTableOperation.isIfExists)
-      case useCatalogOperation: UseCatalogOperation =>
-        catalogManager.setCurrentCatalog(useCatalogOperation.getCatalogName)
+      case useOperation: UseOperation => applyUseOperation(useOperation)
       case _ => throw new TableException(
         "Unsupported SQL query! sqlUpdate() only accepts a single SQL statements of " +
-          "type INSERT, CREATE TABLE, DROP TABLE, USE CATALOG")
+          "type INSERT, CREATE TABLE, DROP TABLE, USE CATALOG, USE [catalog.]database")
     }
+  }
+
+  /** Apply use operation to current table environment. */
+  private def applyUseOperation(useOperation: UseOperation): Unit = {
+      useOperation match {
+        case useCatalogOperation: UseCatalogOperation =>
+          catalogManager.setCurrentCatalog(useCatalogOperation.getCatalogName)
+        case useDatabaseOperation: UseDatabaseOperation => {
+          val fullDatabaseName = useDatabaseOperation.getFullDatabaseName
+          if (fullDatabaseName.length == 2) {
+            catalogManager.setCurrentCatalog(fullDatabaseName(0))
+            catalogManager.setCurrentDatabase(fullDatabaseName(1))
+          } else catalogManager.setCurrentDatabase(fullDatabaseName(0))
+        }
+      }
   }
 
   protected def createTable(tableOperation: QueryOperation): TableImpl = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -467,7 +467,8 @@ abstract class TableEnvImpl(
 
     if (operations.size != 1) throw new TableException(
       "Unsupported SQL query! sqlUpdate() only accepts a single SQL statement of type " +
-        "INSERT, CREATE TABLE, DROP TABLE, USE CATALOG, USE [catalog.]database, CREATE DATABASE")
+        "INSERT, CREATE TABLE, DROP TABLE, USE CATALOG, USE [catalog.]database, " +
+        "CREATE DATABASE, DROP DATABASE, ALTER DATABASE")
 
     operations.get(0) match {
       case op: CatalogSinkModifyOperation =>
@@ -498,11 +499,17 @@ abstract class TableEnvImpl(
           dropDatabaseOperation.isIfExists,
           dropDatabaseOperation.isRestrict,
           false)
+      case alterDatabaseOperation: AlterDatabaseOperation =>
+        catalogManager.alterDatabase(
+          alterDatabaseOperation.getCatalogName,
+          alterDatabaseOperation.getDatabaseName,
+          alterDatabaseOperation.getCatalogDatabase,
+          false)
       case useOperation: UseOperation => applyUseOperation(useOperation)
       case _ => throw new TableException(
         "Unsupported SQL query! sqlUpdate() only accepts a single SQL statements of " +
           "type INSERT, CREATE TABLE, DROP TABLE, USE CATALOG, USE [catalog.]database, " +
-          "CREATE DATABASE")
+          "CREATE DATABASE, DROP DATABASE, ALTER DATABASE")
     }
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -510,7 +510,7 @@ abstract class TableEnvImpl(
           catalog.dropDatabase(
             dropDatabaseOperation.getDatabaseName,
             dropDatabaseOperation.isIfExists,
-            dropDatabaseOperation.isRestrict)
+            dropDatabaseOperation.isCascade)
         } catch {
           case ex: DatabaseNotEmptyException => throw new ValidationException(exMsg, ex)
           case ex: DatabaseNotExistException => throw new ValidationException(exMsg, ex)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -518,13 +518,9 @@ abstract class TableEnvImpl(
       useOperation match {
         case useCatalogOperation: UseCatalogOperation =>
           catalogManager.setCurrentCatalog(useCatalogOperation.getCatalogName)
-        case useDatabaseOperation: UseDatabaseOperation => {
-          val fullDatabaseName = useDatabaseOperation.getFullDatabaseName
-          if (fullDatabaseName.length == 2) {
-            catalogManager.setCurrentCatalog(fullDatabaseName(0))
-            catalogManager.setCurrentDatabase(fullDatabaseName(1))
-          } else catalogManager.setCurrentDatabase(fullDatabaseName(0))
-        }
+        case useDatabaseOperation: UseDatabaseOperation =>
+          catalogManager.setCurrentCatalog(useDatabaseOperation.getCatalogName)
+          catalogManager.setCurrentDatabase(useDatabaseOperation.getDatabaseName)
       }
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -467,7 +467,7 @@ abstract class TableEnvImpl(
 
     if (operations.size != 1) throw new TableException(
       "Unsupported SQL query! sqlUpdate() only accepts a single SQL statement of type " +
-        "INSERT, CREATE TABLE, DROP TABLE, USE CATALOG, USE [catalog.]database")
+        "INSERT, CREATE TABLE, DROP TABLE, USE CATALOG, USE [catalog.]database, CREATE DATABASE")
 
     operations.get(0) match {
       case op: CatalogSinkModifyOperation =>
@@ -480,6 +480,13 @@ abstract class TableEnvImpl(
           createTableOperation.getCatalogTable,
           createTableOperation.getTableIdentifier,
           createTableOperation.isIgnoreIfExists)
+      case createDatabaseOperation: CreateDatabaseOperation =>
+        catalogManager.createDatabase(
+          createDatabaseOperation.getCatalogName,
+          createDatabaseOperation.getDatabaseName,
+          createDatabaseOperation.getCatalogDatabase,
+          createDatabaseOperation.isIgnoreIfExists,
+          false)
       case dropTableOperation: DropTableOperation =>
         catalogManager.dropTable(
           dropTableOperation.getTableIdentifier,
@@ -487,7 +494,8 @@ abstract class TableEnvImpl(
       case useOperation: UseOperation => applyUseOperation(useOperation)
       case _ => throw new TableException(
         "Unsupported SQL query! sqlUpdate() only accepts a single SQL statements of " +
-          "type INSERT, CREATE TABLE, DROP TABLE, USE CATALOG, USE [catalog.]database")
+          "type INSERT, CREATE TABLE, DROP TABLE, USE CATALOG, USE [catalog.]database, " +
+          "CREATE DATABASE")
     }
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -526,15 +526,11 @@ abstract class TableEnvImpl(
           case ex: DatabaseNotExistException => throw new ValidationException(exMsg, ex)
           case ex: Exception => throw new TableException(exMsg, ex)
         }
-      case useOperation: UseOperation => {
-        useOperation match {
-          case useCatalogOperation: UseCatalogOperation =>
-            catalogManager.setCurrentCatalog(useCatalogOperation.getCatalogName)
-          case useDatabaseOperation: UseDatabaseOperation =>
-            catalogManager.setCurrentCatalog(useDatabaseOperation.getCatalogName)
-            catalogManager.setCurrentDatabase(useDatabaseOperation.getDatabaseName)
-        }
-      }
+      case useCatalogOperation: UseCatalogOperation =>
+        catalogManager.setCurrentCatalog(useCatalogOperation.getCatalogName)
+      case useDatabaseOperation: UseDatabaseOperation =>
+        catalogManager.setCurrentCatalog(useDatabaseOperation.getCatalogName)
+        catalogManager.setCurrentDatabase(useDatabaseOperation.getDatabaseName)
       case _ => throw new TableException(UNSUPPORTED_QUERY_IN_SQL_UPDATE_MSG)
     }
   }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.api.Types;
 import org.apache.flink.table.calcite.CalciteParser;
 import org.apache.flink.table.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CatalogDatabaseImpl;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.CatalogManagerCalciteSchema;
 import org.apache.flink.table.catalog.CatalogTable;
@@ -175,6 +176,13 @@ public class SqlToOperationConverterTest {
 
 	@Test
 	public void testAlterDatabase() {
+		catalogManager.registerCatalog("cat1",
+									new GenericInMemoryCatalog("default", "default"));
+		catalogManager.createDatabase("cat1",
+									"db1",
+									new CatalogDatabaseImpl(new HashMap<>(), null),
+									true,
+									true);
 		final String sql = "alter database cat1.db1 set ('k1'='a')";
 		Operation operation = parse(sql, SqlDialect.DEFAULT);
 		assert operation instanceof AlterDatabaseOperation;

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
@@ -46,6 +46,7 @@ import org.apache.flink.table.operations.CatalogSinkModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
+import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
@@ -168,6 +169,15 @@ public class SqlToOperationConverterTest {
 			assertEquals(expectedIgnoreIfExists[i], createDatabaseOperation.isIgnoreIfExists());
 			assertEquals(expectedPropertySize[i], createDatabaseOperation.getCatalogDatabase().getProperties().size());
 		}
+	}
+
+	@Test
+	public void testAlterDatabase() {
+		final String sql = "alter database cat1.db1 set ('k1'='a')";
+		Operation operation = parse(sql, SqlDialect.DEFAULT);
+		assert operation instanceof AlterDatabaseOperation;
+		assertEquals("db1", ((AlterDatabaseOperation) operation).getDatabaseName());
+		assertEquals("cat1", ((AlterDatabaseOperation) operation).getCatalogName());
 	}
 
 	@Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
@@ -131,15 +131,17 @@ public class SqlToOperationConverterTest {
 		final String sql1 = "USE db1";
 		Operation operation1 = parse(sql1, SqlDialect.DEFAULT);
 		assert operation1 instanceof UseDatabaseOperation;
-		assertArrayEquals(new String[]{"db1"}, ((UseDatabaseOperation) operation1).getFullDatabaseName());
+		assertEquals("builtin", ((UseDatabaseOperation) operation1).getCatalogName());
+		assertEquals("db1", ((UseDatabaseOperation) operation1).getDatabaseName());
 
 		final String sql2 = "USE cat1.db1";
 		Operation operation2 = parse(sql2, SqlDialect.DEFAULT);
 		assert operation2 instanceof UseDatabaseOperation;
-		assertArrayEquals(new String[]{"cat1", "db1"}, ((UseDatabaseOperation) operation2).getFullDatabaseName());
+		assertEquals("cat1", ((UseDatabaseOperation) operation2).getCatalogName());
+		assertEquals("db1", ((UseDatabaseOperation) operation2).getDatabaseName());
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = SqlConversionException.class)
 	public void testUseDatabaseWithException() {
 		final String sql = "USE cat1.db1.tbl1";
 		Operation operation = parse(sql, SqlDialect.DEFAULT);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
@@ -201,7 +201,7 @@ public class SqlToOperationConverterTest {
 		final String[] expectedCatalogs = new String[] {"builtin", "builtin", "cat1", "cat1"};
 		final String expectedDatabase = "db1";
 		final boolean[] expectedIfExists = new boolean[] {false, true, true, true};
-		final boolean[] expectedIsRestricts = new boolean[] {true, true, false, true};
+		final boolean[] expectedIsCascades = new boolean[] {false, false, true, false};
 
 		for (int i = 0; i < dropDatabaseSqls.length; i++) {
 			Operation operation = parse(dropDatabaseSqls[i], SqlDialect.DEFAULT);
@@ -210,7 +210,7 @@ public class SqlToOperationConverterTest {
 			assertEquals(expectedCatalogs[i], dropDatabaseOperation.getCatalogName());
 			assertEquals(expectedDatabase, dropDatabaseOperation.getDatabaseName());
 			assertEquals(expectedIfExists[i], dropDatabaseOperation.isIfExists());
-			assertEquals(expectedIsRestricts[i], dropDatabaseOperation.isRestrict());
+			assertEquals(expectedIsCascades[i], dropDatabaseOperation.isCascade());
 		}
 	}
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
@@ -175,14 +175,13 @@ public class SqlToOperationConverterTest {
 	}
 
 	@Test
-	public void testAlterDatabase() {
+	public void testAlterDatabase() throws Exception {
 		catalogManager.registerCatalog("cat1",
 									new GenericInMemoryCatalog("default", "default"));
-		catalogManager.createDatabase("cat1",
-									"db1",
-									new CatalogDatabaseImpl(new HashMap<>(), "db1_comment"),
-									true,
-									true);
+		catalogManager.getCatalog("cat1").get()
+						.createDatabase("db1",
+								new CatalogDatabaseImpl(new HashMap<>(), "db1_comment"),
+								true);
 		final String sql = "alter database cat1.db1 set ('k1'='a')";
 		Operation operation = parse(sql, SqlDialect.DEFAULT);
 		assert operation instanceof AlterDatabaseOperation;

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
@@ -180,7 +180,7 @@ public class SqlToOperationConverterTest {
 									new GenericInMemoryCatalog("default", "default"));
 		catalogManager.createDatabase("cat1",
 									"db1",
-									new CatalogDatabaseImpl(new HashMap<>(), null),
+									new CatalogDatabaseImpl(new HashMap<>(), "db1_comment"),
 									true,
 									true);
 		final String sql = "alter database cat1.db1 set ('k1'='a')";
@@ -188,6 +188,7 @@ public class SqlToOperationConverterTest {
 		assert operation instanceof AlterDatabaseOperation;
 		assertEquals("db1", ((AlterDatabaseOperation) operation).getDatabaseName());
 		assertEquals("cat1", ((AlterDatabaseOperation) operation).getCatalogName());
+		assertEquals("db1_comment", ((AlterDatabaseOperation) operation).getCatalogDatabase().getComment());
 	}
 
 	@Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
@@ -48,6 +48,7 @@ import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
+import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
 import org.apache.flink.table.planner.PlanningConfigurationBuilder;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.utils.TypeConversions;
@@ -166,6 +167,30 @@ public class SqlToOperationConverterTest {
 			assertEquals(expectedComments[i], createDatabaseOperation.getCatalogDatabase().getComment());
 			assertEquals(expectedIgnoreIfExists[i], createDatabaseOperation.isIgnoreIfExists());
 			assertEquals(expectedPropertySize[i], createDatabaseOperation.getCatalogDatabase().getProperties().size());
+		}
+	}
+
+	@Test
+	public void testDropDatabase() {
+		final String[] dropDatabaseSqls = new String[] {
+				"drop database db1",
+				"drop database if exists db1",
+				"drop database if exists cat1.db1 CASCADE",
+				"drop database if exists cat1.db1 RESTRICT"
+		};
+		final String[] expectedCatalogs = new String[] {"builtin", "builtin", "cat1", "cat1"};
+		final String expectedDatabase = "db1";
+		final boolean[] expectedIfExists = new boolean[] {false, true, true, true};
+		final boolean[] expectedIsRestricts = new boolean[] {true, true, false, true};
+
+		for (int i = 0; i < dropDatabaseSqls.length; i++) {
+			Operation operation = parse(dropDatabaseSqls[i], SqlDialect.DEFAULT);
+			assert operation instanceof DropDatabaseOperation;
+			final DropDatabaseOperation dropDatabaseOperation = (DropDatabaseOperation) operation;
+			assertEquals(expectedCatalogs[i], dropDatabaseOperation.getCatalogName());
+			assertEquals(expectedDatabase, dropDatabaseOperation.getDatabaseName());
+			assertEquals(expectedIfExists[i], dropDatabaseOperation.isIfExists());
+			assertEquals(expectedIsRestricts[i], dropDatabaseOperation.isRestrict());
 		}
 	}
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/catalog/CatalogTableITCase.scala
@@ -544,6 +544,20 @@ class CatalogTableITCase(isStreaming: Boolean) {
     tableEnv.sqlUpdate("use catalog cat2")
     assertEquals("cat2", tableEnv.getCurrentCatalog)
   }
+
+  @Test
+  def testUseDatabase(): Unit = {
+    val catalog = new GenericInMemoryCatalog("cat1")
+    tableEnv.registerCatalog("cat1", catalog)
+    val catalogDB1 = new CatalogDatabaseImpl(new util.HashMap[String, String](), "db1")
+    val catalogDB2 = new CatalogDatabaseImpl(new util.HashMap[String, String](), "db2")
+    catalog.createDatabase("db1", catalogDB1, true)
+    catalog.createDatabase("db2", catalogDB2, true)
+    tableEnv.sqlUpdate("use cat1.db1")
+    assertEquals("db1", tableEnv.getCurrentDatabase)
+    tableEnv.sqlUpdate("use db2")
+    assertEquals("db2", tableEnv.getCurrentDatabase)
+  }
 }
 
 object CatalogTableITCase {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/catalog/CatalogTableITCase.scala
@@ -626,6 +626,21 @@ class CatalogTableITCase(isStreaming: Boolean) {
     }
     tableEnv.sqlUpdate("drop database db1 cascade")
   }
+
+  @Test
+  def testAlterDatabase: Unit = {
+    tableEnv.registerCatalog("cat1", new GenericInMemoryCatalog("default"))
+    tableEnv.sqlUpdate("use catalog cat1")
+    tableEnv.sqlUpdate("create database db1 comment 'db1_comment' with ('k1' = 'v1')")
+    tableEnv.sqlUpdate("alter database db1 set ('k1' = 'a', 'k2' = 'b')")
+    val database = tableEnv.getCatalog("cat1").get().getDatabase("db1")
+    assertEquals("db1_comment", database.getComment)
+    assertEquals(2, database.getProperties.size())
+    val expectedProperty = new util.HashMap[String, String]()
+    expectedProperty.put("k1", "a")
+    expectedProperty.put("k2", "b")
+    assertEquals(expectedProperty, database.getProperties)
+  }
 }
 
 object CatalogTableITCase {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/catalog/CatalogTableITCase.scala
@@ -580,6 +580,52 @@ class CatalogTableITCase(isStreaming: Boolean) {
     expectedProperty.put("k2", "v2")
     assertEquals(expectedProperty, database.getProperties)
   }
+
+  @Test
+  def testDropDatabase: Unit = {
+    tableEnv.registerCatalog("cat1", new GenericInMemoryCatalog("default"))
+    tableEnv.sqlUpdate("use catalog cat1")
+    tableEnv.sqlUpdate("create database db1")
+    tableEnv.sqlUpdate("drop database db1")
+    tableEnv.sqlUpdate("drop database if exists db1")
+    try {
+      tableEnv.sqlUpdate("drop database db1")
+      fail("ValidationException expected")
+    } catch {
+      case _: ValidationException => //ignore
+    }
+    tableEnv.sqlUpdate("create database db1")
+    tableEnv.sqlUpdate("use db1")
+    val ddl1 =
+      """
+        |create table t1(
+        |  a bigint,
+        |  b bigint,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION'
+        |)
+      """.stripMargin
+    tableEnv.sqlUpdate(ddl1)
+    val ddl2 =
+      """
+        |create table t2(
+        |  a bigint,
+        |  b bigint,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION'
+        |)
+      """.stripMargin
+    tableEnv.sqlUpdate(ddl2)
+    try {
+      tableEnv.sqlUpdate("drop database db1")
+      fail("ValidationException expected")
+    } catch {
+      case _: ValidationException => //ignore
+    }
+    tableEnv.sqlUpdate("drop database db1 cascade")
+  }
 }
 
 object CatalogTableITCase {


### PR DESCRIPTION
## What is the purpose of the change
According to FLIP-69, we should support such following DDLs related to the database in the TableEnvironment through `sqlUpdate()` method.
1. createDatabaseStatement:
CREATE DATABASE [ IF NOT EXISTS ] [ catalogName.] dataBaseName [ COMMENT database_comment ]
[WITH ( name=value [, name=value]*)]
2. dropDatabaseStatement:
DROP DATABASE [ IF EXISTS ] [ catalogName.] dataBaseName [ (RESTRICT|CASCADE)]
3. alterDatabaseStatement:
ALTER DATABASE [ catalogName.] dataBaseName SET ( name=value [, name=value]*)
4. useDatabaseStatement:
USE [ catalogName.] dataBaseName

## Brief change log
  - [9c6174e](https://github.com/apache/flink/commit/9c6174ed579f803616f3fce54782eb541a05223a) add use database support in tableEnvironment
  - [37ef49f](https://github.com/apache/flink/commit/37ef49faee99f3e52c95fd3087a9ae8027920bee) add create database support in tableEnvironment
  - [e1b42d8](https://github.com/apache/flink/commit/e1b42d810cc158f8716208c3501be391efd910ce) add drop database support in tableEnvironment
  - [7c5e46d](https://github.com/apache/flink/commit/7c5e46d1f794cb01be5088f5f5d29aec5850bf7f) add alter database support in tableEnvironment


## Verifying this change
This change added tests and can be verified as follows:
  - *SqlToOperationConverterTest#testUseDatabase* and *CatalogTableITCase#testUseDatabase*
  - *SqlToOperationConverterTest#testCreateDatabase* and *CatalogTableITCase#testCreateDatabase*
  - *SqlToOperationConverterTest#testDropDatabase* and *CatalogTableITCase#testDropDatabase*
  - *SqlToOperationConverterTest#testAlterDatabase* and *CatalogTableITCase#testAlterDatabase*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? (not applicable)
