### PR TITLE
[FLINK-14063][table-planner-blink] Operators use fractions to decide how many managed memory to allocate

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/LongHashJoinGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/LongHashJoinGenerator.scala
@@ -105,9 +105,6 @@ object LongHashJoinGenerator {
       probeType: RowType,
       buildKeyMapping: Array[Int],
       probeKeyMapping: Array[Int],
-      managedMemorySize: Long,
-      maxMemorySize: Long,
-      perRequestSize: Long,
       buildRowSize: Int,
       buildRowCount: Long,
       reverseJoinFunction: Boolean,
@@ -175,7 +172,7 @@ object LongHashJoinGenerator {
          |    super(getContainingTask().getJobConfiguration(), getContainingTask(),
          |      $buildSerTerm, $probeSerTerm,
          |      getContainingTask().getEnvironment().getMemoryManager(),
-         |      ${managedMemorySize}L, ${maxMemorySize}L, ${perRequestSize}L,
+         |      computeMemorySize(),
          |      getContainingTask().getEnvironment().getIOManager(),
          |      $buildRowSize,
          |      ${buildRowCount}L / getRuntimeContext().getNumberOfParallelSubtasks());

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenHelper.scala
@@ -73,7 +73,7 @@ object HashAggCodeGenHelper {
         s"= new $mapTypeTerm(" +
         s"this.getContainingTask()," +
         s"this.getContainingTask().getEnvironment().getMemoryManager()," +
-        s"${reservedManagedMemory}L," +
+        s"computeMemorySize()," +
         s" $groupKeyTypesTerm," +
         s" $aggBufferTypesTerm);")
     // close aggregate map and release memory segments

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecHashJoin.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecHashJoin.scala
@@ -204,7 +204,6 @@ class BatchExecHashJoin(
     val memText = config.getConfiguration.getString(
       ExecutionConfigOptions.TABLE_EXEC_RESOURCE_HASH_JOIN_MEMORY)
     val managedMemoryInMB = MemorySize.parse(memText).getMebiBytes
-    val managedMemory = managedMemoryInMB * NodeResourceUtil.SIZE_IN_MB
     val condFunc = JoinUtil.generateConditionFunction(
       config, cluster.getRexBuilder, getJoinInfo, lType, rType)
 
@@ -236,18 +235,12 @@ class BatchExecHashJoin(
         pType,
         buildKeys,
         probeKeys,
-        managedMemory,
-        0,
-        0,
         buildRowSize,
         buildRowCount,
         reverseJoin,
         condFunc)
     } else {
       SimpleOperatorFactory.of(HashJoinOperator.newHashJoinOperator(
-        managedMemory,
-        0,
-        0,
         hashJoinType,
         condFunc,
         reverseJoin,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecOverAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecOverAggregate.scala
@@ -414,7 +414,6 @@ class BatchExecOverAggregate(
         ExecutionConfigOptions.TABLE_EXEC_RESOURCE_EXTERNAL_BUFFER_MEMORY)
       managedMemoryInMB = MemorySize.parse(memText).getMebiBytes
       new BufferDataOverWindowOperator(
-        managedMemoryInMB * NodeResourceUtil.SIZE_IN_MB,
         windowFrames,
         genComparator,
         inputType.getChildren.forall(t => BinaryRow.isInFixedLengthPart(t)))

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSort.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSort.scala
@@ -116,13 +116,7 @@ class BatchExecSort(
     val keyTypes = keys.map(inputType.getTypeAt)
     val codeGen = new SortCodeGenerator(conf, keys, keyTypes, orders, nullsIsLast)
 
-    val memText = conf.getConfiguration.getString(
-      ExecutionConfigOptions.TABLE_EXEC_RESOURCE_SORT_MEMORY)
-    val managedMemoryInMB = MemorySize.parse(memText).getMebiBytes
-    val managedMemory = managedMemoryInMB * NodeResourceUtil.SIZE_IN_MB
-
     val operator = new SortOperator(
-      managedMemory,
       codeGen.generateNormalizedKeyComputer("BatchExecSortComputer"),
       codeGen.generateRecordComparator("BatchExecSortComparator"))
 
@@ -132,6 +126,10 @@ class BatchExecSort(
       operator.asInstanceOf[OneInputStreamOperator[BaseRow, BaseRow]],
       BaseRowTypeInfo.of(outputType),
       input.getParallelism)
+
+    val memText = conf.getConfiguration.getString(
+      ExecutionConfigOptions.TABLE_EXEC_RESOURCE_SORT_MEMORY)
+    val managedMemoryInMB = MemorySize.parse(memText).getMebiBytes
     val resource = NodeResourceUtil.fromManagedMem(managedMemoryInMB)
     ret.setResources(resource, resource)
     ret

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSortMergeJoin.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSortMergeJoin.scala
@@ -237,7 +237,6 @@ class BatchExecSortMergeJoin(
     val rightSortGen = newSortGen(rightAllKey, rightType)
 
     val operator = new SortMergeJoinOperator(
-      0.5,
       externalBufferMemory,
       flinkJoinType,
       estimateOutputSize(getLeft) < estimateOutputSize(getRight),

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/codegen/LongHashJoinGeneratorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/codegen/LongHashJoinGeneratorTest.java
@@ -47,7 +47,7 @@ public class LongHashJoinGeneratorTest extends Int2HashJoinOperatorTest {
 				RowType.of(new IntType(), new IntType()),
 				new int[]{0},
 				new int[]{0},
-				memorySize, memorySize, 0, 20, 10000,
+				20, 10000,
 				reverseJoinFunction,
 				new GeneratedJoinCondition(MyJoinCondition.class.getCanonicalName(), "", new Object[0])
 		);

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/agg/batch/BatchAggTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/agg/batch/BatchAggTestBase.scala
@@ -73,7 +73,7 @@ abstract class BatchAggTestBase extends AggTestBase(isBatchMode = true) {
     val streamConfig = testHarness.getStreamConfig
     streamConfig.setStreamOperatorFactory(args._1)
     streamConfig.setOperatorID(new OperatorID)
-    streamConfig.setManagedMemoryFractionOnHeap(0.99)
+    streamConfig.setManagedMemoryFraction(0.99)
 
     testHarness.invoke()
     testHarness.waitForTaskRunning()

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/agg/batch/BatchAggTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/agg/batch/BatchAggTestBase.scala
@@ -73,6 +73,7 @@ abstract class BatchAggTestBase extends AggTestBase(isBatchMode = true) {
     val streamConfig = testHarness.getStreamConfig
     streamConfig.setStreamOperatorFactory(args._1)
     streamConfig.setOperatorID(new OperatorID)
+    streamConfig.setManagedMemoryFractionOnHeap(0.99)
 
     testHarness.invoke()
     testHarness.waitForTaskRunning()

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/BaseHybridHashTable.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/BaseHybridHashTable.java
@@ -83,17 +83,8 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 	/**
 	 * The total reserved number of memory segments available to the hash join.
 	 */
-	protected final int reservedNumBuffers;
-	/**
-	 * The total max number of memory segments available to the hash join.
-	 */
-	private final int maxNumBuffers;
+	protected final int totalNumBuffers;
 
-	/**
-	 * record number of the allocated segments from the floating pool.
-	 */
-	protected int allocatedFloatingNum;
-	private final int perRequestNumBuffers;
 	private final MemoryManager memManager;
 
 	/**
@@ -173,8 +164,6 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 			Object owner,
 			MemoryManager memManager,
 			long reservedMemorySize,
-			long preferredMemorySize,
-			long perRequestMemorySize,
 			IOManager ioManager,
 			int avgRecordLen,
 			long buildRowCount,
@@ -192,14 +181,12 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 		this.avgRecordLen = avgRecordLen;
 		this.buildRowCount = buildRowCount;
 		this.tryDistinctBuildRow = tryDistinctBuildRow;
-		this.reservedNumBuffers = (int) (reservedMemorySize / memManager.getPageSize());
+		this.totalNumBuffers = (int) (reservedMemorySize / memManager.getPageSize());
 		// some sanity checks first
-		checkArgument(reservedNumBuffers >= MIN_NUM_MEMORY_SEGMENTS);
-		this.maxNumBuffers = (int) (preferredMemorySize / memManager.getPageSize());
-		this.perRequestNumBuffers = (int) (perRequestMemorySize / memManager.getPageSize());
-		this.availableMemory = new ArrayList<>(this.reservedNumBuffers);
+		checkArgument(totalNumBuffers >= MIN_NUM_MEMORY_SEGMENTS);
+		this.availableMemory = new ArrayList<>(this.totalNumBuffers);
 		try {
-			List<MemorySegment> allocates = memManager.allocatePages(owner, this.reservedNumBuffers);
+			List<MemorySegment> allocates = memManager.allocatePages(owner, totalNumBuffers);
 			this.availableMemory.addAll(allocates);
 			allocates.clear();
 		} catch (MemoryAllocationException e) {
@@ -227,10 +214,8 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 
 		this.closed.set(false);
 
-		LOG.info(String.format("Initialize hash table with %d memory segments, each size [%d], the reserved memory %d" +
-						" MB, the max memory %d MB, per allocate {} segments from floating memory pool.",
-				reservedNumBuffers, segmentSize, (long) reservedNumBuffers * segmentSize / 1024 / 1024,
-				(long) maxNumBuffers * segmentSize / 1024 / 1024), perRequestNumBuffers);
+		LOG.info(String.format("Initialize hash table with %d memory segments, each size [%d], the memory %d MB.",
+				totalNumBuffers, segmentSize, (long) totalNumBuffers * segmentSize / 1024 / 1024));
 	}
 
 	/**
@@ -311,31 +296,7 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 			}
 			return toReturn;
 		} else {
-			if (reservedNumBuffers + allocatedFloatingNum >= maxNumBuffers) {
-				//no more memory.
-				return null;
-			} else {
-				int requestNum = Math.min(perRequestNumBuffers, maxNumBuffers - reservedNumBuffers -
-						allocatedFloatingNum);
-				//apply for much more memory.
-				try {
-					List<MemorySegment> allocates = memManager.allocatePages(owner, requestNum);
-					this.availableMemory.addAll(allocates);
-					allocatedFloatingNum += allocates.size();
-					allocates.clear();
-					LOG.info("{} allocate {} floating segments successfully!", owner, requestNum);
-				} catch (MemoryAllocationException e) {
-					LOG.warn("BinaryHashMap can't allocate {} floating pages, and now used {} pages",
-							requestNum, reservedNumBuffers + allocatedFloatingNum, e);
-					//can't allocate much more memory.
-					return null;
-				}
-				if (this.availableMemory.size() > 0) {
-					return this.availableMemory.remove(this.availableMemory.size() - 1);
-				} else {
-					return null;
-				}
-			}
+			return null;
 		}
 	}
 
@@ -473,7 +434,6 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 	public void free() {
 		if (this.closed.get()) {
 			memManager.release(availableMemory);
-			allocatedFloatingNum = 0;
 		} else {
 			throw new IllegalStateException("Cannot release memory until BinaryHashTable is closed!");
 		}
@@ -483,9 +443,7 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 	 * Free the memory not used.
 	 */
 	public void freeCurrent() {
-		int beforeReleaseNum = availableMemory.size();
 		memManager.release(availableMemory);
-		allocatedFloatingNum -= (beforeReleaseNum - availableMemory.size());
 	}
 
 	@VisibleForTesting
@@ -502,8 +460,7 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 	}
 
 	public long getUsedMemoryInBytes() {
-		return (reservedNumBuffers + allocatedFloatingNum - availableMemory.size()) *
-				((long) memManager.getPageSize());
+		return (totalNumBuffers - availableMemory.size()) * ((long) memManager.getPageSize());
 	}
 
 	public long getNumSpillFiles() {
@@ -518,7 +475,7 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 	 * Give up to one-sixth of the memory of the bucket area.
 	 */
 	public int maxInitBufferOfBucketArea(int partitions) {
-		return Math.max(1, ((reservedNumBuffers - 2) / 6) / partitions);
+		return Math.max(1, ((totalNumBuffers - 2) / 6) / partitions);
 	}
 
 	protected List<MemorySegment> readAllBuffers(FileIOChannel.ID id, int blockCount) throws IOException {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/BinaryHashTable.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/BinaryHashTable.java
@@ -172,31 +172,6 @@ public class BinaryHashTable extends BaseHybridHashTable {
 			long reservedMemorySize,
 			IOManager ioManager,
 			int avgRecordLen,
-			int buildRowCount,
-			boolean useBloomFilters,
-			HashJoinType type,
-			JoinCondition condFunc,
-			boolean reverseJoin,
-			boolean[] filterNulls,
-			boolean tryDistinctBuildRow) {
-		this(conf, owner, buildSideSerializer, probeSideSerializer, buildSideProjection, probeSideProjection, memManager,
-				reservedMemorySize, reservedMemorySize, 0, ioManager, avgRecordLen, buildRowCount, useBloomFilters, type, condFunc,
-				reverseJoin, filterNulls, tryDistinctBuildRow);
-	}
-
-	public BinaryHashTable(
-			Configuration conf,
-			Object owner,
-			AbstractRowSerializer buildSideSerializer,
-			AbstractRowSerializer probeSideSerializer,
-			Projection<BaseRow, BinaryRow> buildSideProjection,
-			Projection<BaseRow, BinaryRow> probeSideProjection,
-			MemoryManager memManager,
-			long reservedMemorySize,
-			long preferredMemorySize,
-			long perRequestMemorySize,
-			IOManager ioManager,
-			int avgRecordLen,
 			long buildRowCount,
 			boolean useBloomFilters,
 			HashJoinType type,
@@ -204,7 +179,7 @@ public class BinaryHashTable extends BaseHybridHashTable {
 			boolean reverseJoin,
 			boolean[] filterNulls,
 			boolean tryDistinctBuildRow) {
-		super(conf, owner, memManager, reservedMemorySize, preferredMemorySize, perRequestMemorySize,
+		super(conf, owner, memManager, reservedMemorySize,
 				ioManager, avgRecordLen, buildRowCount, !type.buildLeftSemiOrAnti() && tryDistinctBuildRow);
 		// assign the members
 		this.originBuildSideSerializer = buildSideSerializer;
@@ -484,10 +459,10 @@ public class BinaryHashTable extends BaseHybridHashTable {
 		// 2) We can not guarantee that enough memory segments are available and read the partition
 		//    in, distributing its data among newly created partitions.
 		final int totalBuffersAvailable = this.availableMemory.size() + this.buildSpillRetBufferNumbers;
-		if (totalBuffersAvailable != this.reservedNumBuffers + this.allocatedFloatingNum) {
+		if (totalBuffersAvailable != this.totalNumBuffers) {
 			throw new RuntimeException(String.format("Hash Join bug in memory management: Memory buffers leaked." +
-					" availableMemory(%s), buildSpillRetBufferNumbers(%s), reservedNumBuffers(%s), allocatedFloatingNum(%s)",
-					availableMemory.size(), buildSpillRetBufferNumbers, reservedNumBuffers, allocatedFloatingNum));
+					" availableMemory(%s), buildSpillRetBufferNumbers(%s), reservedNumBuffers(%s)",
+					availableMemory.size(), buildSpillRetBufferNumbers, totalNumBuffers));
 		}
 
 		long numBuckets = p.getBuildSideRecordCount() / BinaryHashBucketArea.NUM_ENTRIES_PER_BUCKET + 1;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHybridHashTable.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHybridHashTable.java
@@ -68,13 +68,10 @@ public abstract class LongHybridHashTable extends BaseHybridHashTable {
 			BinaryRowSerializer probeSideSerializer,
 			MemoryManager memManager,
 			long reservedMemorySize,
-			long preferredMemorySize,
-			long perRequestMemorySize,
 			IOManager ioManager,
 			int avgRecordLen,
 			long buildRowCount) {
-		super(conf, owner, memManager, reservedMemorySize, preferredMemorySize, perRequestMemorySize,
-				ioManager, avgRecordLen, buildRowCount, false);
+		super(conf, owner, memManager, reservedMemorySize, ioManager, avgRecordLen, buildRowCount, false);
 		this.buildSideSerializer = buildSideSerializer;
 		this.probeSideSerializer = probeSideSerializer;
 
@@ -403,10 +400,10 @@ public abstract class LongHybridHashTable extends BaseHybridHashTable {
 		// 2) We can not guarantee that enough memory segments are available and read the partition
 		//    in, distributing its data among newly created partitions.
 		final int totalBuffersAvailable = this.availableMemory.size() + this.buildSpillRetBufferNumbers;
-		if (totalBuffersAvailable != this.reservedNumBuffers + this.allocatedFloatingNum) {
+		if (totalBuffersAvailable != this.totalNumBuffers) {
 			throw new RuntimeException(String.format("Hash Join bug in memory management: Memory buffers leaked." +
-							" availableMemory(%s), buildSpillRetBufferNumbers(%s), reservedNumBuffers(%s), allocatedFloatingNum(%s)",
-					availableMemory.size(), buildSpillRetBufferNumbers, reservedNumBuffers, allocatedFloatingNum));
+							" availableMemory(%s), buildSpillRetBufferNumbers(%s), reservedNumBuffers(%s)",
+					availableMemory.size(), buildSpillRetBufferNumbers, totalNumBuffers));
 		}
 
 		int maxBucketAreaBuffers = MathUtils.roundUpToPowerOfTwo(

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/TableStreamOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/TableStreamOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators;
 
+import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 
@@ -46,4 +47,13 @@ public class TableStreamOperator<OUT> extends AbstractStreamOperator<OUT> {
 		super.dispose();
 	}
 
+	/**
+	 * Compute memory size from memory faction.
+	 */
+	public long computeMemorySize() {
+		double memFraction = getOperatorConfig().getManagedMemoryFractionOnHeap() +
+				getOperatorConfig().getManagedMemoryFractionOffHeap();
+		MemoryManager memManager = getContainingTask().getEnvironment().getMemoryManager();
+		return ((long) memManager.computeNumberOfPages(memFraction)) * memManager.getPageSize();
+	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/TableStreamOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/TableStreamOperator.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.runtime.operators;
 
-import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 
@@ -51,9 +50,7 @@ public class TableStreamOperator<OUT> extends AbstractStreamOperator<OUT> {
 	 * Compute memory size from memory faction.
 	 */
 	public long computeMemorySize() {
-		double memFraction = getOperatorConfig().getManagedMemoryFractionOnHeap() +
-				getOperatorConfig().getManagedMemoryFractionOffHeap();
-		MemoryManager memManager = getContainingTask().getEnvironment().getMemoryManager();
-		return ((long) memManager.computeNumberOfPages(memFraction)) * memManager.getPageSize();
+		return getContainingTask().getEnvironment().getMemoryManager().computeMemorySize(
+				getOperatorConfig().getManagedMemoryFraction());
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/SortMergeJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/SortMergeJoinOperator.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.table.runtime.operators.join;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.metrics.Gauge;
@@ -27,6 +26,7 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.streaming.api.operators.BoundedMultiInput;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.BinaryRow;
 import org.apache.flink.table.dataformat.GenericRow;
@@ -64,8 +64,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class SortMergeJoinOperator extends TableStreamOperator<BaseRow>
 		implements TwoInputStreamOperator<BaseRow, BaseRow, BaseRow>, BoundedMultiInput {
 
-	private final long reservedSortMemory1;
-	private final long reservedSortMemory2;
+	private final double leftMemRatio;
 	private final long externalBufferMemory;
 	private final FlinkJoinType type;
 	private final boolean leftIsSmaller;
@@ -98,32 +97,15 @@ public class SortMergeJoinOperator extends TableStreamOperator<BaseRow>
 	private transient BaseRow rightNullRow;
 	private transient JoinedRow joinedRow;
 
-	@VisibleForTesting
 	public SortMergeJoinOperator(
-			long reservedSortMemory, long externalBufferMemory, FlinkJoinType type, boolean leftIsSmaller,
+			double leftMemRatio, long externalBufferMemory, FlinkJoinType type, boolean leftIsSmaller,
 			GeneratedJoinCondition condFuncCode,
 			GeneratedProjection projectionCode1, GeneratedProjection projectionCode2,
 			GeneratedNormalizedKeyComputer computer1, GeneratedRecordComparator comparator1,
 			GeneratedNormalizedKeyComputer computer2, GeneratedRecordComparator comparator2,
 			GeneratedRecordComparator genKeyComparator,
 			boolean[] filterNulls) {
-		this(reservedSortMemory, reservedSortMemory,
-				externalBufferMemory, type, leftIsSmaller, condFuncCode, projectionCode1, projectionCode2, computer1,
-				comparator1, computer2, comparator2, genKeyComparator, filterNulls);
-	}
-
-	public SortMergeJoinOperator(
-			long reservedSortMemory1,
-			long reservedSortMemory2,
-			long externalBufferMemory, FlinkJoinType type, boolean leftIsSmaller,
-			GeneratedJoinCondition condFuncCode,
-			GeneratedProjection projectionCode1, GeneratedProjection projectionCode2,
-			GeneratedNormalizedKeyComputer computer1, GeneratedRecordComparator comparator1,
-			GeneratedNormalizedKeyComputer computer2, GeneratedRecordComparator comparator2,
-			GeneratedRecordComparator genKeyComparator,
-			boolean[] filterNulls) {
-		this.reservedSortMemory1 = reservedSortMemory1;
-		this.reservedSortMemory2 = reservedSortMemory2;
+		this.leftMemRatio = leftMemRatio;
 		this.externalBufferMemory = externalBufferMemory;
 		this.type = type;
 		this.leftIsSmaller = leftIsSmaller;
@@ -158,16 +140,26 @@ public class SortMergeJoinOperator extends TableStreamOperator<BaseRow>
 		this.memManager = this.getContainingTask().getEnvironment().getMemoryManager();
 		this.ioManager = this.getContainingTask().getEnvironment().getIOManager();
 
+		long totalMemory = computeMemorySize();
+		long totalSortMem = totalMemory - externalBufferMemory;
+		if (totalSortMem < 0) {
+			throw new TableException("Memory size is too small: " +
+					totalMemory + ", please increase manage memory of task manager.");
+		}
+
+		long sortMemory1 = (long) (totalSortMem * leftMemRatio);
+		long sortMemory2 = totalSortMem - sortMemory1;
+
 		// sorter1
 		this.sorter1 = new BinaryExternalSorter(this.getContainingTask(),
-				memManager, reservedSortMemory1,
+				memManager, sortMemory1,
 				ioManager, inputSerializer1, serializer1,
 				computer1.newInstance(cl), comparator1.newInstance(cl), conf);
 		this.sorter1.startThreads();
 
 		// sorter2
 		this.sorter2 = new BinaryExternalSorter(this.getContainingTask(),
-				memManager, reservedSortMemory2, ioManager, inputSerializer2, serializer2,
+				memManager, sortMemory2, ioManager, inputSerializer2, serializer2,
 				computer2.newInstance(cl), comparator2.newInstance(cl), conf);
 		this.sorter2.startThreads();
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/BufferDataOverWindowOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/BufferDataOverWindowOperator.java
@@ -40,7 +40,6 @@ import org.apache.flink.table.runtime.util.StreamRecordCollector;
 public class BufferDataOverWindowOperator extends TableStreamOperator<BaseRow>
 		implements OneInputStreamOperator<BaseRow, BaseRow>, BoundedOneInput {
 
-	private final long memorySize;
 	private final OverWindowFrame[] overWindowFrames;
 	private GeneratedRecordComparator genComparator;
 	private final boolean isRowAllInFixedPart;
@@ -53,16 +52,13 @@ public class BufferDataOverWindowOperator extends TableStreamOperator<BaseRow>
 	private ResettableExternalBuffer currentData;
 
 	/**
-	 * @param memorySize           the memory is assigned to a resettable external buffer.
 	 * @param overWindowFrames     the window frames belong to this operator.
 	 * @param genComparator       the generated sort which is used for generating the comparator among
 	 */
 	public BufferDataOverWindowOperator(
-			long memorySize,
 			OverWindowFrame[] overWindowFrames,
 			GeneratedRecordComparator genComparator,
 			boolean isRowAllInFixedPart) {
-		this.memorySize = memorySize;
 		this.overWindowFrames = overWindowFrames;
 		this.genComparator = genComparator;
 		this.isRowAllInFixedPart = isRowAllInFixedPart;
@@ -81,7 +77,7 @@ public class BufferDataOverWindowOperator extends TableStreamOperator<BaseRow>
 		this.currentData = new ResettableExternalBuffer(
 				getContainingTask().getEnvironment().getMemoryManager(),
 				getContainingTask().getEnvironment().getIOManager(),
-				memManager.allocatePages(this, (int) (memorySize / memManager.getPageSize())),
+				memManager.allocatePages(this, (int) (computeMemorySize() / memManager.getPageSize())),
 				serializer, isRowAllInFixedPart);
 
 		collector = new StreamRecordCollector<>(output);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/SortOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/SortOperator.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.operators.sort;
 
 import org.apache.flink.metrics.Gauge;
+import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -45,7 +46,6 @@ public class SortOperator extends TableStreamOperator<BinaryRow>
 
 	private static final Logger LOG = LoggerFactory.getLogger(SortOperator.class);
 
-	private final long reservedMemorySize;
 	private GeneratedNormalizedKeyComputer gComputer;
 	private GeneratedRecordComparator gComparator;
 
@@ -53,9 +53,9 @@ public class SortOperator extends TableStreamOperator<BinaryRow>
 	private transient StreamRecordCollector<BinaryRow> collector;
 	private transient BinaryRowSerializer binarySerializer;
 
-	public SortOperator(long reservedMemorySize,
-			GeneratedNormalizedKeyComputer gComputer, GeneratedRecordComparator gComparator) {
-		this.reservedMemorySize = reservedMemorySize;
+	public SortOperator(
+			GeneratedNormalizedKeyComputer gComputer,
+			GeneratedRecordComparator gComparator) {
 		this.gComputer = gComputer;
 		this.gComparator = gComparator;
 	}
@@ -74,8 +74,10 @@ public class SortOperator extends TableStreamOperator<BinaryRow>
 		RecordComparator comparator = gComparator.newInstance(cl);
 		gComputer = null;
 		gComparator = null;
+
+		MemoryManager memManager = getContainingTask().getEnvironment().getMemoryManager();
 		this.sorter = new BinaryExternalSorter(this.getContainingTask(),
-				getContainingTask().getEnvironment().getMemoryManager(), reservedMemorySize,
+				memManager, computeMemorySize(),
 				this.getContainingTask().getEnvironment().getIOManager(), inputSerializer,
 				binarySerializer, computer, comparator, getContainingTask().getJobConfiguration());
 		this.sorter.startThreads();

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/hashtable/LongHashTableTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/hashtable/LongHashTableTest.java
@@ -89,9 +89,8 @@ public class LongHashTableTest {
 	private class MyHashTable extends LongHybridHashTable {
 
 		public MyHashTable(long memorySize) {
-			super(conf, LongHashTableTest.this, buildSideSerializer, probeSideSerializer, memManager, memorySize,
-					memorySize, 0, LongHashTableTest.this.ioManager,
-					24, 200000);
+			super(conf, LongHashTableTest.this, buildSideSerializer, probeSideSerializer, memManager,
+					memorySize, LongHashTableTest.this.ioManager, 24, 200000);
 		}
 
 		@Override

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/Int2HashJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/Int2HashJoinOperatorTest.java
@@ -266,6 +266,7 @@ public class Int2HashJoinOperatorTest implements Serializable {
 			testHarness.getStreamConfig().setStreamOperatorFactory((StreamOperatorFactory<?>) operator);
 		}
 		testHarness.getStreamConfig().setOperatorID(new OperatorID());
+		testHarness.getStreamConfig().setManagedMemoryFractionOnHeap(0.99);
 
 		testHarness.invoke();
 		testHarness.waitForTaskRunning();
@@ -398,7 +399,7 @@ public class Int2HashJoinOperatorTest implements Serializable {
 
 	public Object newOperator(long memorySize, HashJoinType type, boolean reverseJoinFunction) {
 		return HashJoinOperator.newHashJoinOperator(
-				memorySize, memorySize, 0, type,
+				type,
 				new GeneratedJoinCondition("", "", new Object[0]) {
 					@Override
 					public JoinCondition newInstance(ClassLoader classLoader) {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/Int2HashJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/Int2HashJoinOperatorTest.java
@@ -266,7 +266,7 @@ public class Int2HashJoinOperatorTest implements Serializable {
 			testHarness.getStreamConfig().setStreamOperatorFactory((StreamOperatorFactory<?>) operator);
 		}
 		testHarness.getStreamConfig().setOperatorID(new OperatorID());
-		testHarness.getStreamConfig().setManagedMemoryFractionOnHeap(0.99);
+		testHarness.getStreamConfig().setManagedMemoryFraction(0.99);
 
 		testHarness.invoke();
 		testHarness.waitForTaskRunning();

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/Int2SortMergeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/Int2SortMergeJoinOperatorTest.java
@@ -184,7 +184,7 @@ public class Int2SortMergeJoinOperatorTest {
 
 	static StreamOperator newOperator(FlinkJoinType type, boolean leftIsSmaller) {
 		return new SortMergeJoinOperator(
-				0.5, 1024 * 1024, type, leftIsSmaller,
+				1024 * 1024, type, leftIsSmaller,
 				new GeneratedJoinCondition("", "", new Object[0]) {
 					@Override
 					public JoinCondition newInstance(ClassLoader classLoader) {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/Int2SortMergeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/Int2SortMergeJoinOperatorTest.java
@@ -184,7 +184,7 @@ public class Int2SortMergeJoinOperatorTest {
 
 	static StreamOperator newOperator(FlinkJoinType type, boolean leftIsSmaller) {
 		return new SortMergeJoinOperator(
-				32 * 32 * 1024, 1024 * 1024, type, leftIsSmaller,
+				0.5, 1024 * 1024, type, leftIsSmaller,
 				new GeneratedJoinCondition("", "", new Object[0]) {
 					@Override
 					public JoinCondition newInstance(ClassLoader classLoader) {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/RandomSortMergeInnerJoinTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/RandomSortMergeInnerJoinTest.java
@@ -254,6 +254,7 @@ public class RandomSortMergeInnerJoinTest {
 		testHarness.setupOutputForSingletonOperatorChain();
 		testHarness.getStreamConfig().setStreamOperator(operator);
 		testHarness.getStreamConfig().setOperatorID(new OperatorID());
+		testHarness.getStreamConfig().setManagedMemoryFractionOnHeap(0.99);
 
 		long initialTime = 0L;
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/RandomSortMergeInnerJoinTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/RandomSortMergeInnerJoinTest.java
@@ -254,7 +254,7 @@ public class RandomSortMergeInnerJoinTest {
 		testHarness.setupOutputForSingletonOperatorChain();
 		testHarness.getStreamConfig().setStreamOperator(operator);
 		testHarness.getStreamConfig().setOperatorID(new OperatorID());
-		testHarness.getStreamConfig().setManagedMemoryFractionOnHeap(0.99);
+		testHarness.getStreamConfig().setManagedMemoryFraction(0.99);
 
 		long initialTime = 0L;
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/String2HashJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/String2HashJoinOperatorTest.java
@@ -84,6 +84,7 @@ public class String2HashJoinOperatorTest implements Serializable {
 		testHarness.setupOutputForSingletonOperatorChain();
 		testHarness.getStreamConfig().setStreamOperator(operator);
 		testHarness.getStreamConfig().setOperatorID(new OperatorID());
+		testHarness.getStreamConfig().setManagedMemoryFractionOnHeap(0.99);
 
 		testHarness.invoke();
 		testHarness.waitForTaskRunning();
@@ -292,7 +293,7 @@ public class String2HashJoinOperatorTest implements Serializable {
 
 	private HashJoinOperator newOperator(long memorySize, HashJoinType type, boolean reverseJoinFunction) {
 		return HashJoinOperator.newHashJoinOperator(
-				memorySize, memorySize, 0, type,
+				type,
 				new GeneratedJoinCondition("", "", new Object[0]) {
 					@Override
 					public JoinCondition newInstance(ClassLoader classLoader) {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/String2HashJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/String2HashJoinOperatorTest.java
@@ -84,7 +84,7 @@ public class String2HashJoinOperatorTest implements Serializable {
 		testHarness.setupOutputForSingletonOperatorChain();
 		testHarness.getStreamConfig().setStreamOperator(operator);
 		testHarness.getStreamConfig().setOperatorID(new OperatorID());
-		testHarness.getStreamConfig().setManagedMemoryFractionOnHeap(0.99);
+		testHarness.getStreamConfig().setManagedMemoryFraction(0.99);
 
 		testHarness.invoke();
 		testHarness.waitForTaskRunning();

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/String2SortMergeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/String2SortMergeJoinOperatorTest.java
@@ -147,6 +147,7 @@ public class String2SortMergeJoinOperatorTest {
 		testHarness.setupOutputForSingletonOperatorChain();
 		testHarness.getStreamConfig().setStreamOperator(operator);
 		testHarness.getStreamConfig().setOperatorID(new OperatorID());
+		testHarness.getStreamConfig().setManagedMemoryFractionOnHeap(0.99);
 
 		long initialTime = 0L;
 
@@ -167,7 +168,7 @@ public class String2SortMergeJoinOperatorTest {
 
 	static StreamOperator newOperator(FlinkJoinType type, boolean leftIsSmaller) {
 		return new SortMergeJoinOperator(
-				32 * 32 * 1024, 1024 * 1024, type, leftIsSmaller,
+				0.5, 1024 * 1024, type, leftIsSmaller,
 				new GeneratedJoinCondition("", "", new Object[0]) {
 					@Override
 					public JoinCondition newInstance(ClassLoader classLoader) {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/String2SortMergeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/String2SortMergeJoinOperatorTest.java
@@ -168,7 +168,7 @@ public class String2SortMergeJoinOperatorTest {
 
 	static StreamOperator newOperator(FlinkJoinType type, boolean leftIsSmaller) {
 		return new SortMergeJoinOperator(
-				0.5, 1024 * 1024, type, leftIsSmaller,
+				1024 * 1024, type, leftIsSmaller,
 				new GeneratedJoinCondition("", "", new Object[0]) {
 					@Override
 					public JoinCondition newInstance(ClassLoader classLoader) {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/String2SortMergeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/String2SortMergeJoinOperatorTest.java
@@ -147,7 +147,7 @@ public class String2SortMergeJoinOperatorTest {
 		testHarness.setupOutputForSingletonOperatorChain();
 		testHarness.getStreamConfig().setStreamOperator(operator);
 		testHarness.getStreamConfig().setOperatorID(new OperatorID());
-		testHarness.getStreamConfig().setManagedMemoryFractionOnHeap(0.99);
+		testHarness.getStreamConfig().setManagedMemoryFraction(0.99);
 
 		long initialTime = 0L;
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/BufferDataOverWindowOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/BufferDataOverWindowOperatorTest.java
@@ -177,7 +177,7 @@ public class BufferDataOverWindowOperatorTest {
 	}
 
 	private void test(OverWindowFrame[] frames, GenericRow[] expect) throws Exception {
-		operator = new BufferDataOverWindowOperator(MEMORY_SIZE, frames, comparator, true) {
+		operator = new BufferDataOverWindowOperator(frames, comparator, true) {
 			{
 				output = new NonBufferOverWindowOperatorTest.ConsumerOutput(new Consumer<BaseRow>() {
 					@Override
@@ -198,6 +198,8 @@ public class BufferDataOverWindowOperatorTest {
 				StreamConfig conf = mock(StreamConfig.class);
 				when(conf.<BaseRow>getTypeSerializerIn1(getUserCodeClassloader()))
 						.thenReturn(inputSer);
+				when(conf.getManagedMemoryFractionOnHeap())
+						.thenReturn(0.99);
 				return conf;
 			}
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/BufferDataOverWindowOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/BufferDataOverWindowOperatorTest.java
@@ -198,7 +198,7 @@ public class BufferDataOverWindowOperatorTest {
 				StreamConfig conf = mock(StreamConfig.class);
 				when(conf.<BaseRow>getTypeSerializerIn1(getUserCodeClassloader()))
 						.thenReturn(inputSer);
-				when(conf.getManagedMemoryFractionOnHeap())
+				when(conf.getManagedMemoryFraction())
 						.thenReturn(0.99);
 				return conf;
 			}


### PR DESCRIPTION

## What is the purpose of the change

Operators allocate memory segments with the amount returned by MemoryManager#computeNumberOfPages.
In this way, Operators can get more memory than expected, which will improve memory utilization.

## Brief change log

- Modify HashTable and LongHashTable
- Modify Agg BytesHashMap
- Modify SortOperator
- Modify SortMergeJoinOperator
- Modify NestedLoopJoin
- Modify over window agg

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no