### PR TITLE
[FLINK-13905][checkpointing] Separate checkpoint triggering into several asynchronous stages

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.state.SharedStateRegistryFactory;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.util.clock.Clock;
 import org.apache.flink.runtime.util.clock.SystemClock;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StringUtils;
@@ -59,8 +60,10 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadLocalRandom;
@@ -185,6 +188,13 @@ public class CheckpointCoordinator {
 	private final CheckpointFailureManager failureManager;
 
 	private final Clock clock;
+
+	/** Flag represents there is an in-flight trigger request. */
+	private boolean isTriggering = false;
+
+	/** A queue to cache those trigger requests which can't be trigger immediately. */
+	private final ArrayDeque<CheckpointTriggerRequest> triggerRequestQueue;
+
 	// --------------------------------------------------------------------------------------------
 
 	public CheckpointCoordinator(
@@ -269,6 +279,7 @@ public class CheckpointCoordinator {
 
 		this.recentPendingCheckpoints = new ArrayDeque<>(NUM_GHOST_CHECKPOINT_IDS);
 		this.masterHooks = new HashMap<>();
+		this.triggerRequestQueue = new ArrayDeque<>();
 
 		this.timer = timer;
 
@@ -361,10 +372,10 @@ public class CheckpointCoordinator {
 				MasterHooks.close(masterHooks.values(), LOG);
 				masterHooks.clear();
 
-				// clear and discard all pending checkpoints
-				abortPendingCheckpoints(
-					new CheckpointException(
-						CheckpointFailureReason.CHECKPOINT_COORDINATOR_SHUTDOWN));
+				final CheckpointException reason = new CheckpointException(
+					CheckpointFailureReason.CHECKPOINT_COORDINATOR_SHUTDOWN);
+				// clear queued requests and in-flight checkpoints
+				abortPendingAndQueuedCheckpoints(reason);
 
 				completedCheckpointStore.shutdown(jobStatus);
 				checkpointIdCounter.shutdown(jobStatus);
@@ -433,26 +444,19 @@ public class CheckpointCoordinator {
 		// TODO, call triggerCheckpoint directly after removing timer thread
 		// for now, execute the trigger in timer thread to avoid competition
 		final CompletableFuture<CompletedCheckpoint> resultFuture = new CompletableFuture<>();
-		timer.execute(() -> {
-			try {
-				triggerCheckpoint(
-					timestamp,
-					checkpointProperties,
-					targetLocation,
-					false,
-					advanceToEndOfEventTime).
-				whenComplete((completedCheckpoint, throwable) -> {
-					if (throwable == null) {
-						resultFuture.complete(completedCheckpoint);
-					} else {
-						resultFuture.completeExceptionally(throwable);
-					}
-				});
-			} catch (CheckpointException e) {
-				Throwable cause = new CheckpointException("Failed to trigger savepoint.", e.getCheckpointFailureReason());
-				resultFuture.completeExceptionally(cause);
+		timer.execute(() -> triggerCheckpoint(
+			timestamp,
+			checkpointProperties,
+			targetLocation,
+			false,
+			advanceToEndOfEventTime)
+		.whenComplete((completedCheckpoint, throwable) -> {
+			if (throwable == null) {
+				resultFuture.complete(completedCheckpoint);
+			} else {
+				resultFuture.completeExceptionally(throwable);
 			}
-		});
+		}));
 		return resultFuture;
 	}
 
@@ -468,15 +472,7 @@ public class CheckpointCoordinator {
 	 * @return a future to the completed checkpoint.
 	 */
 	public CompletableFuture<CompletedCheckpoint> triggerCheckpoint(long timestamp, boolean isPeriodic) {
-		try {
-			return triggerCheckpoint(timestamp, checkpointProperties, null, isPeriodic, false);
-		} catch (CheckpointException e) {
-			long latestGeneratedCheckpointId = getCheckpointIdCounter().get();
-			// here we can not get the failed pending checkpoint's id,
-			// so we pass the negative latest generated checkpoint id as a special flag
-			failureManager.handleJobLevelCheckpointException(e, -1 * latestGeneratedCheckpointId);
-			return FutureUtils.completedExceptionally(e);
-		}
+		return triggerCheckpoint(timestamp, checkpointProperties, null, isPeriodic, false);
 	}
 
 	@VisibleForTesting
@@ -485,76 +481,152 @@ public class CheckpointCoordinator {
 			CheckpointProperties props,
 			@Nullable String externalSavepointLocation,
 			boolean isPeriodic,
-			boolean advanceToEndOfTime) throws CheckpointException {
+			boolean advanceToEndOfTime) {
 
 		if (advanceToEndOfTime && !(props.isSynchronous() && props.isSavepoint())) {
-			throw new IllegalArgumentException("Only synchronous savepoints are allowed to advance the watermark to MAX.");
+			return FutureUtils.completedExceptionally(new IllegalArgumentException(
+				"Only synchronous savepoints are allowed to advance the watermark to MAX."));
 		}
 
-		// make some eager pre-checks
+		final CompletableFuture<CompletedCheckpoint> onCompletionPromise =
+			new CompletableFuture<>();
 		synchronized (lock) {
-			preCheckBeforeTriggeringCheckpoint(isPeriodic, props.forceCheckpoint());
-		}
-
-		// check if all tasks that we need to trigger are running.
-		// if not, abort the checkpoint
-		Execution[] executions = new Execution[tasksToTrigger.length];
-		for (int i = 0; i < tasksToTrigger.length; i++) {
-			Execution ee = tasksToTrigger[i].getCurrentExecutionAttempt();
-			if (ee == null) {
-				LOG.info("Checkpoint triggering task {} of job {} is not being executed at the moment. Aborting checkpoint.",
-						tasksToTrigger[i].getTaskNameWithSubtaskIndex(),
-						job);
-				throw new CheckpointException(CheckpointFailureReason.NOT_ALL_REQUIRED_TASKS_RUNNING);
-			} else if (ee.getState() == ExecutionState.RUNNING) {
-				executions[i] = ee;
-			} else {
-				LOG.info("Checkpoint triggering task {} of job {} is not in state {} but {} instead. Aborting checkpoint.",
-						tasksToTrigger[i].getTaskNameWithSubtaskIndex(),
-						job,
-						ExecutionState.RUNNING,
-						ee.getState());
-				throw new CheckpointException(CheckpointFailureReason.NOT_ALL_REQUIRED_TASKS_RUNNING);
+			if (isTriggering || !triggerRequestQueue.isEmpty()) {
+				// we can't trigger checkpoint directly if there is a trigger request being processed
+				// or queued
+				triggerRequestQueue.add(new CheckpointTriggerRequest(
+					timestamp,
+					props,
+					externalSavepointLocation,
+					isPeriodic,
+					advanceToEndOfTime,
+					onCompletionPromise));
+				return onCompletionPromise;
 			}
 		}
+		startTriggeringCheckpoint(
+			timestamp,
+			props,
+			externalSavepointLocation,
+			isPeriodic,
+			advanceToEndOfTime,
+			onCompletionPromise);
+		return onCompletionPromise;
+	}
 
-		// next, check if all tasks that need to acknowledge the checkpoint are running.
-		// if not, abort the checkpoint
-		Map<ExecutionAttemptID, ExecutionVertex> ackTasks = new HashMap<>(tasksToWaitFor.length);
-
-		for (ExecutionVertex ev : tasksToWaitFor) {
-			Execution ee = ev.getCurrentExecutionAttempt();
-			if (ee != null) {
-				ackTasks.put(ee.getAttemptId(), ev);
-			} else {
-				LOG.info("Checkpoint acknowledging task {} of job {} is not being executed at the moment. Aborting checkpoint.",
-						ev.getTaskNameWithSubtaskIndex(),
-						job);
-				throw new CheckpointException(CheckpointFailureReason.NOT_ALL_REQUIRED_TASKS_RUNNING);
-			}
-		}
-
-		// we will actually trigger this checkpoint!
-
-		final CheckpointStorageLocation checkpointStorageLocation;
-		final long checkpointID;
+	private void startTriggeringCheckpoint(
+		long timestamp,
+		CheckpointProperties props,
+		@Nullable String externalSavepointLocation,
+		boolean isPeriodic,
+		boolean advanceToEndOfTime,
+		CompletableFuture<CompletedCheckpoint> onCompletionPromise) {
 
 		try {
-			// this must happen outside the coordinator-wide lock, because it communicates
-			// with external services (in HA mode) and may block for a while.
-			checkpointID = checkpointIdCounter.getAndIncrement();
+			// make some eager pre-checks
+			synchronized (lock) {
+				preCheckBeforeTriggeringCheckpoint(isPeriodic, props.forceCheckpoint());
+			}
 
-			checkpointStorageLocation = props.isSavepoint() ?
-					checkpointStorage.initializeLocationForSavepoint(checkpointID, externalSavepointLocation) :
-					checkpointStorage.initializeLocationForCheckpoint(checkpointID);
+			final Execution[] executions = getTriggerExecutions();
+			final Map<ExecutionAttemptID, ExecutionVertex> ackTasks = getAckTasks();
+
+			// we will actually trigger this checkpoint!
+			Preconditions.checkState(!isTriggering);
+			isTriggering = true;
+
+			final CompletableFuture<PendingCheckpoint> pendingCheckpointCompletableFuture =
+				initializeCheckpoint(props, externalSavepointLocation)
+					.thenApplyAsync(
+						(checkpointIdAndStorageLocation) -> createPendingCheckpoint(
+							timestamp,
+							props,
+							ackTasks,
+							isPeriodic,
+							checkpointIdAndStorageLocation.checkpointId,
+							checkpointIdAndStorageLocation.checkpointStorageLocation,
+							onCompletionPromise),
+						timer);
+
+			pendingCheckpointCompletableFuture
+				.thenCompose(this::snapshotMasterState)
+				.whenCompleteAsync(
+					(ignored, throwable) -> {
+						final PendingCheckpoint checkpoint =
+							FutureUtils.getWithoutException(pendingCheckpointCompletableFuture);
+
+						if (throwable == null && checkpoint != null && !checkpoint.isDiscarded()) {
+							// no exception, no discarding, everything is OK
+							snapshotTaskState(
+								timestamp,
+								checkpoint.getCheckpointId(),
+								checkpoint.getCheckpointStorageLocation(),
+								props,
+								executions,
+								advanceToEndOfTime);
+							onTriggerSuccess();
+						} else {
+								// the initialization might not be finished yet
+								if (checkpoint == null) {
+									onTriggerFailure(onCompletionPromise, throwable);
+								} else {
+									onTriggerFailure(checkpoint, throwable);
+								}
+						}
+					},
+					timer);
+		} catch (Throwable throwable) {
+			onTriggerFailure(onCompletionPromise, throwable);
 		}
-		catch (Throwable t) {
-			int numUnsuccessful = numUnsuccessfulCheckpointsTriggers.incrementAndGet();
-			LOG.warn("Failed to trigger checkpoint for job {} ({} consecutive failed attempts so far).",
-					job,
-					numUnsuccessful,
-					t);
-			throw new CheckpointException(CheckpointFailureReason.EXCEPTION, t);
+	}
+
+	/**
+	 * Initialize the checkpoint trigger asynchronously. It will be executed in io thread due to
+	 * it might be time-consuming.
+	 *
+	 * @param props checkpoint properties
+	 * @param externalSavepointLocation the external savepoint location, it might be null
+	 * @return the future of initialized result, checkpoint id and checkpoint location
+	 */
+	private CompletableFuture<CheckpointIdAndStorageLocation> initializeCheckpoint(
+		CheckpointProperties props,
+		@Nullable String externalSavepointLocation) {
+
+		return CompletableFuture.supplyAsync(() -> {
+			try {
+				// this must happen outside the coordinator-wide lock, because it communicates
+				// with external services (in HA mode) and may block for a while.
+				long checkpointID = checkpointIdCounter.getAndIncrement();
+
+				CheckpointStorageLocation checkpointStorageLocation = props.isSavepoint() ?
+					checkpointStorage
+						.initializeLocationForSavepoint(checkpointID, externalSavepointLocation) :
+					checkpointStorage.initializeLocationForCheckpoint(checkpointID);
+
+				return new CheckpointIdAndStorageLocation(checkpointID, checkpointStorageLocation);
+			} catch (Throwable throwable) {
+				throw new CompletionException(throwable);
+			}
+		}, executor);
+	}
+
+	private PendingCheckpoint createPendingCheckpoint(
+		long timestamp,
+		CheckpointProperties props,
+		Map<ExecutionAttemptID, ExecutionVertex> ackTasks,
+		boolean isPeriodic,
+		long checkpointID,
+		CheckpointStorageLocation checkpointStorageLocation,
+		CompletableFuture<CompletedCheckpoint> onCompletionPromise) {
+
+		synchronized (lock) {
+			try {
+				// since we haven't created the PendingCheckpoint yet, we need to check the
+				// global state here.
+				preCheckGlobalState(isPeriodic);
+			} catch (Throwable t) {
+				throw new CompletionException(t);
+			}
 		}
 
 		final PendingCheckpoint checkpoint = new PendingCheckpoint(
@@ -565,7 +637,8 @@ public class CheckpointCoordinator {
 			masterHooks.keySet(),
 			props,
 			checkpointStorageLocation,
-			executor);
+			executor,
+			onCompletionPromise);
 
 		if (statsTracker != null) {
 			PendingCheckpointStats callback = statsTracker.reportPendingCheckpoint(
@@ -576,85 +649,183 @@ public class CheckpointCoordinator {
 			checkpoint.setStatsCallback(callback);
 		}
 
-		// schedule the timer that will clean up the expired checkpoints
-		final Runnable canceller = () -> {
-			synchronized (lock) {
-				// only do the work if the checkpoint is not discarded anyways
-				// note that checkpoint completion discards the pending checkpoint object
-				if (!checkpoint.isDiscarded()) {
-					LOG.info("Checkpoint {} of job {} expired before completing.", checkpointID, job);
+		synchronized (lock) {
 
-					abortPendingCheckpoint(
-						checkpoint,
-						new CheckpointException(CheckpointFailureReason.CHECKPOINT_EXPIRED));
-				}
+			pendingCheckpoints.put(checkpointID, checkpoint);
+
+			ScheduledFuture<?> cancellerHandle = timer.schedule(
+				new CheckpointCanceller(checkpoint),
+				checkpointTimeout, TimeUnit.MILLISECONDS);
+
+			if (!checkpoint.setCancellerHandle(cancellerHandle)) {
+				// checkpoint is already disposed!
+				cancellerHandle.cancel(false);
 			}
-		};
-
-		try {
-			// re-acquire the coordinator-wide lock
-			synchronized (lock) {
-				preCheckBeforeTriggeringCheckpoint(isPeriodic, props.forceCheckpoint());
-
-				LOG.info("Triggering checkpoint {} @ {} for job {}.", checkpointID, timestamp, job);
-
-				pendingCheckpoints.put(checkpointID, checkpoint);
-
-				ScheduledFuture<?> cancellerHandle = timer.schedule(
-						canceller,
-						checkpointTimeout, TimeUnit.MILLISECONDS);
-
-				if (!checkpoint.setCancellerHandle(cancellerHandle)) {
-					// checkpoint is already disposed!
-					cancellerHandle.cancel(false);
-				}
-
-				// TODO, asynchronously snapshots master hook without waiting here
-				for (MasterTriggerRestoreHook<?> masterHook : masterHooks.values()) {
-					final MasterState masterState =
-						MasterHooks.triggerHook(masterHook, checkpointID, timestamp, executor)
-							.get(checkpointTimeout, TimeUnit.MILLISECONDS);
-					checkpoint.acknowledgeMasterState(masterHook.getIdentifier(), masterState);
-				}
-				Preconditions.checkState(checkpoint.areMasterStatesFullyAcknowledged());
-			}
-			// end of lock scope
-
-			final CheckpointOptions checkpointOptions = new CheckpointOptions(
-					props.getCheckpointType(),
-					checkpointStorageLocation.getLocationReference());
-
-			// send the messages to the tasks that trigger their checkpoint
-			for (Execution execution: executions) {
-				if (props.isSynchronous()) {
-					execution.triggerSynchronousSavepoint(checkpointID, timestamp, checkpointOptions, advanceToEndOfTime);
-				} else {
-					execution.triggerCheckpoint(checkpointID, timestamp, checkpointOptions);
-				}
-			}
-
-			numUnsuccessfulCheckpointsTriggers.set(0);
-			return checkpoint.getCompletionFuture();
 		}
-		catch (Throwable t) {
-			int numUnsuccessful = numUnsuccessfulCheckpointsTriggers.incrementAndGet();
-			LOG.warn("Failed to trigger checkpoint {} for job {}. ({} consecutive failed attempts so far)",
-					checkpointID, job, numUnsuccessful, t);
 
-			synchronized (lock) {
-				if (!checkpoint.isDiscarded()) {
-					abortPendingCheckpoint(
-						checkpoint,
-						new CheckpointException(
-							CheckpointFailureReason.TRIGGER_CHECKPOINT_FAILURE, t));
+		LOG.info("Triggering checkpoint {} @ {} for job {}.", checkpointID, timestamp, job);
+		return checkpoint;
+	}
+
+	/**
+	 * Snapshot master hook states asynchronously.
+	 *
+	 * @param checkpoint the pending checkpoint
+	 * @return the future represents master hook states are finished or not
+	 */
+	private CompletableFuture<Void> snapshotMasterState(PendingCheckpoint checkpoint) {
+		if (masterHooks.isEmpty()) {
+			return CompletableFuture.completedFuture(null);
+		}
+
+		final long checkpointID = checkpoint.getCheckpointId();
+		final long timestamp = checkpoint.getCheckpointTimestamp();
+
+		final CompletableFuture<Void> masterStateCompletableFuture = new CompletableFuture<>();
+		for (MasterTriggerRestoreHook<?> masterHook : masterHooks.values()) {
+			MasterHooks
+				.triggerHook(masterHook, checkpointID, timestamp, executor)
+				.whenCompleteAsync(
+					(masterState, throwable) -> {
+						try {
+							synchronized (lock) {
+								if (masterStateCompletableFuture.isDone()) {
+									return;
+								}
+								if (checkpoint.isDiscarded()) {
+									throw new IllegalStateException(
+										"Checkpoint " + checkpointID + " has been discarded");
+								}
+								if (throwable == null) {
+									checkpoint.acknowledgeMasterState(
+										masterHook.getIdentifier(), masterState);
+									if (checkpoint.areMasterStatesFullyAcknowledged()) {
+										masterStateCompletableFuture.complete(null);
+									}
+								} else {
+									masterStateCompletableFuture.completeExceptionally(throwable);
+								}
+							}
+						} catch (Throwable t) {
+							masterStateCompletableFuture.completeExceptionally(t);
+						}
+					},
+					timer);
+		}
+		return masterStateCompletableFuture;
+	}
+
+	/**
+	 * Snapshot task state.
+	 *
+	 * @param timestamp the timestamp of this checkpoint reques
+	 * @param checkpointID the checkpoint id
+	 * @param checkpointStorageLocation the checkpoint location
+	 * @param props the checkpoint properties
+	 * @param executions the executions which should be triggered
+	 * @param advanceToEndOfTime Flag indicating if the source should inject a {@code MAX_WATERMARK}
+	 *                               in the pipeline to fire any registered event-time timers.
+	 */
+	private void snapshotTaskState(
+		long timestamp,
+		long checkpointID,
+		CheckpointStorageLocation checkpointStorageLocation,
+		CheckpointProperties props,
+		Execution[] executions,
+		boolean advanceToEndOfTime) {
+
+		final CheckpointOptions checkpointOptions = new CheckpointOptions(
+			props.getCheckpointType(),
+			checkpointStorageLocation.getLocationReference());
+
+		// send the messages to the tasks that trigger their checkpoint
+		for (Execution execution: executions) {
+			if (props.isSynchronous()) {
+				execution.triggerSynchronousSavepoint(checkpointID, timestamp, checkpointOptions, advanceToEndOfTime);
+			} else {
+				execution.triggerCheckpoint(checkpointID, timestamp, checkpointOptions);
+			}
+		}
+	}
+
+	/**
+	 * Trigger request is successful.
+	 * NOTE, it must be invoked if trigger request is successful.
+	 */
+	private void onTriggerSuccess() {
+		isTriggering = false;
+		numUnsuccessfulCheckpointsTriggers.set(0);
+		checkQueuedCheckpointTriggerRequest();
+	}
+
+	/**
+	 * The trigger request is failed prematurely without a proper initialization.
+	 * There is no resource to release, but the completion promise needs to fail manually here.
+	 *
+	 * @param onCompletionPromise the completion promise of the checkpoint/savepoint
+	 * @param throwable the reason of trigger failure
+	 */
+	private void onTriggerFailure(
+		CompletableFuture<CompletedCheckpoint> onCompletionPromise, Throwable throwable) {
+		final CheckpointException checkpointException =
+			getCheckpointException(CheckpointFailureReason.TRIGGER_CHECKPOINT_FAILURE, throwable);
+		onCompletionPromise.completeExceptionally(checkpointException);
+		onTriggerFailure((PendingCheckpoint) null, checkpointException);
+	}
+
+	/**
+	 * The trigger request is failed.
+	 * NOTE, it must be invoked if trigger request is failed.
+	 *
+	 * @param checkpoint the pending checkpoint which is failed. It could be null if it's failed
+	 *                   prematurely without a proper initialization.
+	 * @param throwable the reason of trigger failure
+	 */
+	private void onTriggerFailure(@Nullable PendingCheckpoint checkpoint, Throwable throwable) {
+		try {
+			if (checkpoint != null && !checkpoint.isDiscarded()) {
+				int numUnsuccessful = numUnsuccessfulCheckpointsTriggers.incrementAndGet();
+				LOG.warn(
+					"Failed to trigger checkpoint {} for job {}. ({} consecutive failed attempts so far)",
+					checkpoint.getCheckpointId(),
+					job,
+					numUnsuccessful,
+					throwable);
+				final CheckpointException cause =
+					getCheckpointException(
+						CheckpointFailureReason.TRIGGER_CHECKPOINT_FAILURE, throwable);
+				synchronized (lock) {
+					abortPendingCheckpoint(checkpoint, cause);
 				}
 			}
+		} finally {
+			isTriggering = false;
+			checkQueuedCheckpointTriggerRequest();
+		}
+	}
 
-			// rethrow the CheckpointException directly.
-			if (t instanceof CheckpointException) {
-				throw (CheckpointException) t;
+	/**
+	 * Checks whether there is a trigger request queued. Consumes it if there is one.
+	 * NOTE: this must be called after each triggering
+	 */
+	private void checkQueuedCheckpointTriggerRequest() {
+		synchronized (lock) {
+			if (triggerRequestQueue.isEmpty()) {
+				return;
 			}
-			throw new CheckpointException(CheckpointFailureReason.EXCEPTION, t);
+		}
+		final CheckpointTriggerRequest request;
+		synchronized (lock) {
+			request = triggerRequestQueue.poll();
+		}
+		if (request != null) {
+			startTriggeringCheckpoint(
+				request.timestamp,
+				request.props,
+				request.externalSavepointLocation,
+				request.isPeriodic,
+				request.advanceToEndOfTime,
+				request.onCompletionPromise);
 		}
 	}
 
@@ -705,12 +876,9 @@ public class CheckpointCoordinator {
 				if (message.getReason() == null) {
 					checkpointException =
 						new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED);
-				} else if (message.getReason() instanceof CheckpointException) {
-					checkpointException = (CheckpointException) message.getReason();
 				} else {
-					checkpointException =
-						new CheckpointException(
-							CheckpointFailureReason.JOB_FAILURE, message.getReason());
+					checkpointException = getCheckpointException(
+						CheckpointFailureReason.JOB_FAILURE, message.getReason());
 				}
 				abortPendingCheckpoint(
 					checkpoint,
@@ -1181,12 +1349,16 @@ public class CheckpointCoordinator {
 		return completedCheckpointStore;
 	}
 
-	public CheckpointIDCounter getCheckpointIdCounter() {
-		return checkpointIdCounter;
-	}
-
 	public long getCheckpointTimeout() {
 		return checkpointTimeout;
+	}
+
+	public ArrayDeque<CheckpointTriggerRequest> getTriggerRequestQueue() {
+		return triggerRequestQueue;
+	}
+
+	public boolean isTriggering() {
+		return isTriggering;
 	}
 
 	@VisibleForTesting
@@ -1231,8 +1403,9 @@ public class CheckpointCoordinator {
 				currentPeriodicTrigger = null;
 			}
 
-			abortPendingCheckpoints(
-				new CheckpointException(CheckpointFailureReason.CHECKPOINT_COORDINATOR_SUSPEND));
+			final CheckpointException reason =
+				new CheckpointException(CheckpointFailureReason.CHECKPOINT_COORDINATOR_SUSPEND);
+			abortPendingAndQueuedCheckpoints(reason);
 
 			numUnsuccessfulCheckpointsTriggers.set(0);
 		}
@@ -1419,6 +1592,15 @@ public class CheckpointCoordinator {
 	}
 
 	private void preCheckBeforeTriggeringCheckpoint(boolean isPeriodic, boolean forceCheckpoint) throws CheckpointException {
+		preCheckGlobalState(isPeriodic);
+
+		if (!forceCheckpoint) {
+			checkConcurrentCheckpoints();
+			checkMinPauseBetweenCheckpoints();
+		}
+	}
+
+	private void preCheckGlobalState(boolean isPeriodic) throws CheckpointException {
 		// abort if the coordinator has been shutdown in the meantime
 		if (shutdown) {
 			throw new CheckpointException(CheckpointFailureReason.CHECKPOINT_COORDINATOR_SHUTDOWN);
@@ -1428,10 +1610,149 @@ public class CheckpointCoordinator {
 		if (isPeriodic && !periodicScheduling) {
 			throw new CheckpointException(CheckpointFailureReason.PERIODIC_SCHEDULER_SHUTDOWN);
 		}
+	}
 
-		if (!forceCheckpoint) {
-			checkConcurrentCheckpoints();
-			checkMinPauseBetweenCheckpoints();
+	/**
+	 * Check if all tasks that we need to trigger are running. If not, abort the checkpoint.
+	 *
+	 * @return the executions need to be triggered.
+	 * @throws CheckpointException the exception fails checking
+	 */
+	private Execution[] getTriggerExecutions() throws CheckpointException {
+		Execution[] executions = new Execution[tasksToTrigger.length];
+		for (int i = 0; i < tasksToTrigger.length; i++) {
+			Execution ee = tasksToTrigger[i].getCurrentExecutionAttempt();
+			if (ee == null) {
+				LOG.info(
+					"Checkpoint triggering task {} of job {} is not being executed at the moment. Aborting checkpoint.",
+					tasksToTrigger[i].getTaskNameWithSubtaskIndex(),
+					job);
+				throw new CheckpointException(
+					CheckpointFailureReason.NOT_ALL_REQUIRED_TASKS_RUNNING);
+			} else if (ee.getState() == ExecutionState.RUNNING) {
+				executions[i] = ee;
+			} else {
+				LOG.info(
+					"Checkpoint triggering task {} of job {} is not in state {} but {} instead. Aborting checkpoint.",
+					tasksToTrigger[i].getTaskNameWithSubtaskIndex(),
+					job,
+					ExecutionState.RUNNING,
+					ee.getState());
+				throw new CheckpointException(
+					CheckpointFailureReason.NOT_ALL_REQUIRED_TASKS_RUNNING);
+			}
+		}
+		return executions;
+	}
+
+	/**
+	 * Check if all tasks that need to acknowledge the checkpoint are running.
+	 * If not, abort the checkpoint
+	 *
+	 * @return the execution vertices which should give an ack response
+	 * @throws CheckpointException the exception fails checking
+	 */
+	private Map<ExecutionAttemptID, ExecutionVertex> getAckTasks() throws CheckpointException {
+		Map<ExecutionAttemptID, ExecutionVertex> ackTasks = new HashMap<>(tasksToWaitFor.length);
+
+		for (ExecutionVertex ev : tasksToWaitFor) {
+			Execution ee = ev.getCurrentExecutionAttempt();
+			if (ee != null) {
+				ackTasks.put(ee.getAttemptId(), ev);
+			} else {
+				LOG.info(
+					"Checkpoint acknowledging task {} of job {} is not being executed at the moment. Aborting checkpoint.",
+					ev.getTaskNameWithSubtaskIndex(),
+					job);
+				throw new CheckpointException(
+					CheckpointFailureReason.NOT_ALL_REQUIRED_TASKS_RUNNING);
+			}
+		}
+		return ackTasks;
+	}
+
+	private void abortPendingAndQueuedCheckpoints(CheckpointException exception) {
+		assert(Thread.holdsLock(lock));
+		CheckpointTriggerRequest request;
+		while ((request = triggerRequestQueue.poll()) != null) {
+			request.onCompletionPromise.completeExceptionally(exception);
+		}
+		abortPendingCheckpoints(exception);
+	}
+
+	/**
+	 * The canceller of checkpoint. The checkpoint might be cancelled if it doesn't finish in a
+	 * configured period.
+	 */
+	private class CheckpointCanceller implements Runnable {
+
+		private final PendingCheckpoint pendingCheckpoint;
+
+		private CheckpointCanceller(PendingCheckpoint pendingCheckpoint) {
+			this.pendingCheckpoint = checkNotNull(pendingCheckpoint);
+		}
+
+		@Override
+		public void run() {
+			synchronized (lock) {
+				// only do the work if the checkpoint is not discarded anyways
+				// note that checkpoint completion discards the pending checkpoint object
+				if (!pendingCheckpoint.isDiscarded()) {
+					LOG.info("Checkpoint {} of job {} expired before completing.",
+						pendingCheckpoint.getCheckpointId(), job);
+
+					abortPendingCheckpoint(
+						pendingCheckpoint,
+						new CheckpointException(CheckpointFailureReason.CHECKPOINT_EXPIRED));
+				}
+			}
+		}
+	}
+
+	private static CheckpointException getCheckpointException(
+		CheckpointFailureReason defaultReason, Throwable throwable) {
+
+		final Optional<CheckpointException> checkpointExceptionOptional =
+			ExceptionUtils.findThrowable(throwable, CheckpointException.class);
+		return checkpointExceptionOptional
+			.orElseGet(() -> new CheckpointException(defaultReason, throwable));
+	}
+
+	private static class CheckpointIdAndStorageLocation {
+		private final long checkpointId;
+		private final CheckpointStorageLocation checkpointStorageLocation;
+
+		CheckpointIdAndStorageLocation(
+			long checkpointId,
+			CheckpointStorageLocation checkpointStorageLocation) {
+
+			this.checkpointId = checkpointId;
+			this.checkpointStorageLocation = checkNotNull(checkpointStorageLocation);
+		}
+	}
+
+	private static class CheckpointTriggerRequest {
+		private final long timestamp;
+		private final CheckpointProperties props;
+		private final @Nullable String externalSavepointLocation;
+		private final boolean isPeriodic;
+		private final boolean advanceToEndOfTime;
+		private final CompletableFuture<CompletedCheckpoint> onCompletionPromise;
+
+		CheckpointTriggerRequest(
+			long timestamp,
+			CheckpointProperties props,
+			@Nullable String externalSavepointLocation,
+			boolean isPeriodic,
+			boolean advanceToEndOfTime,
+			CompletableFuture<CompletedCheckpoint> onCompletionPromise) {
+
+			this.timestamp = timestamp;
+			this.props = checkNotNull(props);
+			this.externalSavepointLocation = externalSavepointLocation;
+			this.isPeriodic = isPeriodic;
+			this.advanceToEndOfTime = advanceToEndOfTime;
+			this.onCompletionPromise = checkNotNull(onCompletionPromise);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -163,9 +163,9 @@ public class CheckpointCoordinator {
 	 * Non-volatile, because only accessed in synchronized scope */
 	private boolean periodicScheduling;
 
-	/** Flag whether a trigger request could not be handled immediately. Non-volatile, because only
-	 * accessed in synchronized scope */
-	private boolean triggerRequestQueued;
+	/** Flag whether periodic triggering is suspended (too many concurrent pending checkpoint).
+	 * Non-volatile, because only accessed in synchronized scope */
+	private boolean periodicTriggeringSuspended;
 
 	/** Flag marking the coordinator as shut down (not accepting any messages any more). */
 	private volatile boolean shutdown;
@@ -355,7 +355,7 @@ public class CheckpointCoordinator {
 				LOG.info("Stopping checkpoint coordinator for job {}.", job);
 
 				periodicScheduling = false;
-				triggerRequestQueued = false;
+				periodicTriggeringSuspended = false;
 
 				// shut down the hooks
 				MasterHooks.close(masterHooks.values(), LOG);
@@ -884,7 +884,7 @@ public class CheckpointCoordinator {
 		} finally {
 			pendingCheckpoints.remove(checkpointId);
 
-			triggerQueuedRequests();
+			resumePeriodicTriggering();
 		}
 
 		rememberRecentCheckpointId(checkpointId);
@@ -952,25 +952,25 @@ public class CheckpointCoordinator {
 	}
 
 	/**
-	 * Triggers the queued request, if there is one.
+	 * Resumes suspended periodic triggering.
 	 *
 	 * <p>NOTE: The caller of this method must hold the lock when invoking the method!
 	 */
-	private void triggerQueuedRequests() {
-		if (triggerRequestQueued) {
-			triggerRequestQueued = false;
+	private void resumePeriodicTriggering() {
+		assert(Thread.holdsLock(lock));
+
+		if (shutdown || !periodicScheduling) {
+			return;
+		}
+		if (periodicTriggeringSuspended) {
+			periodicTriggeringSuspended = false;
 
 			// trigger the checkpoint from the trigger timer, to finish the work of this thread before
 			// starting with the next checkpoint
-			if (periodicScheduling) {
-				if (currentPeriodicTrigger != null) {
-					currentPeriodicTrigger.cancel(false);
-				}
-				currentPeriodicTrigger = scheduleTriggerWithDelay(0L);
+			if (currentPeriodicTrigger != null) {
+				currentPeriodicTrigger.cancel(false);
 			}
-			else {
-				timer.execute(new ScheduledTrigger());
-			}
+			currentPeriodicTrigger = scheduleTriggerWithDelay(0L);
 		}
 	}
 
@@ -1223,7 +1223,7 @@ public class CheckpointCoordinator {
 
 	public void stopCheckpointScheduler() {
 		synchronized (lock) {
-			triggerRequestQueued = false;
+			periodicTriggeringSuspended = false;
 			periodicScheduling = false;
 
 			if (currentPeriodicTrigger != null) {
@@ -1273,7 +1273,7 @@ public class CheckpointCoordinator {
 	 */
 	private void checkConcurrentCheckpoints() throws CheckpointException {
 		if (pendingCheckpoints.size() >= maxConcurrentCheckpointAttempts) {
-			triggerRequestQueued = true;
+			periodicTriggeringSuspended = true;
 			if (currentPeriodicTrigger != null) {
 				currentPeriodicTrigger.cancel(false);
 				currentPeriodicTrigger = null;
@@ -1413,7 +1413,7 @@ public class CheckpointCoordinator {
 				pendingCheckpoints.remove(pendingCheckpoint.getCheckpointId());
 				rememberRecentCheckpointId(pendingCheckpoint.getCheckpointId());
 
-				triggerQueuedRequests();
+				resumePeriodicTriggering();
 			}
 		}
 	}
@@ -1430,13 +1430,7 @@ public class CheckpointCoordinator {
 		}
 
 		if (!forceCheckpoint) {
-			if (triggerRequestQueued) {
-				LOG.warn("Trying to trigger another checkpoint for job {} while one was queued already.", job);
-				throw new CheckpointException(CheckpointFailureReason.ALREADY_QUEUED);
-			}
-
 			checkConcurrentCheckpoints();
-
 			checkMinPauseBetweenCheckpoints();
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -98,7 +98,6 @@ public class CheckpointFailureManager {
 		CheckpointFailureReason reason = exception.getCheckpointFailureReason();
 		switch (reason) {
 			case PERIODIC_SCHEDULER_SHUTDOWN:
-			case ALREADY_QUEUED:
 			case TOO_MANY_CONCURRENT_CHECKPOINTS:
 			case MINIMUM_TIME_BETWEEN_CHECKPOINTS:
 			case NOT_ALL_REQUIRED_TASKS_RUNNING:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -117,6 +117,7 @@ public class CheckpointFailureManager {
 
 			case EXCEPTION:
 			case CHECKPOINT_EXPIRED:
+			case TASK_FAILURE:
 			case TASK_CHECKPOINT_FAILURE:
 			case TRIGGER_CHECKPOINT_FAILURE:
 			case FINALIZE_CHECKPOINT_FAILURE:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
@@ -25,8 +25,6 @@ public enum CheckpointFailureReason {
 
 	PERIODIC_SCHEDULER_SHUTDOWN(true, "Periodic checkpoint scheduler is shut down."),
 
-	ALREADY_QUEUED(true, "Another checkpoint request has already been queued."),
-
 	TOO_MANY_CONCURRENT_CHECKPOINTS(true, "The maximum number of concurrent checkpoints is exceeded"),
 
 	MINIMUM_TIME_BETWEEN_CHECKPOINTS(true, "The minimum time between checkpoints is still pending. " +

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
@@ -62,6 +62,8 @@ public enum CheckpointFailureReason {
 
 	JOB_FAILOVER_REGION(false, "FailoverRegion is restarting."),
 
+	TASK_FAILURE(false, "Task has failed."),
+
 	TASK_CHECKPOINT_FAILURE(false, "Task local checkpoint failure."),
 
 	FINALIZE_CHECKPOINT_FAILURE(false, "Failure to finalize checkpoint."),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -118,7 +118,30 @@ public class PendingCheckpoint {
 
 	private volatile ScheduledFuture<?> cancellerHandle;
 
+	private CheckpointException failureCause = null;
+
 	// --------------------------------------------------------------------------------------------
+	public PendingCheckpoint(
+		JobID jobId,
+		long checkpointId,
+		long checkpointTimestamp,
+		Map<ExecutionAttemptID, ExecutionVertex> verticesToConfirm,
+		Collection<String> masterStateIdentifiers,
+		CheckpointProperties props,
+		CheckpointStorageLocation targetLocation,
+		Executor executor) {
+
+		this(
+			jobId,
+			checkpointId,
+			checkpointTimestamp,
+			verticesToConfirm,
+			masterStateIdentifiers,
+			props,
+			targetLocation,
+			executor,
+			new CompletableFuture<>());
+	}
 
 	public PendingCheckpoint(
 			JobID jobId,
@@ -128,7 +151,8 @@ public class PendingCheckpoint {
 			Collection<String> masterStateIdentifiers,
 			CheckpointProperties props,
 			CheckpointStorageLocation targetLocation,
-			Executor executor) {
+			Executor executor,
+			CompletableFuture<CompletedCheckpoint> onCompletionPromise) {
 
 		checkArgument(verticesToConfirm.size() > 0,
 				"Checkpoint needs at least one vertex that commits the checkpoint");
@@ -145,7 +169,7 @@ public class PendingCheckpoint {
 		this.masterStates = new ArrayList<>(masterStateIdentifiers.size());
 		this.notYetAcknowledgedMasterStates = new HashSet<>(masterStateIdentifiers);
 		this.acknowledgedTasks = new HashSet<>(verticesToConfirm.size());
-		this.onCompletionPromise = new CompletableFuture<>();
+		this.onCompletionPromise = checkNotNull(onCompletionPromise);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -160,6 +184,10 @@ public class PendingCheckpoint {
 
 	public long getCheckpointId() {
 		return checkpointId;
+	}
+
+	public CheckpointStorageLocation getCheckpointStorageLocation() {
+		return targetLocation;
 	}
 
 	public long getCheckpointTimestamp() {
@@ -242,6 +270,10 @@ public class PendingCheckpoint {
 				throw new IllegalStateException("A canceller handle was already set");
 			}
 		}
+	}
+
+	public CheckpointException getFailureCause() {
+		return failureCause;
 	}
 
 	// ------------------------------------------------------------------------
@@ -425,9 +457,9 @@ public class PendingCheckpoint {
 	 */
 	public void abort(CheckpointFailureReason reason, @Nullable Throwable cause) {
 		try {
-			CheckpointException exception = new CheckpointException(reason, cause);
-			onCompletionPromise.completeExceptionally(exception);
-			reportFailedCheckpoint(exception);
+			failureCause = new CheckpointException(reason, cause);
+			onCompletionPromise.completeExceptionally(failureCause);
+			reportFailedCheckpoint(failureCause);
 			assertAbortSubsumedForced(reason);
 		} finally {
 			dispose(true);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -984,6 +984,24 @@ public class FutureUtils {
 	}
 
 	/**
+	 * Gets the result of a completable future without any exception thrown.
+	 *
+	 * @param future the completable future specified.
+	 * @param <T> the type of result
+	 * @return the result of completable future,
+	 * or null if it's unfinished or finished exceptionally
+	 */
+	public static <T> T getWithoutException(CompletableFuture<T> future) {
+		if (future.isDone() && !future.isCompletedExceptionally()) {
+			try {
+				return future.get();
+			} catch (InterruptedException | ExecutionException ignored) {
+			}
+		}
+		return null;
+	}
+
+	/**
 	 * Runnable to complete the given future with a {@link TimeoutException}.
 	 */
 	private static final class Timeout implements Runnable {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
@@ -21,7 +21,8 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.CheckpointCoordinatorBuilder;
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.CheckpointCoordinatorConfigurationBuilder;
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
@@ -36,7 +37,6 @@ import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
-import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.testutils.RecoverableCompletedCheckpointStore;
@@ -96,16 +96,11 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 
 	private ManuallyTriggeredScheduledExecutor manuallyTriggeredScheduledExecutor;
 
-	private CheckpointFailureManager failureManager;
-
 	@Rule
 	public TemporaryFolder tmpFolder = new TemporaryFolder();
 
 	@Before
 	public void setUp() throws Exception {
-		failureManager = new CheckpointFailureManager(
-			0,
-			NoOpFailJobCall.INSTANCE);
 		manuallyTriggeredScheduledExecutor = new ManuallyTriggeredScheduledExecutor();
 	}
 
@@ -147,28 +142,13 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 		CompletedCheckpointStore store = new RecoverableCompletedCheckpointStore();
 
 		// set up the coordinator and validate the initial state
-		CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-			600000,
-			600000,
-			0,
-			Integer.MAX_VALUE,
-			CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-			true,
-			false,
-			0);
-		CheckpointCoordinator coord = new CheckpointCoordinator(
-			jid,
-			chkConfig,
-			arrayExecutionVertices,
-			arrayExecutionVertices,
-			arrayExecutionVertices,
-			new StandaloneCheckpointIDCounter(),
-			store,
-			new MemoryStateBackend(),
-			Executors.directExecutor(),
-			manuallyTriggeredScheduledExecutor,
-			SharedStateRegistry.DEFAULT_FACTORY,
-			failureManager);
+		CheckpointCoordinator coord =
+			new CheckpointCoordinatorBuilder()
+				.setJobId(jid)
+				.setTasks(arrayExecutionVertices)
+				.setCompletedCheckpointStore(store)
+				.setTimer(manuallyTriggeredScheduledExecutor)
+				.build();
 
 		// trigger the checkpoint
 		coord.triggerCheckpoint(timestamp, false);
@@ -281,28 +261,19 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 
 			CompletedCheckpointStore store = new RecoverableCompletedCheckpointStore(2);
 
-			CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-				600000,
-				600000,
-				0,
-				Integer.MAX_VALUE,
-				CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-				true,
-				isPreferCheckpoint,
-				0);
-			CheckpointCoordinator coord = new CheckpointCoordinator(
-				jid,
-				chkConfig,
-				new ExecutionVertex[] { stateful1, stateless1 },
-				new ExecutionVertex[] { stateful1, stateless1 },
-				new ExecutionVertex[] { stateful1, stateless1 },
-				checkpointIDCounter,
-				store,
-				new MemoryStateBackend(),
-				Executors.directExecutor(),
-				manuallyTriggeredScheduledExecutor,
-				SharedStateRegistry.DEFAULT_FACTORY,
-				failureManager);
+			CheckpointCoordinatorConfiguration chkConfig =
+				new CheckpointCoordinatorConfigurationBuilder()
+					.setPreferCheckpointForRecovery(isPreferCheckpoint)
+					.build();
+			CheckpointCoordinator coord =
+				new CheckpointCoordinatorBuilder()
+					.setJobId(jid)
+					.setCheckpointCoordinatorConfiguration(chkConfig)
+					.setCheckpointIDCounter(checkpointIDCounter)
+					.setCompletedCheckpointStore(store)
+					.setTasks(new ExecutionVertex[] { stateful1, stateless1 })
+					.setTimer(manuallyTriggeredScheduledExecutor)
+					.build();
 
 			//trigger a checkpoint and wait to become a completed checkpoint
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture =
@@ -435,28 +406,12 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 			allExecutionVertices.toArray(new ExecutionVertex[allExecutionVertices.size()]);
 
 		// set up the coordinator and validate the initial state
-		CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-			600000,
-			600000,
-			0,
-			Integer.MAX_VALUE,
-			CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-			true,
-			false,
-			0);
-		CheckpointCoordinator coord = new CheckpointCoordinator(
-			jid,
-			chkConfig,
-			arrayExecutionVertices,
-			arrayExecutionVertices,
-			arrayExecutionVertices,
-			new StandaloneCheckpointIDCounter(),
-			new StandaloneCompletedCheckpointStore(1),
-			new MemoryStateBackend(),
-			Executors.directExecutor(),
-			manuallyTriggeredScheduledExecutor,
-			SharedStateRegistry.DEFAULT_FACTORY,
-			failureManager);
+		CheckpointCoordinator coord =
+			new CheckpointCoordinatorBuilder()
+				.setJobId(jid)
+				.setTasks(arrayExecutionVertices)
+				.setTimer(manuallyTriggeredScheduledExecutor)
+				.build();
 
 		// trigger the checkpoint
 		coord.triggerCheckpoint(timestamp, false);
@@ -614,28 +569,12 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 		ExecutionVertex[] arrayExecutionVertices = allExecutionVertices.toArray(new ExecutionVertex[allExecutionVertices.size()]);
 
 		// set up the coordinator and validate the initial state
-		CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-			600000,
-			600000,
-			0,
-			Integer.MAX_VALUE,
-			CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-			true,
-			false,
-			0);
-		CheckpointCoordinator coord = new CheckpointCoordinator(
-			jid,
-			chkConfig,
-			arrayExecutionVertices,
-			arrayExecutionVertices,
-			arrayExecutionVertices,
-			new StandaloneCheckpointIDCounter(),
-			new StandaloneCompletedCheckpointStore(1),
-			new MemoryStateBackend(),
-			Executors.directExecutor(),
-			manuallyTriggeredScheduledExecutor,
-			SharedStateRegistry.DEFAULT_FACTORY,
-			failureManager);
+		CheckpointCoordinator coord =
+			new CheckpointCoordinatorBuilder()
+				.setJobId(jid)
+				.setTasks(arrayExecutionVertices)
+				.setTimer(manuallyTriggeredScheduledExecutor)
+				.build();
 
 		// trigger the checkpoint
 		coord.triggerCheckpoint(timestamp, false);
@@ -870,28 +809,12 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 		when(standaloneCompletedCheckpointStore.getLatestCheckpoint(false)).thenReturn(completedCheckpoint);
 
 		// set up the coordinator and validate the initial state
-		CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-			600000,
-			600000,
-			0,
-			Integer.MAX_VALUE,
-			CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-			true,
-			false,
-			0);
-		CheckpointCoordinator coord = new CheckpointCoordinator(
-			new JobID(),
-			chkConfig,
-			newJobVertex1.getTaskVertices(),
-			newJobVertex1.getTaskVertices(),
-			newJobVertex1.getTaskVertices(),
-			new StandaloneCheckpointIDCounter(),
-			standaloneCompletedCheckpointStore,
-			new MemoryStateBackend(),
-			Executors.directExecutor(),
-			manuallyTriggeredScheduledExecutor,
-			SharedStateRegistry.DEFAULT_FACTORY,
-			failureManager);
+		CheckpointCoordinator coord =
+			new CheckpointCoordinatorBuilder()
+				.setTasks(newJobVertex1.getTaskVertices())
+				.setCompletedCheckpointStore(standaloneCompletedCheckpointStore)
+				.setTimer(manuallyTriggeredScheduledExecutor)
+				.build();
 
 		coord.restoreLatestCheckpointedState(tasks, false, true);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -22,9 +22,9 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.CheckpointCoordinatorBuilder;
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.CheckpointCoordinatorConfigurationBuilder;
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
-import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -47,7 +47,6 @@ import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.filesystem.FileStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
-import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.testutils.RecoverableCompletedCheckpointStore;
 import org.apache.flink.util.ExceptionUtils;
@@ -109,8 +108,6 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 	private static final String TASK_MANAGER_LOCATION_INFO = "Unknown location";
 
-	private CheckpointFailureManager failureManager;
-
 	private ManuallyTriggeredScheduledExecutor manuallyTriggeredScheduledExecutor;
 
 	@Rule
@@ -118,51 +115,16 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 	@Before
 	public void setUp() throws Exception {
-		failureManager = new CheckpointFailureManager(
-			0,
-			NoOpFailJobCall.INSTANCE);
 		manuallyTriggeredScheduledExecutor = new ManuallyTriggeredScheduledExecutor();
 	}
 
 	@Test
 	public void testCheckpointAbortsIfTriggerTasksAreNotExecuted() {
 		try {
-			final JobID jid = new JobID();
 			final long timestamp = System.currentTimeMillis();
 
-			// create some mock Execution vertices that receive the checkpoint trigger messages
-			ExecutionVertex triggerVertex1 = mock(ExecutionVertex.class);
-			ExecutionVertex triggerVertex2 = mock(ExecutionVertex.class);
-
-			// create some mock Execution vertices that need to ack the checkpoint
-			final ExecutionAttemptID ackAttemptID1 = new ExecutionAttemptID();
-			final ExecutionAttemptID ackAttemptID2 = new ExecutionAttemptID();
-			ExecutionVertex ackVertex1 = mockExecutionVertex(ackAttemptID1);
-			ExecutionVertex ackVertex2 = mockExecutionVertex(ackAttemptID2);
-
 			// set up the coordinator and validate the initial state
-			CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-				600000,
-				600000,
-				0,
-				Integer.MAX_VALUE,
-				CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-				true,
-				false,
-				0);
-			CheckpointCoordinator coord = new CheckpointCoordinator(
-				jid,
-				chkConfig,
-				new ExecutionVertex[] { triggerVertex1, triggerVertex2 },
-				new ExecutionVertex[] { ackVertex1, ackVertex2 },
-				new ExecutionVertex[] {},
-				new StandaloneCheckpointIDCounter(),
-				new StandaloneCompletedCheckpointStore(1),
-				new MemoryStateBackend(),
-				Executors.directExecutor(),
-				manuallyTriggeredScheduledExecutor,
-				SharedStateRegistry.DEFAULT_FACTORY,
-				failureManager);
+			CheckpointCoordinator coord = getCheckpointCoordinator();
 
 			// nothing should be happening
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
@@ -189,51 +151,9 @@ public class CheckpointCoordinatorTest extends TestLogger {
 	@Test
 	public void testCheckpointAbortsIfTriggerTasksAreFinished() {
 		try {
-			final JobID jid = new JobID();
 			final long timestamp = System.currentTimeMillis();
 
-			// create some mock Execution vertices that receive the checkpoint trigger messages
-			final ExecutionAttemptID triggerAttemptID1 = new ExecutionAttemptID();
-			final ExecutionAttemptID triggerAttemptID2 = new ExecutionAttemptID();
-			ExecutionVertex triggerVertex1 = mockExecutionVertex(triggerAttemptID1);
-			JobVertexID jobVertexID2 = new JobVertexID();
-			ExecutionVertex triggerVertex2 = mockExecutionVertex(
-				triggerAttemptID2,
-				jobVertexID2,
-				Collections.singletonList(OperatorID.fromJobVertexID(jobVertexID2)),
-				1,
-				1,
-				ExecutionState.FINISHED);
-
-			// create some mock Execution vertices that need to ack the checkpoint
-			final ExecutionAttemptID ackAttemptID1 = new ExecutionAttemptID();
-			final ExecutionAttemptID ackAttemptID2 = new ExecutionAttemptID();
-			ExecutionVertex ackVertex1 = mockExecutionVertex(ackAttemptID1);
-			ExecutionVertex ackVertex2 = mockExecutionVertex(ackAttemptID2);
-
-			// set up the coordinator and validate the initial state
-			CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-				600000,
-				600000,
-				0,
-				Integer.MAX_VALUE,
-				CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-				true,
-				false,
-				0);
-			CheckpointCoordinator coord = new CheckpointCoordinator(
-				jid,
-				chkConfig,
-				new ExecutionVertex[] { triggerVertex1, triggerVertex2 },
-				new ExecutionVertex[] { ackVertex1, ackVertex2 },
-				new ExecutionVertex[] {},
-				new StandaloneCheckpointIDCounter(),
-				new StandaloneCompletedCheckpointStore(1),
-				new MemoryStateBackend(),
-				Executors.directExecutor(),
-				manuallyTriggeredScheduledExecutor,
-				SharedStateRegistry.DEFAULT_FACTORY,
-				failureManager);
+			CheckpointCoordinator coord = getCheckpointCoordinator();
 
 			// nothing should be happening
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
@@ -260,42 +180,9 @@ public class CheckpointCoordinatorTest extends TestLogger {
 	@Test
 	public void testCheckpointAbortsIfAckTasksAreNotExecuted() {
 		try {
-			final JobID jid = new JobID();
 			final long timestamp = System.currentTimeMillis();
 
-			// create some mock Execution vertices that need to ack the checkpoint
-			final ExecutionAttemptID triggerAttemptID1 = new ExecutionAttemptID();
-			final ExecutionAttemptID triggerAttemptID2 = new ExecutionAttemptID();
-			ExecutionVertex triggerVertex1 = mockExecutionVertex(triggerAttemptID1);
-			ExecutionVertex triggerVertex2 = mockExecutionVertex(triggerAttemptID2);
-
-			// create some mock Execution vertices that receive the checkpoint trigger messages
-			ExecutionVertex ackVertex1 = mock(ExecutionVertex.class);
-			ExecutionVertex ackVertex2 = mock(ExecutionVertex.class);
-
-			// set up the coordinator and validate the initial state
-			CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-				600000,
-				600000,
-				0,
-				Integer.MAX_VALUE,
-				CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-				true,
-				false,
-				0);
-			CheckpointCoordinator coord = new CheckpointCoordinator(
-				jid,
-				chkConfig,
-				new ExecutionVertex[] { triggerVertex1, triggerVertex2 },
-				new ExecutionVertex[] { ackVertex1, ackVertex2 },
-				new ExecutionVertex[] {},
-				new StandaloneCheckpointIDCounter(),
-				new StandaloneCompletedCheckpointStore(1),
-				new MemoryStateBackend(),
-				Executors.directExecutor(),
-				manuallyTriggeredScheduledExecutor,
-				SharedStateRegistry.DEFAULT_FACTORY,
-				failureManager);
+			CheckpointCoordinator coord = getCheckpointCoordinator();
 
 			// nothing should be happening
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
@@ -347,7 +234,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			});
 
 		// set up the coordinator
-		CheckpointCoordinator coord = getCheckpointCoordinator(jid, vertex1, vertex2, checkpointFailureManager, manuallyTriggeredScheduledExecutor);
+		CheckpointCoordinator coord = getCheckpointCoordinator(jid, vertex1, vertex2, checkpointFailureManager);
 
 		try {
 			// trigger the checkpoint. this should succeed
@@ -401,7 +288,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			ExecutionVertex vertex2 = mockExecutionVertex(attemptID2);
 
 			// set up the coordinator and validate the initial state
-			CheckpointCoordinator coord = getCheckpointCoordinator(jid, vertex1, vertex2, failureManager, manuallyTriggeredScheduledExecutor);
+			CheckpointCoordinator coord = getCheckpointCoordinator(jid, vertex1, vertex2);
 
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 			assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -491,7 +378,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			ExecutionVertex vertex1 = mockExecutionVertex(attemptID1);
 			ExecutionVertex vertex2 = mockExecutionVertex(attemptID2);
 			// set up the coordinator and validate the initial state
-			CheckpointCoordinator coord = getCheckpointCoordinator(jid, vertex1, vertex2, failureManager, manuallyTriggeredScheduledExecutor);
+			CheckpointCoordinator coord = getCheckpointCoordinator(jid, vertex1, vertex2);
 
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 			assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -603,7 +490,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			ExecutionVertex vertex2 = mockExecutionVertex(attemptID2);
 
 			// set up the coordinator and validate the initial state
-			CheckpointCoordinator coord = getCheckpointCoordinator(jid, vertex1, vertex2, failureManager, manuallyTriggeredScheduledExecutor);
+			CheckpointCoordinator coord = getCheckpointCoordinator(jid, vertex1, vertex2);
 
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 			assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -761,28 +648,15 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			ExecutionVertex commitVertex = mockExecutionVertex(commitAttemptID);
 
 			// set up the coordinator and validate the initial state
-			CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-				600000,
-				600000,
-				0,
-				Integer.MAX_VALUE,
-				CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-				true,
-				false,
-				0);
-			CheckpointCoordinator coord = new CheckpointCoordinator(
-				jid,
-				chkConfig,
-				new ExecutionVertex[] { triggerVertex1, triggerVertex2 },
-				new ExecutionVertex[] { ackVertex1, ackVertex2, ackVertex3 },
-				new ExecutionVertex[] { commitVertex },
-				new StandaloneCheckpointIDCounter(),
-				new StandaloneCompletedCheckpointStore(2),
-				new MemoryStateBackend(),
-				Executors.directExecutor(),
-				manuallyTriggeredScheduledExecutor,
-				SharedStateRegistry.DEFAULT_FACTORY,
-				failureManager);
+			CheckpointCoordinator coord =
+				new CheckpointCoordinatorBuilder()
+					.setJobId(jid)
+					.setTasksToTrigger(new ExecutionVertex[] { triggerVertex1, triggerVertex2 })
+					.setTasksToWaitFor(new ExecutionVertex[] { ackVertex1, ackVertex2, ackVertex3 })
+					.setTasksToCommitTo(new ExecutionVertex[] { commitVertex })
+					.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
+					.setTimer(manuallyTriggeredScheduledExecutor)
+					.build();
 
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 			assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -905,28 +779,15 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			ExecutionVertex commitVertex = mockExecutionVertex(commitAttemptID);
 
 			// set up the coordinator and validate the initial state
-			CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-				600000,
-				600000,
-				0,
-				Integer.MAX_VALUE,
-				CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-				true,
-				false,
-				0);
-			CheckpointCoordinator coord = new CheckpointCoordinator(
-				jid,
-				chkConfig,
-				new ExecutionVertex[] { triggerVertex1, triggerVertex2 },
-				new ExecutionVertex[] { ackVertex1, ackVertex2, ackVertex3 },
-				new ExecutionVertex[] { commitVertex },
-				new StandaloneCheckpointIDCounter(),
-				new StandaloneCompletedCheckpointStore(10),
-				new MemoryStateBackend(),
-				Executors.directExecutor(),
-				manuallyTriggeredScheduledExecutor,
-				SharedStateRegistry.DEFAULT_FACTORY,
-				failureManager);
+			CheckpointCoordinator coord =
+				new CheckpointCoordinatorBuilder()
+					.setJobId(jid)
+					.setTasksToTrigger(new ExecutionVertex[] { triggerVertex1, triggerVertex2 })
+					.setTasksToWaitFor(new ExecutionVertex[] { ackVertex1, ackVertex2, ackVertex3 })
+					.setTasksToCommitTo(new ExecutionVertex[] { commitVertex })
+					.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(10))
+					.setTimer(manuallyTriggeredScheduledExecutor)
+					.build();
 
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 			assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -1081,29 +942,15 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			ExecutionVertex commitVertex = mockExecutionVertex(commitAttemptID);
 
 			// set up the coordinator
-			// the timeout for the checkpoint is a 200 milliseconds
-			CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-				600000,
-				200,
-				0,
-				Integer.MAX_VALUE,
-				CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-				true,
-				false,
-				0);
-			CheckpointCoordinator coord = new CheckpointCoordinator(
-				jid,
-				chkConfig,
-				new ExecutionVertex[] { triggerVertex },
-				new ExecutionVertex[] { ackVertex1, ackVertex2 },
-				new ExecutionVertex[] { commitVertex },
-				new StandaloneCheckpointIDCounter(),
-				new StandaloneCompletedCheckpointStore(2),
-				new MemoryStateBackend(),
-				Executors.directExecutor(),
-				manuallyTriggeredScheduledExecutor,
-				SharedStateRegistry.DEFAULT_FACTORY,
-				failureManager);
+			CheckpointCoordinator coord =
+				new CheckpointCoordinatorBuilder()
+					.setJobId(jid)
+					.setTasksToTrigger(new ExecutionVertex[] { triggerVertex })
+					.setTasksToWaitFor(new ExecutionVertex[] { ackVertex1, ackVertex2 })
+					.setTasksToCommitTo(new ExecutionVertex[] { commitVertex })
+					.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
+					.setTimer(manuallyTriggeredScheduledExecutor)
+					.build();
 
 			// trigger a checkpoint, partially acknowledged
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture =
@@ -1161,28 +1008,15 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			ExecutionVertex ackVertex2 = mockExecutionVertex(ackAttemptID2);
 			ExecutionVertex commitVertex = mockExecutionVertex(commitAttemptID);
 
-			CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-				200000,
-				200000,
-				0,
-				Integer.MAX_VALUE,
-				CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-				true,
-				false,
-				0);
-			CheckpointCoordinator coord = new CheckpointCoordinator(
-				jid,
-				chkConfig,
-				new ExecutionVertex[] { triggerVertex },
-				new ExecutionVertex[] { ackVertex1, ackVertex2 },
-				new ExecutionVertex[] { commitVertex },
-				new StandaloneCheckpointIDCounter(),
-				new StandaloneCompletedCheckpointStore(2),
-				new MemoryStateBackend(),
-				Executors.directExecutor(),
-				manuallyTriggeredScheduledExecutor,
-				SharedStateRegistry.DEFAULT_FACTORY,
-				failureManager);
+			CheckpointCoordinator coord =
+				new CheckpointCoordinatorBuilder()
+					.setJobId(jid)
+					.setTasksToTrigger(new ExecutionVertex[] { triggerVertex })
+					.setTasksToWaitFor(new ExecutionVertex[] { ackVertex1, ackVertex2 })
+					.setTasksToCommitTo(new ExecutionVertex[] { commitVertex })
+					.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
+					.setTimer(manuallyTriggeredScheduledExecutor)
+					.build();
 
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture =
 				coord.triggerCheckpoint(timestamp, false);
@@ -1235,28 +1069,19 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 		final long timestamp = 1L;
 
-		CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-			20000L,
-			20000L,
-			0L,
-			1,
-			CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-			true,
-			false,
-			0);
-		CheckpointCoordinator coord = new CheckpointCoordinator(
-			jobId,
-			chkConfig,
-			new ExecutionVertex[] { triggerVertex },
-			new ExecutionVertex[] {triggerVertex, ackVertex1, ackVertex2},
-			new ExecutionVertex[0],
-			new StandaloneCheckpointIDCounter(),
-			new StandaloneCompletedCheckpointStore(1),
-			new MemoryStateBackend(),
-			Executors.directExecutor(),
-			manuallyTriggeredScheduledExecutor,
-			SharedStateRegistry.DEFAULT_FACTORY,
-			failureManager);
+		CheckpointCoordinatorConfiguration chkConfig =
+			new CheckpointCoordinatorConfigurationBuilder()
+				.setMaxConcurrentCheckpoints(1)
+				.build();
+		CheckpointCoordinator coord =
+			new CheckpointCoordinatorBuilder()
+				.setJobId(jobId)
+				.setCheckpointCoordinatorConfiguration(chkConfig)
+				.setTasksToTrigger(new ExecutionVertex[] { triggerVertex })
+				.setTasksToWaitFor(new ExecutionVertex[] {triggerVertex, ackVertex1, ackVertex2})
+				.setTasksToCommitTo(new ExecutionVertex[0])
+				.setTimer(manuallyTriggeredScheduledExecutor)
+				.build();
 
 		final CompletableFuture<CompletedCheckpoint> checkpointFuture =
 			coord.triggerCheckpoint(timestamp, false);
@@ -1364,7 +1189,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		ExecutionVertex vertex2 = mockExecutionVertex(attemptID2);
 
 		// set up the coordinator and validate the initial state
-		CheckpointCoordinator coord = getCheckpointCoordinator(jid, vertex1, vertex2, failureManager, manuallyTriggeredScheduledExecutor);
+		CheckpointCoordinator coord = getCheckpointCoordinator(jid, vertex1, vertex2);
 
 		assertEquals(0, coord.getNumberOfPendingCheckpoints());
 		assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -1504,28 +1329,14 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		StandaloneCheckpointIDCounter counter = new StandaloneCheckpointIDCounter();
 
 		// set up the coordinator and validate the initial state
-		CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-			600000,
-			600000,
-			0,
-			Integer.MAX_VALUE,
-			CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-			true,
-			false,
-			0);
-		CheckpointCoordinator coord = new CheckpointCoordinator(
-			jid,
-			chkConfig,
-			new ExecutionVertex[] { vertex1, vertex2 },
-			new ExecutionVertex[] { vertex1, vertex2 },
-			new ExecutionVertex[] { vertex1, vertex2 },
-			counter,
-			new StandaloneCompletedCheckpointStore(10),
-			new MemoryStateBackend(),
-			Executors.directExecutor(),
-			manuallyTriggeredScheduledExecutor,
-			SharedStateRegistry.DEFAULT_FACTORY,
-			failureManager);
+		CheckpointCoordinator coord =
+			new CheckpointCoordinatorBuilder()
+				.setJobId(jid)
+				.setTasks(new ExecutionVertex[]{ vertex1, vertex2 })
+				.setCheckpointIDCounter(counter)
+				.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(10))
+				.setTimer(manuallyTriggeredScheduledExecutor)
+				.build();
 
 		String savepointDir = tmpFolder.newFolder().getAbsolutePath();
 
@@ -1618,28 +1429,23 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				return null;
 			}).when(execution).notifyCheckpointComplete(anyLong(), anyLong());
 
-			CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-				10,        // periodic interval is 10 ms
-				200000,    // timeout is very long (200 s)
-				0L,        // no extra delay
-				maxConcurrentAttempts,
-				CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-				true,
-				false,
-				0);
-			CheckpointCoordinator coord = new CheckpointCoordinator(
-				jid,
-				chkConfig,
-				new ExecutionVertex[] { triggerVertex },
-				new ExecutionVertex[] { ackVertex },
-				new ExecutionVertex[] { commitVertex },
-				new StandaloneCheckpointIDCounter(),
-				new StandaloneCompletedCheckpointStore(2),
-				new MemoryStateBackend(),
-				Executors.directExecutor(),
-				manuallyTriggeredScheduledExecutor,
-				SharedStateRegistry.DEFAULT_FACTORY,
-				failureManager);
+			CheckpointCoordinatorConfiguration chkConfig =
+				new CheckpointCoordinatorConfigurationBuilder()
+					.setCheckpointInterval(10) // periodic interval is 10 ms
+					.setCheckpointTimeout(200000) // timeout is very long (200 s)
+					.setMinPauseBetweenCheckpoints(0L) // no extra delay
+					.setMaxConcurrentCheckpoints(maxConcurrentAttempts)
+					.build();
+			CheckpointCoordinator coord =
+				new CheckpointCoordinatorBuilder()
+					.setJobId(jid)
+					.setCheckpointCoordinatorConfiguration(chkConfig)
+					.setTasksToTrigger(new ExecutionVertex[] { triggerVertex })
+					.setTasksToWaitFor(new ExecutionVertex[] { ackVertex })
+					.setTasksToCommitTo(new ExecutionVertex[] { commitVertex })
+					.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
+					.setTimer(manuallyTriggeredScheduledExecutor)
+					.build();
 
 			coord.startCheckpointScheduler();
 
@@ -1691,28 +1497,23 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			ExecutionVertex ackVertex = mockExecutionVertex(ackAttemptID);
 			ExecutionVertex commitVertex = mockExecutionVertex(commitAttemptID);
 
-			CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-				10,        // periodic interval is 10 ms
-				200000,    // timeout is very long (200 s)
-				0L,        // no extra delay
-				maxConcurrentAttempts, // max two concurrent checkpoints
-				CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-				true,
-				false,
-				0);
-			CheckpointCoordinator coord = new CheckpointCoordinator(
-				jid,
-				chkConfig,
-				new ExecutionVertex[] { triggerVertex },
-				new ExecutionVertex[] { ackVertex },
-				new ExecutionVertex[] { commitVertex },
-				new StandaloneCheckpointIDCounter(),
-				new StandaloneCompletedCheckpointStore(2),
-				new MemoryStateBackend(),
-				Executors.directExecutor(),
-				manuallyTriggeredScheduledExecutor,
-				SharedStateRegistry.DEFAULT_FACTORY,
-				failureManager);
+			CheckpointCoordinatorConfiguration chkConfig =
+				new CheckpointCoordinatorConfigurationBuilder()
+					.setCheckpointInterval(10) // periodic interval is 10 ms
+					.setCheckpointTimeout(200000) // timeout is very long (200 s)
+					.setMinPauseBetweenCheckpoints(0L) // no extra delay
+					.setMaxConcurrentCheckpoints(maxConcurrentAttempts)
+					.build();
+			CheckpointCoordinator coord =
+				new CheckpointCoordinatorBuilder()
+					.setJobId(jid)
+					.setCheckpointCoordinatorConfiguration(chkConfig)
+					.setTasksToTrigger(new ExecutionVertex[] { triggerVertex })
+					.setTasksToWaitFor(new ExecutionVertex[] { ackVertex })
+					.setTasksToCommitTo(new ExecutionVertex[] { commitVertex })
+					.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
+					.setTimer(manuallyTriggeredScheduledExecutor)
+					.build();
 
 			coord.startCheckpointScheduler();
 
@@ -1767,28 +1568,23 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			final AtomicReference<ExecutionState> currentState = new AtomicReference<>(ExecutionState.CREATED);
 			when(triggerVertex.getCurrentExecutionAttempt().getState()).thenAnswer(invocation -> currentState.get());
 
-			CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-				10,        // periodic interval is 10 ms
-				200000,    // timeout is very long (200 s)
-				0L,        // no extra delay
-				2, // max two concurrent checkpoints
-				CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-				true,
-				false,
-				0);
-			CheckpointCoordinator coord = new CheckpointCoordinator(
-				jid,
-				chkConfig,
-				new ExecutionVertex[] { triggerVertex },
-				new ExecutionVertex[] { ackVertex },
-				new ExecutionVertex[] { commitVertex },
-				new StandaloneCheckpointIDCounter(),
-				new StandaloneCompletedCheckpointStore(2),
-				new MemoryStateBackend(),
-				Executors.directExecutor(),
-				manuallyTriggeredScheduledExecutor,
-				SharedStateRegistry.DEFAULT_FACTORY,
-				failureManager);
+			CheckpointCoordinatorConfiguration chkConfig =
+				new CheckpointCoordinatorConfigurationBuilder()
+					.setCheckpointInterval(10) // periodic interval is 10 ms
+					.setCheckpointTimeout(200000) // timeout is very long (200 s)
+					.setMinPauseBetweenCheckpoints(0) // no extra delay
+					.setMaxConcurrentCheckpoints(2) // max two concurrent checkpoints
+					.build();
+			CheckpointCoordinator coord =
+				new CheckpointCoordinatorBuilder()
+					.setJobId(jid)
+					.setCheckpointCoordinatorConfiguration(chkConfig)
+					.setTasksToTrigger(new ExecutionVertex[] { triggerVertex })
+					.setTasksToWaitFor(new ExecutionVertex[] { ackVertex })
+					.setTasksToCommitTo(new ExecutionVertex[] { commitVertex })
+					.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
+					.setTimer(manuallyTriggeredScheduledExecutor)
+					.build();
 
 			coord.startCheckpointScheduler();
 
@@ -1823,28 +1619,19 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 		StandaloneCheckpointIDCounter checkpointIDCounter = new StandaloneCheckpointIDCounter();
 
-		CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-			100000,
-			200000,
-			0L,
-			1, // max one checkpoint at a time => should not affect savepoints
-			CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-			true,
-			false,
-			0);
-		CheckpointCoordinator coord = new CheckpointCoordinator(
-			jobId,
-			chkConfig,
-			new ExecutionVertex[] { vertex1 },
-			new ExecutionVertex[] { vertex1 },
-			new ExecutionVertex[] { vertex1 },
-			checkpointIDCounter,
-			new StandaloneCompletedCheckpointStore(2),
-			new MemoryStateBackend(),
-			Executors.directExecutor(),
-			manuallyTriggeredScheduledExecutor,
-			SharedStateRegistry.DEFAULT_FACTORY,
-			failureManager);
+		CheckpointCoordinatorConfiguration chkConfig =
+			new CheckpointCoordinatorConfigurationBuilder()
+				.setMaxConcurrentCheckpoints(1) // max one checkpoint at a time => should not affect savepoints
+				.build();
+		CheckpointCoordinator coord =
+			new CheckpointCoordinatorBuilder()
+				.setJobId(jobId)
+				.setCheckpointCoordinatorConfiguration(chkConfig)
+				.setTasks(new ExecutionVertex[] { vertex1 })
+				.setCheckpointIDCounter(checkpointIDCounter)
+				.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
+				.setTimer(manuallyTriggeredScheduledExecutor)
+				.build();
 
 		List<CompletableFuture<CompletedCheckpoint>> savepointFutures = new ArrayList<>();
 
@@ -1879,33 +1666,17 @@ public class CheckpointCoordinatorTest extends TestLogger {
 	 */
 	@Test
 	public void testMinDelayBetweenSavepoints() throws Exception {
-		JobID jobId = new JobID();
-
-		final ExecutionAttemptID attemptID1 = new ExecutionAttemptID();
-		ExecutionVertex vertex1 = mockExecutionVertex(attemptID1);
-
-		CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-			100000,
-			200000,
-			100000000L, // very long min delay => should not affect savepoints
-			1,
-			CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-			true,
-			false,
-			0);
-		CheckpointCoordinator coord = new CheckpointCoordinator(
-			jobId,
-			chkConfig,
-			new ExecutionVertex[] { vertex1 },
-			new ExecutionVertex[] { vertex1 },
-			new ExecutionVertex[] { vertex1 },
-			new StandaloneCheckpointIDCounter(),
-			new StandaloneCompletedCheckpointStore(2),
-			new MemoryStateBackend(),
-			Executors.directExecutor(),
-			manuallyTriggeredScheduledExecutor,
-			SharedStateRegistry.DEFAULT_FACTORY,
-			failureManager);
+		CheckpointCoordinatorConfiguration chkConfig =
+			new CheckpointCoordinatorConfigurationBuilder()
+				.setMinPauseBetweenCheckpoints(100000000L) // very long min delay => should not affect savepoints
+				.setMaxConcurrentCheckpoints(1)
+				.build();
+		CheckpointCoordinator coord =
+			new CheckpointCoordinatorBuilder()
+				.setCheckpointCoordinatorConfiguration(chkConfig)
+				.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
+				.setTimer(manuallyTriggeredScheduledExecutor)
+				.build();
 
 		String savepointDir = tmpFolder.newFolder().getAbsolutePath();
 
@@ -1922,36 +1693,18 @@ public class CheckpointCoordinatorTest extends TestLogger {
 	@Test
 	public void testExternalizedCheckpoints() throws Exception {
 		try {
-			final JobID jid = new JobID();
 			final long timestamp = System.currentTimeMillis();
 
-			// create some mock Execution vertices that receive the checkpoint trigger messages
-			final ExecutionAttemptID attemptID1 = new ExecutionAttemptID();
-			ExecutionVertex vertex1 = mockExecutionVertex(attemptID1);
-
 			// set up the coordinator and validate the initial state
-			CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-				600000,
-				600000,
-				0,
-				Integer.MAX_VALUE,
-				CheckpointRetentionPolicy.RETAIN_ON_FAILURE,
-				true,
-				false,
-				0);
-			CheckpointCoordinator coord = new CheckpointCoordinator(
-				jid,
-				chkConfig,
-				new ExecutionVertex[] { vertex1 },
-				new ExecutionVertex[] { vertex1 },
-				new ExecutionVertex[] { vertex1 },
-				new StandaloneCheckpointIDCounter(),
-				new StandaloneCompletedCheckpointStore(1),
-				new MemoryStateBackend(),
-				Executors.directExecutor(),
-				manuallyTriggeredScheduledExecutor,
-				SharedStateRegistry.DEFAULT_FACTORY,
-				failureManager);
+			CheckpointCoordinatorConfiguration chkConfig =
+				new CheckpointCoordinatorConfigurationBuilder()
+					.setCheckpointRetentionPolicy(CheckpointRetentionPolicy.RETAIN_ON_FAILURE)
+					.build();
+			CheckpointCoordinator coord =
+				new CheckpointCoordinatorBuilder()
+					.setCheckpointCoordinatorConfiguration(chkConfig)
+					.setTimer(manuallyTriggeredScheduledExecutor)
+					.build();
 
 			CompletableFuture<CompletedCheckpoint> checkpointFuture =
 				coord.triggerCheckpoint(timestamp, false);
@@ -2167,31 +1920,12 @@ public class CheckpointCoordinatorTest extends TestLogger {
 	@Test
 	public void testCheckpointStatsTrackerPendingCheckpointCallback() throws Exception {
 		final long timestamp = System.currentTimeMillis();
-		ExecutionVertex vertex1 = mockExecutionVertex(new ExecutionAttemptID());
 
 		// set up the coordinator and validate the initial state
-		CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-			600000,
-			600000,
-			0,
-			Integer.MAX_VALUE,
-			CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-			true,
-			false,
-			0);
-		CheckpointCoordinator coord = new CheckpointCoordinator(
-			new JobID(),
-			chkConfig,
-			new ExecutionVertex[]{vertex1},
-			new ExecutionVertex[]{vertex1},
-			new ExecutionVertex[]{vertex1},
-			new StandaloneCheckpointIDCounter(),
-			new StandaloneCompletedCheckpointStore(1),
-			new MemoryStateBackend(),
-			Executors.directExecutor(),
-			manuallyTriggeredScheduledExecutor,
-			SharedStateRegistry.DEFAULT_FACTORY,
-			failureManager);
+		CheckpointCoordinator coord =
+			new CheckpointCoordinatorBuilder()
+				.setTimer(manuallyTriggeredScheduledExecutor)
+				.build();
 
 		CheckpointStatsTracker tracker = mock(CheckpointStatsTracker.class);
 		coord.setCheckpointStatsTracker(tracker);
@@ -2214,33 +1948,14 @@ public class CheckpointCoordinatorTest extends TestLogger {
 	 */
 	@Test
 	public void testCheckpointStatsTrackerRestoreCallback() throws Exception {
-		ExecutionVertex vertex1 = mockExecutionVertex(new ExecutionAttemptID());
-
 		StandaloneCompletedCheckpointStore store = new StandaloneCompletedCheckpointStore(1);
 
 		// set up the coordinator and validate the initial state
-		CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-			600000,
-			600000,
-			0,
-			Integer.MAX_VALUE,
-			CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-			true,
-			false,
-			0);
-		CheckpointCoordinator coord = new CheckpointCoordinator(
-			new JobID(),
-			chkConfig,
-			new ExecutionVertex[]{vertex1},
-			new ExecutionVertex[]{vertex1},
-			new ExecutionVertex[]{vertex1},
-			new StandaloneCheckpointIDCounter(),
-			store,
-			new MemoryStateBackend(),
-			Executors.directExecutor(),
-			manuallyTriggeredScheduledExecutor,
-			SharedStateRegistry.DEFAULT_FACTORY,
-			failureManager);
+		CheckpointCoordinator coord =
+			new CheckpointCoordinatorBuilder()
+				.setCompletedCheckpointStore(store)
+				.setTimer(manuallyTriggeredScheduledExecutor)
+				.build();
 
 		store.addCheckpoint(new CompletedCheckpoint(
 			new JobID(),
@@ -2289,32 +2004,19 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		final List<SharedStateRegistry> createdSharedStateRegistries = new ArrayList<>(2);
 
 		// set up the coordinator and validate the initial state
-		CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-			600000,
-			600000,
-			0,
-			Integer.MAX_VALUE,
-			CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-			true,
-			false,
-			0);
-		CheckpointCoordinator coord = new CheckpointCoordinator(
-			jid,
-			chkConfig,
-			arrayExecutionVertices,
-			arrayExecutionVertices,
-			arrayExecutionVertices,
-			new StandaloneCheckpointIDCounter(),
-			store,
-			new MemoryStateBackend(),
-			Executors.directExecutor(),
-			manuallyTriggeredScheduledExecutor,
-				deleteExecutor -> {
-					SharedStateRegistry instance = new SharedStateRegistry(deleteExecutor);
-					createdSharedStateRegistries.add(instance);
-					return instance;
-				},
-			failureManager);
+		CheckpointCoordinator coord =
+			new CheckpointCoordinatorBuilder()
+				.setJobId(jid)
+				.setTasks(arrayExecutionVertices)
+				.setCompletedCheckpointStore(store)
+				.setTimer(manuallyTriggeredScheduledExecutor)
+				.setSharedStateRegistryFactory(
+					deleteExecutor -> {
+						SharedStateRegistry instance = new SharedStateRegistry(deleteExecutor);
+						createdSharedStateRegistries.add(instance);
+						return instance;
+					})
+				.build();
 
 		final int numCheckpoints = 3;
 
@@ -2464,8 +2166,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 						public void failJobDueToTaskFailure(Throwable cause, ExecutionAttemptID failingTask) {
 							throw new AssertionError("This method should not be called for the test.");
 						}
-					}),
-			manuallyTriggeredScheduledExecutor);
+					}));
 
 		final CompletableFuture<CompletedCheckpoint> savepointFuture = coordinator
 				.triggerSynchronousSavepoint(10L, false, "test-dir");
@@ -2497,32 +2198,13 @@ public class CheckpointCoordinatorTest extends TestLogger {
 	 */
 	@Test
 	public void testTriggerCheckpointAfterCancel() throws Exception {
-		ExecutionVertex vertex1 = mockExecutionVertex(new ExecutionAttemptID());
-
 		// set up the coordinator
-		CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-			600000,
-			600000,
-			0,
-			Integer.MAX_VALUE,
-			CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-			true,
-			false,
-			0);
 		TestingCheckpointIDCounter idCounter = new TestingCheckpointIDCounter();
-		CheckpointCoordinator coord = new CheckpointCoordinator(
-			new JobID(),
-			chkConfig,
-			new ExecutionVertex[]{vertex1},
-			new ExecutionVertex[]{vertex1},
-			new ExecutionVertex[]{vertex1},
-			idCounter,
-			new StandaloneCompletedCheckpointStore(1),
-			new MemoryStateBackend(),
-			Executors.directExecutor(),
-			manuallyTriggeredScheduledExecutor,
-			SharedStateRegistry.DEFAULT_FACTORY,
-			failureManager);
+		CheckpointCoordinator coord =
+			new CheckpointCoordinatorBuilder()
+				.setCheckpointIDCounter(idCounter)
+				.setTimer(manuallyTriggeredScheduledExecutor)
+				.build();
 		idCounter.setOwner(coord);
 
 		try {
@@ -2540,35 +2222,57 @@ public class CheckpointCoordinatorTest extends TestLogger {
 	}
 
 	private CheckpointCoordinator getCheckpointCoordinator(
-			final JobID jobId,
-			final ExecutionVertex vertex1,
-			final ExecutionVertex vertex2,
-			final CheckpointFailureManager failureManager,
-			final ScheduledExecutor timer) {
+		JobID jobId,
+		ExecutionVertex vertex1,
+		ExecutionVertex vertex2) {
 
-		final CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-				600000,
-				600000,
-				0,
-				Integer.MAX_VALUE,
-				CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-				true,
-				false,
-				0);
+		return new CheckpointCoordinatorBuilder()
+			.setJobId(jobId)
+			.setTasks(new ExecutionVertex[]{ vertex1, vertex2 })
+			.setTimer(manuallyTriggeredScheduledExecutor)
+			.build();
+	}
 
-		return new CheckpointCoordinator(
-				jobId,
-				chkConfig,
-				new ExecutionVertex[]{vertex1, vertex2},
-				new ExecutionVertex[]{vertex1, vertex2},
-				new ExecutionVertex[]{vertex1, vertex2},
-				new StandaloneCheckpointIDCounter(),
-				new StandaloneCompletedCheckpointStore(1),
-				new MemoryStateBackend(),
-				Executors.directExecutor(),
-				timer,
-				SharedStateRegistry.DEFAULT_FACTORY,
-				failureManager);
+	private CheckpointCoordinator getCheckpointCoordinator(
+		JobID jobId,
+		ExecutionVertex vertex1,
+		ExecutionVertex vertex2,
+		CheckpointFailureManager failureManager) {
+
+		return new CheckpointCoordinatorBuilder()
+			.setJobId(jobId)
+			.setTasks(new ExecutionVertex[]{ vertex1, vertex2 })
+			.setTimer(manuallyTriggeredScheduledExecutor)
+			.setFailureManager(failureManager)
+			.build();
+	}
+
+	private CheckpointCoordinator getCheckpointCoordinator() {
+		final ExecutionAttemptID triggerAttemptID1 = new ExecutionAttemptID();
+		final ExecutionAttemptID triggerAttemptID2 = new ExecutionAttemptID();
+		ExecutionVertex triggerVertex1 = mockExecutionVertex(triggerAttemptID1);
+		JobVertexID jobVertexID2 = new JobVertexID();
+		ExecutionVertex triggerVertex2 = mockExecutionVertex(
+			triggerAttemptID2,
+			jobVertexID2,
+			Collections.singletonList(OperatorID.fromJobVertexID(jobVertexID2)),
+			1,
+			1,
+			ExecutionState.FINISHED);
+
+		// create some mock Execution vertices that need to ack the checkpoint
+		final ExecutionAttemptID ackAttemptID1 = new ExecutionAttemptID();
+		final ExecutionAttemptID ackAttemptID2 = new ExecutionAttemptID();
+		ExecutionVertex ackVertex1 = mockExecutionVertex(ackAttemptID1);
+		ExecutionVertex ackVertex2 = mockExecutionVertex(ackAttemptID2);
+
+		// set up the coordinator and validate the initial state
+		return new CheckpointCoordinatorBuilder()
+			.setTasksToTrigger(new ExecutionVertex[] { triggerVertex1, triggerVertex2 })
+			.setTasksToWaitFor(new ExecutionVertex[] { ackVertex1, ackVertex2 })
+			.setTasksToCommitTo(new ExecutionVertex[] {})
+			.setTimer(manuallyTriggeredScheduledExecutor)
+			.build();
 	}
 
 	private PendingCheckpoint declineSynchronousSavepoint(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -74,7 +74,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -442,11 +441,7 @@ public class CheckpointCoordinatorTestingUtils {
 		));
 		if (slot != null) {
 			// is there a better way to do this?
-			//noinspection unchecked
-			AtomicReferenceFieldUpdater<Execution, LogicalSlot> slotUpdater =
-				(AtomicReferenceFieldUpdater<Execution, LogicalSlot>)
-					Whitebox.getInternalState(exec, "ASSIGNED_SLOT_UPDATER");
-			slotUpdater.compareAndSet(exec, null, slot);
+			Whitebox.setInternalState(exec, "assignedResource", slot);
 		}
 
 		when(exec.getAttemptId()).thenReturn(attemptID);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -24,6 +24,9 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.mock.Whitebox;
+import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -33,6 +36,7 @@ import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGate
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway.CheckpointConsumer;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
@@ -43,7 +47,11 @@ import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
+import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.SharedStateRegistryFactory;
+import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
@@ -354,13 +362,13 @@ public class CheckpointCoordinatorTestingUtils {
 		return executionJobVertex;
 	}
 
-	static ExecutionVertex mockExecutionVertex(ExecutionAttemptID attemptID) throws Exception {
+	static ExecutionVertex mockExecutionVertex(ExecutionAttemptID attemptID) {
 		return mockExecutionVertex(attemptID, (LogicalSlot) null);
 	}
 
 	static ExecutionVertex mockExecutionVertex(
 		ExecutionAttemptID attemptID,
-		CheckpointConsumer checkpointConsumer) throws Exception {
+		CheckpointConsumer checkpointConsumer) {
 
 		final SimpleAckingTaskManagerGateway taskManagerGateway = new SimpleAckingTaskManagerGateway();
 		taskManagerGateway.setCheckpointConsumer(checkpointConsumer);
@@ -369,7 +377,7 @@ public class CheckpointCoordinatorTestingUtils {
 
 	static ExecutionVertex mockExecutionVertex(
 		ExecutionAttemptID attemptID,
-		TaskManagerGateway taskManagerGateway) throws Exception {
+		TaskManagerGateway taskManagerGateway) {
 
 		TestingLogicalSlotBuilder slotBuilder = new TestingLogicalSlotBuilder();
 		slotBuilder.setTaskManagerGateway(taskManagerGateway);
@@ -379,7 +387,7 @@ public class CheckpointCoordinatorTestingUtils {
 
 	static ExecutionVertex mockExecutionVertex(
 		ExecutionAttemptID attemptID,
-		@Nullable LogicalSlot slot) throws Exception {
+		@Nullable LogicalSlot slot) {
 
 		JobVertexID jobVertexID = new JobVertexID();
 		return mockExecutionVertex(
@@ -399,7 +407,7 @@ public class CheckpointCoordinatorTestingUtils {
 		int parallelism,
 		int maxParallelism,
 		ExecutionState state,
-		ExecutionState ... successiveStates) throws Exception {
+		ExecutionState ... successiveStates) {
 
 		return mockExecutionVertex(
 			attemptID,
@@ -420,7 +428,7 @@ public class CheckpointCoordinatorTestingUtils {
 		int parallelism,
 		int maxParallelism,
 		ExecutionState state,
-		ExecutionState ... successiveStates) throws Exception {
+		ExecutionState ... successiveStates) {
 
 		ExecutionVertex vertex = mock(ExecutionVertex.class);
 
@@ -564,6 +572,211 @@ public class CheckpointCoordinatorTestingUtils {
 			when(v.getJobVertex()).thenReturn(vertex);
 		}
 		return vertex;
+	}
+
+	/**
+	 * A helper builder for {@link CheckpointCoordinatorConfiguration} to deduplicate test codes.
+	 */
+	public static class CheckpointCoordinatorConfigurationBuilder {
+		private long checkpointInterval = 600000;
+
+		private long checkpointTimeout = 600000;
+
+		private long minPauseBetweenCheckpoints = 0;
+
+		private int maxConcurrentCheckpoints = Integer.MAX_VALUE;
+
+		private CheckpointRetentionPolicy checkpointRetentionPolicy =
+			CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION;
+
+		private boolean isExactlyOnce = true;
+
+		private boolean isPreferCheckpointForRecovery = false;
+
+		private int tolerableCpFailureNumber = 0;
+
+		public CheckpointCoordinatorConfigurationBuilder setCheckpointInterval(long checkpointInterval) {
+			this.checkpointInterval = checkpointInterval;
+			return this;
+		}
+
+		public CheckpointCoordinatorConfigurationBuilder setCheckpointTimeout(long checkpointTimeout) {
+			this.checkpointTimeout = checkpointTimeout;
+			return this;
+		}
+
+		public CheckpointCoordinatorConfigurationBuilder setMinPauseBetweenCheckpoints(long minPauseBetweenCheckpoints) {
+			this.minPauseBetweenCheckpoints = minPauseBetweenCheckpoints;
+			return this;
+		}
+
+		public CheckpointCoordinatorConfigurationBuilder setMaxConcurrentCheckpoints(int maxConcurrentCheckpoints) {
+			this.maxConcurrentCheckpoints = maxConcurrentCheckpoints;
+			return this;
+		}
+
+		public CheckpointCoordinatorConfigurationBuilder setCheckpointRetentionPolicy(
+			CheckpointRetentionPolicy checkpointRetentionPolicy) {
+			this.checkpointRetentionPolicy = checkpointRetentionPolicy;
+			return this;
+		}
+
+		public CheckpointCoordinatorConfigurationBuilder setExactlyOnce(boolean exactlyOnce) {
+			isExactlyOnce = exactlyOnce;
+			return this;
+		}
+
+		public CheckpointCoordinatorConfigurationBuilder setPreferCheckpointForRecovery(boolean preferCheckpointForRecovery) {
+			isPreferCheckpointForRecovery = preferCheckpointForRecovery;
+			return this;
+		}
+
+		public CheckpointCoordinatorConfigurationBuilder setTolerableCpFailureNumber(int tolerableCpFailureNumber) {
+			this.tolerableCpFailureNumber = tolerableCpFailureNumber;
+			return this;
+		}
+
+		public CheckpointCoordinatorConfiguration build() {
+			return new CheckpointCoordinatorConfiguration(
+				checkpointInterval,
+				checkpointTimeout,
+				minPauseBetweenCheckpoints,
+				maxConcurrentCheckpoints,
+				checkpointRetentionPolicy,
+				isExactlyOnce,
+				isPreferCheckpointForRecovery,
+				tolerableCpFailureNumber);
+		}
+	}
+
+	/**
+	 * A helper builder for {@link CheckpointCoordinator} to deduplicate test codes.
+	 */
+	public static class CheckpointCoordinatorBuilder {
+		private JobID jobId = new JobID();
+
+		private CheckpointCoordinatorConfiguration checkpointCoordinatorConfiguration =
+			new CheckpointCoordinatorConfigurationBuilder().build();
+
+		private ExecutionVertex[] tasksToTrigger;
+
+		private ExecutionVertex[] tasksToWaitFor;
+
+		private ExecutionVertex[] tasksToCommitTo;
+
+		private CheckpointIDCounter checkpointIDCounter =
+			new StandaloneCheckpointIDCounter();
+
+		private CompletedCheckpointStore completedCheckpointStore =
+			new StandaloneCompletedCheckpointStore(1);
+
+		private StateBackend checkpointStateBackend = new MemoryStateBackend();
+
+		private Executor ioExecutor = Executors.directExecutor();
+
+		private ScheduledExecutor timer = new ManuallyTriggeredScheduledExecutor();
+
+		private SharedStateRegistryFactory sharedStateRegistryFactory =
+			SharedStateRegistry.DEFAULT_FACTORY;
+
+		private CheckpointFailureManager failureManager =
+			new CheckpointFailureManager(0, NoOpFailJobCall.INSTANCE);
+
+		public CheckpointCoordinatorBuilder() {
+			ExecutionVertex vertex = mockExecutionVertex(new ExecutionAttemptID());
+			ExecutionVertex[] defaultVertices = new ExecutionVertex[] { vertex };
+			tasksToTrigger = defaultVertices;
+			tasksToWaitFor = defaultVertices;
+			tasksToCommitTo = defaultVertices;
+		}
+
+		public CheckpointCoordinatorBuilder setJobId(JobID jobId) {
+			this.jobId = jobId;
+			return this;
+		}
+
+		public CheckpointCoordinatorBuilder setCheckpointCoordinatorConfiguration(
+			CheckpointCoordinatorConfiguration checkpointCoordinatorConfiguration) {
+			this.checkpointCoordinatorConfiguration = checkpointCoordinatorConfiguration;
+			return this;
+		}
+
+		public CheckpointCoordinatorBuilder setTasks(ExecutionVertex[] tasks) {
+			this.tasksToTrigger = tasks;
+			this.tasksToWaitFor = tasks;
+			this.tasksToCommitTo = tasks;
+			return this;
+		}
+
+		public CheckpointCoordinatorBuilder setTasksToTrigger(ExecutionVertex[] tasksToTrigger) {
+			this.tasksToTrigger = tasksToTrigger;
+			return this;
+		}
+
+		public CheckpointCoordinatorBuilder setTasksToWaitFor(ExecutionVertex[] tasksToWaitFor) {
+			this.tasksToWaitFor = tasksToWaitFor;
+			return this;
+		}
+
+		public CheckpointCoordinatorBuilder setTasksToCommitTo(ExecutionVertex[] tasksToCommitTo) {
+			this.tasksToCommitTo = tasksToCommitTo;
+			return this;
+		}
+
+		public CheckpointCoordinatorBuilder setCheckpointIDCounter(
+			CheckpointIDCounter checkpointIDCounter) {
+			this.checkpointIDCounter = checkpointIDCounter;
+			return this;
+		}
+
+		public CheckpointCoordinatorBuilder setCompletedCheckpointStore(
+			CompletedCheckpointStore completedCheckpointStore) {
+			this.completedCheckpointStore = completedCheckpointStore;
+			return this;
+		}
+
+		public CheckpointCoordinatorBuilder setCheckpointStateBackend(StateBackend checkpointStateBackend) {
+			this.checkpointStateBackend = checkpointStateBackend;
+			return this;
+		}
+
+		public CheckpointCoordinatorBuilder setIoExecutor(Executor exioExecutorecutor) {
+			this.ioExecutor = ioExecutor;
+			return this;
+		}
+
+		public CheckpointCoordinatorBuilder setTimer(ScheduledExecutor timer) {
+			this.timer = timer;
+			return this;
+		}
+
+		public CheckpointCoordinatorBuilder setSharedStateRegistryFactory(
+			SharedStateRegistryFactory sharedStateRegistryFactory) {
+			this.sharedStateRegistryFactory = sharedStateRegistryFactory;
+			return this;
+		}
+
+		public CheckpointCoordinatorBuilder setFailureManager(
+			CheckpointFailureManager failureManager) {
+			this.failureManager = failureManager;
+			return this;
+		}
+
+		public CheckpointCoordinator build() {
+			return new CheckpointCoordinator(
+				jobId,
+				checkpointCoordinatorConfiguration,
+				tasksToTrigger,
+				tasksToWaitFor,
+				tasksToCommitTo,
+				checkpointIDCounter,
+				completedCheckpointStore,
+				checkpointStateBackend,
+				ioExecutor,
+				timer,
+				sharedStateRegistryFactory,
+				failureManager);
+		}
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FailoverStrategyCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FailoverStrategyCheckpointCoordinatorTest.java
@@ -95,10 +95,12 @@ public class FailoverStrategyCheckpointCoordinatorTest extends TestLogger {
 		// only trigger the periodic scheduling
 		// we can't trigger all scheduled task, because there is also a cancellation scheduled
 		manualThreadExecutor.triggerPeriodicScheduledTasks();
+		manualThreadExecutor.triggerAll();
 		assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
 
 		for (int i = 1; i < maxConcurrentCheckpoints; i++) {
 			checkpointCoordinator.triggerCheckpoint(System.currentTimeMillis(), false);
+			manualThreadExecutor.triggerAll();
 			assertEquals(i + 1, checkpointCoordinator.getNumberOfPendingCheckpoints());
 			assertTrue(checkpointCoordinator.isCurrentPeriodicTriggerAvailable());
 		}
@@ -106,6 +108,7 @@ public class FailoverStrategyCheckpointCoordinatorTest extends TestLogger {
 		// as we only support limited concurrent checkpoints, after checkpoint triggered more than the limits,
 		// the currentPeriodicTrigger would been assigned as null.
 		checkpointCoordinator.triggerCheckpoint(System.currentTimeMillis(), false);
+		manualThreadExecutor.triggerAll();
 		assertFalse(checkpointCoordinator.isCurrentPeriodicTriggerAvailable());
 		assertEquals(maxConcurrentCheckpoints, checkpointCoordinator.getNumberOfPendingCheckpoints());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
@@ -56,6 +56,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -799,6 +800,29 @@ public class FutureUtilsTest extends TestLogger {
 		Throwable actualException = getThrowable(source);
 
 		assertThat(targetException, is(equalTo(actualException)));
+	}
+
+	@Test
+	public void testGetWithoutException() {
+		final CompletableFuture<Integer> completableFuture = new CompletableFuture<>();
+		completableFuture.complete(1);
+
+		assertEquals(new Integer(1), FutureUtils.getWithoutException(completableFuture));
+	}
+
+	@Test
+	public void testGetWithoutExceptionWithAnException() {
+		final CompletableFuture<Integer> completableFuture = new CompletableFuture<>();
+		completableFuture.completeExceptionally(new RuntimeException("expected"));
+
+		assertNull(FutureUtils.getWithoutException(completableFuture));
+	}
+
+	@Test
+	public void testGetWithoutExceptionWithoutFinishing() {
+		final CompletableFuture<Integer> completableFuture = new CompletableFuture<>();
+
+		assertNull(FutureUtils.getWithoutException(completableFuture));
 	}
 
 	private static Throwable getThrowable(CompletableFuture<?> completableFuture) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.failover.AdaptedRestartPipelinedRegionStrategyNG;
 import org.apache.flink.runtime.executiongraph.restart.FixedDelayRestartStrategy;
+import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -49,6 +50,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.Matchers.empty;
@@ -65,15 +67,23 @@ public class AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest 
 
 	private ComponentMainThreadExecutor componentMainThreadExecutor;
 
+	private SimpleAckingTaskManagerGateway taskManagerGateway;
+
 	@Before
 	public void setUp() {
 		manualMainThreadExecutor = new ManuallyTriggeredScheduledExecutor();
 		componentMainThreadExecutor = new ComponentMainThreadExecutorServiceAdapter(manualMainThreadExecutor, Thread.currentThread());
+		taskManagerGateway = new SimpleAckingTaskManagerGateway();
 	}
 
 	@Test
 	public void abortPendingCheckpointsWhenRestartingTasks() throws Exception {
 		final JobGraph jobGraph = createStreamingJobGraph();
+		final CountDownLatch checkpointTriggeredLatch = new CountDownLatch(1);
+		taskManagerGateway.setCheckpointConsumer(
+			(executionAttemptID, jobId, checkpointId, timestamp, checkpointOptions, advanceToEndOfEventTime) -> {
+				checkpointTriggeredLatch.countDown();
+			});
 		final ExecutionGraph executionGraph = createExecutionGraph(jobGraph);
 
 		final Iterator<ExecutionVertex> vertexIterator = executionGraph.getAllExecutionVertices().iterator();
@@ -85,6 +95,7 @@ public class AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest 
 		checkState(checkpointCoordinator != null);
 
 		checkpointCoordinator.triggerCheckpoint(System.currentTimeMillis(),  false);
+		checkpointTriggeredLatch.await();
 		assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
 		long checkpointId = checkpointCoordinator.getPendingCheckpoints().keySet().iterator().next();
 
@@ -137,7 +148,7 @@ public class AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest 
 			.setJobGraph(jobGraph)
 			.setRestartStrategy(new FixedDelayRestartStrategy(10, 0))
 			.setFailoverStrategyFactory(AdaptedRestartPipelinedRegionStrategyNG::new)
-			.setSlotProvider(new SimpleSlotProvider(jobGraph.getJobID(), 2))
+			.setSlotProvider(new SimpleSlotProvider(jobGraph.getJobID(), 2, taskManagerGateway))
 			.build();
 
 		enableCheckpointing(executionGraph);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestExecutionSlotAllocator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestExecutionSlotAllocator.java
@@ -41,6 +41,8 @@ public class TestExecutionSlotAllocator implements ExecutionSlotAllocator, SlotO
 
 	private final Map<ExecutionVertexID, SlotExecutionVertexAssignment> pendingRequests = new HashMap<>();
 
+	private final TestingLogicalSlotBuilder logicalSlotBuilder = new TestingLogicalSlotBuilder();
+
 	private boolean autoCompletePendingRequests = true;
 
 	private final List<LogicalSlot> returnedSlots = new ArrayList<>();
@@ -87,7 +89,7 @@ public class TestExecutionSlotAllocator implements ExecutionSlotAllocator, SlotO
 		checkState(slotVertexAssignment != null);
 		slotVertexAssignment
 			.getLogicalSlotFuture()
-			.complete(new TestingLogicalSlotBuilder()
+			.complete(logicalSlotBuilder
 				.setSlotOwner(this)
 				.createTestingLogicalSlot());
 	}
@@ -139,5 +141,9 @@ public class TestExecutionSlotAllocator implements ExecutionSlotAllocator, SlotO
 
 	public List<LogicalSlot> getReturnedSlots() {
 		return new ArrayList<>(returnedSlots);
+	}
+
+	public TestingLogicalSlotBuilder getLogicalSlotBuilder() {
+		return logicalSlotBuilder;
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

* This PR aims to separating checkpoint triggering into several asynchronous stages.
* This is the heart part of threading model refactoring.

## Brief change log

* Unify all error handling of checkpoint failure.
* Change the semantic from queued to suspended if there are too many in-flight checkpoints.
* Separate the triggering from synchronous to asynchronous.
  * The last commit is a bit large although I have done some preparations in the prior and this PR :(
  * Introduces an `isTriggering` variable to avoid competition between in-flight checkpoint trigger and the later one. Because we have to keep the order of triggering and avoid concurrent competition.
  * Introduces a `triggerRequestQueue` which is used to queue the trigger request which can't be triggered at that moment.
  * There are only two exits of triggering, `onTriggerSuccess` and `OnTriggerFailure`. Either of them must be called at the end of triggering lifecycle. In there, we maintain the status of `isTriggering`.
  * Do not invoke `CheckpointFailureManager#handleJobLevelCheckpointException` when trigger failure. It's useless for now. And it's also a blocking operation to get the current checkpoint id.
  * There are lots of test cases need to change because `triggerCheckpoint` becomes an asynchronous operation. We need to manually trigger the asynchronous trigger stages.
  * `triggerCheckpoint` will not throw exception directly even it fails at the very beginning. All error handling outside checkpoint coordinator should be through return value of `triggerCheckpoint`. In this way, we don't need "try catch" everywhere.

## Verifying this change

* There are a lot of existing test cases and this change also added tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: it should be no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
