### PR TITLE
[FLINK-15025][python][legal] Fix the license and notice issue of flink-python module

### DIFF
--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -198,6 +198,9 @@ under the License.
 					<include>pyflink-udf-runner.sh</include>
 				</includes>
 			</resource>
+			<resource>
+				<directory>src/main/resources</directory>
+			</resource>
 		</resources>
 		<plugins>
 			<plugin>


### PR DESCRIPTION

## What is the purpose of the change

*The license files of the bundled third-party dependencies which are not of apache license are not bundled in the jar of flink-python and the NOTICE file is also incorrect. This PR tries to solve this issue*

## Brief change log

  - *Update the pom of flink-python to include src/main/resources into the jar

## Verifying this change

This change is a license/notice file correction work without any test coverage. Have verified manually.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
