### PR TITLE
[FLINK-14974][runtime] Calculate managed memory fractions with BigDecimal and round down it properly

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -735,6 +735,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 		final StreamConfig map3Config = new StreamConfig(vertex3.getConfiguration());
 		assertEquals(1.0, map3Config.getManagedMemoryFractionOnHeap(), 0.000001);
 		assertEquals(1.0, map3Config.getManagedMemoryFractionOffHeap(), 0.000001);
+
 	}
 
 	private JobGraph createJobGraphForManagedMemoryFractionTest(


### PR DESCRIPTION

## What is the purpose of the change

This PR is to change `StreamingJobGraphGenerator#setManagedMemoryFractionForOperator` to use `BigDecimal#divide(otherValue, scale, RoundMode.ROUND_DOWN)` to calculate managed memory fractions. In this way, the sum of the fractions will not exceed 1.0. 
Otherwise fractions summed up to be more than 1.0 may result in the last operator to fail to allocate managed memory it is supposed to be able to acquire.

## Brief change log

  - *Changed `StreamingJobGraphGenerator#setManagedMemoryFractionForOperator` to use `BigDecimal#divide(otherValue, scale, RoundMode.ROUND_DOWN)` to calculate managed memory fractions*


## Verifying this change

This change added tests and can be verified as follows:

  - *The case StreamingJobGraphGeneratorTest#testManagedMemoryFractionForSpecifiedResourceSpec is adjusted to verify this change*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
