### PR TITLE
[FLINK-14903][table] Relax structured types constraints

### DIFF
--- a/flink-python/src/test/java/org/apache/flink/table/functions/python/PythonTypeUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/functions/python/PythonTypeUtilsTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.functions.python;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.runtime.RowSerializer;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.runtime.typeutils.BaseRowSerializer;
 import org.apache.flink.table.runtime.typeutils.PythonTypeUtils;
 import org.apache.flink.table.types.logical.BigIntType;
@@ -78,8 +79,8 @@ public class PythonTypeUtilsTest {
 
 	@Test
 	public void testUnsupportedTypeSerializer() {
-		LogicalType logicalType = new UnresolvedUserDefinedType("", "", "");
-		String expectedTestException = "Python UDF doesn't support logical type ``.``.`` currently.";
+		LogicalType logicalType = new UnresolvedUserDefinedType(UnresolvedIdentifier.of("cat", "db", "MyType"));
+		String expectedTestException = "Python UDF doesn't support logical type `cat`.`db`.`MyType` currently.";
 		try {
 			PythonTypeUtils.toFlinkTypeSerializer(logicalType);
 		} catch (Exception e) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/UnresolvedIdentifier.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/UnresolvedIdentifier.java
@@ -34,15 +34,15 @@ import java.util.stream.Stream;
 
 /**
  * Identifier of an object, such as table, view, function or type in a catalog. This identifier
- * cannot be used directly to access an object in a {@link CatalogManager}, but has to be first
+ * cannot be used directly to access an object in a catalog manager, but has to be first
  * fully resolved into {@link ObjectIdentifier}.
  */
 @Internal
-public class UnresolvedIdentifier {
+public final class UnresolvedIdentifier {
 
-	private final String catalogName;
+	private final @Nullable String catalogName;
 
-	private final String databaseName;
+	private final @Nullable String databaseName;
 
 	private final String objectName;
 
@@ -52,7 +52,7 @@ public class UnresolvedIdentifier {
 	 * identifier with catalog, database and object name).
 	 *
 	 * @param path array of identifier segments
-	 * @return an identifier that must be resolved before accessing an object from a {@link CatalogManager}
+	 * @return an identifier that must be resolved before accessing an object from a catalog manager
 	 */
 	public static UnresolvedIdentifier of(String... path) {
 		if (path == null) {
@@ -95,6 +95,16 @@ public class UnresolvedIdentifier {
 		return objectName;
 	}
 
+	/**
+	 * Returns a string that summarizes this instance for printing to a console or log.
+	 */
+	public String asSummaryString() {
+		return Stream.of(catalogName, databaseName, objectName)
+			.filter(Objects::nonNull)
+			.map(EncodingUtils::escapeIdentifier)
+			.collect(Collectors.joining("."));
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -104,8 +114,8 @@ public class UnresolvedIdentifier {
 			return false;
 		}
 		UnresolvedIdentifier that = (UnresolvedIdentifier) o;
-		return catalogName.equals(that.catalogName) &&
-			databaseName.equals(that.databaseName) &&
+		return Objects.equals(catalogName, that.catalogName) &&
+			Objects.equals(databaseName, that.databaseName) &&
 			objectName.equals(that.objectName);
 	}
 
@@ -116,12 +126,6 @@ public class UnresolvedIdentifier {
 
 	@Override
 	public String toString() {
-		return Stream.of(
-			catalogName,
-			databaseName,
-			objectName
-		).filter(Objects::nonNull)
-			.map(EncodingUtils::escapeIdentifier)
-			.collect(Collectors.joining("."));
+		return asSummaryString();
 	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DistinctType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DistinctType.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.types.logical;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.util.Preconditions;
 
@@ -67,7 +68,7 @@ public final class DistinctType extends UserDefinedType {
 				"Source type must not be a user-defined type.");
 		}
 
-		public Builder setDescription(String description) {
+		public Builder description(String description) {
 			this.description = Preconditions.checkNotNull(description, "Description must not be null");
 			return this;
 		}
@@ -92,8 +93,20 @@ public final class DistinctType extends UserDefinedType {
 		this.sourceType = Preconditions.checkNotNull(sourceType, "Source type must not be null.");
 	}
 
+	/**
+	 * Creates a builder for a {@link DistinctType}.
+	 */
+	public static DistinctType.Builder newBuilder(ObjectIdentifier objectIdentifier, LogicalType sourceType) {
+		return new DistinctType.Builder(objectIdentifier, sourceType);
+	}
+
 	public LogicalType getSourceType() {
 		return sourceType;
+	}
+
+	public ObjectIdentifier getObjectIdentifier() {
+		return getOptionalObjectIdentifier()
+			.orElseThrow(() -> new TableException("Object identifier expected."));
 	}
 
 	@Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/StructuredType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/StructuredType.java
@@ -35,17 +35,24 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Logical type of a user-defined object structured type. Structured types contain one or more
+ * Logical type of a user-defined object structured type. Structured types contain zero, one or more
  * attributes. Each attribute consists of a name and a type. A type cannot be defined so that one of
  * its attribute types (transitively) uses itself.
+ *
+ * <p>There are two kinds of structured types. Types that are stored in a catalog and are identified
+ * by an {@link ObjectIdentifier} or anonymously defined, unregistered types (usually reflectively
+ * extracted) that are identified by an implementation {@link Class}.
  *
  * <p>A structured type can declare a super type and allows single inheritance for more complex type
  * hierarchies, similar to JVM-based languages.
  *
- * <p>A structured type must be declared {@code final} for preventing further inheritance (default
+ * <p>A structured type can be declared {@code final} for preventing further inheritance (default
  * behavior) or {@code not final} for allowing subtypes.
  *
- * <p>A structured type must be declared {@code not instantiable} if a more specific type is
+ * <p>A structured type must offer a default constructor with zero arguments or a full constructor
+ * that assigns all attributes.
+ *
+ * <p>A structured type can be declared {@code not instantiable} if a more specific type is
  * required or {@code instantiable} if instances can be created from this type (default behavior).
  *
  * <p>A structured type declares comparision properties of either {@code none} (no equality),
@@ -132,11 +139,13 @@ public final class StructuredType extends UserDefinedType {
 	/**
 	 * A builder for a {@link StructuredType}. Intended for future extensibility.
 	 */
-	public static class Builder {
+	public static final class Builder {
 
-		private final ObjectIdentifier objectIdentifier;
+		private final @Nullable ObjectIdentifier objectIdentifier;
 
-		private final List<StructuredAttribute> attributes;
+		private final @Nullable Class<?> implementationClass;
+
+		private List<StructuredAttribute> attributes = new ArrayList<>();
 
 		private boolean isNullable = true;
 
@@ -150,51 +159,59 @@ public final class StructuredType extends UserDefinedType {
 
 		private @Nullable String description;
 
-		private @Nullable Class<?> implementationClass;
+		public Builder(Class<?> implementationClass) {
+			this.objectIdentifier = null;
+			this.implementationClass =
+				Preconditions.checkNotNull(implementationClass, "Implementation class must not be null.");
+		}
 
-		public Builder(ObjectIdentifier objectIdentifier, List<StructuredAttribute> attributes) {
-			this.objectIdentifier = Preconditions.checkNotNull(objectIdentifier, "Object identifier must not be null.");
+		public Builder(ObjectIdentifier objectIdentifier) {
+			this.objectIdentifier =
+				Preconditions.checkNotNull(objectIdentifier, "Object identifier must not be null.");
+			this.implementationClass = null;
+		}
+
+		public Builder(ObjectIdentifier objectIdentifier, Class<?> implementationClass) {
+			this.objectIdentifier =
+				Preconditions.checkNotNull(objectIdentifier, "Object identifier must not be null.");
+			this.implementationClass =
+				Preconditions.checkNotNull(implementationClass, "Implementation class must not be null.");
+		}
+
+		public Builder attributes(List<StructuredAttribute> attributes) {
 			this.attributes = Collections.unmodifiableList(
 				new ArrayList<>(
 					Preconditions.checkNotNull(attributes, "Attributes must not be null.")));
-
-			Preconditions.checkArgument(
-				attributes.size() > 0,
-				"Attribute list must not be empty.");
+			return this;
 		}
 
-		public Builder setNullable(boolean isNullable) {
+		public Builder isNullable(boolean isNullable) {
 			this.isNullable = isNullable;
 			return this;
 		}
 
-		public Builder setDescription(String description) {
+		public Builder description(String description) {
 			this.description = Preconditions.checkNotNull(description, "Description must not be null.");
 			return this;
 		}
 
-		public Builder setFinal(boolean isFinal) {
+		public Builder isFinal(boolean isFinal) {
 			this.isFinal = isFinal;
 			return this;
 		}
 
-		public Builder setInstantiable(boolean isInstantiable) {
+		public Builder isInstantiable(boolean isInstantiable) {
 			this.isInstantiable = isInstantiable;
 			return this;
 		}
 
-		public Builder setComparision(StructuredComparision comparision) {
+		public Builder comparision(StructuredComparision comparision) {
 			this.comparision = Preconditions.checkNotNull(comparision, "Comparision must not be null.");
 			return this;
 		}
 
-		public Builder setSuperType(@Nullable StructuredType superType) {
+		public Builder superType(StructuredType superType) {
 			this.superType = Preconditions.checkNotNull(superType, "Super type must not be null.");
-			return this;
-		}
-
-		public Builder setImplementationClass(Class<?> implementationClass) {
-			this.implementationClass = Preconditions.checkNotNull(implementationClass, "Implementation class must not null.");
 			return this;
 		}
 
@@ -239,11 +256,42 @@ public final class StructuredType extends UserDefinedType {
 			isFinal,
 			description);
 
+		Preconditions.checkArgument(
+			objectIdentifier != null || implementationClass != null,
+			"An identifier is missing.");
+
 		this.attributes = attributes;
 		this.isInstantiable = isInstantiable;
 		this.comparision = comparision;
 		this.superType = superType;
 		this.implementationClass = implementationClass;
+	}
+
+	/**
+	 * Creates a builder for a {@link StructuredType} that has been stored in a catalog and is
+	 * identified by an {@link ObjectIdentifier}.
+	 */
+	public static StructuredType.Builder newBuilder(ObjectIdentifier objectIdentifier) {
+		return new StructuredType.Builder(objectIdentifier);
+	}
+
+	/**
+	 * Creates a builder for a {@link StructuredType} that has been stored in a catalog and is
+	 * identified by an {@link ObjectIdentifier}. The optional implementation class defines supported
+	 * conversions.
+	 */
+	public static StructuredType.Builder newBuilder(
+			ObjectIdentifier objectIdentifier,
+			Class<?> implementationClass) {
+		return new StructuredType.Builder(objectIdentifier, implementationClass);
+	}
+
+	/**
+	 * Creates a builder for a {@link StructuredType} that is not stored in a catalog and is
+	 * identified by an implementation {@link Class}.
+	 */
+	public static StructuredType.Builder newBuilder(Class<?> implementationClass) {
+		return new StructuredType.Builder(implementationClass);
 	}
 
 	public List<StructuredAttribute> getAttributes() {
@@ -270,7 +318,7 @@ public final class StructuredType extends UserDefinedType {
 	public LogicalType copy(boolean isNullable) {
 		return new StructuredType(
 			isNullable,
-			getObjectIdentifier(),
+			getOptionalObjectIdentifier().orElse(null),
 			attributes.stream().map(StructuredAttribute::copy).collect(Collectors.toList()),
 			isFinal(),
 			isInstantiable,
@@ -278,6 +326,15 @@ public final class StructuredType extends UserDefinedType {
 			superType == null ? null : (StructuredType) superType.copy(),
 			getDescription().orElse(null),
 			implementationClass);
+	}
+
+	@Override
+	public String asSummaryString() {
+		if (getOptionalObjectIdentifier().isPresent()) {
+			return asSerializableString();
+		}
+		assert implementationClass != null;
+		return implementationClass.getName();
 	}
 
 	@Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/StructuredType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/StructuredType.java
@@ -185,7 +185,7 @@ public final class StructuredType extends UserDefinedType {
 			return this;
 		}
 
-		public Builder isNullable(boolean isNullable) {
+		public Builder setNullable(boolean isNullable) {
 			this.isNullable = isNullable;
 			return this;
 		}
@@ -195,12 +195,12 @@ public final class StructuredType extends UserDefinedType {
 			return this;
 		}
 
-		public Builder isFinal(boolean isFinal) {
+		public Builder setFinal(boolean isFinal) {
 			this.isFinal = isFinal;
 			return this;
 		}
 
-		public Builder isInstantiable(boolean isInstantiable) {
+		public Builder setInstantiable(boolean isInstantiable) {
 			this.isInstantiable = isInstantiable;
 			return this;
 		}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/UnresolvedUserDefinedType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/UnresolvedUserDefinedType.java
@@ -20,20 +20,14 @@ package org.apache.flink.table.types.logical;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.api.TableException;
-import org.apache.flink.table.utils.EncodingUtils;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.util.Preconditions;
-
-import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
- * Placeholder type of an unresolved user-defined type that is identified by a partially or fully
- * qualified path ({@code [catalog].[database].[type]}).
+ * Placeholder type of an unresolved user-defined type that is identified by an {@link UnresolvedIdentifier}.
  *
  * <p>It assumes that a type has been registered in a catalog and just needs to be resolved to a
  * {@link DistinctType} or {@link StructuredType}.
@@ -45,56 +39,30 @@ import java.util.stream.Stream;
 @PublicEvolving
 public final class UnresolvedUserDefinedType extends LogicalType {
 
-	private final @Nullable String catalog;
+	private final UnresolvedIdentifier unresolvedIdentifier;
 
-	private final @Nullable String database;
-
-	private final String typeIdentifier;
-
-	public UnresolvedUserDefinedType(
-			boolean isNullable,
-			@Nullable String catalog,
-			@Nullable String database,
-			String typeIdentifier) {
+	public UnresolvedUserDefinedType(boolean isNullable, UnresolvedIdentifier unresolvedIdentifier) {
 		super(isNullable, LogicalTypeRoot.UNRESOLVED);
-		this.catalog = catalog;
-		this.database = database;
-		this.typeIdentifier = Preconditions.checkNotNull(
-			typeIdentifier,
+		this.unresolvedIdentifier = Preconditions.checkNotNull(unresolvedIdentifier,
 			"Type identifier must not be null.");
 	}
 
-	public UnresolvedUserDefinedType(
-			@Nullable String catalog,
-			@Nullable String database,
-			String typeIdentifier) {
-		this(true, catalog, database, typeIdentifier);
+	public UnresolvedUserDefinedType(UnresolvedIdentifier unresolvedIdentifier) {
+		this(true, unresolvedIdentifier);
 	}
 
-	public Optional<String> getCatalog() {
-		return Optional.ofNullable(catalog);
-	}
-
-	public Optional<String> getDatabase() {
-		return Optional.ofNullable(database);
-	}
-
-	public String getTypeIdentifier() {
-		return typeIdentifier;
+	public UnresolvedIdentifier getUnresolvedIdentifier() {
+		return unresolvedIdentifier;
 	}
 
 	@Override
 	public LogicalType copy(boolean isNullable) {
-		return new UnresolvedUserDefinedType(isNullable, catalog, database, typeIdentifier);
+		return new UnresolvedUserDefinedType(isNullable, unresolvedIdentifier);
 	}
 
 	@Override
 	public String asSummaryString() {
-		final String path = Stream.of(catalog, database, typeIdentifier)
-			.filter(Objects::nonNull)
-			.map(EncodingUtils::escapeIdentifier)
-			.collect(Collectors.joining("."));
-		return withNullability(path);
+		return withNullability(unresolvedIdentifier.asSummaryString());
 	}
 
 	@Override
@@ -141,13 +109,11 @@ public final class UnresolvedUserDefinedType extends LogicalType {
 			return false;
 		}
 		UnresolvedUserDefinedType that = (UnresolvedUserDefinedType) o;
-		return Objects.equals(catalog, that.catalog) &&
-			Objects.equals(database, that.database) &&
-			typeIdentifier.equals(that.typeIdentifier);
+		return unresolvedIdentifier.equals(that.unresolvedIdentifier);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(super.hashCode(), catalog, database, typeIdentifier);
+		return Objects.hash(super.hashCode(), unresolvedIdentifier);
 	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeParser.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeParser.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.types.logical.AnyType;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
@@ -557,10 +558,18 @@ public final class LogicalTypeParser {
 				nextToken(TokenType.IDENTIFIER);
 				parts.add(tokenAsString());
 			}
-			return new UnresolvedUserDefinedType(
-				lastPart(parts, 2),
-				lastPart(parts, 1),
-				lastPart(parts, 0));
+			final String catPart = lastPart(parts, 2);
+			final String dbPart = lastPart(parts, 1);
+			final String objPart = lastPart(parts, 0);
+			final UnresolvedIdentifier identifier;
+			if (catPart != null) {
+				identifier = UnresolvedIdentifier.of(catPart, dbPart, objPart);
+			} else if (dbPart != null) {
+				identifier = UnresolvedIdentifier.of(dbPart, objPart);
+			} else {
+				identifier = UnresolvedIdentifier.of(objPart);
+			}
+			return new UnresolvedUserDefinedType(identifier);
 		}
 
 		private @Nullable String lastPart(List<String> parts, int inversePos) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeParser.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeParser.java
@@ -58,6 +58,7 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -384,7 +385,7 @@ public final class LogicalTypeParser {
 
 		private int tokenAsInt() {
 			try {
-				return Integer.valueOf(token().value);
+				return Integer.parseInt(token().value);
 			} catch (NumberFormatException e) {
 				throw parsingError("Invalid integer value.", e);
 			}
@@ -558,18 +559,10 @@ public final class LogicalTypeParser {
 				nextToken(TokenType.IDENTIFIER);
 				parts.add(tokenAsString());
 			}
-			final String catPart = lastPart(parts, 2);
-			final String dbPart = lastPart(parts, 1);
-			final String objPart = lastPart(parts, 0);
-			final UnresolvedIdentifier identifier;
-			if (catPart != null) {
-				identifier = UnresolvedIdentifier.of(catPart, dbPart, objPart);
-			} else if (dbPart != null) {
-				identifier = UnresolvedIdentifier.of(dbPart, objPart);
-			} else {
-				identifier = UnresolvedIdentifier.of(objPart);
-			}
-			return new UnresolvedUserDefinedType(identifier);
+			final String[] identifierParts = Stream.of(lastPart(parts, 2), lastPart(parts, 1), lastPart(parts, 0))
+				.filter(Objects::nonNull)
+				.toArray(String[]::new);
+			return new UnresolvedUserDefinedType(UnresolvedIdentifier.of(identifierParts));
 		}
 
 		private @Nullable String lastPart(List<String> parts, int inversePos) {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCompatibleCheckTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCompatibleCheckTest.java
@@ -274,23 +274,22 @@ public class LogicalTypeCompatibleCheckTest {
 	}
 
 	private static DistinctType createDistinctType(LogicalType sourceType) {
-		return new DistinctType.Builder(
-			ObjectIdentifier.of("cat", "db", UUID.randomUUID().toString()),
-			sourceType)
-			.setDescription("Money type desc.")
+		return DistinctType.newBuilder(
+				ObjectIdentifier.of("cat", "db", UUID.randomUUID().toString()),
+				sourceType)
+			.description("Money type desc.")
 			.build();
 	}
 
 	private static StructuredType createUserType(LogicalType... children) {
-		return new StructuredType.Builder(
-			ObjectIdentifier.of("cat", "db", "User"),
-			Arrays.stream(children).map(lt ->
-				new StructuredType.StructuredAttribute(UUID.randomUUID().toString(), lt))
-				.collect(Collectors.toList()))
-			.setDescription("User type desc.")
-			.setFinal(true)
-			.setInstantiable(true)
-			.setImplementationClass(User.class)
+		return StructuredType.newBuilder(ObjectIdentifier.of("cat", "db", "User"), User.class)
+			.attributes(
+				Arrays.stream(children)
+					.map(lt -> new StructuredType.StructuredAttribute(UUID.randomUUID().toString(), lt))
+					.collect(Collectors.toList()))
+			.description("User type desc.")
+			.isFinal(true)
+			.isInstantiable(true)
 			.build();
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCompatibleCheckTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCompatibleCheckTest.java
@@ -288,8 +288,8 @@ public class LogicalTypeCompatibleCheckTest {
 					.map(lt -> new StructuredType.StructuredAttribute(UUID.randomUUID().toString(), lt))
 					.collect(Collectors.toList()))
 			.description("User type desc.")
-			.isFinal(true)
-			.isInstantiable(true)
+			.setFinal(true)
+			.setInstantiable(true)
 			.build();
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeDuplicatorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeDuplicatorTest.java
@@ -114,7 +114,7 @@ public class LogicalTypeDuplicatorTest {
 		return new DistinctType.Builder(
 				ObjectIdentifier.of("cat", "db", "Money"),
 				replacedType)
-			.setDescription("Money type desc.")
+			.description("Money type desc.")
 			.build();
 	}
 
@@ -127,27 +127,25 @@ public class LogicalTypeDuplicatorTest {
 	}
 
 	private static StructuredType createHumanType() {
-		return new StructuredType.Builder(
-				ObjectIdentifier.of("cat", "db", "Human"),
+		return StructuredType.newBuilder(ObjectIdentifier.of("cat", "db", "Human"), Human.class)
+			.attributes(
 				Collections.singletonList(
 					new StructuredType.StructuredAttribute("name", new VarCharType(), "Description.")))
-			.setDescription("Human type desc.")
-			.setFinal(false)
-			.setInstantiable(false)
-			.setImplementationClass(Human.class)
+			.description("Human type desc.")
+			.isFinal(false)
+			.isInstantiable(false)
 			.build();
 	}
 
 	private static StructuredType createUserType(LogicalType replacedType) {
-		return new StructuredType.Builder(
-				ObjectIdentifier.of("cat", "db", "User"),
+		return StructuredType.newBuilder(ObjectIdentifier.of("cat", "db", "User"), User.class)
+			.attributes(
 				Collections.singletonList(
 					new StructuredType.StructuredAttribute("setting", replacedType)))
-			.setDescription("User type desc.")
-			.setFinal(false)
-			.setInstantiable(true)
-			.setImplementationClass(User.class)
-			.setSuperType(createHumanType())
+			.description("User type desc.")
+			.isFinal(false)
+			.isInstantiable(true)
+			.superType(createHumanType())
 			.build();
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeDuplicatorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeDuplicatorTest.java
@@ -132,8 +132,8 @@ public class LogicalTypeDuplicatorTest {
 				Collections.singletonList(
 					new StructuredType.StructuredAttribute("name", new VarCharType(), "Description.")))
 			.description("Human type desc.")
-			.isFinal(false)
-			.isInstantiable(false)
+			.setFinal(false)
+			.setInstantiable(false)
 			.build();
 	}
 
@@ -143,8 +143,8 @@ public class LogicalTypeDuplicatorTest {
 				Collections.singletonList(
 					new StructuredType.StructuredAttribute("setting", replacedType)))
 			.description("User type desc.")
-			.isFinal(false)
-			.isInstantiable(true)
+			.setFinal(false)
+			.setInstantiable(true)
 			.superType(createHumanType())
 			.build();
 	}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeParserTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeParserTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.types;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.types.logical.AnyType;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
@@ -397,26 +398,26 @@ public class LogicalTypeParserTest {
 
 			TestSpec
 				.forString("cat.db.MyType")
-				.expectType(new UnresolvedUserDefinedType("cat", "db", "MyType")),
+				.expectType(new UnresolvedUserDefinedType(UnresolvedIdentifier.of("cat", "db", "MyType"))),
 
 			TestSpec
 				.forString("`db`.`MyType`")
-				.expectType(new UnresolvedUserDefinedType(null, "db", "MyType")),
+				.expectType(new UnresolvedUserDefinedType(UnresolvedIdentifier.of("db", "MyType"))),
 
 			TestSpec
 				.forString("MyType")
-				.expectType(new UnresolvedUserDefinedType(null, null, "MyType")),
+				.expectType(new UnresolvedUserDefinedType(UnresolvedIdentifier.of("MyType"))),
 
 			TestSpec
 				.forString("ARRAY<MyType>")
-				.expectType(new ArrayType(new UnresolvedUserDefinedType(null, null, "MyType"))),
+				.expectType(new ArrayType(new UnresolvedUserDefinedType(UnresolvedIdentifier.of("MyType")))),
 
 			TestSpec
 				.forString("ROW<f0 MyType, f1 `c`.`d`.`t`>")
 				.expectType(
 					RowType.of(
-						new UnresolvedUserDefinedType(null, null, "MyType"),
-						new UnresolvedUserDefinedType("c", "d", "t"))
+						new UnresolvedUserDefinedType(UnresolvedIdentifier.of("MyType")),
+						new UnresolvedUserDefinedType(UnresolvedIdentifier.of("c", "d", "t")))
 				),
 
 			// error message testing

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.expressions.TimeIntervalUnit;
 import org.apache.flink.table.expressions.TimePointUnit;
 import org.apache.flink.table.types.logical.AnyType;
@@ -615,9 +616,11 @@ public class LogicalTypesTest {
 	@Test
 	public void testUnresolvedUserDefinedType() {
 		final UnresolvedUserDefinedType unresolvedType =
-			new UnresolvedUserDefinedType("catalog", "database", "Type");
+			new UnresolvedUserDefinedType(UnresolvedIdentifier.of("catalog", "database", "Type"));
 
-		testEquality(unresolvedType, new UnresolvedUserDefinedType("different", "database", "Type"));
+		testEquality(
+			unresolvedType,
+			new UnresolvedUserDefinedType(UnresolvedIdentifier.of("different", "database", "Type")));
 
 		testStringSummary(unresolvedType, "`catalog`.`database`.`Type`");
 	}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -789,8 +789,8 @@ public class LogicalTypesTest {
 				Collections.singletonList(
 					new StructuredType.StructuredAttribute("name", UDT_NAME_TYPE, "Description.")))
 			.description("Human type desc.")
-			.isFinal(false)
-			.isInstantiable(false)
+			.setFinal(false)
+			.setInstantiable(false)
 			.build();
 	}
 
@@ -809,8 +809,8 @@ public class LogicalTypesTest {
 				Collections.singletonList(
 					new StructuredType.StructuredAttribute("setting", UDT_SETTING_TYPE)))
 			.description("User type desc.")
-			.isFinal(isFinal)
-			.isInstantiable(true)
+			.setFinal(isFinal)
+			.setInstantiable(true)
 			.superType(createHumanType(false))
 			.build();
 	}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -513,13 +513,13 @@ public class LogicalTypesTest {
 	@Test
 	public void testStructuredType() {
 		testAll(
-			createUserType(true),
+			createUserType(true, true),
 			"`cat`.`db`.`User`",
 			"`cat`.`db`.`User`",
 			new Class[]{Row.class, User.class},
 			new Class[]{Row.class, Human.class, User.class},
 			new LogicalType[]{UDT_NAME_TYPE, UDT_SETTING_TYPE},
-			createUserType(false)
+			createUserType(true, false)
 		);
 
 		testConversions(
@@ -528,7 +528,7 @@ public class LogicalTypesTest {
 			new Class[]{Row.class, Human.class});
 
 		// not every Human is User
-		assertFalse(createUserType(true).supportsInputConversion(Human.class));
+		assertFalse(createUserType(true, true).supportsInputConversion(Human.class));
 
 		// User is not implementing SpecialHuman
 		assertFalse(createHumanType(true).supportsInputConversion(User.class));
@@ -649,6 +649,28 @@ public class LogicalTypesTest {
 		testInvalidStringSerializability(varBinaryType);
 	}
 
+	@Test
+	public void testUnregisteredStructuredType() {
+		final StructuredType structuredType = createUserType(false, true);
+
+		testEquality(structuredType, createUserType(false, false));
+
+		testNullability(structuredType);
+
+		testJavaSerializability(structuredType);
+
+		testInvalidStringSerializability(structuredType);
+
+		testStringSummary(structuredType, User.class.getName());
+
+		testConversions(
+			structuredType,
+			new Class[]{Row.class, User.class},
+			new Class[]{Row.class, Human.class, User.class});
+
+		testChildren(structuredType, new LogicalType[]{UDT_NAME_TYPE, UDT_SETTING_TYPE});
+	}
+
 	// --------------------------------------------------------------------------------------------
 
 	private static void testAll(
@@ -747,10 +769,10 @@ public class LogicalTypesTest {
 	}
 
 	private DistinctType createDistinctType(String typeName) {
-		return new DistinctType.Builder(
+		return DistinctType.newBuilder(
 				ObjectIdentifier.of("cat", "db", typeName),
 				new DecimalType(10, 2))
-			.setDescription("Money type desc.")
+			.description("Money type desc.")
 			.build();
 	}
 
@@ -759,27 +781,37 @@ public class LogicalTypesTest {
 	private static final LogicalType UDT_SETTING_TYPE = new IntType();
 
 	private StructuredType createHumanType(boolean useDifferentImplementation) {
-		return new StructuredType.Builder(
+		return StructuredType.newBuilder(
 				ObjectIdentifier.of("cat", "db", "Human"),
+				useDifferentImplementation ? SpecialHuman.class : Human.class
+			)
+			.attributes(
 				Collections.singletonList(
 					new StructuredType.StructuredAttribute("name", UDT_NAME_TYPE, "Description.")))
-			.setDescription("Human type desc.")
-			.setFinal(false)
-			.setInstantiable(false)
-			.setImplementationClass(useDifferentImplementation ? SpecialHuman.class : Human.class)
+			.description("Human type desc.")
+			.isFinal(false)
+			.isInstantiable(false)
 			.build();
 	}
 
-	private StructuredType createUserType(boolean isFinal) {
-		return new StructuredType.Builder(
+	private StructuredType createUserType(boolean isRegistered, boolean isFinal) {
+		final StructuredType.Builder builder;
+		if (isRegistered) {
+			builder = StructuredType.newBuilder(
 				ObjectIdentifier.of("cat", "db", "User"),
+				User.class);
+		} else {
+			builder = StructuredType.newBuilder(
+				User.class);
+		}
+		return builder
+			.attributes(
 				Collections.singletonList(
 					new StructuredType.StructuredAttribute("setting", UDT_SETTING_TYPE)))
-			.setDescription("User type desc.")
-			.setFinal(isFinal)
-			.setInstantiable(true)
-			.setImplementationClass(User.class)
-			.setSuperType(createHumanType(false))
+			.description("User type desc.")
+			.isFinal(isFinal)
+			.isInstantiable(true)
+			.superType(createHumanType(false))
 			.build();
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/types/LogicalTypeAssignableTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/types/LogicalTypeAssignableTest.java
@@ -275,23 +275,22 @@ public class LogicalTypeAssignableTest {
 	}
 
 	private static DistinctType createDistinctType(LogicalType sourceType) {
-		return new DistinctType.Builder(
-			ObjectIdentifier.of("cat", "db", UUID.randomUUID().toString()),
-			sourceType)
-			.setDescription("Money type desc.")
+		return DistinctType.newBuilder(
+				ObjectIdentifier.of("cat", "db", UUID.randomUUID().toString()),
+				sourceType)
+			.description("Money type desc.")
 			.build();
 	}
 
 	private static StructuredType createUserType(LogicalType... children) {
-		return new StructuredType.Builder(
-			ObjectIdentifier.of("cat", "db", "User"),
-			Arrays.stream(children).map(lt ->
-				new StructuredType.StructuredAttribute(UUID.randomUUID().toString(), lt))
-				.collect(Collectors.toList()))
-			.setDescription("User type desc.")
-			.setFinal(true)
-			.setInstantiable(true)
-			.setImplementationClass(User.class)
+		return StructuredType.newBuilder(ObjectIdentifier.of("cat", "db", "User"), User.class)
+			.attributes(
+				Arrays.stream(children)
+					.map(lt -> new StructuredType.StructuredAttribute(UUID.randomUUID().toString(), lt))
+					.collect(Collectors.toList()))
+			.description("User type desc.")
+			.isFinal(true)
+			.isInstantiable(true)
 			.build();
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/types/LogicalTypeAssignableTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/types/LogicalTypeAssignableTest.java
@@ -289,8 +289,8 @@ public class LogicalTypeAssignableTest {
 					.map(lt -> new StructuredType.StructuredAttribute(UUID.randomUUID().toString(), lt))
 					.collect(Collectors.toList()))
 			.description("User type desc.")
-			.isFinal(true)
-			.isInstantiable(true)
+			.setFinal(true)
+			.setInstantiable(true)
 			.build();
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

In order to allow type extraction of structured types that are not registered in a catalog, we need to relax the structured type concept to "inline or anonymous structured types" that are not identified by an object identifier in a catalog but the fully qualified implementation class.

This PR also fixes issues with `UnresolvedIdentifier`

## Brief change log

- Use `UnresolvedIdentifier` everywhere
- Fix equals of `UnresolvedIdentifier`
- Make `ObjectIdentifier` optional for anonymous structured types

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
