### PR TITLE
[FLINK-14957] Remove deprecated -yst option

### DIFF
--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -360,7 +360,6 @@ Action "run" compiles and runs a program.
                                           (memory, cores)
      -yqu,--yarnqueue <arg>               Specify YARN queue.
      -ys,--yarnslots <arg>                Number of slots per TaskManager
-     -yst,--yarnstreaming                 Start Flink in streaming mode
      -yt,--yarnship <arg>                 Ship files in the specified directory
                                           (t for transfer), multiple options are 
                                           supported.

--- a/docs/ops/cli.zh.md
+++ b/docs/ops/cli.zh.md
@@ -355,7 +355,6 @@ Action "run" compiles and runs a program.
                                           (memory, cores)
      -yqu,--yarnqueue <arg>               Specify YARN queue.
      -ys,--yarnslots <arg>                Number of slots per TaskManager
-     -yst,--yarnstreaming                 Start Flink in streaming mode
      -yt,--yarnship <arg>                 Ship files in the specified directory
                                           (t for transfer), multiple options are
                                           supported.

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -134,12 +134,6 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 	private final Option zookeeperNamespace;
 	private final Option nodeLabel;
 	private final Option help;
-
-	/**
-	 * @deprecated Streaming mode has been deprecated without replacement.
-	 */
-	@Deprecated
-	private final Option streaming;
 	private final Option name;
 	private final Option applicationType;
 
@@ -208,7 +202,6 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 			.valueSeparator()
 			.desc("use value for given property")
 			.build();
-		streaming = new Option(shortPrefix + "st", longPrefix + "streaming", false, "Start Flink in streaming mode");
 		name = new Option(shortPrefix + "nm", longPrefix + "name", true, "Set a custom name for the application on YARN");
 		applicationType = new Option(shortPrefix + "at", longPrefix + "applicationType", true, "Set a custom application type for the application on YARN");
 		zookeeperNamespace = new Option(shortPrefix + "z", longPrefix + "zookeeperNamespace", true, "Namespace to create the Zookeeper sub-paths for high availability mode");
@@ -227,7 +220,6 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 		allOptions.addOption(DETACHED_OPTION);
 		allOptions.addOption(SHUTDOWN_IF_ATTACHED_OPTION);
 		allOptions.addOption(YARN_DETACHED_OPTION);
-		allOptions.addOption(streaming);
 		allOptions.addOption(name);
 		allOptions.addOption(applicationId);
 		allOptions.addOption(applicationType);


### PR DESCRIPTION
## What is the purpose of the change

As codebase moved, "-yst" option in FlinkYarnSessionCl doesn't work anymore. We can remove it.

## Brief change log

* Remove "-yst" option.
* Delete related docs.

## Verifying this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

Changes in both en-docs and zh-docs.