### PR TITLE
[FLINK-14940][travis] Fix error code handling for maven calls

### DIFF
--- a/tools/travis_watchdog.sh
+++ b/tools/travis_watchdog.sh
@@ -284,8 +284,6 @@ case $TEST in
             printf "==============================================================================\n"
 
             run_with_watchdog "$MVN_E2E"
-
-            EXIT_CODE=$?
         else
             printf "\n==============================================================================\n"
             printf "Previous build failure detected, skipping java end-to-end tests.\n"


### PR DESCRIPTION
`run_with_watchdog` automatically updates `EXIT_CODE`, but we were still checking the exit_code of run_with_watchdog after executing the e2e tests. Since the function ran without an error it returns 0, causing us to overwrite the value written into EXIT_CODE.