### PR TITLE
[FLINK-14865][python] fix unstable tests PyFlinkBlinkStreamUserDefinedFunctionTests#test_udf_in_join_condition_2

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonDriverEnvUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonDriverEnvUtils.java
@@ -110,7 +110,6 @@ public final class PythonDriverEnvUtils {
 
 		List<File> internalLibs = extractBasicDependenciesFromResource(
 			tmpDir,
-			PythonDriverEnvUtils.class.getClassLoader(),
 			UUID.randomUUID().toString(),
 			true);
 

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonDriverEnvUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonDriverEnvUtils.java
@@ -87,7 +87,8 @@ public final class PythonDriverEnvUtils {
 	 * @param pythonLibFiles The dependent Python files.
 	 * @return PythonEnvironment the Python environment which will be executed in Python process.
 	 */
-	public static PythonEnvironment preparePythonEnvironment(List<Path> pythonLibFiles) throws IOException {
+	public static PythonEnvironment preparePythonEnvironment(List<Path> pythonLibFiles)
+		throws IOException, InterruptedException {
 		PythonEnvironment env = new PythonEnvironment();
 
 		// 1. setup temporary local directory for the user files

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonResourceExtractor.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonResourceExtractor.java
@@ -32,7 +32,7 @@ import static org.apache.flink.python.util.ResourceUtil.extractBasicDependencies
  */
 public class PythonResourceExtractor {
 
-	public static void main(String[] args) throws IOException {
+	public static void main(String[] args) throws IOException, InterruptedException {
 		String tmpdir = System.getProperty("java.io.tmpdir");
 
 		List<File> files = extractBasicDependenciesFromResource(

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonResourceExtractor.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonResourceExtractor.java
@@ -37,7 +37,6 @@ public class PythonResourceExtractor {
 
 		List<File> files = extractBasicDependenciesFromResource(
 			tmpdir,
-			PythonResourceExtractor.class.getClassLoader(),
 			UUID.randomUUID().toString(),
 			true);
 

--- a/flink-python/src/main/java/org/apache/flink/python/AbstractPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/python/AbstractPythonFunctionRunner.java
@@ -323,7 +323,6 @@ public abstract class AbstractPythonFunctionRunner<IN, OUT> implements PythonFun
 			try {
 				pythonInternalLibs = ResourceUtil.extractBasicDependenciesFromResource(
 					tmpdir,
-					this.getClass().getClassLoader(),
 					prefix,
 					false);
 			} catch (IOException | InterruptedException e) {

--- a/flink-python/src/main/java/org/apache/flink/python/AbstractPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/python/AbstractPythonFunctionRunner.java
@@ -326,7 +326,7 @@ public abstract class AbstractPythonFunctionRunner<IN, OUT> implements PythonFun
 					this.getClass().getClassLoader(),
 					prefix,
 					false);
-			} catch (IOException e) {
+			} catch (IOException | InterruptedException e) {
 				throw new RuntimeException(e);
 			}
 			String pythonWorkerCommand = null;

--- a/flink-python/src/main/java/org/apache/flink/python/util/ResourceUtil.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/ResourceUtil.java
@@ -47,31 +47,76 @@ public class ResourceUtil {
 			String tmpdir,
 			ClassLoader classLoader,
 			String prefix,
-			boolean skipShellScript) throws IOException {
+			boolean skipShellScript) throws IOException, InterruptedException {
 		List<File> extractedFiles = new ArrayList<>();
 		for (String fileName : PYTHON_BASIC_DEPENDENCIES) {
 			if (skipShellScript && fileName.endsWith(".sh")) {
 				continue;
 			}
+
 			File file = new File(tmpdir, prefix + fileName);
-
-			try (OutputStream out = new BufferedOutputStream(new FileOutputStream(file));
-				InputStream in = classLoader.getResourceAsStream(fileName)) {
-				// This util will use in the extract program before launching pyflink shell,
-				// so it must do this itself to minimize the dependencies.
-				final byte[] buf = new byte[BUFF_SIZE];
-				int bytesRead = in.read(buf);
-				while (bytesRead >= 0) {
-					out.write(buf, 0, bytesRead);
-					bytesRead = in.read(buf);
-				}
-			}
-
-			if (file.getName().endsWith(".sh")) {
-				file.setExecutable(true);
+			if (fileName.endsWith(".sh")) {
+				// TODO: This is a hacky solution to prevent subprocesses to hold the file descriptor of shell scripts,
+				// which will cause the execution of shell scripts failed with the exception "test file is busy"
+				// randomly. It's a bug of JDK, see https://bugs.openjdk.java.net/browse/JDK-8068370. After moving flink
+				// python jar to lib directory, we can solve this problem elegantly by extracting these files only once.
+				String javaExecutable = String.join(File.separator, System.getProperty("java.home"), "bin", "java");
+				String classPath = new File(
+					ResourceUtil.class.getProtectionDomain().getCodeSource().getLocation().getPath()).getAbsolutePath();
+				new ProcessBuilder(
+					javaExecutable,
+					"-cp",
+					classPath,
+					ResourceUtil.class.getName(),
+					tmpdir,
+					prefix,
+					fileName).inheritIO().start().waitFor();
+			} else {
+				copyBytes(
+					classLoader.getResourceAsStream(fileName),
+					new BufferedOutputStream(new FileOutputStream(file)));
 			}
 			extractedFiles.add(file);
 		}
 		return extractedFiles;
+	}
+
+	/**
+	 * This main method is used to create the shell script in a subprocess, see the "TODO" hints in method
+	 * { @link ResourceUtil#extractBasicDependenciesFromResource }.
+	 * @param args First argument is the directory where shell script will be created. Second argument is the prefix of
+	 *             the shell script. Third argument is the fileName of the shell script.
+	 * @throws IOException
+	 */
+	public static void main(String[] args) throws IOException {
+		String tmpdir = args[0];
+		String prefix = args[1];
+		String fileName = args[2];
+		File file = new File(tmpdir, prefix + fileName);
+
+		copyBytes(
+			ResourceUtil.class.getClassLoader().getResourceAsStream(fileName),
+			new BufferedOutputStream(new FileOutputStream(file)));
+
+		file.setExecutable(true);
+	}
+
+	/**
+	 * This util class will be executed in a separated java process. So implementing this method here instead of reusing
+	 * flink-core utils to minimize its dependencies, which will make the code much simple.
+	 * simple.
+	 * @param input The input stream.
+	 * @param output The output stream.
+	 * @throws IOException
+	 */
+	public static void copyBytes(InputStream input, OutputStream output) throws IOException {
+		try (InputStream in = input; OutputStream out = output) {
+			final byte[] buf = new byte[BUFF_SIZE];
+			int bytesRead = in.read(buf);
+			while (bytesRead >= 0) {
+				out.write(buf, 0, bytesRead);
+				bytesRead = in.read(buf);
+			}
+		}
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/python/util/ResourceUtil.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/ResourceUtil.java
@@ -40,7 +40,6 @@ public class ResourceUtil {
 
 	public static List<File> extractBasicDependenciesFromResource(
 			String tmpdir,
-			ClassLoader classLoader,
 			String prefix,
 			boolean skipShellScript) throws IOException, InterruptedException {
 		List<File> extractedFiles = new ArrayList<>();

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverEnvUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverEnvUtilsTest.java
@@ -67,7 +67,7 @@ public class PythonDriverEnvUtilsTest {
 	}
 
 	@Test
-	public void testPreparePythonEnvironment() throws IOException {
+	public void testPreparePythonEnvironment() throws IOException, InterruptedException {
 		// xxx/a.zip, xxx/subdir/b.py, xxx/subdir/c.zip
 		File a = new File(tmpDirPath.toString() + File.separator + "a.zip");
 		a.createNewFile();

--- a/flink-python/src/test/java/org/apache/flink/python/util/ResourceUtilTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/util/ResourceUtilTest.java
@@ -49,11 +49,9 @@ public class ResourceUtilTest {
 		});
 		Runtime.getRuntime().addShutdownHook(hook);
 		try {
-			ClassLoader classLoader = ResourceUtil.class.getClassLoader();
 			String prefix = "tmp_";
 			List<File> files = ResourceUtil.extractBasicDependenciesFromResource(
 				tmpdir.getAbsolutePath(),
-				classLoader,
 				prefix,
 				true);
 			files.forEach(file -> assertTrue(file.exists()));
@@ -64,7 +62,6 @@ public class ResourceUtilTest {
 			files.forEach(File::delete);
 			files = ResourceUtil.extractBasicDependenciesFromResource(
 				tmpdir.getAbsolutePath(),
-				classLoader,
 				prefix,
 				false);
 			files.forEach(file -> assertTrue(file.exists()));

--- a/flink-python/src/test/java/org/apache/flink/python/util/ResourceUtilTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/util/ResourceUtilTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertTrue;
 public class ResourceUtilTest {
 
 	@Test
-	public void testExtractBasicDependenciesFromResource() throws IOException {
+	public void testExtractBasicDependenciesFromResource() throws IOException, InterruptedException {
 		File tmpdir = File.createTempFile(UUID.randomUUID().toString(), null);
 		tmpdir.delete();
 		tmpdir.mkdirs();


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixes the unstable tests PyFlinkBlinkStreamUserDefinedFunctionTests#test_udf_in_join_condition_2*

## Brief change log

  - *Create and write the shell script file in subprocess to avoid the "text file is busy" exception.*

## Verifying this change

This change is already covered by existing tests, such as *test_udf.py*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
