### PR TITLE
[FLINK-13195][sql-client] Add create table support for SqlClient

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -296,6 +296,9 @@ public class CliClient {
 			case INSERT_INTO:
 				callInsertInto(cmdCall);
 				break;
+			case CREATE_TABLE:
+				callCreateTable(cmdCall);
+				break;
 			case CREATE_VIEW:
 				callCreateView(cmdCall);
 				break;
@@ -523,6 +526,16 @@ public class CliClient {
 			return false;
 		}
 		return true;
+	}
+
+	private void callCreateTable(SqlCommandCall cmdCall) {
+		try {
+			executor.createTable(sessionId, cmdCall.operands[0]);
+		} catch (SqlExecutionException e) {
+			printExecutionException(e);
+			return;
+		}
+		terminal.flush();
 	}
 
 	private void callCreateView(SqlCommandCall cmdCall) {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
@@ -42,6 +42,7 @@ public final class CliStrings {
 	public static final AttributedString MESSAGE_HELP = new AttributedStringBuilder()
 		.append("The following commands are available:\n\n")
 		.append(formatCommand(SqlCommand.CLEAR, "Clears the current terminal."))
+		.append(formatCommand(SqlCommand.CREATE_TABLE, "Create table under current catalog and database."))
 		.append(formatCommand(SqlCommand.CREATE_VIEW, "Creates a virtual table from a SQL query. Syntax: 'CREATE VIEW <name> AS <query>;'"))
 		.append(formatCommand(SqlCommand.DESCRIBE, "Describes the schema of a table with the given name."))
 		.append(formatCommand(SqlCommand.DROP_VIEW, "Deletes a previously created virtual table. Syntax: 'DROP VIEW <name>;'"))

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
@@ -127,6 +127,8 @@ public final class SqlCommandParser {
 			"(INSERT\\s+INTO.*)",
 			SINGLE_OPERAND),
 
+		CREATE_TABLE("(CREATE\\s+TABLE\\s+.*)", SINGLE_OPERAND),
+
 		CREATE_VIEW(
 			"CREATE\\s+VIEW\\s+(\\S+)\\s+AS\\s+(.*)",
 			(operands) -> {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -114,6 +114,11 @@ public interface Executor {
 	List<String> listDatabases(String sessionId) throws SqlExecutionException;
 
 	/**
+	 * Create a table with a DDL sentence.
+	 */
+	void createTable(String sessionId, String ddl) throws SqlExecutionException;
+
+	/**
 	 * Lists all tables in the current database of the current catalog.
 	 */
 	List<String> listTables(String sessionId) throws SqlExecutionException;

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -338,6 +338,17 @@ public class LocalExecutor implements Executor {
 	}
 
 	@Override
+	public void createTable(String sessionId, String ddl) throws SqlExecutionException {
+		final ExecutionContext<?> context = getExecutionContext(sessionId);
+		final TableEnvironment tEnv = context.getTableEnvironment();
+		try {
+			tEnv.sqlUpdate(ddl);
+		} catch (Exception e) {
+			throw new SqlExecutionException("Could not create a table from ddl: " + ddl, e);
+		}
+	}
+
+	@Override
 	public List<String> listTables(String sessionId) throws SqlExecutionException {
 		final ExecutionContext<?> context = getExecutionContext(sessionId);
 		final TableEnvironment tableEnv = context.getTableEnvironment();

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -272,6 +272,11 @@ public class CliClientTest extends TestLogger {
 		}
 
 		@Override
+		public void createTable(String sessionId, String ddl) throws SqlExecutionException {
+
+		}
+
+		@Override
 		public List<String> listTables(String sessionId) throws SqlExecutionException {
 			return null;
 		}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
@@ -174,6 +174,11 @@ public class CliResultViewTest {
 		}
 
 		@Override
+		public void createTable(String sessionId, String ddl) throws SqlExecutionException {
+
+		}
+
+		@Override
 		public List<String> listTables(String sessionId) throws SqlExecutionException {
 			return null;
 		}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
@@ -76,6 +76,10 @@ public class SqlCommandParserTest {
 		testInvalidSqlCommand("source"); // missing path
 		testValidSqlCommand("USE CATALOG default", new SqlCommandCall(SqlCommand.USE_CATALOG, new String[]{"default"}));
 		testValidSqlCommand("use default", new SqlCommandCall(SqlCommand.USE, new String[] {"default"}));
+		testValidSqlCommand("create Table hello(a int)", new SqlCommandCall(SqlCommand.CREATE_TABLE, new String[]{"create Table hello(a int)"}));
+		testValidSqlCommand("  CREATE TABLE hello(a int)", new SqlCommandCall(SqlCommand.CREATE_TABLE, new String[]{"CREATE TABLE hello(a int)"}));
+		testInvalidSqlCommand("CREATE tables");
+		testInvalidSqlCommand("CREATE   tables");
 		testInvalidSqlCommand("use catalog");
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Let the flink SQL client support create table statement  so that users don't have to define their tables in YAML configurations and can just input in the interactive client. 
The old PR https://github.com/apache/flink/pull/9981 is a deprecated one, because after FLINK-14672 we've introduced the stateful executor at SQL client side.

## Brief change log

Add the create table parse and direct to the  tableEnv method.

## Verifying this change

This change is already covered by existing tests, such as :
1. LocalExecutorITCase#testCreateTable
2. LocalExecutorITCase#testCreateTableUnderDefaultCatalog
3. LocalExecutorITCase#testCreateTableWithMultiSession

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented). 
