### PR TITLE
[FLINK-14951][tests] Harden the thread safety of State TTL backend tests

### DIFF
--- a/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/MonotonicTTLTimeProvider.java
+++ b/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/MonotonicTTLTimeProvider.java
@@ -19,11 +19,14 @@
 package org.apache.flink.streaming.tests;
 
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+import org.apache.flink.util.function.FunctionWithException;
 
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import java.io.Serializable;
+
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * A stub implementation of a {@link TtlTimeProvider} which guarantees that
@@ -54,14 +57,24 @@ final class MonotonicTTLTimeProvider implements TtlTimeProvider, Serializable {
 	private static final Object lock = new Object();
 
 	@GuardedBy("lock")
-	static long freeze() {
+	static <T, E extends Throwable> T doWithFrozenTime(FunctionWithException<Long, T, E> action) throws E {
 		synchronized (lock) {
-			if (!timeIsFrozen || lastReturnedProcessingTime == Long.MIN_VALUE) {
-				timeIsFrozen = true;
-				return getCurrentTimestamp();
-			} else {
-				return lastReturnedProcessingTime;
-			}
+			final long timestampBeforeUpdate = freeze();
+			T result = action.apply(timestampBeforeUpdate);
+			final long timestampAfterUpdate = unfreezeTime();
+
+			checkState(timestampAfterUpdate == timestampBeforeUpdate,
+				"Timestamps before and after the update do not match.");
+			return result;
+		}
+	}
+
+	private static long freeze() {
+		if (!timeIsFrozen || lastReturnedProcessingTime == Long.MIN_VALUE) {
+			timeIsFrozen = true;
+			return getCurrentTimestamp();
+		} else {
+			return lastReturnedProcessingTime;
 		}
 	}
 
@@ -87,11 +100,8 @@ final class MonotonicTTLTimeProvider implements TtlTimeProvider, Serializable {
 		return lastReturnedProcessingTime;
 	}
 
-	@GuardedBy("lock")
-	static long unfreezeTime() {
-		synchronized (lock) {
-			timeIsFrozen = false;
-			return lastReturnedProcessingTime;
-		}
+	private static long unfreezeTime() {
+		timeIsFrozen = false;
+		return lastReturnedProcessingTime;
 	}
 }

--- a/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/TtlVerifyUpdateFunction.java
+++ b/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/TtlVerifyUpdateFunction.java
@@ -47,7 +47,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * Update state with TTL for each verifier.
@@ -114,19 +113,13 @@ class TtlVerifyUpdateFunction extends RichFlatMapFunction<TtlStateUpdate, String
 			TtlStateVerifier<?, ?> verifier,
 			Object update) throws Exception {
 
-		final long timestampBeforeUpdate = MonotonicTTLTimeProvider.freeze();
-		State state = states.get(verifier.getId());
-		Object valueBeforeUpdate = verifier.get(state);
-		verifier.update(state, update);
-		Object updatedValue = verifier.get(state);
-		final long timestampAfterUpdate = MonotonicTTLTimeProvider.unfreezeTime();
-
-		checkState(
-				timestampAfterUpdate == timestampBeforeUpdate,
-				"Timestamps before and after the update do not match."
-		);
-
-		return new TtlUpdateContext<>(valueBeforeUpdate, update, updatedValue, timestampAfterUpdate);
+		return MonotonicTTLTimeProvider.doWithFrozenTime(frozenTimestamp -> {
+			State state = states.get(verifier.getId());
+			Object valueBeforeUpdate = verifier.get(state);
+			verifier.update(state, update);
+			Object updatedValue = verifier.get(state);
+			return new TtlUpdateContext<>(valueBeforeUpdate, update, updatedValue, frozenTimestamp);
+		});
 	}
 
 	@Override


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The State TTL RocksDb/file backend tests now contains thread safety issue during the call of MonotonicTTLTimeProvider. This PR harden the thread safety of that class.


## Brief change log

Replace the freeze/unfreeze function with `doWithFrozenTime`, which run user defined function in synchronize state.


## Verifying this change

This change added tests and can be verified as follows:
 - Set `taskmanager.numberOfTaskSlots` to `PARALLELISM` and run State TTL RocksDb/file backend end to end test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

cc @azagrebin 