### PR TITLE
[FLINK-14902][Connector-JDBC]JDBCTableSource Supports AsyncLookupFunction

### DIFF
--- a/flink-connectors/flink-jdbc/pom.xml
+++ b/flink-connectors/flink-jdbc/pom.xml
@@ -82,5 +82,12 @@ under the License.
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/ConnectionManager.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/ConnectionManager.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+/**
+ * Connection Manager to manage {@link JDBCConnection}.
+ */
+public class ConnectionManager implements Serializable {
+
+	private static final Logger LOG = LoggerFactory.getLogger(ConnectionManager.class);
+	private static final long serialVersionUID = 1L;
+
+	private final int poolSize;
+	private final String drivername;
+	private final String dbURL;
+	private final String username;
+	private final String password;
+	private final String query;
+	private transient BlockingQueue<JDBCConnection> jdbcConnectionPool;
+
+	public ConnectionManager(
+		int poolSize, String drivername,
+		String dbURL, String username,
+		String password, String query) {
+
+		this.poolSize = poolSize;
+		this.drivername = drivername;
+		this.dbURL = dbURL;
+		this.username = username;
+		this.password = password;
+		this.query = query;
+	}
+
+	/**
+	 * Init connection pool.
+	 * @throws SQLException
+	 * @throws ClassNotFoundException
+	 */
+	public void initPool() throws SQLException, ClassNotFoundException {
+
+		LOG.info("Init connection pool and pool size is " + poolSize);
+		if (null == jdbcConnectionPool) {
+			jdbcConnectionPool = new ArrayBlockingQueue(poolSize);
+		}
+
+		for (int i = 0; i < poolSize; i++) {
+			jdbcConnectionPool.add(createJDBCConnection());
+		}
+	}
+
+	private JDBCConnection createJDBCConnection()
+		throws SQLException, ClassNotFoundException {
+		Connection dbConn;
+		PreparedStatement statement;
+		Class.forName(drivername);
+		if (null == username) {
+			dbConn = DriverManager.getConnection(dbURL);
+		} else {
+			dbConn = DriverManager.getConnection(dbURL, username, password);
+		}
+		statement = dbConn.prepareStatement(query);
+		return new JDBCConnection(dbConn, statement);
+	}
+
+	/**
+	 * Acquire JDBCConnection. If no available, it will be blocked here.
+	 * @return JDBCConnection.
+	 */
+	public JDBCConnection acquireJDBCConnection() {
+		return jdbcConnectionPool.poll();
+	}
+
+	/**
+	 * Release JDBCConnection when finish lookup.
+	 * @param jdbcConnection
+	 */
+	public void releaseJDBCConnection(JDBCConnection jdbcConnection) {
+		jdbcConnectionPool.add(jdbcConnection);
+	}
+
+	public void close() throws SQLException {
+		for (int i = 0; i < poolSize; i++) {
+			JDBCConnection jdbcConnection = jdbcConnectionPool.poll();
+			if (null != jdbcConnection) {
+				jdbcConnection.close();
+			}
+		}
+	}
+}
+
+
+
+

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCAsyncLookupFunction.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCAsyncLookupFunction.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.table.functions.AsyncTableFunction;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.types.Row;
+
+import org.apache.flink.shaded.guava18.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava18.com.google.common.cache.CacheBuilder;
+import org.apache.flink.shaded.guava18.com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.api.java.io.jdbc.JDBCUtils.getFieldFromResultSet;
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * A {@link AsyncTableFunction} used in temporal table join as an async lookup function.
+ *
+ * <p>Support batch query to avoid frequent accessing to remote databases.
+ * 1.The batch querySize default 1.
+ *
+ * <p>Support setting connection pool size to avoid frequent creating and destroying connection.
+ * or avoid creating unlimited connections.
+ * 1.The connection pool size default 10.
+ *
+ * <p>Support setting thread pool size to avoid frequent creating and destroying thread.
+ * 1.The thread pool size default 10.
+ *
+ * <p>Support cache the result to avoid frequent accessing to remote databases.
+ * 1.The cacheMaxSize is -1 means not use cache.
+ * 2.For real-time data, you need to set the TTL of cache.
+ */
+public class JDBCAsyncLookupFunction extends AsyncTableFunction<Row> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(JDBCAsyncLookupFunction.class);
+	private static final long serialVersionUID = 1L;
+	private int currentQuerySize = 0;
+
+	private final String[] fieldNames;
+	private final TypeInformation[] fieldTypes;
+	private final TypeInformation[] keyTypes;
+	private final int[] keySqlTypes;
+	private final int[] keyNameIndex;
+	private final int[] outputSqlTypes;
+	private final long cacheMaxSize;
+	private final long cacheExpireMs;
+	private final int maxRetryTimes;
+	private final int batchQuerySize;
+	private final int threadPoolSize;
+
+	private ConnectionManager connectionManager;
+	private transient ExecutorService executorService;
+	private transient Cache<Row, List<Row>> cache;
+	private transient Map<Row, List<CompletableFuture<Collection<Row>>>> batchQueryMap;
+
+	public JDBCAsyncLookupFunction(
+		JDBCOptions options, JDBCLookupOptions lookupOptions,
+		String[] fieldNames, TypeInformation[] fieldTypes, String[] keyNames) {
+
+		this.fieldNames = fieldNames;
+		this.fieldTypes = fieldTypes;
+		List<String> nameList = Arrays.asList(fieldNames);
+		this.keyTypes = Arrays.stream(keyNames)
+			.map(s -> {
+				checkArgument(nameList.contains(s),
+					"keyName %s can't find in fieldNames %s.", s, nameList);
+				return fieldTypes[nameList.indexOf(s)];
+			})
+			.toArray(TypeInformation[]::new);
+		this.keySqlTypes = Arrays.stream(keyTypes).mapToInt(JDBCTypeUtil::typeInformationToSqlType).toArray();
+		this.keyNameIndex = Arrays.stream(keyNames).mapToInt(key -> nameList.indexOf(key)).toArray();
+		this.outputSqlTypes = Arrays.stream(fieldTypes).mapToInt(JDBCTypeUtil::typeInformationToSqlType).toArray();
+		this.cacheMaxSize = lookupOptions.getCacheMaxSize();
+		this.cacheExpireMs = lookupOptions.getCacheExpireMs();
+		this.maxRetryTimes = lookupOptions.getMaxRetryTimes();
+		this.batchQuerySize = lookupOptions.getBatchQuerySize();
+		this.threadPoolSize = lookupOptions.getThreadPoolSize();
+		String query = options.getDialect().getBatchSelectFromStatement(
+				options.getTableName(), fieldNames, keyNames, batchQuerySize);
+		connectionManager = new ConnectionManager(
+			lookupOptions.getMaxPoolSize(), options.getDriverName(),
+			options.getDbURL(), options.getUsername(), options.getPassword(), query);
+	}
+
+	@Override
+	public void open(FunctionContext context) throws Exception {
+
+		connectionManager.initPool();
+		// Create lru memory cache
+		this.cache = cacheMaxSize == -1 || cacheExpireMs == -1 ? null : CacheBuilder.newBuilder()
+			.expireAfterWrite(cacheExpireMs, TimeUnit.MILLISECONDS)
+			.maximumSize(cacheMaxSize)
+			.build();
+		// Create async lookup thread pool
+		ThreadFactory threadFactory = new ThreadFactoryBuilder()
+			.setDaemon(true)
+			.setNameFormat("Flink JDBCAsyncLookupFunction Thread %d")
+			.build();
+		executorService = Executors.newFixedThreadPool(threadPoolSize, threadFactory);
+		// Create global batch query map
+		if (batchQueryMap == null) {
+			batchQueryMap = new HashMap<>();
+		}
+	}
+
+	public void eval(CompletableFuture<Collection<Row>> result, Object... keys) {
+		Row keyRow = Row.of(keys);
+		if (cache != null) {
+			List<Row> cachedRows = cache.getIfPresent(keyRow);
+			if (cachedRows != null) {
+				result.complete(cachedRows);
+				return;
+			}
+		}
+
+		List resultFutureList = batchQueryMap.get(keyRow);
+		if (null == resultFutureList) {
+			List resultList = new ArrayList();
+			resultList.add(result);
+			batchQueryMap.put(keyRow, resultList);
+		} else {
+			resultFutureList.add(result);
+		}
+		currentQuerySize++;
+		if (currentQuerySize < batchQuerySize) {
+			return;
+		}
+
+		Map<Row, List<CompletableFuture<Collection<Row>>>> localQueryMap = new HashMap<>();
+		localQueryMap.putAll(batchQueryMap);
+		currentQuerySize = 0;
+		batchQueryMap.clear();
+
+		CompletableFuture.runAsync(new Runnable() {
+			@Override
+			public void run() {
+				JDBCConnection jdbcConnection = connectionManager.acquireJDBCConnection();
+				try {
+					executeAsyncLookup(localQueryMap, jdbcConnection);
+				} finally {
+					connectionManager.releaseJDBCConnection(jdbcConnection);
+				}
+			}
+		}, executorService);
+	}
+
+	/**
+	 * Execute async query for JDBCAsyncLookupFunction.
+	 * @param keysMap Map to store lookup Keys and corresponding future.
+	 * @param jdbcConnection JDBCConnection accesses to remote databases.
+	 */
+	private void executeAsyncLookup(
+		Map<Row, List<CompletableFuture<Collection<Row>>>> keysMap, JDBCConnection jdbcConnection) {
+
+		PreparedStatement statement = jdbcConnection.getStatement();
+		for (int retry = 1; retry <= maxRetryTimes; retry++) {
+			try {
+				// Set statement
+				int keysMapIndex = 0;
+				for (Row keys : keysMap.keySet()) {
+					for (int i = 0; i < keysMap.get(keys).size(); i++) {
+						for (int j = 0; j < keys.getArity(); j++) {
+							JDBCUtils.setField(statement, keySqlTypes[j], keys.getField(j),
+								keysMapIndex * keys.getArity() + j);
+						}
+						keysMapIndex++;
+					}
+				}
+				// Get data from resultSet
+				Map<Row, List<Row>> resultData = new HashMap<>();
+				try (ResultSet resultSet = statement.executeQuery()) {
+					while (resultSet.next()) {
+						Row value = new Row(outputSqlTypes.length);
+						for (int i = 0; i < outputSqlTypes.length; i++) {
+							value.setField(i, getFieldFromResultSet(i, outputSqlTypes[i], resultSet));
+						}
+						Row key = Row.project(value, keyNameIndex);
+						if (null == resultData.get(key)) {
+							List<Row> rows = new ArrayList<>();
+							rows.add(value);
+							resultData.put(key, rows);
+						} else {
+							List<Row> rows = resultData.get(key);
+							rows.add(value);
+						}
+					}
+				}
+				// Return data by called future#complete
+				for (Map.Entry entry : keysMap.entrySet()) {
+					List<CompletableFuture<Collection<Row>>> futures =
+						(List<CompletableFuture<Collection<Row>>>) entry.getValue();
+
+					futures.stream().forEach(future -> {
+						List<Row> rows = resultData.get(entry.getKey());
+						if (null == rows) {
+							future.complete(Collections.emptyList());
+						} else {
+							if (cache != null) {
+								cache.put((Row) entry.getKey(), rows);
+							}
+							future.complete(rows);
+						}
+					});
+				}
+				break;
+			} catch (SQLException e) {
+				if (retry >= maxRetryTimes) {
+					for (Map.Entry entry : keysMap.entrySet()) {
+						List<CompletableFuture<Collection<Row>>> futures =
+							(List<CompletableFuture<Collection<Row>>>) entry.getValue();
+						futures.stream().forEach(future -> {
+							future.completeExceptionally(new RuntimeException("Execution of JDBC statement failed.", e));
+						});
+					}
+				}
+				try {
+					Thread.sleep(1000 * retry);
+				} catch (InterruptedException e1) {
+					throw new RuntimeException(e1);
+				}
+			}
+		}
+	}
+
+	@Override
+	public TypeInformation<Row> getResultType() {
+		return new RowTypeInfo(fieldTypes, fieldNames);
+	}
+
+	public static JDBCLookupBuilder builder() {
+		return new JDBCLookupBuilder();
+	}
+
+	/**
+	 * Close resources.
+	 * @throws IOException
+	 */
+	@Override
+	public void close() throws IOException {
+		if (cache != null) {
+			cache.cleanUp();
+			cache = null;
+		}
+		if (executorService != null) {
+			executorService.shutdown();
+		}
+		if (connectionManager != null) {
+			try {
+				connectionManager.close();
+			} catch (SQLException e) {
+				LOG.info("JDBC could not be closed: " + e.getMessage());
+			}
+		}
+	}
+
+}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCConnection.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCConnection.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/**
+ * JDBCConnection to wrap {@link Connection} and {@link PreparedStatement}.
+ */
+public class JDBCConnection {
+
+	private Connection dbConn;
+	private PreparedStatement statement;
+
+	public JDBCConnection(Connection dbConn, PreparedStatement statement) {
+		this.dbConn = dbConn;
+		this.statement = statement;
+	}
+
+	public Connection getDbConn() {
+		return dbConn;
+	}
+
+	public PreparedStatement getStatement() {
+		return statement;
+	}
+
+	/**
+	 * Close connection and statement.
+	 * @throws SQLException
+	 */
+	public void close() throws SQLException {
+		if (statement != null) {
+			try {
+				statement.close();
+			} finally {
+				statement = null;
+			}
+		}
+		if (dbConn != null) {
+			try {
+				dbConn.close();
+			} finally {
+				dbConn = null;
+			}
+		}
+	}
+
+}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCLookupBuilder.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCLookupBuilder.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Builder for {@link JDBCLookupFunction} and {@link JDBCAsyncLookupFunction}.
+ */
+public class JDBCLookupBuilder {
+
+	private JDBCOptions options;
+	private JDBCLookupOptions lookupOptions;
+	private String[] fieldNames;
+	private TypeInformation[] fieldTypes;
+	private String[] keyNames;
+
+	/**
+	 * required, jdbc options.
+	 */
+	public JDBCLookupBuilder setOptions(JDBCOptions options) {
+		this.options = options;
+		return this;
+	}
+
+	/**
+	 * optional, lookup related options.
+	 */
+	public JDBCLookupBuilder setLookupOptions(JDBCLookupOptions lookupOptions) {
+		this.lookupOptions = lookupOptions;
+		return this;
+	}
+
+	/**
+	 * required, field names of this jdbc table.
+	 */
+	public JDBCLookupBuilder setFieldNames(String[] fieldNames) {
+		this.fieldNames = fieldNames;
+		return this;
+	}
+
+	/**
+	 * required, field types of this jdbc table.
+	 */
+	public JDBCLookupBuilder setFieldTypes(TypeInformation[] fieldTypes) {
+		this.fieldTypes = fieldTypes;
+		return this;
+	}
+
+	/**
+	 * required, key names to query this jdbc table.
+	 */
+	public JDBCLookupBuilder setKeyNames(String[] keyNames) {
+		this.keyNames = keyNames;
+		return this;
+	}
+
+	public JDBCLookupFunction buildLookup() {
+		checkNotNull(options, "No JDBCOptions supplied.");
+		if (lookupOptions == null) {
+			lookupOptions = JDBCLookupOptions.builder().build();
+		}
+		checkNotNull(fieldNames, "No fieldNames supplied.");
+		checkNotNull(fieldTypes, "No fieldTypes supplied.");
+		checkNotNull(keyNames, "No keyNames supplied.");
+
+		return new JDBCLookupFunction(options, lookupOptions, fieldNames, fieldTypes, keyNames);
+	}
+
+	public JDBCAsyncLookupFunction buildAsyncLookup() {
+		checkNotNull(options, "No JDBCOptions supplied.");
+		if (lookupOptions == null) {
+			lookupOptions = JDBCLookupOptions.builder().build();
+		}
+		checkNotNull(fieldNames, "No fieldNames supplied.");
+		checkNotNull(fieldTypes, "No fieldTypes supplied.");
+		checkNotNull(keyNames, "No keyNames supplied.");
+
+		return new JDBCAsyncLookupFunction(options, lookupOptions, fieldNames, fieldTypes, keyNames);
+	}
+
+}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCLookupFunction.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCLookupFunction.java
@@ -43,7 +43,6 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.api.java.io.jdbc.JDBCUtils.getFieldFromResultSet;
 import static org.apache.flink.util.Preconditions.checkArgument;
-import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A {@link TableFunction} to query fields from JDBC by keys.
@@ -105,8 +104,8 @@ public class JDBCLookupFunction extends TableFunction<Row> {
 				options.getTableName(), fieldNames, keyNames);
 	}
 
-	public static Builder builder() {
-		return new Builder();
+	public static JDBCLookupBuilder builder() {
+		return new JDBCLookupBuilder();
 	}
 
 	@Override
@@ -227,73 +226,5 @@ public class JDBCLookupFunction extends TableFunction<Row> {
 	@Override
 	public TypeInformation<?>[] getParameterTypes(Class<?>[] signature) {
 		return keyTypes;
-	}
-
-	/**
-	 * Builder for a {@link JDBCLookupFunction}.
-	 */
-	public static class Builder {
-		private JDBCOptions options;
-		private JDBCLookupOptions lookupOptions;
-		private String[] fieldNames;
-		private TypeInformation[] fieldTypes;
-		private String[] keyNames;
-
-		/**
-		 * required, jdbc options.
-		 */
-		public Builder setOptions(JDBCOptions options) {
-			this.options = options;
-			return this;
-		}
-
-		/**
-		 * optional, lookup related options.
-		 */
-		public Builder setLookupOptions(JDBCLookupOptions lookupOptions) {
-			this.lookupOptions = lookupOptions;
-			return this;
-		}
-
-		/**
-		 * required, field names of this jdbc table.
-		 */
-		public Builder setFieldNames(String[] fieldNames) {
-			this.fieldNames = fieldNames;
-			return this;
-		}
-
-		/**
-		 * required, field types of this jdbc table.
-		 */
-		public Builder setFieldTypes(TypeInformation[] fieldTypes) {
-			this.fieldTypes = fieldTypes;
-			return this;
-		}
-
-		/**
-		 * required, key names to query this jdbc table.
-		 */
-		public Builder setKeyNames(String[] keyNames) {
-			this.keyNames = keyNames;
-			return this;
-		}
-
-		/**
-		 * Finalizes the configuration and checks validity.
-		 *
-		 * @return Configured JDBCLookupFunction
-		 */
-		public JDBCLookupFunction build() {
-			checkNotNull(options, "No JDBCOptions supplied.");
-			if (lookupOptions == null) {
-				lookupOptions = JDBCLookupOptions.builder().build();
-			}
-			checkNotNull(fieldNames, "No fieldNames supplied.");
-			checkNotNull(fieldTypes, "No fieldTypes supplied.");
-			checkNotNull(keyNames, "No keyNames supplied.");
-
-			return new JDBCLookupFunction(options, lookupOptions, fieldNames, fieldTypes, keyNames);
-		}
 	}
 }

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCOptions.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCOptions.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * Common options of {@link JDBCScanOptions} and {@link JDBCLookupOptions} for the JDBC connector.
+ * Common options of {@link JDBCOptions} and {@link JDBCLookupOptions} for the JDBC connector.
  */
 public class JDBCOptions {
 

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
@@ -103,7 +103,7 @@ public class JDBCTableSource implements
 				.setFieldTypes(returnType.getFieldTypes())
 				.setFieldNames(returnType.getFieldNames())
 				.setKeyNames(lookupKeys)
-				.build();
+				.buildLookup();
 	}
 
 	@Override
@@ -118,12 +118,18 @@ public class JDBCTableSource implements
 
 	@Override
 	public AsyncTableFunction<Row> getAsyncLookupFunction(String[] lookupKeys) {
-		throw new UnsupportedOperationException();
+		return JDBCAsyncLookupFunction.builder()
+			.setOptions(options)
+			.setLookupOptions(lookupOptions)
+			.setFieldTypes(returnType.getFieldTypes())
+			.setFieldNames(returnType.getFieldNames())
+			.setKeyNames(lookupKeys)
+			.buildAsyncLookup();
 	}
 
 	@Override
 	public boolean isAsyncEnabled() {
-		return false;
+		return true;
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

JDBCTableSource supports AsyncLookupFunction for temporal table join

## Brief change log

1. Add JDBCConnection to wrap Connection and PreparedStatement.
2.Add ConnectionManager to manage JDBCConnection.
3.Share JDBCLookupOptions with JDBCLookupFunction and JDBCAsyncLookupFunction
4.ShareJDBCLookupBuilder with JDBCLookupFunction and JDBCAsyncLookupFunction
5.Add JDBCAsyncLookupFunction to support Async lookup JDBC.

## Verifying this change
This change added tests and can be verified as follows:

1.JDBCLookupFunctionITCase#test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
