### PR TITLE
[FLINK-14817][doc] Fix misleading documentation using method chaining…

### DIFF
--- a/docs/dev/table/config.md
+++ b/docs/dev/table/config.md
@@ -52,11 +52,12 @@ table environment.
 // instantiate table environment
 TableEnvironment tEnv = ...
 
-tEnv.getConfig()        // access high-level configuration
-  .getConfiguration()   // set low-level key-value options
-  .setString("table.exec.mini-batch.enabled", "true")
-  .setString("table.exec.mini-batch.allow-latency", "5 s")
-  .setString("table.exec.mini-batch.size", "5000");
+// access flink configuration
+Configuration configuration = tEnv.getConfig().getConfiguration();
+// set low-level key-value options
+configuration.setString("table.exec.mini-batch.enabled", "true");
+configuration.setString("table.exec.mini-batch.allow-latency", "5 s");
+configuration.setString("table.exec.mini-batch.size", "5000");
 {% endhighlight %}
 </div>
 
@@ -65,11 +66,12 @@ tEnv.getConfig()        // access high-level configuration
 // instantiate table environment
 val tEnv: TableEnvironment = ...
 
-tEnv.getConfig         // access high-level configuration
-  .getConfiguration    // set low-level key-value options
-  .setString("table.exec.mini-batch.enabled", "true")
-  .setString("table.exec.mini-batch.allow-latency", "5 s")
-  .setString("table.exec.mini-batch.size", "5000")
+// access flink configuration
+val configuration = tEnv.getConfig().getConfiguration()
+// set low-level key-value options
+configuration.setString("table.exec.mini-batch.enabled", "true")
+configuration.setString("table.exec.mini-batch.allow-latency", "5 s")
+configuration.setString("table.exec.mini-batch.size", "5000")
 {% endhighlight %}
 </div>
 
@@ -78,11 +80,12 @@ tEnv.getConfig         // access high-level configuration
 # instantiate table environment
 t_env = ...
 
-t_env.get_config()        # access high-level configuration
-  .get_configuration()    # set low-level key-value options
-  .set_string("table.exec.mini-batch.enabled", "true")
-  .set_string("table.exec.mini-batch.allow-latency", "5 s")
-  .set_string("table.exec.mini-batch.size", "5000");
+# access flink configuration
+configuration = t_env.get_config().get_configuration();
+# set low-level key-value options
+configuration.set_string("table.exec.mini-batch.enabled", "true");
+configuration.set_string("table.exec.mini-batch.allow-latency", "5 s");
+configuration.set_string("table.exec.mini-batch.size", "5000");
 {% endhighlight %}
 </div>
 </div>

--- a/docs/dev/table/config.zh.md
+++ b/docs/dev/table/config.zh.md
@@ -52,11 +52,12 @@ table environment.
 // instantiate table environment
 TableEnvironment tEnv = ...
 
-tEnv.getConfig()        // access high-level configuration
-  .getConfiguration()   // set low-level key-value options
-  .setString("table.exec.mini-batch.enabled", "true")
-  .setString("table.exec.mini-batch.allow-latency", "5 s")
-  .setString("table.exec.mini-batch.size", "5000");
+// access flink configuration
+Configuration configuration = tEnv.getConfig().getConfiguration();
+// set low-level key-value options
+configuration.setString("table.exec.mini-batch.enabled", "true");
+configuration.setString("table.exec.mini-batch.allow-latency", "5 s");
+configuration.setString("table.exec.mini-batch.size", "5000");
 {% endhighlight %}
 </div>
 
@@ -65,11 +66,12 @@ tEnv.getConfig()        // access high-level configuration
 // instantiate table environment
 val tEnv: TableEnvironment = ...
 
-tEnv.getConfig         // access high-level configuration
-  .getConfiguration    // set low-level key-value options
-  .setString("table.exec.mini-batch.enabled", "true")
-  .setString("table.exec.mini-batch.allow-latency", "5 s")
-  .setString("table.exec.mini-batch.size", "5000")
+// access flink configuration
+val configuration = tEnv.getConfig().getConfiguration()
+// set low-level key-value options
+configuration.setString("table.exec.mini-batch.enabled", "true")
+configuration.setString("table.exec.mini-batch.allow-latency", "5 s")
+configuration.setString("table.exec.mini-batch.size", "5000")
 {% endhighlight %}
 </div>
 
@@ -78,11 +80,12 @@ tEnv.getConfig         // access high-level configuration
 # instantiate table environment
 t_env = ...
 
-t_env.get_config()        # access high-level configuration
-  .get_configuration()    # set low-level key-value options
-  .set_string("table.exec.mini-batch.enabled", "true")
-  .set_string("table.exec.mini-batch.allow-latency", "5 s")
-  .set_string("table.exec.mini-batch.size", "5000");
+# access flink configuration
+configuration = t_env.get_config().get_configuration();
+# set low-level key-value options
+configuration.set_string("table.exec.mini-batch.enabled", "true");
+configuration.set_string("table.exec.mini-batch.allow-latency", "5 s");
+configuration.set_string("table.exec.mini-batch.size", "5000");
 {% endhighlight %}
 </div>
 </div>

--- a/docs/dev/table/tuning/streaming_aggregation_optimization.md
+++ b/docs/dev/table/tuning/streaming_aggregation_optimization.md
@@ -56,11 +56,12 @@ The following examples show how to enable these options.
 // instantiate table environment
 TableEnvironment tEnv = ...
 
-tEnv.getConfig()        // access high-level configuration
-  .getConfiguration()   // set low-level key-value options
-  .setString("table.exec.mini-batch.enabled", "true")  // enable mini-batch optimization
-  .setString("table.exec.mini-batch.allow-latency", "5 s") // use 5 seconds to buffer input records
-  .setString("table.exec.mini-batch.size", "5000"); // the maximum number of records can be buffered by each aggregate operator task
+// access flink configuration
+Configuration configuration = tEnv.getConfig().getConfiguration();
+// set low-level key-value options
+configuration.setString("table.exec.mini-batch.enabled", "true"); // enable mini-batch optimization
+configuration.setString("table.exec.mini-batch.allow-latency", "5 s"); // use 5 seconds to buffer input records
+configuration.setString("table.exec.mini-batch.size", "5000"); // the maximum number of records can be buffered by each aggregate operator task
 {% endhighlight %}
 </div>
 
@@ -69,11 +70,12 @@ tEnv.getConfig()        // access high-level configuration
 // instantiate table environment
 val tEnv: TableEnvironment = ...
 
-tEnv.getConfig         // access high-level configuration
-  .getConfiguration    // set low-level key-value options
-  .setString("table.exec.mini-batch.enabled", "true") // enable mini-batch optimization
-  .setString("table.exec.mini-batch.allow-latency", "5 s") // use 5 seconds to buffer input records
-  .setString("table.exec.mini-batch.size", "5000") // the maximum number of records can be buffered by each aggregate operator task
+// access flink configuration
+val configuration = tEnv.getConfig().getConfiguration()
+// set low-level key-value options
+configuration.setString("table.exec.mini-batch.enabled", "true") // enable mini-batch optimization
+configuration.setString("table.exec.mini-batch.allow-latency", "5 s") // use 5 seconds to buffer input records
+configuration.setString("table.exec.mini-batch.size", "5000") // the maximum number of records can be buffered by each aggregate operator task
 {% endhighlight %}
 </div>
 
@@ -82,11 +84,12 @@ tEnv.getConfig         // access high-level configuration
 # instantiate table environment
 t_env = ...
 
-t_env.get_config()        # access high-level configuration
-  .get_configuration()    # set low-level key-value options
-  .set_string("table.exec.mini-batch.enabled", "true") # enable mini-batch optimization
-  .set_string("table.exec.mini-batch.allow-latency", "5 s") # use 5 seconds to buffer input records
-  .set_string("table.exec.mini-batch.size", "5000"); # the maximum number of records can be buffered by each aggregate operator task
+# access flink configuration
+configuration = t_env.get_config().get_configuration();
+# set low-level key-value options
+configuration.set_string("table.exec.mini-batch.enabled", "true"); # enable mini-batch optimization
+configuration.set_string("table.exec.mini-batch.allow-latency", "5 s"); # use 5 seconds to buffer input records
+configuration.set_string("table.exec.mini-batch.size", "5000"); # the maximum number of records can be buffered by each aggregate operator task
 {% endhighlight %}
 </div>
 </div>
@@ -120,12 +123,13 @@ The following examples show how to enable the local-global aggregation.
 // instantiate table environment
 TableEnvironment tEnv = ...
 
-tEnv.getConfig()        // access high-level configuration
-  .getConfiguration()   // set low-level key-value options
-  .setString("table.exec.mini-batch.enabled", "true")  // local-global aggregation depends on mini-batch is enabled
-  .setString("table.exec.mini-batch.allow-latency", "5 s")
-  .setString("table.exec.mini-batch.size", "5000")
-  .setString("table.optimizer.agg-phase-strategy", "TWO_PHASE"); // enable two-phase, i.e. local-global aggregation
+// access flink configuration
+Configuration configuration = tEnv.getConfig().getConfiguration();
+// set low-level key-value options
+configuration.setString("table.exec.mini-batch.enabled", "true"); // local-global aggregation depends on mini-batch is enabled
+configuration.setString("table.exec.mini-batch.allow-latency", "5 s");
+configuration.setString("table.exec.mini-batch.size", "5000");
+configuration.setString("table.optimizer.agg-phase-strategy", "TWO_PHASE"); // enable two-phase, i.e. local-global aggregation
 {% endhighlight %}
 </div>
 
@@ -134,12 +138,13 @@ tEnv.getConfig()        // access high-level configuration
 // instantiate table environment
 val tEnv: TableEnvironment = ...
 
-tEnv.getConfig         // access high-level configuration
-  .getConfiguration    // set low-level key-value options
-  .setString("table.exec.mini-batch.enabled", "true") // local-global aggregation depends on mini-batch is enabled
-  .setString("table.exec.mini-batch.allow-latency", "5 s")
-  .setString("table.exec.mini-batch.size", "5000")
-  .setString("table.optimizer.agg-phase-strategy", "TWO_PHASE") // enable two-phase, i.e. local-global aggregation
+// access flink configuration
+val configuration = tEnv.getConfig().getConfiguration()
+// set low-level key-value options
+configuration.setString("table.exec.mini-batch.enabled", "true") // local-global aggregation depends on mini-batch is enabled
+configuration.setString("table.exec.mini-batch.allow-latency", "5 s")
+configuration.setString("table.exec.mini-batch.size", "5000")
+configuration.setString("table.optimizer.agg-phase-strategy", "TWO_PHASE") // enable two-phase, i.e. local-global aggregation
 {% endhighlight %}
 </div>
 
@@ -148,12 +153,13 @@ tEnv.getConfig         // access high-level configuration
 # instantiate table environment
 t_env = ...
 
-t_env.get_config()        # access high-level configuration
-  .get_configuration()    # set low-level key-value options
-  .set_string("table.exec.mini-batch.enabled", "true") # local-global aggregation depends on mini-batch is enabled
-  .set_string("table.exec.mini-batch.allow-latency", "5 s")
-  .set_string("table.exec.mini-batch.size", "5000")
-  .set_string("table.optimizer.agg-phase-strategy", "TWO_PHASE"); # enable two-phase, i.e. local-global aggregation
+# access flink configuration
+configuration = t_env.get_config().get_configuration();
+# set low-level key-value options
+configuration.set_string("table.exec.mini-batch.enabled", "true"); # local-global aggregation depends on mini-batch is enabled
+configuration.set_string("table.exec.mini-batch.allow-latency", "5 s");
+configuration.set_string("table.exec.mini-batch.size", "5000");
+configuration.set_string("table.optimizer.agg-phase-strategy", "TWO_PHASE"); # enable two-phase, i.e. local-global aggregation
 {% endhighlight %}
 </div>
 </div>

--- a/docs/dev/table/tuning/streaming_aggregation_optimization.zh.md
+++ b/docs/dev/table/tuning/streaming_aggregation_optimization.zh.md
@@ -56,11 +56,12 @@ The following examples show how to enable these options.
 // instantiate table environment
 TableEnvironment tEnv = ...
 
-tEnv.getConfig()        // access high-level configuration
-  .getConfiguration()   // set low-level key-value options
-  .setString("table.exec.mini-batch.enabled", "true")  // enable mini-batch optimization
-  .setString("table.exec.mini-batch.allow-latency", "5 s") // use 5 seconds to buffer input records
-  .setString("table.exec.mini-batch.size", "5000"); // the maximum number of records can be buffered by each aggregate operator task
+// access flink configuration
+Configuration configuration = tEnv.getConfig().getConfiguration();
+// set low-level key-value options
+configuration.setString("table.exec.mini-batch.enabled", "true"); // enable mini-batch optimization
+configuration.setString("table.exec.mini-batch.allow-latency", "5 s"); // use 5 seconds to buffer input records
+configuration.setString("table.exec.mini-batch.size", "5000"); // the maximum number of records can be buffered by each aggregate operator task
 {% endhighlight %}
 </div>
 
@@ -69,11 +70,12 @@ tEnv.getConfig()        // access high-level configuration
 // instantiate table environment
 val tEnv: TableEnvironment = ...
 
-tEnv.getConfig         // access high-level configuration
-  .getConfiguration    // set low-level key-value options
-  .setString("table.exec.mini-batch.enabled", "true") // enable mini-batch optimization
-  .setString("table.exec.mini-batch.allow-latency", "5 s") // use 5 seconds to buffer input records
-  .setString("table.exec.mini-batch.size", "5000") // the maximum number of records can be buffered by each aggregate operator task
+// access flink configuration
+val configuration = tEnv.getConfig().getConfiguration()
+// set low-level key-value options
+configuration.setString("table.exec.mini-batch.enabled", "true") // enable mini-batch optimization
+configuration.setString("table.exec.mini-batch.allow-latency", "5 s") // use 5 seconds to buffer input records
+configuration.setString("table.exec.mini-batch.size", "5000") // the maximum number of records can be buffered by each aggregate operator task
 {% endhighlight %}
 </div>
 
@@ -82,11 +84,12 @@ tEnv.getConfig         // access high-level configuration
 # instantiate table environment
 t_env = ...
 
-t_env.get_config()        # access high-level configuration
-  .get_configuration()    # set low-level key-value options
-  .set_string("table.exec.mini-batch.enabled", "true") # enable mini-batch optimization
-  .set_string("table.exec.mini-batch.allow-latency", "5 s") # use 5 seconds to buffer input records
-  .set_string("table.exec.mini-batch.size", "5000"); # the maximum number of records can be buffered by each aggregate operator task
+# access flink configuration
+configuration = t_env.get_config().get_configuration();
+# set low-level key-value options
+configuration.set_string("table.exec.mini-batch.enabled", "true"); # enable mini-batch optimization
+configuration.set_string("table.exec.mini-batch.allow-latency", "5 s"); # use 5 seconds to buffer input records
+configuration.set_string("table.exec.mini-batch.size", "5000"); # the maximum number of records can be buffered by each aggregate operator task
 {% endhighlight %}
 </div>
 </div>
@@ -120,12 +123,13 @@ The following examples show how to enable the local-global aggregation.
 // instantiate table environment
 TableEnvironment tEnv = ...
 
-tEnv.getConfig()        // access high-level configuration
-  .getConfiguration()   // set low-level key-value options
-  .setString("table.exec.mini-batch.enabled", "true")  // local-global aggregation depends on mini-batch is enabled
-  .setString("table.exec.mini-batch.allow-latency", "5 s")
-  .setString("table.exec.mini-batch.size", "5000")
-  .setString("table.optimizer.agg-phase-strategy", "TWO_PHASE"); // enable two-phase, i.e. local-global aggregation
+// access flink configuration
+Configuration configuration = tEnv.getConfig().getConfiguration();
+// set low-level key-value options
+configuration.setString("table.exec.mini-batch.enabled", "true"); // local-global aggregation depends on mini-batch is enabled
+configuration.setString("table.exec.mini-batch.allow-latency", "5 s");
+configuration.setString("table.exec.mini-batch.size", "5000");
+configuration.setString("table.optimizer.agg-phase-strategy", "TWO_PHASE"); // enable two-phase, i.e. local-global aggregation
 {% endhighlight %}
 </div>
 
@@ -134,12 +138,13 @@ tEnv.getConfig()        // access high-level configuration
 // instantiate table environment
 val tEnv: TableEnvironment = ...
 
-tEnv.getConfig         // access high-level configuration
-  .getConfiguration    // set low-level key-value options
-  .setString("table.exec.mini-batch.enabled", "true") // local-global aggregation depends on mini-batch is enabled
-  .setString("table.exec.mini-batch.allow-latency", "5 s")
-  .setString("table.exec.mini-batch.size", "5000")
-  .setString("table.optimizer.agg-phase-strategy", "TWO_PHASE") // enable two-phase, i.e. local-global aggregation
+// access flink configuration
+val configuration = tEnv.getConfig().getConfiguration()
+// set low-level key-value options
+configuration.setString("table.exec.mini-batch.enabled", "true") // local-global aggregation depends on mini-batch is enabled
+configuration.setString("table.exec.mini-batch.allow-latency", "5 s")
+configuration.setString("table.exec.mini-batch.size", "5000")
+configuration.setString("table.optimizer.agg-phase-strategy", "TWO_PHASE") // enable two-phase, i.e. local-global aggregation
 {% endhighlight %}
 </div>
 
@@ -148,12 +153,13 @@ tEnv.getConfig         // access high-level configuration
 # instantiate table environment
 t_env = ...
 
-t_env.get_config()        # access high-level configuration
-  .get_configuration()    # set low-level key-value options
-  .set_string("table.exec.mini-batch.enabled", "true") # local-global aggregation depends on mini-batch is enabled
-  .set_string("table.exec.mini-batch.allow-latency", "5 s")
-  .set_string("table.exec.mini-batch.size", "5000")
-  .set_string("table.optimizer.agg-phase-strategy", "TWO_PHASE"); # enable two-phase, i.e. local-global aggregation
+# access flink configuration
+configuration = t_env.get_config().get_configuration();
+# set low-level key-value options
+configuration.set_string("table.exec.mini-batch.enabled", "true"); # local-global aggregation depends on mini-batch is enabled
+configuration.set_string("table.exec.mini-batch.allow-latency", "5 s");
+configuration.set_string("table.exec.mini-batch.size", "5000");
+configuration.set_string("table.optimizer.agg-phase-strategy", "TWO_PHASE"); # enable two-phase, i.e. local-global aggregation
 {% endhighlight %}
 </div>
 </div>


### PR DESCRIPTION
… of Configuration

## What is the purpose of the change

In the document, there are some misleading code examples, e.g.

```
// instantiate table environment
TableEnvironment tEnv = ...tEnv.getConfig()        // access high-level configuration
  .getConfiguration()   // set low-level key-value options
  .setString("table.exec.mini-batch.enabled", "true")  // enable mini-batch optimization
  .setString("table.exec.mini-batch.allow-latency", "5 s") // use 5 seconds to buffer input records
  .setString("table.exec.mini-batch.size", "5000"); // the maximum number of records can be buffered by each aggregate operator task
```
It seems `Configuration` supports method chaining, while it's not true since the return type of `Configuration#setString` is Void.

This PR updates the documentation to fix this.

## Brief change log

  - Break the chaining call of `Documentation#setXXX`

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)