### PR TITLE
[FLINK-14721][hive]HiveTableSource implement LimitableTableSource interface

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientWrapper;
 import org.apache.flink.table.catalog.hive.descriptors.HiveCatalogValidator;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.sources.InputFormatTableSource;
+import org.apache.flink.table.sources.LimitableTableSource;
 import org.apache.flink.table.sources.PartitionableTableSource;
 import org.apache.flink.table.sources.ProjectableTableSource;
 import org.apache.flink.table.sources.TableSource;
@@ -51,7 +52,8 @@ import java.util.Map;
 /**
  * A TableSource implementation to read data from Hive tables.
  */
-public class HiveTableSource extends InputFormatTableSource<BaseRow> implements PartitionableTableSource, ProjectableTableSource<BaseRow> {
+public class HiveTableSource extends InputFormatTableSource<BaseRow>
+		implements PartitionableTableSource, ProjectableTableSource<BaseRow>, LimitableTableSource<BaseRow> {
 
 	private final JobConf jobConf;
 	private final ObjectPath tablePath;
@@ -64,6 +66,8 @@ public class HiveTableSource extends InputFormatTableSource<BaseRow> implements 
 	private boolean initAllPartitions;
 	private boolean partitionPruned;
 	private int[] projectedFields;
+	private boolean isLimitPushDown = false;
+	private long limit = -1;
 
 	public HiveTableSource(JobConf jobConf, ObjectPath tablePath, CatalogTable catalogTable) {
 		this.jobConf = Preconditions.checkNotNull(jobConf);
@@ -82,7 +86,9 @@ public class HiveTableSource extends InputFormatTableSource<BaseRow> implements 
 							List<Map<String, String>> partitionList,
 							boolean initAllPartitions,
 							boolean partitionPruned,
-							int[] projectedFields) {
+							int[] projectedFields,
+							boolean isLimitPushDown,
+							long limit) {
 		this.jobConf = Preconditions.checkNotNull(jobConf);
 		this.tablePath = Preconditions.checkNotNull(tablePath);
 		this.catalogTable = Preconditions.checkNotNull(catalogTable);
@@ -92,6 +98,8 @@ public class HiveTableSource extends InputFormatTableSource<BaseRow> implements 
 		this.initAllPartitions = initAllPartitions;
 		this.partitionPruned = partitionPruned;
 		this.projectedFields = projectedFields;
+		this.isLimitPushDown = isLimitPushDown;
+		this.limit = limit;
 	}
 
 	@Override
@@ -99,8 +107,7 @@ public class HiveTableSource extends InputFormatTableSource<BaseRow> implements 
 		if (!initAllPartitions) {
 			initAllPartitions();
 		}
-		return new HiveTableInputFormat(
-				jobConf, catalogTable, allHivePartitions, projectedFields, hiveVersion);
+		return new HiveTableInputFormat(jobConf, catalogTable, allHivePartitions, projectedFields, hiveVersion, limit);
 	}
 
 	@Override
@@ -126,6 +133,17 @@ public class HiveTableSource extends InputFormatTableSource<BaseRow> implements 
 	}
 
 	@Override
+	public boolean isLimitPushedDown() {
+		return isLimitPushDown;
+	}
+
+	@Override
+	public TableSource<BaseRow> applyLimit(long limit) {
+		return new HiveTableSource(jobConf, tablePath, catalogTable, allHivePartitions, hiveVersion,
+						partitionList, initAllPartitions, partitionPruned, projectedFields, true, limit);
+	}
+
+	@Override
 	public List<Map<String, String>> getPartitions() {
 		if (!initAllPartitions) {
 			initAllPartitions();
@@ -145,8 +163,8 @@ public class HiveTableSource extends InputFormatTableSource<BaseRow> implements 
 																			"partition spec %s", partitionSpec));
 				remainingHivePartitions.add(hiveTablePartition);
 			}
-			return new HiveTableSource(jobConf, tablePath, catalogTable, remainingHivePartitions,
-					hiveVersion, partitionList, true, true, projectedFields);
+			return new HiveTableSource(jobConf, tablePath, catalogTable, remainingHivePartitions, hiveVersion,
+						partitionList, true, true, projectedFields, isLimitPushDown, limit);
 		}
 	}
 
@@ -234,12 +252,15 @@ public class HiveTableSource extends InputFormatTableSource<BaseRow> implements 
 		if (projectedFields != null) {
 			explain += ", ProjectedFields: " + Arrays.toString(projectedFields);
 		}
+		if (isLimitPushDown) {
+			explain += String.format(", LimitPushDown %s, Limit %d", isLimitPushDown, limit);
+		}
 		return super.explainSource() + explain;
 	}
 
 	@Override
 	public TableSource<BaseRow> projectFields(int[] fields) {
 		return new HiveTableSource(jobConf, tablePath, catalogTable, allHivePartitions, hiveVersion,
-				partitionList, initAllPartitions, partitionPruned, fields);
+				partitionList, initAllPartitions, partitionPruned, fields, isLimitPushDown, limit);
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -67,7 +67,7 @@ public class HiveTableSource extends InputFormatTableSource<BaseRow>
 	private boolean partitionPruned;
 	private int[] projectedFields;
 	private boolean isLimitPushDown = false;
-	private long limit = -1;
+	private long limit = -1L;
 
 	public HiveTableSource(JobConf jobConf, ObjectPath tablePath, CatalogTable catalogTable) {
 		this.jobConf = Preconditions.checkNotNull(jobConf);
@@ -107,7 +107,7 @@ public class HiveTableSource extends InputFormatTableSource<BaseRow>
 		if (!initAllPartitions) {
 			initAllPartitions();
 		}
-		return new HiveTableInputFormat(jobConf, catalogTable, allHivePartitions, projectedFields, hiveVersion, limit);
+		return new HiveTableInputFormat(jobConf, catalogTable, allHivePartitions, projectedFields, limit, hiveVersion);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
@@ -75,6 +75,11 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<BaseRow, H
 	// indices of fields to be returned, with projection applied (if any)
 	private int[] selectedFields;
 
+	//We should limit the input read count of this splits, -1 represents no limit.
+	private long limit;
+
+	private transient long currentReadCount = 0L;
+
 	private transient SplitReader reader;
 
 	private transient Configuration parameters;
@@ -84,11 +89,13 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<BaseRow, H
 			CatalogTable catalogTable,
 			List<HiveTablePartition> partitions,
 			int[] projectedFields,
+			long limit,
 			String hiveVersion) {
 		super(jobConf.getCredentials());
 		this.partitionKeys = catalogTable.getPartitionKeys();
 		this.fieldTypes = catalogTable.getSchema().getFieldDataTypes();
 		this.fieldNames = catalogTable.getSchema().getFieldNames();
+		this.limit = limit;
 		this.hiveVersion = hiveVersion;
 		checkNotNull(catalogTable, "catalogTable can not be null.");
 		this.partitions = checkNotNull(partitions, "partitions can not be null.");
@@ -111,6 +118,7 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<BaseRow, H
 		} else {
 			this.reader = new HiveMapredSplitReader(jobConf, partitionKeys, fieldTypes, selectedFields, split);
 		}
+		currentReadCount = 0L;
 	}
 
 	private boolean useOrcVectorizedRead(HiveTablePartition partition) {
@@ -168,11 +176,16 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<BaseRow, H
 
 	@Override
 	public boolean reachedEnd() throws IOException {
-		return reader.reachedEnd();
+		if (limit > 0 && currentReadCount > limit) {
+			return true;
+		} else {
+			return reader.reachedEnd();
+		}
 	}
 
 	@Override
 	public BaseRow nextRecord(BaseRow reuse) throws IOException {
+		currentReadCount++;
 		return reader.nextRecord(reuse);
 	}
 
@@ -233,6 +246,7 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<BaseRow, H
 		out.writeObject(fieldNames);
 		out.writeObject(partitions);
 		out.writeObject(selectedFields);
+		out.writeObject(limit);
 		out.writeObject(hiveVersion);
 	}
 
@@ -253,6 +267,7 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<BaseRow, H
 		fieldNames = (String[]) in.readObject();
 		partitions = (List<HiveTablePartition>) in.readObject();
 		selectedFields = (int[]) in.readObject();
+		limit = (long) in.readObject();
 		hiveVersion = (String) in.readObject();
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
@@ -176,7 +176,7 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<BaseRow, H
 
 	@Override
 	public boolean reachedEnd() throws IOException {
-		if (limit > 0 && currentReadCount > limit) {
+		if (limit > 0 && currentReadCount >= limit) {
 			return true;
 		} else {
 			return reader.reachedEnd();

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
@@ -238,6 +238,8 @@ public class HiveTableSourceTest {
 						.addRow(new Object[]{"c"})
 						.addRow(new Object[]{"d"})
 						.commit();
+			//Add this to obtain correct stats of table to avoid FLINK-14965 problem
+			hiveShell.execute("analyze table src COMPUTE STATISTICS");
 			TableEnvironment tableEnv = HiveTestUtils.createTableEnv();
 			tableEnv.registerCatalog(catalogName, hiveCatalog);
 			Table table = tableEnv.sqlQuery("select * from hive.`default`.src limit 1");
@@ -245,7 +247,8 @@ public class HiveTableSourceTest {
 			assertEquals(4, explain.length);
 			String logicalPlan = explain[2];
 			String physicalPlan = explain[3];
-			String expectedExplain = "HiveTableSource(a) TablePath: default.src, PartitionPruned: false, LimitPushDown";
+			String expectedExplain = "HiveTableSource(a) TablePath: default.src, PartitionPruned: false, " +
+									"PartitionNums: 1, LimitPushDown true, Limit 1";
 			assertTrue(logicalPlan.contains(expectedExplain));
 			assertTrue(physicalPlan.contains(expectedExplain));
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
@@ -227,4 +227,35 @@ public class HiveTableSourceTest {
 		}
 	}
 
+	@Test
+	public void testLimitPushDown() throws Exception {
+		hiveShell.execute("create table src (a string)");
+		final String catalogName = "hive";
+		try {
+			HiveTestUtils.createTextTableInserter(hiveShell, "default", "src")
+						.addRow(new Object[]{"a"})
+						.addRow(new Object[]{"b"})
+						.addRow(new Object[]{"c"})
+						.addRow(new Object[]{"d"})
+						.commit();
+			TableEnvironment tableEnv = HiveTestUtils.createTableEnv();
+			tableEnv.registerCatalog(catalogName, hiveCatalog);
+			Table table = tableEnv.sqlQuery("select * from hive.`default`.src limit 1");
+			String[] explain = tableEnv.explain(table).split("==.*==\n");
+			assertEquals(4, explain.length);
+			String logicalPlan = explain[2];
+			String physicalPlan = explain[3];
+			String expectedExplain = "HiveTableSource(a) TablePath: default.src, PartitionPruned: false, LimitPushDown";
+			assertTrue(logicalPlan.contains(expectedExplain));
+			assertTrue(physicalPlan.contains(expectedExplain));
+
+			List<Row> rows = JavaConverters.seqAsJavaListConverter(TableUtil.collect((TableImpl) table)).asJava();
+			assertEquals(1, rows.size());
+			Object[] rowStrings = rows.stream().map(Row::toString).sorted().toArray();
+			assertArrayEquals(new String[]{"a"}, rowStrings);
+		} finally {
+			hiveShell.execute("drop table src");
+		}
+	}
+
 }


### PR DESCRIPTION
## What is the purpose of the change

*HiveTableSource implement LimitableTableSource interface*


## Brief change log
HiveTableSource implement LimitableTableSource interface and add tests for it.


## Verifying this change

This change added tests and can be verified as follows:
  - *Added HiveTableSourceTest#testLimitPushDown*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? (not applicable)
