### PR TITLE
[FLINK-14909][runtime] Let tasks get scheduled in topological order when possible

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocator.java
@@ -79,8 +79,8 @@ public class DefaultExecutionSlotAllocator implements ExecutionSlotAllocator {
 	}
 
 	@Override
-	public Collection<SlotExecutionVertexAssignment> allocateSlotsFor(
-			Collection<ExecutionVertexSchedulingRequirements> executionVertexSchedulingRequirements) {
+	public List<SlotExecutionVertexAssignment> allocateSlotsFor(
+			List<ExecutionVertexSchedulingRequirements> executionVertexSchedulingRequirements) {
 
 		validateSchedulingRequirements(executionVertexSchedulingRequirements);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -258,22 +258,25 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 	// ------------------------------------------------------------------------
 
 	@Override
-	public void allocateSlotsAndDeploy(final Collection<ExecutionVertexDeploymentOption> executionVertexDeploymentOptions) {
+	public void allocateSlotsAndDeploy(final List<ExecutionVertexDeploymentOption> executionVertexDeploymentOptions) {
 		validateDeploymentOptions(executionVertexDeploymentOptions);
 
 		final Map<ExecutionVertexID, ExecutionVertexDeploymentOption> deploymentOptionsByVertex =
 			groupDeploymentOptionsByVertexId(executionVertexDeploymentOptions);
 
-		final Set<ExecutionVertexID> verticesToDeploy = deploymentOptionsByVertex.keySet();
+		final List<ExecutionVertexID> verticesToDeploy = executionVertexDeploymentOptions.stream()
+			.map(ExecutionVertexDeploymentOption::getExecutionVertexId)
+			.collect(Collectors.toList());
+
 		final Map<ExecutionVertexID, ExecutionVertexVersion> requiredVersionByVertex =
 			executionVertexVersioner.recordVertexModifications(verticesToDeploy);
 
 		transitionToScheduled(verticesToDeploy);
 
-		final Collection<SlotExecutionVertexAssignment> slotExecutionVertexAssignments =
+		final List<SlotExecutionVertexAssignment> slotExecutionVertexAssignments =
 			allocateSlots(executionVertexDeploymentOptions);
 
-		final Collection<DeploymentHandle> deploymentHandles = createDeploymentHandles(
+		final List<DeploymentHandle> deploymentHandles = createDeploymentHandles(
 			requiredVersionByVertex,
 			deploymentOptionsByVertex,
 			slotExecutionVertexAssignments);
@@ -301,7 +304,7 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 				Function.identity()));
 	}
 
-	private Collection<SlotExecutionVertexAssignment> allocateSlots(final Collection<ExecutionVertexDeploymentOption> executionVertexDeploymentOptions) {
+	private List<SlotExecutionVertexAssignment> allocateSlots(final List<ExecutionVertexDeploymentOption> executionVertexDeploymentOptions) {
 		return executionSlotAllocator.allocateSlotsFor(executionVertexDeploymentOptions
 			.stream()
 			.map(ExecutionVertexDeploymentOption::getExecutionVertexId)
@@ -310,10 +313,10 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 			.collect(Collectors.toList()));
 	}
 
-	private static Collection<DeploymentHandle> createDeploymentHandles(
+	private static List<DeploymentHandle> createDeploymentHandles(
 		final Map<ExecutionVertexID, ExecutionVertexVersion> requiredVersionByVertex,
 		final Map<ExecutionVertexID, ExecutionVertexDeploymentOption> deploymentOptionsByVertex,
-		final Collection<SlotExecutionVertexAssignment> slotExecutionVertexAssignments) {
+		final List<SlotExecutionVertexAssignment> slotExecutionVertexAssignments) {
 
 		return slotExecutionVertexAssignments
 			.stream()
@@ -335,7 +338,7 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 		return schedulingStrategy instanceof LazyFromSourcesSchedulingStrategy;
 	}
 
-	private void deployIndividually(final Collection<DeploymentHandle> deploymentHandles) {
+	private void deployIndividually(final List<DeploymentHandle> deploymentHandles) {
 		for (final DeploymentHandle deploymentHandle : deploymentHandles) {
 			FutureUtils.assertNoException(
 				deploymentHandle
@@ -346,12 +349,12 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 		}
 	}
 
-	private void waitForAllSlotsAndDeploy(final Collection<DeploymentHandle> deploymentHandles) {
+	private void waitForAllSlotsAndDeploy(final List<DeploymentHandle> deploymentHandles) {
 		FutureUtils.assertNoException(
 			assignAllResources(deploymentHandles).handle(deployAll(deploymentHandles)));
 	}
 
-	private CompletableFuture<Void> assignAllResources(final Collection<DeploymentHandle> deploymentHandles) {
+	private CompletableFuture<Void> assignAllResources(final List<DeploymentHandle> deploymentHandles) {
 		final List<CompletableFuture<Void>> slotAssignedFutures = new ArrayList<>();
 		for (DeploymentHandle deploymentHandle : deploymentHandles) {
 			final CompletableFuture<Void> slotAssigned = deploymentHandle
@@ -363,7 +366,7 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 		return FutureUtils.waitForAll(slotAssignedFutures);
 	}
 
-	private BiFunction<Void, Throwable, Void> deployAll(final Collection<DeploymentHandle> deploymentHandles) {
+	private BiFunction<Void, Throwable, Void> deployAll(final List<DeploymentHandle> deploymentHandles) {
 		return (ignored, throwable) -> {
 			propagateIfNonNull(throwable);
 			for (final DeploymentHandle deploymentHandle : deploymentHandles) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotAllocator.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.scheduler;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 
-import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -34,8 +34,8 @@ public interface ExecutionSlotAllocator {
 	 *
 	 * @param executionVertexSchedulingRequirements The requirements for scheduling the executions.
 	 */
-	Collection<SlotExecutionVertexAssignment> allocateSlotsFor(
-			Collection<ExecutionVertexSchedulingRequirements> executionVertexSchedulingRequirements);
+	List<SlotExecutionVertexAssignment> allocateSlotsFor(
+			List<ExecutionVertexSchedulingRequirements> executionVertexSchedulingRequirements);
 
 	/**
 	 * Cancel an ongoing slot request.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -93,6 +93,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -318,7 +319,7 @@ public abstract class SchedulerBase implements SchedulerNG {
 		return tasks;
 	}
 
-	protected void transitionToScheduled(final Collection<ExecutionVertexID> verticesToDeploy) {
+	protected void transitionToScheduled(final List<ExecutionVertexID> verticesToDeploy) {
 		verticesToDeploy.forEach(executionVertexId -> getExecutionVertex(executionVertexId)
 			.getCurrentExecutionAttempt()
 			.transitionState(ExecutionState.SCHEDULED));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerOperations.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerOperations.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.runtime.scheduler.strategy.SchedulingStrategy;
 
-import java.util.Collection;
+import java.util.List;
 
 /**
  * Component which is used by {@link SchedulingStrategy} to commit scheduling decisions.
@@ -29,9 +29,10 @@ public interface SchedulerOperations {
 
 	/**
 	 * Allocate slots and deploy the vertex when slots are returned.
+	 * The given order will be respected, i.e. tasks with smaller indices will be deployed earlier.
 	 * Only vertices in CREATED state will be accepted. Errors will happen if scheduling Non-CREATED vertices.
 	 *
-	 * @param executionVertexDeploymentOptions The tasks to be deployed and deployment options
+	 * @param executionVertexDeploymentOptions The deployment options of tasks to be deployed
 	 */
-	void allocateSlotsAndDeploy(Collection<ExecutionVertexDeploymentOption> executionVertexDeploymentOptions);
+	void allocateSlotsAndDeploy(List<ExecutionVertexDeploymentOption> executionVertexDeploymentOptions);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/LazyFromSourcesSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/LazyFromSourcesSchedulingStrategy.java
@@ -146,7 +146,7 @@ public class LazyFromSourcesSchedulingStrategy implements SchedulingStrategy {
 				.map(executionVertexID -> new ExecutionVertexDeploymentOption(
 					executionVertexID,
 					deploymentOptions.get(executionVertexID)))
-				.collect(Collectors.toSet()));
+				.collect(Collectors.toList()));
 	}
 
 	private Predicate<SchedulingExecutionVertex<?, ?>> isInputConstraintSatisfied() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingStrategyUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingStrategyUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.strategy;
+
+import org.apache.flink.runtime.scheduler.DeploymentOption;
+import org.apache.flink.runtime.scheduler.ExecutionVertexDeploymentOption;
+import org.apache.flink.util.IterableUtils;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Utils for {@link SchedulingStrategy}.
+ */
+class SchedulingStrategyUtils {
+
+	static Set<ExecutionVertexID> getAllVertexIdsFromTopology(final SchedulingTopology<?, ?> topology) {
+		return IterableUtils.toStream(topology.getVertices())
+			.map(SchedulingExecutionVertex::getId)
+			.collect(Collectors.toSet());
+	}
+
+	static Set<SchedulingExecutionVertex<?, ?>> getVerticesFromIds(
+			final SchedulingTopology<?, ?> topology,
+			final Set<ExecutionVertexID> vertexIds) {
+
+		return vertexIds.stream()
+			.map(topology::getVertexOrThrow)
+			.collect(Collectors.toSet());
+	}
+
+	static List<ExecutionVertexDeploymentOption> createExecutionVertexDeploymentOptionsInTopologicalOrder(
+			final SchedulingTopology<?, ?> topology,
+			final Set<ExecutionVertexID> verticesToDeploy,
+			final Function<ExecutionVertexID, DeploymentOption> deploymentOptionRetriever) {
+
+		return IterableUtils.toStream(topology.getVertices())
+			.map(SchedulingExecutionVertex::getId)
+			.filter(verticesToDeploy::contains)
+			.map(executionVertexID -> new ExecutionVertexDeploymentOption(
+				executionVertexID,
+				deploymentOptionRetriever.apply(executionVertexID)))
+			.collect(Collectors.toList());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestExecutionSlotAllocator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestExecutionSlotAllocator.java
@@ -46,7 +46,7 @@ public class TestExecutionSlotAllocator implements ExecutionSlotAllocator, SlotO
 	private final List<LogicalSlot> returnedSlots = new ArrayList<>();
 
 	@Override
-	public Collection<SlotExecutionVertexAssignment> allocateSlotsFor(final Collection<ExecutionVertexSchedulingRequirements> schedulingRequirementsCollection) {
+	public List<SlotExecutionVertexAssignment> allocateSlotsFor(final List<ExecutionVertexSchedulingRequirements> schedulingRequirementsCollection) {
 		final List<SlotExecutionVertexAssignment> slotVertexAssignments = createSlotVertexAssignments(schedulingRequirementsCollection);
 		registerPendingRequests(slotVertexAssignments);
 		maybeCompletePendingRequests();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/EagerSchedulingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/EagerSchedulingStrategyTest.java
@@ -26,14 +26,13 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.runtime.scheduler.strategy.StrategyTestUtil.getExecutionVertexIdsFromDeployOptions;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -61,23 +60,26 @@ public class EagerSchedulingStrategyTest extends TestLogger {
 	 */
 	@Test
 	public void testStartScheduling() {
-		JobVertexID jobVertexID = new JobVertexID();
-		testingSchedulingTopology.addSchedulingExecutionVertex(new TestingSchedulingExecutionVertex(jobVertexID, 0));
-		testingSchedulingTopology.addSchedulingExecutionVertex(new TestingSchedulingExecutionVertex(jobVertexID, 1));
-		testingSchedulingTopology.addSchedulingExecutionVertex(new TestingSchedulingExecutionVertex(jobVertexID, 2));
-		testingSchedulingTopology.addSchedulingExecutionVertex(new TestingSchedulingExecutionVertex(jobVertexID, 3));
-		testingSchedulingTopology.addSchedulingExecutionVertex(new TestingSchedulingExecutionVertex(jobVertexID, 4));
+		final JobVertexID jobVertexID = new JobVertexID();
+		final List<TestingSchedulingExecutionVertex> executionVertices = Arrays.asList(
+			new TestingSchedulingExecutionVertex(jobVertexID, 4),
+			new TestingSchedulingExecutionVertex(jobVertexID, 0),
+			new TestingSchedulingExecutionVertex(jobVertexID, 2),
+			new TestingSchedulingExecutionVertex(jobVertexID, 1),
+			new TestingSchedulingExecutionVertex(jobVertexID, 3));
+		testingSchedulingTopology.addSchedulingExecutionVertices(executionVertices);
 
 		schedulingStrategy.startScheduling();
 
 		assertThat(testingSchedulerOperations.getScheduledVertices(), hasSize(1));
 
-		Collection<ExecutionVertexDeploymentOption> scheduledVertices = testingSchedulerOperations.getScheduledVertices().get(0);
-		Collection<ExecutionVertexID> scheduledVertexIDs = getExecutionVertexIdsFromDeployOptions(scheduledVertices);
-		assertThat(scheduledVertexIDs, hasSize(5));
-		for (TestingSchedulingExecutionVertex schedulingExecutionVertex : testingSchedulingTopology.getVertices()) {
-			assertThat(scheduledVertexIDs, hasItem(schedulingExecutionVertex.getId()));
-		}
+		final List<ExecutionVertexDeploymentOption> scheduledVertices = testingSchedulerOperations.getScheduledVertices().get(0);
+		final List<ExecutionVertexID> scheduledVertexIDs = getExecutionVertexIdsFromDeployOptions(scheduledVertices);
+
+		final List<ExecutionVertexID> executionVertexIDs = executionVertices.stream()
+			.map(TestingSchedulingExecutionVertex::getId)
+			.collect(Collectors.toList());
+		assertEquals(executionVertexIDs, scheduledVertexIDs);
 	}
 
 	/**
@@ -85,30 +87,34 @@ public class EagerSchedulingStrategyTest extends TestLogger {
 	 */
 	@Test
 	public void testRestartTasks() {
-		JobVertexID jobVertexID = new JobVertexID();
-		testingSchedulingTopology.addSchedulingExecutionVertex(new TestingSchedulingExecutionVertex(jobVertexID, 0));
-		testingSchedulingTopology.addSchedulingExecutionVertex(new TestingSchedulingExecutionVertex(jobVertexID, 1));
-		testingSchedulingTopology.addSchedulingExecutionVertex(new TestingSchedulingExecutionVertex(jobVertexID, 2));
-		testingSchedulingTopology.addSchedulingExecutionVertex(new TestingSchedulingExecutionVertex(jobVertexID, 3));
-		testingSchedulingTopology.addSchedulingExecutionVertex(new TestingSchedulingExecutionVertex(jobVertexID, 4));
+		final JobVertexID jobVertexID = new JobVertexID();
+		final List<TestingSchedulingExecutionVertex> executionVertices = Arrays.asList(
+			new TestingSchedulingExecutionVertex(jobVertexID, 4),
+			new TestingSchedulingExecutionVertex(jobVertexID, 0),
+			new TestingSchedulingExecutionVertex(jobVertexID, 2),
+			new TestingSchedulingExecutionVertex(jobVertexID, 1),
+			new TestingSchedulingExecutionVertex(jobVertexID, 3));
+		testingSchedulingTopology.addSchedulingExecutionVertices(executionVertices);
 
-		Set<ExecutionVertexID> verticesToRestart1 = new HashSet<>(Arrays.asList(
-				new ExecutionVertexID(jobVertexID, 0),
-				new ExecutionVertexID(jobVertexID, 4)));
-		schedulingStrategy.restartTasks(verticesToRestart1);
+		final List<ExecutionVertexID> verticesToRestart1 = Arrays.asList(
+				new ExecutionVertexID(jobVertexID, 4),
+				new ExecutionVertexID(jobVertexID, 0));
+		schedulingStrategy.restartTasks(new HashSet<>(verticesToRestart1));
 
-		Set<ExecutionVertexID> verticesToRestart2 = new HashSet<>(Arrays.asList(
-				new ExecutionVertexID(jobVertexID, 1),
+		final List<ExecutionVertexID> verticesToRestart2 = Arrays.asList(
 				new ExecutionVertexID(jobVertexID, 2),
-				new ExecutionVertexID(jobVertexID, 3)));
-		schedulingStrategy.restartTasks(verticesToRestart2);
+				new ExecutionVertexID(jobVertexID, 1),
+				new ExecutionVertexID(jobVertexID, 3));
+		schedulingStrategy.restartTasks(new HashSet<>(verticesToRestart2));
 
 		assertThat(testingSchedulerOperations.getScheduledVertices(), hasSize(2));
 
-		Collection<ExecutionVertexDeploymentOption> scheduledVertices1 = testingSchedulerOperations.getScheduledVertices().get(0);
-		assertThat(getExecutionVertexIdsFromDeployOptions(scheduledVertices1), containsInAnyOrder(verticesToRestart1.toArray()));
+		final List<ExecutionVertexDeploymentOption> scheduledVertices1 =
+			testingSchedulerOperations.getScheduledVertices().get(0);
+		assertEquals(verticesToRestart1, getExecutionVertexIdsFromDeployOptions(scheduledVertices1));
 
-		Collection<ExecutionVertexDeploymentOption> scheduledVertices2 = testingSchedulerOperations.getScheduledVertices().get(1);
-		assertThat(getExecutionVertexIdsFromDeployOptions(scheduledVertices2), containsInAnyOrder(verticesToRestart2.toArray()));
+		final List<ExecutionVertexDeploymentOption> scheduledVertices2 =
+			testingSchedulerOperations.getScheduledVertices().get(1);
+		assertEquals(verticesToRestart2, getExecutionVertexIdsFromDeployOptions(scheduledVertices2));
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/StrategyTestUtil.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/StrategyTestUtil.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.scheduler.strategy;
 
 import org.apache.flink.runtime.scheduler.ExecutionVertexDeploymentOption;
 
-import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 
 /**
@@ -28,8 +28,8 @@ import java.util.stream.Collectors;
  */
 public class StrategyTestUtil {
 
-	static Collection<ExecutionVertexID> getExecutionVertexIdsFromDeployOptions(
-		Collection<ExecutionVertexDeploymentOption> deploymentOptions) {
+	static List<ExecutionVertexID> getExecutionVertexIdsFromDeployOptions(
+			final List<ExecutionVertexDeploymentOption> deploymentOptions) {
 
 		return deploymentOptions.stream()
 			.map(ExecutionVertexDeploymentOption::getExecutionVertexId)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestSchedulingStrategy.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestSchedulingStrategy.java
@@ -25,7 +25,6 @@ import org.apache.flink.runtime.scheduler.ExecutionVertexDeploymentOption;
 import org.apache.flink.runtime.scheduler.SchedulerOperations;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -69,7 +68,7 @@ public class TestSchedulingStrategy implements SchedulingStrategy {
 	public void onPartitionConsumable(final ExecutionVertexID executionVertexId, final ResultPartitionID resultPartitionId) {
 	}
 
-	public void schedule(final Set<ExecutionVertexID> verticesToSchedule) {
+	public void schedule(final List<ExecutionVertexID> verticesToSchedule) {
 		allocateSlotsAndDeploy(verticesToSchedule);
 	}
 
@@ -81,14 +80,14 @@ public class TestSchedulingStrategy implements SchedulingStrategy {
 		return receivedVerticesToRestart;
 	}
 
-	private void allocateSlotsAndDeploy(final Set<ExecutionVertexID> verticesToSchedule) {
+	private void allocateSlotsAndDeploy(final List<ExecutionVertexID> verticesToSchedule) {
 		final List<ExecutionVertexDeploymentOption> executionVertexDeploymentOptions =
 			createExecutionVertexDeploymentOptions(verticesToSchedule);
 		schedulerOperations.allocateSlotsAndDeploy(executionVertexDeploymentOptions);
 	}
 
 	private List<ExecutionVertexDeploymentOption> createExecutionVertexDeploymentOptions(
-			final Collection<ExecutionVertexID> vertices) {
+			final List<ExecutionVertexID> vertices) {
 
 		final List<ExecutionVertexDeploymentOption> executionVertexDeploymentOptions = new ArrayList<>(vertices.size());
 		for (ExecutionVertexID executionVertexID : vertices) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulerOperations.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulerOperations.java
@@ -22,7 +22,6 @@ import org.apache.flink.runtime.scheduler.ExecutionVertexDeploymentOption;
 import org.apache.flink.runtime.scheduler.SchedulerOperations;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -31,18 +30,18 @@ import java.util.List;
  */
 public class TestingSchedulerOperations implements SchedulerOperations {
 
-	private final List<Collection<ExecutionVertexDeploymentOption>> scheduledVertices = new ArrayList<>();
+	private final List<List<ExecutionVertexDeploymentOption>> scheduledVertices = new ArrayList<>();
 
 	@Override
-	public void allocateSlotsAndDeploy(Collection<ExecutionVertexDeploymentOption> executionVertexDeploymentOptions) {
+	public void allocateSlotsAndDeploy(List<ExecutionVertexDeploymentOption> executionVertexDeploymentOptions) {
 		scheduledVertices.add(executionVertexDeploymentOptions);
 	}
 
-	List<Collection<ExecutionVertexDeploymentOption>> getScheduledVertices() {
+	List<List<ExecutionVertexDeploymentOption>> getScheduledVertices() {
 		return Collections.unmodifiableList(scheduledVertices);
 	}
 
-	Collection<ExecutionVertexDeploymentOption> getLatestScheduledVertices() {
-		return Collections.unmodifiableCollection(scheduledVertices.get(scheduledVertices.size() - 1));
+	List<ExecutionVertexDeploymentOption> getLatestScheduledVertices() {
+		return Collections.unmodifiableList(scheduledVertices.get(scheduledVertices.size() - 1));
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -40,7 +41,8 @@ import static org.apache.flink.util.Preconditions.checkState;
 public class TestingSchedulingTopology
 	implements SchedulingTopology<TestingSchedulingExecutionVertex, TestingSchedulingResultPartition> {
 
-	private final Map<ExecutionVertexID, TestingSchedulingExecutionVertex> schedulingExecutionVertices = new HashMap<>();
+	// Use linked map here to so we can get the values in inserted order
+	private final Map<ExecutionVertexID, TestingSchedulingExecutionVertex> schedulingExecutionVertices = new LinkedHashMap<>();
 
 	private final Map<IntermediateResultPartitionID, TestingSchedulingResultPartition> schedulingResultPartitions = new HashMap<>();
 
@@ -83,7 +85,7 @@ public class TestingSchedulingTopology
 		}
 	}
 
-	private void addSchedulingExecutionVertices(List<TestingSchedulingExecutionVertex> vertices) {
+	void addSchedulingExecutionVertices(List<TestingSchedulingExecutionVertex> vertices) {
 		for (TestingSchedulingExecutionVertex vertex : vertices) {
 			addSchedulingExecutionVertex(vertex);
 		}


### PR DESCRIPTION
## What is the purpose of the change

This PR is to let tasks in a batch get scheduled in topological order.
There can be 2 benefits:
1. there would be less chance for a task to get launched before its upstream tasks, which reduces requestPartitionState RPCs to JobMaster.
2. logs could be more readable

## Brief change log

  - *Change DefaultScheduler to respect the scheduled vertex order from scheduling strategy*
  - *Change scheduling strategies to schedule vertices in topological order*


## Verifying this change

This change added tests and can be verified as follows:
  - *Added unit tests to verify that DefaultScheduler respects the scheduled vertex order from scheduling strategy*
  - *Adjusted unit tests of eager and lazy scheduling strategy to match results in order*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
