### PR TITLE
[FLINK-15030][runtime] Fix deadlock problem of blocking ResultPartition with minimum required buffers.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -188,7 +188,8 @@ public class ResultPartitionFactory {
 				numberOfSubpartitions * networkBuffersPerChannel + floatingNetworkBuffersPerGate : Integer.MAX_VALUE;
 			// If the partition type is back pressure-free, we register with the buffer pool for
 			// callbacks to release memory.
-			return bufferPoolFactory.createBufferPool(numberOfSubpartitions,
+			return bufferPoolFactory.createBufferPool(
+				numberOfSubpartitions + 1,
 				maxNumberOfMemorySegments,
 				type.hasBackPressure() ? Optional.empty() : Optional.of(p));
 		};

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmarkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmarkTest.java
@@ -103,7 +103,7 @@ public class StreamNetworkThroughputBenchmarkTest {
 		int writers = 2;
 		int channels = 2;
 
-		env.setUp(writers, channels, 100, false, writers * channels, writers * channels *
+		env.setUp(writers, channels, 100, false, writers * channels + writers, writers * channels *
 			NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL.defaultValue());
 		env.executeBenchmark(10_000);
 		env.tearDown();

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BackPressureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BackPressureITCase.java
@@ -91,7 +91,7 @@ public class BackPressureITCase extends TestLogger {
 		final Configuration configuration = new Configuration();
 
 		final int memorySegmentSizeKb = 32;
-		final String networkBuffersMemory = (memorySegmentSizeKb * NUM_TASKS) + "kb";
+		final String networkBuffersMemory = (memorySegmentSizeKb * (NUM_TASKS + NUM_TASKS - 1)) + "kb";
 
 		configuration.setString(TaskManagerOptions.MEMORY_SEGMENT_SIZE, memorySegmentSizeKb + "kb");
 		configuration.setString(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MIN, networkBuffersMemory);


### PR DESCRIPTION
## What is the purpose of the change
Currently, BoundedBlockingSubpartition relies on the add of next BufferConsumer to flush and recycle the previous one, which means at least (numSubpartition + 1) buffers is needed to make the bounded blocking ResultPartition work. However, ResultPartitionFactory gives only (numSubpartition) required buffers to BufferPool of bounded blocking ResultPartition which may lead to deadlock problem. This PR tries to fix the problem by increasing the number of required buffers by 1.

## Brief change log

  - The number of required buffers of the BufferPool of ResultPartition is increased by one to (numSubpartition + 1).
  - A new test case is added to verify the change.


## Verifying this change

A new test case ResultPartitionTest#testWriteToBlockingResultPartitionWithMinimumBuffers is added.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
