### PR TITLE
[FLINK-15034] Bump FRocksDB version for memory control

### DIFF
--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.data-artisans:frocksdbjni:5.17.2-artisans-1.0
+- com.data-artisans:frocksdbjni:5.17.2-artisans-2.0
 - com.google.code.findbugs:jsr305:1.3.9
 - com.twitter:chill-java:0.7.6
 - com.twitter:chill_2.11:0.7.6

--- a/flink-state-backends/flink-statebackend-rocksdb/pom.xml
+++ b/flink-state-backends/flink-statebackend-rocksdb/pom.xml
@@ -57,7 +57,7 @@ under the License.
 		<dependency>
 			<groupId>com.data-artisans</groupId>
 			<artifactId>frocksdbjni</artifactId>
-			<version>5.17.2-artisans-1.0</version>
+			<version>5.17.2-artisans-2.0</version>
 		</dependency>
 
 		<!-- test dependencies -->


### PR DESCRIPTION

## What is the purpose of the change

Since FLINK-14483 has already been resolved and a new version of FRocksDB has been released, we should bump the FRocksDB version in Flink for next steps in memory control.

## Brief change log
Bump FRocksDB version in `flink-state-backends/flink-statebackend-rocksdb/pom.xml`


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **yes**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **will be updated in docs of FLINK-14495**
