### PR TITLE
[FLINK-14663]Distinguish catalogColumnStats' unknown  value and real values

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV120.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV120.java
@@ -184,13 +184,9 @@ public class HiveShimV120 extends HiveShimV111 {
 			Object hmsLowDate = dateStatsClz.getMethod("getLowValue").invoke(dateStats);
 			Class hmsDateClz = hmsHighDate.getClass();
 			Method hmsDateDays = hmsDateClz.getMethod("getDaysSinceEpoch");
-			Long highDateDays = isSetHighValue ? (Long) hmsDateDays.invoke(hmsHighDate) : null;
-			Long lowDateDays = isSetLowValue ? (Long) hmsDateDays.invoke(hmsLowDate) : null;
-			return new CatalogColumnStatisticsDataDate(
-					isSetLowValue ? new Date(lowDateDays) : null,
-					isSetHighValue ? new Date(highDateDays) : null,
-					numDV,
-					numNull);
+			Date highDateDays = isSetHighValue ? new Date((Long) hmsDateDays.invoke(hmsHighDate)) : null;
+			Date lowDateDays = isSetLowValue ? new Date((Long) hmsDateDays.invoke(hmsLowDate)) : null;
+			return new CatalogColumnStatisticsDataDate(lowDateDays, highDateDays, numDV, numNull);
 		} catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
 			throw new CatalogException("Failed to create Flink statistics for date column", e);
 		}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV120.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV120.java
@@ -132,14 +132,26 @@ public class HiveShimV120 extends HiveShimV111 {
 	public ColumnStatisticsData toHiveDateColStats(CatalogColumnStatisticsDataDate flinkDateColStats) {
 		try {
 			Class dateStatsClz = Class.forName("org.apache.hadoop.hive.metastore.api.DateColumnStatsData");
-			Object dateStats = dateStatsClz.getDeclaredConstructor(long.class, long.class)
-					.newInstance(flinkDateColStats.getNullCount(), flinkDateColStats.getNdv());
+			Object dateStats = dateStatsClz.getDeclaredConstructor().newInstance();
+			dateStatsClz.getMethod("clear").invoke(dateStats);
+			if (null != flinkDateColStats.getNdv()) {
+				dateStatsClz.getMethod("setNumDVs", long.class).invoke(dateStats, flinkDateColStats.getNdv());
+			}
+			if (null != flinkDateColStats.getNullCount()) {
+				dateStatsClz.getMethod("setNumNulls", long.class).invoke(dateStats, flinkDateColStats.getNullCount());
+			}
 			Class hmsDateClz = Class.forName("org.apache.hadoop.hive.metastore.api.Date");
-			Method setHigh = dateStatsClz.getDeclaredMethod("setHighValue", hmsDateClz);
-			Method setLow = dateStatsClz.getDeclaredMethod("setLowValue", hmsDateClz);
 			Constructor hmsDateConstructor = hmsDateClz.getConstructor(long.class);
-			setHigh.invoke(dateStats, hmsDateConstructor.newInstance(flinkDateColStats.getMax().getDaysSinceEpoch()));
-			setLow.invoke(dateStats, hmsDateConstructor.newInstance(flinkDateColStats.getMin().getDaysSinceEpoch()));
+			if (null != flinkDateColStats.getMax()) {
+				Method setHigh = dateStatsClz.getDeclaredMethod("setHighValue", hmsDateClz);
+				setHigh.invoke(dateStats,
+							hmsDateConstructor.newInstance(flinkDateColStats.getMax().getDaysSinceEpoch()));
+			}
+			if (null != flinkDateColStats.getMin()) {
+				Method setLow = dateStatsClz.getDeclaredMethod("setLowValue", hmsDateClz);
+				setLow.invoke(dateStats,
+							hmsDateConstructor.newInstance(flinkDateColStats.getMin().getDaysSinceEpoch()));
+			}
 			Class colStatsClz = ColumnStatisticsData.class;
 			return (ColumnStatisticsData) colStatsClz.getDeclaredMethod("dateStats", dateStatsClz).invoke(null, dateStats);
 		} catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
@@ -162,15 +174,23 @@ public class HiveShimV120 extends HiveShimV111 {
 		try {
 			Object dateStats = ColumnStatisticsData.class.getDeclaredMethod("getDateStats").invoke(hiveDateColStats);
 			Class dateStatsClz = dateStats.getClass();
-			long numDV = (long) dateStatsClz.getMethod("getNumDVs").invoke(dateStats);
-			long numNull = (long) dateStatsClz.getMethod("getNumNulls").invoke(dateStats);
+			boolean isSetNumDv = (boolean) dateStatsClz.getMethod("isSetNumDVs").invoke(dateStats);
+			boolean isSetNumNull = (boolean) dateStatsClz.getMethod("isSetNumNulls").invoke(dateStats);
+			boolean isSetHighValue = (boolean) dateStatsClz.getMethod("isSetHighValue").invoke(dateStats);
+			boolean isSetLowValue = (boolean) dateStatsClz.getMethod("isSetLowValue").invoke(dateStats);
+			Long numDV = isSetNumDv ? (Long) dateStatsClz.getMethod("getNumDVs").invoke(dateStats) : null;
+			Long numNull = isSetNumNull ? (Long) dateStatsClz.getMethod("getNumNulls").invoke(dateStats) : null;
 			Object hmsHighDate = dateStatsClz.getMethod("getHighValue").invoke(dateStats);
 			Object hmsLowDate = dateStatsClz.getMethod("getLowValue").invoke(dateStats);
 			Class hmsDateClz = hmsHighDate.getClass();
 			Method hmsDateDays = hmsDateClz.getMethod("getDaysSinceEpoch");
-			long highDateDays = (long) hmsDateDays.invoke(hmsHighDate);
-			long lowDateDays = (long) hmsDateDays.invoke(hmsLowDate);
-			return new CatalogColumnStatisticsDataDate(new Date(lowDateDays), new Date(highDateDays), numDV, numNull);
+			Long highDateDays = isSetHighValue ? (Long) hmsDateDays.invoke(hmsHighDate) : null;
+			Long lowDateDays = isSetLowValue ? (Long) hmsDateDays.invoke(hmsLowDate) : null;
+			return new CatalogColumnStatisticsDataDate(
+					isSetLowValue ? new Date(lowDateDays) : null,
+					isSetHighValue ? new Date(highDateDays) : null,
+					numDV,
+					numNull);
 		} catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
 			throw new CatalogException("Failed to create Flink statistics for date column", e);
 		}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveStatsUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveStatsUtil.java
@@ -217,7 +217,7 @@ public class HiveStatsUtil {
 					hiveBoolStats.setNumFalses(booleanColStat.getFalseCount());
 				}
 				if (null != booleanColStat.getNullCount()) {
-					hiveBoolStats.setNumNulls(booleanColStat.getTrueCount());
+					hiveBoolStats.setNumNulls(booleanColStat.getNullCount());
 				}
 				return ColumnStatisticsData.booleanStats(hiveBoolStats);
 			}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveStatsUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveStatsUtil.java
@@ -139,38 +139,38 @@ public class HiveStatsUtil {
 		if (stats.isSetBinaryStats()) {
 			BinaryColumnStatsData binaryStats = stats.getBinaryStats();
 			return new CatalogColumnStatisticsDataBinary(
-					binaryStats.getMaxColLen(),
-					binaryStats.getAvgColLen(),
-					binaryStats.getNumNulls());
+					binaryStats.isSetMaxColLen() ? binaryStats.getMaxColLen() : null,
+					binaryStats.isSetAvgColLen() ? binaryStats.getAvgColLen() : null,
+					binaryStats.isSetNumNulls() ? binaryStats.getNumNulls() : null);
 		} else if (stats.isSetBooleanStats()) {
 			BooleanColumnStatsData booleanStats = stats.getBooleanStats();
 			return new CatalogColumnStatisticsDataBoolean(
-					booleanStats.getNumTrues(),
-					booleanStats.getNumFalses(),
-					booleanStats.getNumNulls());
+					booleanStats.isSetNumTrues() ? booleanStats.getNumTrues() : null,
+					booleanStats.isSetNumFalses() ? booleanStats.getNumFalses() : null,
+					booleanStats.isSetNumNulls() ? booleanStats.getNumNulls() : null);
 		} else if (hiveShim.isDateStats(stats)) {
 			return hiveShim.toFlinkDateColStats(stats);
 		} else if (stats.isSetDoubleStats()) {
 				DoubleColumnStatsData doubleStats = stats.getDoubleStats();
 				return new CatalogColumnStatisticsDataDouble(
-						doubleStats.getLowValue(),
-						doubleStats.getHighValue(),
-						doubleStats.getNumDVs(),
-						doubleStats.getNumNulls());
+						doubleStats.isSetLowValue() ? doubleStats.getLowValue() : null,
+						doubleStats.isSetHighValue() ? doubleStats.getHighValue() : null,
+						doubleStats.isSetNumDVs() ? doubleStats.getNumDVs() : null,
+						doubleStats.isSetNumNulls() ? doubleStats.getNumNulls() : null);
 		} else if (stats.isSetLongStats()) {
 				LongColumnStatsData longColStats = stats.getLongStats();
 				return new CatalogColumnStatisticsDataLong(
-						longColStats.getLowValue(),
-						longColStats.getHighValue(),
-						longColStats.getNumDVs(),
-						longColStats.getNumNulls());
+						longColStats.isSetLowValue() ? longColStats.getLowValue() : null,
+						longColStats.isSetHighValue() ? longColStats.getHighValue() : null,
+						longColStats.isSetNumDVs() ? longColStats.getNumDVs() : null,
+						longColStats.isSetNumNulls() ? longColStats.getNumNulls() : null);
 		} else if (stats.isSetStringStats()) {
 			StringColumnStatsData stringStats = stats.getStringStats();
 			return new CatalogColumnStatisticsDataString(
-					stringStats.getMaxColLen(),
-					stringStats.getAvgColLen(),
-					stringStats.getNumDVs(),
-					stringStats.getNumNulls());
+					stringStats.isSetMaxColLen() ? stringStats.getMaxColLen() : null,
+					stringStats.isSetAvgColLen() ? stringStats.getAvgColLen() : null,
+					stringStats.isSetNumDVs() ? stringStats.getNumDVs() : null,
+					stringStats.isSetNumDVs() ? stringStats.getNumNulls() : null);
 		} else {
 			LOG.warn("Flink does not support converting ColumnStatisticsData '{}' for Hive column type '{}' yet.", stats, colType);
 			return null;
@@ -189,16 +189,37 @@ public class HiveStatsUtil {
 		|| type.equals(LogicalTypeRoot.VARCHAR)) {
 			if (colStat instanceof CatalogColumnStatisticsDataString) {
 				CatalogColumnStatisticsDataString stringColStat = (CatalogColumnStatisticsDataString) colStat;
-				return ColumnStatisticsData.stringStats(new StringColumnStatsData(stringColStat.getMaxLength(), stringColStat.getAvgLength(), stringColStat.getNullCount(), stringColStat.getNdv()));
+				StringColumnStatsData hiveStringColumnStats = new StringColumnStatsData();
+				hiveStringColumnStats.clear();
+				if (null != stringColStat.getMaxLength()) {
+					hiveStringColumnStats.setMaxColLen(stringColStat.getMaxLength());
+				}
+				if (null != stringColStat.getAvgLength()) {
+					hiveStringColumnStats.setAvgColLen(stringColStat.getAvgLength());
+				}
+				if (null != stringColStat.getNullCount()) {
+					hiveStringColumnStats.setNumNulls(stringColStat.getNullCount());
+				}
+				if (null != stringColStat.getNdv()) {
+					hiveStringColumnStats.setNumDVs(stringColStat.getNdv());
+				}
+				return ColumnStatisticsData.stringStats(hiveStringColumnStats);
 			}
 		} else if (type.equals(LogicalTypeRoot.BOOLEAN)) {
 			if (colStat instanceof CatalogColumnStatisticsDataBoolean) {
 				CatalogColumnStatisticsDataBoolean booleanColStat = (CatalogColumnStatisticsDataBoolean) colStat;
-				BooleanColumnStatsData boolStats = new BooleanColumnStatsData(
-						booleanColStat.getTrueCount(),
-						booleanColStat.getFalseCount(),
-						booleanColStat.getNullCount());
-				return ColumnStatisticsData.booleanStats(boolStats);
+				BooleanColumnStatsData hiveBoolStats = new BooleanColumnStatsData();
+				hiveBoolStats.clear();
+				if (null != booleanColStat.getTrueCount()) {
+					hiveBoolStats.setNumTrues(booleanColStat.getTrueCount());
+				}
+				if (null != booleanColStat.getFalseCount()) {
+					hiveBoolStats.setNumFalses(booleanColStat.getFalseCount());
+				}
+				if (null != booleanColStat.getNullCount()) {
+					hiveBoolStats.setNumNulls(booleanColStat.getTrueCount());
+				}
+				return ColumnStatisticsData.booleanStats(hiveBoolStats);
 			}
 		} else if (type.equals(LogicalTypeRoot.TINYINT)
 				|| type.equals(LogicalTypeRoot.SMALLINT)
@@ -209,19 +230,41 @@ public class HiveStatsUtil {
 				|| type.equals(LogicalTypeRoot.TIMESTAMP_WITH_TIME_ZONE)) {
 			if (colStat instanceof CatalogColumnStatisticsDataLong) {
 				CatalogColumnStatisticsDataLong longColStat = (CatalogColumnStatisticsDataLong) colStat;
-				LongColumnStatsData longColumnStatsData = new LongColumnStatsData(longColStat.getNullCount(), longColStat.getNdv());
-				longColumnStatsData.setHighValue(longColStat.getMax());
-				longColumnStatsData.setLowValue(longColStat.getMin());
-				return ColumnStatisticsData.longStats(longColumnStatsData);
+				LongColumnStatsData hiveLongColStats = new LongColumnStatsData();
+				hiveLongColStats.clear();
+				if (null != longColStat.getMax()) {
+					hiveLongColStats.setHighValue(longColStat.getMax());
+				}
+				if (null != longColStat.getMin()) {
+					hiveLongColStats.setLowValue(longColStat.getMin());
+				}
+				if (null != longColStat.getNdv()) {
+					hiveLongColStats.setNumDVs(longColStat.getNdv());
+				}
+				if (null != longColStat.getNullCount()) {
+					hiveLongColStats.setNumNulls(longColStat.getNullCount());
+				}
+				return ColumnStatisticsData.longStats(hiveLongColStats);
 			}
 		} else if (type.equals(LogicalTypeRoot.FLOAT)
 				|| type.equals(LogicalTypeRoot.DOUBLE)) {
 			if (colStat instanceof CatalogColumnStatisticsDataDouble) {
 				CatalogColumnStatisticsDataDouble doubleColumnStatsData = (CatalogColumnStatisticsDataDouble) colStat;
-				DoubleColumnStatsData floatStats = new DoubleColumnStatsData(doubleColumnStatsData.getNullCount(), doubleColumnStatsData.getNdv());
-				floatStats.setHighValue(doubleColumnStatsData.getMax());
-				floatStats.setLowValue(doubleColumnStatsData.getMin());
-				return ColumnStatisticsData.doubleStats(floatStats);
+				DoubleColumnStatsData hiveFloatStats = new DoubleColumnStatsData();
+				hiveFloatStats.clear();
+				if (null != doubleColumnStatsData.getMax()) {
+					hiveFloatStats.setHighValue(doubleColumnStatsData.getMax());
+				}
+				if (null != doubleColumnStatsData.getMin()) {
+					hiveFloatStats.setLowValue(doubleColumnStatsData.getMin());
+				}
+				if (null != doubleColumnStatsData.getNullCount()) {
+					hiveFloatStats.setNumNulls(doubleColumnStatsData.getNullCount());
+				}
+				if (null != doubleColumnStatsData.getNdv()) {
+					hiveFloatStats.setNumDVs(doubleColumnStatsData.getNdv());
+				}
+				return ColumnStatisticsData.doubleStats(hiveFloatStats);
 			}
 		} else if (type.equals(LogicalTypeRoot.DATE)) {
 			if (colStat instanceof CatalogColumnStatisticsDataDate) {
@@ -232,8 +275,18 @@ public class HiveStatsUtil {
 				|| type.equals(LogicalTypeRoot.BINARY)) {
 			if (colStat instanceof CatalogColumnStatisticsDataBinary) {
 				CatalogColumnStatisticsDataBinary binaryColumnStatsData = (CatalogColumnStatisticsDataBinary) colStat;
-				BinaryColumnStatsData binaryColumnStats = new BinaryColumnStatsData(binaryColumnStatsData.getMaxLength(), binaryColumnStatsData.getAvgLength(), binaryColumnStatsData.getNullCount());
-				return ColumnStatisticsData.binaryStats(binaryColumnStats);
+				BinaryColumnStatsData hiveBinaryColumnStats = new BinaryColumnStatsData();
+				hiveBinaryColumnStats.clear();
+				if (null != binaryColumnStatsData.getMaxLength()) {
+					hiveBinaryColumnStats.setMaxColLen(binaryColumnStatsData.getMaxLength());
+				}
+				if (null != binaryColumnStatsData.getAvgLength()) {
+					hiveBinaryColumnStats.setAvgColLen(binaryColumnStatsData.getAvgLength());
+				}
+				if (null != binaryColumnStatsData.getNullCount()) {
+					hiveBinaryColumnStats.setNumNulls(binaryColumnStatsData.getNullCount());
+				}
+				return ColumnStatisticsData.binaryStats(hiveBinaryColumnStats);
 			}
 		}
 		throw new CatalogException(String.format("Flink does not support converting ColumnStats '%s' for Hive column " +

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
@@ -97,14 +97,15 @@ public class HiveCatalogHiveMetadataTest extends HiveCatalogTestBase {
 		CatalogTable catalogTable = new CatalogTableImpl(tableSchema, getBatchTableProperties(), TEST_COMMENT);
 		catalog.createTable(path1, catalogTable, false);
 		Map<String, CatalogColumnStatisticsDataBase> columnStatisticsDataBaseMap = new HashMap<>();
-		columnStatisticsDataBaseMap.put("first", new CatalogColumnStatisticsDataString(10, 5.2, 3, 100));
-		columnStatisticsDataBaseMap.put("second", new CatalogColumnStatisticsDataLong(0, 1000, 3, 0));
-		columnStatisticsDataBaseMap.put("third", new CatalogColumnStatisticsDataBoolean(15, 20, 3));
-		columnStatisticsDataBaseMap.put("fourth", new CatalogColumnStatisticsDataDouble(15.02, 20.01, 3, 10));
-		columnStatisticsDataBaseMap.put("fifth", new CatalogColumnStatisticsDataLong(0, 20, 3, 2));
-		columnStatisticsDataBaseMap.put("sixth", new CatalogColumnStatisticsDataBinary(150, 20, 3));
+		columnStatisticsDataBaseMap.put("first", new CatalogColumnStatisticsDataString(10L, 5.2, 3L, 100L));
+		columnStatisticsDataBaseMap.put("second", new CatalogColumnStatisticsDataLong(0L, 1000L, 3L, 0L));
+		columnStatisticsDataBaseMap.put("third", new CatalogColumnStatisticsDataBoolean(15L, 20L, 3L));
+		columnStatisticsDataBaseMap.put("fourth", new CatalogColumnStatisticsDataDouble(15.02, 20.01, 3L, 10L));
+		columnStatisticsDataBaseMap.put("fifth", new CatalogColumnStatisticsDataLong(0L, 20L, 3L, 2L));
+		columnStatisticsDataBaseMap.put("sixth", new CatalogColumnStatisticsDataBinary(150L, 20D, 3L));
 		if (supportDateStats) {
-			columnStatisticsDataBaseMap.put("seventh", new CatalogColumnStatisticsDataDate(new Date(71L), new Date(17923L), 1321, 0L));
+			columnStatisticsDataBaseMap.put("seventh", new CatalogColumnStatisticsDataDate(
+					new Date(71L), new Date(17923L), 132L, 0L));
 		}
 		CatalogColumnStatistics catalogColumnStatistics = new CatalogColumnStatistics(columnStatisticsDataBaseMap);
 		catalog.alterTableColumnStatistics(path1, catalogColumnStatistics, false);
@@ -120,7 +121,7 @@ public class HiveCatalogHiveMetadataTest extends HiveCatalogTestBase {
 		CatalogPartitionSpec partitionSpec = createPartitionSpec();
 		catalog.createPartition(path1, partitionSpec, createPartition(), true);
 		Map<String, CatalogColumnStatisticsDataBase> columnStatisticsDataBaseMap = new HashMap<>();
-		columnStatisticsDataBaseMap.put("first", new CatalogColumnStatisticsDataString(10, 5.2, 3, 100));
+		columnStatisticsDataBaseMap.put("first", new CatalogColumnStatisticsDataString(10L, 5.2, 3L, 100L));
 		CatalogColumnStatistics catalogColumnStatistics = new CatalogColumnStatistics(columnStatisticsDataBaseMap);
 		catalog.alterPartitionColumnStatistics(path1, partitionSpec, catalogColumnStatistics, false);
 

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
@@ -142,7 +142,7 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 		CatalogColumnStatisticsDataLong longColStats = new CatalogColumnStatisticsDataLong(-123L, 763322L, 23L, 79L);
 		CatalogColumnStatisticsDataString stringColStats = new CatalogColumnStatisticsDataString(152L, 43.5D, 20L, 0L);
 		CatalogColumnStatisticsDataDate dateColStats = new CatalogColumnStatisticsDataDate(new Date(71L),
-			new Date(17923L), 1321, 0L);
+			new Date(17923L), 1321L, 0L);
 		CatalogColumnStatisticsDataDouble doubleColStats = new CatalogColumnStatisticsDataDouble(-123.35D, 7633.22D, 23L, 79L);
 		CatalogColumnStatisticsDataBinary binaryColStats = new CatalogColumnStatisticsDataBinary(755L, 43.5D, 20L);
 		Map<String, CatalogColumnStatisticsDataBase> colStatsMap = new HashMap<>(6);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataBase.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataBase.java
@@ -28,20 +28,20 @@ public abstract class CatalogColumnStatisticsDataBase {
 	/**
 	 * number of null values.
 	 */
-	private final long nullCount;
+	private final Long nullCount;
 
 	private final Map<String, String> properties;
 
-	public CatalogColumnStatisticsDataBase(long nullCount) {
+	public CatalogColumnStatisticsDataBase(Long nullCount) {
 		this(nullCount, new HashMap<>());
 	}
 
-	public CatalogColumnStatisticsDataBase(long nullCount, Map<String, String> properties) {
+	public CatalogColumnStatisticsDataBase(Long nullCount, Map<String, String> properties) {
 		this.nullCount = nullCount;
 		this.properties = properties;
 	}
 
-	public long getNullCount() {
+	public Long getNullCount() {
 		return nullCount;
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataBinary.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataBinary.java
@@ -28,30 +28,31 @@ public class CatalogColumnStatisticsDataBinary extends CatalogColumnStatisticsDa
 	/**
 	 * max length of all values.
 	 */
-	private final long maxLength;
+	private final Long maxLength;
 
 	/**
 	 * average length of all values.
 	 */
-	private final double avgLength;
+	private final Double avgLength;
 
-	public CatalogColumnStatisticsDataBinary(long maxLength, double avgLength, long nullCount) {
+	public CatalogColumnStatisticsDataBinary(Long maxLength, Double avgLength, Long nullCount) {
 		super(nullCount);
 		this.maxLength = maxLength;
 		this.avgLength = avgLength;
 	}
 
-	public CatalogColumnStatisticsDataBinary(long maxLength, double avgLength, long nullCount, Map<String, String> properties) {
+	public CatalogColumnStatisticsDataBinary(Long maxLength, Double avgLength, Long nullCount,
+											Map<String, String> properties) {
 		super(nullCount, properties);
 		this.maxLength = maxLength;
 		this.avgLength = avgLength;
 	}
 
-	public long getMaxLength() {
+	public Long getMaxLength() {
 		return maxLength;
 	}
 
-	public double getAvgLength() {
+	public Double getAvgLength() {
 		return avgLength;
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataBoolean.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataBoolean.java
@@ -28,20 +28,20 @@ public class CatalogColumnStatisticsDataBoolean extends CatalogColumnStatisticsD
 	/**
 	 * number of "true" values.
 	 */
-	private final long trueCount;
+	private final Long trueCount;
 
 	/**
 	 * number of "false" values.
 	 */
-	private final long falseCount;
+	private final Long falseCount;
 
-	public CatalogColumnStatisticsDataBoolean(long trueCount, long falseCount, long nullCount) {
+	public CatalogColumnStatisticsDataBoolean(Long trueCount, Long falseCount, Long nullCount) {
 		super(nullCount);
 		this.trueCount = trueCount;
 		this.falseCount = falseCount;
 	}
 
-	public CatalogColumnStatisticsDataBoolean(long trueCount, long falseCount, long nullCount, Map<String, String> properties) {
+	public CatalogColumnStatisticsDataBoolean(Long trueCount, Long falseCount, Long nullCount, Map<String, String> properties) {
 		super(nullCount, properties);
 		this.trueCount = trueCount;
 		this.falseCount = falseCount;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataDate.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataDate.java
@@ -38,16 +38,16 @@ public class CatalogColumnStatisticsDataDate extends CatalogColumnStatisticsData
 	/**
 	 * number of distinct values.
 	 */
-	private final long ndv;
+	private final Long ndv;
 
-	public CatalogColumnStatisticsDataDate(Date min, Date max, long ndv, long nullCount) {
+	public CatalogColumnStatisticsDataDate(Date min, Date max, Long ndv, Long nullCount) {
 		super(nullCount);
 		this.min = min;
 		this.max = max;
 		this.ndv = ndv;
 	}
 
-	public CatalogColumnStatisticsDataDate(Date min, Date max, long ndv, long nullCount, Map<String, String> properties) {
+	public CatalogColumnStatisticsDataDate(Date min, Date max, Long ndv, Long nullCount, Map<String, String> properties) {
 		super(nullCount, properties);
 		this.min = min;
 		this.max = max;
@@ -62,7 +62,7 @@ public class CatalogColumnStatisticsDataDate extends CatalogColumnStatisticsData
 		return max;
 	}
 
-	public long getNdv() {
+	public Long getNdv() {
 		return ndv;
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataDouble.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataDouble.java
@@ -28,41 +28,41 @@ public class CatalogColumnStatisticsDataDouble extends CatalogColumnStatisticsDa
 	/**
 	 * mim value.
 	 */
-	private final double min;
+	private final Double min;
 
 	/**
 	 * max value.
 	 */
-	private final double max;
+	private final Double max;
 
 	/**
 	 * number of distinct values.
 	 */
-	private final long ndv;
+	private final Long ndv;
 
-	public CatalogColumnStatisticsDataDouble(double min, double max, long ndv, long nullCount) {
+	public CatalogColumnStatisticsDataDouble(Double min, Double max, Long ndv, Long nullCount) {
 		super(nullCount);
 		this.min = min;
 		this.max = max;
 		this.ndv = ndv;
 	}
 
-	public CatalogColumnStatisticsDataDouble(double min, double max, long ndv, long nullCount, Map<String, String> properties) {
+	public CatalogColumnStatisticsDataDouble(Double min, Double max, Long ndv, Long nullCount, Map<String, String> properties) {
 		super(nullCount, properties);
 		this.min = min;
 		this.max = max;
 		this.ndv = ndv;
 	}
 
-	public double getMin() {
+	public Double getMin() {
 		return min;
 	}
 
-	public double getMax() {
+	public Double getMax() {
 		return max;
 	}
 
-	public long getNdv() {
+	public Long getNdv() {
 		return ndv;
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataLong.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataLong.java
@@ -28,41 +28,41 @@ public class CatalogColumnStatisticsDataLong extends CatalogColumnStatisticsData
 	/**
 	 * mim value.
 	 */
-	private final long min;
+	private final Long min;
 
 	/**
 	 * max value.
 	 */
-	private final long max;
+	private final Long max;
 
 	/**
 	 * number of distinct values.
 	 */
-	private final long ndv;
+	private final Long ndv;
 
-	public CatalogColumnStatisticsDataLong(long min, long max, long ndv, long nullCount) {
+	public CatalogColumnStatisticsDataLong(Long min, Long max, Long ndv, Long nullCount) {
 		super(nullCount);
 		this.min = min;
 		this.max = max;
 		this.ndv = ndv;
 	}
 
-	public CatalogColumnStatisticsDataLong(long min, long max, long ndv, long nullCount, Map<String, String> properties) {
+	public CatalogColumnStatisticsDataLong(Long min, Long max, Long ndv, Long nullCount, Map<String, String> properties) {
 		super(nullCount, properties);
 		this.min = min;
 		this.max = max;
 		this.ndv = ndv;
 	}
 
-	public long getMin() {
+	public Long getMin() {
 		return min;
 	}
 
-	public long getMax() {
+	public Long getMax() {
 		return max;
 	}
 
-	public long getNdv() {
+	public Long getNdv() {
 		return ndv;
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataString.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataString.java
@@ -28,41 +28,41 @@ public class CatalogColumnStatisticsDataString extends CatalogColumnStatisticsDa
 	/**
 	 * max length of all values.
 	 */
-	private final long maxLength;
+	private final Long maxLength;
 
 	/**
 	 * average length of all values.
 	 */
-	private final double avgLength;
+	private final Double avgLength;
 
 	/**
 	 * number of distinct values.
 	 */
-	private final long ndv;
+	private final Long ndv;
 
-	public CatalogColumnStatisticsDataString(long maxLength, double avgLength, long ndv, long nullCount) {
+	public CatalogColumnStatisticsDataString(Long maxLength, Double avgLength, Long ndv, Long nullCount) {
 		super(nullCount);
 		this.maxLength = maxLength;
 		this.avgLength = avgLength;
 		this.ndv = ndv;
 	}
 
-	public CatalogColumnStatisticsDataString(long maxLength, double avgLength, long ndv, long nullCount, Map<String, String> properties) {
+	public CatalogColumnStatisticsDataString(Long maxLength, Double avgLength, Long ndv, Long nullCount, Map<String, String> properties) {
 		super(nullCount, properties);
 		this.maxLength = maxLength;
 		this.avgLength = avgLength;
 		this.ndv = ndv;
 	}
 
-	public long getMaxLength() {
+	public Long getMaxLength() {
 		return maxLength;
 	}
 
-	public double getAvgLength() {
+	public Double getAvgLength() {
 		return avgLength;
 	}
 
-	public long getNdv() {
+	public Long getNdv() {
 		return ndv;
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/CatalogTableStatisticsConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/CatalogTableStatisticsConverter.java
@@ -82,7 +82,9 @@ public class CatalogTableStatisticsConverter {
 			CatalogColumnStatisticsDataBoolean booleanData = (CatalogColumnStatisticsDataBoolean) columnStatisticsData;
 			avgLen = 1.0;
 			maxLen = 1;
-			if ((booleanData.getFalseCount() == 0 && booleanData.getTrueCount() > 0) ||
+			if (null == booleanData.getFalseCount() || null == booleanData.getTrueCount()) {
+				ndv = 2L;
+			} else if ((booleanData.getFalseCount() == 0 && booleanData.getTrueCount() > 0) ||
 					(booleanData.getFalseCount() > 0 && booleanData.getTrueCount() == 0)) {
 				ndv = 1L;
 			} else {
@@ -106,11 +108,11 @@ public class CatalogTableStatisticsConverter {
 			CatalogColumnStatisticsDataString strData = (CatalogColumnStatisticsDataString) columnStatisticsData;
 			ndv = strData.getNdv();
 			avgLen = strData.getAvgLength();
-			maxLen = (int) strData.getMaxLength();
+			maxLen = null == strData.getMaxLength() ? null : strData.getMaxLength().intValue();
 		} else if (columnStatisticsData instanceof CatalogColumnStatisticsDataBinary) {
 			CatalogColumnStatisticsDataBinary binaryData = (CatalogColumnStatisticsDataBinary) columnStatisticsData;
 			avgLen = binaryData.getAvgLength();
-			maxLen = (int) binaryData.getMaxLength();
+			maxLen = null == binaryData.getMaxLength() ? null : binaryData.getMaxLength().intValue();
 		} else if (columnStatisticsData instanceof CatalogColumnStatisticsDataDate) {
 			CatalogColumnStatisticsDataDate dateData = (CatalogColumnStatisticsDataDate) columnStatisticsData;
 			ndv = dateData.getNdv();

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/catalog/CatalogStatisticsTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/catalog/CatalogStatisticsTest.java
@@ -126,7 +126,7 @@ public class CatalogStatisticsTest {
 		CatalogColumnStatisticsDataLong longColStats = new CatalogColumnStatisticsDataLong(-123L, 763322L, 23L, 77L);
 		CatalogColumnStatisticsDataString stringColStats = new CatalogColumnStatisticsDataString(152L, 43.5D, 20L, 0L);
 		CatalogColumnStatisticsDataDate dateColStats =
-				new CatalogColumnStatisticsDataDate(new Date(71L), new Date(17923L), 100, 0L);
+				new CatalogColumnStatisticsDataDate(new Date(71L), new Date(17923L), 100L, 0L);
 		CatalogColumnStatisticsDataDouble doubleColStats =
 				new CatalogColumnStatisticsDataDouble(-123.35D, 7633.22D, 73L, 27L);
 		Map<String, CatalogColumnStatisticsDataBase> colStatsMap = new HashMap<>(6);


### PR DESCRIPTION
## What is the purpose of the change

*When converting from hive stats to Flink's column stats, we didn't check whether some columns stats is really set or just an initial value. This PR we aim to change the CatalogColumnStatisticsDataBase and its subclass's stats from primitive types to corresponding boxed-type.*


## Brief change log

  - *[68e7752](https://github.com/apache/flink/commit/68e77528300eadcbeaa62372d676b01e268c39a8) Distinguish catalogColumnStats' unknown  value and real values*



## Verifying this change

This change is already covered by existing tests, such as *HiveCatalogHiveMetadataTest#testAlterTableColumnStatistics* and so on.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
