### PR TITLE
[FLINK-14914][table] refactor CatalogFunction by adding Language support

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -36,6 +36,7 @@ import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.catalog.CatalogViewImpl;
+import org.apache.flink.table.catalog.FunctionLanguage;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
@@ -1080,6 +1081,11 @@ public class HiveCatalog extends AbstractCatalog {
 		String functionClassName = isGeneric ?
 			FLINK_FUNCTION_PREFIX + function.getClassName() :
 			function.getClassName();
+
+		if (!function.getFunctionLanguage().equals(FunctionLanguage.JAVA)) {
+			throw new UnsupportedOperationException("HiveCatalog supports only creating" +
+				" JAVA based function for now");
+		}
 
 		return new Function(
 			// due to https://issues.apache.org/jira/browse/HIVE-22053, we have to normalize function name ourselves

--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -797,6 +797,14 @@ class CatalogFunction(object):
         """
         return self._j_catalog_function.isGeneric()
 
+    def get_function_language(self):
+        """
+        Get the language used for the function definition.
+
+        :return: the language type of the function definition
+        """
+        return self._j_catalog_function.getFunctionLanguage()
+
 
 class ObjectPath(object):
     """

--- a/flink-python/pyflink/table/tests/test_catalog.py
+++ b/flink-python/pyflink/table/tests/test_catalog.py
@@ -68,6 +68,7 @@ class CatalogTestBase(PyFlinkTestCase):
     def check_catalog_function_equals(self, f1, f2):
         self.assertEqual(f1.get_class_name(), f2.get_class_name())
         self.assertEqual(f1.is_generic(), f2.is_generic())
+        self.assertEqual(f1.get_function_language(), f2.get_function_language())
 
     def check_catalog_partition_equals(self, p1, p2):
         self.assertEqual(p1.get_properties(), p2.get_properties())

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogFunctionImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogFunctionImpl.java
@@ -24,16 +24,23 @@ import org.apache.flink.util.StringUtils;
 import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A catalog function implementation.
  */
 public class CatalogFunctionImpl implements CatalogFunction {
 	private final String className; // Fully qualified class name of the function
+	private final FunctionLanguage functionLanguage;
 
 	public CatalogFunctionImpl(String className) {
+		this(className, FunctionLanguage.JAVA);
+	}
+
+	public CatalogFunctionImpl(String className, FunctionLanguage functionLanguage) {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(className), "className cannot be null or empty");
 		this.className = className;
+		this.functionLanguage = checkNotNull(functionLanguage, "functionLanguage cannot be null");
 	}
 
 	@Override
@@ -43,7 +50,7 @@ public class CatalogFunctionImpl implements CatalogFunction {
 
 	@Override
 	public CatalogFunction copy() {
-		return new CatalogFunctionImpl(getClassName());
+		return new CatalogFunctionImpl(getClassName(), functionLanguage);
 	}
 
 	@Override
@@ -70,9 +77,15 @@ public class CatalogFunctionImpl implements CatalogFunction {
 	}
 
 	@Override
+	public FunctionLanguage getFunctionLanguage() {
+		return functionLanguage;
+	}
+
+	@Override
 	public String toString() {
 		return "CatalogFunctionImpl{" +
-			"className='" + getClassName() +
+			"className='" + getClassName() + "', " +
+			"functionLanguage='" + getFunctionLanguage() +
 			"'}";
 	}
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
@@ -162,6 +162,6 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 
 	@Override
 	protected CatalogFunction createAnotherFunction() {
-		return new CatalogFunctionImpl(TestSimpleUDF.class.getCanonicalName());
+		return new CatalogFunctionImpl(TestSimpleUDF.class.getCanonicalName(), FunctionLanguage.SCALA);
 	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogFunction.java
@@ -59,4 +59,11 @@ public interface CatalogFunction {
 	 * @return whether the function is a generic Flink function
 	 */
 	boolean isGeneric();
+
+	/**
+	 * Get the language used for the definition of function.
+	 *
+	 * @return  the language type of the function definition
+	 */
+	FunctionLanguage getFunctionLanguage();
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/FunctionLanguage.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/FunctionLanguage.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * Categorizes the language semantics of a {@link CatalogFunction}.
+ */
+@PublicEvolving
+public enum FunctionLanguage {
+
+	JAVA,
+
+	SCALA,
+
+	PYTHON
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
@@ -1323,6 +1323,7 @@ public abstract class CatalogTest {
 	protected void checkEquals(CatalogFunction f1, CatalogFunction f2) {
 		assertEquals(f1.getClassName(), f2.getClassName());
 		assertEquals(f1.isGeneric(), f2.isGeneric());
+		assertEquals(f1.getFunctionLanguage(), f2.getFunctionLanguage());
 	}
 
 	protected void checkEquals(CatalogColumnStatistics cs1, CatalogColumnStatistics cs2) {


### PR DESCRIPTION
## What is the purpose of the change
 Refactor CatalogFunction interface and impls to add language field so that the language setting can be used by function DDL.

## Brief change log

Add getLanguage function in CatalogFunction interface and CatalogFunctionImpl
When adding non JAVA defined function to HiveCatalog, runtime exception will be thrown.

## Verifying this change
This change added tests and can be verified in existing test cases in:

  - HiveCatalogGenericMetadataTest
  - GenericInMemoryCatalogFactoryTest
  - HiveCatalogHiveMetadataTest
  - test_catalog in flnk-python module

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes )
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
