### PR TITLE
[FLINK-14552][table] Enable partition statistics in blink planner

### DIFF
--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/plan/stats/TableStatsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/plan/stats/TableStatsTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.stats;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test for {@link TableStats}.
+ */
+public class TableStatsTest {
+
+	@Test
+	public void testMerge() {
+		Map<String, ColumnStats> colStats1 = new HashMap<>();
+		colStats1.put("a", new ColumnStats(4L, 5L, 2D, 3, 15, 2));
+		TableStats stats1 = new TableStats(30, colStats1);
+
+		Map<String, ColumnStats> colStats2 = new HashMap<>();
+		colStats2.put("a", new ColumnStats(3L, 15L, 12D, 23, 35, 6));
+		TableStats stats2 = new TableStats(32, colStats2);
+
+		Map<String, ColumnStats> colStatsMerge = new HashMap<>();
+		colStatsMerge.put("a", new ColumnStats(7L, 20L, 7D, 23, 35, 2));
+		Assert.assertEquals(new TableStats(62, colStatsMerge), stats1.merge(stats2));
+	}
+
+	@Test
+	public void testMergeLackColumnStats() {
+		Map<String, ColumnStats> colStats1 = new HashMap<>();
+		colStats1.put("a", new ColumnStats(4L, 5L, 2D, 3, 15, 2));
+		colStats1.put("b", new ColumnStats(4L, 5L, 2D, 3, 15, 2));
+		TableStats stats1 = new TableStats(30, colStats1);
+
+		Map<String, ColumnStats> colStats2 = new HashMap<>();
+		colStats2.put("a", new ColumnStats(3L, 15L, 12D, 23, 35, 6));
+		TableStats stats2 = new TableStats(32, colStats2);
+
+		Map<String, ColumnStats> colStatsMerge = new HashMap<>();
+		colStatsMerge.put("a", new ColumnStats(7L, 20L, 7D, 23, 35, 2));
+		Assert.assertEquals(new TableStats(62, colStatsMerge), stats1.merge(stats2));
+	}
+
+	@Test
+	public void testMergeUnknownRowCount() {
+		TableStats stats1 = new TableStats(-1, new HashMap<>());
+		TableStats stats2 = new TableStats(32, new HashMap<>());
+		Assert.assertEquals(new TableStats(-1, new HashMap<>()), stats1.merge(stats2));
+
+		stats1 = new TableStats(-1, new HashMap<>());
+		stats2 = new TableStats(-1, new HashMap<>());
+		Assert.assertEquals(new TableStats(-1, new HashMap<>()), stats1.merge(stats2));
+
+		stats1 = new TableStats(-3, new HashMap<>());
+		stats2 = new TableStats(-2, new HashMap<>());
+		Assert.assertEquals(new TableStats(-1, new HashMap<>()), stats1.merge(stats2));
+	}
+
+	@Test
+	public void testMergeColumnStatsUnknown() {
+		ColumnStats columnStats0 = new ColumnStats(4L, 5L, 2D, 3, 15, 2);
+		ColumnStats columnStats1 = new ColumnStats(4L, null, 2D, 3, 15, 2);
+		ColumnStats columnStats2 = new ColumnStats(4L, 5L, 2D, null, 15, 2);
+		ColumnStats columnStats3 = new ColumnStats(null, 5L, 2D, 3, 15, 2);
+		ColumnStats columnStats4 = new ColumnStats(4L, 5L, 2D, 3, null, 2);
+		ColumnStats columnStats5 = new ColumnStats(4L, 5L, 2D, 3, 15, null);
+		ColumnStats columnStats6 = new ColumnStats(4L, 5L, null, 3, 15, 2);
+
+		Assert.assertEquals(new ColumnStats(8L, null, 2D, 3, 15, 2), columnStats0.merge(columnStats1));
+		Assert.assertEquals(new ColumnStats(8L, 10L, 2D, null, 15, 2), columnStats0.merge(columnStats2));
+		Assert.assertEquals(new ColumnStats(null, 10L, 2D, 3, 15, 2), columnStats0.merge(columnStats3));
+		Assert.assertEquals(new ColumnStats(8L, 10L, 2D, 3, null, 2), columnStats0.merge(columnStats4));
+		Assert.assertEquals(new ColumnStats(8L, 10L, 2D, 3, 15, null), columnStats0.merge(columnStats5));
+		Assert.assertEquals(new ColumnStats(8L, 10L, null, 3, 15, 2), columnStats0.merge(columnStats6));
+		Assert.assertEquals(new ColumnStats(8L, 10L, null, 3, 15, 2), columnStats6.merge(columnStats6));
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReader.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReader.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.catalog.ConnectorCatalogTable;
+import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.QueryOperationCatalogView;
 import org.apache.flink.table.planner.catalog.CatalogSchemaTable;
 import org.apache.flink.table.planner.catalog.QueryOperationCatalogViewTable;
@@ -109,8 +110,8 @@ public class FlinkCalciteCatalogReader extends CalciteCatalogReader {
 			ConnectorCatalogTable<?, ?> connectorTable = (ConnectorCatalogTable<?, ?>) baseTable;
 			if ((connectorTable).getTableSource().isPresent()) {
 				return convertSourceTable(relOptSchema,
-					names,
 					rowType,
+					schemaTable.getTableIdentifier(),
 					connectorTable,
 					schemaTable.getStatistic(),
 					schemaTable.isStreamingMode());
@@ -155,8 +156,8 @@ public class FlinkCalciteCatalogReader extends CalciteCatalogReader {
 
 	private static FlinkPreparingTableBase convertSourceTable(
 			RelOptSchema relOptSchema,
-			List<String> names,
 			RelDataType rowType,
+			ObjectIdentifier tableIdentifier,
 			ConnectorCatalogTable<?, ?> table,
 			FlinkStatistic statistic,
 			boolean isStreamingMode) {
@@ -173,7 +174,7 @@ public class FlinkCalciteCatalogReader extends CalciteCatalogReader {
 
 		return new TableSourceTable<>(
 			relOptSchema,
-			names,
+			tableIdentifier,
 			rowType,
 			statistic,
 			tableSource,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.plan.schema
 
 import org.apache.flink.table.api.TableException
-import org.apache.flink.table.catalog.CatalogTable
+import org.apache.flink.table.catalog.{CatalogTable, ObjectIdentifier}
 import org.apache.flink.table.factories.{TableFactoryUtil, TableSourceFactory}
 import org.apache.flink.table.sources.{StreamTableSource, TableSource}
 
@@ -70,7 +70,7 @@ class CatalogSourceTable[T](
     val cluster = context.getCluster
     val tableSourceTable = new TableSourceTable[T](
       relOptSchema,
-      names,
+      schemaTable.getTableIdentifier,
       rowType,
       statistic,
       tableSource,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/TableSourceTable.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/TableSourceTable.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.schema
 
-import org.apache.flink.table.catalog.CatalogTable
+import org.apache.flink.table.catalog.{CatalogTable, ObjectIdentifier}
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
 import org.apache.flink.table.sources.{TableSource, TableSourceValidation}
 
@@ -28,6 +28,7 @@ import org.apache.flink.table.api.{TableException, WatermarkSpec}
 
 import org.apache.calcite.plan.{RelOptSchema, RelOptTable}
 
+import java.util
 import java.util.{List => JList}
 
 import scala.collection.JavaConverters._
@@ -39,19 +40,27 @@ import scala.collection.JavaConverters._
   *
   * <p>It also defines the [[copy]] method used for push down rules.
   *
+  * @param tableIdentifier full path of the table to retrieve.
   * @param tableSource The [[TableSource]] for which is converted to a Calcite Table
   * @param isStreamingMode A flag that tells if the current table is in stream mode
   * @param catalogTable Catalog table where this table source table comes from
   */
 class TableSourceTable[T](
     relOptSchema: RelOptSchema,
-    names: JList[String],
+    val tableIdentifier: ObjectIdentifier,
     rowType: RelDataType,
     statistic: FlinkStatistic,
     val tableSource: TableSource[T],
     val isStreamingMode: Boolean,
     val catalogTable: CatalogTable)
-  extends FlinkPreparingTableBase(relOptSchema, rowType, names, statistic) {
+  extends FlinkPreparingTableBase(
+    relOptSchema,
+    rowType,
+    util.Arrays.asList(
+      tableIdentifier.getCatalogName,
+      tableIdentifier.getDatabaseName,
+      tableIdentifier.getObjectName),
+    statistic) {
 
   Preconditions.checkNotNull(tableSource)
   Preconditions.checkNotNull(statistic)
@@ -79,8 +88,14 @@ class TableSourceTable[T](
     * @return New TableSourceTable instance with specified table source and [[FlinkStatistic]]
     */
   def copy(tableSource: TableSource[_], statistic: FlinkStatistic): TableSourceTable[T] = {
-    new TableSourceTable[T](relOptSchema, names, rowType, statistic,
-      tableSource.asInstanceOf[TableSource[T]], isStreamingMode, catalogTable)
+    new TableSourceTable[T](
+      relOptSchema,
+      tableIdentifier,
+      rowType,
+      statistic,
+      tableSource.asInstanceOf[TableSource[T]],
+      isStreamingMode,
+      catalogTable)
   }
 
   /**
@@ -100,7 +115,13 @@ class TableSourceTable[T](
           .map(idx => rowType.getFieldList.get(idx))
           .toList
           .asJava)
-    new TableSourceTable[T](relOptSchema, names, newRowType, statistic,
-      tableSource.asInstanceOf[TableSource[T]], isStreamingMode, catalogTable)
+    new TableSourceTable[T](
+      relOptSchema,
+      tableIdentifier,
+      newRowType,
+      statistic,
+      tableSource.asInstanceOf[TableSource[T]],
+      isStreamingMode,
+      catalogTable)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/testTableSources.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/testTableSources.scala
@@ -805,6 +805,16 @@ object TestPartitionableSourceFactory {
     .field("part2", DataTypes.INT())
     .build()
 
+  /**
+    * For java invoking.
+    */
+  def registerTableSource(
+      tEnv: TableEnvironment,
+      tableName: String,
+      isBounded: Boolean): Unit = {
+    registerTableSource(tEnv, tableName, isBounded, tableSchema = tableSchema)
+  }
+
   def registerTableSource(
       tEnv: TableEnvironment,
       tableName: String,


### PR DESCRIPTION

## What is the purpose of the change

Now after partition pruning, we will lost stats.
Actually, we have partition stats in catalog.
We need update statistics after partition pruning in PushPartitionIntoTableSourceScanRule.

## Brief change log

- Add merge method to `TableStats`.
- Add table identifier to `TableSourceTable`
- Update stats in `PushPartitionIntoTableSourceScanRule`.

## Verifying this change

`CatalogStatisticsTest.testGetPartitionStatsFromCatalog`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs
