### PR TITLE
[hotfix] Improve error message in JDBCUpsertTableSink

### DIFF
--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSink.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSink.java
@@ -69,7 +69,7 @@ public class JDBCUpsertTableSink implements UpsertStreamTableSink<Row> {
 
 	private JDBCUpsertOutputFormat newFormat() {
 		if (!isAppendOnly && (keyFields == null || keyFields.length == 0)) {
-			throw new UnsupportedOperationException("JDBCUpsertTableSink can not support ");
+			throw new UnsupportedOperationException("JDBCUpsertTableSink doesn't support upsert without key fields.");
 		}
 
 		// sql types


### PR DESCRIPTION
## What is the purpose of the change

* The error message in JDBCUpsertTableSink#newFormat() is incomplete.

## Brief change log

* Improve error message in JDBCUpsertTableSink#newFormat()

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
