### PR TITLE
[FLINK-14976][cassandra] Release semaphore on all Throwable's in send()

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBase.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBase.java
@@ -132,7 +132,7 @@ public abstract class CassandraSinkBase<IN, V> extends RichSinkFunction<IN> impl
 		final ListenableFuture<V> result;
 		try {
 			result = send(value);
-		} catch (Exception e) {
+		} catch (Throwable e) {
 			semaphore.release();
 			throw e;
 		}

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseTest.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.util.Preconditions;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
-import com.datastax.driver.core.exceptions.InvalidQueryException;
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.junit.Assert;
@@ -42,9 +41,13 @@ import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 
 import static org.apache.flink.util.ExceptionUtils.findSerializedThrowable;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
 
@@ -81,7 +84,7 @@ public class CassandraSinkBaseTest {
 			casSinkFunc.enqueueCompletableFuture(CompletableFuture.completedFuture(null));
 
 			final int originalPermits = casSinkFunc.getAvailablePermits();
-			Assert.assertThat(originalPermits, greaterThan(0));
+			assertThat(originalPermits, greaterThan(0));
 			Assert.assertEquals(0, casSinkFunc.getAcquiredPermits());
 
 			casSinkFunc.invoke("hello");
@@ -277,21 +280,29 @@ public class CassandraSinkBaseTest {
 	}
 
 	@Test(timeout = DEFAULT_TEST_TIMEOUT)
-	public void testReleaseOnSendException() throws Exception {
+	public void testReleaseOnThrowingSend() throws Exception {
 		final CassandraSinkBaseConfig config = CassandraSinkBaseConfig.newBuilder()
 			.setMaxConcurrentRequests(1)
 			.build();
 
-		try (TestCassandraSink testCassandraSink = createOpenedSendExceptionTestCassandraSink(config)) {
-			Assert.assertEquals(1, testCassandraSink.getAvailablePermits());
-			Assert.assertEquals(0, testCassandraSink.getAcquiredPermits());
+		Function<String, ListenableFuture<ResultSet>> failingSendFunction = ignoredMessage -> {
+			throwCheckedAsUnchecked(new Throwable("expected"));
+			//noinspection ReturnOfNull
+			return null;
+		};
 
+		try (TestCassandraSink testCassandraSink = new MockCassandraSink(config, failingSendFunction)) {
+			testCassandraSink.open(new Configuration());
+			assertThat(testCassandraSink.getAvailablePermits(), is(1));
+			assertThat(testCassandraSink.getAcquiredPermits(), is(0));
+
+			//noinspection OverlyBroadCatchBlock,NestedTryStatement
 			try {
-				testCassandraSink.invoke("N/A");
-			} catch (Exception e) {
-				Assert.assertTrue(e instanceof InvalidQueryException);
-				Assert.assertEquals(1, testCassandraSink.getAvailablePermits());
-				Assert.assertEquals(0, testCassandraSink.getAcquiredPermits());
+				testCassandraSink.invoke("none");
+			} catch (Throwable e) {
+				assertThat(e, instanceOf(Throwable.class));
+				assertThat(testCassandraSink.getAvailablePermits(), is(1));
+				assertThat(testCassandraSink.getAcquiredPermits(), is(0));
 			}
 		}
 	}
@@ -355,10 +366,9 @@ public class CassandraSinkBaseTest {
 		return testHarness;
 	}
 
-	private TestCassandraSink createOpenedSendExceptionTestCassandraSink(CassandraSinkBaseConfig config) {
-		final TestCassandraSink testCassandraSink = new SendExceptionTestCassandraSink(config);
-		testCassandraSink.open(new Configuration());
-		return testCassandraSink;
+	private static <T extends Throwable> void throwCheckedAsUnchecked(Throwable ex) throws T {
+		//noinspection unchecked
+		throw (T) ex;
 	}
 
 	private static class TestCassandraSink extends CassandraSinkBase<String, ResultSet> implements AutoCloseable {
@@ -410,14 +420,19 @@ public class CassandraSinkBaseTest {
 		}
 	}
 
-	private static class SendExceptionTestCassandraSink extends TestCassandraSink {
-		SendExceptionTestCassandraSink(CassandraSinkBaseConfig config) {
+	private static class MockCassandraSink extends TestCassandraSink {
+		private static final long serialVersionUID = -3363195776692829911L;
+
+		private final Function<String, ListenableFuture<ResultSet>> sendFunction;
+
+		MockCassandraSink(CassandraSinkBaseConfig config, Function<String, ListenableFuture<ResultSet>> sendFunction) {
 			super(config, new NoOpCassandraFailureHandler());
+			this.sendFunction = sendFunction;
 		}
 
 		@Override
 		public ListenableFuture<ResultSet> send(String value) {
-			throw new InvalidQueryException("For test purposes");
+			return this.sendFunction.apply(value);
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

https://github.com/apache/flink/pull/8967 changed the Cassandra connector to catch `Exception` and release the semaphore correctly, however this is not general enough as e.g. `Error` can still lead to deadlock. Change code to catch all `Throwable` instead.


## Brief change log

  - Release Semaphore correctly on all Throwable in send()

## Verifying this change

This change added tests and can be verified as follows:
  - Added unit test that validates semaphore released if `Error` in send(); test fails before change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
