### PR TITLE
[FLINK-14840] Use Executor interface in SQL cli

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/DeploymentEntry.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/DeploymentEntry.java
@@ -165,4 +165,9 @@ public class DeploymentEntry extends ConfigEntry {
 
 		return new DeploymentEntry(properties);
 	}
+
+	@Override
+	public String toString() {
+		return "DeploymentEntry{" + "properties=" + properties + '}';
+	}
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/ProgramTargetDescriptor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/ProgramTargetDescriptor.java
@@ -20,61 +20,35 @@ package org.apache.flink.table.client.gateway;
 
 import org.apache.flink.api.common.JobID;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * Describes the target where a table program has been submitted to.
  */
 public class ProgramTargetDescriptor {
 
-	private final String clusterId;
-
 	private final String jobId;
 
-	private final String webInterfaceUrl;
-
-	public ProgramTargetDescriptor(String clusterId, String jobId, String webInterfaceUrl) {
-		this.clusterId = clusterId;
-		this.jobId = jobId;
-		this.webInterfaceUrl = webInterfaceUrl;
-	}
-
-	public String getClusterId() {
-		return clusterId;
+	public ProgramTargetDescriptor(String jobId) {
+		this.jobId = checkNotNull(jobId);
 	}
 
 	public String getJobId() {
 		return jobId;
 	}
 
-	public String getWebInterfaceUrl() {
-		return webInterfaceUrl;
-	}
-
 	@Override
 	public String toString() {
-		return String.format(
-			"Cluster ID: %s\n" +
-			"Job ID: %s\n" +
-			"Web interface: %s",
-			clusterId, jobId, webInterfaceUrl);
+		return String.format("Job ID: %s\n", jobId);
 	}
 
 	/**
 	 * Creates a program target description from deployment classes.
 	 *
-	 * @param clusterId cluster id
 	 * @param jobId job id
-	 * @param <C> cluster id type
 	 * @return program target descriptor
 	 */
-	public static <C> ProgramTargetDescriptor of(C clusterId, JobID jobId, String webInterfaceUrl) {
-		String clusterIdString;
-		try {
-			// check if cluster id has a toString method
-			clusterId.getClass().getDeclaredMethod("toString");
-			clusterIdString = clusterId.toString();
-		} catch (NoSuchMethodException e) {
-			clusterIdString = clusterId.getClass().getSimpleName();
-		}
-		return new ProgramTargetDescriptor(clusterIdString, jobId.toString(), webInterfaceUrl);
+	public static ProgramTargetDescriptor of(JobID jobId) {
+		return new ProgramTargetDescriptor(jobId.toString());
 	}
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ProgramDeployer.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ProgramDeployer.java
@@ -18,163 +18,72 @@
 
 package org.apache.flink.table.client.gateway.local;
 
-import org.apache.flink.api.common.JobExecutionResult;
-import org.apache.flink.client.ClientUtils;
-import org.apache.flink.client.deployment.ClusterDescriptor;
-import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.table.client.gateway.SqlExecutionException;
-import org.apache.flink.table.client.gateway.local.result.Result;
+import org.apache.flink.api.dag.Pipeline;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.core.execution.DefaultExecutorServiceLoader;
+import org.apache.flink.core.execution.Executor;
+import org.apache.flink.core.execution.ExecutorFactory;
+import org.apache.flink.core.execution.ExecutorServiceLoader;
+import org.apache.flink.core.execution.JobClient;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * The helper class to deploy a table program on the cluster.
  */
-public class ProgramDeployer<C> implements Runnable {
+public class ProgramDeployer {
 	private static final Logger LOG = LoggerFactory.getLogger(ProgramDeployer.class);
 
-	private final ExecutionContext<C> context;
-	private final JobGraph jobGraph;
+	private final Configuration configuration;
+	private final Pipeline pipeline;
 	private final String jobName;
-	private final Result<C> result;
-	private final boolean awaitJobResult;
-	private final BlockingQueue<JobExecutionResult> executionResultBucket;
 
 	/**
 	 * Deploys a table program on the cluster.
 	 *
-	 * @param context        context with deployment information
+	 * @param configuration  the {@link Configuration} that is used for deployment
 	 * @param jobName        job name of the Flink job to be submitted
-	 * @param jobGraph       Flink job graph
-	 * @param result         result that receives information about the target cluster
-	 * @param awaitJobResult block for a job execution result from the cluster
+	 * @param pipeline       Flink {@link Pipeline} to execute
 	 */
 	public ProgramDeployer(
-			ExecutionContext<C> context,
+			Configuration configuration,
 			String jobName,
-			JobGraph jobGraph,
-			Result<C> result,
-			boolean awaitJobResult) {
-		this.context = context;
-		this.jobGraph = jobGraph;
+			Pipeline pipeline) {
+		this.configuration = configuration;
+		this.pipeline = pipeline;
 		this.jobName = jobName;
-		this.result = result;
-		this.awaitJobResult = awaitJobResult;
-		executionResultBucket = new LinkedBlockingDeque<>(1);
 	}
 
-	@Override
-	public void run() {
-		LOG.info("Submitting job {} for query {}`", jobGraph.getJobID(), jobName);
+	public CompletableFuture<JobClient> deploy() {
+		LOG.info("Submitting job {} for query {}`", pipeline, jobName);
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Submitting job {} with the following environment: \n{}",
-					jobGraph.getJobID(), context.getEnvironment());
+			LOG.debug("Submitting job {} with configuration: \n{}", pipeline, configuration);
 		}
-		deployJob(context, jobGraph, result);
-	}
 
-	public JobExecutionResult fetchExecutionResult() {
-		return executionResultBucket.poll();
-	}
+		if (configuration.get(DeploymentOptions.TARGET) == null) {
+			throw new RuntimeException("No execution.target specified in your configuration file.");
+		}
 
-	/**
-	 * Deploys a job. Depending on the deployment creates a new job cluster. It saves the cluster id in
-	 * the result and blocks until job completion.
-	 */
-	private <T> void deployJob(ExecutionContext<T> context, JobGraph jobGraph, Result<T> result) {
-		// create or retrieve cluster and deploy job
-		try (final ClusterDescriptor<T> clusterDescriptor = context.createClusterDescriptor()) {
-			try {
-				// new cluster
-				if (context.getClusterId() == null) {
-					deployJobOnNewCluster(clusterDescriptor, jobGraph, result, context.getClassLoader());
-				}
-				// reuse existing cluster
-				else {
-					deployJobOnExistingCluster(context.getClusterId(), clusterDescriptor, jobGraph, result);
-				}
-			} catch (Exception e) {
-				throw new SqlExecutionException("Could not retrieve or create a cluster.", e);
-			}
-		} catch (SqlExecutionException e) {
-			throw e;
+		ExecutorServiceLoader executorServiceLoader = DefaultExecutorServiceLoader.INSTANCE;
+		final ExecutorFactory executorFactory;
+		try {
+			executorFactory = executorServiceLoader.getExecutorFactory(configuration);
 		} catch (Exception e) {
-			throw new SqlExecutionException("Could not locate a cluster.", e);
+			throw new RuntimeException("Could not retrieve ExecutorFactory.", e);
 		}
-	}
 
-	private <T> void deployJobOnNewCluster(
-			ClusterDescriptor<T> clusterDescriptor,
-			JobGraph jobGraph,
-			Result<T> result,
-			ClassLoader classLoader) throws Exception {
-		ClusterClient<T> clusterClient = null;
+		final Executor executor = executorFactory.getExecutor(configuration);
+		CompletableFuture<JobClient> jobClient;
 		try {
-			// deploy job cluster with job attached
-			clusterClient = clusterDescriptor.deployJobCluster(context.getClusterSpec(), jobGraph, false);
-			// save information about the new cluster
-			result.setClusterInformation(clusterClient.getClusterId(), clusterClient.getWebInterfaceURL());
-			// get result
-			if (awaitJobResult) {
-				// we need to hard cast for now
-				final JobExecutionResult jobResult = clusterClient
-						.requestJobResult(jobGraph.getJobID())
-						.get()
-						.toJobExecutionResult(context.getClassLoader()); // throws exception if job fails
-				executionResultBucket.add(jobResult);
-			}
-		} finally {
-			try {
-				if (clusterClient != null) {
-					clusterClient.close();
-				}
-			} catch (Exception e) {
-				// ignore
-			}
+			jobClient = executor.execute(pipeline, configuration);
+		} catch (Exception e) {
+			throw new RuntimeException("Could not execute program.", e);
 		}
-	}
-
-	private <T> void deployJobOnExistingCluster(
-			T clusterId,
-			ClusterDescriptor<T> clusterDescriptor,
-			JobGraph jobGraph,
-			Result<T> result) throws Exception {
-		ClusterClient<T> clusterClient = null;
-		try {
-			// retrieve existing cluster
-			clusterClient = clusterDescriptor.retrieve(clusterId);
-			String webInterfaceUrl;
-			// retrieving the web interface URL might fail on legacy pre-FLIP-6 code paths
-			// TODO remove this once we drop support for legacy deployment code
-			try {
-				webInterfaceUrl = clusterClient.getWebInterfaceURL();
-			} catch (Exception e) {
-				webInterfaceUrl = "N/A";
-			}
-			// save the cluster information
-			result.setClusterInformation(clusterClient.getClusterId(), webInterfaceUrl);
-			// submit job (and get result)
-			if (awaitJobResult) {
-				// throws exception if job fails
-				final JobExecutionResult jobResult = ClientUtils.submitJobAndWaitForResult(clusterClient, jobGraph, context.getClassLoader());
-				executionResultBucket.add(jobResult);
-			} else {
-				ClientUtils.submitJob(clusterClient, jobGraph);
-			}
-		} finally {
-			try {
-				if (clusterClient != null) {
-					clusterClient.close();
-				}
-			} catch (Exception e) {
-				// ignore
-			}
-		}
+		return jobClient;
 	}
 }
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
@@ -57,7 +57,11 @@ public class ResultStore {
 	/**
 	 * Creates a result. Might start threads or opens sockets so every created result must be closed.
 	 */
-	public <T> DynamicResult<T> createResult(Environment env, TableSchema schema, ExecutionConfig config) {
+	public <T> DynamicResult<T> createResult(
+			Environment env,
+			TableSchema schema,
+			ExecutionConfig config,
+			ClassLoader classLoader) {
 
 		final RowTypeInfo outputType = new RowTypeInfo(schema.getFieldTypes(), schema.getFieldNames());
 
@@ -67,7 +71,13 @@ public class ResultStore {
 			final int gatewayPort = getGatewayPort(env.getDeployment());
 
 			if (env.getExecution().isChangelogMode()) {
-				return new ChangelogCollectStreamResult<>(outputType, schema, config, gatewayAddress, gatewayPort);
+				return new ChangelogCollectStreamResult<>(
+						outputType,
+						schema,
+						config,
+						gatewayAddress,
+						gatewayPort,
+						classLoader);
 			} else {
 				return new MaterializedCollectStreamResult<>(
 						outputType,
@@ -75,7 +85,8 @@ public class ResultStore {
 						config,
 						gatewayAddress,
 						gatewayPort,
-						env.getExecution().getMaxTableResultRows());
+						env.getExecution().getMaxTableResultRows(),
+						classLoader);
 			}
 
 		} else {
@@ -83,7 +94,7 @@ public class ResultStore {
 			if (!env.getExecution().isTableMode()) {
 				throw new SqlExecutionException("Results of batch queries can only be served in table mode.");
 			}
-			return new MaterializedCollectBatchResult<>(schema, outputType, config);
+			return new MaterializedCollectBatchResult<>(schema, outputType, config, classLoader);
 		}
 	}
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/ChangelogCollectStreamResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/ChangelogCollectStreamResult.java
@@ -39,9 +39,14 @@ public class ChangelogCollectStreamResult<C> extends CollectStreamResult<C> impl
 	private List<Tuple2<Boolean, Row>> changeRecordBuffer;
 	private static final int CHANGE_RECORD_BUFFER_SIZE = 5_000;
 
-	public ChangelogCollectStreamResult(RowTypeInfo outputType, TableSchema tableSchema, ExecutionConfig config,
-			InetAddress gatewayAddress, int gatewayPort) {
-		super(outputType, tableSchema, config, gatewayAddress, gatewayPort);
+	public ChangelogCollectStreamResult(
+			RowTypeInfo outputType,
+			TableSchema tableSchema,
+			ExecutionConfig config,
+			InetAddress gatewayAddress,
+			int gatewayPort,
+			ClassLoader classLoader) {
+		super(outputType, tableSchema, config, gatewayAddress, gatewayPort, classLoader);
 
 		// prepare for changelog
 		changeRecordBuffer = new ArrayList<>();
@@ -57,7 +62,7 @@ public class ChangelogCollectStreamResult<C> extends CollectStreamResult<C> impl
 		synchronized (resultLock) {
 			// retrieval thread is alive return a record if available
 			// but the program must not have failed
-			if (isRetrieving() && executionException == null) {
+			if (isRetrieving() && executionException.get() == null) {
 				if (changeRecordBuffer.isEmpty()) {
 					return TypedResult.empty();
 				} else {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/CollectStreamResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/CollectStreamResult.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.client.gateway.local.result;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -38,6 +39,11 @@ import org.apache.flink.types.Row;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A result that works similarly to {@link DataStreamUtils#collect(DataStream)}.
@@ -50,14 +56,19 @@ public abstract class CollectStreamResult<C> extends BasicResult<C> implements D
 	private final SocketStreamIterator<Tuple2<Boolean, Row>> iterator;
 	private final CollectStreamTableSink collectTableSink;
 	private final ResultRetrievalThread retrievalThread;
-	private final JobMonitoringThread monitoringThread;
-	private ProgramDeployer<C> deployer;
+	private final ClassLoader classLoader;
+	private CompletableFuture<JobExecutionResult> jobExecutionResultFuture;
 
 	protected final Object resultLock;
-	protected SqlExecutionException executionException;
+	protected AtomicReference<SqlExecutionException> executionException = new AtomicReference<>();
 
-	public CollectStreamResult(RowTypeInfo outputType, TableSchema tableSchema, ExecutionConfig config,
-			InetAddress gatewayAddress, int gatewayPort) {
+	public CollectStreamResult(
+			RowTypeInfo outputType,
+			TableSchema tableSchema,
+			ExecutionConfig config,
+			InetAddress gatewayAddress,
+			int gatewayPort,
+			ClassLoader classLoader) {
 		this.outputType = outputType;
 
 		resultLock = new Object();
@@ -76,7 +87,8 @@ public abstract class CollectStreamResult<C> extends BasicResult<C> implements D
 		// pass binding address and port such that sink knows where to send to
 		collectTableSink = new CollectStreamTableSink(iterator.getBindAddress(), iterator.getPort(), serializer, tableSchema);
 		retrievalThread = new ResultRetrievalThread();
-		monitoringThread = new JobMonitoringThread();
+
+		this.classLoader = checkNotNull(classLoader);
 	}
 
 	@Override
@@ -85,13 +97,43 @@ public abstract class CollectStreamResult<C> extends BasicResult<C> implements D
 	}
 
 	@Override
-	public void startRetrieval(ProgramDeployer<C> deployer) {
+	public void startRetrieval(ProgramDeployer deployer) {
 		// start listener thread
 		retrievalThread.start();
 
-		// start deployer
-		this.deployer = deployer;
-		monitoringThread.start();
+		// we have to check for exceptions in two places here because job submission can fail
+		// at different stages. For batch file sources, the job manager will check if the file
+		// exists and job submission will already fail at that early stage, meaning we will not
+		// get a job client. For streaming file sources, this check only happens when the job
+		// was already successfully submitted.
+		jobExecutionResultFuture = deployer
+				.deploy()
+				.thenCompose(jobClient -> {
+					// fetch the job execution result, so that an attached cluster will shut down
+					CompletableFuture<JobExecutionResult> result = jobClient.getJobExecutionResult(
+							classLoader);
+
+					return result.whenComplete((unusedJobResult, jobException) -> {
+						if (jobException != null) {
+							executionException.compareAndSet(
+									null,
+									new SqlExecutionException(
+											"Error while submitting job.", jobException));
+						}
+						try {
+							jobClient.close();
+						} catch (Exception e) {
+							throw new CompletionException("Error while closing JobClient.", e);
+						}
+					});
+				})
+				.whenComplete((unused, throwable) -> {
+					if (throwable != null) {
+						executionException.compareAndSet(
+								null,
+								new SqlExecutionException("Error while submitting job.", throwable));
+					}
+				});
 	}
 
 	@Override
@@ -103,26 +145,25 @@ public abstract class CollectStreamResult<C> extends BasicResult<C> implements D
 	public void close() {
 		retrievalThread.isRunning = false;
 		retrievalThread.interrupt();
-		monitoringThread.interrupt();
 		iterator.close();
 	}
 
 	// --------------------------------------------------------------------------------------------
 
 	protected <T> TypedResult<T> handleMissingResult() {
+
 		// check if the monitoring thread is still there
 		// we need to wait until we know what is going on
-		if (monitoringThread.isAlive()) {
+		if (!jobExecutionResultFuture.isDone()) {
 			return TypedResult.empty();
 		}
-		// the job finished with an exception
-		else if (executionException != null) {
-			throw executionException;
+
+		if (executionException.get() != null) {
+			throw executionException.get();
 		}
+
 		// we assume that a bounded job finished
-		else {
-			return TypedResult.endOfStream();
-		}
+		return TypedResult.endOfStream();
 	}
 
 	protected boolean isRetrieving() {
@@ -130,20 +171,6 @@ public abstract class CollectStreamResult<C> extends BasicResult<C> implements D
 	}
 
 	protected abstract void processRecord(Tuple2<Boolean, Row> change);
-
-	// --------------------------------------------------------------------------------------------
-
-	private class JobMonitoringThread extends Thread {
-
-		@Override
-		public void run() {
-			try {
-				deployer.run();
-			} catch (SqlExecutionException e) {
-				executionException = e;
-			}
-		}
-	}
 
 	// --------------------------------------------------------------------------------------------
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/DynamicResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/DynamicResult.java
@@ -46,7 +46,7 @@ public interface DynamicResult<C> extends Result<C> {
 	/**
 	 * Starts the table program using the given deployer and monitors it's execution.
 	 */
-	void startRetrieval(ProgramDeployer<C> deployer);
+	void startRetrieval(ProgramDeployer deployer);
 
 	/**
 	 * Returns the table sink required by this result type.

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectBatchResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectBatchResult.java
@@ -35,6 +35,12 @@ import org.apache.flink.util.AbstractID;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Collects results using accumulators and returns them as table snapshots.
@@ -45,23 +51,26 @@ public class MaterializedCollectBatchResult<C> extends BasicResult<C> implements
 	private final String accumulatorName;
 	private final CollectBatchTableSink tableSink;
 	private final Object resultLock;
-	private final Thread retrievalThread;
+	private final ClassLoader classLoader;
 
-	private ProgramDeployer<C> deployer;
 	private int pageSize;
 	private int pageCount;
-	private SqlExecutionException executionException;
+	private AtomicReference<SqlExecutionException> executionException = new AtomicReference<>();
 	private List<Row> resultTable;
 
 	private volatile boolean snapshotted = false;
 
-	public MaterializedCollectBatchResult(TableSchema tableSchema, RowTypeInfo outputType, ExecutionConfig config) {
+	public MaterializedCollectBatchResult(
+			TableSchema tableSchema,
+			RowTypeInfo outputType,
+			ExecutionConfig config,
+			ClassLoader classLoader) {
 		this.outputType = outputType;
 
 		accumulatorName = new AbstractID().toString();
 		tableSink = new CollectBatchTableSink(accumulatorName, outputType.createSerializer(config), tableSchema);
 		resultLock = new Object();
-		retrievalThread = new ResultRetrievalThread();
+		this.classLoader = checkNotNull(classLoader);
 
 		pageCount = 0;
 	}
@@ -77,9 +86,44 @@ public class MaterializedCollectBatchResult<C> extends BasicResult<C> implements
 	}
 
 	@Override
-	public void startRetrieval(ProgramDeployer<C> deployer) {
-		this.deployer = deployer;
-		retrievalThread.start();
+	public void startRetrieval(ProgramDeployer deployer) {
+		// we have to check for exceptions in two places here because job submission can fail
+		// at different stages. For batch file sources, the job manager will check if the file
+		// exists and job submission will already fail at that early stage, meaning we will not
+		// get a job client. For streaming file sources, this check only happens when the job
+		// was already successfully submitted.
+		deployer
+				.deploy()
+				.thenCompose(jobClient -> {
+
+					CompletableFuture<JobExecutionResult> result = jobClient.getJobExecutionResult(
+							classLoader);
+
+					return result.handle((unusedJobResult, jobException) -> {
+						if (jobException != null) {
+							executionException.compareAndSet(
+									null,
+									new SqlExecutionException(
+											"Error while submitting job.",
+											jobException));
+						}
+						try {
+							jobClient.close();
+						} catch (Exception e) {
+							throw new CompletionException("Error while closing JobClient.", e);
+						}
+						return unusedJobResult;
+					});
+				})
+				.thenAccept(new ResultRetrievalHandler())
+				.whenComplete((unused, throwable) -> {
+					if (throwable != null) {
+						executionException.compareAndSet(null,
+								new SqlExecutionException(
+										"Error while submitting job.",
+										throwable));
+					}
+				});
 	}
 
 	@Override
@@ -88,9 +132,7 @@ public class MaterializedCollectBatchResult<C> extends BasicResult<C> implements
 	}
 
 	@Override
-	public void close() {
-		retrievalThread.interrupt();
-	}
+	public void close() {}
 
 	@Override
 	public List<Row> retrievePage(int page) {
@@ -105,13 +147,15 @@ public class MaterializedCollectBatchResult<C> extends BasicResult<C> implements
 	@Override
 	public TypedResult<Integer> snapshot(int pageSize) {
 		synchronized (resultLock) {
-			// wait for a result
-			if (retrievalThread.isAlive() && null == resultTable) {
-				return TypedResult.empty();
-			}
 			// the job finished with an exception
-			else if (executionException != null) {
-				throw executionException;
+			SqlExecutionException e = executionException.get();
+			if (e != null) {
+				throw e;
+			}
+
+			// wait for a result
+			if (null == resultTable) {
+				return TypedResult.empty();
 			}
 			// we return a payload result the first time and EoS for the rest of times as if the results
 			// are retrieved dynamically
@@ -128,14 +172,12 @@ public class MaterializedCollectBatchResult<C> extends BasicResult<C> implements
 
 	// --------------------------------------------------------------------------------------------
 
-	private class ResultRetrievalThread extends Thread {
+	private class ResultRetrievalHandler implements Consumer<JobExecutionResult> {
 
 		@Override
-		public void run() {
+		public void accept(JobExecutionResult jobExecutionResult) {
 			try {
-				deployer.run();
-				final JobExecutionResult result = deployer.fetchExecutionResult();
-				final ArrayList<byte[]> accResult = result.getAccumulatorResult(accumulatorName);
+				final ArrayList<byte[]> accResult = jobExecutionResult.getAccumulatorResult(accumulatorName);
 				if (accResult == null) {
 					throw new SqlExecutionException("The accumulator could not retrieve the result.");
 				}
@@ -145,9 +187,7 @@ public class MaterializedCollectBatchResult<C> extends BasicResult<C> implements
 					MaterializedCollectBatchResult.this.resultTable = resultTable;
 				}
 			} catch (ClassNotFoundException | IOException e) {
-				executionException = new SqlExecutionException("Serialization error while deserializing collected data.", e);
-			} catch (SqlExecutionException e) {
-				executionException = e;
+				throw new SqlExecutionException("Serialization error while deserializing collected data.", e);
 			}
 		}
 	}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResult.java
@@ -97,8 +97,9 @@ public class MaterializedCollectStreamResult<C> extends CollectStreamResult<C> i
 			InetAddress gatewayAddress,
 			int gatewayPort,
 			int maxRowCount,
-			int overcommitThreshold) {
-		super(outputType, tableSchema, config, gatewayAddress, gatewayPort);
+			int overcommitThreshold,
+			ClassLoader classLoader) {
+		super(outputType, tableSchema, config, gatewayAddress, gatewayPort, classLoader);
 
 		if (maxRowCount <= 0) {
 			this.maxRowCount = Integer.MAX_VALUE;
@@ -124,7 +125,8 @@ public class MaterializedCollectStreamResult<C> extends CollectStreamResult<C> i
 			ExecutionConfig config,
 			InetAddress gatewayAddress,
 			int gatewayPort,
-			int maxRowCount) {
+			int maxRowCount,
+			ClassLoader classLoader) {
 
 		this(
 			outputType,
@@ -133,7 +135,8 @@ public class MaterializedCollectStreamResult<C> extends CollectStreamResult<C> i
 			gatewayAddress,
 			gatewayPort,
 			maxRowCount,
-			computeMaterializedTableOvercommit(maxRowCount));
+			computeMaterializedTableOvercommit(maxRowCount),
+			classLoader);
 	}
 
 	@Override
@@ -150,7 +153,7 @@ public class MaterializedCollectStreamResult<C> extends CollectStreamResult<C> i
 		synchronized (resultLock) {
 			// retrieval thread is dead and there are no results anymore
 			// or program failed
-			if ((!isRetrieving() && isLastSnapshot) || executionException != null) {
+			if ((!isRetrieving() && isLastSnapshot) || executionException.get() != null) {
 				return handleMissingResult();
 			}
 			// this snapshot is the last result that can be delivered

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -361,7 +361,7 @@ public class CliClientTest extends TestLogger {
 			if (failExecution) {
 				throw new SqlExecutionException("Fail execution.");
 			}
-			return new ProgramTargetDescriptor("testClusterId", "testJobId", "http://testcluster:1234");
+			return new ProgramTargetDescriptor("testJobId");
 		}
 	}
 }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/EnvironmentTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/EnvironmentTest.java
@@ -58,6 +58,7 @@ public class EnvironmentTest {
 		replaceVars1.put("$VAR_RESULT_MODE", "table");
 		replaceVars1.put("$VAR_UPDATE_MODE", "");
 		replaceVars1.put("$VAR_MAX_ROWS", "100");
+		replaceVars1.put("$VAR_RESTART_STRATEGY_TYPE", "failure-rate");
 		final Environment env1 = EnvironmentFileUtil.parseModified(
 			DEFAULTS_ENVIRONMENT_FILE,
 			replaceVars1);

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
@@ -268,6 +268,7 @@ public class ExecutionContextTest {
 		replaceVars.put("$VAR_RESULT_MODE", "changelog");
 		replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
 		replaceVars.put("$VAR_MAX_ROWS", "100");
+		replaceVars.put("$VAR_RESTART_STRATEGY_TYPE", "failure-rate");
 		return createExecutionContext(DEFAULTS_ENVIRONMENT_FILE, replaceVars);
 	}
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -24,8 +24,8 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.client.cli.util.DummyClusterClientServiceLoader;
-import org.apache.flink.client.cli.util.DummyCustomCommandLine;
+import org.apache.flink.client.cli.DefaultCLI;
+import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
@@ -1107,32 +1107,32 @@ public class LocalExecutorITCase extends TestLogger {
 		replaceVars.put("$VAR_MAX_ROWS", "100");
 		replaceVars.put("$VAR_RESTART_STRATEGY_TYPE", "failure-rate");
 		return new LocalExecutor(
-			EnvironmentFileUtil.parseModified(DEFAULTS_ENVIRONMENT_FILE, replaceVars),
-			Collections.emptyList(),
-			clusterClient.getFlinkConfiguration(),
-			new DummyCustomCommandLine(),
-			new DummyClusterClientServiceLoader(clusterClient));
+				EnvironmentFileUtil.parseModified(DEFAULTS_ENVIRONMENT_FILE, replaceVars),
+				Collections.emptyList(),
+				clusterClient.getFlinkConfiguration(),
+				new DefaultCLI(clusterClient.getFlinkConfiguration()),
+				new DefaultClusterClientServiceLoader());
 	}
 
 	private <T> LocalExecutor createModifiedExecutor(ClusterClient<T> clusterClient, Map<String, String> replaceVars) throws Exception {
 		replaceVars.putIfAbsent("$VAR_RESTART_STRATEGY_TYPE", "failure-rate");
 		return new LocalExecutor(
-			EnvironmentFileUtil.parseModified(DEFAULTS_ENVIRONMENT_FILE, replaceVars),
-			Collections.emptyList(),
-			clusterClient.getFlinkConfiguration(),
-			new DummyCustomCommandLine(),
-			new DummyClusterClientServiceLoader(clusterClient));
+				EnvironmentFileUtil.parseModified(DEFAULTS_ENVIRONMENT_FILE, replaceVars),
+				Collections.emptyList(),
+				clusterClient.getFlinkConfiguration(),
+				new DefaultCLI(clusterClient.getFlinkConfiguration()),
+				new DefaultClusterClientServiceLoader());
 	}
 
 	private <T> LocalExecutor createModifiedExecutor(
 			String yamlFile, ClusterClient<T> clusterClient, Map<String, String> replaceVars) throws Exception {
 		replaceVars.putIfAbsent("$VAR_RESTART_STRATEGY_TYPE", "failure-rate");
 		return new LocalExecutor(
-			EnvironmentFileUtil.parseModified(yamlFile, replaceVars),
-			Collections.emptyList(),
-			clusterClient.getFlinkConfiguration(),
-			new DummyCustomCommandLine(),
-			new DummyClusterClientServiceLoader(clusterClient));
+				EnvironmentFileUtil.parseModified(yamlFile, replaceVars),
+				Collections.emptyList(),
+				clusterClient.getFlinkConfiguration(),
+				new DefaultCLI(clusterClient.getFlinkConfiguration()),
+				new DefaultClusterClientServiceLoader());
 	}
 
 	private List<String> retrieveTableResult(

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResultTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResultTest.java
@@ -169,7 +169,8 @@ public class MaterializedCollectStreamResultTest {
 				gatewayAddress,
 				gatewayPort,
 				maxRowCount,
-				overcommitThreshold);
+				overcommitThreshold,
+				MaterializedCollectStreamResultTest.class.getClassLoader());
 		}
 
 		public TestMaterializedCollectStreamResult(
@@ -186,7 +187,8 @@ public class MaterializedCollectStreamResultTest {
 				config,
 				gatewayAddress,
 				gatewayPort,
-				maxRowCount);
+				maxRowCount,
+				MaterializedCollectStreamResultTest.class.getClassLoader());
 		}
 
 		@Override

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
@@ -134,7 +134,7 @@ execution:
   result-mode: "$VAR_RESULT_MODE"
   max-table-result-rows: "$VAR_MAX_ROWS"
   restart-strategy:
-    type: failure-rate
+    type: "$VAR_RESTART_STRATEGY_TYPE"
     max-failures-per-interval: 10
     failure-rate-interval: 99000
     delay: 1000


### PR DESCRIPTION
## What is the purpose of the change

* Change the SQL cli to use the new `Executor` interface and `JobClient` instead of manually going through cluster descriptor/cluster specification.

This also does not print the cluster ID and web interface URL anymore
when submitting because there is no portable way of retrieving these.
Previously, even for YARN the printed cluster id was not usable because
it was just the class name of the implementation class.

## Verifying this change

This change is covered by existing tests and ITcases that were adapted.

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
