### PR TITLE
[FLINK-14189][runtime] Extend TaskExecutor to support dynamic slot allocation

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/resources/Resource.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/resources/Resource.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -65,6 +66,14 @@ public abstract class Resource implements Serializable {
 		checkArgument(value.compareTo(other.value) >= 0, "Try to subtract a larger resource from this one.");
 
 		return create(value.subtract(other.value));
+	}
+
+	public Resource divide(BigDecimal by) {
+		return create(value.divide(by, 16, RoundingMode.DOWN));
+	}
+
+	public Resource divide(int by) {
+		return divide(BigDecimal.valueOf(by));
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/configuration/MemorySize.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/MemorySize.java
@@ -147,6 +147,11 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
 		return new MemorySize(product.longValue());
 	}
 
+	public MemorySize divide(long by) {
+		checkArgument(by >= 0, "divisor must be >= 0");
+		return new MemorySize(bytes / by);
+	}
+
 	// ------------------------------------------------------------------------
 	//  Parsing
 	// ------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -190,8 +190,33 @@ public class TaskManagerOptions {
 				.build());
 
 	// ------------------------------------------------------------------------
-	//  Memory Options
+	//  Resource Options
 	// ------------------------------------------------------------------------
+
+	/**
+	 * This config option describes number of cpu cores of task executors.
+	 * In case of Yarn / Mesos / Kubernetes, it is used to launch a container for the task executor.
+	 *
+	 * <p>DO NOT USE THIS CONFIG OPTION.
+	 * This config option is currently only used internally, for passing cpu cores into task executors
+	 * for dynamic fine grained slot resource management. The feature is not completed at the moment,
+	 * and the config option is experimental and might be changed / removed in the future. Thus, we do
+	 * not expose this config option to users.
+	 *
+	 * <p>For configuring the cpu cores of container on Yarn / Mesos / Kubernetes, please use
+	 * {@link YarnConfigOptions#VCORES}, {@link MesosTaskManagerParameters#MESOS_RM_TASKS_CPUS} and
+	 * {@link KubernetesConfigOptions#TASK_MANAGER_CPU}.
+	 */
+	@Documentation.ExcludeFromDocumentation
+	public static final ConfigOption<Double> CPU_CORES =
+		key("taskmanager.cpu.cores")
+			.doubleType()
+			.noDefaultValue()
+			.withDescription("CPU cores for the TaskExecutors. In case of Yarn setups, this value will be rounded to "
+				+ "the closest positive integer. If not explicitly configured, legacy config options "
+				+ "'yarn.containers.vcores', 'mesos.resourcemanager.tasks.cpus' and 'kubernetes.taskmanager.cpu' will be "
+				+ "used for Yarn / Mesos / Kubernetes setups, and '" + NUM_TASK_SLOTS.key() + "' will be used for "
+				+ "standalone setups (approximate number of slots).");
 
 	/**
 	 * Total Process Memory size for the TaskExecutors.

--- a/flink-core/src/test/java/org/apache/flink/api/common/resources/ResourceTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/resources/ResourceTest.java
@@ -98,6 +98,34 @@ public class ResourceTest extends TestLogger {
 		v1.subtract(v2);
 	}
 
+	@Test
+	public void testDivide() {
+		final Resource resource = new TestResource(0.04);
+		final BigDecimal by = BigDecimal.valueOf(0.1);
+		assertTestResourceValueEquals(0.4, resource.divide(by));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testDivideNegative() {
+		final Resource resource = new TestResource(1.2);
+		final BigDecimal by = BigDecimal.valueOf(-0.5);
+		resource.divide(by);
+	}
+
+	@Test
+	public void testDivideInteger() {
+		final Resource resource = new TestResource(0.12);
+		final int by = 4;
+		assertTestResourceValueEquals(0.03, resource.divide(by));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testDivideNegativeInteger() {
+		final Resource resource = new TestResource(1.2);
+		final int by = -5;
+		resource.divide(by);
+	}
+
 	private static void assertTestResourceValueEquals(final double value, final Resource resource) {
 		assertEquals(new TestResource(value), resource);
 	}

--- a/flink-core/src/test/java/org/apache/flink/configuration/MemorySizeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/MemorySizeTest.java
@@ -25,8 +25,10 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static org.apache.flink.configuration.MemorySize.MemoryUnit.MEGA_BYTES;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 /**
@@ -220,4 +222,15 @@ public class MemorySizeTest {
 		assertEquals(7, MemorySize.parse("7 mebibytes", MEGA_BYTES).getMebiBytes());
 	}
 
+	@Test
+	public void testDivideByLong() {
+		final MemorySize memory = new MemorySize(100L);
+		assertThat(memory.divide(23), is(new MemorySize(4L)));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testDivideByNegativeLong() {
+		final MemorySize memory = new MemorySize(100L);
+		memory.divide(-23L);
+	}
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
@@ -119,7 +119,7 @@ public class KubernetesResourceManager extends ActiveResourceManager<KubernetesW
 			fatalErrorHandler,
 			resourceManagerMetricGroup);
 		this.clusterId = flinkConfig.getString(KubernetesConfigOptions.CLUSTER_ID);
-		this.defaultCpus = flinkConfig.getDouble(KubernetesConfigOptions.TASK_MANAGER_CPU, numSlotsPerTaskManager);
+		this.defaultCpus = taskExecutorResourceSpec.getCpuCores().getValue().doubleValue();
 
 		this.kubeClient = createFlinkKubeClient();
 
@@ -334,5 +334,10 @@ public class KubernetesResourceManager extends ActiveResourceManager<KubernetesW
 
 	protected FlinkKubeClient createFlinkKubeClient() {
 		return KubeClientFactory.fromConfiguration(flinkConfig);
+	}
+
+	@Override
+	protected double getCpuCores(Configuration configuration) {
+		return flinkConfig.getDouble(KubernetesConfigOptions.TASK_MANAGER_CPU, numSlotsPerTaskManager);
 	}
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerTest.java
@@ -42,6 +42,7 @@ import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.JobLeaderIdService;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.SlotRequest;
+import org.apache.flink.runtime.resourcemanager.TaskExecutorRegistration;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.resourcemanager.utils.MockResourceManagerRuntimeServices;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
@@ -326,12 +327,16 @@ public class KubernetesResourceManagerTest extends KubernetesTestBase {
 
 		final SlotReport slotReport = new SlotReport(new SlotStatus(new SlotID(resourceID, 1), ResourceProfile.ZERO));
 
+		TaskExecutorRegistration taskExecutorRegistration = new TaskExecutorRegistration(
+			resourceID.toString(),
+			resourceID,
+			1234,
+			new HardwareDescription(1, 2L, 3L, 4L),
+			ResourceProfile.ZERO,
+			ResourceProfile.ZERO);
 		CompletableFuture<Integer> numberRegisteredSlotsFuture = rmGateway
 			.registerTaskExecutor(
-				resourceID.toString(),
-				resourceID,
-				1234,
-				new HardwareDescription(1, 2L, 3L, 4L),
+				taskExecutorRegistration,
 				TIMEOUT)
 			.thenCompose(
 				(RegistrationResponse response) -> {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesUtilsTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesUtilsTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.kubernetes;
 
+import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
@@ -260,6 +261,7 @@ public class KubernetesUtilsTest extends TestLogger {
 			String mainClassArgs) {
 
 		final TaskExecutorResourceSpec taskExecutorResourceSpec = new TaskExecutorResourceSpec(
+			new CPUResource(1.0),
 			new MemorySize(0), // frameworkHeapSize
 			new MemorySize(0), // frameworkOffHeapSize
 			new MemorySize(111), // taskHeapSize

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
@@ -42,6 +42,7 @@ import org.apache.flink.mesos.util.MesosArtifactServer;
 import org.apache.flink.mesos.util.MesosConfiguration;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
+import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.FutureUtils;
@@ -193,7 +194,9 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 		this.workersInLaunch = new HashMap<>(8);
 		this.workersBeingReturned = new HashMap<>(8);
 
-		this.slotsPerWorker = createWorkerSlotProfiles(flinkConfig);
+		this.slotsPerWorker = TaskExecutorResourceUtils.createDefaultWorkerSlotProfiles(
+			taskManagerParameters.containeredParameters().getTaskExecutorResourceSpec(),
+			taskManagerParameters.containeredParameters().numSlots());
 	}
 
 	protected ActorRef createSelfActor() {

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -149,8 +149,6 @@ public class MesosTaskManagerParameters {
 	 */
 	public static final String MESOS_RESOURCEMANAGER_TASKS_CONTAINER_TYPE_DOCKER = "docker";
 
-	private final double cpus;
-
 	private final int gpus;
 
 	private final int disk;
@@ -178,7 +176,6 @@ public class MesosTaskManagerParameters {
 	private final List<String> uris;
 
 	public MesosTaskManagerParameters(
-			double cpus,
 			int gpus,
 			int disk,
 			ContainerType containerType,
@@ -193,7 +190,6 @@ public class MesosTaskManagerParameters {
 			Option<String> taskManagerHostname,
 			List<String> uris) {
 
-		this.cpus = cpus;
 		this.gpus = gpus;
 		this.disk = disk;
 		this.containerType = Preconditions.checkNotNull(containerType);
@@ -213,7 +209,7 @@ public class MesosTaskManagerParameters {
 	 * Get the CPU units to use for the TaskManager process.
 	 */
 	public double cpus() {
-		return cpus;
+		return containeredParameters.getTaskExecutorResourceSpec().getCpuCores().getValue().doubleValue();
 	}
 
 	/**
@@ -312,7 +308,7 @@ public class MesosTaskManagerParameters {
 	@Override
 	public String toString() {
 		return "MesosTaskManagerParameters{" +
-			"cpus=" + cpus +
+			"cpus=" + cpus() +
 			", gpus=" + gpus +
 			", containerType=" + containerType +
 			", containerImageName=" + containerImageName +
@@ -336,22 +332,9 @@ public class MesosTaskManagerParameters {
 	public static MesosTaskManagerParameters create(Configuration flinkConfig) {
 
 		List<ConstraintEvaluator> constraints = parseConstraints(flinkConfig.getString(MESOS_CONSTRAINTS_HARD_HOSTATTR));
-		MemorySize totalProcessMemory = MemorySize.parse(flinkConfig.getInteger(MESOS_RM_TASKS_MEMORY_MB) + "m");
-		TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils
-			.newResourceSpecBuilder(flinkConfig)
-			.withTotalProcessMemory(totalProcessMemory)
-			.build();
 
 		// parse the common parameters
-		ContaineredTaskManagerParameters containeredParameters = ContaineredTaskManagerParameters.create(
-			flinkConfig,
-			taskExecutorResourceSpec,
-			flinkConfig.getInteger(MESOS_RM_TASKS_SLOTS));
-
-		double cpus = flinkConfig.getDouble(MESOS_RM_TASKS_CPUS);
-		if (cpus <= 0.0) {
-			cpus = Math.max(containeredParameters.numSlots(), 1.0);
-		}
+		ContaineredTaskManagerParameters containeredParameters = createContaineredTaskManagerParameters(flinkConfig);
 
 		int gpus = flinkConfig.getInteger(MESOS_RM_TASKS_GPUS);
 
@@ -404,7 +387,6 @@ public class MesosTaskManagerParameters {
 		Option<String> tmBootstrapCommand = Option.apply(flinkConfig.getString(MESOS_TM_BOOTSTRAP_CMD));
 
 		return new MesosTaskManagerParameters(
-			cpus,
 			gpus,
 			disk,
 			containerType,
@@ -418,6 +400,26 @@ public class MesosTaskManagerParameters {
 			tmBootstrapCommand,
 			taskManagerHostname,
 			uris);
+	}
+
+	private static ContaineredTaskManagerParameters createContaineredTaskManagerParameters(final Configuration flinkConfig) {
+		double cpus = getCpuCores(flinkConfig);
+		MemorySize totalProcessMemory = MemorySize.parse(flinkConfig.getInteger(MESOS_RM_TASKS_MEMORY_MB) + "m");
+		TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils
+			.newResourceSpecBuilder(flinkConfig)
+			.withCpuCores(cpus)
+			.withTotalProcessMemory(totalProcessMemory)
+			.build();
+
+		return ContaineredTaskManagerParameters.create(
+			flinkConfig,
+			taskExecutorResourceSpec,
+			flinkConfig.getInteger(MESOS_RM_TASKS_SLOTS));
+	}
+
+	private static double getCpuCores(final Configuration configuration) {
+		double fallback = configuration.getInteger(MESOS_RM_TASKS_SLOTS);
+		return TaskExecutorResourceUtils.getCpuCoresWithFallback(configuration, fallback).getValue().doubleValue();
 	}
 
 	private static List<ConstraintEvaluator> parseConstraints(String mesosConstraints) {

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -337,8 +337,10 @@ public class MesosTaskManagerParameters {
 
 		List<ConstraintEvaluator> constraints = parseConstraints(flinkConfig.getString(MESOS_CONSTRAINTS_HARD_HOSTATTR));
 		MemorySize totalProcessMemory = MemorySize.parse(flinkConfig.getInteger(MESOS_RM_TASKS_MEMORY_MB) + "m");
-		TaskExecutorResourceSpec taskExecutorResourceSpec =
-			TaskExecutorResourceUtils.resourceSpecFromConfig(flinkConfig, totalProcessMemory);
+		TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils
+			.newResourceSpecBuilder(flinkConfig)
+			.withTotalProcessMemory(totalProcessMemory)
+			.build();
 
 		// parse the common parameters
 		ContaineredTaskManagerParameters containeredParameters = ContaineredTaskManagerParameters.create(

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -277,12 +277,13 @@ public class MesosResourceManagerTest extends TestLogger {
 			MemorySize totalProcessMemory = MemorySize.parse("2g");
 			TaskExecutorResourceSpec spec = TaskExecutorResourceUtils
 				.newResourceSpecBuilder(flinkConfig)
+				.withCpuCores(1.0)
 				.withTotalProcessMemory(totalProcessMemory)
 				.build();
 			ContaineredTaskManagerParameters containeredParams =
 				new ContaineredTaskManagerParameters(spec, 4, new HashMap<String, String>());
 			MesosTaskManagerParameters tmParams = new MesosTaskManagerParameters(
-				1.0, 1, 0, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams,
+				1, 0, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams,
 				Collections.<Protos.Volume>emptyList(), Collections.<Protos.Parameter>emptyList(), false,
 				Collections.<ConstraintEvaluator>emptyList(), "", Option.<String>empty(),
 				Option.<String>empty(), Collections.<String>emptyList());

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -62,6 +62,7 @@ import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.JobLeaderIdService;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.SlotRequest;
+import org.apache.flink.runtime.resourcemanager.TaskExecutorRegistration;
 import org.apache.flink.runtime.resourcemanager.slotmanager.ResourceActions;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
@@ -662,8 +663,14 @@ public class MesosResourceManagerTest extends TestLogger {
 			final int dataPort = 1234;
 			final HardwareDescription hardwareDescription = new HardwareDescription(1, 2L, 3L, 4L);
 			// send registration message
+			TaskExecutorRegistration taskExecutorRegistration = new TaskExecutorRegistration(
+				task1Executor.address,
+				task1Executor.resourceID,
+				dataPort,
+				hardwareDescription,
+				ResourceProfile.ZERO);
 			CompletableFuture<RegistrationResponse> successfulFuture =
-				resourceManager.registerTaskExecutor(task1Executor.address, task1Executor.resourceID, dataPort, hardwareDescription, ResourceProfile.ZERO, timeout);
+				resourceManager.registerTaskExecutor(taskExecutorRegistration, timeout);
 			RegistrationResponse response = successfulFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 			assertTrue(response instanceof TaskExecutorRegistrationSuccess);
 			final TaskExecutorRegistrationSuccess registrationResponse = (TaskExecutorRegistrationSuccess) response;

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -668,6 +668,7 @@ public class MesosResourceManagerTest extends TestLogger {
 				task1Executor.resourceID,
 				dataPort,
 				hardwareDescription,
+				ResourceProfile.ZERO,
 				ResourceProfile.ZERO);
 			CompletableFuture<RegistrationResponse> successfulFuture =
 				resourceManager.registerTaskExecutor(taskExecutorRegistration, timeout);

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -663,7 +663,7 @@ public class MesosResourceManagerTest extends TestLogger {
 			final HardwareDescription hardwareDescription = new HardwareDescription(1, 2L, 3L, 4L);
 			// send registration message
 			CompletableFuture<RegistrationResponse> successfulFuture =
-				resourceManager.registerTaskExecutor(task1Executor.address, task1Executor.resourceID, dataPort, hardwareDescription, timeout);
+				resourceManager.registerTaskExecutor(task1Executor.address, task1Executor.resourceID, dataPort, hardwareDescription, ResourceProfile.ZERO, timeout);
 			RegistrationResponse response = successfulFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 			assertTrue(response instanceof TaskExecutorRegistrationSuccess);
 			final TaskExecutorRegistrationSuccess registrationResponse = (TaskExecutorRegistrationSuccess) response;

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -275,7 +275,10 @@ public class MesosResourceManagerTest extends TestLogger {
 			ContainerSpecification containerSpecification = new ContainerSpecification();
 
 			MemorySize totalProcessMemory = MemorySize.parse("2g");
-			TaskExecutorResourceSpec spec = TaskExecutorResourceUtils.resourceSpecFromConfig(flinkConfig, totalProcessMemory);
+			TaskExecutorResourceSpec spec = TaskExecutorResourceUtils
+				.newResourceSpecBuilder(flinkConfig)
+				.withTotalProcessMemory(totalProcessMemory)
+				.build();
 			ContaineredTaskManagerParameters containeredParams =
 				new ContaineredTaskManagerParameters(spec, 4, new HashMap<String, String>());
 			MesosTaskManagerParameters tmParams = new MesosTaskManagerParameters(

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.mesos.runtime.clusterframework;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.util.TestLogger;
 
 import com.netflix.fenzo.ConstraintEvaluator;
@@ -222,6 +223,14 @@ public class MesosTaskManagerParametersTest extends TestLogger {
 	@Test(expected = IllegalConfigurationException.class)
 	public void testNegativeNumberOfGPUs() throws Exception {
 		MesosTaskManagerParameters.create(withGPUConfiguration(-1));
+	}
+
+	@Test
+	public void testConfigCpuCores() {
+		Configuration config = getConfiguration();
+		config.setDouble(TaskManagerOptions.CPU_CORES, 1.5);
+		MesosTaskManagerParameters mesosTaskManagerParameters = MesosTaskManagerParameters.create(config);
+		assertThat(mesosTaskManagerParameters.cpus(), is(1.5));
 	}
 
 	private static Configuration getConfiguration() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceSpec.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceSpec.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.clusterframework;
 
+import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.configuration.MemorySize;
 
 import java.io.Serializable;
@@ -74,6 +75,8 @@ import java.io.Serializable;
  */
 public class TaskExecutorResourceSpec implements Serializable {
 
+	private final CPUResource cpuCores;
+
 	private final MemorySize frameworkHeapSize;
 
 	private final MemorySize frameworkOffHeapMemorySize;
@@ -91,6 +94,7 @@ public class TaskExecutorResourceSpec implements Serializable {
 	private final MemorySize jvmOverheadSize;
 
 	public TaskExecutorResourceSpec(
+		CPUResource cpuCores,
 		MemorySize frameworkHeapSize,
 		MemorySize frameworkOffHeapSize,
 		MemorySize taskHeapSize,
@@ -100,6 +104,7 @@ public class TaskExecutorResourceSpec implements Serializable {
 		MemorySize jvmMetaspaceSize,
 		MemorySize jvmOverheadSize) {
 
+		this.cpuCores = cpuCores;
 		this.frameworkHeapSize = frameworkHeapSize;
 		this.frameworkOffHeapMemorySize = frameworkOffHeapSize;
 		this.taskHeapSize = taskHeapSize;
@@ -108,6 +113,10 @@ public class TaskExecutorResourceSpec implements Serializable {
 		this.managedMemorySize = managedMemorySize;
 		this.jvmMetaspaceSize = jvmMetaspaceSize;
 		this.jvmOverheadSize = jvmOverheadSize;
+	}
+
+	public CPUResource getCpuCores() {
+		return cpuCores;
 	}
 
 	public MemorySize getFrameworkHeapSize() {
@@ -161,7 +170,8 @@ public class TaskExecutorResourceSpec implements Serializable {
 	@Override
 	public String toString() {
 		return "TaskExecutorResourceSpec {"
-			+ "frameworkHeapSize=" + frameworkHeapSize.toString()
+			+ "cpuCores=" + cpuCores.getValue().doubleValue()
+			+ ", frameworkHeapSize=" + frameworkHeapSize.toString()
 			+ ", frameworkOffHeapSize=" + frameworkOffHeapMemorySize.toString()
 			+ ", taskHeapSize=" + taskHeapSize.toString()
 			+ ", taskOffHeapSize=" + taskOffHeapSize.toString()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceSpecBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceSpecBuilder.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.clusterframework;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.TaskManagerOptions;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Builder for {@link TaskExecutorResourceSpec}.
+ */
+public class TaskExecutorResourceSpecBuilder {
+
+	private final Configuration configuration;
+
+	private TaskExecutorResourceSpecBuilder(final Configuration configuration) {
+		this.configuration = new Configuration(checkNotNull(configuration));
+	}
+
+	static TaskExecutorResourceSpecBuilder newBuilder(final Configuration configuration) {
+		return new TaskExecutorResourceSpecBuilder(configuration);
+	}
+
+	public TaskExecutorResourceSpecBuilder withTotalProcessMemory(MemorySize totalProcessMemory) {
+		configuration.setString(TaskManagerOptions.TOTAL_PROCESS_MEMORY, totalProcessMemory.toString());
+		return this;
+	}
+
+	public TaskExecutorResourceSpec build() {
+		return TaskExecutorResourceUtils.resourceSpecFromConfig(configuration);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceSpecBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceSpecBuilder.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.clusterframework;
 
+import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
@@ -37,6 +38,15 @@ public class TaskExecutorResourceSpecBuilder {
 
 	static TaskExecutorResourceSpecBuilder newBuilder(final Configuration configuration) {
 		return new TaskExecutorResourceSpecBuilder(configuration);
+	}
+
+	public TaskExecutorResourceSpecBuilder withCpuCores(double cpuCores) {
+		return withCpuCores(new CPUResource(cpuCores));
+	}
+
+	public TaskExecutorResourceSpecBuilder withCpuCores(CPUResource cpuCores) {
+		configuration.setDouble(TaskManagerOptions.CPU_CORES, cpuCores.getValue().doubleValue());
+		return this;
 	}
 
 	public TaskExecutorResourceSpecBuilder withTotalProcessMemory(MemorySize totalProcessMemory) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
@@ -30,7 +30,9 @@ import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -89,6 +91,14 @@ public class TaskExecutorResourceUtils {
 	// ------------------------------------------------------------------------
 	//  Generating Default Slot Resource Profiles
 	// ------------------------------------------------------------------------
+
+	public static List<ResourceProfile> createDefaultWorkerSlotProfiles(
+			TaskExecutorResourceSpec taskExecutorResourceSpec,
+			int numberOfSlots) {
+		final ResourceProfile resourceProfile =
+			generateDefaultSlotResourceProfile(taskExecutorResourceSpec, numberOfSlots);
+		return Collections.nCopies(numberOfSlots, resourceProfile);
+	}
 
 	@VisibleForTesting
 	public static ResourceProfile generateDefaultSlotResourceProfile(Configuration configuration) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
@@ -85,12 +85,8 @@ public class TaskExecutorResourceUtils {
 	//  Memory Configuration Calculations
 	// ------------------------------------------------------------------------
 
-	public static TaskExecutorResourceSpec resourceSpecFromConfig(
-			final Configuration config,
-			final MemorySize totalProcessMemory) {
-		final Configuration copiedConfig = new Configuration(config);
-		copiedConfig.setString(TaskManagerOptions.TOTAL_PROCESS_MEMORY, totalProcessMemory.toString());
-		return resourceSpecFromConfig(copiedConfig);
+	public static TaskExecutorResourceSpecBuilder newResourceSpecBuilder(final Configuration config) {
+		return TaskExecutorResourceSpecBuilder.newBuilder(config);
 	}
 
 	public static TaskExecutorResourceSpec resourceSpecFromConfig(final Configuration config) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
@@ -88,7 +88,7 @@ public class TaskExecutorResourceUtils {
 	}
 
 	// ------------------------------------------------------------------------
-	//  Generating Default Slot Resource Profiles
+	//  Generating Slot Resource Profiles
 	// ------------------------------------------------------------------------
 
 	public static List<ResourceProfile> createDefaultWorkerSlotProfiles(
@@ -108,6 +108,16 @@ public class TaskExecutorResourceUtils {
 			.setTaskOffHeapMemory(taskExecutorResourceSpec.getTaskOffHeapSize().divide(numberOfSlots))
 			.setManagedMemory(taskExecutorResourceSpec.getManagedMemorySize().divide(numberOfSlots))
 			.setShuffleMemory(taskExecutorResourceSpec.getShuffleMemSize().divide(numberOfSlots))
+			.build();
+	}
+
+	public static ResourceProfile generateTotalAvailableResourceProfile(TaskExecutorResourceSpec taskExecutorResourceSpec) {
+		return ResourceProfile.newBuilder()
+			.setCpuCores(taskExecutorResourceSpec.getCpuCores())
+			.setTaskHeapMemory(taskExecutorResourceSpec.getTaskHeapSize())
+			.setTaskOffHeapMemory(taskExecutorResourceSpec.getTaskOffHeapSize())
+			.setManagedMemory(taskExecutorResourceSpec.getManagedMemorySize())
+			.setShuffleMemory(taskExecutorResourceSpec.getShuffleMemSize())
 			.build();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.clusterframework;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
@@ -98,13 +97,6 @@ public class TaskExecutorResourceUtils {
 		final ResourceProfile resourceProfile =
 			generateDefaultSlotResourceProfile(taskExecutorResourceSpec, numberOfSlots);
 		return Collections.nCopies(numberOfSlots, resourceProfile);
-	}
-
-	@VisibleForTesting
-	public static ResourceProfile generateDefaultSlotResourceProfile(Configuration configuration) {
-		return generateDefaultSlotResourceProfile(
-			resourceSpecFromConfig(configuration),
-			configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS));
 	}
 
 	public static ResourceProfile generateDefaultSlotResourceProfile(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceBudgetManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceBudgetManager.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.clusterframework.types;
+
+import org.apache.flink.util.Preconditions;
+
+/**
+ * Budget manager for {@link ResourceProfile}.
+ *
+ * <p>For a given total resource budget, this class handles reserving and releasing resources
+ * from the budget, and rejects reservations if they cannot be satisfied by the remaining budget.
+ *
+ * <p>Both the total budget and the reservations are in the form of {@link ResourceProfile}.
+ */
+public class ResourceBudgetManager {
+
+	private final ResourceProfile totalBudget;
+
+	private ResourceProfile availableBudget;
+
+	public ResourceBudgetManager(final ResourceProfile totalBudget) {
+		checkResourceProfileNotNullOrUnknown(totalBudget);
+		this.totalBudget = totalBudget;
+		this.availableBudget = totalBudget;
+	}
+
+	public ResourceProfile getTotalBudget() {
+		return totalBudget;
+	}
+
+	public ResourceProfile getAvailableBudget() {
+		return availableBudget;
+	}
+
+	public boolean reserve(final ResourceProfile reservation) {
+		checkResourceProfileNotNullOrUnknown(reservation);
+		if (!availableBudget.isMatching(reservation)) {
+			return false;
+		}
+
+		availableBudget = availableBudget.subtract(reservation);
+		return true;
+	}
+
+	public boolean release(final ResourceProfile reservation) {
+		checkResourceProfileNotNullOrUnknown(reservation);
+		ResourceProfile newAvailableBudget = availableBudget.merge(reservation);
+		if (!totalBudget.isMatching(newAvailableBudget)) {
+			return false;
+		}
+
+		availableBudget = newAvailableBudget;
+		return true;
+	}
+
+	private static void checkResourceProfileNotNullOrUnknown(final ResourceProfile resourceProfile) {
+		Preconditions.checkNotNull(resourceProfile);
+		Preconditions.checkArgument(!resourceProfile.equals(ResourceProfile.UNKNOWN));
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/SlotID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/SlotID.java
@@ -46,6 +46,11 @@ public class SlotID implements ResourceIDRetrievable, Serializable {
 		this.slotNumber = slotNumber;
 	}
 
+	private SlotID(ResourceID resourceID) {
+		this.resourceId = checkNotNull(resourceID, "ResourceID must not be null");
+		this.slotNumber = -1;
+	}
+
 	// ------------------------------------------------------------------------
 
 	@Override
@@ -83,5 +88,12 @@ public class SlotID implements ResourceIDRetrievable, Serializable {
 	@Override
 	public String toString() {
 		return resourceId + "_" + slotNumber;
+	}
+
+	/**
+	 * Generate a SlotID without actual slot index for dynamic slot allocation.
+	 */
+	public static SlotID generateDynamicSlotID(ResourceID resourceID) {
+		return new SlotID(resourceID);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/SlotID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/SlotID.java
@@ -87,7 +87,7 @@ public class SlotID implements ResourceIDRetrievable, Serializable {
 
 	@Override
 	public String toString() {
-		return resourceId + "_" + slotNumber;
+		return resourceId + "_" + (slotNumber >= 0 ? slotNumber : "dynamic");
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
@@ -96,7 +96,11 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 		this.env = env;
 
 		this.numSlotsPerTaskManager = flinkConfig.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
-		this.taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(flinkConfig);
+		double defaultCpus = getCpuCores(flinkConfig);
+		this.taskExecutorResourceSpec = TaskExecutorResourceUtils
+			.newResourceSpecBuilder(flinkConfig)
+			.withCpuCores(defaultCpus)
+			.build();
 		this.defaultMemoryMB = taskExecutorResourceSpec.getTotalProcessMemorySize().getMebiBytes();
 
 		this.resourceProfilesPerWorker = createWorkerSlotProfiles(flinkConfig);
@@ -117,4 +121,6 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 	}
 
 	protected abstract Configuration loadClientConfiguration();
+
+	protected abstract double getCpuCores(final Configuration configuration);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
@@ -103,7 +103,8 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 			.build();
 		this.defaultMemoryMB = taskExecutorResourceSpec.getTotalProcessMemorySize().getMebiBytes();
 
-		this.resourceProfilesPerWorker = createWorkerSlotProfiles(flinkConfig);
+		this.resourceProfilesPerWorker = TaskExecutorResourceUtils
+			.createDefaultWorkerSlotProfiles(taskExecutorResourceSpec, numSlotsPerTaskManager);
 
 		// Load the flink config uploaded by flink client
 		this.flinkClientConfig = loadClientConfiguration();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -22,9 +22,6 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -67,7 +64,6 @@ import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorHeartbeatPayload;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorRegistrationSuccess;
-import org.apache.flink.runtime.taskexecutor.TaskManagerServices;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 
@@ -75,7 +71,6 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -1198,18 +1193,6 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
 	protected int getNumberRequiredTaskManagerSlots() {
 		return slotManager.getNumberPendingTaskManagerSlots();
-	}
-
-	// ------------------------------------------------------------------------
-	//  Helper methods
-	// ------------------------------------------------------------------------
-
-	public static Collection<ResourceProfile> createWorkerSlotProfiles(Configuration config) {
-		final int numSlots = config.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
-		final long managedMemoryBytes = MemorySize.parse(config.getString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "0b")).getBytes();
-
-		final ResourceProfile resourceProfile = TaskManagerServices.computeSlotResourceProfile(numSlots, managedMemoryBytes);
-		return Collections.nCopies(numSlots, resourceProfile);
 	}
 }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -365,6 +365,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 			final ResourceID taskExecutorResourceId,
 			final int dataPort,
 			final HardwareDescription hardwareDescription,
+			final ResourceProfile defaultResourceProfile,
 			final Time timeout) {
 
 		CompletableFuture<TaskExecutorGateway> taskExecutorGatewayFuture = getRpcService().connect(taskExecutorAddress, TaskExecutorGateway.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -26,9 +26,7 @@ import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
-import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
@@ -92,21 +90,13 @@ public interface ResourceManagerGateway extends FencedRpcGateway<ResourceManager
 	/**
 	 * Register a {@link TaskExecutor} at the resource manager.
 	 *
-	 * @param taskExecutorAddress The address of the TaskExecutor that registers
-	 * @param resourceId The resource ID of the TaskExecutor that registers
-	 * @param dataPort port used for data communication between TaskExecutors
-	 * @param hardwareDescription of the registering TaskExecutor
-	 * @param defaultResourceProfile of the registering TaskExecutor
+	 * @param taskExecutorRegistration the task executor registration.
 	 * @param timeout The timeout for the response.
 	 *
 	 * @return The future to the response by the ResourceManager.
 	 */
 	CompletableFuture<RegistrationResponse> registerTaskExecutor(
-		String taskExecutorAddress,
-		ResourceID resourceId,
-		int dataPort,
-		HardwareDescription hardwareDescription,
-		ResourceProfile defaultResourceProfile,
+		TaskExecutorRegistration taskExecutorRegistration,
 		@RpcTimeout Time timeout);
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.InstanceID;
@@ -95,6 +96,7 @@ public interface ResourceManagerGateway extends FencedRpcGateway<ResourceManager
 	 * @param resourceId The resource ID of the TaskExecutor that registers
 	 * @param dataPort port used for data communication between TaskExecutors
 	 * @param hardwareDescription of the registering TaskExecutor
+	 * @param defaultResourceProfile of the registering TaskExecutor
 	 * @param timeout The timeout for the response.
 	 *
 	 * @return The future to the response by the ResourceManager.
@@ -104,6 +106,7 @@ public interface ResourceManagerGateway extends FencedRpcGateway<ResourceManager
 		ResourceID resourceId,
 		int dataPort,
 		HardwareDescription hardwareDescription,
+		ResourceProfile defaultResourceProfile,
 		@RpcTimeout Time timeout);
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/TaskExecutorRegistration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/TaskExecutorRegistration.java
@@ -57,17 +57,24 @@ public class TaskExecutorRegistration implements Serializable {
 	 */
 	private final ResourceProfile defaultSlotResourceProfile;
 
+	/**
+	 * The task executor total resource profile.
+	 */
+	private final ResourceProfile totalResourceProfile;
+
 	public TaskExecutorRegistration(
 			final String taskExecutorAddress,
 			final ResourceID resourceId,
 			final int dataPort,
 			final HardwareDescription hardwareDescription,
-			final ResourceProfile defaultSlotResourceProfile) {
+			final ResourceProfile defaultSlotResourceProfile,
+			final ResourceProfile totalResourceProfile) {
 		this.taskExecutorAddress = checkNotNull(taskExecutorAddress);
 		this.resourceId = checkNotNull(resourceId);
 		this.dataPort = dataPort;
 		this.hardwareDescription = checkNotNull(hardwareDescription);
 		this.defaultSlotResourceProfile = checkNotNull(defaultSlotResourceProfile);
+		this.totalResourceProfile = checkNotNull(totalResourceProfile);
 	}
 
 	public String getTaskExecutorAddress() {
@@ -88,5 +95,9 @@ public class TaskExecutorRegistration implements Serializable {
 
 	public ResourceProfile getDefaultSlotResourceProfile() {
 		return defaultSlotResourceProfile;
+	}
+
+	public ResourceProfile getTotalResourceProfile() {
+		return totalResourceProfile;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/TaskExecutorRegistration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/TaskExecutorRegistration.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.instance.HardwareDescription;
+
+import java.io.Serializable;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Information provided by the TaskExecutor when it registers to the ResourceManager.
+ */
+public class TaskExecutorRegistration implements Serializable {
+	private static final long serialVersionUID = -5727832919954047964L;
+
+	/**
+	 * The address of the TaskExecutor that registers.
+	 */
+	private final String taskExecutorAddress;
+
+	/**
+	 * The resource ID of the TaskExecutor that registers.
+	 */
+	private final ResourceID resourceId;
+
+	/**
+	 * Port used for data communication between TaskExecutors.
+	 */
+	private final int dataPort;
+
+	/**
+	 * HardwareDescription of the registering TaskExecutor.
+	 */
+	private final HardwareDescription hardwareDescription;
+
+	/**
+	 * The default resource profile for slots requested with unknown resource requirements.
+	 */
+	private final ResourceProfile defaultSlotResourceProfile;
+
+	public TaskExecutorRegistration(
+			final String taskExecutorAddress,
+			final ResourceID resourceId,
+			final int dataPort,
+			final HardwareDescription hardwareDescription,
+			final ResourceProfile defaultSlotResourceProfile) {
+		this.taskExecutorAddress = checkNotNull(taskExecutorAddress);
+		this.resourceId = checkNotNull(resourceId);
+		this.dataPort = dataPort;
+		this.hardwareDescription = checkNotNull(hardwareDescription);
+		this.defaultSlotResourceProfile = checkNotNull(defaultSlotResourceProfile);
+	}
+
+	public String getTaskExecutorAddress() {
+		return taskExecutorAddress;
+	}
+
+	public ResourceID getResourceId() {
+		return resourceId;
+	}
+
+	public int getDataPort() {
+		return dataPort;
+	}
+
+	public HardwareDescription getHardwareDescription() {
+		return hardwareDescription;
+	}
+
+	public ResourceProfile getDefaultSlotResourceProfile() {
+		return defaultSlotResourceProfile;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -854,6 +854,7 @@ public class SlotManagerImpl implements SlotManager {
 			slotId,
 			pendingSlotRequest.getJobId(),
 			allocationId,
+			pendingSlotRequest.getResourceProfile(),
 			pendingSlotRequest.getTargetAddress(),
 			resourceManagerId,
 			taskManagerRequestTimeout);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -1005,7 +1005,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 				resourceManagerAddress.getAddress(),
 				resourceManagerAddress.getResourceManagerId(),
 				getMainThreadExecutor(),
-				new ResourceManagerRegistrationListener());
+				new ResourceManagerRegistrationListener(),
+				taskManagerConfiguration.getDefaultSlotResourceProfile());
 		resourceManagerConnection.start();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.JobManagerTaskRestore;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
@@ -818,6 +819,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		final SlotID slotId,
 		final JobID jobId,
 		final AllocationID allocationId,
+		final ResourceProfile resourceProfile,
 		final String targetAddress,
 		final ResourceManagerId resourceManagerId,
 		final Time timeout) {
@@ -834,7 +836,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 			}
 
 			if (taskSlotTable.isSlotFree(slotId.getSlotNumber())) {
-				if (taskSlotTable.allocateSlot(slotId.getSlotNumber(), jobId, allocationId, taskManagerConfiguration.getTimeout())) {
+				if (taskSlotTable.allocateSlot(slotId.getSlotNumber(), jobId, allocationId, resourceProfile, taskManagerConfiguration.getTimeout())) {
 					log.info("Allocated slot for {}.", allocationId);
 				} else {
 					log.info("Could not allocate slot for {}.", allocationId);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -77,6 +77,7 @@ import org.apache.flink.runtime.query.KvStateServer;
 import org.apache.flink.runtime.registration.RegistrationConnectionListener;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
+import org.apache.flink.runtime.resourcemanager.TaskExecutorRegistration;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -993,20 +994,24 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 		log.info("Connecting to ResourceManager {}.", resourceManagerAddress);
 
+		final TaskExecutorRegistration taskExecutorRegistration = new TaskExecutorRegistration(
+			getAddress(),
+			getResourceID(),
+			taskManagerLocation.dataPort(),
+			hardwareDescription,
+			taskManagerConfiguration.getDefaultSlotResourceProfile()
+		);
+
 		resourceManagerConnection =
 			new TaskExecutorToResourceManagerConnection(
 				log,
 				getRpcService(),
-				getAddress(),
-				getResourceID(),
 				taskManagerConfiguration.getRetryingRegistrationConfiguration(),
-				taskManagerLocation.dataPort(),
-				hardwareDescription,
 				resourceManagerAddress.getAddress(),
 				resourceManagerAddress.getResourceManagerId(),
 				getMainThreadExecutor(),
 				new ResourceManagerRegistrationListener(),
-				taskManagerConfiguration.getDefaultSlotResourceProfile());
+				taskExecutorRegistration);
 		resourceManagerConnection.start();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -999,7 +999,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 			getResourceID(),
 			taskManagerLocation.dataPort(),
 			hardwareDescription,
-			taskManagerConfiguration.getDefaultSlotResourceProfile()
+			taskManagerConfiguration.getDefaultSlotResourceProfile(),
+			taskManagerConfiguration.getTotalResourceProfile()
 		);
 
 		resourceManagerConnection =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -54,6 +55,7 @@ public interface TaskExecutorGateway extends RpcGateway {
 	 * @param slotId slot id for the request
 	 * @param jobId for which to request a slot
 	 * @param allocationId id for the request
+	 * @param resourceProfile of requested slot, used only for dynamic slot allocation and will be ignored otherwise
 	 * @param targetAddress to which to offer the requested slots
 	 * @param resourceManagerId current leader id of the ResourceManager
 	 * @param timeout for the operation
@@ -63,6 +65,7 @@ public interface TaskExecutorGateway extends RpcGateway {
 		SlotID slotId,
 		JobID jobId,
 		AllocationID allocationId,
+		ResourceProfile resourceProfile,
 		String targetAddress,
 		ResourceManagerId resourceManagerId,
 		@RpcTimeout Time timeout);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnection.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.registration.RegisteredRpcConnection;
 import org.apache.flink.runtime.registration.RegistrationConnectionListener;
@@ -57,6 +58,8 @@ public class TaskExecutorToResourceManagerConnection
 
 	private final RegistrationConnectionListener<TaskExecutorToResourceManagerConnection, TaskExecutorRegistrationSuccess> registrationListener;
 
+	private final ResourceProfile defaultSlotResourceProfile;
+
 	public TaskExecutorToResourceManagerConnection(
 			Logger log,
 			RpcService rpcService,
@@ -68,7 +71,8 @@ public class TaskExecutorToResourceManagerConnection
 			String resourceManagerAddress,
 			ResourceManagerId resourceManagerId,
 			Executor executor,
-			RegistrationConnectionListener<TaskExecutorToResourceManagerConnection, TaskExecutorRegistrationSuccess> registrationListener) {
+			RegistrationConnectionListener<TaskExecutorToResourceManagerConnection, TaskExecutorRegistrationSuccess> registrationListener,
+			ResourceProfile defaultSlotResourceProfile) {
 
 		super(log, resourceManagerAddress, resourceManagerId, executor);
 
@@ -79,6 +83,7 @@ public class TaskExecutorToResourceManagerConnection
 		this.dataPort = dataPort;
 		this.hardwareDescription = checkNotNull(hardwareDescription);
 		this.registrationListener = checkNotNull(registrationListener);
+		this.defaultSlotResourceProfile = checkNotNull(defaultSlotResourceProfile);
 	}
 
 	@Override
@@ -92,7 +97,8 @@ public class TaskExecutorToResourceManagerConnection
 			taskManagerAddress,
 			taskManagerResourceId,
 			dataPort,
-			hardwareDescription);
+			hardwareDescription,
+			defaultSlotResourceProfile);
 	}
 
 	@Override
@@ -125,6 +131,8 @@ public class TaskExecutorToResourceManagerConnection
 
 		private final HardwareDescription hardwareDescription;
 
+		private final ResourceProfile defaultSlotResourceProfile;
+
 		ResourceManagerRegistration(
 				Logger log,
 				RpcService rpcService,
@@ -134,13 +142,15 @@ public class TaskExecutorToResourceManagerConnection
 				String taskExecutorAddress,
 				ResourceID resourceID,
 				int dataPort,
-				HardwareDescription hardwareDescription) {
+				HardwareDescription hardwareDescription,
+				ResourceProfile defaultSlotResourceProfile) {
 
 			super(log, rpcService, "ResourceManager", ResourceManagerGateway.class, targetAddress, resourceManagerId, retryingRegistrationConfiguration);
 			this.taskExecutorAddress = checkNotNull(taskExecutorAddress);
 			this.resourceID = checkNotNull(resourceID);
 			this.dataPort = dataPort;
 			this.hardwareDescription = checkNotNull(hardwareDescription);
+			this.defaultSlotResourceProfile = checkNotNull(defaultSlotResourceProfile);
 		}
 
 		@Override
@@ -153,6 +163,7 @@ public class TaskExecutorToResourceManagerConnection
 				resourceID,
 				dataPort,
 				hardwareDescription,
+				defaultSlotResourceProfile,
 				timeout);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnection.java
@@ -19,9 +19,6 @@
 package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
-import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.registration.RegisteredRpcConnection;
 import org.apache.flink.runtime.registration.RegistrationConnectionListener;
 import org.apache.flink.runtime.registration.RegistrationResponse;
@@ -29,6 +26,7 @@ import org.apache.flink.runtime.registration.RetryingRegistration;
 import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
+import org.apache.flink.runtime.resourcemanager.TaskExecutorRegistration;
 import org.apache.flink.runtime.rpc.RpcService;
 
 import org.slf4j.Logger;
@@ -46,44 +44,28 @@ public class TaskExecutorToResourceManagerConnection
 
 	private final RpcService rpcService;
 
-	private final String taskManagerAddress;
-
-	private final ResourceID taskManagerResourceId;
-
 	private final RetryingRegistrationConfiguration retryingRegistrationConfiguration;
-
-	private final int dataPort;
-
-	private final HardwareDescription hardwareDescription;
 
 	private final RegistrationConnectionListener<TaskExecutorToResourceManagerConnection, TaskExecutorRegistrationSuccess> registrationListener;
 
-	private final ResourceProfile defaultSlotResourceProfile;
+	private final TaskExecutorRegistration taskExecutorRegistration;
 
 	public TaskExecutorToResourceManagerConnection(
 			Logger log,
 			RpcService rpcService,
-			String taskManagerAddress,
-			ResourceID taskManagerResourceId,
 			RetryingRegistrationConfiguration retryingRegistrationConfiguration,
-			int dataPort,
-			HardwareDescription hardwareDescription,
 			String resourceManagerAddress,
 			ResourceManagerId resourceManagerId,
 			Executor executor,
 			RegistrationConnectionListener<TaskExecutorToResourceManagerConnection, TaskExecutorRegistrationSuccess> registrationListener,
-			ResourceProfile defaultSlotResourceProfile) {
+			TaskExecutorRegistration taskExecutorRegistration) {
 
 		super(log, resourceManagerAddress, resourceManagerId, executor);
 
 		this.rpcService = checkNotNull(rpcService);
-		this.taskManagerAddress = checkNotNull(taskManagerAddress);
-		this.taskManagerResourceId = checkNotNull(taskManagerResourceId);
 		this.retryingRegistrationConfiguration = checkNotNull(retryingRegistrationConfiguration);
-		this.dataPort = dataPort;
-		this.hardwareDescription = checkNotNull(hardwareDescription);
 		this.registrationListener = checkNotNull(registrationListener);
-		this.defaultSlotResourceProfile = checkNotNull(defaultSlotResourceProfile);
+		this.taskExecutorRegistration = checkNotNull(taskExecutorRegistration);
 	}
 
 	@Override
@@ -94,11 +76,7 @@ public class TaskExecutorToResourceManagerConnection
 			getTargetAddress(),
 			getTargetLeaderId(),
 			retryingRegistrationConfiguration,
-			taskManagerAddress,
-			taskManagerResourceId,
-			dataPort,
-			hardwareDescription,
-			defaultSlotResourceProfile);
+			taskExecutorRegistration);
 	}
 
 	@Override
@@ -123,15 +101,7 @@ public class TaskExecutorToResourceManagerConnection
 	private static class ResourceManagerRegistration
 			extends RetryingRegistration<ResourceManagerId, ResourceManagerGateway, TaskExecutorRegistrationSuccess> {
 
-		private final String taskExecutorAddress;
-
-		private final ResourceID resourceID;
-
-		private final int dataPort;
-
-		private final HardwareDescription hardwareDescription;
-
-		private final ResourceProfile defaultSlotResourceProfile;
+		private final TaskExecutorRegistration taskExecutorRegistration;
 
 		ResourceManagerRegistration(
 				Logger log,
@@ -139,18 +109,10 @@ public class TaskExecutorToResourceManagerConnection
 				String targetAddress,
 				ResourceManagerId resourceManagerId,
 				RetryingRegistrationConfiguration retryingRegistrationConfiguration,
-				String taskExecutorAddress,
-				ResourceID resourceID,
-				int dataPort,
-				HardwareDescription hardwareDescription,
-				ResourceProfile defaultSlotResourceProfile) {
+				TaskExecutorRegistration taskExecutorRegistration) {
 
 			super(log, rpcService, "ResourceManager", ResourceManagerGateway.class, targetAddress, resourceManagerId, retryingRegistrationConfiguration);
-			this.taskExecutorAddress = checkNotNull(taskExecutorAddress);
-			this.resourceID = checkNotNull(resourceID);
-			this.dataPort = dataPort;
-			this.hardwareDescription = checkNotNull(hardwareDescription);
-			this.defaultSlotResourceProfile = checkNotNull(defaultSlotResourceProfile);
+			this.taskExecutorRegistration = taskExecutorRegistration;
 		}
 
 		@Override
@@ -159,11 +121,7 @@ public class TaskExecutorToResourceManagerConnection
 
 			Time timeout = Time.milliseconds(timeoutMillis);
 			return resourceManager.registerTaskExecutor(
-				taskExecutorAddress,
-				resourceID,
-				dataPort,
-				hardwareDescription,
-				defaultSlotResourceProfile,
+				taskExecutorRegistration,
 				timeout);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
@@ -27,6 +27,7 @@ import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
 import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
@@ -48,6 +49,8 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 	private static final Logger LOG = LoggerFactory.getLogger(TaskManagerConfiguration.class);
 
 	private final int numberSlots;
+
+	private final ResourceProfile defaultSlotResourceProfile;
 
 	private final String[] tmpDirectories;
 
@@ -79,6 +82,7 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 
 	public TaskManagerConfiguration(
 			int numberSlots,
+			ResourceProfile defaultSlotResourceProfile,
 			String[] tmpDirectories,
 			Time timeout,
 			@Nullable Time maxRegistrationDuration,
@@ -94,6 +98,7 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 			RetryingRegistrationConfiguration retryingRegistrationConfiguration) {
 
 		this.numberSlots = numberSlots;
+		this.defaultSlotResourceProfile = defaultSlotResourceProfile;
 		this.tmpDirectories = Preconditions.checkNotNull(tmpDirectories);
 		this.timeout = Preconditions.checkNotNull(timeout);
 		this.maxRegistrationDuration = maxRegistrationDuration;
@@ -111,6 +116,10 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 
 	public int getNumberSlots() {
 		return numberSlots;
+	}
+
+	public ResourceProfile getDefaultSlotResourceProfile() {
+		return defaultSlotResourceProfile;
 	}
 
 	public Time getTimeout() {
@@ -176,7 +185,7 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 	//  Static factory methods
 	// --------------------------------------------------------------------------------------------
 
-	public static TaskManagerConfiguration fromConfiguration(Configuration configuration) {
+	public static TaskManagerConfiguration fromConfiguration(Configuration configuration, ResourceProfile defaultSlotResourceProfile) {
 		int numberSlots = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS, 1);
 
 		if (numberSlots == -1) {
@@ -259,6 +268,7 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 
 		return new TaskManagerConfiguration(
 			numberSlots,
+			defaultSlotResourceProfile,
 			tmpDirPaths,
 			timeout,
 			finiteRegistrationDuration,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -33,7 +33,6 @@ import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
 import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.entrypoint.ClusterConfiguration;
@@ -378,10 +377,8 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 			taskManagerMetricGroup.f1,
 			rpcService.getExecutor()); // TODO replace this later with some dedicated executor for io.
 
-		ResourceProfile defaultSlotResourceProfile = TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(
-			taskExecutorResourceSpec,
-			taskManagerServicesConfiguration.getNumberOfSlots());
-		TaskManagerConfiguration taskManagerConfiguration = TaskManagerConfiguration.fromConfiguration(configuration, defaultSlotResourceProfile);
+		TaskManagerConfiguration taskManagerConfiguration =
+			TaskManagerConfiguration.fromConfiguration(configuration, taskExecutorResourceSpec);
 
 		String metricQueryServiceAddress = metricRegistry.getMetricQueryServiceGatewayRpcAddress();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -25,7 +25,6 @@ import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
@@ -196,7 +195,8 @@ public class TaskManagerServicesConfiguration {
 			Configuration configuration,
 			ResourceID resourceID,
 			InetAddress remoteAddress,
-			boolean localCommunicationOnly) {
+			boolean localCommunicationOnly,
+			TaskExecutorResourceSpec taskExecutorResourceSpec) {
 		final String[] tmpDirs = ConfigurationUtils.parseTempDirectories(configuration);
 		String[] localStateRootDir = ConfigurationUtils.parseLocalStateDirectories(configuration);
 		if (localStateRootDir.length == 0) {
@@ -212,7 +212,6 @@ public class TaskManagerServicesConfiguration {
 
 		final RetryingRegistrationConfiguration retryingRegistrationConfiguration = RetryingRegistrationConfiguration.fromConfiguration(configuration);
 
-		final TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(configuration);
 		return new TaskManagerServicesConfiguration(
 			configuration,
 			resourceID,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -155,6 +155,10 @@ public class TaskManagerServicesConfiguration {
 		return pageSize;
 	}
 
+	public TaskExecutorResourceSpec getTaskExecutorResourceSpec() {
+		return taskExecutorResourceSpec;
+	}
+
 	public MemorySize getShuffleMemorySize() {
 		return taskExecutorResourceSpec.getShuffleMemSize();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/SlotOffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/SlotOffer.java
@@ -41,7 +41,6 @@ public class SlotOffer implements Serializable {
 	private final ResourceProfile resourceProfile;
 
 	public SlotOffer(final AllocationID allocationID, final int index, final ResourceProfile resourceProfile) {
-		Preconditions.checkArgument(0 <= index, "The index must be greater than 0.");
 		this.allocationId = Preconditions.checkNotNull(allocationID);
 		this.slotIndex = index;
 		this.resourceProfile = Preconditions.checkNotNull(resourceProfile);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
@@ -83,7 +83,7 @@ public class TaskSlot implements AutoCloseable {
 		final int memoryPageSize,
 		final JobID jobId,
 		final AllocationID allocationId) {
-		Preconditions.checkArgument(0 <= index, "The index must be greater than 0.");
+
 		this.index = index;
 		this.resourceProfile = Preconditions.checkNotNull(resourceProfile);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotState.java
@@ -24,6 +24,5 @@ package org.apache.flink.runtime.taskexecutor.slot;
 enum TaskSlotState {
 	ACTIVE, // Slot is in active use by a job manager responsible for a job
 	ALLOCATED, // Slot has been allocated for a job but not yet given to a job manager
-	RELEASING, // Slot is not empty but tasks are failed. Upon removal of all tasks, it will be released
-	FREE // Slot is free
+	RELEASING // Slot is not empty but tasks are failed. Upon removal of all tasks, it will be released
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
@@ -22,7 +22,9 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceBudgetManager;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.memory.MemoryManager;
@@ -37,7 +39,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -61,11 +62,24 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(TaskSlotTable.class);
 
+	/**
+	 * Number of slots in static slot allocation.
+	 * If slot is requested with an index, the requested index must within the range of [0, numberSlots).
+	 * When generating slot report, we should always generate slots with index in [0, numberSlots) even the slot does not exist.
+	 */
+	private final int numberSlots;
+
+	/** Slot resource profile for static slot allocation. */
+	private final ResourceProfile defaultSlotResourceProfile;
+
+	/** Page size for memory manager. */
+	private final int memoryPageSize;
+
 	/** Timer service used to time out allocated slots. */
 	private final TimerService<AllocationID> timerService;
 
 	/** The list of all task slots. */
-	private final List<TaskSlot> taskSlots;
+	private final Map<Integer, TaskSlot> taskSlots;
 
 	/** Mapping from allocation id to task slot. */
 	private final Map<AllocationID, TaskSlot> allocationIDTaskSlotMap;
@@ -82,16 +96,29 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 	/** Whether the table has been started. */
 	private volatile boolean started;
 
-	public TaskSlotTable(
-		final List<TaskSlot> taskSlots,
-		final TimerService<AllocationID> timerService) {
+	/** Index of next allocated slot, for dynamic slot allocation. */
+	private int nextSlotIndex;
 
-		int numberSlots = taskSlots.size();
+	private final ResourceBudgetManager budgetManager;
+
+	public TaskSlotTable(
+		final int numberSlots,
+		final ResourceProfile totalAvailableResourceProfile,
+		final ResourceProfile defaultSlotResourceProfile,
+		final int memoryPageSize,
+		final TimerService<AllocationID> timerService) {
 
 		Preconditions.checkArgument(0 < numberSlots, "The number of task slots must be greater than 0.");
 
-		this.taskSlots = new ArrayList<>(taskSlots);
+		this.numberSlots = numberSlots;
+		this.defaultSlotResourceProfile = Preconditions.checkNotNull(defaultSlotResourceProfile);
+		this.memoryPageSize = memoryPageSize;
+
+		this.taskSlots = new HashMap<>(numberSlots);
+
 		this.timerService = Preconditions.checkNotNull(timerService);
+
+		budgetManager = new ResourceBudgetManager(Preconditions.checkNotNull(totalAvailableResourceProfile));
 
 		allocationIDTaskSlotMap = new HashMap<>(numberSlots);
 
@@ -101,6 +128,7 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 
 		slotActions = null;
 		started = false;
+		nextSlotIndex = numberSlots;
 	}
 
 	/**
@@ -122,13 +150,14 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 	public void stop() {
 		started = false;
 		timerService.stop();
-		taskSlots.forEach(TaskSlot::close);
+		taskSlots.values().forEach(TaskSlot::close);
+		taskSlots.clear();
 		slotActions = null;
 	}
 
 	@VisibleForTesting
 	public boolean isStopped() {
-		return !started && taskSlots.stream().allMatch(slot -> slot.getMemoryManager().isShutdown());
+		return !started && taskSlots.values().stream().allMatch(slot -> slot.getMemoryManager().isShutdown());
 	}
 
 	/**
@@ -152,21 +181,40 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 	// ---------------------------------------------------------------------
 
 	public SlotReport createSlotReport(ResourceID resourceId) {
-		final int numberSlots = taskSlots.size();
-
-		List<SlotStatus> slotStatuses = Arrays.asList(new SlotStatus[numberSlots]);
+		List<SlotStatus> slotStatuses = new ArrayList<>();
 
 		for (int i = 0; i < numberSlots; i++) {
-			TaskSlot taskSlot = taskSlots.get(i);
-			SlotID slotId = new SlotID(resourceId, taskSlot.getIndex());
+			SlotID slotId = new SlotID(resourceId, i);
+			SlotStatus slotStatus;
+			if (taskSlots.containsKey(i)) {
+				TaskSlot taskSlot = taskSlots.get(i);
 
-			SlotStatus slotStatus = new SlotStatus(
-				slotId,
-				taskSlot.getResourceProfile(),
-				taskSlot.getJobId(),
-				taskSlot.getAllocationId());
+				slotStatus = new SlotStatus(
+					slotId,
+					taskSlot.getResourceProfile(),
+					taskSlot.getJobId(),
+					taskSlot.getAllocationId());
+			} else {
+				slotStatus = new SlotStatus(
+					slotId,
+					defaultSlotResourceProfile,
+					null,
+					null);
+			}
 
-			slotStatuses.set(i, slotStatus);
+			slotStatuses.add(slotStatus);
+		}
+
+		for (TaskSlot taskSlot : taskSlots.values()) {
+			if (taskSlot.getIndex() >= numberSlots) {
+				SlotID slotID = new SlotID(resourceId, taskSlot.getIndex());
+				SlotStatus slotStatus = new SlotStatus(
+					slotID,
+					taskSlot.getResourceProfile(),
+					taskSlot.getJobId(),
+					taskSlot.getAllocationId());
+				slotStatuses.add(slotStatus);
+			}
 		}
 
 		final SlotReport slotReport = new SlotReport(slotStatuses);
@@ -179,46 +227,92 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 	// ---------------------------------------------------------------------
 
 	/**
-	 * Allocate the slot with the given index for the given job and allocation id. Returns true if
-	 * the slot could be allocated. Otherwise it returns false.
+	 * Allocate the slot with the given index for the given job and allocation id. If negative index is
+	 * given, a new auto increasing index will be generated. Returns true if the slot could be allocated.
+	 * Otherwise it returns false.
 	 *
-	 * @param index of the task slot to allocate
+	 * @param index of the task slot to allocate, use negative value for dynamic slot allocation
 	 * @param jobId to allocate the task slot for
 	 * @param allocationId identifying the allocation
 	 * @param slotTimeout until the slot times out
 	 * @return True if the task slot could be allocated; otherwise false
 	 */
+	@VisibleForTesting
 	public boolean allocateSlot(int index, JobID jobId, AllocationID allocationId, Time slotTimeout) {
+		return allocateSlot(index, jobId, allocationId, defaultSlotResourceProfile, slotTimeout);
+	}
+
+	/**
+	 * Allocate the slot with the given index for the given job and allocation id. If negative index is
+	 * given, a new auto increasing index will be generated. Returns true if the slot could be allocated.
+	 * Otherwise it returns false.
+	 *
+	 * @param index of the task slot to allocate, use negative value for dynamic slot allocation
+	 * @param jobId to allocate the task slot for
+	 * @param allocationId identifying the allocation
+	 * @param resourceProfile of the requested slot, used only for dynamic slot allocation and will be ignored otherwise
+	 * @param slotTimeout until the slot times out
+	 * @return True if the task slot could be allocated; otherwise false
+	 */
+	public boolean allocateSlot(int index, JobID jobId, AllocationID allocationId, ResourceProfile resourceProfile, Time slotTimeout) {
 		checkInit();
+
+		Preconditions.checkArgument(index < numberSlots);
 
 		TaskSlot taskSlot = allocationIDTaskSlotMap.get(allocationId);
 		if (taskSlot != null) {
 			LOG.info("Allocation ID {} is already allocated in {}.", allocationId, taskSlot);
 			return false;
 		}
-		taskSlot = taskSlots.get(index);
 
-		boolean result = taskSlot.allocate(jobId, allocationId);
-
-		if (result) {
-			// update the allocation id to task slot map
-			allocationIDTaskSlotMap.put(allocationId, taskSlot);
-
-			// register a timeout for this slot since it's in state allocated
-			timerService.registerTimeout(allocationId, slotTimeout.getSize(), slotTimeout.getUnit());
-
-			// add this slot to the set of job slots
-			Set<AllocationID> slots = slotsPerJob.get(jobId);
-
-			if (slots == null) {
-				slots = new HashSet<>(4);
-				slotsPerJob.put(jobId, slots);
-			}
-
-			slots.add(allocationId);
+		if (index >= 0) {
+			resourceProfile = defaultSlotResourceProfile;
 		}
 
-		return result;
+		if (taskSlots.containsKey(index)) {
+			TaskSlot duplicatedTaskSlot = taskSlots.get(index);
+			LOG.info("Slot with index {} already exist, with resource profile {}, job id {} and allocation id {}.",
+				index,
+				duplicatedTaskSlot.getResourceProfile(),
+				duplicatedTaskSlot.getJobId(),
+				duplicatedTaskSlot.getAllocationId());
+			return duplicatedTaskSlot.getJobId().equals(jobId) &&
+				duplicatedTaskSlot.getAllocationId().equals(allocationId);
+		}
+
+		if (index < 0) {
+			index = nextSlotIndex++;
+		}
+
+		if (!budgetManager.reserve(resourceProfile)) {
+			LOG.info("Cannot allocate the requested resources. Trying to allocate {}, "
+					+ "while the currently remaining available resources are {}, total is {}.",
+				resourceProfile,
+				budgetManager.getAvailableBudget(),
+				budgetManager.getTotalBudget());
+			return false;
+		}
+
+		taskSlot = new TaskSlot(index, resourceProfile, memoryPageSize, jobId, allocationId);
+		taskSlots.put(index, taskSlot);
+
+		// update the allocation id to task slot map
+		allocationIDTaskSlotMap.put(allocationId, taskSlot);
+
+		// register a timeout for this slot since it's in state allocated
+		timerService.registerTimeout(allocationId, slotTimeout.getSize(), slotTimeout.getUnit());
+
+		// add this slot to the set of job slots
+		Set<AllocationID> slots = slotsPerJob.get(jobId);
+
+		if (slots == null) {
+			slots = new HashSet<>(4);
+			slotsPerJob.put(jobId, slots);
+		}
+
+		slots.add(allocationId);
+
+		return true;
 	}
 
 	/**
@@ -315,7 +409,7 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 
 			final JobID jobId = taskSlot.getJobId();
 
-			if (taskSlot.markFree()) {
+			if (taskSlot.isEmpty()) {
 				// remove the allocation id to task slot mapping
 				allocationIDTaskSlotMap.remove(allocationId);
 
@@ -334,6 +428,10 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 				if (slots.isEmpty()) {
 					slotsPerJob.remove(jobId);
 				}
+
+				taskSlot.close();
+				taskSlots.remove(taskSlot.getIndex());
+				budgetManager.release(taskSlot.getResourceProfile());
 
 				return taskSlot.getIndex();
 			} else {
@@ -378,7 +476,7 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 	public boolean isAllocated(int index, JobID jobId, AllocationID allocationId) {
 		TaskSlot taskSlot = taskSlots.get(index);
 
-		return taskSlot.isAllocated(jobId, allocationId);
+		return taskSlot != null && taskSlot.isAllocated(jobId, allocationId);
 	}
 
 	/**
@@ -405,9 +503,7 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 	 * @return True if the task slot is free; otherwise false
 	 */
 	public boolean isSlotFree(int index) {
-		TaskSlot taskSlot = taskSlots.get(index);
-
-		return taskSlot.isFree();
+		return !taskSlots.containsKey(index);
 	}
 
 	/**
@@ -555,7 +651,11 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 	 * @return Allocation id of the specified slot if allocated; otherwise null
 	 */
 	public AllocationID getCurrentAllocation(int index) {
-		return taskSlots.get(index).getAllocationId();
+		TaskSlot taskSlot = taskSlots.get(index);
+		if (taskSlot == null) {
+			return null;
+		}
+		return taskSlot.getAllocationId();
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.clusterframework;
 
+import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
@@ -145,6 +146,7 @@ public class BootstrapToolsTest extends TestLogger {
 	public void testGetTaskManagerShellCommand() {
 		final Configuration cfg = new Configuration();
 		final TaskExecutorResourceSpec taskExecutorResourceSpec = new TaskExecutorResourceSpec(
+			new CPUResource(1.0),
 			new MemorySize(0), // frameworkHeapSize
 			new MemorySize(0), // frameworkOffHeapSize
 			new MemorySize(111), // taskHeapSize

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtilsTest.java
@@ -33,6 +33,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -511,6 +512,13 @@ public class TaskExecutorResourceUtilsTest extends TestLogger {
 		conf.setString(TaskManagerOptions.JVM_OVERHEAD_MAX, jvmOverhead.getMebiBytes() + "m");
 
 		validateFail(conf);
+	}
+
+	@Test
+	public void testCreateDefaultWorkerSlotProfiles() {
+		assertThat(
+			TaskExecutorResourceUtils.createDefaultWorkerSlotProfiles(TM_RESOURCE_SPEC, NUMBER_OF_SLOTS),
+			is(Arrays.asList(DEFAULT_RESOURCE_PROFILE, DEFAULT_RESOURCE_PROFILE)));
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceBudgetManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceBudgetManagerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.clusterframework.types;
+
+import org.apache.flink.configuration.MemorySize;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link ResourceBudgetManager}.
+ */
+public class ResourceBudgetManagerTest {
+
+	@Test
+	public void testReserve() {
+		ResourceBudgetManager budgetManager = new ResourceBudgetManager(createResourceProfile(1.0, 100));
+
+		assertThat(budgetManager.reserve(createResourceProfile(0.7, 70)), Matchers.is(true));
+		assertThat(budgetManager.getAvailableBudget(), is(createResourceProfile(0.3, 30)));
+	}
+
+	@Test
+	public void testReserveFail() {
+		ResourceBudgetManager budgetManager = new ResourceBudgetManager(createResourceProfile(1.0, 100));
+
+		assertThat(budgetManager.reserve(createResourceProfile(1.2, 120)), Matchers.is(false));
+		assertThat(budgetManager.getAvailableBudget(), is(createResourceProfile(1.0, 100)));
+	}
+
+	@Test
+	public void testRelease() {
+		ResourceBudgetManager budgetManager = new ResourceBudgetManager(createResourceProfile(1.0, 100));
+
+		assertThat(budgetManager.reserve(createResourceProfile(0.7, 70)), Matchers.is(true));
+		assertThat(budgetManager.release(createResourceProfile(0.5, 50)), Matchers.is(true));
+		assertThat(budgetManager.getAvailableBudget(), is(createResourceProfile(0.8, 80)));
+	}
+
+	@Test
+	public void testReleaseFail() {
+		ResourceBudgetManager budgetManager = new ResourceBudgetManager(createResourceProfile(1.0, 100));
+
+		assertThat(budgetManager.reserve(createResourceProfile(0.7, 70)), Matchers.is(true));
+		assertThat(budgetManager.release(createResourceProfile(0.8, 80)), Matchers.is(false));
+		assertThat(budgetManager.getAvailableBudget(), is(createResourceProfile(0.3, 30)));
+	}
+
+	private static ResourceProfile createResourceProfile(double cpus, int memory) {
+		return ResourceProfile.newBuilder().setCpuCores(cpus).setTaskHeapMemory(MemorySize.parse(memory + "m")).build();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
@@ -235,8 +235,15 @@ public class ResourceManagerTaskExecutorTest extends TestLogger {
 					},
 					TestingUtils.defaultExecutor()));
 
+			TaskExecutorRegistration taskExecutorRegistration = new TaskExecutorRegistration(
+				taskExecutorGateway.getAddress(),
+				taskExecutorResourceID,
+				dataPort,
+				hardwareDescription,
+				ResourceProfile.ZERO);
+
 			CompletableFuture<RegistrationResponse> firstFuture =
-				rmGateway.registerTaskExecutor(taskExecutorGateway.getAddress(), taskExecutorResourceID, dataPort, hardwareDescription, ResourceProfile.ZERO, fastTimeout);
+				rmGateway.registerTaskExecutor(taskExecutorRegistration, fastTimeout);
 			try {
 				firstFuture.get();
 				fail("Should have failed because connection to taskmanager is delayed beyond timeout");
@@ -249,7 +256,7 @@ public class ResourceManagerTaskExecutorTest extends TestLogger {
 			// second registration after timeout is with no delay, expecting it to be succeeded
 			rpcService.resetRpcGatewayFutureFunction();
 			CompletableFuture<RegistrationResponse> secondFuture =
-				rmGateway.registerTaskExecutor(taskExecutorGateway.getAddress(), taskExecutorResourceID, dataPort, hardwareDescription, ResourceProfile.ZERO, TIMEOUT);
+				rmGateway.registerTaskExecutor(taskExecutorRegistration, TIMEOUT);
 			RegistrationResponse response = secondFuture.get();
 			assertTrue(response instanceof TaskExecutorRegistrationSuccess);
 
@@ -335,11 +342,7 @@ public class ResourceManagerTaskExecutorTest extends TestLogger {
 
 	private CompletableFuture<RegistrationResponse> registerTaskExecutor(ResourceManagerGateway resourceManagerGateway, String taskExecutorAddress) {
 		return resourceManagerGateway.registerTaskExecutor(
-			taskExecutorAddress,
-			taskExecutorResourceID,
-			dataPort,
-			hardwareDescription,
-			ResourceProfile.ZERO,
+			new TaskExecutorRegistration(taskExecutorAddress, taskExecutorResourceID, dataPort, hardwareDescription, ResourceProfile.ZERO),
 			TIMEOUT);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
@@ -236,7 +236,7 @@ public class ResourceManagerTaskExecutorTest extends TestLogger {
 					TestingUtils.defaultExecutor()));
 
 			CompletableFuture<RegistrationResponse> firstFuture =
-				rmGateway.registerTaskExecutor(taskExecutorGateway.getAddress(), taskExecutorResourceID, dataPort, hardwareDescription, fastTimeout);
+				rmGateway.registerTaskExecutor(taskExecutorGateway.getAddress(), taskExecutorResourceID, dataPort, hardwareDescription, ResourceProfile.ZERO, fastTimeout);
 			try {
 				firstFuture.get();
 				fail("Should have failed because connection to taskmanager is delayed beyond timeout");
@@ -249,7 +249,7 @@ public class ResourceManagerTaskExecutorTest extends TestLogger {
 			// second registration after timeout is with no delay, expecting it to be succeeded
 			rpcService.resetRpcGatewayFutureFunction();
 			CompletableFuture<RegistrationResponse> secondFuture =
-				rmGateway.registerTaskExecutor(taskExecutorGateway.getAddress(), taskExecutorResourceID, dataPort, hardwareDescription, TIMEOUT);
+				rmGateway.registerTaskExecutor(taskExecutorGateway.getAddress(), taskExecutorResourceID, dataPort, hardwareDescription, ResourceProfile.ZERO, TIMEOUT);
 			RegistrationResponse response = secondFuture.get();
 			assertTrue(response instanceof TaskExecutorRegistrationSuccess);
 
@@ -339,6 +339,7 @@ public class ResourceManagerTaskExecutorTest extends TestLogger {
 			taskExecutorResourceID,
 			dataPort,
 			hardwareDescription,
+			ResourceProfile.ZERO,
 			TIMEOUT);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
@@ -240,6 +240,7 @@ public class ResourceManagerTaskExecutorTest extends TestLogger {
 				taskExecutorResourceID,
 				dataPort,
 				hardwareDescription,
+				ResourceProfile.ZERO,
 				ResourceProfile.ZERO);
 
 			CompletableFuture<RegistrationResponse> firstFuture =
@@ -342,7 +343,13 @@ public class ResourceManagerTaskExecutorTest extends TestLogger {
 
 	private CompletableFuture<RegistrationResponse> registerTaskExecutor(ResourceManagerGateway resourceManagerGateway, String taskExecutorAddress) {
 		return resourceManagerGateway.registerTaskExecutor(
-			new TaskExecutorRegistration(taskExecutorAddress, taskExecutorResourceID, dataPort, hardwareDescription, ResourceProfile.ZERO),
+			new TaskExecutorRegistration(
+				taskExecutorAddress,
+				taskExecutorResourceID,
+				dataPort,
+				hardwareDescription,
+				ResourceProfile.ZERO,
+				ResourceProfile.ZERO),
 			TIMEOUT);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -160,12 +160,14 @@ public class ResourceManagerTest extends TestLogger {
 	}
 
 	private void registerTaskExecutor(ResourceManagerGateway resourceManagerGateway, ResourceID taskExecutorId, String taskExecutorAddress) throws Exception {
-		final CompletableFuture<RegistrationResponse> registrationFuture = resourceManagerGateway.registerTaskExecutor(
+		TaskExecutorRegistration taskExecutorRegistration = new TaskExecutorRegistration(
 			taskExecutorAddress,
 			taskExecutorId,
 			dataPort,
 			hardwareDescription,
-			ResourceProfile.ZERO,
+			ResourceProfile.ZERO);
+		final CompletableFuture<RegistrationResponse> registrationFuture = resourceManagerGateway.registerTaskExecutor(
+			taskExecutorRegistration,
 			TestingUtils.TIMEOUT());
 
 		assertThat(registrationFuture.get(), instanceOf(RegistrationResponse.Success.class));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -165,6 +165,7 @@ public class ResourceManagerTest extends TestLogger {
 			taskExecutorId,
 			dataPort,
 			hardwareDescription,
+			ResourceProfile.ZERO,
 			ResourceProfile.ZERO);
 		final CompletableFuture<RegistrationResponse> registrationFuture = resourceManagerGateway.registerTaskExecutor(
 			taskExecutorRegistration,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -20,9 +20,6 @@ package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
@@ -41,7 +38,6 @@ import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerInfo;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
-import org.apache.flink.runtime.taskexecutor.TaskManagerServices;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
@@ -273,25 +269,5 @@ public class ResourceManagerTest extends TestLogger {
 		resourceManagerLeaderElectionService.isLeader(resourceManagerId.toUUID()).get();
 
 		return resourceManager;
-	}
-
-	/**
-	 * Tests that RM and TM create the same slot resource profiles.
-	 */
-	@Test
-	public void testCreateWorkerSlotProfiles() {
-		final Configuration config = new Configuration();
-		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "100m");
-		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 5);
-
-		final ResourceProfile rmCalculatedResourceProfile =
-			ResourceManager.createWorkerSlotProfiles(config).iterator().next();
-
-		final ResourceProfile tmCalculatedResourceProfile =
-			TaskManagerServices.computeSlotResourceProfile(
-				config.getInteger(TaskManagerOptions.NUM_TASK_SLOTS),
-				MemorySize.parse(config.getString(TaskManagerOptions.MANAGED_MEMORY_SIZE)).getBytes());
-
-		assertEquals(rmCalculatedResourceProfile, tmCalculatedResourceProfile);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -169,6 +169,7 @@ public class ResourceManagerTest extends TestLogger {
 			taskExecutorId,
 			dataPort,
 			hardwareDescription,
+			ResourceProfile.ZERO,
 			TestingUtils.TIMEOUT());
 
 		assertThat(registrationFuture.get(), instanceOf(RegistrationResponse.Success.class));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
-import org.apache.flink.api.java.tuple.Tuple5;
+import org.apache.flink.api.java.tuple.Tuple6;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
@@ -136,8 +136,8 @@ public class SlotManagerImplTest extends TestLogger {
 		final JobID jobId = new JobID();
 
 		final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
-			.setRequestSlotFunction(tuple5 -> {
-				assertThat(tuple5.f4, is(equalTo(resourceManagerId)));
+			.setRequestSlotFunction(tuple6 -> {
+				assertThat(tuple6.f5, is(equalTo(resourceManagerId)));
 				return new CompletableFuture<>();
 			})
 			.createTestingTaskExecutorGateway();
@@ -264,11 +264,11 @@ public class SlotManagerImplTest extends TestLogger {
 		ResourceActions resourceManagerActions = new TestingResourceActionsBuilder().build();
 
 		try (SlotManagerImpl slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
-			final CompletableFuture<Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId>> requestFuture = new CompletableFuture<>();
+			final CompletableFuture<Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId>> requestFuture = new CompletableFuture<>();
 			// accept an incoming slot request
 			final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
-				.setRequestSlotFunction(tuple5 -> {
-					requestFuture.complete(Tuple5.of(tuple5.f0, tuple5.f1, tuple5.f2, tuple5.f3, tuple5.f4));
+				.setRequestSlotFunction(tuple6 -> {
+					requestFuture.complete(Tuple6.of(tuple6.f0, tuple6.f1, tuple6.f2, tuple6.f3, tuple6.f4, tuple6.f5));
 					return CompletableFuture.completedFuture(Acknowledge.get());
 				})
 				.createTestingTaskExecutorGateway();
@@ -284,7 +284,7 @@ public class SlotManagerImplTest extends TestLogger {
 
 			assertTrue("The slot request should be accepted", slotManager.registerSlotRequest(slotRequest));
 
-			assertThat(requestFuture.get(), is(equalTo(Tuple5.of(slotId, jobId, allocationId, targetAddress, resourceManagerId))));
+			assertThat(requestFuture.get(), is(equalTo(Tuple6.of(slotId, jobId, allocationId, resourceProfile, targetAddress, resourceManagerId))));
 
 			TaskManagerSlot slot = slotManager.getSlot(slotId);
 
@@ -305,7 +305,7 @@ public class SlotManagerImplTest extends TestLogger {
 		final AllocationID allocationId = new AllocationID();
 
 		final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
-			.setRequestSlotFunction(slotIDJobIDAllocationIDStringResourceManagerIdTuple5 -> new CompletableFuture<>())
+			.setRequestSlotFunction(slotIDJobIDAllocationIDStringResourceManagerIdTuple6 -> new CompletableFuture<>())
 			.createTestingTaskExecutorGateway();
 
 		final ResourceProfile resourceProfile = ResourceProfile.fromResources(1.0, 1);
@@ -359,11 +359,11 @@ public class SlotManagerImplTest extends TestLogger {
 			.setAllocateResourceConsumer(ignored -> numberAllocateResourceCalls.incrementAndGet())
 			.build();
 
-		final CompletableFuture<Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId>> requestFuture = new CompletableFuture<>();
+		final CompletableFuture<Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId>> requestFuture = new CompletableFuture<>();
 		// accept an incoming slot request
 		final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
-			.setRequestSlotFunction(tuple5 -> {
-				requestFuture.complete(Tuple5.of(tuple5.f0, tuple5.f1, tuple5.f2, tuple5.f3, tuple5.f4));
+			.setRequestSlotFunction(tuple6 -> {
+				requestFuture.complete(Tuple6.of(tuple6.f0, tuple6.f1, tuple6.f2, tuple6.f3, tuple6.f4, tuple6.f5));
 				return CompletableFuture.completedFuture(Acknowledge.get());
 			})
 			.createTestingTaskExecutorGateway();
@@ -383,7 +383,7 @@ public class SlotManagerImplTest extends TestLogger {
 				taskExecutorConnection,
 				slotReport);
 
-			assertThat(requestFuture.get(), is(equalTo(Tuple5.of(slotId, jobId, allocationId, targetAddress, resourceManagerId))));
+			assertThat(requestFuture.get(), is(equalTo(Tuple6.of(slotId, jobId, allocationId, resourceProfile, targetAddress, resourceManagerId))));
 
 			TaskManagerSlot slot = slotManager.getSlot(slotId);
 
@@ -886,8 +886,8 @@ public class SlotManagerImplTest extends TestLogger {
 
 		final CompletableFuture<SlotID> requestedSlotFuture = new CompletableFuture<>();
 		final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
-			.setRequestSlotFunction(tuple5 -> {
-				requestedSlotFuture.complete(tuple5.f0);
+			.setRequestSlotFunction(tuple6 -> {
+				requestedSlotFuture.complete(tuple6.f0);
 				return CompletableFuture.completedFuture(Acknowledge.get());
 			})
 			.createTestingTaskExecutorGateway();
@@ -1059,12 +1059,12 @@ public class SlotManagerImplTest extends TestLogger {
 			final SlotRequest slotRequest = new SlotRequest(new JobID(), new AllocationID(), ResourceProfile.UNKNOWN, "foobar");
 			slotManager.registerSlotRequest(slotRequest);
 
-			final BlockingQueue<Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId>> requestSlotQueue = new ArrayBlockingQueue<>(1);
+			final BlockingQueue<Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId>> requestSlotQueue = new ArrayBlockingQueue<>(1);
 			final BlockingQueue<CompletableFuture<Acknowledge>> responseQueue = new ArrayBlockingQueue<>(1);
 
 			final TestingTaskExecutorGateway testingTaskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
-				.setRequestSlotFunction(slotIDJobIDAllocationIDStringResourceManagerIdTuple5 -> {
-					requestSlotQueue.offer(slotIDJobIDAllocationIDStringResourceManagerIdTuple5);
+				.setRequestSlotFunction(slotIDJobIDAllocationIDStringResourceManagerIdTuple6 -> {
+					requestSlotQueue.offer(slotIDJobIDAllocationIDStringResourceManagerIdTuple6);
 					try {
 						return responseQueue.take();
 					} catch (InterruptedException ignored) {
@@ -1082,7 +1082,7 @@ public class SlotManagerImplTest extends TestLogger {
 
 			slotManager.registerTaskManager(taskExecutionConnection, slotReport);
 
-			final Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId> firstRequest = requestSlotQueue.take();
+			final Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId> firstRequest = requestSlotQueue.take();
 
 			final CompletableFuture<Acknowledge> secondManualSlotRequestResponse = new CompletableFuture<>();
 			responseQueue.offer(secondManualSlotRequestResponse);
@@ -1090,7 +1090,7 @@ public class SlotManagerImplTest extends TestLogger {
 			// fail first request
 			firstManualSlotRequestResponse.completeExceptionally(new SlotAllocationException("Test exception"));
 
-			final Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId> secondRequest = requestSlotQueue.take();
+			final Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId> secondRequest = requestSlotQueue.take();
 
 			assertThat(secondRequest.f2, equalTo(firstRequest.f2));
 			assertThat(secondRequest.f0, equalTo(firstRequest.f0));
@@ -1115,12 +1115,12 @@ public class SlotManagerImplTest extends TestLogger {
 			final SlotRequest slotRequest1 = new SlotRequest(jobID, new AllocationID(), ResourceProfile.UNKNOWN, "foobar");
 			slotManager.registerSlotRequest(slotRequest1);
 
-			final BlockingQueue<Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId>> requestSlotQueue = new ArrayBlockingQueue<>(1);
+			final BlockingQueue<Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId>> requestSlotQueue = new ArrayBlockingQueue<>(1);
 			final BlockingQueue<CompletableFuture<Acknowledge>> responseQueue = new ArrayBlockingQueue<>(1);
 
 			final TestingTaskExecutorGateway testingTaskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
-					.setRequestSlotFunction(slotIDJobIDAllocationIDStringResourceManagerIdTuple5 -> {
-						requestSlotQueue.offer(slotIDJobIDAllocationIDStringResourceManagerIdTuple5);
+					.setRequestSlotFunction(slotIDJobIDAllocationIDStringResourceManagerIdTuple6 -> {
+						requestSlotQueue.offer(slotIDJobIDAllocationIDStringResourceManagerIdTuple6);
 						try {
 							return responseQueue.take();
 						} catch (InterruptedException ignored) {
@@ -1138,7 +1138,7 @@ public class SlotManagerImplTest extends TestLogger {
 
 			slotManager.registerTaskManager(taskExecutionConnection, slotReport);
 
-			final Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId> firstRequest = requestSlotQueue.take();
+			final Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId> firstRequest = requestSlotQueue.take();
 
 			final CompletableFuture<Acknowledge> secondManualSlotRequestResponse = new CompletableFuture<>();
 			responseQueue.offer(secondManualSlotRequestResponse);
@@ -1149,7 +1149,7 @@ public class SlotManagerImplTest extends TestLogger {
 			// fail first request
 			firstManualSlotRequestResponse.completeExceptionally(new TimeoutException("Test exception to fail first allocation"));
 
-			final Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId> secondRequest = requestSlotQueue.take();
+			final Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId> secondRequest = requestSlotQueue.take();
 
 			// fail second request
 			secondManualSlotRequestResponse.completeExceptionally(new SlotOccupiedException("Test exception", slotRequest1.getAllocationId(), jobID));
@@ -1546,8 +1546,8 @@ public class SlotManagerImplTest extends TestLogger {
 
 	private void registerTaskExecutorWithTwoSlots(SlotManagerImpl slotManager, CompletableFuture<JobID> firstRequestSlotFuture) {
 		final TestingTaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
-			.setRequestSlotFunction(slotIDJobIDAllocationIDStringResourceManagerIdTuple5 -> {
-				firstRequestSlotFuture.complete(slotIDJobIDAllocationIDStringResourceManagerIdTuple5.f1);
+			.setRequestSlotFunction(slotIDJobIDAllocationIDStringResourceManagerIdTuple6 -> {
+				firstRequestSlotFuture.complete(slotIDJobIDAllocationIDStringResourceManagerIdTuple6.f1);
 				return CompletableFuture.completedFuture(Acknowledge.get());
 			})
 			.createTestingTaskExecutorGateway();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.Executors;
@@ -206,11 +208,13 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 	private TaskManagerServicesConfiguration createTaskManagerServiceConfiguration(
 			Configuration config) throws IOException {
 		config.setString(TaskManagerOptions.TOTAL_FLINK_MEMORY, TOTAL_FLINK_MEMORY_MB + "m");
+		TaskExecutorResourceSpec spec = TaskExecutorResourceUtils.resourceSpecFromConfig(config);
 		return TaskManagerServicesConfiguration.fromConfiguration(
 			config,
 			ResourceID.generate(),
 			InetAddress.getLocalHost(),
-			true);
+			true,
+			spec);
 	}
 
 	private TaskManagerServices createTaskManagerServices(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -358,6 +358,7 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 						slotStatus.getSlotID(),
 						jobId,
 						taskDeploymentDescriptor.getAllocationId(),
+						ResourceProfile.ZERO,
 						jobMasterAddress,
 						testingResourceManagerGateway.getFencingToken(),
 						timeout

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -21,11 +21,14 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.testutils.BlockerSync;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
@@ -421,10 +424,14 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 	}
 
 	private TestingTaskExecutor createTestingTaskExecutor(TaskManagerServices taskManagerServices, TaskExecutorPartitionTracker partitionTracker, String metricQueryServiceAddress) throws IOException {
-		Configuration configuration = new Configuration();
+		final Configuration configuration = new Configuration();
+		configuration.setString(TaskManagerOptions.TOTAL_PROCESS_MEMORY, "1g");
+		final ResourceProfile defaultSlotResourceProfile =
+			TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(configuration);
+
 		return new TestingTaskExecutor(
 			RPC,
-			TaskManagerConfiguration.fromConfiguration(configuration),
+			TaskManagerConfiguration.fromConfiguration(configuration, defaultSlotResourceProfile),
 			haServices,
 			taskManagerServices,
 			new HeartbeatServices(10_000L, 30_000L),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -426,12 +426,10 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 	private TestingTaskExecutor createTestingTaskExecutor(TaskManagerServices taskManagerServices, TaskExecutorPartitionTracker partitionTracker, String metricQueryServiceAddress) throws IOException {
 		final Configuration configuration = new Configuration();
 		configuration.setString(TaskManagerOptions.TOTAL_PROCESS_MEMORY, "1g");
-		final ResourceProfile defaultSlotResourceProfile =
-			TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(configuration);
 
 		return new TestingTaskExecutor(
 			RPC,
-			TaskManagerConfiguration.fromConfiguration(configuration, defaultSlotResourceProfile),
+			TaskManagerConfiguration.fromConfiguration(configuration, TaskExecutorResourceUtils.resourceSpecFromConfig(configuration)),
 			haServices,
 			taskManagerServices,
 			new HeartbeatServices(10_000L, 30_000L),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -19,17 +19,20 @@
 package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple3;
-import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
@@ -93,14 +96,17 @@ import org.apache.flink.runtime.taskexecutor.exceptions.TaskManagerException;
 import org.apache.flink.runtime.taskexecutor.partition.ClusterPartitionReport;
 import org.apache.flink.runtime.taskexecutor.slot.SlotNotFoundException;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskexecutor.slot.TaskSlot;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotUtils;
+import org.apache.flink.runtime.taskexecutor.slot.TimerService;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.NoOpTaskManagerActions;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerActions;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TestCheckpointResponder;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.ExceptionUtils;
@@ -142,7 +148,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.runtime.taskexecutor.slot.TaskSlotUtils.createDefaultSlots;
@@ -179,6 +184,18 @@ import static org.mockito.Mockito.when;
 public class TaskExecutorTest extends TestLogger {
 
 	public static final HeartbeatServices HEARTBEAT_SERVICES = new HeartbeatServices(1000L, 1000L);
+
+	private static final TaskExecutorResourceSpec TM_RESOURCE_SPEC = new TaskExecutorResourceSpec(
+		new CPUResource(1.0),
+		MemorySize.parse("1m"),
+		MemorySize.parse("2m"),
+		MemorySize.parse("3m"),
+		MemorySize.parse("4m"),
+		MemorySize.parse("5m"),
+		MemorySize.parse("6m"),
+		MemorySize.parse("7m"),
+		MemorySize.parse("8m"));
+
 	@Rule
 	public final TemporaryFolder tmp = new TemporaryFolder();
 
@@ -192,6 +209,8 @@ public class TaskExecutorTest extends TestLogger {
 	private TestingRpcService rpc;
 
 	private BlobCacheService dummyBlobCacheService;
+
+	private TimerService<AllocationID> timerService;
 
 	private Configuration configuration;
 
@@ -214,6 +233,8 @@ public class TaskExecutorTest extends TestLogger {
 	@Before
 	public void setup() throws IOException {
 		rpc = new TestingRpcService();
+		timerService = new TimerService<>(TestingUtils.defaultExecutor(), timeout.toMilliseconds());
+
 		dummyBlobCacheService = new BlobCacheService(
 			new Configuration(),
 			new VoidBlobStore(),
@@ -602,11 +623,11 @@ public class TaskExecutorTest extends TestLogger {
 		ResourceManagerGateway rmGateway2 = mock(ResourceManagerGateway.class);
 
 		when(rmGateway1.registerTaskExecutor(
-					anyString(), any(ResourceID.class), anyInt(), any(HardwareDescription.class), any(Time.class)))
+					anyString(), any(ResourceID.class), anyInt(), any(HardwareDescription.class), any(ResourceProfile.class), any(Time.class)))
 			.thenReturn(CompletableFuture.completedFuture(
 				new TaskExecutorRegistrationSuccess(new InstanceID(), rmResourceId1, new ClusterInformation("localhost", 1234))));
 		when(rmGateway2.registerTaskExecutor(
-					anyString(), any(ResourceID.class), anyInt(), any(HardwareDescription.class), any(Time.class)))
+					anyString(), any(ResourceID.class), anyInt(), any(HardwareDescription.class), any(ResourceProfile.class), any(Time.class)))
 			.thenReturn(CompletableFuture.completedFuture(
 				new TaskExecutorRegistrationSuccess(new InstanceID(), rmResourceId2, new ClusterInformation("localhost", 1234))));
 
@@ -638,7 +659,7 @@ public class TaskExecutorTest extends TestLogger {
 			resourceManagerLeaderRetriever.notifyListener(address1, leaderId1);
 
 			verify(rmGateway1, Mockito.timeout(timeout.toMilliseconds())).registerTaskExecutor(
-					eq(taskManagerAddress), eq(taskManagerLocation.getResourceID()), anyInt(), any(HardwareDescription.class), any(Time.class));
+					eq(taskManagerAddress), eq(taskManagerLocation.getResourceID()), anyInt(), any(HardwareDescription.class), any(ResourceProfile.class), any(Time.class));
 			assertNotNull(taskManager.getResourceManagerConnection());
 
 			// cancel the leader
@@ -648,7 +669,7 @@ public class TaskExecutorTest extends TestLogger {
 			resourceManagerLeaderRetriever.notifyListener(address2, leaderId2);
 
 			verify(rmGateway2, Mockito.timeout(timeout.toMilliseconds())).registerTaskExecutor(
-					eq(taskManagerAddress), eq(taskManagerLocation.getResourceID()), anyInt(), any(HardwareDescription.class), any(Time.class));
+					eq(taskManagerAddress), eq(taskManagerLocation.getResourceID()), anyInt(), any(HardwareDescription.class), any(ResourceProfile.class), any(Time.class));
 			assertNotNull(taskManager.getResourceManagerConnection());
 		}
 		finally {
@@ -1359,10 +1380,7 @@ public class TaskExecutorTest extends TestLogger {
 	 */
 	@Test
 	public void testIgnoringSlotRequestsIfNotRegistered() throws Exception {
-		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
-		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder().setTaskSlotTable(taskSlotTable).build();
-
-		final TaskExecutor taskExecutor = createTaskExecutor(taskManagerServices);
+		final TaskExecutor taskExecutor = createTaskExecutor(1);
 
 		taskExecutor.start();
 
@@ -1452,13 +1470,7 @@ public class TaskExecutorTest extends TestLogger {
 	 */
 	@Test
 	public void testInitialSlotReport() throws Exception {
-		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
-		final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
-		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
-			.setTaskSlotTable(taskSlotTable)
-			.setTaskManagerLocation(taskManagerLocation)
-			.build();
-		final TaskExecutor taskExecutor = createTaskExecutor(taskManagerServices);
+		final TaskExecutor taskExecutor = createTaskExecutor(1);
 
 		taskExecutor.start();
 
@@ -1475,7 +1487,37 @@ public class TaskExecutorTest extends TestLogger {
 			rpc.registerGateway(testingResourceManagerGateway.getAddress(), testingResourceManagerGateway);
 			resourceManagerLeaderRetriever.notifyListener(testingResourceManagerGateway.getAddress(), testingResourceManagerGateway.getFencingToken().toUUID());
 
-			assertThat(initialSlotReportFuture.get(), equalTo(taskManagerLocation.getResourceID()));
+			assertThat(initialSlotReportFuture.get(), equalTo(taskExecutor.getResourceID()));
+		} finally {
+			RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+		}
+	}
+
+	@Test
+	public void testRegisterWithDefaultSlotResourceProfile() throws Exception {
+		final TaskExecutor taskExecutor = createTaskExecutor(1);
+
+		taskExecutor.start();
+
+		try {
+			final TestingResourceManagerGateway testingResourceManagerGateway = new TestingResourceManagerGateway();
+			final CompletableFuture<ResourceProfile> registeredDefaultSlotResourceProfileFuture = new CompletableFuture<>();
+
+			final ResourceID ownResourceId = testingResourceManagerGateway.getOwnResourceId();
+			testingResourceManagerGateway.setRegisterTaskExecutorFunction(t -> {
+				registeredDefaultSlotResourceProfileFuture.complete(t.f4);
+				return CompletableFuture.completedFuture(
+					new TaskExecutorRegistrationSuccess(
+						new InstanceID(),
+						ownResourceId,
+						new ClusterInformation("localhost", 1234)));
+			});
+
+			rpc.registerGateway(testingResourceManagerGateway.getAddress(), testingResourceManagerGateway);
+			resourceManagerLeaderRetriever.notifyListener(testingResourceManagerGateway.getAddress(), testingResourceManagerGateway.getFencingToken().toUUID());
+
+			assertThat(registeredDefaultSlotResourceProfileFuture.get(),
+				equalTo(TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(TM_RESOURCE_SPEC, 2)));
 		} finally {
 			RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
 		}
@@ -1518,12 +1560,9 @@ public class TaskExecutorTest extends TestLogger {
 
 			final CountDownLatch numberRegistrations = new CountDownLatch(2);
 
-			testingResourceManagerGateway.setRegisterTaskExecutorFunction(new Function<Tuple4<String, ResourceID, Integer, HardwareDescription>, CompletableFuture<RegistrationResponse>>() {
-				@Override
-				public CompletableFuture<RegistrationResponse> apply(Tuple4<String, ResourceID, Integer, HardwareDescription> stringResourceIDIntegerHardwareDescriptionTuple4) {
+			testingResourceManagerGateway.setRegisterTaskExecutorFunction(t -> {
 					numberRegistrations.countDown();
 					return registrationResponse;
-				}
 			});
 
 			responseQueue.offer(FutureUtils.completedExceptionally(new FlinkException("Test exception")));
@@ -1894,6 +1933,16 @@ public class TaskExecutorTest extends TestLogger {
 			Executors.directExecutor());
 	}
 
+	private TaskExecutor createTaskExecutor(int numberOFSlots) {
+		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(numberOFSlots);
+		final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
+			.setTaskSlotTable(taskSlotTable)
+			.setTaskManagerLocation(taskManagerLocation)
+			.build();
+		return createTaskExecutor(taskManagerServices);
+	}
+
 	@Nonnull
 	private TaskExecutor createTaskExecutor(TaskManagerServices taskManagerServices) {
 		return createTaskExecutor(taskManagerServices, HEARTBEAT_SERVICES, metricQueryServiceAddress);
@@ -1906,7 +1955,7 @@ public class TaskExecutorTest extends TestLogger {
 	private TaskExecutor createTaskExecutor(TaskManagerServices taskManagerServices, HeartbeatServices heartbeatServices, String metricQueryServiceAddress, TaskExecutorPartitionTracker taskExecutorPartitionTracker) {
 		return new TaskExecutor(
 			rpc,
-			TaskManagerConfiguration.fromConfiguration(configuration),
+			TaskManagerConfiguration.fromConfiguration(configuration, TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(TM_RESOURCE_SPEC, 2)),
 			haServices,
 			taskManagerServices,
 			heartbeatServices,
@@ -1925,7 +1974,7 @@ public class TaskExecutorTest extends TestLogger {
 	private TestingTaskExecutor createTestingTaskExecutor(TaskManagerServices taskManagerServices, HeartbeatServices heartbeatServices, String metricQueryServiceAddress) {
 		return new TestingTaskExecutor(
 			rpc,
-			TaskManagerConfiguration.fromConfiguration(configuration),
+			TaskManagerConfiguration.fromConfiguration(configuration, TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(TM_RESOURCE_SPEC, 2)),
 			haServices,
 			taskManagerServices,
 			heartbeatServices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -1976,7 +1976,7 @@ public class TaskExecutorTest extends TestLogger {
 			assertThat(slotReport, containsInAnyOrder(
 					new SlotStatus(new SlotID(resourceId, 0), DEFAULT_RESOURCE_PROFILE),
 					new SlotStatus(new SlotID(resourceId, 1), DEFAULT_RESOURCE_PROFILE),
-					new SlotStatus(new SlotID(resourceId, 2), resourceProfile, jobId, allocationId)));
+					new SlotStatus(SlotID.generateDynamicSlotID(resourceId), resourceProfile, jobId, allocationId)));
 		} finally {
 			RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -1499,7 +1499,8 @@ public class TaskExecutorTest extends TestLogger {
 
 	@Test
 	public void testRegisterWithDefaultSlotResourceProfile() throws Exception {
-		final TaskExecutor taskExecutor = createTaskExecutor(1);
+		final int numberOfSlots = 2;
+		final TaskExecutor taskExecutor = createTaskExecutor(numberOfSlots);
 
 		taskExecutor.start();
 
@@ -1521,7 +1522,7 @@ public class TaskExecutorTest extends TestLogger {
 			resourceManagerLeaderRetriever.notifyListener(testingResourceManagerGateway.getAddress(), testingResourceManagerGateway.getFencingToken().toUUID());
 
 			assertThat(registeredDefaultSlotResourceProfileFuture.get(),
-				equalTo(TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(TM_RESOURCE_SPEC, 2)));
+				equalTo(TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(TM_RESOURCE_SPEC, numberOfSlots)));
 		} finally {
 			RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
 		}
@@ -1944,6 +1945,7 @@ public class TaskExecutorTest extends TestLogger {
 			.setTaskSlotTable(taskSlotTable)
 			.setTaskManagerLocation(taskManagerLocation)
 			.build();
+		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, numberOFSlots);
 		return createTaskExecutor(taskManagerServices);
 	}
 
@@ -1959,7 +1961,7 @@ public class TaskExecutorTest extends TestLogger {
 	private TaskExecutor createTaskExecutor(TaskManagerServices taskManagerServices, HeartbeatServices heartbeatServices, String metricQueryServiceAddress, TaskExecutorPartitionTracker taskExecutorPartitionTracker) {
 		return new TaskExecutor(
 			rpc,
-			TaskManagerConfiguration.fromConfiguration(configuration, TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(TM_RESOURCE_SPEC, 2)),
+			TaskManagerConfiguration.fromConfiguration(configuration, TM_RESOURCE_SPEC),
 			haServices,
 			taskManagerServices,
 			heartbeatServices,
@@ -1978,7 +1980,7 @@ public class TaskExecutorTest extends TestLogger {
 	private TestingTaskExecutor createTestingTaskExecutor(TaskManagerServices taskManagerServices, HeartbeatServices heartbeatServices, String metricQueryServiceAddress) {
 		return new TestingTaskExecutor(
 			rpc,
-			TaskManagerConfiguration.fromConfiguration(configuration, TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(TM_RESOURCE_SPEC, 2)),
+			TaskManagerConfiguration.fromConfiguration(configuration, TM_RESOURCE_SPEC),
 			haServices,
 			taskManagerServices,
 			heartbeatServices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnectionTest.java
@@ -20,6 +20,7 @@
 package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.instance.HardwareDescription;
@@ -107,7 +108,8 @@ public class TaskExecutorToResourceManagerConnectionTest extends TestLogger {
 			RESOURCE_MANAGER_ADDRESS,
 			RESOURCE_MANAGER_ID,
 			Executors.directExecutor(),
-			new TestRegistrationConnectionListener<>());
+			new TestRegistrationConnectionListener<>(),
+			ResourceProfile.ZERO);
 	}
 
 	private static TaskExecutorRegistrationSuccess successfulRegistration() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnectionTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.registration.RegistrationConnectionListener;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
+import org.apache.flink.runtime.resourcemanager.TaskExecutorRegistration;
 import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.util.TestLogger;
@@ -78,11 +79,11 @@ public class TaskExecutorToResourceManagerConnectionTest extends TestLogger {
 	public void testResourceManagerRegistration() throws Exception {
 		final TaskExecutorToResourceManagerConnection resourceManagerRegistration = createTaskExecutorToResourceManagerConnection();
 
-		testingResourceManagerGateway.setRegisterTaskExecutorFunction(tuple -> {
-			final String actualAddress = tuple.f0;
-			final ResourceID actualResourceId = tuple.f1;
-			final Integer actualDataPort = tuple.f2;
-			final HardwareDescription actualHardwareDescription = tuple.f3;
+		testingResourceManagerGateway.setRegisterTaskExecutorFunction(taskExecutorRegistration -> {
+			final String actualAddress = taskExecutorRegistration.getTaskExecutorAddress();
+			final ResourceID actualResourceId = taskExecutorRegistration.getResourceId();
+			final Integer actualDataPort = taskExecutorRegistration.getDataPort();
+			final HardwareDescription actualHardwareDescription = taskExecutorRegistration.getHardwareDescription();
 
 			assertThat(actualAddress, is(equalTo(TASK_MANAGER_ADDRESS)));
 			assertThat(actualResourceId, is(equalTo(TASK_MANAGER_RESOURCE_ID)));
@@ -97,19 +98,22 @@ public class TaskExecutorToResourceManagerConnectionTest extends TestLogger {
 	}
 
 	private TaskExecutorToResourceManagerConnection createTaskExecutorToResourceManagerConnection() {
+		final TaskExecutorRegistration taskExecutorRegistration = new TaskExecutorRegistration(
+			TASK_MANAGER_ADDRESS,
+			TASK_MANAGER_RESOURCE_ID,
+			TASK_MANAGER_DATA_PORT,
+			TASK_MANAGER_HARDWARE_DESCRIPTION,
+			ResourceProfile.ZERO
+		);
 		return new TaskExecutorToResourceManagerConnection(
 			LOGGER,
 			rpcService,
-			TASK_MANAGER_ADDRESS,
-			TASK_MANAGER_RESOURCE_ID,
 			RetryingRegistrationConfiguration.defaultConfiguration(),
-			TASK_MANAGER_DATA_PORT,
-			TASK_MANAGER_HARDWARE_DESCRIPTION,
 			RESOURCE_MANAGER_ADDRESS,
 			RESOURCE_MANAGER_ID,
 			Executors.directExecutor(),
 			new TestRegistrationConnectionListener<>(),
-			ResourceProfile.ZERO);
+			taskExecutorRegistration);
 	}
 
 	private static TaskExecutorRegistrationSuccess successfulRegistration() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnectionTest.java
@@ -103,6 +103,7 @@ public class TaskExecutorToResourceManagerConnectionTest extends TestLogger {
 			TASK_MANAGER_RESOURCE_ID,
 			TASK_MANAGER_DATA_PORT,
 			TASK_MANAGER_HARDWARE_DESCRIPTION,
+			ResourceProfile.ZERO,
 			ResourceProfile.ZERO
 		);
 		return new TaskExecutorToResourceManagerConnection(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
@@ -194,12 +193,10 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
 	private TestingTaskExecutor createTaskExecutor(TaskManagerServices taskManagerServices, String metricQueryServiceAddress, Configuration configuration) {
 		final Configuration copiedConf = new Configuration(configuration);
 		copiedConf.setString(TaskManagerOptions.TOTAL_FLINK_MEMORY, "1g");
-		final ResourceProfile defaultSlotResourceProfile =
-			TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(copiedConf);
 
 		return new TestingTaskExecutor(
 			testingRpcService,
-			TaskManagerConfiguration.fromConfiguration(copiedConf, defaultSlotResourceProfile),
+			TaskManagerConfiguration.fromConfiguration(copiedConf, TaskExecutorResourceUtils.resourceSpecFromConfig(copiedConf)),
 			haServices,
 			taskManagerServices,
 			heartbeatServices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -20,11 +20,12 @@ package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.api.java.tuple.Tuple5;
+import org.apache.flink.api.java.tuple.Tuple6;
 import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
@@ -64,7 +65,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 
 	private final BiFunction<TaskDeploymentDescriptor, JobMasterId, CompletableFuture<Acknowledge>> submitTaskConsumer;
 
-	private final Function<Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId>, CompletableFuture<Acknowledge>> requestSlotFunction;
+	private final Function<Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId>, CompletableFuture<Acknowledge>> requestSlotFunction;
 
 	private final BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> freeSlotFunction;
 
@@ -84,7 +85,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 			BiConsumer<ResourceID, AllocatedSlotReport> heartbeatJobManagerConsumer,
 			BiConsumer<JobID, Throwable> disconnectJobManagerConsumer,
 			BiFunction<TaskDeploymentDescriptor, JobMasterId, CompletableFuture<Acknowledge>> submitTaskConsumer,
-			Function<Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId>, CompletableFuture<Acknowledge>> requestSlotFunction,
+			Function<Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId>, CompletableFuture<Acknowledge>> requestSlotFunction,
 			BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> freeSlotFunction,
 			Consumer<ResourceID> heartbeatResourceManagerConsumer,
 			Consumer<Exception> disconnectResourceManagerConsumer,
@@ -106,8 +107,8 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 	}
 
 	@Override
-	public CompletableFuture<Acknowledge> requestSlot(SlotID slotId, JobID jobId, AllocationID allocationId, String targetAddress, ResourceManagerId resourceManagerId, Time timeout) {
-		return requestSlotFunction.apply(Tuple5.of(slotId, jobId, allocationId, targetAddress, resourceManagerId));
+	public CompletableFuture<Acknowledge> requestSlot(SlotID slotId, JobID jobId, AllocationID allocationId, ResourceProfile resourceProfile, String targetAddress, ResourceManagerId resourceManagerId, Time timeout) {
+		return requestSlotFunction.apply(Tuple6.of(slotId, jobId, allocationId, resourceProfile, targetAddress, resourceManagerId));
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
@@ -19,9 +19,10 @@
 package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.java.tuple.Tuple5;
+import org.apache.flink.api.java.tuple.Tuple6;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -48,7 +49,7 @@ public class TestingTaskExecutorGatewayBuilder {
 	private static final BiConsumer<ResourceID, AllocatedSlotReport> NOOP_HEARTBEAT_JOBMANAGER_CONSUMER = (ignoredA, ignoredB) -> {};
 	private static final BiConsumer<JobID, Throwable> NOOP_DISCONNECT_JOBMANAGER_CONSUMER = (ignoredA, ignoredB) -> {};
 	private static final BiFunction<TaskDeploymentDescriptor, JobMasterId, CompletableFuture<Acknowledge>> NOOP_SUBMIT_TASK_CONSUMER = (ignoredA, ignoredB) -> CompletableFuture.completedFuture(Acknowledge.get());
-	private static final Function<Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId>, CompletableFuture<Acknowledge>> NOOP_REQUEST_SLOT_FUNCTION = ignored -> CompletableFuture.completedFuture(Acknowledge.get());
+	private static final Function<Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId>, CompletableFuture<Acknowledge>> NOOP_REQUEST_SLOT_FUNCTION = ignored -> CompletableFuture.completedFuture(Acknowledge.get());
 	private static final BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> NOOP_FREE_SLOT_FUNCTION = (ignoredA, ignoredB) -> CompletableFuture.completedFuture(Acknowledge.get());
 	private static final Consumer<ResourceID> NOOP_HEARTBEAT_RESOURCE_MANAGER_CONSUMER = ignored -> {};
 	private static final Consumer<Exception> NOOP_DISCONNECT_RESOURCE_MANAGER_CONSUMER = ignored -> {};
@@ -60,7 +61,7 @@ public class TestingTaskExecutorGatewayBuilder {
 	private BiConsumer<ResourceID, AllocatedSlotReport> heartbeatJobManagerConsumer = NOOP_HEARTBEAT_JOBMANAGER_CONSUMER;
 	private BiConsumer<JobID, Throwable> disconnectJobManagerConsumer = NOOP_DISCONNECT_JOBMANAGER_CONSUMER;
 	private BiFunction<TaskDeploymentDescriptor, JobMasterId, CompletableFuture<Acknowledge>> submitTaskConsumer = NOOP_SUBMIT_TASK_CONSUMER;
-	private Function<Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId>, CompletableFuture<Acknowledge>> requestSlotFunction = NOOP_REQUEST_SLOT_FUNCTION;
+	private Function<Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId>, CompletableFuture<Acknowledge>> requestSlotFunction = NOOP_REQUEST_SLOT_FUNCTION;
 	private BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> freeSlotFunction = NOOP_FREE_SLOT_FUNCTION;
 	private Consumer<ResourceID> heartbeatResourceManagerConsumer = NOOP_HEARTBEAT_RESOURCE_MANAGER_CONSUMER;
 	private Consumer<Exception> disconnectResourceManagerConsumer = NOOP_DISCONNECT_RESOURCE_MANAGER_CONSUMER;
@@ -93,7 +94,7 @@ public class TestingTaskExecutorGatewayBuilder {
 		return this;
 	}
 
-	public TestingTaskExecutorGatewayBuilder setRequestSlotFunction(Function<Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId>, CompletableFuture<Acknowledge>> requestSlotFunction) {
+	public TestingTaskExecutorGatewayBuilder setRequestSlotFunction(Function<Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId>, CompletableFuture<Acknowledge>> requestSlotFunction) {
 		this.requestSlotFunction = requestSlotFunction;
 		return this;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableTest.java
@@ -21,6 +21,11 @@ package org.apache.flink.runtime.taskexecutor.slot;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.taskexecutor.SlotReport;
+import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Sets;
@@ -28,10 +33,13 @@ import org.apache.flink.shaded.guava18.com.google.common.collect.Sets;
 import org.apache.commons.collections.IteratorUtils;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -103,6 +111,132 @@ public class TaskSlotTableTest extends TestLogger {
 			Iterator<TaskSlot> allocatedSlots = taskSlotTable.getAllocatedSlots(jobId);
 			assertThat(allocatedSlots.next().getIndex(), is(0));
 			assertThat(allocatedSlots.hasNext(), is(false));
+		} finally {
+			taskSlotTable.stop();
+		}
+	}
+
+	@Test
+	public void testFreeSlot() throws SlotNotFoundException {
+		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(2);
+
+		try {
+			taskSlotTable.start(new TestingSlotActionsBuilder().build());
+
+			final JobID jobId = new JobID();
+			final AllocationID allocationId1 = new AllocationID();
+			final AllocationID allocationId2 = new AllocationID();
+
+			assertThat(taskSlotTable.allocateSlot(0, jobId, allocationId1, SLOT_TIMEOUT), is(true));
+			assertThat(taskSlotTable.allocateSlot(1, jobId, allocationId2, SLOT_TIMEOUT), is(true));
+
+			assertThat(taskSlotTable.freeSlot(allocationId2), is(1));
+
+			Iterator<TaskSlot> allocatedSlots = taskSlotTable.getAllocatedSlots(jobId);
+			assertThat(allocatedSlots.next().getIndex(), is(0));
+			assertThat(allocatedSlots.hasNext(), is(false));
+			assertThat(taskSlotTable.isAllocated(1, jobId, allocationId1), is(false));
+			assertThat(taskSlotTable.isSlotFree(1), is(true));
+		} finally {
+			taskSlotTable.stop();
+		}
+	}
+
+	@Test
+	public void testSlotAllocationWithDynamicSlotId() {
+		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(2);
+
+		try {
+			taskSlotTable.start(new TestingSlotActionsBuilder().build());
+
+			final JobID jobId = new JobID();
+			final AllocationID allocationId = new AllocationID();
+
+			assertThat(taskSlotTable.allocateSlot(-1, jobId, allocationId, SLOT_TIMEOUT), is(true));
+
+			Iterator<TaskSlot> allocatedSlots = taskSlotTable.getAllocatedSlots(jobId);
+			assertThat(allocatedSlots.next().getIndex(), is(2));
+			assertThat(allocatedSlots.hasNext(), is(false));
+			assertThat(taskSlotTable.isAllocated(2, jobId, allocationId), is(true));
+		} finally {
+			taskSlotTable.stop();
+		}
+	}
+
+	@Test
+	public void testSlotAllocationWithResourceProfile() {
+		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(2);
+
+		try {
+			taskSlotTable.start(new TestingSlotActionsBuilder().build());
+
+			final JobID jobId = new JobID();
+			final AllocationID allocationId = new AllocationID();
+			final ResourceProfile resourceProfile = TaskSlotUtils.DEFAULT_RESOURCE_PROFILE
+				.merge(ResourceProfile.newBuilder().setCpuCores(0.1).build());
+
+			assertThat(taskSlotTable.allocateSlot(-1, jobId, allocationId, resourceProfile, SLOT_TIMEOUT), is(true));
+
+			Iterator<TaskSlot> allocatedSlots = taskSlotTable.getAllocatedSlots(jobId);
+			TaskSlot allocatedSlot = allocatedSlots.next();
+			assertThat(allocatedSlot.getIndex(), is(2));
+			assertThat(allocatedSlot.getResourceProfile(), is(resourceProfile));
+			assertThat(allocatedSlots.hasNext(), is(false));
+		} finally {
+			taskSlotTable.stop();
+		}
+	}
+
+	@Test
+	public void testSlotAllocationWithResourceProfileFailure() {
+		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(2);
+
+		try {
+			taskSlotTable.start(new TestingSlotActionsBuilder().build());
+
+			final JobID jobId = new JobID();
+			final AllocationID allocationId = new AllocationID();
+			ResourceProfile resourceProfile = TaskSlotUtils.DEFAULT_RESOURCE_PROFILE;
+			resourceProfile = resourceProfile.merge(resourceProfile).merge(resourceProfile);
+
+			assertThat(taskSlotTable.allocateSlot(-1, jobId, allocationId, resourceProfile, SLOT_TIMEOUT), is(false));
+
+			Iterator<TaskSlot> allocatedSlots = taskSlotTable.getAllocatedSlots(jobId);
+			assertThat(allocatedSlots.hasNext(), is(false));
+		} finally {
+			taskSlotTable.stop();
+		}
+	}
+
+	@Test
+	public void testGenerateSlotReport() throws SlotNotFoundException {
+		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(3);
+
+		try {
+			taskSlotTable.start(new TestingSlotActionsBuilder().build());
+
+			final JobID jobId = new JobID();
+			final AllocationID allocationId1 = new AllocationID();
+			final AllocationID allocationId2 = new AllocationID();
+			final AllocationID allocationId3 = new AllocationID();
+
+			assertThat(taskSlotTable.allocateSlot(0, jobId, allocationId1, SLOT_TIMEOUT), is(true)); // index 0
+			assertThat(taskSlotTable.allocateSlot(-1, jobId, allocationId2, SLOT_TIMEOUT), is(true)); // index 3
+			assertThat(taskSlotTable.allocateSlot(-1, jobId, allocationId3, SLOT_TIMEOUT), is(true)); // index 4
+
+			assertThat(taskSlotTable.freeSlot(allocationId2), is(3));
+
+			ResourceID resourceId = ResourceID.generate();
+			SlotReport slotReport = taskSlotTable.createSlotReport(resourceId);
+			List<SlotStatus> slotStatuses = new ArrayList<>();
+			slotReport.iterator().forEachRemaining(slotStatuses::add);
+
+			assertThat(slotStatuses.size(), is(4));
+			assertThat(slotStatuses, containsInAnyOrder(
+				is(new SlotStatus(new SlotID(resourceId, 0), TaskSlotUtils.DEFAULT_RESOURCE_PROFILE, jobId, allocationId1)),
+				is(new SlotStatus(new SlotID(resourceId, 1), TaskSlotUtils.DEFAULT_RESOURCE_PROFILE, null, null)),
+				is(new SlotStatus(new SlotID(resourceId, 2), TaskSlotUtils.DEFAULT_RESOURCE_PROFILE, null, null)),
+				is(new SlotStatus(new SlotID(resourceId, 4), TaskSlotUtils.DEFAULT_RESOURCE_PROFILE, jobId, allocationId3))));
 		} finally {
 			taskSlotTable.stop();
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableTest.java
@@ -136,6 +136,7 @@ public class TaskSlotTableTest extends TestLogger {
 			assertThat(allocatedSlots.next().getIndex(), is(0));
 			assertThat(allocatedSlots.hasNext(), is(false));
 			assertThat(taskSlotTable.isAllocated(1, jobId, allocationId1), is(false));
+			assertThat(taskSlotTable.isAllocated(1, jobId, allocationId2), is(false));
 			assertThat(taskSlotTable.isSlotFree(1), is(true));
 		} finally {
 			taskSlotTable.stop();
@@ -155,9 +156,9 @@ public class TaskSlotTableTest extends TestLogger {
 			assertThat(taskSlotTable.allocateSlot(-1, jobId, allocationId, SLOT_TIMEOUT), is(true));
 
 			Iterator<TaskSlot> allocatedSlots = taskSlotTable.getAllocatedSlots(jobId);
-			assertThat(allocatedSlots.next().getIndex(), is(2));
+			assertThat(allocatedSlots.next().getIndex(), is(-1));
 			assertThat(allocatedSlots.hasNext(), is(false));
-			assertThat(taskSlotTable.isAllocated(2, jobId, allocationId), is(true));
+			assertThat(taskSlotTable.isAllocated(-1, jobId, allocationId), is(true));
 		} finally {
 			taskSlotTable.stop();
 		}
@@ -179,7 +180,7 @@ public class TaskSlotTableTest extends TestLogger {
 
 			Iterator<TaskSlot> allocatedSlots = taskSlotTable.getAllocatedSlots(jobId);
 			TaskSlot allocatedSlot = allocatedSlots.next();
-			assertThat(allocatedSlot.getIndex(), is(2));
+			assertThat(allocatedSlot.getIndex(), is(-1));
 			assertThat(allocatedSlot.getResourceProfile(), is(resourceProfile));
 			assertThat(allocatedSlots.hasNext(), is(false));
 		} finally {
@@ -224,7 +225,7 @@ public class TaskSlotTableTest extends TestLogger {
 			assertThat(taskSlotTable.allocateSlot(-1, jobId, allocationId2, SLOT_TIMEOUT), is(true)); // index 3
 			assertThat(taskSlotTable.allocateSlot(-1, jobId, allocationId3, SLOT_TIMEOUT), is(true)); // index 4
 
-			assertThat(taskSlotTable.freeSlot(allocationId2), is(3));
+			assertThat(taskSlotTable.freeSlot(allocationId2), is(-1));
 
 			ResourceID resourceId = ResourceID.generate();
 			SlotReport slotReport = taskSlotTable.createSlotReport(resourceId);
@@ -236,7 +237,7 @@ public class TaskSlotTableTest extends TestLogger {
 				is(new SlotStatus(new SlotID(resourceId, 0), TaskSlotUtils.DEFAULT_RESOURCE_PROFILE, jobId, allocationId1)),
 				is(new SlotStatus(new SlotID(resourceId, 1), TaskSlotUtils.DEFAULT_RESOURCE_PROFILE, null, null)),
 				is(new SlotStatus(new SlotID(resourceId, 2), TaskSlotUtils.DEFAULT_RESOURCE_PROFILE, null, null)),
-				is(new SlotStatus(new SlotID(resourceId, 4), TaskSlotUtils.DEFAULT_RESOURCE_PROFILE, jobId, allocationId3))));
+				is(new SlotStatus(SlotID.generateDynamicSlotID(resourceId), TaskSlotUtils.DEFAULT_RESOURCE_PROFILE, jobId, allocationId3))));
 		} finally {
 			taskSlotTable.stop();
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotUtils.java
@@ -25,22 +25,18 @@ import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
 /** Testing utility and factory methods for {@link TaskSlotTable} and {@link TaskSlot}s. */
 public enum TaskSlotUtils {
 	;
 
 	private static final long DEFAULT_SLOT_TIMEOUT = 10000L;
 
-	private static final ResourceProfile DEFAULT_RESOURCE_PROFILE = ResourceProfile.newBuilder()
-		.setCpuCores(Double.MAX_VALUE)
-		.setTaskHeapMemory(MemorySize.MAX_VALUE)
-		.setTaskOffHeapMemory(MemorySize.MAX_VALUE)
+	public static final ResourceProfile DEFAULT_RESOURCE_PROFILE = ResourceProfile.newBuilder()
+		.setCpuCores(1.0)
+		.setTaskHeapMemory(new MemorySize(100 * 1024))
+		.setTaskOffHeapMemory(MemorySize.ZERO)
 		.setManagedMemory(new MemorySize(10 * MemoryManager.MIN_PAGE_SIZE))
-		.setShuffleMemory(MemorySize.MAX_VALUE)
+		.setShuffleMemory(new MemorySize(100 * 1024))
 		.build();
 
 	public static TaskSlotTable createTaskSlotTable(int numberOfSlots) {
@@ -58,17 +54,23 @@ public enum TaskSlotUtils {
 	private static TaskSlotTable createTaskSlotTable(
 			int numberOfSlots,
 			TimerService<AllocationID> timerService) {
-		return new TaskSlotTable(createDefaultSlots(numberOfSlots), timerService);
+		return new TaskSlotTable(
+			numberOfSlots,
+			createTotalResourceProfile(numberOfSlots),
+			DEFAULT_RESOURCE_PROFILE,
+			MemoryManager.MIN_PAGE_SIZE,
+			timerService);
+	}
+
+	public static ResourceProfile createTotalResourceProfile(int numberOfSlots) {
+		ResourceProfile result = DEFAULT_RESOURCE_PROFILE;
+		for (int i = 0; i < numberOfSlots - 1; ++i) {
+			result = result.merge(DEFAULT_RESOURCE_PROFILE);
+		}
+		return result;
 	}
 
 	public static TimerService<AllocationID> createDefaultTimerService(long shutdownTimeout) {
 		return new TimerService<>(TestingUtils.defaultExecutor(), shutdownTimeout);
-	}
-
-	public static List<TaskSlot> createDefaultSlots(int numberOfSlots) {
-		return IntStream
-			.range(0, numberOfSlots)
-			.mapToObj(index -> new TaskSlot(index, DEFAULT_RESOURCE_PROFILE, MemoryManager.MIN_PAGE_SIZE))
-			.collect(Collectors.toList());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -30,7 +30,9 @@ import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.execution.Environment;
@@ -167,7 +169,12 @@ public class JvmExitOnFatalErrorTest {
 
 				final ShuffleEnvironment<?, ?> shuffleEnvironment = new NettyShuffleEnvironmentBuilder().build();
 
-				final TaskManagerRuntimeInfo tmInfo = TaskManagerConfiguration.fromConfiguration(taskManagerConfig);
+				final Configuration copiedConf = new Configuration(taskManagerConfig);
+				copiedConf.setString(TaskManagerOptions.TOTAL_FLINK_MEMORY, "1024m");
+				final ResourceProfile defaultSlotResourceProfile =
+					TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(copiedConf);
+
+				final TaskManagerRuntimeInfo tmInfo = TaskManagerConfiguration.fromConfiguration(taskManagerConfig, defaultSlotResourceProfile);
 
 				final Executor executor = Executors.newCachedThreadPool();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -32,7 +32,6 @@ import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.execution.Environment;
@@ -171,10 +170,9 @@ public class JvmExitOnFatalErrorTest {
 
 				final Configuration copiedConf = new Configuration(taskManagerConfig);
 				copiedConf.setString(TaskManagerOptions.TOTAL_FLINK_MEMORY, "1024m");
-				final ResourceProfile defaultSlotResourceProfile =
-					TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(copiedConf);
 
-				final TaskManagerRuntimeInfo tmInfo = TaskManagerConfiguration.fromConfiguration(taskManagerConfig, defaultSlotResourceProfile);
+				final TaskManagerRuntimeInfo tmInfo = TaskManagerConfiguration
+					.fromConfiguration(taskManagerConfig, TaskExecutorResourceUtils.resourceSpecFromConfig(copiedConf));
 
 				final Executor executor = Executors.newCachedThreadPool();
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/UtilsTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/UtilsTest.java
@@ -190,7 +190,10 @@ public class UtilsTest extends TestLogger {
 			hdfsDelegationTokenKind, service));
 		amCredentials.writeTokenStorageFile(new org.apache.hadoop.fs.Path(credentialFile.getAbsolutePath()), yarnConf);
 
-		TaskExecutorResourceSpec spec = TaskExecutorResourceUtils.resourceSpecFromConfig(flinkConf, MemorySize.parse("1g"));
+		TaskExecutorResourceSpec spec = TaskExecutorResourceUtils
+			.newResourceSpecBuilder(flinkConf)
+			.withTotalProcessMemory(MemorySize.parse("1g"))
+			.build();
 		ContaineredTaskManagerParameters tmParams = new ContaineredTaskManagerParameters(spec, 1, new HashMap<>(1));
 		Configuration taskManagerConf = new Configuration();
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -446,7 +446,10 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 	private void validateClusterSpecification(ClusterSpecification clusterSpecification) throws FlinkException {
 		MemorySize totalProcessMemory = MemorySize.parse(clusterSpecification.getTaskManagerMemoryMB() + "m");
 		try {
-			TaskExecutorResourceUtils.resourceSpecFromConfig(flinkConfiguration, totalProcessMemory);
+			TaskExecutorResourceUtils
+				.newResourceSpecBuilder(flinkConfiguration)
+				.withTotalProcessMemory(totalProcessMemory)
+				.build();
 		} catch (IllegalArgumentException iae) {
 			throw new FlinkException("Inconsistent cluster specification.", iae);
 		}

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.JobLeaderIdService;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.SlotRequest;
+import org.apache.flink.runtime.resourcemanager.TaskExecutorRegistration;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.resourcemanager.utils.MockResourceManagerRuntimeServices;
@@ -407,14 +408,14 @@ public class YarnResourceManagerTest extends TestLogger {
 				final SlotReport slotReport = new SlotReport(
 					new SlotStatus(new SlotID(taskManagerResourceId, 1), resourceProfile));
 
+				TaskExecutorRegistration taskExecutorRegistration = new TaskExecutorRegistration(
+					taskHost,
+					taskManagerResourceId,
+					dataPort,
+					hardwareDescription,
+					ResourceProfile.ZERO);
 				CompletableFuture<Integer> numberRegisteredSlotsFuture = rmGateway
-					.registerTaskExecutor(
-						taskHost,
-						taskManagerResourceId,
-						dataPort,
-						hardwareDescription,
-						ResourceProfile.ZERO,
-						Time.seconds(10L))
+					.registerTaskExecutor(taskExecutorRegistration, Time.seconds(10L))
 					.thenCompose(
 						(RegistrationResponse response) -> {
 							assertThat(response, instanceOf(TaskExecutorRegistrationSuccess.class));

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -413,6 +413,7 @@ public class YarnResourceManagerTest extends TestLogger {
 					taskManagerResourceId,
 					dataPort,
 					hardwareDescription,
+					ResourceProfile.ZERO,
 					ResourceProfile.ZERO);
 				CompletableFuture<Integer> numberRegisteredSlotsFuture = rmGateway
 					.registerTaskExecutor(taskExecutorRegistration, Time.seconds(10L))

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -413,6 +413,7 @@ public class YarnResourceManagerTest extends TestLogger {
 						taskManagerResourceId,
 						dataPort,
 						hardwareDescription,
+						ResourceProfile.ZERO,
 						Time.seconds(10L))
 					.thenCompose(
 						(RegistrationResponse response) -> {


### PR DESCRIPTION
## What is the purpose of the change

This PR is part fo FLIP-56. It extends `TaskExecutor` to support dynamic slot allocation.
With this PR, the `TaskExecutor` now supports both previous static slot allocation and the new dynamic allocation.
- For dynamic slot allocation, a special `SlotID` (with negative slot index) needs to be provided, as well as a `ResourceProfile` to describe the requested slot resources.
- For static slot allocation, a normal `SlotID` (with slot index in the range of `[0, slotNumber)`) needs to be provided. In such cases, the provided `ResourceProfile` will be ignored, and the default slot resource profile derived from configuration will be used.

This PR is based on #10146.

## Brief change log

- 75d805dfaecb953e72cf84a4439e549a26118539..b083c68650acd6b097dc7049276df080196db26f: Commits of previous PRs.
- aaf47129e5cc2adfd03c0c96749745b22937ee57: Hotfix of refactoring `TaskSlotTable` and `TaskSlot`.
- 0fec80f46457a9f7bd4fdd783c68d4acfd1d65d6: Dynamically create a slot on allocation and destroy a slot on free.
- 0fe0b6618d55bb1d111ed22f7692806bdb07075d: Support allocate slots without pre-defined slot id.
- 8c661dbf866f0153c2c41b370c766e627817a0a6: Introduce `ResourceProfileBudgetManager.` for managing resource reserving and releasing of slots.
- 8d126889bb9986eb575656e2be028c5357e3f1e2: Use `ResourceProfileBudgetManager.` to bookkeep allocated / available resources on the TM side.
- a005c509ee928ea0e30d47a5a94946bd59622166: Generate slot report with TM available resources.
- c54d7b94b9ca46e6b8dc2a072919ab0b1deed022: Task executor supports allocating slots with dynamic resources.

## Verifying this change

Added unit test cases in `TaskSlotTableTest` and `TaskExecutorTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
