### PR TITLE
[FLINK-14795][tests] Rework TaskExecutorPartitionLifecycleTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTrackerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTrackerImplTest.java
@@ -18,8 +18,16 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
+import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.PartitionInfo;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
+import org.apache.flink.runtime.shuffle.ShuffleIOOwnerContext;
 import org.apache.flink.runtime.taskexecutor.partition.ClusterPartitionReport;
 import org.apache.flink.util.TestLogger;
 
@@ -27,10 +35,15 @@ import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 
 import org.junit.Test;
 
+import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
 
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 
@@ -62,5 +75,129 @@ public class TaskExecutorPartitionTrackerImplTest extends TestLogger {
 		assertThat(reportEntry.getDataSetId(), is(dataSetId));
 		assertThat(reportEntry.getNumTotalPartitions(), is(numberOfPartitions));
 		assertThat(reportEntry.getHostedPartitions(), hasItems(clusterPartitionId));
+	}
+
+	@Test
+	public void testStopTrackingAndReleaseJobPartitions() throws Exception {
+		final TestingShuffleEnvironment testingShuffleEnvironment = new TestingShuffleEnvironment();
+		final CompletableFuture<Collection<ResultPartitionID>> shuffleReleaseFuture = new CompletableFuture<>();
+		testingShuffleEnvironment.releasePartitionsLocallyFuture = shuffleReleaseFuture;
+
+		final ResultPartitionID resultPartitionId1 = new ResultPartitionID();
+		final ResultPartitionID resultPartitionId2 = new ResultPartitionID();
+
+		final TaskExecutorPartitionTracker partitionTracker = new TaskExecutorPartitionTrackerImpl(testingShuffleEnvironment);
+		partitionTracker.startTrackingPartition(new JobID(), new TaskExecutorPartitionInfo(resultPartitionId1, new IntermediateDataSetID(), 1));
+		partitionTracker.startTrackingPartition(new JobID(), new TaskExecutorPartitionInfo(resultPartitionId2, new IntermediateDataSetID(), 1));
+		partitionTracker.stopTrackingAndReleaseJobPartitions(Collections.singleton(resultPartitionId1));
+
+		assertThat(shuffleReleaseFuture.get(), hasItem(resultPartitionId1));
+	}
+
+	@Test
+	public void testStopTrackingAndReleaseJobPartitionsFor() throws Exception {
+		final TestingShuffleEnvironment testingShuffleEnvironment = new TestingShuffleEnvironment();
+		final CompletableFuture<Collection<ResultPartitionID>> shuffleReleaseFuture = new CompletableFuture<>();
+		testingShuffleEnvironment.releasePartitionsLocallyFuture = shuffleReleaseFuture;
+
+		final JobID jobId1 = new JobID();
+		final JobID jobId2 = new JobID();
+		final ResultPartitionID resultPartitionId1 = new ResultPartitionID();
+		final ResultPartitionID resultPartitionId2 = new ResultPartitionID();
+
+		final TaskExecutorPartitionTracker partitionTracker = new TaskExecutorPartitionTrackerImpl(testingShuffleEnvironment);
+		partitionTracker.startTrackingPartition(jobId1, new TaskExecutorPartitionInfo(resultPartitionId1, new IntermediateDataSetID(), 1));
+		partitionTracker.startTrackingPartition(jobId2, new TaskExecutorPartitionInfo(resultPartitionId2, new IntermediateDataSetID(), 1));
+		partitionTracker.stopTrackingAndReleaseJobPartitionsFor(jobId1);
+
+		assertThat(shuffleReleaseFuture.get(), hasItem(resultPartitionId1));
+	}
+
+	@Test
+	public void promoteJobPartitions() throws Exception {
+		final TestingShuffleEnvironment testingShuffleEnvironment = new TestingShuffleEnvironment();
+		final CompletableFuture<Collection<ResultPartitionID>> shuffleReleaseFuture = new CompletableFuture<>();
+		testingShuffleEnvironment.releasePartitionsLocallyFuture = shuffleReleaseFuture;
+
+		final JobID jobId = new JobID();
+		final ResultPartitionID resultPartitionId1 = new ResultPartitionID();
+		final ResultPartitionID resultPartitionId2 = new ResultPartitionID();
+
+		final TaskExecutorPartitionTracker partitionTracker = new TaskExecutorPartitionTrackerImpl(testingShuffleEnvironment);
+		partitionTracker.startTrackingPartition(jobId, new TaskExecutorPartitionInfo(resultPartitionId1, new IntermediateDataSetID(), 1));
+		partitionTracker.startTrackingPartition(jobId, new TaskExecutorPartitionInfo(resultPartitionId2, new IntermediateDataSetID(), 1));
+		partitionTracker.promoteJobPartitions(Collections.singleton(resultPartitionId1));
+
+		partitionTracker.stopTrackingAndReleaseJobPartitionsFor(jobId);
+		assertThat(shuffleReleaseFuture.get(), not(hasItem(resultPartitionId1)));
+	}
+
+	@Test
+	public void stopTrackingAndReleaseAllClusterPartitions() throws Exception {
+		final TestingShuffleEnvironment testingShuffleEnvironment = new TestingShuffleEnvironment();
+		final CompletableFuture<Collection<ResultPartitionID>> shuffleReleaseFuture = new CompletableFuture<>();
+		testingShuffleEnvironment.releasePartitionsLocallyFuture = shuffleReleaseFuture;
+
+		final ResultPartitionID resultPartitionId1 = new ResultPartitionID();
+		final ResultPartitionID resultPartitionId2 = new ResultPartitionID();
+
+		final TaskExecutorPartitionTracker partitionTracker = new TaskExecutorPartitionTrackerImpl(testingShuffleEnvironment);
+		partitionTracker.startTrackingPartition(new JobID(), new TaskExecutorPartitionInfo(resultPartitionId1, new IntermediateDataSetID(), 1));
+		partitionTracker.startTrackingPartition(new JobID(), new TaskExecutorPartitionInfo(resultPartitionId2, new IntermediateDataSetID(), 1));
+		partitionTracker.promoteJobPartitions(Collections.singleton(resultPartitionId1));
+
+		partitionTracker.stopTrackingAndReleaseAllClusterPartitions();
+		assertThat(shuffleReleaseFuture.get(), hasItem(resultPartitionId1));
+	}
+
+	private static class TestingShuffleEnvironment implements ShuffleEnvironment<ResultPartition, SingleInputGate> {
+
+		private final ShuffleEnvironment<ResultPartition, SingleInputGate> backingShuffleEnvironment =
+			new NettyShuffleEnvironmentBuilder().build();
+
+		CompletableFuture<Collection<ResultPartitionID>> releasePartitionsLocallyFuture = null;
+
+		@Override
+		public int start() throws IOException {
+			return backingShuffleEnvironment.start();
+		}
+
+		@Override
+		public ShuffleIOOwnerContext createShuffleIOOwnerContext(String ownerName, ExecutionAttemptID executionAttemptID, MetricGroup parentGroup) {
+			return backingShuffleEnvironment.createShuffleIOOwnerContext(ownerName, executionAttemptID, parentGroup);
+		}
+
+		@Override
+		public Collection<ResultPartition> createResultPartitionWriters(ShuffleIOOwnerContext ownerContext, Collection<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors) {
+			return backingShuffleEnvironment.createResultPartitionWriters(ownerContext, resultPartitionDeploymentDescriptors);
+		}
+
+		@Override
+		public void releasePartitionsLocally(Collection<ResultPartitionID> partitionIds) {
+			backingShuffleEnvironment.releasePartitionsLocally(partitionIds);
+			if (releasePartitionsLocallyFuture != null) {
+				releasePartitionsLocallyFuture.complete(partitionIds);
+			}
+		}
+
+		@Override
+		public Collection<ResultPartitionID> getPartitionsOccupyingLocalResources() {
+			return backingShuffleEnvironment.getPartitionsOccupyingLocalResources();
+		}
+
+		@Override
+		public Collection<SingleInputGate> createInputGates(ShuffleIOOwnerContext ownerContext, PartitionProducerStateProvider partitionProducerStateProvider, Collection<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors) {
+			return backingShuffleEnvironment.createInputGates(ownerContext, partitionProducerStateProvider, inputGateDeploymentDescriptors);
+		}
+
+		@Override
+		public boolean updatePartitionInfo(ExecutionAttemptID consumerID, PartitionInfo partitionInfo) throws IOException, InterruptedException {
+			return backingShuffleEnvironment.updatePartitionInfo(consumerID, partitionInfo);
+		}
+
+		@Override
+		public void close() throws Exception {
+			backingShuffleEnvironment.close();
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/TestingTaskExecutorPartitionTracker.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/TestingTaskExecutorPartitionTracker.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.taskexecutor.partition.ClusterPartitionReport;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Test {@link TaskExecutorPartitionTracker} implementation.
+ */
+public class TestingTaskExecutorPartitionTracker implements TaskExecutorPartitionTracker {
+
+	private Function<JobID, Boolean> isTrackingPartitionsForFunction = ignored -> false;
+	private Function<ResultPartitionID, Boolean> isPartitionTrackedFunction = ignored -> false;
+	private Function<JobID, Collection<PartitionTrackerEntry<JobID, TaskExecutorPartitionInfo>>> stopTrackingAllPartitionsFunction = ignored -> Collections.emptySet();
+	private Consumer<JobID> stopTrackingAndReleaseAllPartitionsConsumer = ignored -> {};
+	private BiConsumer<JobID, TaskExecutorPartitionInfo> startTrackingPartitionsConsumer = (ignoredA, ignoredB) -> {};
+	private Consumer<Collection<ResultPartitionID>> stopTrackingAndReleasePartitionsConsumer = ignored -> {};
+	private Function<Collection<ResultPartitionID>, Collection<PartitionTrackerEntry<JobID, TaskExecutorPartitionInfo>>> stopTrackingPartitionsFunction = ignored -> Collections.emptySet();
+	private Runnable stopTrackingAllClusterPartitionsRunnable = () -> {};
+	private Consumer<Collection<ResultPartitionID>> promotePartitionsConsumer = ignored -> {};
+
+	public void setStartTrackingPartitionsConsumer(BiConsumer<JobID, TaskExecutorPartitionInfo> startTrackingPartitionsConsumer) {
+		this.startTrackingPartitionsConsumer = startTrackingPartitionsConsumer;
+	}
+
+	public void setIsTrackingPartitionsForFunction(Function<JobID, Boolean> isTrackingPartitionsForFunction) {
+		this.isTrackingPartitionsForFunction = isTrackingPartitionsForFunction;
+	}
+
+	public void setIsPartitionTrackedFunction(Function<ResultPartitionID, Boolean> isPartitionTrackedFunction) {
+		this.isPartitionTrackedFunction = isPartitionTrackedFunction;
+	}
+
+	public void setStopTrackingAllPartitionsFunction(Function<JobID, Collection<PartitionTrackerEntry<JobID, TaskExecutorPartitionInfo>>> stopTrackingAllPartitionsFunction) {
+		this.stopTrackingAllPartitionsFunction = stopTrackingAllPartitionsFunction;
+	}
+
+	public void setPromotePartitionsConsumer(Consumer<Collection<ResultPartitionID>> promotePartitionsConsumer) {
+		this.promotePartitionsConsumer = promotePartitionsConsumer;
+	}
+
+	public void setStopTrackingAndReleaseAllPartitionsConsumer(Consumer<JobID> stopTrackingAndReleaseAllPartitionsConsumer) {
+		this.stopTrackingAndReleaseAllPartitionsConsumer = stopTrackingAndReleaseAllPartitionsConsumer;
+	}
+
+	public void setStopTrackingAndReleasePartitionsConsumer(Consumer<Collection<ResultPartitionID>> stopTrackingAndReleasePartitionsConsumer) {
+		this.stopTrackingAndReleasePartitionsConsumer = stopTrackingAndReleasePartitionsConsumer;
+	}
+
+	public void setStopTrackingPartitionsFunction(Function<Collection<ResultPartitionID>, Collection<PartitionTrackerEntry<JobID, TaskExecutorPartitionInfo>>> stopTrackingPartitionsFunction) {
+		this.stopTrackingPartitionsFunction = stopTrackingPartitionsFunction;
+	}
+
+	@Override
+	public void startTrackingPartition(JobID producingJobId, TaskExecutorPartitionInfo partitionInfo) {
+		startTrackingPartitionsConsumer.accept(producingJobId, partitionInfo);
+	}
+
+	@Override
+	public void stopTrackingAndReleaseJobPartitions(Collection<ResultPartitionID> resultPartitionIds) {
+		stopTrackingAndReleasePartitionsConsumer.accept(resultPartitionIds);
+	}
+
+	@Override
+	public void stopTrackingAndReleaseJobPartitionsFor(JobID producingJobId) {
+		stopTrackingAndReleaseAllPartitionsConsumer.accept(producingJobId);
+	}
+
+	@Override
+	public void promoteJobPartitions(Collection<ResultPartitionID> partitionsToPromote) {
+		promotePartitionsConsumer.accept(partitionsToPromote);
+	}
+
+	@Override
+	public void stopTrackingAndReleaseAllClusterPartitions() {
+		stopTrackingAllClusterPartitionsRunnable.run();
+	}
+
+	@Override
+	public ClusterPartitionReport createClusterPartitionReport() {
+		return new ClusterPartitionReport(Collections.emptyList());
+	}
+
+	@Override
+	public Collection<PartitionTrackerEntry<JobID, TaskExecutorPartitionInfo>> stopTrackingPartitionsFor(JobID key) {
+		return stopTrackingAllPartitionsFunction.apply(key);
+	}
+
+	@Override
+	public Collection<PartitionTrackerEntry<JobID, TaskExecutorPartitionInfo>> stopTrackingPartitions(Collection<ResultPartitionID> resultPartitionIds) {
+		return stopTrackingPartitionsFunction.apply(resultPartitionIds);
+	}
+
+	@Override
+	public boolean isTrackingPartitionsFor(JobID key) {
+		return isTrackingPartitionsForFunction.apply(key);
+	}
+
+	@Override
+	public boolean isPartitionTracked(ResultPartitionID resultPartitionID) {
+		return isPartitionTrackedFunction.apply(resultPartitionID);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -23,32 +23,25 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.BlockerSync;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.Executors;
-import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.runtime.executiongraph.PartitionInfo;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
-import org.apache.flink.runtime.io.network.partition.PartitionProducerStateProvider;
 import org.apache.flink.runtime.io.network.partition.PartitionTestUtils;
-import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
-import org.apache.flink.runtime.io.network.partition.TaskExecutorPartitionInfo;
 import org.apache.flink.runtime.io.network.partition.TaskExecutorPartitionTracker;
-import org.apache.flink.runtime.io.network.partition.TaskExecutorPartitionTrackerImpl;
-import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
+import org.apache.flink.runtime.io.network.partition.TestingTaskExecutorPartitionTracker;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmaster.JMTMRegistrationSuccess;
 import org.apache.flink.runtime.jobmaster.JobMasterGateway;
@@ -63,7 +56,6 @@ import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGate
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
-import org.apache.flink.runtime.shuffle.ShuffleIOOwnerContext;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotUtils;
@@ -73,7 +65,6 @@ import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.TriConsumer;
 
-import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -90,12 +81,13 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.StreamSupport;
 
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -166,15 +158,20 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 		final JobManagerTable jobManagerTable = new JobManagerTable();
 		jobManagerTable.put(jobId, jobManagerConnection);
 
-		final TestingShuffleEnvironment shuffleEnvironment = new TestingShuffleEnvironment();
-
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
 			.setJobManagerTable(jobManagerTable)
-			.setShuffleEnvironment(shuffleEnvironment)
+			.setShuffleEnvironment(new NettyShuffleEnvironmentBuilder().build())
 			.setTaskSlotTable(createTaskSlotTable())
 			.build();
 
-		final TaskExecutorPartitionTracker partitionTracker = new TaskExecutorPartitionTrackerImpl(shuffleEnvironment);
+		final TestingTaskExecutorPartitionTracker partitionTracker = new TestingTaskExecutorPartitionTracker();
+
+		final AtomicBoolean trackerIsTrackingPartitions = new AtomicBoolean(false);
+		partitionTracker.setIsTrackingPartitionsForFunction(jobId -> trackerIsTrackingPartitions.get());
+
+		final CompletableFuture<Collection<ResultPartitionID>> firstReleasePartitionsCallFuture = new CompletableFuture<>();
+		partitionTracker.setStopTrackingAndReleasePartitionsConsumer(firstReleasePartitionsCallFuture::complete);
+
 		final ResultPartitionDeploymentDescriptor resultPartitionDeploymentDescriptor = PartitionTestUtils.createPartitionDeploymentDescriptor(ResultPartitionType.BLOCKING);
 		final ResultPartitionID resultPartitionId = resultPartitionDeploymentDescriptor.getShuffleDescriptor().getResultPartitionID();
 
@@ -189,12 +186,8 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 			// baseline, jobmanager was added in test setup
 			runInTaskExecutorThreadAndWait(taskExecutor, () -> assertTrue(jobManagerTable.contains(jobId)));
 
-			runInTaskExecutorThreadAndWait(taskExecutor, () -> partitionTracker.startTrackingPartition(
-				jobId,
-				TaskExecutorPartitionInfo.from(resultPartitionDeploymentDescriptor)));
-
-			final CompletableFuture<Collection<ResultPartitionID>> firstReleasePartitionsCallFuture = new CompletableFuture<>();
-			runInTaskExecutorThreadAndWait(taskExecutor, () -> shuffleEnvironment.releasePartitionsLocallyFuture = firstReleasePartitionsCallFuture);
+			trackerIsTrackingPartitions.set(true);
+			assertThat(firstReleasePartitionsCallFuture.isDone(), is(false));
 
 			taskExecutorGateway.releaseOrPromotePartitions(jobId, Collections.singleton(new ResultPartitionID()), Collections.emptySet());
 
@@ -206,8 +199,7 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 			// once this returns we know that the TE has exited releasePartitions and associated connection checks
 			runInTaskExecutorThreadAndWait(taskExecutor, () -> assertTrue(jobManagerTable.contains(jobId)));
 
-			final CompletableFuture<Collection<ResultPartitionID>> secondReleasePartitionsCallFuture = new CompletableFuture<>();
-			runInTaskExecutorThreadAndWait(taskExecutor, () -> shuffleEnvironment.releasePartitionsLocallyFuture = secondReleasePartitionsCallFuture);
+			trackerIsTrackingPartitions.set(false);
 
 			// the TM should check whether partitions are still stored, and afterwards terminate the connection
 			releaseOrPromoteCall.accept(taskExecutor, jobId, resultPartitionId);
@@ -219,100 +211,51 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 	}
 
 	@Test
-	public void testBlockingPartitionReleaseAfterJobMasterDisconnect() throws Exception {
+	public void testPartitionReleaseAfterJobMasterDisconnect() throws Exception {
 		testPartitionRelease(
-			(jobId, partitionId, taskExecutorGateway) -> taskExecutorGateway.disconnectJobManager(jobId, new Exception("test")),
-			true,
-			true,
-			ResultPartitionType.BLOCKING);
-	}
+			(jobId, partitionId, taskExecutor, taskExecutorGateway, partitionTracker) -> {
+				final CompletableFuture<JobID> releasePartitionsForJobFuture = new CompletableFuture<>();
+				runInTaskExecutorThreadAndWait(taskExecutor, () -> partitionTracker.setStopTrackingAndReleaseAllPartitionsConsumer(releasePartitionsForJobFuture::complete));
 
-	@Test
-	public void testPipelinedPartitionNotReleasedAfterJobMasterDisconnect() throws Exception {
-		testPartitionRelease(
-			(jobId, partitionId, taskExecutorGateway) -> taskExecutorGateway.disconnectJobManager(jobId, new Exception("test")),
-			false,
-			false,
-			ResultPartitionType.PIPELINED);
-	}
-
-	@Test
-	public void testBlockingPartitionReleaseAfterReleaseCall() throws Exception {
-		testPartitionRelease(
-			(jobId, partitionId, taskExecutorGateway) -> taskExecutorGateway.releaseOrPromotePartitions(jobId, Collections.singleton(partitionId), Collections.emptySet()),
-			true,
-			true,
-			ResultPartitionType.BLOCKING);
-	}
-
-	@Test
-	public void testPipelinedPartitionReleaseAfterReleaseCall() throws Exception {
-		testPartitionRelease(
-			(jobId, partitionId, taskExecutorGateway) -> taskExecutorGateway.releaseOrPromotePartitions(jobId, Collections.singleton(partitionId), Collections.emptySet()),
-			true,
-			true,
-			ResultPartitionType.PIPELINED);
-	}
-
-	@Test
-	public void testBlockingPartitionReleaseAfterShutdown() throws Exception {
-		// don't do any explicit release action, so that the partition must be cleaned up on shutdown
-		testPartitionRelease(
-			(jobId, partitionId, taskExecutorGateway) -> { },
-			false,
-			false,
-			ResultPartitionType.BLOCKING);
-	}
-
-	@Test
-	public void testPipelinedPartitionReleaseAfterShutdown() throws Exception {
-		// don't do any explicit release action, so that the partition must be cleaned up on shutdown
-		testPartitionRelease(
-			(jobId, partitionId, taskExecutorGateway) -> { },
-			false,
-			false,
-			ResultPartitionType.PIPELINED);
-	}
-
-	@Test
-	public void testPromotedBlockingPartitionNotReleasedAfterPromotionCall() throws Exception {
-		testPartitionRelease(
-			(jobId, partitionId, taskExecutorGateway) -> taskExecutorGateway.releaseOrPromotePartitions(jobId, Collections.emptySet(), Collections.singleton(partitionId)),
-			true,
-			false,
-			ResultPartitionType.BLOCKING);
-	}
-
-	@Test
-	public void testPromotedBlockingPartitionReleasedAfterShutdown() throws Exception {
-		// don't do any explicit release action, so that the partition must be cleaned up on shutdown
-		testPartitionRelease(
-			(jobId, partitionId, taskExecutorGateway) -> taskExecutorGateway.releaseOrPromotePartitions(jobId, Collections.emptySet(), Collections.singleton(partitionId)),
-			false,
-			false,
-			ResultPartitionType.BLOCKING);
-	}
-
-	@Test
-	public void testPromotedBlockingPartitionNotReleasedAfterJobMasterDisconnect() throws Exception {
-		testPartitionRelease(
-			(jobId, partitionId, taskExecutorGateway) -> {
-				taskExecutorGateway.releaseOrPromotePartitions(jobId, Collections.emptySet(), Collections.singleton(partitionId));
 				taskExecutorGateway.disconnectJobManager(jobId, new Exception("test"));
-			},
-			true,
-			false,
-			ResultPartitionType.BLOCKING);
+
+				assertThat(releasePartitionsForJobFuture.get(), equalTo(jobId));
+			}
+		);
 	}
 
-	private void testPartitionRelease(
-		TriConsumer<JobID, ResultPartitionID, TaskExecutorGateway> releaseAction,
-		boolean waitForRelease,
-		boolean shouldBeReleasedAfterWait,
-		ResultPartitionType resultPartitionType) throws Exception {
+	@Test
+	public void testPartitionReleaseAfterReleaseCall() throws Exception {
+		testPartitionRelease(
+			(jobId, partitionId, taskExecutor, taskExecutorGateway, partitionTracker) -> {
+				final CompletableFuture<Collection<ResultPartitionID>> releasePartitionsFuture = new CompletableFuture<>();
+				runInTaskExecutorThreadAndWait(taskExecutor, () -> partitionTracker.setStopTrackingAndReleasePartitionsConsumer(releasePartitionsFuture::complete));
+
+				taskExecutorGateway.releaseOrPromotePartitions(jobId, Collections.singleton(partitionId), Collections.emptySet());
+
+				assertThat(releasePartitionsFuture.get(), hasItems(partitionId));
+			}
+		);
+	}
+
+	@Test
+	public void testPartitionPromotion() throws Exception {
+		testPartitionRelease(
+			(jobId, partitionId, taskExecutor, taskExecutorGateway, partitionTracker) -> {
+				final CompletableFuture<Collection<ResultPartitionID>> releasePartitionsFuture = new CompletableFuture<>();
+				runInTaskExecutorThreadAndWait(taskExecutor, () -> partitionTracker.setPromotePartitionsConsumer(releasePartitionsFuture::complete));
+
+				taskExecutorGateway.releaseOrPromotePartitions(jobId, Collections.emptySet(), Collections.singleton(partitionId));
+
+				assertThat(releasePartitionsFuture.get(), hasItems(partitionId));
+			}
+		);
+	}
+
+	private void testPartitionRelease(TestAction testAction) throws Exception {
 
 		final ResultPartitionDeploymentDescriptor taskResultPartitionDescriptor =
-			PartitionTestUtils.createPartitionDeploymentDescriptor(resultPartitionType);
+			PartitionTestUtils.createPartitionDeploymentDescriptor(ResultPartitionType.BLOCKING);
 		final ExecutionAttemptID eid1 = taskResultPartitionDescriptor.getShuffleDescriptor().getResultPartitionID().getProducerId();
 
 		final TaskDeploymentDescriptor taskDeploymentDescriptor =
@@ -342,7 +285,7 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 			new File[]{tmp.newFolder()},
 			Executors.directExecutor());
 
-		final TestingShuffleEnvironment shuffleEnvironment = new TestingShuffleEnvironment();
+		final ShuffleEnvironment<?, ?> shuffleEnvironment = new NettyShuffleEnvironmentBuilder().build();
 
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
 			.setTaskSlotTable(taskSlotTable)
@@ -367,7 +310,7 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 			})
 			.build();
 
-		final TaskExecutorPartitionTracker partitionTracker = new TaskExecutorPartitionTrackerImpl(shuffleEnvironment);
+		final TestingTaskExecutorPartitionTracker partitionTracker = new TestingTaskExecutorPartitionTracker();
 
 		final TestingTaskExecutor taskExecutor = createTestingTaskExecutor(taskManagerServices, partitionTracker, metricQueryServiceAddress);
 
@@ -431,39 +374,26 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 			// This ensures TM has been successfully registered to JM.
 			slotOfferedLatch.await();
 
+			final CompletableFuture<ResultPartitionID> startTrackingFuture = new CompletableFuture<>();
+			runInTaskExecutorThreadAndWait(taskExecutor, () -> partitionTracker.setStartTrackingPartitionsConsumer((jobId, partitionInfo) -> startTrackingFuture.complete(partitionInfo.getResultPartitionId())));
+
 			taskExecutorGateway.submitTask(taskDeploymentDescriptor, jobMasterGateway.getFencingToken(), timeout)
 				.get();
 
 			TestingInvokable.sync.awaitBlocker();
 
-			// the task is still running => the partition is in in-progress
-			runInTaskExecutorThreadAndWait(
-				taskExecutor,
-				() -> assertThat(partitionTracker.isTrackingPartitionsFor(jobId), is(resultPartitionType.isBlocking())));
+			// the task is still running => the partition is in in-progress and should be tracked
+			assertThat(startTrackingFuture.get(), equalTo(taskResultPartitionDescriptor.getShuffleDescriptor().getResultPartitionID()));
 
 			TestingInvokable.sync.releaseBlocker();
 			taskFinishedFuture.get(timeout.getSize(), timeout.getUnit());
 
-			// the task is finished => the partition should be finished now
-			runInTaskExecutorThreadAndWait(
-				taskExecutor,
-				() -> assertThat(partitionTracker.isTrackingPartitionsFor(jobId), is(resultPartitionType.isBlocking())));
-
-			final CompletableFuture<Collection<ResultPartitionID>> releasePartitionsFuture = new CompletableFuture<>();
-			runInTaskExecutorThreadAndWait(
-				taskExecutor,
-				() -> shuffleEnvironment.releasePartitionsLocallyFuture = releasePartitionsFuture);
-
-			releaseAction.accept(
+			testAction.accept(
 				jobId,
 				taskResultPartitionDescriptor.getShuffleDescriptor().getResultPartitionID(),
-				taskExecutorGateway);
-
-			if (waitForRelease) {
-				Collection<ResultPartitionID> resultPartitionIDS = releasePartitionsFuture.get();
-				Matcher<Iterable<? extends ResultPartitionID>> resultPartitionIdMatcher = contains(taskResultPartitionDescriptor.getShuffleDescriptor().getResultPartitionID());
-				assertThat(resultPartitionIDS, shouldBeReleasedAfterWait ? resultPartitionIdMatcher : not(resultPartitionIdMatcher));
-			}
+				taskExecutor,
+				taskExecutorGateway,
+				partitionTracker);
 		} finally {
 			RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
 		}
@@ -522,54 +452,8 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 		).get();
 	}
 
-	private static class TestingShuffleEnvironment implements ShuffleEnvironment<ResultPartition, SingleInputGate> {
-
-		private final ShuffleEnvironment<ResultPartition, SingleInputGate> backingShuffleEnvironment =
-			new NettyShuffleEnvironmentBuilder().build();
-
-		CompletableFuture<Collection<ResultPartitionID>> releasePartitionsLocallyFuture = null;
-
-		@Override
-		public int start() throws IOException {
-			return backingShuffleEnvironment.start();
-		}
-
-		@Override
-		public ShuffleIOOwnerContext createShuffleIOOwnerContext(String ownerName, ExecutionAttemptID executionAttemptID, MetricGroup parentGroup) {
-			return backingShuffleEnvironment.createShuffleIOOwnerContext(ownerName, executionAttemptID, parentGroup);
-		}
-
-		@Override
-		public Collection<ResultPartition> createResultPartitionWriters(ShuffleIOOwnerContext ownerContext, Collection<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors) {
-			return backingShuffleEnvironment.createResultPartitionWriters(ownerContext, resultPartitionDeploymentDescriptors);
-		}
-
-		@Override
-		public void releasePartitionsLocally(Collection<ResultPartitionID> partitionIds) {
-			backingShuffleEnvironment.releasePartitionsLocally(partitionIds);
-			if (releasePartitionsLocallyFuture != null) {
-				releasePartitionsLocallyFuture.complete(partitionIds);
-			}
-		}
-
-		@Override
-		public Collection<ResultPartitionID> getPartitionsOccupyingLocalResources() {
-			return backingShuffleEnvironment.getPartitionsOccupyingLocalResources();
-		}
-
-		@Override
-		public Collection<SingleInputGate> createInputGates(ShuffleIOOwnerContext ownerContext, PartitionProducerStateProvider partitionProducerStateProvider, Collection<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors) {
-			return backingShuffleEnvironment.createInputGates(ownerContext, partitionProducerStateProvider, inputGateDeploymentDescriptors);
-		}
-
-		@Override
-		public boolean updatePartitionInfo(ExecutionAttemptID consumerID, PartitionInfo partitionInfo) throws IOException, InterruptedException {
-			return backingShuffleEnvironment.updatePartitionInfo(consumerID, partitionInfo);
-		}
-
-		@Override
-		public void close() throws Exception {
-			backingShuffleEnvironment.close();
-		}
+	@FunctionalInterface
+	private interface TestAction {
+		void accept(JobID jobId, ResultPartitionID resultPartitionId, TaskExecutor taskExecutor, TaskExecutorGateway taskExecutorGateway, TestingTaskExecutorPartitionTracker partitionTracker) throws Exception;
 	}
 }


### PR DESCRIPTION
This PR pulls apart `TaskExecutorPartitionLifecycleTest` to test interactions between the TE <-> partition tracker, and partition tracker <-> shuffle environment separately.

The current approach is too indirect and not suitable for some tests; particularly when the partition tracker does _something_ but doesn't interact with the shuffle environment.
This came up when I added eager return statements to the tracker when the given collection was empty.

Several tests in the `TaskExecutorPartitionLifecycleTest` have been removed completely as they test now irrelevant behavior; the TE doesn't care about the partition type as this is an implementation detail of the tracker. Now that we use a test implementation of the tracker this detail has become irrelevant.
The core structure of the remaining tests has been retained.

The new `TaskExecutorPartitionTrackerImplTest` is a new unit test thats interactions between the tracker and shuffle environment. Specifically it checks under what circumstances partitions are being tracked or released.

