### PR TITLE
[FLINK-15016][build] Remove unused dependency

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -93,12 +93,6 @@ under the License.
 			<artifactId>flink-test-utils-junit</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<scope>test</scope>
-		</dependency>
-
 		<!-- Joda, jackson, and lombok are used to test that serialization and type extraction
 			work with types from those libraries -->
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request removes a direct dependency from the module `flink-core` because it is not used.
This makes the `pom` clearer and the dependency tree of Flink less complex, which contributes to make the project more easy to maintain.

## Brief change log

- remove dependency `commons-io` from `flink-core` 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: **no**
  - The S3 file system connector: (**no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
