### PR TITLE
[FLINK-14907]  [filesystem] Make Azure Storage Key configurable via Environment Variable

### DIFF
--- a/docs/ops/filesystems/azure.md
+++ b/docs/ops/filesystems/azure.md
@@ -62,17 +62,24 @@ cp ./opt/flink-azure-fs-hadoop-{{ site.version }}.jar ./plugins/azure-fs-hadoop/
 
 `flink-azure-fs-hadoop` registers default FileSystem wrappers for URIs with the *wasb://* and *wasbs://* (SSL encrypted access) scheme.
 
-#### Configurations setup
-After setting up the Azure Blob Storage FileSystem wrapper, you need to configure credentials to make sure that Flink is allowed to access Azure Blob Storage.
+### Credentials Configuration
 
-To allow for easy adoption, you can use the same configuration keys in `flink-conf.yaml` as in Hadoop's `core-site.xml`
-
-You can see the configuration keys in the [Hadoop Azure Blob Storage documentation](https://hadoop.apache.org/docs/current/hadoop-azure/index.html#Configuring_Credentials).
-
-There are some required configurations that must be added to `flink-conf.yaml`:
+Hadoop's Azure Filesystem supports configuration of credentials via the Hadoop configuration as 
+outlined in the [Hadoop Azure Blob Storage documentation](https://hadoop.apache.org/docs/current/hadoop-azure/index.html#Configuring_Credentials).
+For convenience Flink forwards all Flink configurations with a key prefix of `fs.azure` to the 
+Hadoop configuration of the filesystem. Consequentially, the azure blob storage key can be configured 
+in `flink-conf.yaml` via:
 
 {% highlight yaml %}
-fs.azure.account.key.youraccount.blob.core.windows.net: Azure Blob Storage access key
+fs.azure.account.key.<account_name>.blob.core.windows.net: <azure_storage_key>
+{% endhighlight %}
+
+Alternatively, the the filesystem can be configured to read the Azure Blob Storage key from an 
+environment variable `AZURE_STORAGE_KEY` by setting the following configuration keys in 
+`flink-conf.yaml`.  
+
+{% highlight yaml %}
+fs.azure.account.keyprovider.<account_name>.blob.core.windows.net: org.apache.flink.fs.azurefs.EnvironmentVariableKeyProvider
 {% endhighlight %}
 
 {% top %}

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/EnvironmentVariableKeyProvider.java
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/EnvironmentVariableKeyProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.azure.KeyProvider;
+import org.apache.hadoop.fs.azure.KeyProviderException;
+
+/**
+ * An implementation of {@link org.apache.hadoop.fs.azure.KeyProvider}, which reads the Azure
+ * storage key from an environment variable named "AZURE_STORAGE_KEY".
+ *
+ */
+public class EnvironmentVariableKeyProvider implements KeyProvider {
+
+	public static final String AZURE_STORAGE_KEY_ENV_VARIABLE = "AZURE_STORAGE_KEY";
+
+	@Override
+	public String getStorageAccountKey(
+			final String s,
+			final Configuration configuration) throws KeyProviderException {
+
+		String azureStorageKey = System.getenv(AZURE_STORAGE_KEY_ENV_VARIABLE);
+
+		if (azureStorageKey != null) {
+			return azureStorageKey;
+		} else {
+			throw new KeyProviderException("Unable to retrieve Azure storage key from environment. \""
+					+ AZURE_STORAGE_KEY_ENV_VARIABLE + "\" not set.");
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Make Azure Storage Key configurable via Environment Variable


## Brief change log
* update documentation on credential configuration for ABS
* add EnvironmentVariableKeyProvider for Azure Blob Storage

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - build Flink
  - set Flink configuration as outlined in documentation
  - set AZURE_STORAGE_KEY environment variable
  - use wasbs:// for checkpoints or as file input for a testing job
  - (test_azure_fs.sh can be modified to test this)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs, JavaDocs
