### PR TITLE
[FLINK-14948][client] Implement shutDownCluster for MiniClusterClient

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -65,9 +65,7 @@ public interface ClusterClient<T> extends AutoCloseable {
 	/**
 	 * Shut down the cluster that this client communicate with.
 	 */
-	default void shutDownCluster() {
-		throw new UnsupportedOperationException();
-	}
+	void shutDownCluster();
 
 	/**
 	 * Returns an URL (as a string) to the cluster web interface.

--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -134,6 +134,17 @@ public class MiniClusterClient implements ClusterClient<MiniClusterClient.MiniCl
 	}
 
 	@Override
+	public void shutDownCluster() {
+		try {
+			miniCluster.closeAsync().get();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		} catch (ExecutionException e) {
+			LOG.error("Error while shutting down cluster", e);
+		}
+	}
+
+	@Override
 	public String getWebInterfaceURL() {
 		try {
 			return miniCluster.getRestAddress().get().toString();


### PR DESCRIPTION
## What is the purpose of the change

Indeed, we *can* implement proper `shutDownCluster` method for `MiniClusterClient`

## Verifying this change

Straightforward.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable)

cc @kl0u @aljoscha @zjffdu 
