### PR TITLE
[FLINK-14949] [Runtime/Task] Task cancellation can be stuck against out-of-thread error

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -993,8 +993,8 @@ public class Task implements Runnable, TaskActions, PartitionProducerStateProvid
 			cancelOrFailAndCancelInvokableInternal(targetState, cause);
 		} catch (Throwable t) {
 			if (ExceptionUtils.isJvmFatalOrOutOfMemoryError(t)) {
-				notifyFatalError(String.format("%s (%s) with state %s ran into fatal error on cancellation.",
-					taskNameWithSubtask, executionId, targetState), t);
+				String message = String.format("FATAL - exception in cancelling task %s (%s).", taskNameWithSubtask, executionId);
+				notifyFatalError(message, t);
 			} else {
 				throw t;
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -989,6 +989,20 @@ public class Task implements Runnable, TaskActions, PartitionProducerStateProvid
 	}
 
 	private void cancelOrFailAndCancelInvokable(ExecutionState targetState, Throwable cause) {
+		try {
+			cancelOrFailAndCancelInvokableInternal(targetState, cause);
+		} catch (Throwable t) {
+			if (ExceptionUtils.isJvmFatalOrOutOfMemoryError(t)) {
+				notifyFatalError(String.format("%s (%s) with state %s ran into fatal error on cancellation.",
+					taskNameWithSubtask, executionId, targetState), t);
+			} else {
+				throw t;
+			}
+		}
+	}
+
+	@VisibleForTesting
+	void cancelOrFailAndCancelInvokableInternal(ExecutionState targetState, Throwable cause) {
 		while (true) {
 			ExecutionState current = executionState;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -83,8 +83,11 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 /**
@@ -822,6 +825,78 @@ public class TaskTest extends TestLogger {
 			triggerLatch.trigger();
 			task.getExecutingThread().interrupt();
 			task.getExecutingThread().join();
+		}
+	}
+
+	/**
+	 * Tests that a fatal error gotten from canceling task is notified.
+	 */
+	@Test
+	public void testFatalErrorOnCanceling() throws Exception {
+		final AwaitFatalErrorTaskManagerActions taskManagerActions =
+			new AwaitFatalErrorTaskManagerActions();
+
+		final Configuration config = new Configuration();
+		config.setLong(TaskManagerOptions.TASK_CANCELLATION_INTERVAL, 5);
+		config.setLong(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT, 50);
+
+		final Task task = spy(createTaskBuilder()
+			.setInvokable(InvokableBlockingWithTrigger.class)
+			.setTaskManagerConfig(config)
+			.setTaskManagerActions(taskManagerActions)
+			.build());
+
+		doThrow(OutOfMemoryError.class).when(task).cancelOrFailAndCancelInvokableInternal(eq(ExecutionState.CANCELING), eq(null));
+
+		try {
+			task.startTaskThread();
+
+			awaitLatch.await();
+
+			task.cancelExecution();
+
+			// wait for the notification of notifyFatalError
+			taskManagerActions.latch.await();
+		} catch (Throwable t) {
+			fail("No exception is expected to be thrown by fatal error handling");
+		} finally {
+			triggerLatch.trigger();
+		}
+	}
+
+	/**
+	 * Tests that a fatal error gotten from externally failing task is notified.
+	 */
+	@Test
+	public void testFatalErrorOnFailingExternally() throws Exception {
+		final AwaitFatalErrorTaskManagerActions taskManagerActions =
+			new AwaitFatalErrorTaskManagerActions();
+
+		final Configuration config = new Configuration();
+		config.setLong(TaskManagerOptions.TASK_CANCELLATION_INTERVAL, 5);
+		config.setLong(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT, 50);
+
+		final Task task = spy(createTaskBuilder()
+			.setInvokable(InvokableBlockingWithTrigger.class)
+			.setTaskManagerConfig(config)
+			.setTaskManagerActions(taskManagerActions)
+			.build());
+
+		doThrow(UnknownError.class).when(task).cancelOrFailAndCancelInvokableInternal(eq(ExecutionState.FAILED), any(Throwable.class));
+
+		try {
+			task.startTaskThread();
+
+			awaitLatch.await();
+
+			task.failExternally(new RuntimeException("test"));
+
+			// wait for the notification of notifyFatalError
+			taskManagerActions.latch.await();
+		} catch (Throwable t) {
+			fail("No exception is expected to be thrown by fatal error handling");
+		} finally {
+			triggerLatch.trigger();
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -865,42 +865,6 @@ public class TaskTest extends TestLogger {
 	}
 
 	/**
-	 * Tests that a fatal error gotten from externally failing task is notified.
-	 */
-	@Test
-	public void testFatalErrorOnFailingExternally() throws Exception {
-		final AwaitFatalErrorTaskManagerActions taskManagerActions =
-			new AwaitFatalErrorTaskManagerActions();
-
-		final Configuration config = new Configuration();
-		config.setLong(TaskManagerOptions.TASK_CANCELLATION_INTERVAL, 5);
-		config.setLong(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT, 50);
-
-		final Task task = spy(createTaskBuilder()
-			.setInvokable(InvokableBlockingWithTrigger.class)
-			.setTaskManagerConfig(config)
-			.setTaskManagerActions(taskManagerActions)
-			.build());
-
-		doThrow(UnknownError.class).when(task).cancelOrFailAndCancelInvokableInternal(eq(ExecutionState.FAILED), any(Throwable.class));
-
-		try {
-			task.startTaskThread();
-
-			awaitLatch.await();
-
-			task.failExternally(new RuntimeException("test"));
-
-			// wait for the notification of notifyFatalError
-			taskManagerActions.latch.await();
-		} catch (Throwable t) {
-			fail("No exception is expected to be thrown by fatal error handling");
-		} finally {
-			triggerLatch.trigger();
-		}
-	}
-
-	/**
 	 * Tests that the task configuration is respected and overwritten by the execution config.
 	 */
 	@Test


### PR DESCRIPTION
##  What is the purpose of the change

This pull request added an additional safety net against fatal error thrown from starting task cancellation by notifying the fatal error to taskmanager. Without it, if a fatal or out-of-memory error happens while initiating task cancellation, one or more critical threads that are responsible for cancellation either gracefully or forcefully may not be spawned, thereby job state machine being permanently stuck in a non-terminal state such as FAILING (by stuck task cancellation). The fatal error notification added by this patch can restart JVM cleaning up the state letting job state machine make progress.

## Brief change log

  - Catch fatal or OOM error from task cancellation initiation and notify fatal error to taskmanager.
  - Added a unit test for cancelling task by mocking the fatal error.

NOTE: Instead of catching fatal/OOM errors from each thread start, added a catch at a higher level by internalizing `cancelOrFailAndCancelInvokable`, as it would make sense to notify fatal error no matter where such error comes from during the function. In addition, doing so made unit testing easier by mocking.

## Verifying this change

  - Added a unit test for fatal error on cancelling task.
  - Manually verified that by using an app intentionally leaking threads, job state machine is not stuck by restarting taskmanager JVM where thread limit was hit and everything else was impacted by that. Without the patch, one or more tasks have cancellation completely stuck, leading to stuck job state machine.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
