### PR TITLE
[hotfix][rocksdb] fix exception message upon failure to create directory

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
@@ -190,7 +190,7 @@ public class RocksIncrementalSnapshotStrategy<K> extends RocksDBSnapshotStrategy
 
 			if (!directory.exists() && !directory.mkdirs()) {
 				throw new IOException("Local state base directory for checkpoint " + checkpointId +
-					" already exists: " + directory);
+					" does not exist and could not be created: " + directory);
 			}
 
 			// introduces an extra directory because RocksDB wants a non-existing directory for native checkpoints.


### PR DESCRIPTION
## What is the purpose of the change

This hotfix changes an exception message in `RocksIncrementalSnapshotStrategy#prepareLocalSnapshotDirectory()` which was wrong and may have mislead debugging steps when not looking into Flink's code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/flink/10335)
<!-- Reviewable:end -->
