### PR TITLE
[FLINK-14993][metrics] FrontMetricGroup passes reporter-specific parameters

### DIFF
--- a/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/metrics/jmx/JMXReporterTest.java
+++ b/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/metrics/jmx/JMXReporterTest.java
@@ -129,8 +129,8 @@ public class JMXReporterTest extends TestLogger {
 			}
 		};
 
-		rep1.notifyOfAddedMetric(g1, "rep1", new FrontMetricGroup<>(new ReporterScopedSettings(0), mg));
-		rep2.notifyOfAddedMetric(g2, "rep2", new FrontMetricGroup<>(new ReporterScopedSettings(0), mg));
+		rep1.notifyOfAddedMetric(g1, "rep1", new FrontMetricGroup<>(createReporterScopedSettings(0), mg));
+		rep2.notifyOfAddedMetric(g2, "rep2", new FrontMetricGroup<>(createReporterScopedSettings(0), mg));
 
 		MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
 
@@ -183,9 +183,9 @@ public class JMXReporterTest extends TestLogger {
 			}
 		};
 
-		rep1.notifyOfAddedMetric(g1, "rep1", new FrontMetricGroup<>(new ReporterScopedSettings(0), mg));
+		rep1.notifyOfAddedMetric(g1, "rep1", new FrontMetricGroup<>(createReporterScopedSettings(0), mg));
 
-		rep2.notifyOfAddedMetric(g2, "rep2", new FrontMetricGroup<>(new ReporterScopedSettings(1), mg));
+		rep2.notifyOfAddedMetric(g2, "rep2", new FrontMetricGroup<>(createReporterScopedSettings(1), mg));
 
 		ObjectName objectName1 = new ObjectName(JMX_DOMAIN_PREFIX + "taskmanager.rep1", JMXReporter.generateJmxTable(mg.getAllVariables()));
 		ObjectName objectName2 = new ObjectName(JMX_DOMAIN_PREFIX + "taskmanager.rep2", JMXReporter.generateJmxTable(mg.getAllVariables()));
@@ -303,5 +303,9 @@ public class JMXReporterTest extends TestLogger {
 				registry.shutdown().get();
 			}
 		}
+	}
+
+	private static ReporterScopedSettings createReporterScopedSettings(int reporterIndex) {
+		return new ReporterScopedSettings(reporterIndex, ',');
 	}
 }

--- a/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/metrics/jmx/JMXReporterTest.java
+++ b/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/metrics/jmx/JMXReporterTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.groups.FrontMetricGroup;
+import org.apache.flink.runtime.metrics.groups.ReporterScopedSettings;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.util.TestLogger;
 
@@ -128,8 +129,8 @@ public class JMXReporterTest extends TestLogger {
 			}
 		};
 
-		rep1.notifyOfAddedMetric(g1, "rep1", new FrontMetricGroup<>(0, new TaskManagerMetricGroup(reg, "host", "tm")));
-		rep2.notifyOfAddedMetric(g2, "rep2", new FrontMetricGroup<>(0, new TaskManagerMetricGroup(reg, "host", "tm")));
+		rep1.notifyOfAddedMetric(g1, "rep1", new FrontMetricGroup<>(new ReporterScopedSettings(0), mg));
+		rep2.notifyOfAddedMetric(g2, "rep2", new FrontMetricGroup<>(new ReporterScopedSettings(0), mg));
 
 		MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
 
@@ -182,9 +183,9 @@ public class JMXReporterTest extends TestLogger {
 			}
 		};
 
-		rep1.notifyOfAddedMetric(g1, "rep1", new FrontMetricGroup<>(0, new TaskManagerMetricGroup(reg, "host", "tm")));
+		rep1.notifyOfAddedMetric(g1, "rep1", new FrontMetricGroup<>(new ReporterScopedSettings(0), mg));
 
-		rep2.notifyOfAddedMetric(g2, "rep2", new FrontMetricGroup<>(1, new TaskManagerMetricGroup(reg, "host", "tm")));
+		rep2.notifyOfAddedMetric(g2, "rep2", new FrontMetricGroup<>(new ReporterScopedSettings(1), mg));
 
 		ObjectName objectName1 = new ObjectName(JMX_DOMAIN_PREFIX + "taskmanager.rep1", JMXReporter.generateJmxTable(mg.getAllVariables()));
 		ObjectName objectName2 = new ObjectName(JMX_DOMAIN_PREFIX + "taskmanager.rep2", JMXReporter.generateJmxTable(mg.getAllVariables()));

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
@@ -87,7 +87,7 @@ public class PrometheusReporterTest extends TestLogger {
 			MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
 			Collections.singletonList(createReporterSetup("test1", portRangeProvider.next())));
 		metricGroup = new FrontMetricGroup<>(
-			new ReporterScopedSettings(0),
+			createReporterScopedSettings(),
 			new TaskManagerMetricGroup(registry, HOST_NAME, TASK_MANAGER));
 		reporter = (PrometheusReporter) registry.getReporters().get(0);
 	}
@@ -176,13 +176,13 @@ public class PrometheusReporterTest extends TestLogger {
 
 		Counter metric1 = new SimpleCounter();
 		FrontMetricGroup<TaskManagerJobMetricGroup> metricGroup1 = new FrontMetricGroup<>(
-			new ReporterScopedSettings(0),
+			createReporterScopedSettings(),
 			new TaskManagerJobMetricGroup(registry, tmMetricGroup, JobID.generate(), "job_1"));
 		reporter.notifyOfAddedMetric(metric1, metricName, metricGroup1);
 
 		Counter metric2 = new SimpleCounter();
 		FrontMetricGroup<TaskManagerJobMetricGroup> metricGroup2 = new FrontMetricGroup<>(
-			new ReporterScopedSettings(0),
+			createReporterScopedSettings(),
 			new TaskManagerJobMetricGroup(registry, tmMetricGroup, JobID.generate(), "job_2"));
 		reporter.notifyOfAddedMetric(metric2, metricName, metricGroup2);
 
@@ -344,5 +344,9 @@ public class PrometheusReporterTest extends TestLogger {
 			base += 100;
 			return String.valueOf(lowEnd) + "-" + String.valueOf(highEnd);
 		}
+	}
+
+	private static ReporterScopedSettings createReporterScopedSettings() {
+		return new ReporterScopedSettings(0, ',');
 	}
 }

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.groups.FrontMetricGroup;
+import org.apache.flink.runtime.metrics.groups.ReporterScopedSettings;
 import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.util.TestLogger;
@@ -85,7 +86,9 @@ public class PrometheusReporterTest extends TestLogger {
 		registry = new MetricRegistryImpl(
 			MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
 			Collections.singletonList(createReporterSetup("test1", portRangeProvider.next())));
-		metricGroup = new FrontMetricGroup<>(0, new TaskManagerMetricGroup(registry, HOST_NAME, TASK_MANAGER));
+		metricGroup = new FrontMetricGroup<>(
+			new ReporterScopedSettings(0),
+			new TaskManagerMetricGroup(registry, HOST_NAME, TASK_MANAGER));
 		reporter = (PrometheusReporter) registry.getReporters().get(0);
 	}
 
@@ -172,11 +175,15 @@ public class PrometheusReporterTest extends TestLogger {
 		String metricName = "metric";
 
 		Counter metric1 = new SimpleCounter();
-		FrontMetricGroup<TaskManagerJobMetricGroup> metricGroup1 = new FrontMetricGroup<>(0, new TaskManagerJobMetricGroup(registry, tmMetricGroup, JobID.generate(), "job_1"));
+		FrontMetricGroup<TaskManagerJobMetricGroup> metricGroup1 = new FrontMetricGroup<>(
+			new ReporterScopedSettings(0),
+			new TaskManagerJobMetricGroup(registry, tmMetricGroup, JobID.generate(), "job_1"));
 		reporter.notifyOfAddedMetric(metric1, metricName, metricGroup1);
 
 		Counter metric2 = new SimpleCounter();
-		FrontMetricGroup<TaskManagerJobMetricGroup> metricGroup2 = new FrontMetricGroup<>(0, new TaskManagerJobMetricGroup(registry, tmMetricGroup, JobID.generate(), "job_2"));
+		FrontMetricGroup<TaskManagerJobMetricGroup> metricGroup2 = new FrontMetricGroup<>(
+			new ReporterScopedSettings(0),
+			new TaskManagerJobMetricGroup(registry, tmMetricGroup, JobID.generate(), "job_2"));
 		reporter.notifyOfAddedMetric(metric2, metricName, metricGroup2);
 
 		reporter.notifyOfRemovedMetric(metric1, metricName, metricGroup1);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistry.java
@@ -38,14 +38,6 @@ public interface MetricRegistry {
 	char getDelimiter();
 
 	/**
-	 * Returns the configured delimiter for the reporter with the given index.
-	 *
-	 * @param index index of the reporter whose delimiter should be used
-	 * @return configured reporter delimiter, or global delimiter if index is invalid
-	 */
-	char getDelimiter(int index);
-
-	/**
 	 * Returns the number of registered reporters.
 	 */
 	int getNumberReporters();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/NoOpMetricRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/NoOpMetricRegistry.java
@@ -41,11 +41,6 @@ public class NoOpMetricRegistry implements MetricRegistry {
 	}
 
 	@Override
-	public char getDelimiter(int index) {
-		return delimiter;
-	}
-
-	@Override
 	public int getNumberReporters() {
 		return 0;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
@@ -242,7 +242,7 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 	 */
 	@Override
 	public String getMetricIdentifier(String metricName, CharacterFilter filter) {
-		return getMetricIdentifier(metricName, filter, -1);
+		return getMetricIdentifier(metricName, filter, -1, registry.getDelimiter());
 	}
 
 	/**
@@ -252,11 +252,11 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 	 * @param metricName metric name
 	 * @param filter character filter which is applied to the scope components if not null.
 	 * @param reporterIndex index of the reporter whose delimiter should be used
+	 * @param delimiter delimiter to use
 	 * @return fully qualified metric name
 	 */
-	public String getMetricIdentifier(String metricName, CharacterFilter filter, int reporterIndex) {
+	public String getMetricIdentifier(String metricName, CharacterFilter filter, int reporterIndex, char delimiter) {
 		if (scopeStrings.length == 0 || (reporterIndex < 0 || reporterIndex >= scopeStrings.length)) {
-			char delimiter = registry.getDelimiter();
 			String newScopeString;
 			if (filter != null) {
 				newScopeString = ScopeFormat.concat(filter, delimiter, scopeComponents);
@@ -266,7 +266,6 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 			}
 			return newScopeString + delimiter + metricName;
 		} else {
-			char delimiter = registry.getDelimiter(reporterIndex);
 			if (scopeStrings[reporterIndex] == null) {
 				if (filter != null) {
 					scopeStrings[reporterIndex] = ScopeFormat.concat(filter, delimiter, scopeComponents);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
@@ -30,21 +30,21 @@ import org.apache.flink.metrics.CharacterFilter;
  */
 public class FrontMetricGroup<P extends AbstractMetricGroup<?>> extends ProxyMetricGroup<P> {
 
-	protected int reporterIndex;
+	private final ReporterScopedSettings settings;
 
-	public FrontMetricGroup(int reporterIndex, P reference) {
+	public FrontMetricGroup(ReporterScopedSettings settings, P reference) {
 		super(reference);
-		this.reporterIndex = reporterIndex;
+		this.settings = settings;
 	}
 
 	@Override
 	public String getMetricIdentifier(String metricName) {
-		return parentMetricGroup.getMetricIdentifier(metricName, null, this.reporterIndex);
+		return parentMetricGroup.getMetricIdentifier(metricName, null, this.settings.getReporterIndex());
 	}
 
 	@Override
 	public String getMetricIdentifier(String metricName, CharacterFilter filter) {
-		return parentMetricGroup.getMetricIdentifier(metricName, filter, this.reporterIndex);
+		return parentMetricGroup.getMetricIdentifier(metricName, filter, this.settings.getReporterIndex());
 	}
 
 	public String getLogicalScope(CharacterFilter filter) {
@@ -52,6 +52,6 @@ public class FrontMetricGroup<P extends AbstractMetricGroup<?>> extends ProxyMet
 	}
 
 	public String getLogicalScope(CharacterFilter filter, char delimiter) {
-		return parentMetricGroup.getLogicalScope(filter, delimiter, this.reporterIndex);
+		return parentMetricGroup.getLogicalScope(filter, delimiter, this.settings.getReporterIndex());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
@@ -39,16 +39,16 @@ public class FrontMetricGroup<P extends AbstractMetricGroup<?>> extends ProxyMet
 
 	@Override
 	public String getMetricIdentifier(String metricName) {
-		return parentMetricGroup.getMetricIdentifier(metricName, null, this.settings.getReporterIndex());
+		return parentMetricGroup.getMetricIdentifier(metricName, null, this.settings.getReporterIndex(), this.settings.getDelimiter());
 	}
 
 	@Override
 	public String getMetricIdentifier(String metricName, CharacterFilter filter) {
-		return parentMetricGroup.getMetricIdentifier(metricName, filter, this.settings.getReporterIndex());
+		return parentMetricGroup.getMetricIdentifier(metricName, filter, this.settings.getReporterIndex(), this.settings.getDelimiter());
 	}
 
 	public String getLogicalScope(CharacterFilter filter) {
-		return parentMetricGroup.getLogicalScope(filter);
+		return parentMetricGroup.getLogicalScope(filter, this.settings.getDelimiter());
 	}
 
 	public String getLogicalScope(CharacterFilter filter, char delimiter) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/ReporterScopedSettings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/ReporterScopedSettings.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.groups;
+
+import org.apache.flink.util.Preconditions;
+
+/**
+ * Encapsulates all settings that are defined per reporter.
+ */
+public class ReporterScopedSettings {
+
+	private final int reporterIndex;
+
+	public ReporterScopedSettings(int reporterIndex) {
+		Preconditions.checkArgument(reporterIndex >= 0);
+		this.reporterIndex = reporterIndex;
+	}
+
+	public int getReporterIndex() {
+		return reporterIndex;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/ReporterScopedSettings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/ReporterScopedSettings.java
@@ -26,12 +26,19 @@ public class ReporterScopedSettings {
 
 	private final int reporterIndex;
 
-	public ReporterScopedSettings(int reporterIndex) {
+	private final char delimiter;
+
+	public ReporterScopedSettings(int reporterIndex, char delimiter) {
 		Preconditions.checkArgument(reporterIndex >= 0);
 		this.reporterIndex = reporterIndex;
+		this.delimiter = delimiter;
 	}
 
 	public int getReporterIndex() {
 		return reporterIndex;
+	}
+
+	public char getDelimiter() {
+		return delimiter;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
@@ -266,8 +266,8 @@ public class AbstractMetricGroupTest extends TestLogger {
 			// no caching should occur
 			assertEquals("A.X.C.D.1", group.getMetricIdentifier("1", FILTER_B));
 			// invalid reporter indices do not throw errors
-			assertEquals("A.X.C.D.1", group.getMetricIdentifier("1", FILTER_B, -1));
-			assertEquals("A.X.C.D.1", group.getMetricIdentifier("1", FILTER_B, 2));
+			assertEquals("A.X.C.D.1", group.getMetricIdentifier("1", FILTER_B, -1, '.'));
+			assertEquals("A.X.C.D.1", group.getMetricIdentifier("1", FILTER_B, 2, '.'));
 		} finally {
 			testRegistry.shutdown().get();
 		}
@@ -323,11 +323,6 @@ public class AbstractMetricGroupTest extends TestLogger {
 
 		@Override
 		public char getDelimiter() {
-			return 0;
-		}
-
-		@Override
-		public char getDelimiter(int index) {
 			return 0;
 		}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricMonitorTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricMonitorTest.java
@@ -169,11 +169,6 @@ public class RocksDBNativeMetricMonitorTest {
 		}
 
 		@Override
-		public char getDelimiter(int index) {
-			return 0;
-		}
-
-		@Override
 		public int getNumberReporters() {
 			return 0;
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/LatencyStatsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/LatencyStatsTest.java
@@ -187,11 +187,6 @@ public class LatencyStatsTest extends TestLogger {
 		}
 
 		@Override
-		public char getDelimiter(int index) {
-			return 0;
-		}
-
-		@Override
 		public int getNumberReporters() {
 			return 0;
 		}


### PR DESCRIPTION
This PR extends the `FrontMetricGroup` to pass more reporter-specific parameters (in this PR only the delimiter; the character filter comes next).

The `FrontMetricGroup` only purpose is to inject reporter-specific arguments in scope-related calls, so that neither reporters or groups themselves have to handle this.

Currently the front group only passes the reporter index which the `AbstractMetricGroup` then uses to query the MetricRegistry for the delimiter to use.
This is a fairly roundabout way of doing it since the MR already knows at the time of creation of the FMG what the delimiter will be.
It also unnecessarily couples the MR to the scope generation in the AMG.

In the future additional reporter-specific arguments can be added to the FrontMetricGroup (character filters in FLINK-14410, delimiters for logical scopes in FLINK-7957).