### PR TITLE
[FLINK-14997] Avoid to call unnecessary delete within RocksDBState's mergeNamespaces implementation

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
@@ -118,9 +118,9 @@ class RocksDBAggregatingState<K, N, T, ACC, R>
 					setCurrentNamespace(source);
 					final byte[] sourceKey = serializeCurrentKeyWithGroupAndNamespace();
 					final byte[] valueBytes = backend.db.get(columnFamily, sourceKey);
-					backend.db.delete(columnFamily, writeOptions, sourceKey);
 
 					if (valueBytes != null) {
+						backend.db.delete(columnFamily, writeOptions, sourceKey);
 						dataInputView.setBuffer(valueBytes);
 						ACC value = valueSerializer.deserialize(dataInputView);
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
@@ -187,9 +187,9 @@ class RocksDBListState<K, N, V>
 					final byte[] sourceKey = serializeCurrentKeyWithGroupAndNamespace();
 
 					byte[] valueBytes = backend.db.get(columnFamily, sourceKey);
-					backend.db.delete(columnFamily, writeOptions, sourceKey);
 
 					if (valueBytes != null) {
+						backend.db.delete(columnFamily, writeOptions, sourceKey);
 						backend.db.merge(columnFamily, writeOptions, targetKey, valueBytes);
 					}
 				}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
@@ -111,9 +111,9 @@ class RocksDBReducingState<K, N, V>
 					setCurrentNamespace(source);
 					final byte[] sourceKey = serializeCurrentKeyWithGroupAndNamespace();
 					final byte[] valueBytes = backend.db.get(columnFamily, sourceKey);
-					backend.db.delete(columnFamily, writeOptions, sourceKey);
 
 					if (valueBytes != null) {
+						backend.db.delete(columnFamily, writeOptions, sourceKey);
 						dataInputView.setBuffer(valueBytes);
 						V value = valueSerializer.deserialize(dataInputView);
 


### PR DESCRIPTION
##  What is the purpose of the change

This helps to improve the performance after FLINK-7700 resolved.

## Brief change log

Changes to `RocksDBAggregatingState.java`, `RocksDBListState.java` and `RocksDBReducingState.java` which have the `mergeNamespaces` method.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
