### PR TITLE
[FLINK-14990][Table-Api]Add bit function inncluding bitand bitor bitnot bitxor

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -741,6 +741,38 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 			OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.STRING)),
 		SqlFunctionCategory.STRING);
 
+	public static final SqlFunction BITAND = new SqlFunction(
+		"BITAND",
+		SqlKind.OTHER_FUNCTION,
+		ReturnTypes.ARG0,
+		null,
+		OperandTypes.family(SqlTypeFamily.NUMERIC, SqlTypeFamily.NUMERIC),
+		SqlFunctionCategory.NUMERIC);
+
+	public static final SqlFunction BITNOT = new SqlFunction(
+		"BITNOT",
+		SqlKind.OTHER_FUNCTION,
+		ReturnTypes.ARG0,
+		null,
+		OperandTypes.family(SqlTypeFamily.NUMERIC),
+		SqlFunctionCategory.NUMERIC);
+
+	public static final SqlFunction BITOR = new SqlFunction(
+		"BITOR",
+		SqlKind.OTHER_FUNCTION,
+		ReturnTypes.ARG0,
+		null,
+		OperandTypes.family(SqlTypeFamily.NUMERIC, SqlTypeFamily.NUMERIC),
+		SqlFunctionCategory.NUMERIC);
+
+	public static final SqlFunction BITXOR = new SqlFunction(
+		"BITXOR",
+		SqlKind.OTHER_FUNCTION,
+		ReturnTypes.ARG0,
+		null,
+		OperandTypes.family(SqlTypeFamily.NUMERIC, SqlTypeFamily.NUMERIC),
+		SqlFunctionCategory.NUMERIC);
+
 	/**
 	 * <code>AUXILIARY_GROUP</code> aggregate function.
 	 * Only be used in internally.

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
@@ -753,6 +753,85 @@ object FunctionGenerator {
     Seq(FLOAT, INTEGER),
     BuiltInMethods.TRUNCATE_FLOAT)
 
+  addSqlFunctionMethod(
+    BITAND,
+    Seq(TINYINT, TINYINT),
+    BuiltInMethods.BITAND_BYTE)
+
+  addSqlFunctionMethod(
+    BITAND,
+    Seq(SMALLINT, SMALLINT),
+    BuiltInMethods.BITAND_SHORT)
+
+  addSqlFunctionMethod(
+    BITAND,
+    Seq(INTEGER, INTEGER),
+    BuiltInMethods.BITAND_INTEGER)
+
+  addSqlFunctionMethod(
+    BITAND,
+    Seq(BIGINT, BIGINT),
+    BuiltInMethods.BITAND_LONG)
+
+  addSqlFunctionMethod(
+    BITNOT,
+    Seq(TINYINT),
+    BuiltInMethods.BITNOT_BYTE)
+
+  addSqlFunctionMethod(
+    BITNOT,
+    Seq(SMALLINT),
+    BuiltInMethods.BITNOT_SHORT)
+
+  addSqlFunctionMethod(
+    BITNOT,
+    Seq(INTEGER),
+    BuiltInMethods.BITNOT_INTEGER)
+
+  addSqlFunctionMethod(
+    BITNOT,
+    Seq(BIGINT),
+    BuiltInMethods.BITNOT_LONG)
+
+  addSqlFunctionMethod(
+    BITOR,
+    Seq(TINYINT, TINYINT),
+    BuiltInMethods.BITOR_BYTE)
+
+  addSqlFunctionMethod(
+    BITOR,
+    Seq(SMALLINT, SMALLINT),
+    BuiltInMethods.BITOR_SHORT)
+
+  addSqlFunctionMethod(
+    BITOR,
+    Seq(INTEGER, INTEGER),
+    BuiltInMethods.BITOR_INTEGER)
+
+  addSqlFunctionMethod(
+    BITOR,
+    Seq(BIGINT, BIGINT),
+    BuiltInMethods.BITOR_LONG)
+
+  addSqlFunctionMethod(
+    BITXOR,
+    Seq(TINYINT, TINYINT),
+    BuiltInMethods.BITXOR_BYTE)
+
+  addSqlFunctionMethod(
+    BITXOR,
+    Seq(SMALLINT, SMALLINT),
+    BuiltInMethods.BITXOR_SHORT)
+
+  addSqlFunctionMethod(
+    BITXOR,
+    Seq(INTEGER, INTEGER),
+    BuiltInMethods.BITXOR_INTEGER)
+
+  addSqlFunctionMethod(
+    BITXOR,
+    Seq(BIGINT, BIGINT),
+    BuiltInMethods.BITXOR_LONG)
 
   // ----------------------------------------------------------------------------------------------
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -4121,4 +4121,23 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "IS_ALPHA(f33)",
       "false")
   }
+
+  @Test
+  def testBitFunction(): Unit = {
+    testSqlApi(
+      "BITAND(3, 1)",
+      "1")
+
+    testSqlApi(
+      "BITOR(3, 1)",
+      "3")
+
+    testSqlApi(
+      "BITXOR(3, 1)",
+      "2")
+
+    testSqlApi(
+      "BITNOT(3)",
+      "-4")
+  }
 }


### PR DESCRIPTION
##What is the purpose of the change

Add bit function to blink planner.Including: bitand, bitor, bitnot and bitxor

## Brief change log
1. Add bit operator in FlinkSqlOperatorTable
2. Add bit SqlFunctionMethod in FunctionGenerator

## Verifying this change

This change added tests and can be verified as follows:

1.Add ScalarFunctionsTest#testBitFunction to verify

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
