### PR TITLE
[FLINK-14936][runtime] Introduce MemoryManager#computeMemorySize to calculate managed memory size from a fraction

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -585,6 +585,20 @@ public class MemoryManager {
 		return (int) (budgetByType.maxTotalNumberOfPages() * fraction);
 	}
 
+	/**
+	 * Computes the memory size corresponding to the fraction of all memory governed by this MemoryManager.
+	 *
+	 * @param fraction The fraction of all memory governed by this MemoryManager
+	 * @return The memory size corresponding to the memory fraction
+	 */
+	public long computeMemorySize(double fraction) {
+		Preconditions.checkArgument(
+			fraction > 0 && fraction <= 1,
+			"The fraction of memory to allocate must within (0, 1], was: %s", fraction);
+
+		return (long) (budgetByType.maxTotalBudget() * fraction);
+	}
+
 	private MemorySegment allocateManagedSegment(MemoryType memoryType, Object owner) {
 		switch (memoryType) {
 			case HEAP:

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerTest.java
@@ -40,6 +40,7 @@ import static org.apache.flink.runtime.memory.MemoryManager.AllocationRequest.of
 import static org.apache.flink.runtime.memory.MemoryManager.AllocationRequest.ofType;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.number.OrderingComparison.lessThanOrEqualTo;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -296,6 +297,30 @@ public class MemoryManagerTest {
 
 		memoryManager.releaseAll(owner1);
 		memoryManager.releaseAllMemory(owner2, type);
+	}
+
+	@Test
+	public void testComputeMemorySize() {
+		double fraction = 0.6;
+		assertEquals((long) (memoryManager.getMemorySize() * fraction), memoryManager.computeMemorySize(fraction));
+
+		fraction = 1.0;
+		assertEquals((long) (memoryManager.getMemorySize() * fraction), memoryManager.computeMemorySize(fraction));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testComputeMemorySizeFailForZeroFraction() {
+		memoryManager.computeMemorySize(0.0);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testComputeMemorySizeFailForTooLargeFraction() {
+		memoryManager.computeMemorySize(1.1);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testComputeMemorySizeFailForNegativeFraction() {
+		memoryManager.computeMemorySize(-0.1);
 	}
 
 	private void testCannotAllocateAnymore(AllocationRequest request) {


### PR DESCRIPTION
## What is the purpose of the change

A `MemoryManager#computeMemorySize(double fraction)` is needed to calculate managed memory bytes from a fraction.
It can be helpful for operators to get the memory size it can reserve and for further #reserveMemory. (Similar to `#computeNumberOfPages`).

Here are two cases that may need this method in near future:
1. Python operator memory management
2. Statebackend memory management

## Brief change log

  - *Added MemoryManager#computeMemorySize*


## Verifying this change

This change added tests and can be verified as follows:
  - *Added unit tests for MemoryManager#computeMemorySize*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
