### PR TITLE
[FLINK-14792][coordination] Implement TE cluster partition release

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTracker.java
@@ -18,6 +18,7 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.taskexecutor.partition.ClusterPartitionReport;
 
 import java.util.Collection;
@@ -49,6 +50,13 @@ public interface TaskExecutorPartitionTracker extends PartitionTracker<JobID, Ta
 	 * Promotes the given partitions.
 	 */
 	void promoteJobPartitions(Collection<ResultPartitionID> partitionsToPromote);
+
+	/**
+	 * Releases partitions associated with the given datasets and stops tracking of partitions that were released.
+	 *
+	 * @param dataSetsToRelease data sets to release
+	 */
+	void stopTrackingAndReleaseClusterPartitions(Collection<IntermediateDataSetID> dataSetsToRelease);
 
 	/**
 	 * Releases and stops tracking all partitions.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTrackerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTrackerImpl.java
@@ -52,6 +52,10 @@ public class TaskExecutorPartitionTrackerImpl extends AbstractPartitionTracker<J
 
 	@Override
 	public void stopTrackingAndReleaseJobPartitions(Collection<ResultPartitionID> partitionsToRelease) {
+		if (partitionsToRelease.isEmpty()) {
+			return;
+		}
+
 		stopTrackingPartitions(partitionsToRelease);
 		shuffleEnvironment.releasePartitionsLocally(partitionsToRelease);
 	}
@@ -66,6 +70,10 @@ public class TaskExecutorPartitionTrackerImpl extends AbstractPartitionTracker<J
 
 	@Override
 	public void promoteJobPartitions(Collection<ResultPartitionID> partitionsToPromote) {
+		if (partitionsToPromote.isEmpty()) {
+			return;
+		}
+
 		final Collection<PartitionTrackerEntry<JobID, TaskExecutorPartitionInfo>> partitionTrackerEntries = stopTrackingPartitions(partitionsToPromote);
 
 		final Map<TaskExecutorPartitionInfo, Set<ResultPartitionID>> newClusterPartitions = partitionTrackerEntries.stream()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTrackerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTrackerImpl.java
@@ -88,6 +88,15 @@ public class TaskExecutorPartitionTrackerImpl extends AbstractPartitionTracker<J
 	}
 
 	@Override
+	public void stopTrackingAndReleaseClusterPartitions(Collection<IntermediateDataSetID> dataSetsToRelease) {
+		for (IntermediateDataSetID dataSetID : dataSetsToRelease) {
+			final DataSetEntry dataSetEntry = clusterPartitions.remove(dataSetID);
+			final Set<ResultPartitionID> partitionIds = dataSetEntry.getPartitionIds();
+			shuffleEnvironment.releasePartitionsLocally(partitionIds);
+		}
+	}
+
+	@Override
 	public void stopTrackingAndReleaseAllClusterPartitions() {
 		clusterPartitions.values().stream().map(DataSetEntry::getPartitionIds).forEach(shuffleEnvironment::releasePartitionsLocally);
 		clusterPartitions.clear();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -57,6 +57,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNo
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.TaskExecutorPartitionInfo;
 import org.apache.flink.runtime.io.network.partition.TaskExecutorPartitionTracker;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.jobgraph.tasks.TaskOperatorEventGateway;
@@ -771,6 +772,11 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		}
 
 		// TODO: Maybe it's better to return an Acknowledge here to notify the JM about the success/failure with an Exception
+	}
+
+	@Override
+	public void releaseClusterPartitions(Collection<IntermediateDataSetID> dataSetsToRelease, Time timeout) {
+		partitionTracker.stopTrackingAndReleaseClusterPartitions(dataSetsToRelease);
 	}
 
 	// ----------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.PartitionInfo;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobmaster.AllocatedSlotReport;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
@@ -113,6 +114,14 @@ public interface TaskExecutorGateway extends RpcGateway, TaskExecutorOperatorEve
 	 * @param partitionsToPromote partitions ids to promote
 	 */
 	void releaseOrPromotePartitions(JobID jobId, Set<ResultPartitionID> partitionToRelease, Set<ResultPartitionID> partitionsToPromote);
+
+	/**
+	 * Releases all cluster partitions belong to any of the given data sets.
+	 *
+	 * @param dataSetsToRelease data sets for which all cluster partitions should be released
+	 * @param timeout for the partitions release operation
+	 */
+	void releaseClusterPartitions(Collection<IntermediateDataSetID> dataSetsToRelease, @RpcTimeout Time timeout);
 
 	/**
 	 * Trigger the checkpoint for the given task. The checkpoint is identified by the checkpoint ID

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTrackerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTrackerImplTest.java
@@ -151,6 +151,27 @@ public class TaskExecutorPartitionTrackerImplTest extends TestLogger {
 		assertThat(shuffleReleaseFuture.get(), hasItem(resultPartitionId1));
 	}
 
+	@Test
+	public void stopTrackingAndReleaseClusterPartitions() throws Exception {
+		final TestingShuffleEnvironment testingShuffleEnvironment = new TestingShuffleEnvironment();
+		final CompletableFuture<Collection<ResultPartitionID>> shuffleReleaseFuture = new CompletableFuture<>();
+		testingShuffleEnvironment.releasePartitionsLocallyFuture = shuffleReleaseFuture;
+
+		final ResultPartitionID resultPartitionId1 = new ResultPartitionID();
+		final ResultPartitionID resultPartitionId2 = new ResultPartitionID();
+
+		final IntermediateDataSetID dataSetId1 = new IntermediateDataSetID();
+		final IntermediateDataSetID dataSetId2 = new IntermediateDataSetID();
+
+		final TaskExecutorPartitionTracker partitionTracker = new TaskExecutorPartitionTrackerImpl(testingShuffleEnvironment);
+		partitionTracker.startTrackingPartition(new JobID(), new TaskExecutorPartitionInfo(resultPartitionId1, dataSetId1, 1));
+		partitionTracker.startTrackingPartition(new JobID(), new TaskExecutorPartitionInfo(resultPartitionId2, dataSetId2, 1));
+		partitionTracker.promoteJobPartitions(Collections.singleton(resultPartitionId1));
+
+		partitionTracker.stopTrackingAndReleaseClusterPartitions(Collections.singleton(dataSetId1));
+		assertThat(shuffleReleaseFuture.get(), hasItem(resultPartitionId1));
+	}
+
 	private static class TestingShuffleEnvironment implements ShuffleEnvironment<ResultPartition, SingleInputGate> {
 
 		private final ShuffleEnvironment<ResultPartition, SingleInputGate> backingShuffleEnvironment =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/TestingTaskExecutorPartitionTracker.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/TestingTaskExecutorPartitionTracker.java
@@ -18,6 +18,7 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.taskexecutor.partition.ClusterPartitionReport;
 
 import java.util.Collection;
@@ -40,6 +41,7 @@ public class TestingTaskExecutorPartitionTracker implements TaskExecutorPartitio
 	private Function<Collection<ResultPartitionID>, Collection<PartitionTrackerEntry<JobID, TaskExecutorPartitionInfo>>> stopTrackingPartitionsFunction = ignored -> Collections.emptySet();
 	private Runnable stopTrackingAllClusterPartitionsRunnable = () -> {};
 	private Consumer<Collection<ResultPartitionID>> promotePartitionsConsumer = ignored -> {};
+	private Consumer<Collection<IntermediateDataSetID>> releaseClusterPartitionsConsumer = ignored -> {};
 
 	public void setStartTrackingPartitionsConsumer(BiConsumer<JobID, TaskExecutorPartitionInfo> startTrackingPartitionsConsumer) {
 		this.startTrackingPartitionsConsumer = startTrackingPartitionsConsumer;
@@ -73,6 +75,10 @@ public class TestingTaskExecutorPartitionTracker implements TaskExecutorPartitio
 		this.stopTrackingPartitionsFunction = stopTrackingPartitionsFunction;
 	}
 
+	public void setReleaseClusterPartitionsConsumer(Consumer<Collection<IntermediateDataSetID>> releaseClusterPartitionsConsumer) {
+		this.releaseClusterPartitionsConsumer = releaseClusterPartitionsConsumer;
+	}
+
 	@Override
 	public void startTrackingPartition(JobID producingJobId, TaskExecutorPartitionInfo partitionInfo) {
 		startTrackingPartitionsConsumer.accept(producingJobId, partitionInfo);
@@ -91,6 +97,11 @@ public class TestingTaskExecutorPartitionTracker implements TaskExecutorPartitio
 	@Override
 	public void promoteJobPartitions(Collection<ResultPartitionID> partitionsToPromote) {
 		promotePartitionsConsumer.accept(partitionsToPromote);
+	}
+
+	@Override
+	public void stopTrackingAndReleaseClusterPartitions(Collection<IntermediateDataSetID> dataSetsToRelease) {
+		releaseClusterPartitionsConsumer.accept(dataSetsToRelease);
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -251,14 +251,14 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 	public void testPartitionPromotion() throws Exception {
 		testPartitionRelease(
 			partitionTracker -> {
-				final CompletableFuture<Collection<ResultPartitionID>> releasePartitionsFuture = new CompletableFuture<>();
-				partitionTracker.setPromotePartitionsConsumer(releasePartitionsFuture::complete);
-				return releasePartitionsFuture;
+				final CompletableFuture<Collection<ResultPartitionID>> promotePartitionsFuture = new CompletableFuture<>();
+				partitionTracker.setPromotePartitionsConsumer(promotePartitionsFuture::complete);
+				return promotePartitionsFuture;
 			},
-			(jobId, partitionId, taskExecutor, taskExecutorGateway, releasePartitionsFuture) -> {
+			(jobId, partitionId, taskExecutor, taskExecutorGateway, promotePartitionsFuture) -> {
 				taskExecutorGateway.releaseOrPromotePartitions(jobId, Collections.emptySet(), Collections.singleton(partitionId));
 
-				assertThat(releasePartitionsFuture.get(), hasItems(partitionId));
+				assertThat(promotePartitionsFuture.get(), hasItems(partitionId));
 			}
 		);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.io.network.partition.TaskExecutorPartitionTracker;
 import org.apache.flink.runtime.io.network.partition.TestingTaskExecutorPartitionTracker;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmaster.JMTMRegistrationSuccess;
 import org.apache.flink.runtime.jobmaster.JobMasterGateway;
@@ -222,8 +223,7 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 				partitionTracker.setStopTrackingAndReleaseAllPartitionsConsumer(releasePartitionsForJobFuture::complete);
 				return releasePartitionsForJobFuture;
 			},
-			(jobId, partitionId, taskExecutor, taskExecutorGateway, releasePartitionsForJobFuture) -> {
-
+			(jobId, resultPartitionDeploymentDescriptor, taskExecutor, taskExecutorGateway, releasePartitionsForJobFuture) -> {
 				taskExecutorGateway.disconnectJobManager(jobId, new Exception("test"));
 
 				assertThat(releasePartitionsForJobFuture.get(), equalTo(jobId));
@@ -239,10 +239,12 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 				partitionTracker.setStopTrackingAndReleasePartitionsConsumer(releasePartitionsFuture::complete);
 				return releasePartitionsFuture;
 			},
-			(jobId, partitionId, taskExecutor, taskExecutorGateway, releasePartitionsFuture) -> {
-				taskExecutorGateway.releaseOrPromotePartitions(jobId, Collections.singleton(partitionId), Collections.emptySet());
+			(jobId, resultPartitionDeploymentDescriptor, taskExecutor, taskExecutorGateway, releasePartitionsFuture) -> {
+				final ResultPartitionID resultPartitionId = resultPartitionDeploymentDescriptor.getShuffleDescriptor().getResultPartitionID();
 
-				assertThat(releasePartitionsFuture.get(), hasItems(partitionId));
+				taskExecutorGateway.releaseOrPromotePartitions(jobId, Collections.singleton(resultPartitionId), Collections.emptySet());
+
+				assertThat(releasePartitionsFuture.get(), hasItems(resultPartitionId));
 			}
 		);
 	}
@@ -255,10 +257,30 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 				partitionTracker.setPromotePartitionsConsumer(promotePartitionsFuture::complete);
 				return promotePartitionsFuture;
 			},
-			(jobId, partitionId, taskExecutor, taskExecutorGateway, promotePartitionsFuture) -> {
-				taskExecutorGateway.releaseOrPromotePartitions(jobId, Collections.emptySet(), Collections.singleton(partitionId));
+			(jobId, resultPartitionDeploymentDescriptor, taskExecutor, taskExecutorGateway, promotePartitionsFuture) -> {
+				final ResultPartitionID resultPartitionId = resultPartitionDeploymentDescriptor.getShuffleDescriptor().getResultPartitionID();
 
-				assertThat(promotePartitionsFuture.get(), hasItems(partitionId));
+				taskExecutorGateway.releaseOrPromotePartitions(jobId, Collections.emptySet(), Collections.singleton(resultPartitionId));
+
+				assertThat(promotePartitionsFuture.get(), hasItems(resultPartitionId));
+			}
+		);
+	}
+
+	@Test
+	public void testClusterPartitionRelease() throws Exception {
+		testPartitionRelease(
+			partitionTracker -> {
+				final CompletableFuture<Collection<IntermediateDataSetID>> releasePartitionsFuture = new CompletableFuture<>();
+				partitionTracker.setReleaseClusterPartitionsConsumer(releasePartitionsFuture::complete);
+				return releasePartitionsFuture;
+			},
+			(jobId, resultPartitionDeploymentDescriptor, taskExecutor, taskExecutorGateway, releasePartitionsFuture) -> {
+				final IntermediateDataSetID dataSetId = resultPartitionDeploymentDescriptor.getResultId();
+
+				taskExecutorGateway.releaseClusterPartitions(Collections.singleton(dataSetId), timeout);
+
+				assertThat(releasePartitionsFuture.get(), hasItems(dataSetId));
 			}
 		);
 	}
@@ -402,7 +424,7 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 
 			testAction.accept(
 				jobId,
-				taskResultPartitionDescriptor.getShuffleDescriptor().getResultPartitionID(),
+				taskResultPartitionDescriptor,
 				taskExecutor,
 				taskExecutorGateway,
 				partitionTrackerSetupResult);
@@ -464,6 +486,6 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 
 	@FunctionalInterface
 	private interface TestAction<C> {
-		void accept(JobID jobId, ResultPartitionID resultPartitionId, TaskExecutor taskExecutor, TaskExecutorGateway taskExecutorGateway, C partitionTrackerSetupResult) throws Exception;
+		void accept(JobID jobId, ResultPartitionDeploymentDescriptor resultPartitionDeploymentDescriptor, TaskExecutor taskExecutor, TaskExecutorGateway taskExecutorGateway, C partitionTrackerSetupResult) throws Exception;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.PartitionInfo;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobmaster.AllocatedSlotReport;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
@@ -140,6 +141,10 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 	@Override
 	public void releaseOrPromotePartitions(JobID jobId, Set<ResultPartitionID> partitionToRelease, Set<ResultPartitionID> partitionsToPromote) {
 		releaseOrPromotePartitionsConsumer.accept(jobId, partitionToRelease, partitionsToPromote);
+	}
+
+	@Override
+	public void releaseClusterPartitions(Collection<IntermediateDataSetID> dataSetsToRelease, Time timeout) {
 	}
 
 	@Override


### PR DESCRIPTION
Based on #10361.

Implements the TaskExecutor logic for releasing cluster partitions.
Additionally, slightly reworks the structure within the `TaskExecutorPartitionTrackerImpl` to not use a `TaskExecutorPartitionInfo` as a key, since this approach _just doesn't work_ for look-ups by `IntermediateDataSetID`; even if the hash is identical we wouldn't be passing the equals check.