### PR TITLE
[FLINK-14943] [Connector/Kafka] make callback protected so that we can override it for different beha…

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
@@ -266,11 +266,11 @@ public class FlinkKafkaProducer<IN>
 
 	/** The callback than handles error propagation or logging callbacks. */
 	@Nullable
-	private transient Callback callback;
+	protected transient Callback callback;
 
 	/** Errors encountered in the async producer are stored here. */
 	@Nullable
-	private transient volatile Exception asyncException;
+	protected transient volatile Exception asyncException;
 
 	/** Number of unacknowledged records. */
 	private final AtomicLong pendingRecords = new AtomicLong();
@@ -947,7 +947,7 @@ public class FlinkKafkaProducer<IN>
 		}
 	}
 
-	private void acknowledgeMessage() {
+	protected void acknowledgeMessage() {
 		pendingRecords.decrementAndGet();
 	}
 


### PR DESCRIPTION
…vior, e.g. swallow certain exceptions (like RecordTooLargeException from Kafka producer). logFailuresOnly is not generic and extensible enough. We want to fail except for certain types of exceptions