### PR TITLE
[FLINK-14846][doc] Correct the default writerbuffer size documentation of RocksDB

### DIFF
--- a/docs/_includes/generated/rocks_db_configurable_configuration.html
+++ b/docs/_includes/generated/rocks_db_configurable_configuration.html
@@ -72,7 +72,7 @@
             <td><h5>state.backend.rocksdb.writebuffer.size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>The amount of data built up in memory (backed by an unsorted log on disk) before converting to a sorted on-disk files. RocksDB has default writebuffer size as '4MB'.</td>
+            <td>The amount of data built up in memory (backed by an unsorted log on disk) before converting to a sorted on-disk files. RocksDB has default writebuffer size as '64MB'.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -94,7 +94,7 @@ public class RocksDBConfigurableOptions implements Serializable {
 		key("state.backend.rocksdb.writebuffer.size")
 			.noDefaultValue()
 			.withDescription("The amount of data built up in memory (backed by an unsorted log on disk) " +
-				"before converting to a sorted on-disk files. RocksDB has default writebuffer size as '4MB'.");
+				"before converting to a sorted on-disk files. RocksDB has default writebuffer size as '64MB'.");
 
 	public static final ConfigOption<String> MAX_WRITE_BUFFER_NUMBER =
 		key("state.backend.rocksdb.writebuffer.count")


### PR DESCRIPTION
## What is the purpose of the change

Correct the default write buffer size of RocksDB to '64MB'.

## Brief change log
Correct the default write buffer size of RocksDB to '64MB'

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
