### PR TITLE
[FLINK-14972] Make Remote(Stream)Environment use Executors.

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
@@ -40,14 +40,11 @@ import org.apache.flink.util.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.jar.JarFile;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -58,27 +55,6 @@ public enum ClientUtils {
 	;
 
 	private static final Logger LOG = LoggerFactory.getLogger(ClientUtils.class);
-
-	public static void checkJarFile(URL jar) throws IOException {
-		File jarFile;
-		try {
-			jarFile = new File(jar.toURI());
-		} catch (URISyntaxException e) {
-			throw new IOException("JAR file path is invalid '" + jar + '\'');
-		}
-		if (!jarFile.exists()) {
-			throw new IOException("JAR file does not exist '" + jarFile.getAbsolutePath() + '\'');
-		}
-		if (!jarFile.canRead()) {
-			throw new IOException("JAR file can't be read '" + jarFile.getAbsolutePath() + '\'');
-		}
-
-		try (JarFile ignored = new JarFile(jarFile)) {
-			// verify that we can open the Jar file
-		} catch (IOException e) {
-			throw new IOException("Error while opening jar file '" + jarFile.getAbsolutePath() + '\'', e);
-		}
-	}
 
 	public static ClassLoader buildUserCodeClassLoader(
 			List<URL> jars,

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/RemoteExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/RemoteExecutor.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment.executors;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.client.deployment.AbstractSessionClusterExecutor;
+import org.apache.flink.client.deployment.StandaloneClientFactory;
+import org.apache.flink.client.deployment.StandaloneClusterId;
+import org.apache.flink.core.execution.Executor;
+
+/**
+ * The {@link Executor} to be used when executing a job on an already running cluster.
+ */
+@Internal
+public class RemoteExecutor extends AbstractSessionClusterExecutor<StandaloneClusterId, StandaloneClientFactory> {
+
+	public static final String NAME = "remote-cluster";
+
+	public RemoteExecutor() {
+		super(new StandaloneClientFactory());
+	}
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/RemoteExecutorFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/RemoteExecutorFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment.executors;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.core.execution.Executor;
+import org.apache.flink.core.execution.ExecutorFactory;
+
+/**
+ * An {@link ExecutorFactory} for {@link RemoteExecutor remote executors}.
+ */
+@Internal
+public class RemoteExecutorFactory implements ExecutorFactory {
+
+	@Override
+	public boolean isCompatibleWith(final Configuration configuration) {
+		return RemoteExecutor.NAME.equalsIgnoreCase(configuration.get(DeploymentOptions.TARGET));
+	}
+
+	@Override
+	public Executor getExecutor(final Configuration configuration) {
+		return new RemoteExecutor();
+	}
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/StandaloneSessionClusterExecutorFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/StandaloneSessionClusterExecutorFactory.java
@@ -34,8 +34,7 @@ public class StandaloneSessionClusterExecutorFactory implements ExecutorFactory 
 
 	@Override
 	public boolean isCompatibleWith(@Nonnull final Configuration configuration) {
-		return configuration.get(DeploymentOptions.TARGET)
-				.equalsIgnoreCase(StandaloneSessionClusterExecutor.NAME);
+		return StandaloneSessionClusterExecutor.NAME.equalsIgnoreCase(configuration.get(DeploymentOptions.TARGET));
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.JarUtils;
 
 import javax.annotation.Nullable;
 
@@ -525,7 +526,7 @@ public class PackagedProgram {
 
 	private static void checkJarFile(URL jarfile) throws ProgramInvocationException {
 		try {
-			ClientUtils.checkJarFile(jarfile);
+			JarUtils.checkJarFile(jarfile);
 		} catch (IOException e) {
 			throw new ProgramInvocationException(e.getMessage(), e);
 		} catch (Throwable t) {

--- a/flink-clients/src/main/resources/META-INF/services/org.apache.flink.core.execution.ExecutorFactory
+++ b/flink-clients/src/main/resources/META-INF/services/org.apache.flink.core.execution.ExecutorFactory
@@ -14,4 +14,5 @@
 # limitations under the License.
 
 org.apache.flink.client.deployment.executors.StandaloneSessionClusterExecutorFactory
+org.apache.flink.client.deployment.executors.RemoteExecutorFactory
 org.apache.flink.client.deployment.executors.LocalExecutorFactory

--- a/flink-core/src/main/java/org/apache/flink/util/JarUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/JarUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.jar.JarFile;
+
+/**
+ * Utility functions for jar files.
+ */
+@Internal
+public class JarUtils {
+
+	public static void checkJarFile(URL jar) throws IOException {
+		File jarFile;
+		try {
+			jarFile = new File(jar.toURI());
+		} catch (URISyntaxException e) {
+			throw new IOException("JAR file path is invalid '" + jar + '\'');
+		}
+		if (!jarFile.exists()) {
+			throw new IOException("JAR file does not exist '" + jarFile.getAbsolutePath() + '\'');
+		}
+		if (!jarFile.canRead()) {
+			throw new IOException("JAR file can't be read '" + jarFile.getAbsolutePath() + '\'');
+		}
+
+		try (JarFile ignored = new JarFile(jarFile)) {
+			// verify that we can open the Jar file
+		} catch (IOException e) {
+			throw new IOException("Error while opening jar file '" + jarFile.getAbsolutePath() + '\'', e);
+		}
+	}
+}

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroExternalJarProgramITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroExternalJarProgramITCase.java
@@ -18,13 +18,13 @@
 
 package org.apache.flink.formats.avro;
 
-import org.apache.flink.client.ClientUtils;
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.formats.avro.testjar.AvroExternalJarProgram;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
 import org.apache.flink.test.util.TestEnvironment;
+import org.apache.flink.util.JarUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.AfterClass;
@@ -68,7 +68,7 @@ public class AvroExternalJarProgramITCase extends TestLogger {
 
 		String jarFile = JAR_FILE;
 		try {
-			ClientUtils.checkJarFile(new File(jarFile).getAbsoluteFile().toURI().toURL());
+			JarUtils.checkJarFile(new File(jarFile).getAbsoluteFile().toURI().toURL());
 		} catch (IOException e) {
 			jarFile = "target/".concat(jarFile);
 		}

--- a/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
@@ -47,19 +47,19 @@ import java.util.List;
 public class RemoteEnvironment extends ExecutionEnvironment {
 
 	/** The hostname of the JobManager. */
-	protected final String host;
+	private final String host;
 
 	/** The port of the JobManager main actor system. */
-	protected final int port;
+	private final int port;
 
 	/** The jar files that need to be attached to each job. */
-	protected final List<URL> jarFiles;
+	private final List<URL> jarFiles;
 
 	/** The configuration used by the client that connects to the cluster. */
-	protected Configuration clientConfiguration;
+	private Configuration clientConfiguration;
 
 	/** The classpaths that need to be attached to each job. */
-	protected final List<URL> globalClasspaths;
+	private final List<URL> globalClasspaths;
 
 	/**
 	 * Creates a new RemoteEnvironment that points to the master (JobManager) described by the

--- a/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironmentConfigUtils.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironmentConfigUtils.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.InvalidProgramException;
+import org.apache.flink.configuration.ConfigUtils;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.util.JarUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A set of tools used by batch and streaming remote environments when
+ * preparing their configurations.
+ */
+@Internal
+public class RemoteEnvironmentConfigUtils {
+
+	public static void validate(final String host, final int port) {
+		if (!ExecutionEnvironment.areExplicitEnvironmentsAllowed()) {
+			throw new InvalidProgramException(
+					"The RemoteEnvironment cannot be instantiated when running in a pre-defined context " +
+							"(such as Command Line Client, Scala Shell, or TestEnvironment)");
+		}
+
+		checkNotNull(host);
+		checkArgument(port > 0 && port < 0xffff);
+	}
+
+	public static void setJobManagerAddressToConfig(final String host, final int port, final Configuration configuration) {
+		final InetSocketAddress address = new InetSocketAddress(host, port);
+		configuration.setString(JobManagerOptions.ADDRESS, address.getHostString());
+		configuration.setInteger(JobManagerOptions.PORT, address.getPort());
+		configuration.setString(RestOptions.ADDRESS, address.getHostString());
+		configuration.setInteger(RestOptions.PORT, address.getPort());
+	}
+
+	public static void setJarURLsToConfig(final String[] jars, final Configuration configuration) {
+		final List<URL> jarURLs = getJarFiles(jars);
+		ConfigUtils.encodeCollectionToConfig(configuration, PipelineOptions.JARS, jarURLs, URL::toString);
+	}
+
+	private static List<URL> getJarFiles(final String[] jars) {
+		return jars == null
+				? Collections.emptyList()
+				: Arrays.stream(jars).map(jarPath -> {
+			try {
+				final URL fileURL = new File(jarPath).getAbsoluteFile().toURI().toURL();
+				JarUtils.checkJarFile(fileURL);
+				return fileURL;
+			} catch (MalformedURLException e) {
+				throw new IllegalArgumentException("JAR file path invalid", e);
+			} catch (IOException e) {
+				throw new RuntimeException("Problem with jar file " + jarPath, e);
+			}
+		}).collect(Collectors.toList());
+	}
+}

--- a/flink-scala-shell/src/test/java/org/apache/flink/api/java/FlinkILoopTest.java
+++ b/flink-scala-shell/src/test/java/org/apache/flink/api/java/FlinkILoopTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.scala.FlinkILoop;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.environment.RemoteStreamEnvironment;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.util.TestLogger;
 
@@ -106,9 +105,9 @@ public class FlinkILoopTest extends TestLogger {
 
 		StreamExecutionEnvironment streamEnv = flinkILoop.scalaSenv().getJavaEnv();
 
-		assertTrue(streamEnv instanceof RemoteStreamEnvironment);
+		assertTrue(streamEnv instanceof ScalaShellRemoteStreamEnvironment);
 
-		RemoteStreamEnvironment remoteStreamEnv = (RemoteStreamEnvironment) streamEnv;
+		ScalaShellRemoteStreamEnvironment remoteStreamEnv = (ScalaShellRemoteStreamEnvironment) streamEnv;
 
 		Configuration forwardedConfiguration = remoteStreamEnv.getClientConfiguration();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -24,11 +24,11 @@ import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.PlanExecutor;
 import org.apache.flink.api.java.ExecutionEnvironment;
-import org.apache.flink.client.ClientUtils;
 import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.util.JarUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -188,7 +188,7 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 			try {
 				URL jarFileUrl = new File(jarFile).getAbsoluteFile().toURI().toURL();
 				this.jarFiles.add(jarFileUrl);
-				ClientUtils.checkJarFile(jarFileUrl);
+				JarUtils.checkJarFile(jarFileUrl);
 			} catch (MalformedURLException e) {
 				throw new IllegalArgumentException("JAR file path is invalid '" + jarFile + "'", e);
 			} catch (IOException e) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -25,12 +25,8 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.PlanExecutor;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.client.ClientUtils;
-import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.ProgramInvocationException;
-import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.JobManagerOptions;
-import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 
@@ -254,22 +250,6 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 			LOG.info("Running remotely at {}:{}", host, port);
 		}
 
-		Configuration configuration = new Configuration();
-		configuration.addAll(clientConfiguration);
-
-		configuration.setString(JobManagerOptions.ADDRESS, host);
-		configuration.setInteger(JobManagerOptions.PORT, port);
-
-		configuration.setInteger(RestOptions.PORT, port);
-
-		final ClusterClient<?> client;
-		try {
-			client = new RestClusterClient<>(configuration, "RemoteStreamEnvironment");
-		}
-		catch (Exception e) {
-			throw new ProgramInvocationException("Cannot establish connection to JobManager: " + e.getMessage(), e);
-		}
-
 		if (savepointRestoreSettings != null) {
 			streamGraph.setSavepointRestoreSettings(savepointRestoreSettings);
 		}
@@ -288,13 +268,6 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 		catch (Exception e) {
 			String term = e.getMessage() == null ? "." : (": " + e.getMessage());
 			throw new ProgramInvocationException("The program execution failed" + term, e);
-		}
-		finally {
-			try {
-				client.close();
-			} catch (Exception e) {
-				LOG.warn("Could not properly shut down the cluster client.", e);
-			}
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -325,6 +325,8 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 		return port;
 	}
 
+	/** @deprecated This method is going to be removed in the next releases. */
+	@Deprecated
 	public Configuration getClientConfiguration() {
 		return clientConfiguration;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -19,7 +19,6 @@ package org.apache.flink.streaming.api.environment;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.PlanExecutor;
@@ -204,48 +203,9 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 		this.savepointRestoreSettings = savepointRestoreSettings;
 	}
 
-	/**
-	 * Executes the job remotely.
-	 *
-	 * <p>This method can be used independent of the {@link StreamExecutionEnvironment} type.
-	 * @return The result of the job execution, containing elapsed time and accumulators.
-	 */
-	@PublicEvolving
-	public static JobExecutionResult executeRemotely(StreamExecutionEnvironment streamExecutionEnvironment,
-		List<URL> jarFiles,
-		String host,
-		int port,
-		Configuration clientConfiguration,
-		List<URL> globalClasspaths,
-		String jobName,
-		SavepointRestoreSettings savepointRestoreSettings
-	) throws ProgramInvocationException {
-		StreamGraph streamGraph = streamExecutionEnvironment.getStreamGraph(jobName);
-		return executeRemotely(streamGraph,
-			streamExecutionEnvironment.getConfig(),
-			jarFiles,
-			host,
-			port,
-			clientConfiguration,
-			globalClasspaths,
-			savepointRestoreSettings);
-	}
-
-	/**
-	 * Execute the given stream graph remotely.
-	 *
-	 * <p>Method for internal use since it exposes stream graph and other implementation details that are subject to change.
-	 * @throws ProgramInvocationException
-	 */
-	private static JobExecutionResult executeRemotely(StreamGraph streamGraph,
-		ExecutionConfig executionConfig,
-		List<URL> jarFiles,
-		String host,
-		int port,
-		Configuration clientConfiguration,
-		List<URL> globalClasspaths,
-		SavepointRestoreSettings savepointRestoreSettings
-	) throws ProgramInvocationException {
+	@Override
+	public JobExecutionResult execute(StreamGraph streamGraph) throws Exception {
+		transformations.clear();
 		if (LOG.isInfoEnabled()) {
 			LOG.info("Running remotely at {}:{}", host, port);
 		}
@@ -269,34 +229,6 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 			String term = e.getMessage() == null ? "." : (": " + e.getMessage());
 			throw new ProgramInvocationException("The program execution failed" + term, e);
 		}
-	}
-
-	@Override
-	public JobExecutionResult execute(StreamGraph streamGraph) throws Exception {
-		transformations.clear();
-		return executeRemotely(streamGraph, jarFiles);
-	}
-
-	/**
-	 * Executes the remote job.
-	 *
-	 * <p>Note: This method exposes stream graph internal in the public API, but cannot be removed for backward compatibility.
-	 * @param streamGraph
-	 *            Stream Graph to execute
-	 * @param jarFiles
-	 * 			  List of jar file URLs to ship to the cluster
-	 * @return The result of the job execution, containing elapsed time and accumulators.
-	 */
-	@Deprecated
-	protected JobExecutionResult executeRemotely(StreamGraph streamGraph, List<URL> jarFiles) throws ProgramInvocationException {
-		return executeRemotely(streamGraph,
-			getConfig(),
-			jarFiles,
-			host,
-			port,
-			clientConfiguration,
-			globalClasspaths,
-			savepointRestoreSettings);
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
@@ -21,9 +21,14 @@ package org.apache.flink.streaming.api.environment;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.RemoteExecutor;
+import org.apache.flink.client.deployment.ClusterClientJobClientAdapter;
+import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.core.execution.Executor;
+import org.apache.flink.core.execution.ExecutorFactory;
+import org.apache.flink.core.execution.ExecutorServiceLoader;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobmaster.JobResult;
@@ -37,8 +42,11 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import javax.annotation.Nonnull;
+
 import java.util.concurrent.CompletableFuture;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -81,8 +89,15 @@ public class RemoteStreamExecutionEnvironmentTest extends TestLogger {
 		);
 
 		final Configuration clientConfiguration = new Configuration();
-		final StreamExecutionEnvironment env = StreamExecutionEnvironment.createRemoteEnvironment(
-			host, port, clientConfiguration);
+		final StreamExecutionEnvironment env = new RemoteStreamEnvironment(
+				new TestExecutorServiceLoader(jobID, mockedClient),
+				host,
+				port,
+				clientConfiguration,
+				null,
+				null,
+				null
+		);
 		env.fromElements(1).map(x -> x * 2);
 		JobExecutionResult actualResult = env.execute("fakeJobName");
 		Assert.assertEquals(jobID, actualResult.getJobID());
@@ -91,9 +106,6 @@ public class RemoteStreamExecutionEnvironmentTest extends TestLogger {
 	@Test
 	public void testRemoteExecutionWithSavepoint() throws Exception {
 		SavepointRestoreSettings restoreSettings = SavepointRestoreSettings.forPath("fakePath");
-		RemoteStreamEnvironment env = new RemoteStreamEnvironment("fakeHost", 1,
-			null, new String[]{}, null, restoreSettings);
-		env.fromElements(1).map(x -> x * 2);
 
 		JobID jobID = new JobID();
 		JobResult jobResult = (new JobResult.Builder())
@@ -108,7 +120,46 @@ public class RemoteStreamExecutionEnvironmentTest extends TestLogger {
 		when(mockedClient.submitJob(any())).thenReturn(CompletableFuture.completedFuture(jobID));
 		when(mockedClient.requestJobResult(eq(jobID))).thenReturn(CompletableFuture.completedFuture(jobResult));
 
+		RemoteStreamEnvironment env = new RemoteStreamEnvironment(
+				new TestExecutorServiceLoader(jobID, mockedClient),
+				"fakeHost",
+				1,
+				null,
+				new String[]{},
+				null,
+				restoreSettings);
+
+		env.fromElements(1).map(x -> x * 2);
+
 		JobExecutionResult actualResult = env.execute("fakeJobName");
 		Assert.assertEquals(jobID, actualResult.getJobID());
+	}
+
+	private static final class TestExecutorServiceLoader implements ExecutorServiceLoader {
+
+		private final JobID jobID;
+		private final ClusterClient<?> clusterClient;
+
+		TestExecutorServiceLoader(final JobID jobID, final ClusterClient<?> clusterClient) {
+			this.jobID = checkNotNull(jobID);
+			this.clusterClient = checkNotNull(clusterClient);
+		}
+
+		@Override
+		public ExecutorFactory getExecutorFactory(@Nonnull Configuration configuration) {
+			return new ExecutorFactory() {
+				@Override
+				public boolean isCompatibleWith(@Nonnull Configuration configuration) {
+					return true;
+				}
+
+				@Override
+				public Executor getExecutor(@Nonnull Configuration configuration) {
+					return (pipeline, config) ->
+							CompletableFuture.completedFuture(
+									new ClusterClientJobClientAdapter<>(clusterClient, jobID));
+				}
+			};
+		}
 	}
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -20,7 +20,6 @@ package org.apache.flink.table.client.gateway.local;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.client.ClientUtils;
 import org.apache.flink.client.cli.CliFrontend;
 import org.apache.flink.client.cli.CliFrontendParser;
 import org.apache.flink.client.cli.CustomCommandLine;
@@ -59,6 +58,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
 import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.JarUtils;
 import org.apache.flink.util.StringUtils;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableMap;
@@ -656,7 +656,7 @@ public class LocalExecutor implements Executor {
 		try {
 			// find jar files
 			for (URL url : jars) {
-				ClientUtils.checkJarFile(url);
+				JarUtils.checkJarFile(url);
 				dependencies.add(url);
 			}
 
@@ -676,7 +676,7 @@ public class LocalExecutor implements Executor {
 					// only consider jars
 					if (f.isFile() && f.getAbsolutePath().toLowerCase().endsWith(".jar")) {
 						final URL url = f.toURI().toURL();
-						ClientUtils.checkJarFile(url);
+						JarUtils.checkJarFile(url);
 						dependencies.add(url);
 					}
 				}

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -230,7 +230,7 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 			Throwable error = errorRef[0];
 			assertNotNull("The program did not fail properly", error);
 
-			assertTrue(error instanceof ProgramInvocationException);
+			assertTrue(error.getCause() instanceof ProgramInvocationException);
 			// all seems well :-)
 		}
 		catch (Exception e) {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnJobClusterExecutorFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnJobClusterExecutorFactory.java
@@ -34,8 +34,7 @@ public class YarnJobClusterExecutorFactory implements ExecutorFactory {
 
 	@Override
 	public boolean isCompatibleWith(@Nonnull final Configuration configuration) {
-		return configuration.get(DeploymentOptions.TARGET)
-				.equalsIgnoreCase(YarnJobClusterExecutor.NAME);
+		return YarnJobClusterExecutor.NAME.equalsIgnoreCase(configuration.get(DeploymentOptions.TARGET));
 	}
 
 	@Override

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnSessionClusterExecutorFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnSessionClusterExecutorFactory.java
@@ -34,8 +34,7 @@ public class YarnSessionClusterExecutorFactory implements ExecutorFactory {
 
 	@Override
 	public boolean isCompatibleWith(@Nonnull final Configuration configuration) {
-		return configuration.get(DeploymentOptions.TARGET)
-				.equalsIgnoreCase(YarnSessionClusterExecutor.NAME);
+		return YarnSessionClusterExecutor.NAME.equalsIgnoreCase(configuration.get(DeploymentOptions.TARGET));
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

This PR makes the `RemoteEnvironment` (batch) and the `RemoteStreamEnvironment` use the newly introduced `Executors`.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
