### PR TITLE
[FLINK-14935][task,runtime] Use RunnableWithException in the Mailbox

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/function/FunctionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/function/FunctionUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.util.function;
 
 import org.apache.flink.util.ExceptionUtils;
 
+import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -112,6 +113,16 @@ public class FunctionUtils {
 			} catch (Throwable t) {
 				ExceptionUtils.rethrow(t);
 			}
+			return result;
+		};
+	}
+
+	/**
+	 * Converts {@link RunnableWithException} into a {@link Callable} that will return the {@code result}.
+	 */
+	public static <T> Callable<T> asCallable(RunnableWithException command, T result) {
+		return () -> {
+			command.run();
 			return result;
 		};
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureTaskWithException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureTaskWithException.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.util.function.RunnableWithException;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.FutureTask;
+
+import static org.apache.flink.util.function.FunctionUtils.asCallable;
+
+/**
+ * {@link FutureTask} that also implements {@link RunnableWithException}.
+ */
+public class FutureTaskWithException<V> extends FutureTask<V> implements RunnableWithException {
+	public FutureTaskWithException(Callable<V> callable) {
+		super(callable);
+	}
+
+	public FutureTaskWithException(RunnableWithException command) {
+		this(asCallable(command, null));
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -1061,9 +1061,9 @@ public class FutureUtils {
 	 *
 	 * @param runnables list of {@link Runnable} candidates to cancel.
 	 */
-	public static void cancelRunnableFutures(@Nonnull List<Runnable> runnables) {
+	public static void cancelRunnableFutures(@Nonnull List<RunnableWithException> runnables) {
 		RuntimeException suppressedExceptions = null;
-		for (Runnable runnable : runnables) {
+		for (RunnableWithException runnable : runnables) {
 			if (runnable instanceof java.util.concurrent.Future) {
 				try {
 					((java.util.concurrent.Future<?>) runnable).cancel(false);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/MailboxExecutor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/MailboxExecutor.java
@@ -24,15 +24,14 @@ import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox;
 import javax.annotation.Nonnull;
 
 import java.util.concurrent.Callable;
-import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.RejectedExecutionException;
 
 /**
- * Interface for an {@link Executor} build around a mailbox-based execution model (see {@link TaskMailbox}). {@code
- * MailboxExecutor} can also execute downstream messages of a mailbox by yielding control from the task thread.
+ * {@link java.util.concurrent.Executor} like interface for an  build around a mailbox-based execution model (see {@link TaskMailbox}).
+ * {@code MailboxExecutor} can also execute downstream messages of a mailbox by yielding control from the task thread.
  *
  * <p>All submission functions can be called from any thread and will enqueue the action for further processing in a
  * FIFO fashion.
@@ -227,21 +226,4 @@ public interface MailboxExecutor {
 	 * @throws IllegalStateException if the mailbox is closed and can no longer supply runnables for yielding.
 	 */
 	boolean tryYield();
-
-	/**
-	 * Provides an {@link Executor} view on this {@code MailboxExecutor}, where submitted tasks will receive the
-	 * given description. The {@link Executor} can be used with {@link java.util.concurrent.CompletableFuture}.
-	 *
-	 * <p>An optional description can (and should) be added to ease debugging and error-reporting. The description
-	 * may contain placeholder that refer to the provided description arguments using {@link java.util.Formatter}
-	 * syntax. The actual description is only formatted on demand.
-	 *
-	 * @param descriptionFormat the optional description for all commands that is used for debugging and
-	 * error-reporting.
-	 * @param descriptionArgs the parameters used to format the final description string.
-	 * @return an {@code Executor} view on this {@code MailboxExecutor}
-	 */
-	default Executor asExecutor(String descriptionFormat, Object... descriptionArgs) {
-		return command -> execute(command, descriptionFormat, descriptionArgs);
-	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
@@ -27,6 +27,7 @@ import org.apache.flink.util.WrappingRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -55,7 +56,7 @@ import static org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox.MIN_P
  * encapsulated {@link TaskMailbox} (which is open-quiesce-close).
  */
 @Internal
-public class MailboxProcessor {
+public class MailboxProcessor implements Closeable {
 
 	private static final Logger LOG = LoggerFactory.getLogger(MailboxProcessor.class);
 
@@ -113,6 +114,7 @@ public class MailboxProcessor {
 	 * Lifecycle method to close the mailbox for action submission/retrieval. This will cancel all instances of
 	 * {@link java.util.concurrent.RunnableFuture} that are still contained in the mailbox.
 	 */
+	@Override
 	public void close() {
 		List<Mail> droppedMails = mailbox.close();
 		if (!droppedMails.isEmpty()) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/MailboxOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/MailboxOperatorTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTaskTestHarness;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.RunnableWithException;
 
 import org.junit.Test;
 
@@ -132,7 +133,7 @@ public class MailboxOperatorTest extends TestLogger {
 		}
 	}
 
-	private static class ReplicatingMail implements Runnable {
+	private static class ReplicatingMail implements RunnableWithException {
 		private int mailCount = -1;
 		private final MailboxExecutor mailboxExecutor;
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -128,6 +128,7 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.RunnableWithException;
 import org.apache.flink.util.function.SupplierWithException;
 
 import org.junit.Assert;
@@ -913,7 +914,7 @@ public class StreamTaskTest extends TestLogger {
 			final AvailabilityTestStreamTask task = new AvailabilityTestStreamTask<>(environment, inputProcessor);
 			final MailboxExecutor executor = task.mailboxProcessor.getMainMailboxExecutor();
 
-			final Runnable completeFutureTask = () -> {
+			final RunnableWithException completeFutureTask = () -> {
 				assertEquals(1, inputProcessor.currentNumProcessCalls);
 				assertTrue(task.mailboxProcessor.isDefaultActionUnavailable());
 				environment.getWriter(1).getAvailableFuture().complete(null);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImplTest.java
@@ -24,7 +24,9 @@ import org.apache.flink.util.Preconditions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -35,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -47,6 +50,9 @@ public class MailboxExecutorImplTest {
 	private MailboxExecutor mailboxExecutor;
 	private ExecutorService otherThreadExecutor;
 	private TaskMailboxImpl mailbox;
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
 
 	@Before
 	public void setUp() throws Exception {
@@ -142,6 +148,16 @@ public class MailboxExecutorImplTest {
 
 		Assert.assertNull(exceptionReference.get());
 		Assert.assertEquals(Thread.currentThread(), testRunnable.wasExecutedBy());
+	}
+
+	@Test
+	public void testPrettyExceptionMessage() {
+		final String description = "Pretty command description";
+		mailboxExecutor.execute(
+			() -> { throw new RuntimeException("Some random exception"); },
+			description);
+		expectedException.expectMessage(containsString(description));
+		mailboxExecutor.tryYield();
 	}
 
 	@Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImplTest.java
@@ -160,15 +160,6 @@ public class MailboxExecutorImplTest {
 		mailboxExecutor.tryYield();
 	}
 
-	@Test
-	public void testExecutorView() throws Exception {
-		CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {}, mailboxExecutor.asExecutor("runAsync"));
-		assertFalse(future.isDone());
-
-		mailboxExecutor.yield();
-		assertTrue(future.isDone());
-	}
-
 	/**
 	 * Test {@link Runnable} that tracks execution.
 	 */

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImplTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.tasks.mailbox;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.streaming.api.operators.MailboxExecutor;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.function.RunnableWithException;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -154,7 +155,9 @@ public class MailboxExecutorImplTest {
 	public void testPrettyExceptionMessage() {
 		final String description = "Pretty command description";
 		mailboxExecutor.execute(
-			() -> { throw new RuntimeException("Some random exception"); },
+			() -> {
+				throw new RuntimeException("Some random exception");
+			},
 			description);
 		expectedException.expectMessage(containsString(description));
 		mailboxExecutor.tryYield();
@@ -163,7 +166,7 @@ public class MailboxExecutorImplTest {
 	/**
 	 * Test {@link Runnable} that tracks execution.
 	 */
-	static class TestRunnable implements Runnable {
+	static class TestRunnable implements RunnableWithException {
 
 		private Thread executedByThread = null;
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxImplTest.java
@@ -46,8 +46,8 @@ import static org.junit.Assert.assertEquals;
  */
 public class TaskMailboxImplTest {
 
-	private static final Runnable NO_OP = () -> {};
-	private static final Runnable POISON_MAIL = NO_OP;
+	private static final RunnableWithException NO_OP = () -> {};
+	private static final RunnableWithException POISON_MAIL = NO_OP;
 	private static final int DEFAULT_PRIORITY = 0;
 	/**
 	 * Object under test.
@@ -107,7 +107,7 @@ public class TaskMailboxImplTest {
 	 * Test the producer-consumer pattern using the blocking methods on the mailbox.
 	 */
 	@Test
-	public void testConcurrentPutTakeBlocking() throws InterruptedException {
+	public void testConcurrentPutTakeBlocking() throws Exception {
 		testPutTake(mailbox -> mailbox.take(DEFAULT_PRIORITY));
 	}
 
@@ -115,7 +115,7 @@ public class TaskMailboxImplTest {
 	 * Test the producer-consumer pattern using the non-blocking methods & waits on the mailbox.
 	 */
 	@Test
-	public void testConcurrentPutTakeNonBlockingAndWait() throws InterruptedException {
+	public void testConcurrentPutTakeNonBlockingAndWait() throws Exception {
 		testPutTake((mailbox -> {
 				Optional<Mail> optionalMail = mailbox.tryTake(DEFAULT_PRIORITY);
 				while (!optionalMail.isPresent()) {
@@ -233,8 +233,7 @@ public class TaskMailboxImplTest {
 	/**
 	 * Test producer-consumer pattern through the mailbox in a concurrent setting (n-writer / 1-reader).
 	 */
-	private void testPutTake(FunctionWithException<TaskMailbox, Mail, InterruptedException> takeMethod)
-			throws InterruptedException {
+	private void testPutTake(FunctionWithException<TaskMailbox, Mail, InterruptedException> takeMethod) throws Exception {
 		final int numThreads = 10;
 		final int numMailsPerThread = 1000;
 		final int[] results = new int[numThreads];


### PR DESCRIPTION
This allows mailbox action to throw an exception.

## Verifying this change

This change is already covered by existing tests and adds a new one `TaskMailboxProcessorTest#testSubmittingRunnableWithException` 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
