### PR TITLE
[FLINK-12484][runtime] synchronize all mailbox actions

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -28,13 +28,10 @@ import org.apache.flink.util.function.SupplierWithException;
 
 import akka.dispatch.OnComplete;
 
-import javax.annotation.Nonnull;
-
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -1053,29 +1050,6 @@ public class FutureUtils {
 				uncaughtExceptionHandler.uncaughtException(Thread.currentThread(), throwable);
 			}
 		});
-	}
-
-	/**
-	 * Cancels all instances of {@link java.util.concurrent.Future} in the given list of runnables without interrupting.
-	 * This method will suppress unexpected exceptions until the whole list is processed and then rethrow.
-	 *
-	 * @param runnables list of {@link Runnable} candidates to cancel.
-	 */
-	public static void cancelRunnableFutures(@Nonnull List<RunnableWithException> runnables) {
-		RuntimeException suppressedExceptions = null;
-		for (RunnableWithException runnable : runnables) {
-			if (runnable instanceof java.util.concurrent.Future) {
-				try {
-					((java.util.concurrent.Future<?>) runnable).cancel(false);
-				} catch (RuntimeException ex) {
-					// safety net to ensure all candidates get cancelled before we let the exception bubble up.
-					suppressedExceptions = ExceptionUtils.firstOrSuppressed(ex, suppressedExceptions);
-				}
-			}
-		}
-		if (suppressedExceptions != null) {
-			throw suppressedExceptions;
-		}
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/MailboxExecutor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/MailboxExecutor.java
@@ -109,22 +109,6 @@ public interface MailboxExecutor {
 	void execute(@Nonnull RunnableWithException command, String descriptionFormat, Object... descriptionArgs);
 
 	/**
-	 * Executes the given command at the next possible time in the mailbox thread. Repeated calls will result in the
-	 * last executed command being executed first.
-	 *
-	 * <p>An optional description can (and should) be added to ease debugging and error-reporting. The description
-	 * may contain placeholder that refer to the provided description arguments using {@link java.util.Formatter}
-	 * syntax. The actual description is only formatted on demand.
-	 *
-	 * @param command the runnable task to add to the mailbox for execution.
-	 * @param descriptionFormat the optional description for the command that is used for debugging and error-reporting.
-	 * @param descriptionArgs the parameters used to format the final description string.
-	 * @throws RejectedExecutionException if this task cannot be accepted for execution, e.g. because the mailbox is
-	 *                                    quiesced or closed.
-	 */
-	void executeFirst(@Nonnull RunnableWithException command, String descriptionFormat, Object... descriptionArgs);
-
-	/**
 	 * Submits the given command for execution in the future in the mailbox thread and returns a Future representing
 	 * that command. The Future's {@code get} method will return {@code null} upon <em>successful</em> completion.
 	 *

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -280,7 +280,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		this.accumulatorMap = getEnvironment().getAccumulatorRegistry().getUserMap();
 		this.recordWriter = createRecordWriterDelegate(configuration, environment);
 		this.actionExecutor = Preconditions.checkNotNull(actionExecutor);
-		this.mailboxProcessor = new MailboxProcessor(this::processInput, mailbox);
+		this.mailboxProcessor = new MailboxProcessor(this::processInput, mailbox, actionExecutor);
 		this.asyncExceptionHandler = new StreamTaskAsyncExceptionHandler(environment);
 	}
 
@@ -1491,12 +1491,10 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	}
 
 	private void invokeProcessingTimeCallback(ProcessingTimeCallback callback, long timestamp) {
-		synchronized (getCheckpointLock()) {
-			try {
-				callback.onProcessingTime(timestamp);
-			} catch (Throwable t) {
-				handleAsyncException("Caught exception while processing timer.", new TimerException(t));
-			}
+		try {
+			callback.onProcessingTime(timestamp);
+		} catch (Throwable t) {
+			handleAsyncException("Caught exception while processing timer.", new TimerException(t));
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -200,6 +200,8 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	/** Flag to mark this task as canceled. */
 	private volatile boolean canceled;
 
+	private volatile boolean disposed;
+
 	/** Thread pool for async snapshot workers. */
 	private ExecutorService asyncOperationsThreadPool;
 
@@ -383,53 +385,55 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		}
 	}
 
+	private void beforeInvoke() throws Exception {
+		disposed = false;
+		LOG.debug("Initializing {}.", getName());
+
+		asyncOperationsThreadPool = Executors.newCachedThreadPool(new ExecutorThreadFactory("AsyncOperations", uncaughtExceptionHandler));
+
+		stateBackend = createStateBackend();
+		checkpointStorage = stateBackend.createCheckpointStorage(getEnvironment().getJobID());
+
+		// if the clock is not already set, then assign a default TimeServiceProvider
+		if (timerService == null) {
+			ThreadFactory timerThreadFactory =
+				new DispatcherThreadFactory(TRIGGER_THREAD_GROUP, "Time Trigger for " + getName());
+
+			timerService = new SystemProcessingTimeService(
+				this::handleTimerException,
+				timerThreadFactory);
+		}
+
+		operatorChain = new OperatorChain<>(this, recordWriter);
+		headOperator = operatorChain.getHeadOperator();
+
+		// task specific initialization
+		init();
+
+		// save the work of reloading state, etc, if the task is already canceled
+		if (canceled) {
+			throw new CancelTaskException();
+		}
+
+		// -------- Invoke --------
+		LOG.debug("Invoking {}", getName());
+
+		// we need to make sure that any triggers scheduled in open() cannot be
+		// executed before all operators are opened
+		synchronized (lock) {
+
+			// both the following operations are protected by the lock
+			// so that we avoid race conditions in the case that initializeState()
+			// registers a timer, that fires before the open() is called.
+
+			initializeStateAndOpen();
+		}
+	}
+
 	@Override
 	public final void invoke() throws Exception {
-
-		boolean disposed = false;
 		try {
-			// -------- Initialize ---------
-			LOG.debug("Initializing {}.", getName());
-
-			asyncOperationsThreadPool = Executors.newCachedThreadPool(new ExecutorThreadFactory("AsyncOperations", uncaughtExceptionHandler));
-
-			stateBackend = createStateBackend();
-			checkpointStorage = stateBackend.createCheckpointStorage(getEnvironment().getJobID());
-
-			// if the clock is not already set, then assign a default TimeServiceProvider
-			if (timerService == null) {
-				ThreadFactory timerThreadFactory =
-					new DispatcherThreadFactory(TRIGGER_THREAD_GROUP, "Time Trigger for " + getName());
-
-				timerService = new SystemProcessingTimeService(
-					this::handleTimerException,
-					timerThreadFactory);
-			}
-
-			operatorChain = new OperatorChain<>(this, recordWriter);
-			headOperator = operatorChain.getHeadOperator();
-
-			// task specific initialization
-			init();
-
-			// save the work of reloading state, etc, if the task is already canceled
-			if (canceled) {
-				throw new CancelTaskException();
-			}
-
-			// -------- Invoke --------
-			LOG.debug("Invoking {}", getName());
-
-			// we need to make sure that any triggers scheduled in open() cannot be
-			// executed before all operators are opened
-			synchronized (lock) {
-
-				// both the following operations are protected by the lock
-				// so that we avoid race conditions in the case that initializeState()
-				// registers a timer, that fires before the open() is called.
-
-				initializeStateAndOpen();
-			}
+			beforeInvoke();
 
 			// final check to exit early before starting to run
 			if (canceled) {
@@ -446,98 +450,104 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 				throw new CancelTaskException();
 			}
 
-			LOG.debug("Finished task {}", getName());
-
-			// make sure no further checkpoint and notification actions happen.
-			// we make sure that no other thread is currently in the locked scope before
-			// we close the operators by trying to acquire the checkpoint scope lock
-			// we also need to make sure that no triggers fire concurrently with the close logic
-			// at the same time, this makes sure that during any "regular" exit where still
-			synchronized (lock) {
-				// this is part of the main logic, so if this fails, the task is considered failed
-				closeAllOperators();
-
-				// make sure no new timers can come
-				timerService.quiesce();
-
-				// let mailbox execution reject all new letters from this point
-				mailboxProcessor.prepareClose();
-
-				// only set the StreamTask to not running after all operators have been closed!
-				// See FLINK-7430
-				isRunning = false;
-			}
-			// processes the remaining mails; no new mails can be enqueued
-			mailboxProcessor.drain();
-
-			// make sure all timers finish
-			timerService.awaitPendingAfterQuiesce();
-
-			LOG.debug("Closed operators for task {}", getName());
-
-			// make sure all buffered data is flushed
-			operatorChain.flushOutputs();
-
-			// make an attempt to dispose the operators such that failures in the dispose call
-			// still let the computation fail
-			tryDisposeAllOperators();
-			disposed = true;
+			afterInvoke();
 		}
 		finally {
-			// clean up everything we initialized
-			isRunning = false;
-
-			// Now that we are outside the user code, we do not want to be interrupted further
-			// upon cancellation. The shutdown logic below needs to make sure it does not issue calls
-			// that block and stall shutdown.
-			// Additionally, the cancellation watch dog will issue a hard-cancel (kill the TaskManager
-			// process) as a backup in case some shutdown procedure blocks outside our control.
-			setShouldInterruptOnCancel(false);
-
-			// clear any previously issued interrupt for a more graceful shutdown
-			Thread.interrupted();
-
-			// stop all timers and threads
-			tryShutdownTimerService();
-
-			// stop all asynchronous checkpoint threads
-			try {
-				cancelables.close();
-				shutdownAsyncThreads();
-			}
-			catch (Throwable t) {
-				// catch and log the exception to not replace the original exception
-				LOG.error("Could not shut down async checkpoint threads", t);
-			}
-
-			// we must! perform this cleanup
-			try {
-				cleanup();
-			}
-			catch (Throwable t) {
-				// catch and log the exception to not replace the original exception
-				LOG.error("Error during cleanup of stream task", t);
-			}
-
-			// if the operators were not disposed before, do a hard dispose
-			if (!disposed) {
-				disposeAllOperators();
-			}
-
-			// release the output resources. this method should never fail.
-			if (operatorChain != null) {
-				// beware: without synchronization, #performCheckpoint() may run in
-				//         parallel and this call is not thread-safe
-				synchronized (lock) {
-					operatorChain.releaseOutputs();
-				}
-			} else {
-				// failed to allocate operatorChain, clean up record writers
-				recordWriter.close();
-			}
-
-			mailboxProcessor.close();
+			cleanUpInvoke();
 		}
+	}
+
+	private void afterInvoke() throws Exception {
+		LOG.debug("Finished task {}", getName());
+
+		// make sure no further checkpoint and notification actions happen.
+		// we make sure that no other thread is currently in the locked scope before
+		// we close the operators by trying to acquire the checkpoint scope lock
+		// we also need to make sure that no triggers fire concurrently with the close logic
+		// at the same time, this makes sure that during any "regular" exit where still
+		synchronized (lock) {
+			// this is part of the main logic, so if this fails, the task is considered failed
+			closeAllOperators();
+
+			// make sure no new timers can come
+			timerService.quiesce();
+
+			// let mailbox execution reject all new letters from this point
+			mailboxProcessor.prepareClose();
+
+			// only set the StreamTask to not running after all operators have been closed!
+			// See FLINK-7430
+			isRunning = false;
+		}
+		// processes the remaining mails; no new mails can be enqueued
+		mailboxProcessor.drain();
+
+		// make sure all timers finish
+		timerService.awaitPendingAfterQuiesce();
+
+		LOG.debug("Closed operators for task {}", getName());
+
+		// make sure all buffered data is flushed
+		operatorChain.flushOutputs();
+
+		// make an attempt to dispose the operators such that failures in the dispose call
+		// still let the computation fail
+		tryDisposeAllOperators();
+		disposed = true;
+	}
+
+	private void cleanUpInvoke() throws Exception {
+		// clean up everything we initialized
+		isRunning = false;
+
+		// Now that we are outside the user code, we do not want to be interrupted further
+		// upon cancellation. The shutdown logic below needs to make sure it does not issue calls
+		// that block and stall shutdown.
+		// Additionally, the cancellation watch dog will issue a hard-cancel (kill the TaskManager
+		// process) as a backup in case some shutdown procedure blocks outside our control.
+		setShouldInterruptOnCancel(false);
+
+		// clear any previously issued interrupt for a more graceful shutdown
+		Thread.interrupted();
+
+		// stop all timers and threads
+		tryShutdownTimerService();
+
+		// stop all asynchronous checkpoint threads
+		try {
+			cancelables.close();
+			shutdownAsyncThreads();
+		} catch (Throwable t) {
+			// catch and log the exception to not replace the original exception
+			LOG.error("Could not shut down async checkpoint threads", t);
+		}
+
+		// we must! perform this cleanup
+		try {
+			cleanup();
+		} catch (Throwable t) {
+			// catch and log the exception to not replace the original exception
+			LOG.error("Error during cleanup of stream task", t);
+		}
+
+		// if the operators were not disposed before, do a hard dispose
+		if (!disposed) {
+			disposeAllOperators();
+		}
+
+		// release the output resources. this method should never fail.
+		if (operatorChain != null) {
+			// beware: without synchronization, #performCheckpoint() may run in
+			//         parallel and this call is not thread-safe
+			synchronized (lock) {
+				operatorChain.releaseOutputs();
+			}
+		} else {
+			// failed to allocate operatorChain, clean up record writers
+			recordWriter.close();
+		}
+
+		mailboxProcessor.close();
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTaskActionExecutor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTaskActionExecutor.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.function.RunnableWithException;
+import org.apache.flink.util.function.ThrowingRunnable;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Executes {@link Runnable}, {@link ThrowingRunnable}, or {@link Callable}.
+ * Intended to customize execution in sub-types of {@link org.apache.flink.streaming.runtime.tasks.StreamTask StreamTask},
+ * e.g. synchronization in {@link org.apache.flink.streaming.runtime.tasks.SourceStreamTask SourceStreamTask}.
+ */
+@Internal
+public interface StreamTaskActionExecutor {
+	void run(RunnableWithException runnable) throws Exception;
+
+	<E extends Throwable> void runThrowing(ThrowingRunnable<E> runnable) throws E;
+
+	<R> R call(Callable<R> callable) throws Exception;
+
+	StreamTaskActionExecutor IMMEDIATE = new StreamTaskActionExecutor() {
+		@Override
+		public void run(RunnableWithException runnable) throws Exception {
+			runnable.run();
+		}
+
+		@Override
+		public <E extends Throwable> void runThrowing(ThrowingRunnable<E> runnable) throws E {
+			runnable.run();
+		}
+
+		@Override
+		public <R> R call(Callable<R> callable) throws Exception {
+			return callable.call();
+		}
+	};
+
+	/**
+	 * Returns an ExecutionDecorator that synchronizes each invocation.
+	 */
+	static SynchronizedStreamTaskActionExecutor synchronizedExecutor() {
+		return synchronizedExecutor(new Object());
+	}
+
+	/**
+	 * Returns an ExecutionDecorator that synchronizes each invocation on a given object.
+	 */
+	static SynchronizedStreamTaskActionExecutor synchronizedExecutor(Object mutex) {
+		return new SynchronizedStreamTaskActionExecutor(mutex);
+	}
+
+	/**
+	 * A {@link StreamTaskActionExecutor} that synchronizes every operation on the provided mutex.
+	 * @deprecated this class should only be used in {@link SourceStreamTask} which exposes the checkpoint lock as part of Public API.
+	 * During transitional period it is used in {@link StreamTask} (until {@link StreamTask#getCheckpointLock()}
+	 * is pushed down to {@link SourceStreamTask}).
+	 */
+	@Deprecated
+	class SynchronizedStreamTaskActionExecutor implements StreamTaskActionExecutor {
+		private final Object mutex;
+
+		public SynchronizedStreamTaskActionExecutor(Object mutex) {
+			this.mutex = mutex;
+		}
+
+		@Override
+		public void run(RunnableWithException runnable) throws Exception {
+			synchronized (mutex) {
+				runnable.run();
+			}
+		}
+
+		@Override
+		public <E extends Throwable> void runThrowing(ThrowingRunnable<E> runnable) throws E {
+			synchronized (mutex) {
+				runnable.run();
+			}
+		}
+
+		@Override
+		public <R> R call(Callable<R> callable) throws Exception {
+			synchronized (mutex) {
+				return callable.call();
+			}
+		}
+
+		/**
+		 * @return an object used for mutual exclusion of all operations that involve data and state mutation. (a.k.a. checkpoint lock).
+		 */
+		public Object getMutex() {
+			return mutex;
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/Mail.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/Mail.java
@@ -23,6 +23,8 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.function.RunnableWithException;
 
+import java.util.concurrent.Future;
+
 /**
  * An executable bound to a specific operator in the chain, such that it can be picked for downstream mailbox.
  */
@@ -62,8 +64,10 @@ public class Mail {
 		return priority;
 	}
 
-	public RunnableWithException getRunnable() {
-		return runnable;
+	public void tryCancel(boolean mayInterruptIfRunning) {
+		if (runnable instanceof Future) {
+			((Future<?>) runnable).cancel(mayInterruptIfRunning);
+		}
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImpl.java
@@ -19,6 +19,8 @@ package org.apache.flink.streaming.runtime.tasks.mailbox;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.api.operators.MailboxExecutor;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.WrappingRuntimeException;
 import org.apache.flink.util.function.RunnableWithException;
 
@@ -39,9 +41,12 @@ public final class MailboxExecutorImpl implements MailboxExecutor {
 
 	private final int priority;
 
-	public MailboxExecutorImpl(@Nonnull TaskMailbox mailbox, int priority) {
+	private final StreamTaskActionExecutor actionExecutor;
+
+	public MailboxExecutorImpl(@Nonnull TaskMailbox mailbox, int priority, StreamTaskActionExecutor actionExecutor) {
 		this.mailbox = mailbox;
 		this.priority = priority;
+		this.actionExecutor = Preconditions.checkNotNull(actionExecutor);
 	}
 
 	@Override
@@ -50,7 +55,7 @@ public final class MailboxExecutorImpl implements MailboxExecutor {
 		final String descriptionFormat,
 		final Object... descriptionArgs) {
 		try {
-			mailbox.put(new Mail(command, priority, descriptionFormat, descriptionArgs));
+			mailbox.put(new Mail(command, priority, actionExecutor, descriptionFormat, descriptionArgs));
 		} catch (IllegalStateException mbex) {
 			throw new RejectedExecutionException(mbex);
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImpl.java
@@ -57,18 +57,6 @@ public final class MailboxExecutorImpl implements MailboxExecutor {
 	}
 
 	@Override
-	public void executeFirst(
-		@Nonnull final RunnableWithException command,
-		final String descriptionFormat,
-		final Object... descriptionArgs) {
-		try {
-			mailbox.putFirst(new Mail(command, priority, descriptionFormat, descriptionArgs));
-		} catch (IllegalStateException mbex) {
-			throw new RejectedExecutionException(mbex);
-		}
-	}
-
-	@Override
 	public void yield() throws InterruptedException {
 		Mail mail = mailbox.take(priority);
 		try {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
@@ -81,8 +81,12 @@ public class MailboxProcessor implements Closeable {
 	private MailboxDefaultAction.Suspension suspendedDefaultAction;
 
 	public MailboxProcessor(MailboxDefaultAction mailboxDefaultAction) {
+		this(mailboxDefaultAction, new TaskMailboxImpl(Thread.currentThread()));
+	}
+
+	public MailboxProcessor(MailboxDefaultAction mailboxDefaultAction, TaskMailbox mailbox) {
 		this.mailboxDefaultAction = Preconditions.checkNotNull(mailboxDefaultAction);
-		mailbox = new TaskMailboxImpl(Thread.currentThread());
+		this.mailbox = mailbox;
 		mainMailboxExecutor = new MailboxExecutorImpl(mailbox, TaskMailbox.MIN_PRIORITY);
 		mailboxLoopRunning = true;
 		suspendedDefaultAction = null;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskExecutionDecorationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskExecutionDecorationTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
+import org.apache.flink.runtime.io.network.api.writer.NonRecordWriter;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
+import org.apache.flink.runtime.util.FatalExitExceptionHandler;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxDefaultAction;
+import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxImpl;
+import org.apache.flink.util.function.RunnableWithException;
+import org.apache.flink.util.function.ThrowingRunnable;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Verifies that {@link StreamTask} {@link StreamTaskActionExecutor decorates execution} of actions that potentially needs to be synchronized.
+ */
+public class StreamTaskExecutionDecorationTest {
+	private CountingStreamTaskActionExecutor decorator;
+	private StreamTask<Object, StreamOperator<Object>> task;
+	private TaskMailboxImpl mailbox;
+
+	@Test
+	public void testAbortCheckpointOnBarrierIsDecorated() throws Exception {
+		task.abortCheckpointOnBarrier(1, null);
+		Assert.assertTrue("execution decorator was not called", decorator.wasCalled());
+	}
+
+	@Test
+	public void testTriggerCheckpointOnBarrierIsDecorated() throws Exception {
+		task.triggerCheckpointOnBarrier(new CheckpointMetaData(1, 2), new CheckpointOptions(CheckpointType.CHECKPOINT, new CheckpointStorageLocationReference(new byte[]{1})), null);
+		Assert.assertTrue("execution decorator was not called", decorator.wasCalled());
+	}
+
+	@Test
+	public void testTriggerCheckpointAsyncIsDecorated() {
+		task.triggerCheckpointAsync(new CheckpointMetaData(1, 2), new CheckpointOptions(CheckpointType.CHECKPOINT, new CheckpointStorageLocationReference(new byte[]{1})), false);
+		Assert.assertTrue("mailbox is empty", mailbox.hasMail());
+		Assert.assertFalse("execution decorator was called preliminary", decorator.wasCalled());
+		mailbox.drain().forEach(m -> {
+			try {
+				m.run();
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		});
+		Assert.assertTrue("execution decorator was not called", decorator.wasCalled());
+	}
+
+	@Test
+	public void testMailboxExecutorIsDecorated() throws Exception {
+		task.mailboxProcessor.getMainMailboxExecutor().execute(() -> task.mailboxProcessor.allActionsCompleted(), "");
+		task.mailboxProcessor.runMailboxLoop();
+		Assert.assertTrue("execution decorator was not called", decorator.wasCalled());
+	}
+
+	@Before
+	public void before() {
+		mailbox = new TaskMailboxImpl();
+		decorator = new CountingStreamTaskActionExecutor();
+		task = new StreamTask<Object, StreamOperator<Object>>(new StreamTaskTest.DeclineDummyEnvironment(), null, FatalExitExceptionHandler.INSTANCE, decorator, mailbox) {
+			@Override
+			protected void init() {
+			}
+
+			@Override
+			protected void processInput(MailboxDefaultAction.Controller controller) {
+			}
+		};
+		task.operatorChain = new OperatorChain<>(task, new NonRecordWriter<>());
+	}
+
+	@After
+	public void after() {
+		decorator = null;
+		task = null;
+	}
+
+	static class CountingStreamTaskActionExecutor extends StreamTaskActionExecutor.SynchronizedStreamTaskActionExecutor {
+		private final AtomicInteger calls = new AtomicInteger(0);
+
+		CountingStreamTaskActionExecutor() {
+			super(new Object());
+		}
+
+		int getCallCount() {
+			return calls.get();
+		}
+
+		boolean wasCalled() {
+			return getCallCount() > 0;
+		}
+
+		@Override
+		public void run(RunnableWithException runnable) throws Exception {
+			calls.incrementAndGet();
+			runnable.run();
+		}
+
+		@Override
+		public <E extends Throwable> void runThrowing(ThrowingRunnable<E> runnable) throws E {
+			calls.incrementAndGet();
+			runnable.run();
+		}
+
+		@Override
+		public <R> R call(Callable<R> callable) throws Exception {
+			calls.incrementAndGet();
+			return callable.call();
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImplTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.streaming.runtime.tasks.mailbox;
 
-import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.streaming.api.operators.MailboxExecutor;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
 import org.apache.flink.util.Preconditions;
@@ -30,16 +29,16 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -52,6 +51,7 @@ public class MailboxExecutorImplTest {
 	private MailboxExecutor mailboxExecutor;
 	private ExecutorService otherThreadExecutor;
 	private TaskMailboxImpl mailbox;
+	private MailboxProcessor mailboxProcessor;
 
 	@Rule
 	public ExpectedException expectedException = ExpectedException.none();
@@ -61,6 +61,7 @@ public class MailboxExecutorImplTest {
 		this.mailbox = new TaskMailboxImpl();
 		this.mailboxExecutor = new MailboxExecutorImpl(mailbox, DEFAULT_PRIORITY, StreamTaskActionExecutor.IMMEDIATE);
 		this.otherThreadExecutor = Executors.newSingleThreadScheduledExecutor();
+		this.mailboxProcessor = new MailboxProcessor(c -> { }, StreamTaskActionExecutor.IMMEDIATE, mailbox, mailboxExecutor);
 	}
 
 	@After
@@ -81,30 +82,29 @@ public class MailboxExecutorImplTest {
 
 	@Test
 	public void testOperations() throws Exception {
-		final TestRunnable testRunnable = new TestRunnable();
-		mailboxExecutor.execute(testRunnable, "testRunnable");
-		Assert.assertEquals(testRunnable, mailbox.take(DEFAULT_PRIORITY).getRunnable());
+		AtomicBoolean wasExecuted = new AtomicBoolean(false);
+		CompletableFuture.runAsync(() -> mailboxExecutor.execute(() -> wasExecuted.set(true), ""), otherThreadExecutor).get();
 
-		CompletableFuture.runAsync(
-			() -> mailboxExecutor.execute(testRunnable, "testRunnable"),
-			otherThreadExecutor).get();
-		Assert.assertEquals(testRunnable, mailbox.take(DEFAULT_PRIORITY).getRunnable());
+		mailbox.take(DEFAULT_PRIORITY).run();
+		Assert.assertTrue(wasExecuted.get());
+	}
 
+	@Test
+	public void testClose() throws Exception {
 		final TestRunnable yieldRun = new TestRunnable();
 		final TestRunnable leftoverRun = new TestRunnable();
 		mailboxExecutor.execute(yieldRun, "yieldRun");
-		Future<?> leftoverFuture = CompletableFuture.supplyAsync(
+		final Future<?> leftoverFuture = CompletableFuture.supplyAsync(
 			() -> mailboxExecutor.submit(leftoverRun, "leftoverRun"),
 			otherThreadExecutor).get();
 
 		assertTrue(mailboxExecutor.tryYield());
-		Assert.assertEquals(Thread.currentThread(), yieldRun.wasExecutedBy());
-		assertFalse(leftoverFuture.isDone());
+		assertEquals(Thread.currentThread(), yieldRun.wasExecutedBy());
 
-		List<Mail> leftoverTasks = mailbox.close();
-		Assert.assertEquals(1, leftoverTasks.size());
+		assertFalse(leftoverFuture.isDone());
 		assertFalse(leftoverFuture.isCancelled());
-		FutureUtils.cancelRunnableFutures(leftoverTasks.stream().map(Mail::getRunnable).collect(Collectors.toList()));
+
+		mailboxProcessor.close();
 		assertTrue(leftoverFuture.isCancelled());
 
 		try {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImplTest.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.runtime.tasks.mailbox;
 
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.streaming.api.operators.MailboxExecutor;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.function.RunnableWithException;
 
@@ -58,7 +59,7 @@ public class MailboxExecutorImplTest {
 	@Before
 	public void setUp() throws Exception {
 		this.mailbox = new TaskMailboxImpl();
-		this.mailboxExecutor = new MailboxExecutorImpl(mailbox, DEFAULT_PRIORITY);
+		this.mailboxExecutor = new MailboxExecutorImpl(mailbox, DEFAULT_PRIORITY, StreamTaskActionExecutor.IMMEDIATE);
 		this.otherThreadExecutor = Executors.newSingleThreadScheduledExecutor();
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

* Synchronize all mailbox actions, so there is no need to acquire checkpoint lock in any code that is executed by the main task thread. This will further allow to drop getCheckpointLock() method from StreamTask

## Brief change log

  - introduce `ExecutionDecorator` field in `StreamTask`, `MailboxProcessor`, `MailboxExecutor`
  - use `SynchronizedExecutionDecorator` as a value for now
  - later (another PR) only `SourceStreamTask` will use it. All other tasks will use a decorator which just executes the action directly

## Verifying this change


This change is covered by a new `StreamTaskExecutionDecorationTest`, as well as existing tests: `SourceStreamTaskTest`, `StreamTaskTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  -- code available through `@PublicEvolving` is modified: `AbstractStreamOperator.getContainingTask.getCheckpointLock` is dropped
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **yes** (coarser lock granularity for SourceStreamTask)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
