### PR TITLE
[FLINK-14838] Cleanup the description about container number config option in Scala and python shell doc

### DIFF
--- a/docs/ops/python_shell.md
+++ b/docs/ops/python_shell.md
@@ -139,7 +139,7 @@ bin/pyflink-shell.sh remote <hostname> <portnumber>
 ### Yarn Python Shell cluster
 
 The shell can deploy a Flink cluster to YARN, which is used exclusively by the
-shell. The number of YARN containers can be controlled by the parameter `-n <arg>`.
+shell.
 The shell deploys a new Flink cluster on YARN and connects the
 cluster. You can also specify options for YARN cluster such as memory for
 JobManager, name of YARN application, etc.
@@ -190,8 +190,6 @@ usage:
                                      all options.
      -jm,--jobManagerMemory <arg>    Memory for JobManager Container with
                                      optional unit (default: MB)
-     -n,--container <arg>            Number of YARN container to allocate
-                                     (=Number of Task Managers)
      -nm,--name <arg>                Set a custom name for the application on
                                      YARN
      -qu,--queue <arg>               Specify YARN queue.

--- a/docs/ops/scala_shell.md
+++ b/docs/ops/scala_shell.md
@@ -234,7 +234,7 @@ bin/start-scala-shell.sh remote <hostname> <portnumber>
 ### Yarn Scala Shell cluster
 
 The shell can deploy a Flink cluster to YARN, which is used exclusively by the
-shell. The number of YARN containers can be controlled by the parameter `-n <arg>`.
+shell.
 The shell deploys a new Flink cluster on YARN and connects the
 cluster. You can also specify options for YARN cluster such as memory for
 JobManager, name of YARN application, etc.
@@ -280,8 +280,6 @@ Starts Flink scala shell connecting to a remote cluster
         Specifies additional jars to be used in Flink
 Command: yarn [options]
 Starts Flink scala shell connecting to a yarn cluster
-  -n arg | --container arg
-        Number of YARN container to allocate (= Number of TaskManagers)
   -jm arg | --jobManagerMemory arg
         Memory for JobManager container with optional unit (default: MB)
   -nm <value> | --name <value>

--- a/docs/ops/scala_shell.zh.md
+++ b/docs/ops/scala_shell.zh.md
@@ -234,7 +234,7 @@ bin/start-scala-shell.sh remote <hostname> <portnumber>
 ### Yarn Scala Shell cluster
 
 The shell can deploy a Flink cluster to YARN, which is used exclusively by the
-shell. The number of YARN containers can be controlled by the parameter `-n <arg>`.
+shell.
 The shell deploys a new Flink cluster on YARN and connects the
 cluster. You can also specify options for YARN cluster such as memory for
 JobManager, name of YARN application, etc.
@@ -280,8 +280,6 @@ Starts Flink scala shell connecting to a remote cluster
         Specifies additional jars to be used in Flink
 Command: yarn [options]
 Starts Flink scala shell connecting to a yarn cluster
-  -n arg | --container arg
-        Number of YARN container to allocate (= Number of TaskManagers)
   -jm arg | --jobManagerMemory arg
         Memory for JobManager container with optional unit (default: MB)
   -nm <value> | --name <value>

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonShellParser.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonShellParser.java
@@ -39,14 +39,6 @@ public class PythonShellParser {
 		.desc("Show the help message with descriptions of all options.")
 		.build();
 
-	private static final Option OPTION_CONTAINER = Option
-		.builder("n")
-		.required(false)
-		.longOpt("container")
-		.hasArg()
-		.desc("Number of YARN container to allocate (=Number of Task Managers)")
-		.build();
-
 	private static final Option OPTION_JM_MEMORY = Option
 		.builder("jm")
 		.required(false)
@@ -156,7 +148,6 @@ public class PythonShellParser {
 
 	private static Options getYarnOptions(Options options) {
 		buildGeneralOptions(options);
-		options.addOption(OPTION_CONTAINER);
 		options.addOption(OPTION_JM_MEMORY);
 		options.addOption(OPTION_NAME);
 		options.addOption(OPTION_QUEUE);
@@ -257,7 +248,6 @@ public class PythonShellParser {
 		options.add(args[0]);
 		options.add("-m");
 		options.add("yarn-cluster");
-		constructYarnOption(options, OPTION_CONTAINER, commandLine);
 		constructYarnOption(options, OPTION_JM_MEMORY, commandLine);
 		constructYarnOption(options, OPTION_NAME, commandLine);
 		constructYarnOption(options, OPTION_QUEUE, commandLine);


### PR DESCRIPTION


## What is the purpose of the change

*This pull request cleanups the description about container number config option in Scala and python shell doc*

## Brief change log

  - *Cleanup the description about container number config option in Scala and python shell doc*


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
