### PR TITLE
[FLINK-14953][formats] use table type to build parquet FilterPredicate

### DIFF
--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetTableSource.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetTableSource.java
@@ -58,8 +58,11 @@ import org.apache.parquet.filter2.predicate.Operators.DoubleColumn;
 import org.apache.parquet.filter2.predicate.Operators.FloatColumn;
 import org.apache.parquet.filter2.predicate.Operators.IntColumn;
 import org.apache.parquet.filter2.predicate.Operators.LongColumn;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.io.InvalidRecordException;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -447,8 +450,16 @@ public class ParquetTableSource
 
 	@Nullable
 	private Tuple2<Column, Comparable> extractColumnAndLiteral(BinaryComparison comp) {
-		TypeInformation<?> typeInfo = getLiteralType(comp);
 		String columnName = getColumnName(comp);
+		ColumnPath columnPath = ColumnPath.fromDotString(columnName);
+		TypeInformation<?> typeInfo = null;
+		try {
+			Type type = parquetSchema.getType(columnPath.toArray());
+			typeInfo = ParquetSchemaConverter.convertParquetTypeToTypeInfo(type);
+		} catch (InvalidRecordException e) {
+			LOG.error("Pushed predicate on undefined field name {} in schema", columnName);
+			return null;
+		}
 
 		// fetch literal and ensure it is comparable
 		Object value = getLiteral(comp);
@@ -463,15 +474,15 @@ public class ParquetTableSource
 		if (typeInfo == BasicTypeInfo.BYTE_TYPE_INFO ||
 			typeInfo == BasicTypeInfo.SHORT_TYPE_INFO ||
 			typeInfo == BasicTypeInfo.INT_TYPE_INFO) {
-			return new Tuple2<>(FilterApi.intColumn(columnName), (Integer) value);
+			return new Tuple2<>(FilterApi.intColumn(columnName), ((Number) value).intValue());
 		} else if (typeInfo == BasicTypeInfo.LONG_TYPE_INFO) {
-			return new Tuple2<>(FilterApi.longColumn(columnName), (Long) value);
+			return new Tuple2<>(FilterApi.longColumn(columnName), ((Number) value).longValue());
 		} else if (typeInfo == BasicTypeInfo.FLOAT_TYPE_INFO) {
-			return new Tuple2<>(FilterApi.floatColumn(columnName), (Float) value);
+			return new Tuple2<>(FilterApi.floatColumn(columnName), ((Number) value).floatValue());
 		} else if (typeInfo == BasicTypeInfo.BOOLEAN_TYPE_INFO) {
 			return new Tuple2<>(FilterApi.booleanColumn(columnName), (Boolean) value);
 		} else if (typeInfo == BasicTypeInfo.DOUBLE_TYPE_INFO) {
-			return new Tuple2<>(FilterApi.doubleColumn(columnName), (Double) value);
+			return new Tuple2<>(FilterApi.doubleColumn(columnName), ((Number) value).doubleValue());
 		} else if (typeInfo == BasicTypeInfo.STRING_TYPE_INFO) {
 			return new Tuple2<>(FilterApi.binaryColumn(columnName), Binary.fromString((String) value));
 		} else {

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/ParquetSchemaConverter.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/ParquetSchemaConverter.java
@@ -71,7 +71,7 @@ public class ParquetSchemaConverter {
 		return (MessageType) convertField(null, typeInformation, Type.Repetition.OPTIONAL, legacyMode);
 	}
 
-	private static TypeInformation<?> convertFields(List<Type> parquetFields) {
+	public static TypeInformation<?> convertFields(List<Type> parquetFields) {
 		List<TypeInformation<?>> types = new ArrayList<>();
 		List<String> names = new ArrayList<>();
 		for (Type field : parquetFields) {
@@ -89,7 +89,7 @@ public class ParquetSchemaConverter {
 			names.toArray(new String[0]));
 	}
 
-	private static TypeInformation<?> convertParquetTypeToTypeInfo(final Type fieldType) {
+	public static TypeInformation<?> convertParquetTypeToTypeInfo(final Type fieldType) {
 		TypeInformation<?> typeInfo;
 		if (fieldType.isPrimitive()) {
 			OriginalType originalType = fieldType.getOriginalType();

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetTableSourceITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetTableSourceITCase.java
@@ -84,7 +84,7 @@ public class ParquetTableSourceITCase extends MultipleProgramsTestBase {
 		batchTableEnvironment.registerTableSource("ParquetTable", tableSource);
 		String query =
 			"SELECT foo " +
-			"FROM ParquetTable WHERE bar.spam >= 30 AND CARDINALITY(arr) >= 1 AND arr[1] <= 50";
+			"FROM ParquetTable WHERE foo >= 1 AND bar.spam >= 30 AND CARDINALITY(arr) >= 1 AND arr[1] <= 50";
 
 		Table table = batchTableEnvironment.sqlQuery(query);
 		DataSet<Row> dataSet = batchTableEnvironment.toDataSet(table, Row.class);

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/utils/TestUtil.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/utils/TestUtil.java
@@ -210,6 +210,7 @@ public class TestUtil {
 			stringArray.add("String");
 
 			final NestedRecord nestedRecord = NestedRecord.newBuilder()
+				.setFoo(1L)
 				.setBar(bar)
 				.setNestedArray(nestedArray)
 				.setStrArray(stringArray)


### PR DESCRIPTION
## What is the purpose of the change
Fix the FilterPredicate built from using type inferred from literal to using table column type

## Brief change log

  - Use table column type to build predicate pair
  - Do a special conversion for an expression whose column type is long but its literal type is an integer.


## Verifying this change

It is tested in ParquetTableSourceITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
