### PR TITLE
[FLINK-12785][StateBackend] RocksDB savepoint recovery can use a lot of unmanaged memory

### DIFF
--- a/docs/_includes/generated/rocks_db_configurable_configuration.html
+++ b/docs/_includes/generated/rocks_db_configurable_configuration.html
@@ -57,6 +57,12 @@
             <td>The maximum number of concurrent background flush and compaction jobs (per TaskManager). RocksDB has default configuration as '1'.</td>
         </tr>
         <tr>
+            <td><h5>state.backend.rocksdb.write-batch-size</h5></td>
+            <td style="word-wrap: break-word;">2097152 bytes</td>
+            <td>MemorySize</td>
+            <td>The max size of the consumed memory for RocksDB batch write, will flush just based on item count if this config set to 0.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.rocksdb.writebuffer.count</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -134,4 +134,10 @@ public class RocksDBConfigurableOptions implements Serializable {
 			.withDescription("The amount of the cache for data blocks in RocksDB. " +
 				"RocksDB has default block-cache size as '8MB'.");
 
+	public static final ConfigOption<MemorySize> WRITE_BATCH_SIZE =
+		key("state.backend.rocksdb.write-batch-size")
+		.memoryType()
+		.defaultValue(MemorySize.parse("2mb"))
+		.withDescription("The max size of the consumed memory for RocksDB batch write, " +
+			"will flush just based on item count if this config set to 0.");
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -73,6 +73,7 @@ import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 
 import java.io.File;
@@ -90,6 +91,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static org.apache.flink.contrib.streaming.state.RocksDBSnapshotTransformFactoryAdaptor.wrapStateSnapshotTransformFactory;
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
@@ -146,6 +148,11 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	 * The write options to use in the states. We disable write ahead logging.
 	 */
 	private final WriteOptions writeOptions;
+
+	/**
+	 * The max memory size for one batch in {@link RocksDBWriteBatchWrapper}.
+	 */
+	private final long writeBatchSize;
 
 	/**
 	 * Information about the k/v states, maintained in the order as we create them. This is used to retrieve the
@@ -218,7 +225,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		RocksDBSerializedCompositeKeyBuilder<K> sharedRocksKeyBuilder,
 		PriorityQueueSetFactory priorityQueueFactory,
 		RocksDbTtlCompactFiltersManager ttlCompactFiltersManager,
-		InternalKeyContext<K> keyContext) {
+		InternalKeyContext<K> keyContext,
+		@Nonnegative long writeBatchSize) {
 
 		super(
 			kvStateRegistry,
@@ -243,6 +251,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		this.kvStateInformation = kvStateInformation;
 
 		this.writeOptions = new WriteOptions().setDisableWAL(true);
+		checkArgument(writeBatchSize >= 0, "Write batch size have to be no negative value.");
+		this.writeBatchSize = writeBatchSize;
 		this.db = db;
 		this.rocksDBResourceGuard = rocksDBResourceGuard;
 		this.checkpointSnapshotStrategy = checkpointSnapshotStrategy;
@@ -590,7 +600,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		Snapshot rocksDBSnapshot = db.getSnapshot();
 		try (
 			RocksIteratorWrapper iterator = RocksDBOperationUtils.getRocksIterator(db, stateMetaInfo.f0);
-			RocksDBWriteBatchWrapper batchWriter = new RocksDBWriteBatchWrapper(db, getWriteOptions())
+			RocksDBWriteBatchWrapper batchWriter = new RocksDBWriteBatchWrapper(db, getWriteOptions(), getWriteBatchSize())
 		) {
 			iterator.seekToFirst();
 
@@ -704,5 +714,10 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	public void compactState(StateDescriptor<?, ?> stateDesc) throws RocksDBException {
 		RocksDbKvStateInfo kvStateInfo = kvStateInformation.get(stateDesc.getName());
 		db.compactRange(kvStateInfo.columnFamilyHandle);
+	}
+
+	@Nonnegative
+	long getWriteBatchSize() {
+		return writeBatchSize;
 	}
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
@@ -59,7 +59,6 @@ import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 
 import java.io.File;
@@ -113,7 +112,7 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
 	private boolean enableTtlCompactionFilter;
 	private RocksDBNativeMetricOptions nativeMetricOptions;
 	private int numberOfTransferingThreads;
-	private final long writeBatchSize;
+	private long writeBatchSize = RocksDBConfigurableOptions.WRITE_BATCH_SIZE.defaultValue().getBytes();
 
 	private RocksDB injectedTestDB; // for testing
 	private ColumnFamilyHandle injectedDefaultColumnFamilyHandle; // for testing
@@ -135,8 +134,7 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
 		MetricGroup metricGroup,
 		@Nonnull Collection<KeyedStateHandle> stateHandles,
 		StreamCompressionDecorator keyGroupCompressionDecorator,
-		CloseableRegistry cancelStreamRegistry,
-		@Nonnegative long writeBatchSize) {
+		CloseableRegistry cancelStreamRegistry) {
 
 		super(
 			kvStateRegistry,
@@ -162,8 +160,6 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
 		this.enableIncrementalCheckpointing = false;
 		this.nativeMetricOptions = new RocksDBNativeMetricOptions();
 		this.numberOfTransferingThreads = RocksDBOptions.CHECKPOINT_TRANSFER_THREAD_NUM.defaultValue();
-		checkArgument(writeBatchSize >= 0, "Write batch size have to be no negative value.");
-		this.writeBatchSize = writeBatchSize;
 	}
 
 	@VisibleForTesting
@@ -204,8 +200,7 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
 			metricGroup,
 			stateHandles,
 			keyGroupCompressionDecorator,
-			cancelStreamRegistry,
-			RocksDBConfigurableOptions.WRITE_BATCH_SIZE.defaultValue().getBytes()
+			cancelStreamRegistry
 		);
 		this.injectedTestDB = injectedTestDB;
 		this.injectedDefaultColumnFamilyHandle = injectedDefaultColumnFamilyHandle;
@@ -228,6 +223,12 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
 
 	RocksDBKeyedStateBackendBuilder<K> setNumberOfTransferingThreads(int numberOfTransferingThreads) {
 		this.numberOfTransferingThreads = numberOfTransferingThreads;
+		return this;
+	}
+
+	RocksDBKeyedStateBackendBuilder<K> setWriteBatchSize(long writeBatchSize) {
+		checkArgument(writeBatchSize >= 0, "Write batch size should be non negative.");
+		this.writeBatchSize = writeBatchSize;
 		return this;
 	}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
@@ -138,7 +138,7 @@ class RocksDBMapState<K, N, UK, UV>
 			return;
 		}
 
-		try (RocksDBWriteBatchWrapper writeBatchWrapper = new RocksDBWriteBatchWrapper(backend.db, writeOptions)) {
+		try (RocksDBWriteBatchWrapper writeBatchWrapper = new RocksDBWriteBatchWrapper(backend.db, writeOptions, backend.getWriteBatchSize())) {
 			for (Map.Entry<UK, UV> entry : map.entrySet()) {
 				byte[] rawKeyBytes = serializeCurrentKeyWithGroupAndNamespacePlusUserKey(entry.getKey(), userKeySerializer);
 				byte[] rawValueBytes = serializeValueNullSensitive(entry.getValue(), userValueSerializer);
@@ -255,7 +255,7 @@ class RocksDBMapState<K, N, UK, UV>
 	public void clear() {
 		try {
 			try (RocksIteratorWrapper iterator = RocksDBOperationUtils.getRocksIterator(backend.db, columnFamily);
-				RocksDBWriteBatchWrapper rocksDBWriteBatchWrapper = new RocksDBWriteBatchWrapper(backend.db, backend.getWriteOptions())) {
+				RocksDBWriteBatchWrapper rocksDBWriteBatchWrapper = new RocksDBWriteBatchWrapper(backend.db, backend.getWriteOptions(), backend.getWriteBatchSize())) {
 
 				final byte[] keyPrefixBytes = serializeCurrentKeyWithGroupAndNamespace();
 				iterator.seek(keyPrefixBytes);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -118,7 +118,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	private static boolean rocksDbInitialized = false;
 
 	private static final int UNDEFINED_NUMBER_OF_TRANSFER_THREADS = -1;
-	private static final long UNDEFINED_BATCH_SIZE = -1;
+	private static final long UNDEFINED_WRITE_BATCH_SIZE = -1;
 
 	// ------------------------------------------------------------------------
 
@@ -285,7 +285,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 		this.defaultMetricOptions = new RocksDBNativeMetricOptions();
 		this.enableTtlCompactionFilter = TernaryBoolean.UNDEFINED;
 		this.memoryConfiguration = new RocksDBMemoryConfiguration();
-		this.writeBatchSize = UNDEFINED_BATCH_SIZE;
+		this.writeBatchSize = UNDEFINED_WRITE_BATCH_SIZE;
 	}
 
 	/**
@@ -328,7 +328,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 			this.numberOfTransferThreads = original.numberOfTransferThreads;
 		}
 
-		if (original.writeBatchSize == UNDEFINED_BATCH_SIZE) {
+		if (original.writeBatchSize == UNDEFINED_WRITE_BATCH_SIZE) {
 			this.writeBatchSize = config.get(WRITE_BATCH_SIZE).getBytes();
 		} else {
 			this.writeBatchSize = original.writeBatchSize;
@@ -912,7 +912,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	 * Gets the max batch size will be used in {@link RocksDBWriteBatchWrapper}.
 	 */
 	public long getWriteBatchSize() {
-		return writeBatchSize == UNDEFINED_BATCH_SIZE ?
+		return writeBatchSize == UNDEFINED_WRITE_BATCH_SIZE ?
 			WRITE_BATCH_SIZE.defaultValue().getBytes() : writeBatchSize;
 	}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -571,7 +571,8 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 			stateHandles,
 			keyGroupCompressionDecorator,
 			cancelStreamRegistry
-		).setEnableIncrementalCheckpointing(isIncrementalCheckpointsEnabled())
+		)
+			.setEnableIncrementalCheckpointing(isIncrementalCheckpointsEnabled())
 			.setEnableTtlCompactionFilter(isTtlCompactionFilterEnabled())
 			.setNumberOfTransferingThreads(getNumberOfTransferThreads())
 			.setNativeMetricOptions(resourceContainer.getMemoryWatcherOptions(defaultMetricOptions))

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBWriteBatchWrapper.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBWriteBatchWrapper.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.contrib.streaming.state;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
 
@@ -27,6 +28,7 @@ import org.rocksdb.RocksDBException;
 import org.rocksdb.WriteBatch;
 import org.rocksdb.WriteOptions;
 
+import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -40,6 +42,8 @@ public class RocksDBWriteBatchWrapper implements AutoCloseable {
 	private static final int MIN_CAPACITY = 100;
 	private static final int MAX_CAPACITY = 1000;
 	private static final int PER_RECORD_BYTES = 100;
+	// default 0 for disable memory size based flush
+	private static final long DEFAULT_BATCH_SIZE = 0;
 
 	private final RocksDB db;
 
@@ -49,22 +53,35 @@ public class RocksDBWriteBatchWrapper implements AutoCloseable {
 
 	private final int capacity;
 
-	public RocksDBWriteBatchWrapper(@Nonnull RocksDB rocksDB) {
-		this(rocksDB, null, 500);
+	@Nonnegative
+	private final long batchSize;
+
+	public RocksDBWriteBatchWrapper(@Nonnull RocksDB rocksDB, long writeBatchSize) {
+		this(rocksDB, null, 500, writeBatchSize);
 	}
 
 	public RocksDBWriteBatchWrapper(@Nonnull RocksDB rocksDB, @Nullable WriteOptions options) {
-		this(rocksDB, options, 500);
+		this(rocksDB, options, 500, DEFAULT_BATCH_SIZE);
 	}
 
-	public RocksDBWriteBatchWrapper(@Nonnull RocksDB rocksDB, @Nullable WriteOptions options, int capacity) {
+	public RocksDBWriteBatchWrapper(@Nonnull RocksDB rocksDB, @Nullable WriteOptions options, long batchSize) {
+		this(rocksDB, options, 500, batchSize);
+	}
+
+	public RocksDBWriteBatchWrapper(@Nonnull RocksDB rocksDB, @Nullable WriteOptions options, int capacity, long batchSize) {
 		Preconditions.checkArgument(capacity >= MIN_CAPACITY && capacity <= MAX_CAPACITY,
 			"capacity should be between " + MIN_CAPACITY + " and " + MAX_CAPACITY);
+		Preconditions.checkArgument(batchSize >= 0, "Max batch size have to be no negative.");
 
 		this.db = rocksDB;
 		this.options = options;
 		this.capacity = capacity;
-		this.batch = new WriteBatch(this.capacity * PER_RECORD_BYTES);
+		this.batchSize = batchSize;
+		if (this.batchSize > 0) {
+			this.batch = new WriteBatch((int) Math.min(this.batchSize, this.capacity * PER_RECORD_BYTES));
+		} else {
+			this.batch = new WriteBatch(this.capacity * PER_RECORD_BYTES);
+		}
 	}
 
 	public void put(
@@ -74,9 +91,7 @@ public class RocksDBWriteBatchWrapper implements AutoCloseable {
 
 		batch.put(handle, key, value);
 
-		if (batch.count() == capacity) {
-			flush();
-		}
+		flushIfNeeded();
 	}
 
 	public void remove(
@@ -85,9 +100,7 @@ public class RocksDBWriteBatchWrapper implements AutoCloseable {
 
 		batch.remove(handle, key);
 
-		if (batch.count() == capacity) {
-			flush();
-		}
+		flushIfNeeded();
 	}
 
 	public void flush() throws RocksDBException {
@@ -112,5 +125,17 @@ public class RocksDBWriteBatchWrapper implements AutoCloseable {
 			flush();
 		}
 		IOUtils.closeQuietly(batch);
+	}
+
+	private void flushIfNeeded() throws RocksDBException {
+		boolean needFlush = batch.count() == capacity || (batchSize > 0 && batch.getDataSize() >= batchSize);
+		if (needFlush) {
+			flush();
+		}
+	}
+
+	@VisibleForTesting
+	long getDataSize() {
+		return batch.getDataSize();
 	}
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBWriteBatchWrapper.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBWriteBatchWrapper.java
@@ -56,6 +56,8 @@ public class RocksDBWriteBatchWrapper implements AutoCloseable {
 	@Nonnegative
 	private final long batchSize;
 
+	private long currentDataSize;
+
 	public RocksDBWriteBatchWrapper(@Nonnull RocksDB rocksDB, long writeBatchSize) {
 		this(rocksDB, null, 500, writeBatchSize);
 	}
@@ -82,6 +84,7 @@ public class RocksDBWriteBatchWrapper implements AutoCloseable {
 		} else {
 			this.batch = new WriteBatch(this.capacity * PER_RECORD_BYTES);
 		}
+		this.currentDataSize = batch.getDataSize();
 	}
 
 	public void put(
@@ -90,6 +93,7 @@ public class RocksDBWriteBatchWrapper implements AutoCloseable {
 		@Nonnull byte[] value) throws RocksDBException {
 
 		batch.put(handle, key, value);
+		this.currentDataSize += calculateConsumedBytes(key, value);
 
 		flushIfNeeded();
 	}
@@ -99,6 +103,7 @@ public class RocksDBWriteBatchWrapper implements AutoCloseable {
 		@Nonnull byte[] key) throws RocksDBException {
 
 		batch.remove(handle, key);
+		this.currentDataSize += calculateConsumedBytes(key, null);
 
 		flushIfNeeded();
 	}
@@ -113,6 +118,7 @@ public class RocksDBWriteBatchWrapper implements AutoCloseable {
 			}
 		}
 		batch.clear();
+		currentDataSize = batch.getDataSize();
 	}
 
 	public WriteOptions getOptions() {
@@ -128,14 +134,46 @@ public class RocksDBWriteBatchWrapper implements AutoCloseable {
 	}
 
 	private void flushIfNeeded() throws RocksDBException {
-		boolean needFlush = batch.count() == capacity || (batchSize > 0 && batch.getDataSize() >= batchSize);
+		boolean needFlush = batch.count() == capacity || (batchSize > 0 && getDataSize() >= batchSize);
 		if (needFlush) {
 			flush();
 		}
 	}
 
+	private long calculateConsumedBytes(byte[] key, byte[] value) {
+		long ret = 2 + calculateVarint32Length(key.length) + key.length;
+		if (value != null) {
+			ret += calculateVarint32Length(value.length) + value.length;
+		}
+		return ret;
+	}
+
+	/**
+	 * Calculate the length after encoded into Varint32, please ref to coding.cc of RocksDB.
+	 */
+	private int calculateVarint32Length(int input) {
+		if (input < (1 << 7)) {
+			return 1;
+		}
+		if (input < (1 << 14)) {
+			return 2;
+		}
+		if (input < (1 << 21)) {
+			return 3;
+		}
+		if (input < (1 << 28)) {
+			return 4;
+		}
+		return 5;
+	}
+
 	@VisibleForTesting
 	long getDataSize() {
-		return batch.getDataSize();
+		return currentDataSize;
+	}
+
+	@VisibleForTesting
+	WriteBatch getBatch() {
+		return batch;
 	}
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBFullRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBFullRestoreOperation.java
@@ -47,6 +47,7 @@ import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
 import org.rocksdb.RocksDBException;
 
+import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 
 import java.io.File;
@@ -61,6 +62,7 @@ import java.util.function.Function;
 import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.END_OF_KEY_GROUP_MARK;
 import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.clearMetaDataFollowsFlag;
 import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.hasMetaDataFollowsFlag;
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * Encapsulates the process of restoring a RocksDB instance from a full snapshot.
@@ -87,6 +89,11 @@ public class RocksDBFullRestoreOperation<K> extends AbstractRocksDBRestoreOperat
 	 */
 	private StreamCompressionDecorator keygroupStreamCompressionDecorator;
 
+	/**
+	 * Write batch size used in {@link RocksDBWriteBatchWrapper}.
+	 */
+	private final long writeBatchSize;
+
 	public RocksDBFullRestoreOperation(
 		KeyGroupRange keyGroupRange,
 		int keyGroupPrefixBytes,
@@ -102,7 +109,8 @@ public class RocksDBFullRestoreOperation<K> extends AbstractRocksDBRestoreOperat
 		RocksDBNativeMetricOptions nativeMetricOptions,
 		MetricGroup metricGroup,
 		@Nonnull Collection<KeyedStateHandle> restoreStateHandles,
-		@Nonnull RocksDbTtlCompactFiltersManager ttlCompactFiltersManager) {
+		@Nonnull RocksDbTtlCompactFiltersManager ttlCompactFiltersManager,
+		@Nonnegative long writeBatchSize) {
 		super(
 			keyGroupRange,
 			keyGroupPrefixBytes,
@@ -119,6 +127,8 @@ public class RocksDBFullRestoreOperation<K> extends AbstractRocksDBRestoreOperat
 			metricGroup,
 			restoreStateHandles,
 			ttlCompactFiltersManager);
+		checkArgument(writeBatchSize >= 0, "Write batch size have to be no negative.");
+		this.writeBatchSize = writeBatchSize;
 	}
 
 	/**
@@ -188,7 +198,7 @@ public class RocksDBFullRestoreOperation<K> extends AbstractRocksDBRestoreOperat
 	 */
 	private void restoreKVStateData() throws IOException, RocksDBException {
 		//for all key-groups in the current state handle...
-		try (RocksDBWriteBatchWrapper writeBatchWrapper = new RocksDBWriteBatchWrapper(db)) {
+		try (RocksDBWriteBatchWrapper writeBatchWrapper = new RocksDBWriteBatchWrapper(db, writeBatchSize)) {
 			for (Tuple2<Integer, Long> keyGroupOffset : currentKeyGroupsStateHandle.getGroupRangeOffsets()) {
 				int keyGroup = keyGroupOffset.f0;
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtilsTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtilsTest.java
@@ -145,7 +145,8 @@ public class RocksDBIncrementalCheckpointUtilsTest extends TestLogger {
 				Collections.singletonList(columnFamilyHandle),
 				targetGroupRange,
 				currentGroupRange,
-				keyGroupPrefixBytes);
+				keyGroupPrefixBytes,
+				RocksDBConfigurableOptions.WRITE_BATCH_SIZE.defaultValue().getBytes());
 
 			for (int i = currentGroupRangeStart; i <= currentGroupRangeEnd; ++i) {
 				for (int j = 0; j < 100; ++j) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBWriteBatchWrapperTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBWriteBatchWrapperTest.java
@@ -31,6 +31,10 @@ import org.rocksdb.WriteOptions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.WRITE_BATCH_SIZE;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests to guard {@link RocksDBWriteBatchWrapper}.
@@ -51,7 +55,7 @@ public class RocksDBWriteBatchWrapperTest {
 		try (RocksDB db = RocksDB.open(folder.newFolder().getAbsolutePath());
 			WriteOptions options = new WriteOptions().setDisableWAL(true);
 			ColumnFamilyHandle handle = db.createColumnFamily(new ColumnFamilyDescriptor("test".getBytes()));
-			RocksDBWriteBatchWrapper writeBatchWrapper = new RocksDBWriteBatchWrapper(db, options, 200)) {
+			RocksDBWriteBatchWrapper writeBatchWrapper = new RocksDBWriteBatchWrapper(db, options, 200, WRITE_BATCH_SIZE.defaultValue().getBytes())) {
 
 			// insert data
 			for (Tuple2<byte[], byte[]> item : data) {
@@ -63,6 +67,54 @@ public class RocksDBWriteBatchWrapperTest {
 			for (Tuple2<byte[], byte[]> item : data) {
 				Assert.assertArrayEquals(item.f1, db.get(handle, item.f0));
 			}
+		}
+	}
+
+	/**
+	 * Tests that {@link RocksDBWriteBatchWrapper} flushes after the memory consumed exceeds the preconfigured value.
+	 */
+	@Test
+	public void testWriteBatchWrapperFlushAfterMemorySizeExceed() throws Exception {
+		try (RocksDB db = RocksDB.open(folder.newFolder().getAbsolutePath());
+			WriteOptions options = new WriteOptions().setDisableWAL(true);
+			ColumnFamilyHandle handle = db.createColumnFamily(new ColumnFamilyDescriptor("test".getBytes()));
+			RocksDBWriteBatchWrapper writeBatchWrapper = new RocksDBWriteBatchWrapper(db, options, 200, 50)) {
+			// sequence (8 bytes) + count (4 bytes)
+			// more information please ref to write_batch.cc in RocksDB
+			assertEquals(12, writeBatchWrapper.getDataSize());
+			byte[] dummy = new byte[6];
+			ThreadLocalRandom.current().nextBytes(dummy);
+			// will add 1 + 1 + 1 + 6 + 1 + 6 = 16 bytes for each KV
+			// format is [handleType|kvType|keyLen|key|valueLen|value]
+			// more information please ref write_batch.cc in RocksDB
+			writeBatchWrapper.put(handle, dummy, dummy);
+			assertEquals(28, writeBatchWrapper.getDataSize());
+			writeBatchWrapper.put(handle, dummy, dummy);
+			assertEquals(44, writeBatchWrapper.getDataSize());
+			writeBatchWrapper.put(handle, dummy, dummy);
+			// will flush all, then an empty write batch
+			assertEquals(12, writeBatchWrapper.getDataSize());
+		}
+	}
+
+	/**
+	 * Tests that {@link RocksDBWriteBatchWrapper} flushes after the kv count exceeds the preconfigured value.
+	 */
+	@Test
+	public void testWriteBatchWrapperFlushAfterCountExceed() throws Exception {
+		try (RocksDB db = RocksDB.open(folder.newFolder().getAbsolutePath());
+			WriteOptions options = new WriteOptions().setDisableWAL(true);
+			ColumnFamilyHandle handle = db.createColumnFamily(new ColumnFamilyDescriptor("test".getBytes()));
+			RocksDBWriteBatchWrapper writeBatchWrapper = new RocksDBWriteBatchWrapper(db, options, 100, 50000)) {
+			byte[] dummy = new byte[2];
+			ThreadLocalRandom.current().nextBytes(dummy);
+			for (int i = 1; i < 100; ++i) {
+				writeBatchWrapper.put(handle, dummy, dummy);
+				// init 12 bytes, each kv consumes 8 bytes
+				assertEquals(12 + 8 * i, writeBatchWrapper.getDataSize());
+			}
+			writeBatchWrapper.put(handle, dummy, dummy);
+			assertEquals(12, writeBatchWrapper.getDataSize());
 		}
 	}
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBWriteBatchWrapperTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBWriteBatchWrapperTest.java
@@ -110,7 +110,7 @@ public class RocksDBWriteBatchWrapperTest {
 			ThreadLocalRandom.current().nextBytes(dummy);
 			for (int i = 1; i < 100; ++i) {
 				writeBatchWrapper.put(handle, dummy, dummy);
-				// init 12 bytes, each kv consumes 8 bytes
+				// each kv consumes 8 bytes
 				assertEquals(initBatchSize + 8 * i, writeBatchWrapper.getDataSize());
 			}
 			writeBatchWrapper.put(handle, dummy, dummy);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBWriteBatchWrapperTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBWriteBatchWrapperTest.java
@@ -27,7 +27,6 @@ import org.junit.rules.TemporaryFolder;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDB;
-import org.rocksdb.WriteBatch;
 import org.rocksdb.WriteOptions;
 
 import java.util.ArrayList;
@@ -116,62 +115,6 @@ public class RocksDBWriteBatchWrapperTest {
 			}
 			writeBatchWrapper.put(handle, dummy, dummy);
 			assertEquals(initBatchSize, writeBatchWrapper.getDataSize());
-		}
-	}
-
-	/**
-	 * Test that the {@link RocksDBWriteBatchWrapper#getDataSize()} implemented by ourself equals to {@link WriteBatch#getDataSize()}.
-	 */
-	@Test
-	public void testWriteBufferDataSize() throws Exception  {
-		try (RocksDB db = RocksDB.open(folder.newFolder().getAbsolutePath());
-			WriteOptions options = new WriteOptions().setDisableWAL(true);
-			ColumnFamilyHandle handle = db.createColumnFamily(new ColumnFamilyDescriptor("test".getBytes()));
-			RocksDBWriteBatchWrapper writeBatchWrapper = new RocksDBWriteBatchWrapper(db, options, 100, 600000000)) {
-			// empty write batch
-			WriteBatch writeBatch = writeBatchWrapper.getBatch();
-			assertEquals(writeBatch.getDataSize(), writeBatchWrapper.getDataSize());
-
-			// len < (1 << 7)
-			byte[] value = "1".getBytes();
-			byte[] a = new byte[1];
-			ThreadLocalRandom.current().nextBytes(a);
-			writeBatchWrapper.put(handle, a, value);
-			assertEquals(writeBatch.getDataSize(), writeBatchWrapper.getDataSize());
-			writeBatchWrapper.remove(handle, a);
-			assertEquals(writeBatch.getDataSize(), writeBatchWrapper.getDataSize());
-
-			// (1 <<7) <= len < (1 << 14)
-			byte[] b = new byte[128]; // 1 << 7
-			ThreadLocalRandom.current().nextBytes(b);
-			writeBatchWrapper.put(handle, b, value);
-			assertEquals(writeBatch.getDataSize(), writeBatchWrapper.getDataSize());
-			writeBatchWrapper.remove(handle, b);
-			assertEquals(writeBatch.getDataSize(), writeBatchWrapper.getDataSize());
-
-			// (1 << 14) <= len < (1 < 21)
-			byte[] c = new byte[16384]; // 1 << 14
-			ThreadLocalRandom.current().nextBytes(b);
-			writeBatchWrapper.put(handle, c, value);
-			assertEquals(writeBatch.getDataSize(), writeBatchWrapper.getDataSize());
-			writeBatchWrapper.remove(handle, c);
-			assertEquals(writeBatch.getDataSize(), writeBatchWrapper.getDataSize());
-
-			// (1 << 21) <= len < (1 < 28)
-			byte[] d = new byte[2097152]; // 1 << 21
-			ThreadLocalRandom.current().nextBytes(d);
-			writeBatchWrapper.put(handle, d, value);
-			assertEquals(writeBatch.getDataSize(), writeBatchWrapper.getDataSize());
-			writeBatchWrapper.remove(handle, d);
-			assertEquals(writeBatch.getDataSize(), writeBatchWrapper.getDataSize());
-
-			// (1 << 28) <= len
-			byte[] e = new byte[268435456]; // 1 << 28
-			ThreadLocalRandom.current().nextBytes(e);
-			writeBatchWrapper.put(handle, e, value);
-			assertEquals(writeBatch.getDataSize(), writeBatchWrapper.getDataSize());
-			writeBatchWrapper.remove(handle, e);
-			assertEquals(writeBatch.getDataSize(), writeBatchWrapper.getDataSize());
 		}
 	}
 }


### PR DESCRIPTION

## What is the purpose of the change

Currently `RocksDBWriteBatchWrapper` will flush the batch just based on item count, will consume too much memory for big kv.
This PR will add consumed memory sized based control policy, will flush the batch either item count or consumed memory size exceeds the configured value.

## Brief change log

- Add a configuration `state.backend.rocksdb.write-batch-size` in `ROcksDBCOnfigurableOptions` to set the batchSize, default 2mb
- Add logic to flush write batch after consumed memory size exceeds the preconfiged value.


## Verifying this change


This change added tests and can be verified as follows:

- `RocksDBWriteBatchWrapperTest#testWriteBatchWrapperFlushAfterMemorySizeExceed` to test that the batch will flush after consumed memory exceeds the preconfigured value
 - `RocksDBWriteBatchWrapperTest#testWriteBatchWrapperFlushAfterCountExceed` to test that the batch will flush after item count exceeds the preconfigured value

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
