### PR TITLE
[FLINK-14959][table-planner-blink] Support precision of LocalZonedTimestampType in blink planner

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LocalZonedTimestampType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LocalZonedTimestampType.java
@@ -64,7 +64,8 @@ public final class LocalZonedTimestampType extends LogicalType {
 	private static final Set<String> NULL_OUTPUT_CONVERSION = conversionSet(
 		java.time.Instant.class.getName(),
 		Integer.class.getName(),
-		Long.class.getName());
+		Long.class.getName(),
+		"org.apache.flink.table.dataformat.SqlTimestamp");
 
 	private static final Set<String> NOT_NULL_INPUT_OUTPUT_CONVERSION = conversionSet(
 		java.time.Instant.class.getName(),

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverter.java
@@ -148,7 +148,7 @@ public class ExpressionConverter implements ExpressionVisitor<RexNode> {
 					.unwrap(FlinkContext.class)
 					.getTableConfig()
 					.getLocalTimeZone());
-				Instant instant = extractValue(valueLiteral, java.time.Instant.class);
+				Instant instant = extractValue(valueLiteral, Instant.class);
 				return this.relBuilder.getRexBuilder().makeTimestampWithLocalTimeZoneLiteral(
 					fromLocalDateTime(LocalDateTime.ofInstant(instant, timeZone.toZoneId())),
 					lzTs.getPrecision());

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverter.java
@@ -63,7 +63,7 @@ import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromDataTypeToLogicalType;
-import static org.apache.flink.table.util.TimestampStringUtils.toTimestampString;
+import static org.apache.flink.table.util.TimestampStringUtils.fromLocalDateTime;
 
 /**
  * Visit expression to generator {@link RexNode}.
@@ -139,7 +139,7 @@ public class ExpressionConverter implements ExpressionVisitor<RexNode> {
 				TimestampType timestampType = (TimestampType) type;
 				LocalDateTime datetime = extractValue(valueLiteral, LocalDateTime.class);
 				return relBuilder.getRexBuilder().makeTimestampLiteral(
-					toTimestampString(datetime), timestampType.getPrecision());
+					fromLocalDateTime(datetime), timestampType.getPrecision());
 			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
 				LocalZonedTimestampType lzTs = (LocalZonedTimestampType) type;
 				TimeZone timeZone = TimeZone.getTimeZone(this.relBuilder.getCluster()
@@ -150,7 +150,7 @@ public class ExpressionConverter implements ExpressionVisitor<RexNode> {
 					.getLocalTimeZone());
 				Instant instant = extractValue(valueLiteral, java.time.Instant.class);
 				return this.relBuilder.getRexBuilder().makeTimestampWithLocalTimeZoneLiteral(
-					toTimestampString(LocalDateTime.ofInstant(instant, timeZone.toZoneId())),
+					fromLocalDateTime(LocalDateTime.ofInstant(instant, timeZone.toZoneId())),
 					lzTs.getPrecision());
 			case INTERVAL_YEAR_MONTH:
 				return this.relBuilder.getRexBuilder().makeIntervalLiteral(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/util/TimestampStringUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/util/TimestampStringUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.util;
+
+import org.apache.calcite.util.TimestampString;
+
+import java.time.LocalDateTime;
+
+/**
+ * Utility functions for calcite's {@link TimestampString}.
+ */
+public class TimestampStringUtils {
+
+	public static TimestampString toTimestampString(LocalDateTime ldt) {
+		return new TimestampString(
+			ldt.getYear(),
+			ldt.getMonthValue(),
+			ldt.getDayOfMonth(),
+			ldt.getHour(),
+			ldt.getMinute(),
+			ldt.getSecond()).withNanos(ldt.getNano());
+	}
+
+	public static LocalDateTime fromTimestampString(TimestampString timestampString) {
+		final String v = timestampString.toString();
+		final int year = Integer.valueOf(v.substring(0, 4));
+		final int month = Integer.valueOf(v.substring(5, 7));
+		final int day = Integer.valueOf(v.substring(8, 10));
+		final int h = Integer.valueOf(v.substring(11, 13));
+		final int m = Integer.valueOf(v.substring(14, 16));
+		final int s = Integer.valueOf(v.substring(17, 19));
+		final int nano = getNanosInSecond(v);
+		return LocalDateTime.of(year, month, day, h, m, s, nano);
+	}
+
+	private static int getNanosInSecond(String v) {
+		switch (v.length()) {
+			case 19: // "1999-12-31 12:34:56"
+				return 0;
+			default:  // "1999-12-31 12:34:56.789123456"
+				return Integer.valueOf(v.substring(20))
+					* (int) Math.pow(10, 9 - (v.length() - 20));
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/util/TimestampStringUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/util/TimestampStringUtils.java
@@ -27,7 +27,7 @@ import java.time.LocalDateTime;
  */
 public class TimestampStringUtils {
 
-	public static TimestampString toTimestampString(LocalDateTime ldt) {
+	public static TimestampString fromLocalDateTime(LocalDateTime ldt) {
 		return new TimestampString(
 			ldt.getYear(),
 			ldt.getMonthValue(),
@@ -37,7 +37,7 @@ public class TimestampStringUtils {
 			ldt.getSecond()).withNanos(ldt.getNano());
 	}
 
-	public static LocalDateTime fromTimestampString(TimestampString timestampString) {
+	public static LocalDateTime toLocalDateTime(TimestampString timestampString) {
 		final String v = timestampString.toString();
 		final int year = Integer.valueOf(v.substring(0, 4));
 		final int month = Integer.valueOf(v.substring(5, 7));

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
@@ -76,7 +76,8 @@ class FlinkTypeFactory(typeSystem: RelDataTypeSystem) extends JavaTypeFactoryImp
       case LogicalTypeRoot.DATE => createSqlType(DATE)
       case LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE => createSqlType(TIME)
       case LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
-        createSqlType(TIMESTAMP_WITH_LOCAL_TIME_ZONE)
+        val lzTs = t.asInstanceOf[LocalZonedTimestampType]
+        createSqlType(TIMESTAMP_WITH_LOCAL_TIME_ZONE, lzTs.getPrecision)
 
       // interval types
       case LogicalTypeRoot.INTERVAL_YEAR_MONTH =>
@@ -438,12 +439,7 @@ object FlinkTypeFactory {
       case TIMESTAMP =>
         new TimestampType(relDataType.getPrecision)
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
-        if (relDataType.getPrecision > 3) {
-          throw new TableException(
-            s"TIMESTAMP_WITH_LOCAL_TIME_ZONE precision is not supported:" +
-                s" ${relDataType.getPrecision}")
-        }
-        new LocalZonedTimestampType(3)
+        new LocalZonedTimestampType(relDataType.getPrecision)
       case typeName if YEAR_INTERVAL_TYPES.contains(typeName) =>
         DataTypes.INTERVAL(DataTypes.MONTH).getLogicalType
       case typeName if DAY_INTERVAL_TYPES.contains(typeName) =>

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeSystem.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeSystem.scala
@@ -44,9 +44,10 @@ class FlinkTypeSystem extends RelDataTypeSystemImpl {
     case SqlTypeName.TIMESTAMP =>
       TimestampType.DEFAULT_PRECISION
 
-    // we currently support only timestamp with local time zone with milliseconds precision
+    // by default we support timestamp with local time zone with microseconds precision
+    // Timestamp(6) with local time zone
     case SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
-      3
+      LocalZonedTimestampType.DEFAULT_PRECISION
 
     case _ =>
       super.getDefaultPrecision(typeName)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeSystem.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeSystem.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.calcite
 
 import org.apache.flink.table.runtime.typeutils.TypeCheckUtils
-import org.apache.flink.table.types.logical.{DecimalType, LogicalType, TimestampType}
+import org.apache.flink.table.types.logical.{DecimalType, LocalZonedTimestampType, LogicalType, TimestampType}
 import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeFactory, RelDataTypeSystemImpl}
 import org.apache.calcite.sql.`type`.{SqlTypeName, SqlTypeUtil}
 
@@ -59,6 +59,10 @@ class FlinkTypeSystem extends RelDataTypeSystemImpl {
     // The maximum precision of TIMESTAMP is 3 in Calcite,
     // change it to 9 to support nanoseconds precision
     case SqlTypeName.TIMESTAMP => TimestampType.MAX_PRECISION
+
+    // The maximum precision of TIMESTAMP_WITH_LOCAL_TIME_ZONE is 3 in Calcite,
+    // change it to 9 to support nanoseconds precision
+    case SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE => LocalZonedTimestampType.MAX_PRECISION
 
     case _ =>
       super.getMaxPrecision(typeName)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -167,17 +167,6 @@ object CodeGenUtils {
     case RAW => className[BinaryGeneric[_]]
   }
 
-  def boxedTypeForUnboxType(clazz: Class[_]): Class[_] = clazz match {
-    case JBoolean.TYPE => classOf[JBoolean]
-    case JByte.TYPE => classOf[JByte]
-    case JShort.TYPE => classOf[JShort]
-    case JInt.TYPE => classOf[JInt]
-    case JLong.TYPE => classOf[JLong]
-    case JFloat.TYPE => classOf[JFloat]
-    case JDouble.TYPE => classOf[JDouble]
-    case _ => clazz
-  }
-
   /**
     * Gets the boxed type term from external type info.
     * We only use TypeInformation to store external type info.

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -167,6 +167,17 @@ object CodeGenUtils {
     case RAW => className[BinaryGeneric[_]]
   }
 
+  def boxedTypeForUnboxType(clazz: Class[_]): Class[_] = clazz match {
+    case JBoolean.TYPE => classOf[JBoolean]
+    case JByte.TYPE => classOf[JByte]
+    case JShort.TYPE => classOf[JShort]
+    case JInt.TYPE => classOf[JInt]
+    case JLong.TYPE => classOf[JLong]
+    case JFloat.TYPE => classOf[JFloat]
+    case JDouble.TYPE => classOf[JDouble]
+    case _ => clazz
+  }
+
   /**
     * Gets the boxed type term from external type info.
     * We only use TypeInformation to store external type info.

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
@@ -389,7 +389,8 @@ class ExprCodeGenerator(ctx: CodeGeneratorContext, nullableInput: Boolean)
   override def visitLiteral(literal: RexLiteral): GeneratedExpression = {
     val resultType = FlinkTypeFactory.toLogicalType(literal.getType)
     val value = resultType.getTypeRoot match {
-      case LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE =>
+      case LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE |
+           LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
         literal.getValueAs(classOf[TimestampString])
       case _ =>
         literal.getValue3

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
@@ -156,7 +156,7 @@ class ExpressionReducer(
           case SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
             val reducedValue = reduced.getField(reducedIdx)
             val value = if (reducedValue != null) {
-              val ins = reduced.getField(reducedIdx).asInstanceOf[SqlTimestamp].toInstant
+              val ins = reducedValue.asInstanceOf[SqlTimestamp].toInstant
               val dt = LocalDateTime.ofInstant(ins, config.getLocalTimeZone)
               toTimestampString(dt)
             } else {
@@ -234,7 +234,7 @@ class ExpressionReducer(
       true)
   }
 
-  def toTimestampString(ldt: LocalDateTime): TimestampString = {
+  private def toTimestampString(ldt: LocalDateTime): TimestampString = {
     new TimestampString(
       ldt.getYear,
       ldt.getMonthValue,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
@@ -28,16 +28,14 @@ import org.apache.flink.table.functions.{FunctionContext, UserDefinedFunction}
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.codegen.FunctionCodeGenerator.generateFunction
 import org.apache.flink.table.planner.plan.utils.PythonUtil.containsPythonCall
-import org.apache.flink.table.runtime.functions.SqlDateTimeUtils
 import org.apache.flink.table.types.logical.RowType
+import org.apache.flink.table.util.TimestampStringUtils.toTimestampString
 import org.apache.calcite.avatica.util.ByteString
 import org.apache.calcite.rex.{RexBuilder, RexExecutor, RexNode}
 import org.apache.calcite.sql.`type`.SqlTypeName
-import org.apache.calcite.util.TimestampString
 import org.apache.commons.lang3.StringEscapeUtils
 import java.io.File
 import java.time.LocalDateTime
-import java.util.TimeZone
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
@@ -232,16 +230,6 @@ class ExpressionReducer(
       valueArg,
       targetType,
       true)
-  }
-
-  private def toTimestampString(ldt: LocalDateTime): TimestampString = {
-    new TimestampString(
-      ldt.getYear,
-      ldt.getMonthValue,
-      ldt.getDayOfMonth,
-      ldt.getHour,
-      ldt.getMinute,
-      ldt.getSecond).withNanos(ldt.getNano)
   }
 }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
@@ -154,7 +154,7 @@ class ExpressionReducer(
             reducedIdx += 1
           case SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
             val value = if (!reduced.isNullAt(reducedIdx)) {
-              val mills = reduced.getField(reducedIdx).asInstanceOf[Long]
+              val mills = reduced.getField(reducedIdx).asInstanceOf[SqlTimestamp].getMillisecond
               Long.box(SqlDateTimeUtils.timestampWithLocalZoneToTimestamp(
                 mills, TimeZone.getTimeZone(config.getLocalTimeZone)))
             } else {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.codegen.FunctionCodeGenerator.generateFunction
 import org.apache.flink.table.planner.plan.utils.PythonUtil.containsPythonCall
 import org.apache.flink.table.types.logical.RowType
-import org.apache.flink.table.util.TimestampStringUtils.toTimestampString
+import org.apache.flink.table.util.TimestampStringUtils.fromLocalDateTime
 import org.apache.calcite.avatica.util.ByteString
 import org.apache.calcite.rex.{RexBuilder, RexExecutor, RexNode}
 import org.apache.calcite.sql.`type`.SqlTypeName
@@ -156,7 +156,7 @@ class ExpressionReducer(
             val value = if (reducedValue != null) {
               val ins = reducedValue.asInstanceOf[SqlTimestamp].toInstant
               val dt = LocalDateTime.ofInstant(ins, config.getLocalTimeZone)
-              toTimestampString(dt)
+              fromLocalDateTime(dt)
             } else {
               reducedValue
             }
@@ -175,7 +175,7 @@ class ExpressionReducer(
             val reducedValue = reduced.getField(reducedIdx)
             val value = if (reducedValue != null) {
               val dt = reducedValue.asInstanceOf[SqlTimestamp].toLocalDateTime
-              toTimestampString(dt)
+              fromLocalDateTime(dt)
             } else {
               reducedValue
             }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -387,12 +387,16 @@ object GenerateUtils {
 
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
         val fieldTerm = newName("timestampWithLocalZone")
-        val millis = unixTimestampToLocalDateTime(literalValue.asInstanceOf[Long])
+        val millis = unixTimestampToLocalDateTime(
+              literalValue.asInstanceOf[TimestampString].getMillisSinceEpoch)
             .atZone(ctx.tableConfig.getLocalTimeZone)
             .toInstant.toEpochMilli
+        val nanoOfMillis = SqlDateTimeUtils.getNanoOfMillisSinceEpoch(
+          literalValue.asInstanceOf[TimestampString].toString)
         val fieldTimestampWithLocalZone =
           s"""
-             |$SQL_TIMESTAMP $fieldTerm = $SQL_TIMESTAMP.fromEpochMillis(${millis}L);
+             |$SQL_TIMESTAMP $fieldTerm =
+             |  $SQL_TIMESTAMP.fromEpochMillis(${millis}L, $nanoOfMillis);
            """.stripMargin
         ctx.addReusableMember(fieldTimestampWithLocalZone)
         generateNonNullLiteral(literalType, fieldTerm, literalValue)
@@ -678,7 +682,7 @@ object GenerateUtils {
       leftTerm: String,
       rightTerm: String): String = t.getTypeRoot match {
     case BOOLEAN => s"($leftTerm == $rightTerm ? 0 : ($leftTerm ? 1 : -1))"
-    case DATE | TIME_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
+    case DATE | TIME_WITHOUT_TIME_ZONE =>
       s"($leftTerm > $rightTerm ? 1 : $leftTerm < $rightTerm ? -1 : 0)"
     case _ if PlannerTypeUtils.isPrimitive(t) =>
       s"($leftTerm > $rightTerm ? 1 : $leftTerm < $rightTerm ? -1 : 0)"

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -26,19 +26,16 @@ import org.apache.flink.table.planner.codegen.CodeGenUtils._
 import org.apache.flink.table.planner.codegen.GeneratedExpression.{ALWAYS_NULL, NEVER_NULL, NO_CODE}
 import org.apache.flink.table.planner.codegen.calls.CurrentTimePointCallGen
 import org.apache.flink.table.planner.plan.utils.SortUtil
-import org.apache.flink.table.runtime.functions.SqlDateTimeUtils
-import org.apache.flink.table.runtime.functions.SqlDateTimeUtils.unixTimestampToLocalDateTime
 import org.apache.flink.table.runtime.types.PlannerTypeUtils
 import org.apache.flink.table.runtime.typeutils.TypeCheckUtils.{isCharacterString, isReference, isTemporal}
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical._
-
 import org.apache.calcite.avatica.util.ByteString
 import org.apache.calcite.util.TimestampString
-
 import org.apache.commons.lang3.StringEscapeUtils
 import java.math.{BigDecimal => JBigDecimal}
 
+import org.apache.flink.table.util.TimestampStringUtils.fromTimestampString
 
 import scala.collection.mutable
 
@@ -374,29 +371,26 @@ object GenerateUtils {
 
       case TIMESTAMP_WITHOUT_TIME_ZONE =>
         val fieldTerm = newName("timestamp")
-        val millis = literalValue.asInstanceOf[TimestampString].getMillisSinceEpoch
-        val nanoOfMillis = SqlDateTimeUtils.getNanoOfMillisSinceEpoch(
-          literalValue.asInstanceOf[TimestampString].toString)
+        val ldt = fromTimestampString(literalValue.asInstanceOf[TimestampString])
+        val ts = SqlTimestamp.fromLocalDateTime(ldt)
         val fieldTimestamp =
           s"""
              |$SQL_TIMESTAMP $fieldTerm =
-             |  $SQL_TIMESTAMP.fromEpochMillis(${millis}L, $nanoOfMillis);
+             |  $SQL_TIMESTAMP.fromEpochMillis(${ts.getMillisecond}L, ${ts.getNanoOfMillisecond});
            """.stripMargin
         ctx.addReusableMember(fieldTimestamp)
         generateNonNullLiteral(literalType, fieldTerm, literalType)
 
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
         val fieldTerm = newName("timestampWithLocalZone")
-        val millis = unixTimestampToLocalDateTime(
-              literalValue.asInstanceOf[TimestampString].getMillisSinceEpoch)
-            .atZone(ctx.tableConfig.getLocalTimeZone)
-            .toInstant.toEpochMilli
-        val nanoOfMillis = SqlDateTimeUtils.getNanoOfMillisSinceEpoch(
-          literalValue.asInstanceOf[TimestampString].toString)
+        val ins =
+          fromTimestampString(literalValue.asInstanceOf[TimestampString])
+          .atZone(ctx.tableConfig.getLocalTimeZone).toInstant
+        val ts = SqlTimestamp.fromInstant(ins)
         val fieldTimestampWithLocalZone =
           s"""
              |$SQL_TIMESTAMP $fieldTerm =
-             |  $SQL_TIMESTAMP.fromEpochMillis(${millis}L, $nanoOfMillis);
+             |  $SQL_TIMESTAMP.fromEpochMillis(${ts.getMillisecond}L, ${ts.getNanoOfMillisecond});
            """.stripMargin
         ctx.addReusableMember(fieldTimestampWithLocalZone)
         generateNonNullLiteral(literalType, fieldTerm, literalValue)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -35,7 +35,7 @@ import org.apache.calcite.util.TimestampString
 import org.apache.commons.lang3.StringEscapeUtils
 import java.math.{BigDecimal => JBigDecimal}
 
-import org.apache.flink.table.util.TimestampStringUtils.fromTimestampString
+import org.apache.flink.table.util.TimestampStringUtils.toLocalDateTime
 
 import scala.collection.mutable
 
@@ -371,7 +371,7 @@ object GenerateUtils {
 
       case TIMESTAMP_WITHOUT_TIME_ZONE =>
         val fieldTerm = newName("timestamp")
-        val ldt = fromTimestampString(literalValue.asInstanceOf[TimestampString])
+        val ldt = toLocalDateTime(literalValue.asInstanceOf[TimestampString])
         val ts = SqlTimestamp.fromLocalDateTime(ldt)
         val fieldTimestamp =
           s"""
@@ -384,7 +384,7 @@ object GenerateUtils {
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
         val fieldTerm = newName("timestampWithLocalZone")
         val ins =
-          fromTimestampString(literalValue.asInstanceOf[TimestampString])
+          toLocalDateTime(literalValue.asInstanceOf[TimestampString])
           .atZone(ctx.tableConfig.getLocalTimeZone).toInstant
         val ts = SqlTimestamp.fromInstant(ins)
         val fieldTimestampWithLocalZone =

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -386,10 +386,16 @@ object GenerateUtils {
         generateNonNullLiteral(literalType, fieldTerm, literalType)
 
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
+        val fieldTerm = newName("timestampWithLocalZone")
         val millis = unixTimestampToLocalDateTime(literalValue.asInstanceOf[Long])
             .atZone(ctx.tableConfig.getLocalTimeZone)
             .toInstant.toEpochMilli
-        generateNonNullLiteral(literalType, millis + "L", literalValue)
+        val fieldTimestampWithLocalZone =
+          s"""
+             |$SQL_TIMESTAMP $fieldTerm = $SQL_TIMESTAMP.fromEpochMillis(${millis}L);
+           """.stripMargin
+        ctx.addReusableMember(fieldTimestampWithLocalZone)
+        generateNonNullLiteral(literalType, fieldTerm, literalValue)
 
       case INTERVAL_YEAR_MONTH =>
         val decimal = BigDecimal(literalValue.asInstanceOf[JBigDecimal])

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/LongHashJoinGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/LongHashJoinGenerator.scala
@@ -52,10 +52,10 @@ object LongHashJoinGenerator {
              TIME_WITHOUT_TIME_ZONE => true
         case TIMESTAMP_WITHOUT_TIME_ZONE =>
           val timestampType = keyType.getTypeAt(0).asInstanceOf[TimestampType]
-          if (SqlTimestamp.isCompact(timestampType.getPrecision)) true else false
+          SqlTimestamp.isCompact(timestampType.getPrecision)
         case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
           val lzTs = keyType.getTypeAt(0).asInstanceOf[LocalZonedTimestampType]
-          if (SqlTimestamp.isCompact(lzTs.getPrecision)) true else false
+          SqlTimestamp.isCompact(lzTs.getPrecision)
         case _ => false
       }
       // TODO decimal and multiKeys support.
@@ -73,6 +73,7 @@ object LongHashJoinGenerator {
     val term = singleType.getTypeRoot match {
       case FLOAT => s"Float.floatToIntBits($getCode)"
       case DOUBLE => s"Double.doubleToLongBits($getCode)"
+      case TIMESTAMP_WITH_LOCAL_TIME_ZONE => s"$getCode.getMillisecond()"
       case _ => getCode
     }
     s"return $term;"

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/LongHashJoinGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/LongHashJoinGenerator.scala
@@ -49,10 +49,13 @@ object LongHashJoinGenerator {
         keyType.getFieldCount == 1 && {
       keyType.getTypeAt(0).getTypeRoot match {
         case BIGINT | INTEGER | SMALLINT | TINYINT | FLOAT | DOUBLE | DATE |
-             TIME_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE => true
+             TIME_WITHOUT_TIME_ZONE => true
         case TIMESTAMP_WITHOUT_TIME_ZONE =>
           val timestampType = keyType.getTypeAt(0).asInstanceOf[TimestampType]
           if (SqlTimestamp.isCompact(timestampType.getPrecision)) true else false
+        case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
+          val lzTs = keyType.getTypeAt(0).asInstanceOf[LocalZonedTimestampType]
+          if (SqlTimestamp.isCompact(lzTs.getPrecision)) true else false
         case _ => false
       }
       // TODO decimal and multiKeys support.

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -251,7 +251,11 @@ object BuiltInMethods {
     classOf[SqlDateTimeUtils], "dateFormat", classOf[String], classOf[String], classOf[TimeZone])
 
   val DATE_FORMAT_TIMESTAMP_STRING_TIME_ZONE = Types.lookupMethod(
-    classOf[SqlDateTimeUtils], "dateFormat", classOf[SqlTimestamp], classOf[String], classOf[TimeZone])
+    classOf[SqlDateTimeUtils],
+    "dateFormat",
+    classOf[SqlTimestamp],
+    classOf[String],
+    classOf[TimeZone])
 
   val DATE_FORMAT_STIRNG_STRING = Types.lookupMethod(
     classOf[SqlDateTimeUtils], "dateFormat", classOf[String], classOf[String])

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -250,8 +250,8 @@ object BuiltInMethods {
   val DATE_FORMAT_STIRNG_STRING_TIME_ZONE = Types.lookupMethod(
     classOf[SqlDateTimeUtils], "dateFormat", classOf[String], classOf[String], classOf[TimeZone])
 
-  val DATE_FORMAT_LONG_STRING_TIME_ZONE = Types.lookupMethod(
-    classOf[SqlDateTimeUtils], "dateFormat", classOf[Long], classOf[String], classOf[TimeZone])
+  val DATE_FORMAT_TIMESTAMP_STRING_TIME_ZONE = Types.lookupMethod(
+    classOf[SqlDateTimeUtils], "dateFormat", classOf[SqlTimestamp], classOf[String], classOf[TimeZone])
 
   val DATE_FORMAT_STIRNG_STRING = Types.lookupMethod(
     classOf[SqlDateTimeUtils], "dateFormat", classOf[String], classOf[String])

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -223,17 +223,17 @@ object BuiltInMethods {
   val TIMESTAMP_TO_STRING_TIME_ZONE = Types.lookupMethod(
     classOf[SqlDateTimeUtils],
     "timestampToString",
-    classOf[Long], classOf[Int], classOf[TimeZone])
+    classOf[SqlTimestamp], classOf[TimeZone])
 
   val TIMESTAMP_TO_TIMESTAMP_WITH_LOCAL_ZONE = Types.lookupMethod(
     classOf[SqlDateTimeUtils],
     "timestampToTimestampWithLocalZone",
-    classOf[Long], classOf[TimeZone])
+    classOf[SqlTimestamp], classOf[TimeZone])
 
   val TIMESTAMP_WITH_LOCAL_ZONE_TO_TIMESTAMP = Types.lookupMethod(
     classOf[SqlDateTimeUtils],
     "timestampWithLocalZoneToTimestamp",
-    classOf[Long], classOf[TimeZone])
+    classOf[SqlTimestamp], classOf[TimeZone])
 
   val STRING_TO_DATE_WITH_FORMAT = Types.lookupMethod(
     classOf[SqlDateTimeUtils],
@@ -392,12 +392,7 @@ object BuiltInMethods {
   val EXTRACT_FROM_TIMESTAMP_TIME_ZONE = Types.lookupMethod(
     classOf[SqlDateTimeUtils],
     "extractFromTimestamp",
-    classOf[TimeUnitRange], classOf[Long], classOf[TimeZone])
-
-  val EXTRACT_FROM_DATE = Types.lookupMethod(
-    classOf[SqlDateTimeUtils],
-    "extractFromDate",
-    classOf[TimeUnitRange], classOf[Long])
+    classOf[TimeUnitRange], classOf[SqlTimestamp], classOf[TimeZone])
 
   val UNIX_TIME_EXTRACT = Types.lookupMethod(
     classOf[SqlDateTimeUtils],

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FloorCeilCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FloorCeilCallGen.scala
@@ -70,10 +70,12 @@ class FloorCeilCallGen(
               if terms.length + 1 == method.getParameterCount &&
                 method.getParameterTypes()(terms.length) == classOf[TimeZone] =>
               val timeZone = ctx.addReusableTimeZone()
+              val longTerm = s"${terms.head}.getMillisecond()"
               s"""
-                 |($internalType) ${qualifyMethod(temporalMethod.get)}(${terms(1)},
-                 |                                                     ${terms.head},
-                 |                                                     $timeZone)
+                 |$SQL_TIMESTAMP.fromEpochMillis(
+                 |  ${qualifyMethod(temporalMethod.get)}(${terms(1)},
+                 |  $longTerm,
+                 |  $timeZone))
                  |""".stripMargin
 
             // for Unix Date / Unix Time

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/MethodCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/MethodCallGen.scala
@@ -18,10 +18,10 @@
 
 package org.apache.flink.table.planner.codegen.calls
 
-import org.apache.flink.table.planner.codegen.CodeGenUtils.{BINARY_STRING, qualifyMethod}
+import org.apache.flink.table.planner.codegen.CodeGenUtils.{BINARY_STRING, qualifyMethod, SQL_TIMESTAMP}
 import org.apache.flink.table.planner.codegen.GenerateUtils.generateCallIfArgsNotNull
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, GeneratedExpression}
-import org.apache.flink.table.types.logical.{LogicalType}
+import org.apache.flink.table.types.logical.{LogicalType, LogicalTypeRoot}
 import java.lang.reflect.Method
 import java.util.TimeZone
 
@@ -33,13 +33,19 @@ class MethodCallGen(method: Method) extends CallGenerator {
       returnType: LogicalType): GeneratedExpression = {
     generateCallIfArgsNotNull(ctx, returnType, operands, !method.getReturnType.isPrimitive) {
       originalTerms => {
-        val terms = originalTerms.zip(method.getParameterTypes).map { case (term, clazz) =>
-          // convert the BinaryString parameter to String if the method parameter accept String
-          if (clazz == classOf[String]) {
-            s"$term.toString()"
-          } else {
-            term
-          }
+        val terms = originalTerms.zipWithIndex.zip(method.getParameterTypes).map {
+          case ((term, i), clazz) =>
+            // convert the BinaryString parameter to String if the method parameter accept String
+            if (clazz == classOf[String]) {
+              s"$term.toString()"
+            } else if ((clazz == classOf[Long] || clazz == classOf[java.lang.Long]) &&
+                operands(i).resultType.getTypeRoot
+                  == LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE) {
+              // convert the SqlTimestamp parameter to Long if the method parameter accept Long
+              s"$term.getMillisecond()"
+            } else {
+              term
+            }
         }
 
         // generate method invoke code and adapt when it's a time zone related function
@@ -59,6 +65,11 @@ class MethodCallGen(method: Method) extends CallGenerator {
         // convert String to BinaryString if the return type is String
         if (method.getReturnType == classOf[String]) {
           s"$BINARY_STRING.fromString($call)"
+        } else if ((method.getReturnType == classOf[Long]
+            || method.getReturnType == classOf[java.lang.Long]) &&
+            returnType.getTypeRoot == LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE) {
+          // convert Long to SqlTimestamp if the return type is Timestamp with local time zone
+          s"$SQL_TIMESTAMP.fromEpochMillis($call)"
         } else {
           call
         }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/MethodCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/MethodCallGen.scala
@@ -34,12 +34,12 @@ class MethodCallGen(method: Method) extends CallGenerator {
     generateCallIfArgsNotNull(ctx, returnType, operands, !method.getReturnType.isPrimitive) {
       originalTerms => {
         val terms = originalTerms.zip(method.getParameterTypes).map { case (term, clazz) =>
-            // convert the BinaryString parameter to String if the method parameter accept String
-            if (clazz == classOf[String]) {
-              s"$term.toString()"
-            } else {
-              term
-            }
+          // convert the BinaryString parameter to String if the method parameter accept String
+          if (clazz == classOf[String]) {
+            s"$term.toString()"
+          } else {
+            term
+          }
         }
 
         // generate method invoke code and adapt when it's a time zone related function

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/MethodCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/MethodCallGen.scala
@@ -18,10 +18,10 @@
 
 package org.apache.flink.table.planner.codegen.calls
 
-import org.apache.flink.table.planner.codegen.CodeGenUtils.{BINARY_STRING, qualifyMethod, SQL_TIMESTAMP}
+import org.apache.flink.table.planner.codegen.CodeGenUtils.{BINARY_STRING, qualifyMethod}
 import org.apache.flink.table.planner.codegen.GenerateUtils.generateCallIfArgsNotNull
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, GeneratedExpression}
-import org.apache.flink.table.types.logical.{LogicalType, LogicalTypeRoot}
+import org.apache.flink.table.types.logical.LogicalType
 import java.lang.reflect.Method
 import java.util.TimeZone
 
@@ -33,16 +33,10 @@ class MethodCallGen(method: Method) extends CallGenerator {
       returnType: LogicalType): GeneratedExpression = {
     generateCallIfArgsNotNull(ctx, returnType, operands, !method.getReturnType.isPrimitive) {
       originalTerms => {
-        val terms = originalTerms.zipWithIndex.zip(method.getParameterTypes).map {
-          case ((term, i), clazz) =>
+        val terms = originalTerms.zip(method.getParameterTypes).map { case (term, clazz) =>
             // convert the BinaryString parameter to String if the method parameter accept String
             if (clazz == classOf[String]) {
               s"$term.toString()"
-            } else if ((clazz == classOf[Long] || clazz == classOf[java.lang.Long]) &&
-                operands(i).resultType.getTypeRoot
-                  == LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE) {
-              // convert the SqlTimestamp parameter to Long if the method parameter accept Long
-              s"$term.getMillisecond()"
             } else {
               term
             }
@@ -65,11 +59,6 @@ class MethodCallGen(method: Method) extends CallGenerator {
         // convert String to BinaryString if the return type is String
         if (method.getReturnType == classOf[String]) {
           s"$BINARY_STRING.fromString($call)"
-        } else if ((method.getReturnType == classOf[Long]
-            || method.getReturnType == classOf[java.lang.Long]) &&
-            returnType.getTypeRoot == LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE) {
-          // convert Long to SqlTimestamp if the return type is Timestamp with local time zone
-          s"$SQL_TIMESTAMP.fromEpochMillis($call)"
         } else {
           call
         }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -999,7 +999,7 @@ object ScalarOperatorGens {
         ctx, targetType, operand, resultNullable = true) { operandTerm =>
         val zone = ctx.addReusableTimeZone()
         val method = qualifyMethod(BuiltInMethods.STRING_TO_TIMESTAMP_TIME_ZONE)
-        s"$method($operandTerm.toString(), $zone)"
+        s"$SQL_TIMESTAMP.fromEpochMillis($method($operandTerm.toString(), $zone))"
       }
 
     // String -> binary
@@ -1092,7 +1092,7 @@ object ScalarOperatorGens {
       generateUnaryOperatorIfNotNull(ctx, targetType, operand) { operandTerm =>
         val zone = ctx.addReusableTimeZone()
         val method = qualifyMethod(BuiltInMethods.DATE_TO_TIMESTAMP_WITH_LOCAL_TIME_ZONE)
-        s"$method($operandTerm, $zone)"
+        s"$SQL_TIMESTAMP.fromEpochMillis($method($operandTerm, $zone))"
       }
 
     // Timestamp with local time zone -> Date
@@ -1100,7 +1100,7 @@ object ScalarOperatorGens {
       generateUnaryOperatorIfNotNull(ctx, targetType, operand) { operandTerm =>
         val zone = ctx.addReusableTimeZone()
         val method = qualifyMethod(BuiltInMethods.TIMESTAMP_WITH_LOCAL_TIME_ZONE_TO_DATE)
-        s"$method($operandTerm, $zone)"
+        s"$method($operandTerm.getMillisecond(), $zone)"
       }
 
     // Time -> Timestamp with local time zone
@@ -1108,7 +1108,7 @@ object ScalarOperatorGens {
       generateUnaryOperatorIfNotNull(ctx, targetType, operand) { operandTerm =>
         val zone = ctx.addReusableTimeZone()
         val method = qualifyMethod(BuiltInMethods.TIME_TO_TIMESTAMP_WITH_LOCAL_TIME_ZONE)
-        s"$method($operandTerm, $zone)"
+        s"$SQL_TIMESTAMP.fromEpochMillis($method($operandTerm, $zone))"
       }
 
     // Timestamp with local time zone -> Time
@@ -1116,7 +1116,7 @@ object ScalarOperatorGens {
       generateUnaryOperatorIfNotNull(ctx, targetType, operand) { operandTerm =>
         val zone = ctx.addReusableTimeZone()
         val method = qualifyMethod(BuiltInMethods.TIMESTAMP_WITH_LOCAL_TIME_ZONE_TO_TIME)
-        s"$method($operandTerm, $zone)"
+        s"$method($operandTerm.getMillisecond(), $zone)"
       }
 
     // Timestamp -> Decimal

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -2258,7 +2258,7 @@ object ScalarOperatorGens {
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
         val method = qualifyMethod(BuiltInMethods.TIMESTAMP_TO_STRING_TIME_ZONE)
         val zone = ctx.addReusableTimeZone()
-        s"$method($operandTerm, 3, $zone)"
+        s"$method($operandTerm.getMillisecond(), 3, $zone)"
     }
 
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -846,7 +846,7 @@ object ScalarOperatorGens {
       generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
         operandTerm =>
           val timeZone = ctx.addReusableTimeZone()
-          s"$method($operandTerm.getMillisecond(), $timeZone)"
+          s"$SQL_TIMESTAMP.fromEpochMillis($method($operandTerm.getMillisecond(), $timeZone))"
       }
 
     case (TIMESTAMP_WITH_LOCAL_TIME_ZONE, TIMESTAMP_WITHOUT_TIME_ZONE) =>
@@ -854,7 +854,7 @@ object ScalarOperatorGens {
       generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
         operandTerm =>
           val zone = ctx.addReusableTimeZone()
-          s"$SQL_TIMESTAMP.fromEpochMillis($method($operandTerm, $zone))"
+          s"$SQL_TIMESTAMP.fromEpochMillis($method($operandTerm.getMillisecond(), $zone))"
       }
 
     // identity casting

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/StringCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/StringCallGen.scala
@@ -210,7 +210,7 @@ object StringCallGen {
       case DATE_FORMAT if operands.size == 2 &&
           isTimestampWithLocalZone(operands.head.resultType) &&
           isCharacterString(operands(1).resultType) =>
-        methodGen(BuiltInMethods.DATE_FORMAT_LONG_STRING_TIME_ZONE)
+        methodGen(BuiltInMethods.DATE_FORMAT_TIMESTAMP_STRING_TIME_ZONE)
 
       case DATE_FORMAT if operands.size == 2 &&
           isCharacterString(operands.head.resultType) &&

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/UserDefinedFunctionUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/UserDefinedFunctionUtils.scala
@@ -47,7 +47,7 @@ import org.apache.calcite.sql.{SqlFunction, SqlOperatorBinding}
 import java.lang.reflect.{Method, Modifier}
 import java.lang.{Integer => JInt, Long => JLong}
 import java.sql.{Date, Time, Timestamp}
-import java.time.LocalDateTime
+import java.time.{Instant, LocalDateTime}
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable
@@ -733,6 +733,10 @@ object UserDefinedFunctionUtils {
         candidate == classOf[Timestamp] && expected == classOf[SqlTimestamp] ||
         candidate == classOf[SqlTimestamp] && expected == classOf[Timestamp] ||
         candidate == classOf[LocalDateTime] && expected == classOf[SqlTimestamp] ||
+        candidate == classOf[SqlTimestamp] && expected == classOf[Instant] ||
+        candidate == classOf[Instant] && expected == classOf[SqlTimestamp] ||
+        candidate == classOf[Instant] && (expected == classOf[Long] ||
+          expected == classOf[JLong]) ||
         classOf[BaseRow].isAssignableFrom(candidate) && expected == classOf[Row] ||
         candidate == classOf[Row] && classOf[BaseRow].isAssignableFrom(expected) ||
         classOf[BaseRow].isAssignableFrom(candidate) && expected == classOf[BaseRow] ||

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/UserDefinedFunctionUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/UserDefinedFunctionUtils.scala
@@ -735,8 +735,6 @@ object UserDefinedFunctionUtils {
         candidate == classOf[LocalDateTime] && expected == classOf[SqlTimestamp] ||
         candidate == classOf[SqlTimestamp] && expected == classOf[Instant] ||
         candidate == classOf[Instant] && expected == classOf[SqlTimestamp] ||
-        candidate == classOf[Instant] && (expected == classOf[Long] ||
-          expected == classOf[JLong]) ||
         classOf[BaseRow].isAssignableFrom(candidate) && expected == classOf[Row] ||
         candidate == classOf[Row] && classOf[BaseRow].isAssignableFrom(expected) ||
         classOf[BaseRow].isAssignableFrom(candidate) && expected == classOf[BaseRow] ||

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
@@ -497,6 +497,9 @@ object AggregateUtil extends Enumeration {
       case TIMESTAMP_WITHOUT_TIME_ZONE =>
         val dt = argTypes(0).asInstanceOf[TimestampType]
         DataTypes.TIMESTAMP(dt.getPrecision).bridgedTo(classOf[SqlTimestamp])
+      case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
+        val dt = argTypes(0).asInstanceOf[LocalZonedTimestampType]
+        DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(dt.getPrecision).bridgedTo(classOf[SqlTimestamp])
 
       case INTERVAL_YEAR_MONTH => DataTypes.INT
       case INTERVAL_DAY_TIME => DataTypes.BIGINT

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.planner.utils.Logging
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromLogicalTypeToDataType
 import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
-import org.apache.flink.table.util.TimestampStringUtils.fromTimestampString
+import org.apache.flink.table.util.TimestampStringUtils.toLocalDateTime
 import org.apache.flink.util.Preconditions
 import org.apache.calcite.plan.RelOptUtil
 import org.apache.calcite.rex._
@@ -338,11 +338,11 @@ class RexNodeToExpressionConverter(
 
       case TIMESTAMP_WITHOUT_TIME_ZONE =>
         val v = literal.getValueAs(classOf[TimestampString])
-        fromTimestampString(v)
+        toLocalDateTime(v)
 
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
         val v = literal.getValueAs(classOf[TimestampString])
-        fromTimestampString(v).atZone(timeZone.toZoneId).toInstant
+        toLocalDateTime(v).atZone(timeZone.toZoneId).toInstant
 
       case TINYINT =>
         // convert from BigDecimal to Byte

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
@@ -345,8 +345,11 @@ class RexNodeToExpressionConverter(
         SqlTimestamp.fromEpochMillis(millisecond, nanoOfMillisecond).toLocalDateTime
 
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
-        val v = literal.getValueAs(classOf[java.lang.Long])
-        unixTimestampToLocalDateTime(v).atZone(timeZone.toZoneId).toInstant
+        val v = literal.getValueAs(classOf[TimestampString])
+        val millisecond = unixTimestampToLocalDateTime(v.getMillisSinceEpoch)
+          .atZone(timeZone.toZoneId).toInstant.toEpochMilli
+        val nanoOfMillisecond = SqlDateTimeUtils.getNanoOfMillisSinceEpoch(v.toString)
+        SqlTimestamp.fromEpochMillis(millisecond, nanoOfMillisecond).toInstant
 
       case TINYINT =>
         // convert from BigDecimal to Byte

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -302,7 +302,7 @@ public class SqlToOperationConverterTest {
 			createTestItem("TIMESTAMP(3)", DataTypes.TIMESTAMP(3)),
 			createTestItem("TIMESTAMP(3) WITHOUT TIME ZONE", DataTypes.TIMESTAMP(3)),
 			createTestItem("TIMESTAMP WITH LOCAL TIME ZONE",
-				DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)),
+				DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(6)),
 			createTestItem("TIMESTAMP(3) WITH LOCAL TIME ZONE",
 				DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)),
 			createTestItem("ARRAY<TIMESTAMP(3) WITH LOCAL TIME ZONE>",

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -653,6 +653,34 @@ class TemporalTypesTest extends ExpressionTestBase {
 
   @Test
   def testDateFormat(): Unit = {
+    config.setLocalTimeZone(ZoneId.of("UTC"))
+
+    testSqlApi(
+      "DATE_FORMAT('2018-03-14 01:02:03', 'yyyy/MM/dd HH:mm:ss')",
+      "2018/03/14 01:02:03")
+
+    testSqlApi(
+      s"DATE_FORMAT(${timestampTz("2018-03-14 01:02:03")}, 'yyyy-MM-dd HH:mm:ss')",
+      "2018-03-14 01:02:03")
+  }
+
+  @Test
+  def testDateFormatShanghai(): Unit = {
+    config.setLocalTimeZone(ZoneId.of("Asia/Shanghai"))
+
+    testSqlApi(
+      "DATE_FORMAT('2018-03-14 01:02:03', 'yyyy/MM/dd HH:mm:ss')",
+      "2018/03/14 01:02:03")
+
+    testSqlApi(
+      s"DATE_FORMAT(${timestampTz("2018-03-14 01:02:03")}, 'yyyy-MM-dd HH:mm:ss')",
+      "2018-03-14 01:02:03")
+  }
+
+  @Test
+  def testDateFormatLosAngeles(): Unit = {
+    config.setLocalTimeZone(ZoneId.of("America/Los_Angeles"))
+
     testSqlApi(
       "DATE_FORMAT('2018-03-14 01:02:03', 'yyyy/MM/dd HH:mm:ss')",
       "2018/03/14 01:02:03")

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -29,11 +29,12 @@ import org.apache.flink.table.planner.utils.DateTimeTestUtil._
 import org.apache.flink.table.typeutils.TimeIntervalTypeInfo
 import org.apache.flink.types.Row
 import org.junit.Test
-
 import java.sql.Timestamp
 import java.text.SimpleDateFormat
 import java.time.{Instant, ZoneId}
 import java.util.{Locale, TimeZone}
+
+import org.apache.flink.table.runtime.typeutils.{LegacyInstantTypeInfo, LegacyLocalDateTimeTypeInfo}
 
 class TemporalTypesTest extends ExpressionTestBase {
 
@@ -293,11 +294,11 @@ class TemporalTypesTest extends ExpressionTestBase {
 
     testSqlApi(
       "CAST(f0 AS TIMESTAMP(3) WITH LOCAL TIME ZONE)",
-      "1990-10-14 00:00:00.000")
+      "1990-10-14 00:00:00")
 
     testSqlApi(
       "CAST(f1 AS TIMESTAMP(3) WITH LOCAL TIME ZONE)",
-      "1970-01-01 10:20:45.000")
+      "1970-01-01 10:20:45")
 
     testSqlApi(
       s"CAST(${timestampTz("2018-03-14 01:02:03")} AS TIME)",
@@ -306,7 +307,6 @@ class TemporalTypesTest extends ExpressionTestBase {
     testSqlApi(
       s"CAST(${timestampTz("2018-03-14 01:02:03")} AS DATE)",
       "2018-03-14")
-
   }
 
   @Test
@@ -677,8 +677,16 @@ class TemporalTypesTest extends ExpressionTestBase {
       "2018/03/14 01:02:03")
 
     testSqlApi(
+      "DATE_FORMAT(TIMESTAMP '2018-03-14 01:02:03.123456', 'yyyy/MM/dd HH:mm:ss.SSSSSS')",
+      "2018/03/14 01:02:03.123456")
+
+    testSqlApi(
       s"DATE_FORMAT(${timestampTz("2018-03-14 01:02:03")}, 'yyyy-MM-dd HH:mm:ss')",
       "2018-03-14 01:02:03")
+
+    testSqlApi(
+      s"DATE_FORMAT(${timestampTz("2018-03-14 01:02:03.123456")}, 'yyyy-MM-dd HH:mm:ss.SSSSSS')",
+      "2018-03-14 01:02:03.123456")
   }
 
   @Test
@@ -690,8 +698,17 @@ class TemporalTypesTest extends ExpressionTestBase {
       "2018/03/14 01:02:03")
 
     testSqlApi(
+      "DATE_FORMAT(TIMESTAMP '2018-03-14 01:02:03.123456', 'yyyy/MM/dd HH:mm:ss.SSSSSS')",
+      "2018/03/14 01:02:03.123456")
+
+    testSqlApi(
       s"DATE_FORMAT(${timestampTz("2018-03-14 01:02:03")}, 'yyyy-MM-dd HH:mm:ss')",
       "2018-03-14 01:02:03")
+
+    testSqlApi(
+      s"DATE_FORMAT(${timestampTz("2018-03-14 01:02:03.123456")}, 'yyyy-MM-dd HH:mm:ss.SSSSSS')",
+      "2018-03-14 01:02:03.123456")
+
   }
 
   @Test
@@ -703,8 +720,17 @@ class TemporalTypesTest extends ExpressionTestBase {
       "2018/03/14 01:02:03")
 
     testSqlApi(
+      "DATE_FORMAT(TIMESTAMP '2018-03-14 01:02:03.123456', 'yyyy/MM/dd HH:mm:ss.SSSSSS')",
+      "2018/03/14 01:02:03.123456")
+
+    testSqlApi(
       s"DATE_FORMAT(${timestampTz("2018-03-14 01:02:03")}, 'yyyy-MM-dd HH:mm:ss')",
       "2018-03-14 01:02:03")
+
+    testSqlApi(
+      s"DATE_FORMAT(${timestampTz("2018-03-14 01:02:03.123456")}, 'yyyy-MM-dd HH:mm:ss.SSSSSS')",
+      "2018-03-14 01:02:03.123456")
+
   }
 
   @Test
@@ -745,12 +771,26 @@ class TemporalTypesTest extends ExpressionTestBase {
     s"CAST(TIMESTAMP '$str' AS TIMESTAMP WITH LOCAL TIME ZONE)"
   }
 
+  private def timestampTz(str: String, precision: Int) = {
+    s"CAST(TIMESTAMP '$str' AS TIMESTAMP($precision) WITH LOCAL TIME ZONE)"
+  }
+
+
   @Test
   def testTemporalShanghai(): Unit = {
     config.setLocalTimeZone(ZoneId.of("Asia/Shanghai"))
 
     testSqlApi(timestampTz("2018-03-14 19:01:02.123"), "2018-03-14 19:01:02.123")
-    testSqlApi(timestampTz("2018-03-14 19:00:00.010"), "2018-03-14 19:00:00.010")
+    testSqlApi(timestampTz("2018-03-14 19:00:00.010"), "2018-03-14 19:00:00.01")
+
+    testSqlApi(
+      s"${timestampTz("2018-03-14 01:02:03.123456789", 9)}",
+      "2018-03-14 01:02:03.123456789")
+
+    testSqlApi(
+      s"${timestampTz("2018-03-14 01:02:03.123456", 6)}",
+      "2018-03-14 01:02:03.123456")
+
 
     // DATE_FORMAT
     testSqlApi(
@@ -793,21 +833,21 @@ class TemporalTypesTest extends ExpressionTestBase {
     testSqlApi("CEIL(TIMESTAMP '2018-01-01 21:00:01' TO YEAR)", "2018-01-01 00:00:00")
     testSqlApi("CEIL(TIMESTAMP '2018-01-02 21:00:01' TO YEAR)", "2019-01-01 00:00:00")
 
-    testSqlApi(s"FLOOR(${timestampTz("2018-03-20 06:44:31")} TO HOUR)", "2018-03-20 06:00:00.000")
-    testSqlApi(s"FLOOR(${timestampTz("2018-03-20 06:44:31")} TO DAY)", "2018-03-20 00:00:00.000")
-    testSqlApi(s"FLOOR(${timestampTz("2018-03-20 00:00:00")} TO DAY)", "2018-03-20 00:00:00.000")
-    testSqlApi(s"FLOOR(${timestampTz("2018-04-01 06:44:31")} TO MONTH)", "2018-04-01 00:00:00.000")
-    testSqlApi(s"FLOOR(${timestampTz("2018-01-01 06:44:31")} TO MONTH)", "2018-01-01 00:00:00.000")
-    testSqlApi(s"CEIL(${timestampTz("2018-03-20 06:44:31")} TO HOUR)", "2018-03-20 07:00:00.000")
-    testSqlApi(s"CEIL(${timestampTz("2018-03-20 06:00:00")} TO HOUR)", "2018-03-20 06:00:00.000")
-    testSqlApi(s"CEIL(${timestampTz("2018-03-20 06:44:31")} TO DAY)", "2018-03-21 00:00:00.000")
-    testSqlApi(s"CEIL(${timestampTz("2018-03-1 00:00:00")} TO DAY)", "2018-03-01 00:00:00.000")
-    testSqlApi(s"CEIL(${timestampTz("2018-03-31 00:00:01")} TO DAY)", "2018-04-01 00:00:00.000")
-    testSqlApi(s"CEIL(${timestampTz("2018-03-01 21:00:01")} TO MONTH)", "2018-03-01 00:00:00.000")
-    testSqlApi(s"CEIL(${timestampTz("2018-03-01 00:00:00")} TO MONTH)", "2018-03-01 00:00:00.000")
-    testSqlApi(s"CEIL(${timestampTz("2018-12-02 00:00:00")} TO MONTH)", "2019-01-01 00:00:00.000")
-    testSqlApi(s"CEIL(${timestampTz("2018-01-01 21:00:01")} TO YEAR)", "2018-01-01 00:00:00.000")
-    testSqlApi(s"CEIL(${timestampTz("2018-01-02 21:00:01")} TO YEAR)", "2019-01-01 00:00:00.000")
+    testSqlApi(s"FLOOR(${timestampTz("2018-03-20 06:44:31")} TO HOUR)", "2018-03-20 06:00:00")
+    testSqlApi(s"FLOOR(${timestampTz("2018-03-20 06:44:31")} TO DAY)", "2018-03-20 00:00:00")
+    testSqlApi(s"FLOOR(${timestampTz("2018-03-20 00:00:00")} TO DAY)", "2018-03-20 00:00:00")
+    testSqlApi(s"FLOOR(${timestampTz("2018-04-01 06:44:31")} TO MONTH)", "2018-04-01 00:00:00")
+    testSqlApi(s"FLOOR(${timestampTz("2018-01-01 06:44:31")} TO MONTH)", "2018-01-01 00:00:00")
+    testSqlApi(s"CEIL(${timestampTz("2018-03-20 06:44:31")} TO HOUR)", "2018-03-20 07:00:00")
+    testSqlApi(s"CEIL(${timestampTz("2018-03-20 06:00:00")} TO HOUR)", "2018-03-20 06:00:00")
+    testSqlApi(s"CEIL(${timestampTz("2018-03-20 06:44:31")} TO DAY)", "2018-03-21 00:00:00")
+    testSqlApi(s"CEIL(${timestampTz("2018-03-1 00:00:00")} TO DAY)", "2018-03-01 00:00:00")
+    testSqlApi(s"CEIL(${timestampTz("2018-03-31 00:00:01")} TO DAY)", "2018-04-01 00:00:00")
+    testSqlApi(s"CEIL(${timestampTz("2018-03-01 21:00:01")} TO MONTH)", "2018-03-01 00:00:00")
+    testSqlApi(s"CEIL(${timestampTz("2018-03-01 00:00:00")} TO MONTH)", "2018-03-01 00:00:00")
+    testSqlApi(s"CEIL(${timestampTz("2018-12-02 00:00:00")} TO MONTH)", "2019-01-01 00:00:00")
+    testSqlApi(s"CEIL(${timestampTz("2018-01-01 21:00:01")} TO YEAR)", "2018-01-01 00:00:00")
+    testSqlApi(s"CEIL(${timestampTz("2018-01-02 21:00:01")} TO YEAR)", "2019-01-01 00:00:00")
 
     // others
     testSqlApi("QUARTER(DATE '2016-04-12')", "2")
@@ -816,11 +856,11 @@ class TemporalTypesTest extends ExpressionTestBase {
       "true")
     testSqlApi(
       "CEIL(f17 TO HOUR)",
-      "1990-10-14 08:00:00.000"
+      "1990-10-14 08:00:00"
     )
     testSqlApi(
       "FLOOR(f17 TO DAY)",
-      "1990-10-14 00:00:00.000"
+      "1990-10-14 00:00:00"
     )
 
     // TIMESTAMP_ADD
@@ -860,10 +900,10 @@ class TemporalTypesTest extends ExpressionTestBase {
     val t2 = timestampTz("2018-03-20 06:00:00")
     // 1521502831000,  2018-03-19 23:40:31 UTC,  2018-03-20 06:10:31 +06:30
     testSqlApi(s"EXTRACT(HOUR FROM $t1)", "6")
-    testSqlApi(s"FLOOR($t1 TO HOUR)", "2018-03-20 06:00:00.000")
-    testSqlApi(s"FLOOR($t2 TO HOUR)", "2018-03-20 06:00:00.000")
-    testSqlApi(s"CEIL($t2 TO HOUR)", "2018-03-20 06:00:00.000")
-    testSqlApi(s"CEIL($t1 TO HOUR)", "2018-03-20 07:00:00.000")
+    testSqlApi(s"FLOOR($t1 TO HOUR)", "2018-03-20 06:00:00")
+    testSqlApi(s"FLOOR($t2 TO HOUR)", "2018-03-20 06:00:00")
+    testSqlApi(s"CEIL($t2 TO HOUR)", "2018-03-20 06:00:00")
+    testSqlApi(s"CEIL($t1 TO HOUR)", "2018-03-20 07:00:00")
   }
 
   @Test
@@ -991,6 +1031,14 @@ class TemporalTypesTest extends ExpressionTestBase {
   }
 
   @Test
+  def test(): Unit = {
+    testSqlApi(
+      s"${timestampTz("1970-01-01 00:00:00.123456789", 9)} > " +
+        s"${timestampTz("1970-01-01 00:00:00.123456788", 9)}",
+      "true")
+  }
+
+  @Test
   def testHighPrecisionTimestamp(): Unit = {
     // EXTRACT should support millisecond/microsecond/nanosecond
     testSqlApi(
@@ -1002,6 +1050,19 @@ class TemporalTypesTest extends ExpressionTestBase {
     testSqlApi(
       "EXTRACT(NANOSECOND FROM TIMESTAMP '1970-01-01 00:00:00.123456789')",
       "123456789")
+
+    testSqlApi(
+      s"EXTRACT(MILLISECOND FROM ${timestampTz("1970-01-01 00:00:00.123456789", 9)})",
+      "123")
+
+    testSqlApi(
+      s"EXTRACT(MICROSECOND FROM ${timestampTz("1970-01-01 00:00:00.123456789", 9)})",
+      "123456")
+
+    testSqlApi(
+      s"EXTRACT(NANOSECOND FROM ${timestampTz("1970-01-01 00:00:00.123456789", 9)})",
+      "123456789")
+
 
     // TIMESTAMPADD should support microsecond/nanosecond
     // TODO: https://issues.apache.org/jira/browse/CALCITE-3530
@@ -1056,6 +1117,33 @@ class TemporalTypesTest extends ExpressionTestBase {
       "CAST(TO_TIMESTAMP('1970-01-01 00:00:00.123456789') AS TIMESTAMP(0))",
       "1970-01-01 00:00:00")
 
+    testSqlApi(
+      s"CAST(${timestampTz("1970-01-01 00:00:00.123456789", 9)} " +
+        "AS TIMESTAMP(6) WITH LOCAL TIME ZONE)",
+      "1970-01-01 00:00:00.123456"
+    )
+
+    testSqlApi(
+      s"CAST(f23 AS TIMESTAMP(6))",
+      "1970-01-01 00:00:00.123456"
+    )
+
+    testSqlApi(
+      s"CAST(f23 AS TIMESTAMP(6) WITH LOCAL TIME ZONE)",
+      "1970-01-01 00:00:00.123456"
+    )
+
+    testSqlApi(
+      s"CAST(f24 AS TIMESTAMP(6))",
+      "1970-01-01 00:00:00.123456"
+    )
+
+    testSqlApi(
+      s"CAST(f24 AS TIMESTAMP(6) WITH LOCAL TIME ZONE)",
+      "1970-01-01 00:00:00.123456"
+    )
+
+
     // DATETIME +/- INTERVAL should support nanosecond
     testSqlApi(
       "TIMESTAMP '1970-02-01 00:00:00.123456789' - INTERVAL '1' MONTH",
@@ -1082,16 +1170,34 @@ class TemporalTypesTest extends ExpressionTestBase {
       "TIMESTAMP '1970-01-01 00:00:00.123456788' < TIMESTAMP '1970-01-01 00:00:00.123456789'",
       "true")
 
+
+    testSqlApi(
+      s"${timestampTz("1970-01-01 00:00:00.123456789", 9)} > " +
+        s"${timestampTz("1970-01-01 00:00:00.123456788", 9)}",
+      "true")
+
+    testSqlApi(
+      s"${timestampTz("1970-01-01 00:00:00.123456788", 9)} < " +
+        s"${timestampTz("1970-01-01 00:00:00.123456789", 9)}",
+      "true")
+
+
     // DATE_FORMAT() should support nanosecond
     testSqlApi(
       "DATE_FORMAT(TIMESTAMP '1970-01-01 00:00:00.123456789', 'yyyy/MM/dd HH:mm:ss.SSSSSSSSS')",
       "1970/01/01 00:00:00.123456789")
+
+    testSqlApi(
+      s"DATE_FORMAT(${timestampTz("2018-03-14 01:02:03.123456789", 9)}, " +
+        "'yyyy-MM-dd HH:mm:ss.SSSSSSSSS')",
+      "2018-03-14 01:02:03.123456789")
+
   }
 
   // ----------------------------------------------------------------------------------------------
 
   override def testData: Row = {
-    val testData = new Row(23)
+    val testData = new Row(25)
     testData.setField(0, localDate("1990-10-14"))
     testData.setField(1, DateTimeTestUtil.localTime("10:20:45"))
     testData.setField(2, localDateTime("1990-10-14 10:20:45.123"))
@@ -1119,6 +1225,9 @@ class TemporalTypesTest extends ExpressionTestBase {
     testData.setField(20, Instant.ofEpochMilli(1520827201000L))
     testData.setField(21, 44L)
     testData.setField(22, 3)
+    testData.setField(23, localDateTime("1970-01-01 00:00:00.123456789")
+      .atZone(config.getLocalTimeZone).toInstant)
+    testData.setField(24, localDateTime("1970-01-01 00:00:00.123456789"))
     testData
   }
 
@@ -1146,6 +1255,9 @@ class TemporalTypesTest extends ExpressionTestBase {
       /* 19 */ Types.INSTANT,
       /* 20 */ Types.INSTANT,
       /* 21 */ Types.LONG,
-      /* 22 */ Types.INT)
+      /* 22 */ Types.INT,
+      /* 23 */ new LegacyInstantTypeInfo(9),
+      /* 24 */ new LegacyLocalDateTimeTypeInfo(9)
+    )
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -1031,14 +1031,6 @@ class TemporalTypesTest extends ExpressionTestBase {
   }
 
   @Test
-  def test(): Unit = {
-    testSqlApi(
-      s"${timestampTz("1970-01-01 00:00:00.123456789", 9)} > " +
-        s"${timestampTz("1970-01-01 00:00:00.123456788", 9)}",
-      "true")
-  }
-
-  @Test
   def testHighPrecisionTimestamp(): Unit = {
     // EXTRACT should support millisecond/microsecond/nanosecond
     testSqlApi(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -29,6 +29,7 @@ import org.apache.flink.table.planner.utils.DateTimeTestUtil._
 import org.apache.flink.table.typeutils.TimeIntervalTypeInfo
 import org.apache.flink.types.Row
 import org.junit.Test
+
 import java.sql.Timestamp
 import java.text.SimpleDateFormat
 import java.time.{Instant, ZoneId}
@@ -289,6 +290,22 @@ class TemporalTypesTest extends ExpressionTestBase {
     testSqlApi(
       "CAST(TIMESTAMP '1970-01-01 00:02:03' AS INT)",
       "123")
+
+    testSqlApi(
+      "CAST(f0 AS TIMESTAMP(3) WITH LOCAL TIME ZONE)",
+      "1990-10-14 00:00:00.000")
+
+    testSqlApi(
+      "CAST(f1 AS TIMESTAMP(3) WITH LOCAL TIME ZONE)",
+      "1970-01-01 10:20:45.000")
+
+    testSqlApi(
+      s"CAST(${timestampTz("2018-03-14 01:02:03")} AS TIME)",
+      "01:02:03")
+
+    testSqlApi(
+      s"CAST(${timestampTz("2018-03-14 01:02:03")} AS DATE)",
+      "2018-03-14")
 
   }
 
@@ -1074,7 +1091,7 @@ class TemporalTypesTest extends ExpressionTestBase {
   // ----------------------------------------------------------------------------------------------
 
   override def testData: Row = {
-    val testData = new Row(24)
+    val testData = new Row(23)
     testData.setField(0, localDate("1990-10-14"))
     testData.setField(1, DateTimeTestUtil.localTime("10:20:45"))
     testData.setField(2, localDateTime("1990-10-14 10:20:45.123"))

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/UserDefinedScalarFunctionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/UserDefinedScalarFunctionTest.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.expressions
 
-import org.apache.flink.api.common.typeinfo.{BasicArrayTypeInfo, TypeInformation}
+import org.apache.flink.api.common.typeinfo.{BasicArrayTypeInfo, BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.{DataTypes, Types, ValidationException}
@@ -27,10 +27,9 @@ import org.apache.flink.table.planner.expressions.utils.{ExpressionTestBase, _}
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions._
 import org.apache.flink.table.planner.utils.DateTimeTestUtil
 import org.apache.flink.types.Row
-
 import org.junit.Test
-
 import java.lang.{Boolean => JBoolean}
+import java.time.ZoneId
 
 class UserDefinedScalarFunctionTest extends ExpressionTestBase {
 
@@ -252,11 +251,78 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       "1990-10-14 12:10:10")
 
     testAllApis(
-      Func13('f6),
-      "Func13(f6)",
-      "Func13(f6)",
+      Func26('f6),
+      "Func26(f6)",
+      "Func26(f6)",
       "1990-10-14 12:10:10")
   }
+
+  @Test
+  def testTimePointsOnPrimitivesInShanghai(): Unit = {
+    config.setLocalTimeZone(ZoneId.of("Asia/Shanghai"))
+
+    testAllApis(
+      Func27('f17),
+      "Func27(f17)",
+      "Func27(f17)",
+      "1990-10-14 12:10:10")
+
+    // Func28 needs a Long parameter, pass a Long
+    testAllApis(
+      Func28('f18),
+      "Func28(f18)",
+      "Func28(f18)",
+      "1970-01-01 08:00:00")
+
+    // Func28 needs a Long parameter, pass a Instant
+    testAllApis(
+      Func28('f17),
+      "Func28(f17)",
+      "Func28(f17)",
+      "1990-10-14 12:10:10")
+
+    // Func29 declares return a Instant, but returns a Long actually
+    // the framework helps convert Long to Instant
+    testAllApis(
+      Func29('f18),
+      "Func29(f18)",
+      "Func29(f18)",
+      "1970-01-01 08:00:00")
+  }
+
+  @Test
+  def testTimePointsOnPrimitivesInLosAngeles(): Unit = {
+    config.setLocalTimeZone(ZoneId.of("America/Los_Angeles"))
+
+    testAllApis(
+      Func27('f17),
+      "Func27(f17)",
+      "Func27(f17)",
+      "1990-10-14 12:10:10")
+
+    // Func28 needs a Long parameter, pass a Long
+    testAllApis(
+      Func28('f18),
+      "Func28(f18)",
+      "Func28(f18)",
+      "1969-12-31 16:00:00")
+
+    // Func28 needs a Long parameter, pass a Instant
+    testAllApis(
+      Func28('f17),
+      "Func28(f17)",
+      "Func28(f17)",
+      "1990-10-14 12:10:10")
+
+    // Func29 declares return a Instant, but returns a Long actually
+    // the framework helps convert Long to Instant
+    testAllApis(
+      Func29('f18),
+      "Func29(f18)",
+      "Func29(f18)",
+      "1969-12-31 16:00:00")
+  }
+
 
   @Test
   def testTimeIntervalsOnPrimitives(): Unit = {
@@ -418,7 +484,7 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
   // ----------------------------------------------------------------------------------------------
 
   override def testData: Row = {
-    val testData = new Row(17)
+    val testData = new Row(19)
     testData.setField(0, 42)
     testData.setField(1, "Test")
     testData.setField(2, null)
@@ -440,6 +506,9 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
     )
     testData.setField(15, new GraduatedStudent("Bob"))
     testData.setField(16, Array(new GraduatedStudent("Bob")))
+    testData.setField(17, DateTimeTestUtil.localDateTime("1990-10-14 12:10:10")
+      .atZone(config.getLocalTimeZone).toInstant)
+    testData.setField(18, 0L)
     testData
   }
 
@@ -461,7 +530,9 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       Types.FLOAT,
       Types.ROW(Types.INT, Types.BOOLEAN, Types.ROW(Types.INT, Types.INT, Types.INT)),
       TypeInformation.of(classOf[GraduatedStudent]),
-      TypeInformation.of(classOf[Array[GraduatedStudent]])
+      TypeInformation.of(classOf[Array[GraduatedStudent]]),
+      BasicTypeInfo.INSTANT_TYPE_INFO,
+      Types.LONG
     )
   }
 
@@ -483,13 +554,16 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
     "Func10" -> Func10,
     "Func11" -> Func11,
     "Func12" -> Func12,
-    "Func13" -> Func13,
     "Func14" -> Func14,
     "Func15" -> Func15,
     "Func16" -> Func16,
     "Func17" -> Func17,
     "Func19" -> Func19,
     "Func20" -> Func20,
+    "Func26" -> Func26,
+    "Func27" -> Func27,
+    "Func28" -> Func28,
+    "Func29" -> Func29,
     "JavaFunc0" -> new JavaFunc0,
     "JavaFunc1" -> new JavaFunc1,
     "JavaFunc2" -> new JavaFunc2,

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/UserDefinedScalarFunctionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/UserDefinedScalarFunctionTest.scala
@@ -267,19 +267,19 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       "Func27(f17)",
       "1990-10-14 12:10:10")
 
-    // Func28 needs a Long parameter, pass a Long
-    testAllApis(
-      Func28('f18),
-      "Func28(f18)",
-      "Func28(f18)",
-      "1970-01-01 08:00:00")
-
     // Func28 needs a Long parameter, pass a Instant
     testAllApis(
       Func28('f17),
       "Func28(f17)",
       "Func28(f17)",
       "1990-10-14 12:10:10")
+
+    testAllApis(
+      Func30('f17),
+      "Func30(f17)",
+      "Func30(f17)",
+      "1990-10-14 12:10:10"
+    )
 
     // Func29 declares return a Instant, but returns a Long actually
     // the framework helps convert Long to Instant
@@ -299,13 +299,6 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       "Func27(f17)",
       "Func27(f17)",
       "1990-10-14 12:10:10")
-
-    // Func28 needs a Long parameter, pass a Long
-    testAllApis(
-      Func28('f18),
-      "Func28(f18)",
-      "Func28(f18)",
-      "1969-12-31 16:00:00")
 
     // Func28 needs a Long parameter, pass a Instant
     testAllApis(
@@ -564,6 +557,7 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
     "Func27" -> Func27,
     "Func28" -> Func28,
     "Func29" -> Func29,
+    "Func30" -> Func30,
     "JavaFunc0" -> new JavaFunc0,
     "JavaFunc1" -> new JavaFunc1,
     "JavaFunc2" -> new JavaFunc2,

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/userDefinedScalarFunctions.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/userDefinedScalarFunctions.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.expressions.utils
 
-import org.apache.flink.api.common.typeinfo.{LocalTimeTypeInfo, SqlTimeTypeInfo, TypeInformation}
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, LocalTimeTypeInfo, SqlTimeTypeInfo, TypeInformation}
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.functions.{FunctionContext, ScalarFunction}
@@ -28,7 +28,7 @@ import org.apache.commons.lang3.StringUtils
 import org.junit.Assert
 import java.lang.{Long => JLong}
 import java.sql.{Date, Time, Timestamp}
-import java.time.LocalDateTime
+import java.time.{Instant, LocalDateTime}
 import java.util.Random
 
 import org.apache.flink.table.dataformat.SqlTimestamp
@@ -154,20 +154,6 @@ object Func12 extends ScalarFunction {
   override def getResultType(signature: Array[Class[_]]): TypeInformation[_] = {
     TimeIntervalTypeInfo.INTERVAL_MILLIS
   }
-}
-
-@SerialVersionUID(1L)
-object Func13 extends ScalarFunction {
-  def eval(c: SqlTimestamp): LocalDateTime = {
-    if (c == null) {
-      null
-    } else {
-      c.toLocalDateTime
-    }
-  }
-
-  override def getResultType(signature: Array[Class[_]]): TypeInformation[_] =
-    LocalTimeTypeInfo.LOCAL_DATE_TIME
 }
 
 @SerialVersionUID(1L)
@@ -416,6 +402,54 @@ object Func24 extends ScalarFunction {
 
   override def getResultType(signature: Array[Class[_]]): TypeInformation[_] =
     Types.ROW(Types.STRING, Types.INT, Types.LONG, Types.STRING)
+}
+
+@SerialVersionUID(1L)
+object Func26 extends ScalarFunction {
+  def eval(c: SqlTimestamp): LocalDateTime = {
+    if (c == null) {
+      null
+    } else {
+      c.toLocalDateTime
+    }
+  }
+
+  override def getResultType(signature: Array[Class[_]]): TypeInformation[_] =
+    LocalTimeTypeInfo.LOCAL_DATE_TIME
+}
+
+@SerialVersionUID(1L)
+object Func27 extends ScalarFunction {
+  def eval(c: SqlTimestamp): Instant = {
+    if (c == null) {
+      null
+    } else {
+      c.toInstant
+    }
+  }
+
+  override def getResultType(signature: Array[Class[_]]): TypeInformation[_] =
+    BasicTypeInfo.INSTANT_TYPE_INFO
+}
+
+@SerialVersionUID(1L)
+object Func28 extends ScalarFunction {
+  def eval(c: Long): Instant = {
+    Instant.ofEpochMilli(c)
+  }
+
+  override def getResultType(signature: Array[Class[_]]): TypeInformation[_] =
+    BasicTypeInfo.INSTANT_TYPE_INFO
+}
+
+@SerialVersionUID(1L)
+object Func29 extends ScalarFunction {
+  def eval(c: Long): Long = {
+    c
+  }
+
+  override def getResultType(signature: Array[Class[_]]): TypeInformation[_] =
+    BasicTypeInfo.INSTANT_TYPE_INFO
 }
 
 /**

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/userDefinedScalarFunctions.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/userDefinedScalarFunctions.scala
@@ -440,6 +440,9 @@ object Func28 extends ScalarFunction {
 
   override def getResultType(signature: Array[Class[_]]): TypeInformation[_] =
     BasicTypeInfo.INSTANT_TYPE_INFO
+
+  override def getParameterTypes(signature: Array[Class[_]]): Array[TypeInformation[_]] =
+    Array(BasicTypeInfo.INSTANT_TYPE_INFO)
 }
 
 @SerialVersionUID(1L)
@@ -451,6 +454,20 @@ object Func29 extends ScalarFunction {
   override def getResultType(signature: Array[Class[_]]): TypeInformation[_] =
     BasicTypeInfo.INSTANT_TYPE_INFO
 }
+
+@SerialVersionUID(1L)
+object Func30 extends ScalarFunction {
+  def eval(c: java.lang.Long): Instant = {
+    Instant.ofEpochMilli(c)
+  }
+
+  override def getResultType(signature: Array[Class[_]]): TypeInformation[_] =
+    BasicTypeInfo.INSTANT_TYPE_INFO
+
+  override def getParameterTypes(signature: Array[Class[_]]): Array[TypeInformation[_]] =
+    Array(BasicTypeInfo.INSTANT_TYPE_INFO)
+}
+
 
 /**
   * A scalar function that always returns TRUE if opened correctly.

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractorTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractorTest.scala
@@ -31,7 +31,6 @@ import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable
 import org.apache.flink.table.planner.functions.utils.ScalarSqlFunction
 import org.apache.flink.table.planner.plan.utils.InputTypeBuilder.inputOf
 import org.apache.flink.table.planner.utils.{DateTimeTestUtil, IntSumAggFunction}
-
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rex.{RexBuilder, RexNode}
 import org.apache.calcite.sql.{SqlIdentifier, SqlPostfixOperator}
@@ -42,12 +41,12 @@ import org.apache.calcite.util.{DateString, TimeString, TimestampString}
 import org.hamcrest.CoreMatchers.is
 import org.junit.Assert.{assertArrayEquals, assertEquals, assertThat, assertTrue}
 import org.junit.Test
-
 import java.math.BigDecimal
 import java.sql.Timestamp
+import java.time.ZoneId
 import java.util.{TimeZone, List => JList}
-import org.apache.flink.table.module.ModuleManager
 
+import org.apache.flink.table.module.ModuleManager
 import org.apache.calcite.sql.parser.SqlParserPos
 
 import scala.collection.JavaConverters._
@@ -848,6 +847,52 @@ class RexNodeExtractorTest extends RexNodeTestBase {
     assertEquals(c2, nonPartitionPredicate3)
   }
 
+  @Test
+  def testTimeLiteralWithLocalTimeZoneConversions(): Unit = {
+    // TIMESTAMP(6), TIMESTAMP(6) WITH LOCAL TIME ZONE
+    val fieldNames = List("timestamp_col", "instant_col").asJava
+    val fieldTypes = makeTypes(SqlTypeName.TIMESTAMP, SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE)
+
+    val timestampString = new TimestampString("2017-09-10 14:23:01.123456")
+    val rexTimestamp = rexBuilder.makeTimestampLiteral(timestampString, 6)
+    val rexInstant = rexBuilder.makeTimestampWithLocalTimeZoneLiteral(timestampString, 6)
+
+    val allRexNodes = List(rexTimestamp, rexInstant)
+
+    val condition = fieldTypes.asScala.zipWithIndex
+      .map((t: (RelDataType, Int)) => rexBuilder.makeInputRef(t._1, t._2))
+      .zip(allRexNodes)
+      .map(t => rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, t._1, t._2))
+      .asJava
+
+    val and = rexBuilder.makeCall(SqlStdOperatorTable.AND, condition)
+
+    val relBuilder: RexBuilder = new RexBuilder(typeFactory)
+
+    val shanghai = ZoneId.of("Asia/Shanghai")
+    val (converted, _) = extractConjunctiveConditions(
+      and,
+      -1,
+      fieldNames,
+      relBuilder,
+      functionCatalog,
+      TimeZone.getTimeZone(shanghai))
+
+    val datetime = DateTimeTestUtil.localDateTime("2017-09-10 14:23:01.123456")
+    val instant = datetime.toInstant(shanghai.getRules.getOffset(datetime))
+
+    {
+      val expected = Array[Expression](
+        // timestamp_col = '2017-09-10 14:23:01.123456'
+        unresolvedCall(EQUALS, unresolvedRef("timestamp_col"), valueLiteral(datetime)),
+        // instant_col = '2017-09-12'
+        unresolvedCall(EQUALS, unresolvedRef("instant_col"), valueLiteral(instant))
+      )
+
+      assertExpressionArrayEquals(expected, converted)
+    }
+  }
+
   private def testExtractSinglePostfixCondition(
       fieldIndex: Integer,
       op: SqlPostfixOperator,
@@ -901,9 +946,10 @@ class RexNodeExtractorTest extends RexNodeTestBase {
       maxCnfNodeCount: Int,
       inputFieldNames: JList[String],
       rexBuilder: RexBuilder,
-      catalog: FunctionCatalog): (Array[Expression], Array[RexNode]) = {
+      catalog: FunctionCatalog,
+      tz: TimeZone = TimeZone.getDefault): (Array[Expression], Array[RexNode]) = {
     RexNodeExtractor.extractConjunctiveConditions(expr, maxCnfNodeCount,
-      inputFieldNames, rexBuilder, catalog, catalogManager, TimeZone.getDefault)
+      inputFieldNames, rexBuilder, catalog, catalogManager, tz)
   }
 
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractorTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractorTest.scala
@@ -25,6 +25,7 @@ import org.apache.flink.table.expressions.utils.ApiExpressionUtils.{unresolvedCa
 import org.apache.flink.table.expressions.{Expression, ExpressionParser}
 import org.apache.flink.table.functions.{AggregateFunctionDefinition, FunctionIdentifier}
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions.{EQUALS, GREATER_THAN, LESS_THAN, LESS_THAN_OR_EQUAL}
+import org.apache.flink.table.module.ModuleManager
 import org.apache.flink.table.planner.expressions.utils.Func1
 import org.apache.flink.table.planner.expressions.{EqualTo, ExpressionBridge, GreaterThan, Literal, PlannerExpression, PlannerExpressionConverter, Sum, UnresolvedFieldReference}
 import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable
@@ -33,7 +34,7 @@ import org.apache.flink.table.planner.plan.utils.InputTypeBuilder.inputOf
 import org.apache.flink.table.planner.utils.{DateTimeTestUtil, IntSumAggFunction}
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rex.{RexBuilder, RexNode}
-import org.apache.calcite.sql.{SqlIdentifier, SqlPostfixOperator}
+import org.apache.calcite.sql.SqlPostfixOperator
 import org.apache.calcite.sql.`type`.SqlTypeName
 import org.apache.calcite.sql.`type`.SqlTypeName.{BIGINT, INTEGER, VARCHAR}
 import org.apache.calcite.sql.fun.{SqlStdOperatorTable, SqlTrimFunction}
@@ -42,12 +43,8 @@ import org.hamcrest.CoreMatchers.is
 import org.junit.Assert.{assertArrayEquals, assertEquals, assertThat, assertTrue}
 import org.junit.Test
 import java.math.BigDecimal
-import java.sql.Timestamp
 import java.time.ZoneId
 import java.util.{TimeZone, List => JList}
-
-import org.apache.flink.table.module.ModuleManager
-import org.apache.calcite.sql.parser.SqlParserPos
 
 import scala.collection.JavaConverters._
 
@@ -885,7 +882,7 @@ class RexNodeExtractorTest extends RexNodeTestBase {
       val expected = Array[Expression](
         // timestamp_col = '2017-09-10 14:23:01.123456'
         unresolvedCall(EQUALS, unresolvedRef("timestamp_col"), valueLiteral(datetime)),
-        // instant_col = '2017-09-12'
+        // instant_col = '2017-09-10T06:23:01.123456Z'
         unresolvedCall(EQUALS, unresolvedRef("instant_col"), valueLiteral(instant))
       )
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -335,7 +335,7 @@ class CalcITCase extends BatchTestBase {
     tEnv.getConfig.setLocalTimeZone(pairs)
     checkResult(
       "SELECT CAST(a AS VARCHAR), b, CAST(b AS VARCHAR) FROM T",
-      Seq(row("1969-07-20 16:17:39", "1969-07-20T20:17:39Z", "1969-07-20 21:17:39.000"))
+      Seq(row("1969-07-20 16:17:39", "1969-07-20T20:17:39Z", "1969-07-20 21:17:39"))
     )
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -45,7 +45,7 @@ import org.junit.Assert.assertEquals
 import org.junit._
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Time, Timestamp}
-import java.time.{LocalDate, LocalDateTime}
+import java.time.{LocalDate, LocalDateTime, ZoneId}
 import java.util
 
 import scala.collection.Seq
@@ -315,6 +315,28 @@ class CalcITCase extends BatchTestBase {
       "SELECT func(text) FROM MyTable",
       Seq(row("a"), row("b"), row("c")
       ))
+  }
+
+  @Test
+  def testTimestampSemantics(): Unit = {
+    // If the timestamp literal '1969-07-20 16:17:39' is inserted in Washington D.C.
+    // and then queried from Paris, it might be shown in the following ways based
+    // on timestamp semantics:
+    // TODO: Add ZonedDateTime/OffsetDateTime
+    val new_york = ZoneId.of("America/New_York")
+    val ldt = localDateTime("1969-07-20 16:17:39")
+    val data = Seq(row(
+      ldt,
+      ldt.toInstant(new_york.getRules.getOffset(ldt))
+    ))
+    registerCollection("T", data, new RowTypeInfo(LOCAL_DATE_TIME, INSTANT), "a, b")
+
+    val pairs = ZoneId.of("Europe/Paris")
+    tEnv.getConfig.setLocalTimeZone(pairs)
+    checkResult(
+      "SELECT CAST(a AS VARCHAR), b, CAST(b AS VARCHAR) FROM T",
+      Seq(row("1969-07-20 16:17:39", "1969-07-20T20:17:39Z", "1969-07-20 21:17:39.000"))
+    )
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSourceITCase.scala
@@ -32,7 +32,7 @@ import java.io.FileWriter
 import java.lang.{Boolean => JBool, Integer => JInt, Long => JLong}
 import java.math.{BigDecimal => JDecimal}
 import java.sql.Timestamp
-import java.time.LocalDateTime
+import java.time.{Instant, LocalDateTime, ZoneId}
 
 import scala.collection.mutable
 
@@ -230,14 +230,15 @@ class TableSourceITCase extends BatchTestBase {
   @Test
   def testMultiTypeSource(): Unit = {
     val tableSchema = TableSchema.builder().fields(
-      Array("a", "b", "c", "d", "e", "f"),
+      Array("a", "b", "c", "d", "e", "f", "g"),
       Array(
         DataTypes.INT(),
         DataTypes.DECIMAL(5, 2),
         DataTypes.VARCHAR(5),
         DataTypes.CHAR(5),
         DataTypes.TIMESTAMP(9).bridgedTo(classOf[LocalDateTime]),
-        DataTypes.TIMESTAMP(9).bridgedTo(classOf[Timestamp])
+        DataTypes.TIMESTAMP(9).bridgedTo(classOf[Timestamp]),
+        DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(9)
       )
     ).build()
 
@@ -260,10 +261,21 @@ class TableSourceITCase extends BatchTestBase {
       null
     )
 
+    val instants = new mutable.MutableList[Instant]
+    for (i <- datetimes.indices) {
+      if (datetimes(i) == null) {
+        instants += null
+      } else {
+        // Assume the time zone of source side is UTC
+        instants += datetimes(i).toInstant(ZoneId.of("UTC").getRules.getOffset(datetimes(i)))
+      }
+    }
+
     val data = new mutable.MutableList[Row]
 
     for (i <- ints.indices) {
-      data += row(ints(i), decimals(i), varchars(i), chars(i), datetimes(i), timestamps(i))
+      data += row(
+        ints(i), decimals(i), varchars(i), chars(i), datetimes(i), timestamps(i), instants(i))
     }
 
     val tableSource = new TestDataTypeTableSource(
@@ -271,13 +283,25 @@ class TableSourceITCase extends BatchTestBase {
       data.seq)
     tEnv.registerTableSource("MyInputFormatTable", tableSource)
     checkResult(
-      "SELECT a, b, c, d, e, f FROM MyInputFormatTable",
+      "SELECT a, b, c, d, e, f, g FROM MyInputFormatTable",
       Seq(
-        row(1, "5.10", "1", "1", "1969-01-01T00:00:00.123456789", "1969-01-01T00:00:00.123456789"),
-        row(2, "6.10", "12", "12", "1970-01-01T00:00:00.123456", "1970-01-01T00:00:00.123456"),
-        row(3, "7.10", "123", "123", "1971-01-01T00:00:00.123", "1971-01-01T00:00:00.123"),
-        row(4, "8.12", "1234", "1234", "1972-01-01T00:00", "1972-01-01T00:00"),
-        row(null, null, null, null, null, null))
+        row(1, "5.10", "1", "1",
+          "1969-01-01T00:00:00.123456789",
+          "1969-01-01T00:00:00.123456789",
+          "1969-01-01T00:00:00.123456789Z"),
+        row(2, "6.10", "12", "12",
+          "1970-01-01T00:00:00.123456",
+          "1970-01-01T00:00:00.123456",
+          "1970-01-01T00:00:00.123456Z"),
+        row(3, "7.10", "123", "123",
+          "1971-01-01T00:00:00.123",
+          "1971-01-01T00:00:00.123",
+          "1971-01-01T00:00:00.123Z"),
+        row(4, "8.12", "1234", "1234",
+          "1972-01-01T00:00",
+          "1972-01-01T00:00",
+          "1972-01-01T00:00:00Z"),
+        row(null, null, null, null, null, null, null))
     )
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TimestampITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TimestampITCase.scala
@@ -25,9 +25,8 @@ import org.apache.flink.table.planner.utils.DateTimeTestUtil._
 import org.apache.flink.table.planner.utils.TestDataTypeTableSource
 import org.apache.flink.types.Row
 import org.junit.Test
-
 import java.sql.Timestamp
-import java.time.LocalDateTime
+import java.time.{Instant, LocalDateTime, ZoneId}
 
 import scala.collection.mutable
 
@@ -37,12 +36,14 @@ class TimestampITCase extends BatchTestBase {
     super.before()
 
     val tableSchema = TableSchema.builder().fields(
-      Array("a", "b", "c", "d"),
+      Array("a", "b", "c", "d", "e", "f"),
       Array(
         DataTypes.INT(),
         DataTypes.BIGINT(),
         DataTypes.TIMESTAMP(9).bridgedTo(classOf[LocalDateTime]),
-        DataTypes.TIMESTAMP(9).bridgedTo(classOf[Timestamp])
+        DataTypes.TIMESTAMP(9).bridgedTo(classOf[Timestamp]),
+        DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(9).bridgedTo(classOf[Instant]),
+        DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(9).bridgedTo(classOf[Instant])
       )
     ).build()
 
@@ -65,10 +66,34 @@ class TimestampITCase extends BatchTestBase {
       null
     )
 
+    val instantsOfDateTime = new mutable.MutableList[Instant]
+    for (i <- datetimes.indices) {
+      if (datetimes(i) == null) {
+        instantsOfDateTime += null
+      } else {
+        // Assume the time zone of source side is UTC
+        instantsOfDateTime +=
+          datetimes(i).toInstant(ZoneId.of("UTC").getRules.getOffset(datetimes(i)))
+      }
+    }
+
+    val instantsOfTimestamp = new mutable.MutableList[Instant]
+    for (i <- timestamps.indices) {
+      if (timestamps(i) == null) {
+        instantsOfTimestamp += null
+      } else {
+        // Assume the time zone of source side is UTC
+        val ldt = timestamps(i).toLocalDateTime
+        instantsOfTimestamp += ldt.toInstant(ZoneId.of("UTC").getRules.getOffset(ldt))
+      }
+    }
+
+
     val data = new mutable.MutableList[Row]
 
     for (i <- ints.indices) {
-      data += row(ints(i), longs(i), datetimes(i), timestamps(i))
+      data += row(ints(i), longs(i), datetimes(i), timestamps(i), instantsOfDateTime(i),
+        instantsOfTimestamp(i))
     }
 
     val tableSource = new TestDataTypeTableSource(
@@ -79,13 +104,25 @@ class TimestampITCase extends BatchTestBase {
 
   @Test
   def testGroupBy(): Unit = {
+    // group by TIMESTAMP(9)
     checkResult(
       "SELECT MAX(a), MIN(a), c FROM T GROUP BY c",
       Seq(
         row(1, 1, "1969-01-01T00:00:00.123456789"),
         row(3, 2, "1970-01-01T00:00:00.123456"),
         row(4, 4, "1970-01-01T00:00:00.123"),
-        row(null, null, null)))
+        row(null, null, null))
+    )
+
+    // group by TIMESTAMP(9) WITH LOCAL TIME ZONE
+    checkResult(
+      "SELECT MAX(a), MIN(a), e FROM T GROUP BY e",
+      Seq(
+        row(1, 1, "1969-01-01T00:00:00.123456789Z"),
+        row(3, 2, "1970-01-01T00:00:00.123456Z"),
+        row(4, 4, "1970-01-01T00:00:00.123Z"),
+        row(null, null, null))
+    )
   }
 
   @Test
@@ -116,8 +153,10 @@ class TimestampITCase extends BatchTestBase {
 
   @Test
   def testJoinOn(): Unit = {
+    // Join On TIMESTAMP(9)
     checkResult(
-      "SELECT * FROM T as T1 JOIN T as T2 ON T1.c = T2.d",
+      "SELECT T1.a, T1.b, T1.c, T1.d, T2.a, T2.b, T2.c, T2.d " +
+        "FROM T as T1 JOIN T as T2 ON T1.c = T2.d",
       Seq(
         row(1, 1, "1969-01-01T00:00:00.123456789", "1969-01-01T00:00:00.123456789",
           1, 1, "1969-01-01T00:00:00.123456789", "1969-01-01T00:00:00.123456789"),
@@ -127,6 +166,21 @@ class TimestampITCase extends BatchTestBase {
           2, 2, "1970-01-01T00:00:00.123456", "1970-01-01T00:00:00.123456"),
         row(4, 4, "1970-01-01T00:00:00.123", "1972-01-01T00:00",
           3, 2, "1970-01-01T00:00:00.123456", "1970-01-01T00:00:00.123")
+      ))
+
+    // Join on TIMESTAMP(9) WITH LOCAL TIME ZONE
+    checkResult(
+      "SELECT T1.a, T1.b, T1.e, T1.f, T2.a, T2.b, T2.e, T2.f " +
+        "FROM T as T1 JOIN T as T2 ON T1.e = T2.f",
+      Seq(
+        row(1, 1, "1969-01-01T00:00:00.123456789Z", "1969-01-01T00:00:00.123456789Z",
+          1, 1, "1969-01-01T00:00:00.123456789Z", "1969-01-01T00:00:00.123456789Z"),
+        row(2, 2, "1970-01-01T00:00:00.123456Z", "1970-01-01T00:00:00.123456Z",
+          2, 2, "1970-01-01T00:00:00.123456Z", "1970-01-01T00:00:00.123456Z"),
+        row(3, 2, "1970-01-01T00:00:00.123456Z", "1970-01-01T00:00:00.123Z",
+          2, 2, "1970-01-01T00:00:00.123456Z", "1970-01-01T00:00:00.123456Z"),
+        row(4, 4, "1970-01-01T00:00:00.123Z", "1972-01-01T00:00:00Z",
+          3, 2, "1970-01-01T00:00:00.123456Z", "1970-01-01T00:00:00.123Z")
       ))
   }
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryRow.java
@@ -21,6 +21,7 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.table.runtime.util.SegmentsUtil;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.TimestampType;
@@ -81,7 +82,6 @@ public final class BinaryRow extends BinarySection implements BaseRow {
 			case TIME_WITHOUT_TIME_ZONE:
 			case INTERVAL_YEAR_MONTH:
 			case BIGINT:
-			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
 			case INTERVAL_DAY_TIME:
 			case FLOAT:
 			case DOUBLE:
@@ -90,6 +90,8 @@ public final class BinaryRow extends BinarySection implements BaseRow {
 				return ((DecimalType) type).getPrecision() <= Decimal.MAX_COMPACT_PRECISION;
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
 				return SqlTimestamp.isCompact(((TimestampType) type).getPrecision());
+			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+				return SqlTimestamp.isCompact(((LocalZonedTimestampType) type).getPrecision());
 			default:
 				return false;
 		}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryWriter.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.runtime.typeutils.BaseMapSerializer;
 import org.apache.flink.table.runtime.typeutils.BaseRowSerializer;
 import org.apache.flink.table.runtime.typeutils.BinaryGenericSerializer;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.TimestampType;
 
@@ -97,14 +98,17 @@ public interface BinaryWriter {
 			case INTERVAL_YEAR_MONTH:
 				writer.writeInt(pos, (int) o);
 				break;
+			case BIGINT:
+			case INTERVAL_DAY_TIME:
+				writer.writeLong(pos, (long) o);
+				break;
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
 				TimestampType timestampType = (TimestampType) type;
 				writer.writeTimestamp(pos, (SqlTimestamp) o, timestampType.getPrecision());
 				break;
-			case BIGINT:
 			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-			case INTERVAL_DAY_TIME:
-				writer.writeLong(pos, (long) o);
+				LocalZonedTimestampType lzTs = (LocalZonedTimestampType) type;
+				writer.writeTimestamp(pos, (SqlTimestamp) o, lzTs.getPrecision());
 				break;
 			case FLOAT:
 				writer.writeFloat(pos, (float) o);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
@@ -122,7 +122,7 @@ public class DataFormatConverters {
 		t2C.put(DataTypes.TIMESTAMP(3).bridgedTo(LocalDateTime.class), new LocalDateTimeConverter(3));
 
 		t2C.put(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).bridgedTo(Long.class), LongConverter.INSTANCE);
-		t2C.put(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).bridgedTo(Instant.class), InstantConverter.INSTANCE);
+		t2C.put(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).bridgedTo(Instant.class), new InstantConverter(3));
 
 		t2C.put(DataTypes.INTERVAL(DataTypes.MONTH()).bridgedTo(Integer.class), IntConverter.INSTANCE);
 		t2C.put(DataTypes.INTERVAL(DataTypes.MONTH()).bridgedTo(int.class), IntConverter.INSTANCE);
@@ -728,27 +728,29 @@ public class DataFormatConverters {
 	/**
 	 * Converter for Instant.
 	 */
-	public static final class InstantConverter extends DataFormatConverter<Long, Instant> {
+	public static final class InstantConverter extends DataFormatConverter<SqlTimestamp, Instant> {
 
 		private static final long serialVersionUID = 1L;
 
-		public static final InstantConverter INSTANCE = new InstantConverter();
+		private final int precision;
 
-		private InstantConverter() {}
-
-		@Override
-		Long toInternalImpl(Instant value) {
-			return value.toEpochMilli();
+		public InstantConverter(int precision) {
+			this.precision = precision;
 		}
 
 		@Override
-		Instant toExternalImpl(Long value) {
-			return Instant.ofEpochMilli(value);
+		SqlTimestamp toInternalImpl(Instant value) {
+			return SqlTimestamp.fromInstant(value);
+		}
+
+		@Override
+		Instant toExternalImpl(SqlTimestamp value) {
+			return value.toInstant();
 		}
 
 		@Override
 		Instant toExternalImpl(BaseRow row, int column) {
-			return toExternalImpl(row.getLong(column));
+			return toExternalImpl(row.getTimestamp(column, precision));
 		}
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter;
 import org.apache.flink.table.runtime.typeutils.BigDecimalTypeInfo;
 import org.apache.flink.table.runtime.typeutils.BinaryStringTypeInfo;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
+import org.apache.flink.table.runtime.typeutils.LegacyInstantTypeInfo;
 import org.apache.flink.table.runtime.typeutils.LegacyLocalDateTimeTypeInfo;
 import org.apache.flink.table.runtime.typeutils.LegacyTimestampTypeInfo;
 import org.apache.flink.table.types.CollectionDataType;
@@ -246,6 +247,9 @@ public class DataFormatConverters {
 				} else if (typeInfo instanceof LegacyTimestampTypeInfo) {
 					LegacyTimestampTypeInfo timestampType = (LegacyTimestampTypeInfo) typeInfo;
 					return new TimestampConverter(timestampType.getPrecision());
+				} else if (typeInfo instanceof LegacyInstantTypeInfo) {
+					LegacyInstantTypeInfo instantTypeInfo = (LegacyInstantTypeInfo) typeInfo;
+					return new InstantConverter(instantTypeInfo.getPrecision());
 				}
 
 				if (clazz == BinaryGeneric.class) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/SqlTimestamp.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/SqlTimestamp.java
@@ -23,12 +23,13 @@ import org.apache.flink.table.runtime.util.SegmentsUtil;
 import org.apache.flink.util.Preconditions;
 
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 /**
- * Immutable SQL TIMESTAMP type with nanosecond precision.
+ * Immutable SQL TIMESTAMP and TIMESTAMP_WITH_LOCAL_TIME_ZONE with nanosecond precision.
  *
  * <p>This class is composite of a millisecond and nanoOfMillisecond. The millisecond part
  * holds the integral second and the milli-of-second. The nanoOfMillisecond holds the
@@ -172,6 +173,40 @@ public class SqlTimestamp implements Comparable<SqlTimestamp> {
 
 		long millisecond = epochDay * MILLIS_PER_DAY + nanoOfDay / 1_000_000;
 		int nanoOfMillisecond = (int) (nanoOfDay % 1_000_000);
+
+		return new SqlTimestamp(millisecond, nanoOfMillisecond);
+	}
+
+	/**
+	 * Convert this {@code SqlTimestamp} object to a {@link Instant}.
+	 *
+	 * @return an instance of {@link Instant}
+	 */
+	public Instant toInstant() {
+		long epochSecond = millisecond / 1000;
+		int milliOfSecond = (int) millisecond % 1000;
+		if (milliOfSecond < 0) {
+			--epochSecond;
+			milliOfSecond += 1000;
+		}
+		long nanoAdjustment = milliOfSecond * 1_000_000 + nanoOfMillisecond;
+		return Instant.ofEpochSecond(epochSecond, nanoAdjustment);
+	}
+
+	/**
+	 * Obtains an instance of {@code SqlTimestamp} from an instance of {@link Instant}.
+	 *
+	 * <p>This returns a {@code SqlTimestmap} with the specified {@link Instant}.
+	 *
+	 * @param instant an instance of {@link Instant}
+	 * @return an instance of {@code SqlTimestamp}
+	 */
+	public static SqlTimestamp fromInstant(Instant instant) {
+		long epochSecond = instant.getEpochSecond();
+		int nanoSecond = instant.getNano();
+
+		long millisecond = epochSecond * 1_000 + nanoSecond / 1_000_000;
+		int nanoOfMillisecond = nanoSecond % 1_000_000;
 
 		return new SqlTimestamp(millisecond, nanoOfMillisecond);
 	}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/SqlTimestamp.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/SqlTimestamp.java
@@ -184,7 +184,7 @@ public class SqlTimestamp implements Comparable<SqlTimestamp> {
 	 */
 	public Instant toInstant() {
 		long epochSecond = millisecond / 1000;
-		int milliOfSecond = (int) millisecond % 1000;
+		int milliOfSecond = (int) (millisecond % 1000);
 		if (milliOfSecond < 0) {
 			--epochSecond;
 			milliOfSecond += 1000;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/TypeGetterSetters.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/TypeGetterSetters.java
@@ -18,6 +18,7 @@
 package org.apache.flink.table.dataformat;
 
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.TimestampType;
@@ -189,13 +190,15 @@ public interface TypeGetterSetters {
 			case TIME_WITHOUT_TIME_ZONE:
 			case INTERVAL_YEAR_MONTH:
 				return row.getInt(ordinal);
+			case BIGINT:
+			case INTERVAL_DAY_TIME:
+				return row.getLong(ordinal);
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
 				TimestampType timestampType = (TimestampType) type;
 				return row.getTimestamp(ordinal, timestampType.getPrecision());
-			case BIGINT:
 			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-			case INTERVAL_DAY_TIME:
-				return row.getLong(ordinal);
+				LocalZonedTimestampType lzTs = (LocalZonedTimestampType) type;
+				return row.getTimestamp(ordinal, lzTs.getPrecision());
 			case FLOAT:
 				return row.getFloat(ordinal);
 			case DOUBLE:

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
@@ -1453,17 +1453,6 @@ public class SqlDateTimeUtils {
 		buf.append((char) ('0' + i % 10));
 	}
 
-	public static int getNanoOfMillisSinceEpoch(final String v) {
-		switch (v.length()) {
-			case 19:
-			case 20:
-				return 0;
-			default:
-				return (Integer.valueOf(v.substring(20)) *
-					(int) Math.pow(10, 9 - (v.length() - 20))) % 1000000;
-		}
-	}
-
 	// TODO: remove if CALCITE-3199 fixed
 	//  https://issues.apache.org/jira/browse/CALCITE-3199
 	public static long unixDateCeil(TimeUnitRange range, long date) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
@@ -632,6 +632,8 @@ public class SqlDateTimeUtils {
 				if (type instanceof TimestampType) {
 					long millis = divide(mod(utcTs, getFactor(startUnit)), startUnit.multiplier);
 					return millis + nanoOfMillisecond;
+				} else {
+					throw new TableException(type + " is unsupported now.");
 				}
 			default:
 				// fall through

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
@@ -1149,12 +1149,12 @@ public class SqlDateTimeUtils {
 				LocalDateTime.ofInstant(Instant.ofEpochMilli(ts), tz.toZoneId()));
 	}
 
-	public static long timestampWithLocalZoneToDate(long ts, TimeZone tz) {
+	public static int timestampWithLocalZoneToDate(long ts, TimeZone tz) {
 		return localDateToUnixDate(LocalDateTime.ofInstant(
 				Instant.ofEpochMilli(ts), tz.toZoneId()).toLocalDate());
 	}
 
-	public static long timestampWithLocalZoneToTime(long ts, TimeZone tz) {
+	public static int timestampWithLocalZoneToTime(long ts, TimeZone tz) {
 		return localTimeToUnixDate(LocalDateTime.ofInstant(
 				Instant.ofEpochMilli(ts), tz.toZoneId()).toLocalTime());
 	}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
@@ -355,11 +355,16 @@ public class SqlDateTimeUtils {
 	 */
 	public static String dateFormat(SqlTimestamp ts, String format, ZoneId zoneId) {
 		DateTimeFormatter formatter = DATETIME_FORMATTER_CACHE.get(format);
-		return ts.toLocalDateTime().atZone(zoneId).format(formatter);
+		Instant instant = ts.toInstant();
+		return LocalDateTime.ofInstant(instant, zoneId.getRules().getOffset(instant)).format(formatter);
 	}
 
 	public static String dateFormat(SqlTimestamp ts, String format) {
 		return dateFormat(ts, format, ZoneId.of("UTC"));
+	}
+
+	public static String dateFormat(SqlTimestamp ts, String format, TimeZone zone) {
+		return dateFormat(ts, format, zone.toZoneId());
 	}
 
 	/**

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/ClassLogicalTypeConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/ClassLogicalTypeConverter.java
@@ -54,12 +54,12 @@ public class ClassLogicalTypeConverter {
 			case TIME_WITHOUT_TIME_ZONE:
 			case INTERVAL_YEAR_MONTH:
 				return Integer.class;
-			case TIMESTAMP_WITHOUT_TIME_ZONE:
-				return SqlTimestamp.class;
 			case BIGINT:
-			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
 			case INTERVAL_DAY_TIME:
 				return Long.class;
+			case TIMESTAMP_WITHOUT_TIME_ZONE:
+			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+				return SqlTimestamp.class;
 			case FLOAT:
 				return Float.class;
 			case DOUBLE:

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/InternalSerializers.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/InternalSerializers.java
@@ -38,6 +38,7 @@ import org.apache.flink.table.runtime.typeutils.SqlTimestampSerializer;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
@@ -63,13 +64,15 @@ public class InternalSerializers {
 			case TIME_WITHOUT_TIME_ZONE:
 			case INTERVAL_YEAR_MONTH:
 				return IntSerializer.INSTANCE;
+			case BIGINT:
+			case INTERVAL_DAY_TIME:
+				return LongSerializer.INSTANCE;
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
 				TimestampType timestampType = (TimestampType) type;
 				return new SqlTimestampSerializer(timestampType.getPrecision());
-			case BIGINT:
 			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-			case INTERVAL_DAY_TIME:
-				return LongSerializer.INSTANCE;
+				LocalZonedTimestampType lzTs = (LocalZonedTimestampType) type;
+				return new SqlTimestampSerializer(lzTs.getPrecision());
 			case FLOAT:
 				return FloatSerializer.INSTANCE;
 			case DOUBLE:

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/LogicalTypeDataTypeConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/LogicalTypeDataTypeConverter.java
@@ -27,12 +27,14 @@ import org.apache.flink.table.dataformat.Decimal;
 import org.apache.flink.table.runtime.typeutils.BigDecimalTypeInfo;
 import org.apache.flink.table.runtime.typeutils.BinaryStringTypeInfo;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
+import org.apache.flink.table.runtime.typeutils.LegacyInstantTypeInfo;
 import org.apache.flink.table.runtime.typeutils.LegacyLocalDateTimeTypeInfo;
 import org.apache.flink.table.runtime.typeutils.LegacyTimestampTypeInfo;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LegacyTypeInformationType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
@@ -107,6 +109,9 @@ public class LogicalTypeDataTypeConverter {
 				} else if (typeInfo instanceof LegacyTimestampTypeInfo) {
 					LegacyTimestampTypeInfo timstampType = (LegacyTimestampTypeInfo) typeInfo;
 					return new TimestampType(timstampType.getPrecision());
+				} else if (typeInfo instanceof LegacyInstantTypeInfo) {
+					LegacyInstantTypeInfo instantTypeInfo = (LegacyInstantTypeInfo) typeInfo;
+					return new LocalZonedTimestampType(instantTypeInfo.getPrecision());
 				} else {
 					return new TypeInformationRawType<>(typeInfo);
 				}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/TypeInfoDataTypeConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/TypeInfoDataTypeConverter.java
@@ -56,8 +56,8 @@ import org.apache.flink.table.typeutils.TimeIntervalTypeInfo;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
 
-import java.time.LocalDateTime;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/TypeInfoDataTypeConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/TypeInfoDataTypeConverter.java
@@ -37,6 +37,7 @@ import org.apache.flink.table.runtime.typeutils.BaseRowTypeInfo;
 import org.apache.flink.table.runtime.typeutils.BigDecimalTypeInfo;
 import org.apache.flink.table.runtime.typeutils.BinaryStringTypeInfo;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
+import org.apache.flink.table.runtime.typeutils.LegacyInstantTypeInfo;
 import org.apache.flink.table.runtime.typeutils.LegacyLocalDateTimeTypeInfo;
 import org.apache.flink.table.runtime.typeutils.LegacyTimestampTypeInfo;
 import org.apache.flink.table.runtime.typeutils.SqlTimestampTypeInfo;
@@ -45,6 +46,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.FieldsDataType;
 import org.apache.flink.table.types.KeyValueDataType;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.TimestampKind;
@@ -55,6 +57,7 @@ import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
 
 import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -119,6 +122,15 @@ public class TypeInfoDataTypeConverter {
 				} else {
 					return TypeConversions.fromDataTypeToLegacyInfo(dataType);
 				}
+			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+				LocalZonedTimestampType lzTs = (LocalZonedTimestampType) logicalType;
+				int precisionLzTs = lzTs.getPrecision();
+				return clazz == SqlTimestamp.class ?
+					new SqlTimestampTypeInfo(precisionLzTs) :
+					(clazz == Instant.class ?
+						((3 == precisionLzTs) ? Types.INSTANT : new LegacyInstantTypeInfo(precisionLzTs)) :
+						TypeConversions.fromDataTypeToLegacyInfo(dataType));
+
 			case DECIMAL:
 				DecimalType decimalType = (DecimalType) logicalType;
 				return clazz == Decimal.class ?

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/LegacyInstantTypeInfo.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/LegacyInstantTypeInfo.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.base.InstantComparator;
+import org.apache.flink.api.common.typeutils.base.InstantSerializer;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * {@link TypeInformation} for {@link Instant}.
+ *
+ * <p>The different between Types.INSTANT is the TypeInformation holds a precision
+ * Reminder: Conversion from DateType to TypeInformation (and back) exists in
+ * TableSourceUtil.computeIndexMapping, which should be fixed after we remove Legacy TypeInformation
+ * TODO: https://issues.apache.org/jira/browse/FLINK-14927
+ */
+public class LegacyInstantTypeInfo extends BasicTypeInfo<Instant> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final int precision;
+
+	public LegacyInstantTypeInfo(int precision) {
+		super(
+			Instant.class,
+			new Class<?>[]{},
+			InstantSerializer.INSTANCE,
+			InstantComparator.class);
+		this.precision = precision;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof LegacyInstantTypeInfo)) {
+			return false;
+		}
+		LegacyInstantTypeInfo that = (LegacyInstantTypeInfo) obj;
+		return this.precision == that.precision;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("TIMESTAMP(%d) WITH LOCAL TIME ZONE", precision);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.getClass().getCanonicalName(), precision);
+	}
+
+	public int getPrecision() {
+		return precision;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/SqlTimestampTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/SqlTimestampTest.java
@@ -21,7 +21,9 @@ package org.apache.flink.table.dataformat;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.util.TimeZone;
 
 /**
  * Test for {@link SqlTimestamp}.
@@ -77,6 +79,29 @@ public class SqlTimestampTest {
 		LocalDateTime ldt4 = LocalDateTime.of(1989, 1, 2, 0, 0, 0, 123456789);
 		java.sql.Timestamp t4 = java.sql.Timestamp.valueOf(ldt4);
 		Assert.assertEquals(SqlTimestamp.fromLocalDateTime(ldt4), SqlTimestamp.fromTimestamp(t4));
+
+		// From Instant to SqlTimestamp and vice versa
+		Instant instant1 = Instant.ofEpochMilli(123L);
+		Instant instant2 = Instant.ofEpochSecond(0L, 123456789L);
+		Instant instant3 = Instant.ofEpochSecond(-2L, 123456789L);
+
+		Assert.assertEquals(instant1, SqlTimestamp.fromInstant(instant1).toInstant());
+		Assert.assertEquals(instant2, SqlTimestamp.fromInstant(instant2).toInstant());
+		Assert.assertEquals(instant3, SqlTimestamp.fromInstant(instant3).toInstant());
+	}
+
+	@Test
+	public void testDaylightSavingTime() {
+		TimeZone tz = TimeZone.getDefault();
+		TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+
+		java.sql.Timestamp dstBegin2018 = java.sql.Timestamp.valueOf("2018-03-11 03:00:00");
+		Assert.assertEquals(dstBegin2018, SqlTimestamp.fromTimestamp(dstBegin2018).toTimestamp());
+
+		java.sql.Timestamp dstBegin2019 = java.sql.Timestamp.valueOf("2019-03-10 02:00:00");
+		Assert.assertEquals(dstBegin2019, SqlTimestamp.fromTimestamp(dstBegin2019).toTimestamp());
+
+		TimeZone.setDefault(tz);
 	}
 
 	@Test
@@ -93,5 +118,8 @@ public class SqlTimestampTest {
 
 		LocalDateTime ldt = LocalDateTime.of(1969, 1, 2, 0, 0, 0, 123456789);
 		Assert.assertEquals("1969-01-02T00:00:00.123456789", SqlTimestamp.fromLocalDateTime(ldt).toString());
+
+		Instant instant = Instant.ofEpochSecond(0L, 123456789L);
+		Assert.assertEquals("1970-01-01T00:00:00.123456789", SqlTimestamp.fromInstant(instant).toString());
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Since FLINK-14080 introduced an internal representation(SqlTimestamp) of TimestampType and LocalZonedTimestampType with precision. This subtask will replace current long with SqlTimestamp, and let blink planner support precision of LocalZonedTimestampType

## Brief change log

- e281ec8 use SqlTimestamp as internal representation of LocalZonedTimestampType
- 8949e59 to 0491744 Fix failures in existing tests
- f9b12b1 Support precision of LocalZonedTimestampType in table source
- 526d170 Support precision of LocalZonedTimestampType in literal and other situations 

## Verifying this change

This change is already covered by existing tests and new tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
