### PR TITLE
[FLINK-14892][docs] Add documentation for checkpoint directory layout

### DIFF
--- a/docs/ops/state/checkpoints.md
+++ b/docs/ops/state/checkpoints.md
@@ -63,6 +63,24 @@ files. The meta data file and data files are stored in the directory that is
 configured via `state.checkpoints.dir` in the configuration files, 
 and also can be specified for per job in the code.
 
+The current checkpoint directory layout which introduced by FLINK-8531 is as follows:
+
+{% highlight yaml %}
+/user-defined-checkpoint-dir
+    |
+    + --shared/
+    + --taskowned/
+    + --chk-00001/
+    + --chk-00002/
+    + --chk-00003/
+    ...
+{% endhighlight %}
+
+The **SHARED** directory is for state that is possibly part of multiple checkpoints, **TASKOWNED** is for state that must never by dropped by the JobManager, and **EXCLUSIVE** is for state that belongs to one checkpoint only. 
+
+<div class="alert alert-warning">
+  <strong>Attention:</strong> The checkpoint directory is not part of a public API and can be changed in the future release.
+</div>
 #### Configure globally via configuration files
 
 {% highlight yaml %}

--- a/docs/ops/state/checkpoints.md
+++ b/docs/ops/state/checkpoints.md
@@ -63,7 +63,7 @@ files. The meta data file and data files are stored in the directory that is
 configured via `state.checkpoints.dir` in the configuration files, 
 and also can be specified for per job in the code.
 
-The current checkpoint directory layout which introduced by FLINK-8531 is as follows:
+The current checkpoint directory layout ([introduced by FLINK-8531](https://issues.apache.org/jira/browse/FLINK-8531)) is as follows:
 
 {% highlight yaml %}
 /user-defined-checkpoint-dir

--- a/docs/ops/state/checkpoints.zh.md
+++ b/docs/ops/state/checkpoints.zh.md
@@ -48,6 +48,24 @@ config.enableExternalizedCheckpoints(ExternalizedCheckpointCleanup.RETAIN_ON_CAN
 
 与 [savepoints](savepoints.html) 相似，checkpoint 由元数据文件、数据文件（与 state backend 相关）组成。可通过配置文件中 "state.checkpoints.dir" 配置项来指定元数据文件和数据文件的存储路径，另外也可以在代码中针对单个作业特别指定该配置项。
 
+当前的 checkpoint 目录结构（由 FLINK-8531 引入）如下所示:
+
+{% highlight yaml %}
+/user-defined-checkpoint-dir
+    |
+    + --shared/
+    + --taskowned/
+    + --chk-00001/
+    + --chk-00002/
+    + --chk-00003/
+    ...
+{% endhighlight %}
+
+其中 **SHARED** 目录保存了可能被多个 checkpoint 引用的文件，**TASKOWNED** 保存了不会被 JobManager 删除的文件，**EXCLUSIVE** 则保存那些仅被单个 checkpoint 引用的文件。
+
+<div class="alert alert-warning">
+  <strong>注意:</strong> Checkpoint 目录不是公共 API 的一部分，因此可能在未来的 Release 中进行改变。
+</div>
 #### 通过配置文件全局配置
 
 {% highlight yaml %}

--- a/docs/ops/state/checkpoints.zh.md
+++ b/docs/ops/state/checkpoints.zh.md
@@ -48,7 +48,7 @@ config.enableExternalizedCheckpoints(ExternalizedCheckpointCleanup.RETAIN_ON_CAN
 
 与 [savepoints](savepoints.html) 相似，checkpoint 由元数据文件、数据文件（与 state backend 相关）组成。可通过配置文件中 "state.checkpoints.dir" 配置项来指定元数据文件和数据文件的存储路径，另外也可以在代码中针对单个作业特别指定该配置项。
 
-当前的 checkpoint 目录结构（由 FLINK-8531 引入）如下所示:
+当前的 checkpoint 目录结构（由 [FLINK-8531](https://issues.apache.org/jira/browse/FLINK-8531) 引入）如下所示:
 
 {% highlight yaml %}
 /user-defined-checkpoint-dir


### PR DESCRIPTION
## What is the purpose of the change

In FLINK-8531, we change the checkpoint directory layout to
```
/user-defined-checkpoint-dir
    |
    + --shared/
    + --taskowned/
    + --chk-00001/
    + --chk-00002/
    + --chk-00003/
    ...
```
But the directory layout did not describe in the doc currently, and some users confused about this in the mail-list, this pr wants to add a description for the checkpoint directory layout in the documentation.



## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
