### PR TITLE
[FLINK-14645][table] Support to keep nullability and precision when converting DataTypes to properties

### DIFF
--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -172,13 +172,13 @@ tableEnvironment
   // declare the schema of the table
   .withSchema(
     new Schema()
-      .field("rowtime", Types.SQL_TIMESTAMP)
+      .field("rowtime", DataTypes.TIMESTAMP(3))
         .rowtime(new Rowtime()
           .timestampsFromField("timestamp")
           .watermarksPeriodicBounded(60000)
         )
-      .field("user", Types.LONG)
-      .field("message", Types.STRING)
+      .field("user", DataTypes.BIGINT())
+      .field("message", DataTypes.STRING())
   )
 
   // specify the update-mode for streaming tables
@@ -217,7 +217,7 @@ table_environment \
     ) \
     .with_schema(  # declare the schema of the table
         Schema()
-        .field("rowtime", DataTypes.TIMESTAMP())
+        .field("rowtime", DataTypes.TIMESTAMP(3))
         .rowtime(
             Rowtime()
             .timestamps_from_field("timestamp")
@@ -270,7 +270,7 @@ tables:
     # declare the schema of the table
     schema:
       - name: rowtime
-        type: TIMESTAMP
+        data-type: TIMESTAMP(3)
         rowtime:
           timestamps:
             type: from-field
@@ -279,9 +279,9 @@ tables:
             type: periodic-bounded
             delay: "60000"
       - name: user
-        type: BIGINT
+        data-type: BIGINT
       - name: message
-        type: VARCHAR
+        data-type: STRING
 {% endhighlight %}
 </div>
 
@@ -289,8 +289,8 @@ tables:
 {% highlight sql %}
 CREATE TABLE MyUserTable (
   `user` BIGINT,
-  message VARCHAR,
-  ts VARCHAR
+  message STRING,
+  ts STRING
 ) WITH (
   -- declare the external system to connect to
   'connector.type' = 'kafka',
@@ -337,9 +337,9 @@ The following example shows a simple schema without time attributes and one-to-o
 {% highlight java %}
 .withSchema(
   new Schema()
-    .field("MyField1", Types.INT)     // required: specify the fields of the table (in this order)
-    .field("MyField2", Types.STRING)
-    .field("MyField3", Types.BOOLEAN)
+    .field("MyField1", DataTypes.INT())     // required: specify the fields of the table (in this order)
+    .field("MyField2", DataTypes.STRING())
+    .field("MyField3", DataTypes.BOOLEAN())
 )
 {% endhighlight %}
 </div>
@@ -359,11 +359,11 @@ The following example shows a simple schema without time attributes and one-to-o
 {% highlight yaml %}
 schema:
   - name: MyField1    # required: specify the fields of the table (in this order)
-    type: INT
+    data-type: INT
   - name: MyField2
-    type: VARCHAR
+    data-type: STRING
   - name: MyField3
-    type: BOOLEAN
+    data-type: BOOLEAN
 {% endhighlight %}
 </div>
 </div>
@@ -375,11 +375,11 @@ For *each field*, the following properties can be declared in addition to the co
 {% highlight java %}
 .withSchema(
   new Schema()
-    .field("MyField1", Types.SQL_TIMESTAMP)
+    .field("MyField1", DataTypes.TIMESTAMP(3))
       .proctime()      // optional: declares this field as a processing-time attribute
-    .field("MyField2", Types.SQL_TIMESTAMP)
+    .field("MyField2", DataTypes.TIMESTAMP(3))
       .rowtime(...)    // optional: declares this field as a event-time attribute
-    .field("MyField3", Types.BOOLEAN)
+    .field("MyField3", DataTypes.BOOLEAN())
       .from("mf3")     // optional: original field in the input that is referenced/aliased by this field
 )
 {% endhighlight %}
@@ -389,9 +389,9 @@ For *each field*, the following properties can be declared in addition to the co
 {% highlight python %}
 .with_schema(
     Schema()
-    .field("MyField1", DataTypes.TIMESTAMP())
+    .field("MyField1", DataTypes.TIMESTAMP(3))
     .proctime()  # optional: declares this field as a processing-time attribute
-    .field("MyField2", DataTypes.TIMESTAMP())
+    .field("MyField2", DataTypes.TIMESTAMP(3))
     .rowtime(...)  # optional: declares this field as a event-time attribute
     .field("MyField3", DataTypes.BOOLEAN())
     .from_origin_field("mf3")  # optional: original field in the input that is referenced/aliased by this field
@@ -403,13 +403,13 @@ For *each field*, the following properties can be declared in addition to the co
 {% highlight yaml %}
 schema:
   - name: MyField1
-    type: TIMESTAMP
+    data-type: TIMESTAMP(3)
     proctime: true    # optional: boolean flag whether this field should be a processing-time attribute
   - name: MyField2
-    type: TIMESTAMP
+    data-type: TIMESTAMP(3)
     rowtime: ...      # optional: wether this field should be a event-time attribute
   - name: MyField3
-    type: BOOLEAN
+    data-type: BOOLEAN
     from: mf3         # optional: original field in the input that is referenced/aliased by this field
 {% endhighlight %}
 </div>
@@ -578,34 +578,8 @@ Make sure to always declare both timestamps and watermarks. Watermarks are requi
 
 ### Type Strings
 
-Because type information is only available in a programming language, the following type strings are supported for being defined in a YAML file:
-
-{% highlight yaml %}
-VARCHAR
-BOOLEAN
-TINYINT
-SMALLINT
-INT
-BIGINT
-FLOAT
-DOUBLE
-DECIMAL
-DATE
-TIME
-TIMESTAMP
-MAP<fieldtype, fieldtype>        # generic map; e.g. MAP<VARCHAR, INT> that is mapped to Flink's MapTypeInfo
-MULTISET<fieldtype>              # multiset; e.g. MULTISET<VARCHAR> that is mapped to Flink's MultisetTypeInfo
-PRIMITIVE_ARRAY<fieldtype>       # primitive array; e.g. PRIMITIVE_ARRAY<INT> that is mapped to Flink's PrimitiveArrayTypeInfo
-OBJECT_ARRAY<fieldtype>          # object array; e.g. OBJECT_ARRAY<POJO(org.mycompany.MyPojoClass)> that is mapped to
-                                 #   Flink's ObjectArrayTypeInfo
-ROW<fieldtype, ...>              # unnamed row; e.g. ROW<VARCHAR, INT> that is mapped to Flink's RowTypeInfo
-                                 #   with indexed fields names f0, f1, ...
-ROW<fieldname fieldtype, ...>    # named row; e.g., ROW<myField VARCHAR, myOtherField INT> that
-                                 #   is mapped to Flink's RowTypeInfo
-POJO<class>                      # e.g., POJO<org.mycompany.MyPojoClass> that is mapped to Flink's PojoTypeInfo
-ANY<class>                       # e.g., ANY<org.mycompany.MyClass> that is mapped to Flink's GenericTypeInfo
-ANY<class, serialized>           # used for type information that is not supported by Flink's Table & SQL API
-{% endhighlight %}
+Because `DataType` is only available in a programming language, type strings are supported for being defined in a YAML file.
+The type strings are the same to type declaration in SQL, please see the [Data Types](types.html) page about how to declare a type in SQL.
 
 {% top %}
 
@@ -1433,9 +1407,9 @@ CREATE TABLE MyUserTable (
   'format.type' = 'csv',                  -- required: specify the schema type
 
   'format.fields.0.name' = 'lon',         -- required: define the schema either by using type information
-  'format.fields.0.type' = 'FLOAT',
+  'format.fields.0.data-type' = 'FLOAT',
   'format.fields.1.name' = 'rideTime',
-  'format.fields.1.type' = 'TIMESTAMP',
+  'format.fields.1.data-type' = 'TIMESTAMP(3)',
 
   'format.derive-schema' = 'true',        -- or use the table's schema
 
@@ -1618,9 +1592,9 @@ CREATE TABLE MyUserTable (
   'format.fail-on-missing-field' = 'true'   -- optional: flag whether to fail if a field is missing or not, false by default
 
   'format.fields.0.name' = 'lon',           -- required: define the schema either by using a type string which parses numbers to corresponding types
-  'format.fields.0.type' = 'FLOAT',
+  'format.fields.0.data-type' = 'FLOAT',
   'format.fields.1.name' = 'rideTime',
-  'format.fields.1.type' = 'TIMESTAMP',
+  'format.fields.1.data-type' = 'TIMESTAMP(3)',
 
   'format.json-schema' =                    -- or by using a JSON schema which parses to DECIMAL and TIMESTAMP
     '{
@@ -1855,8 +1829,8 @@ Use the old one for stream/batch filesystem operations for now.
 {% highlight java %}
 .withFormat(
   new OldCsv()
-    .field("field1", Types.STRING)    // required: ordered format fields
-    .field("field2", Types.TIMESTAMP)
+    .field("field1", DataTypes.STRING())    // required: ordered format fields
+    .field("field2", DataTypes.TIMESTAMP(3))
     .deriveSchema()                   // or use the table's schema
     .fieldDelimiter(",")              // optional: string delimiter "," by default
     .lineDelimiter("\n")              // optional: string delimiter "\n" by default
@@ -1890,9 +1864,9 @@ format:
   type: csv
   fields:                    # required: ordered format fields
     - name: field1
-      type: VARCHAR
+      data-type: STRING
     - name: field2
-      type: TIMESTAMP
+      data-type: TIMESTAMP(3)
   derive-schema: true        # or use the table's schema
   field-delimiter: ","       # optional: string delimiter "," by default
   line-delimiter: "\n"       # optional: string delimiter "\n" by default
@@ -1911,9 +1885,9 @@ CREATE TABLE MyUserTable (
   'format.type' = 'csv',                  -- required: specify the schema type
 
   'format.fields.0.name' = 'lon',         -- required: define the schema either by using type information
-  'format.fields.0.type' = 'FLOAT',
+  'format.fields.0.data-type' = 'STRING',
   'format.fields.1.name' = 'rideTime',
-  'format.fields.1.type' = 'TIMESTAMP',
+  'format.fields.1.data-type' = 'TIMESTAMP(3)',
 
   'format.derive-schema' = 'true',        -- or use the table's schema'
 

--- a/docs/dev/table/connect.zh.md
+++ b/docs/dev/table/connect.zh.md
@@ -172,13 +172,13 @@ tableEnvironment
   // declare the schema of the table
   .withSchema(
     new Schema()
-      .field("rowtime", Types.SQL_TIMESTAMP)
+      .field("rowtime", DataTypes.TIMESTAMP(3))
         .rowtime(new Rowtime()
           .timestampsFromField("timestamp")
           .watermarksPeriodicBounded(60000)
         )
-      .field("user", Types.LONG)
-      .field("message", Types.STRING)
+      .field("user", DataTypes.BIGINT())
+      .field("message", DataTypes.STRING())
   )
 
   // specify the update-mode for streaming tables
@@ -217,7 +217,7 @@ table_environment \
     ) \
     .with_schema(  # declare the schema of the table
         Schema()
-        .field("rowtime", DataTypes.TIMESTAMP())
+        .field("rowtime", DataTypes.TIMESTAMP(3))
         .rowtime(
             Rowtime()
             .timestamps_from_field("timestamp")
@@ -227,7 +227,7 @@ table_environment \
         .field("message", DataTypes.STRING())
     ) \
     .in_append_mode() \
-    .create_temporary_table("MyUserTable")  
+    .create_temporary_table("MyUserTable")
     # specify the update-mode for streaming tables and
     # register as source, sink, or both and under a name
 {% endhighlight %}
@@ -270,7 +270,7 @@ tables:
     # declare the schema of the table
     schema:
       - name: rowtime
-        type: TIMESTAMP
+        data-type: TIMESTAMP(3)
         rowtime:
           timestamps:
             type: from-field
@@ -279,9 +279,9 @@ tables:
             type: periodic-bounded
             delay: "60000"
       - name: user
-        type: BIGINT
+        data-type: BIGINT
       - name: message
-        type: VARCHAR
+        data-type: STRING
 {% endhighlight %}
 </div>
 
@@ -289,8 +289,8 @@ tables:
 {% highlight sql %}
 CREATE TABLE MyUserTable (
   `user` BIGINT,
-  message VARCHAR,
-  ts VARCHAR
+  message STRING,
+  ts STRING
 ) WITH (
   -- declare the external system to connect to
   'connector.type' = 'kafka',
@@ -337,9 +337,9 @@ The following example shows a simple schema without time attributes and one-to-o
 {% highlight java %}
 .withSchema(
   new Schema()
-    .field("MyField1", Types.INT)     // required: specify the fields of the table (in this order)
-    .field("MyField2", Types.STRING)
-    .field("MyField3", Types.BOOLEAN)
+    .field("MyField1", DataTypes.INT())     // required: specify the fields of the table (in this order)
+    .field("MyField2", DataTypes.STRING())
+    .field("MyField3", DataTypes.BOOLEAN())
 )
 {% endhighlight %}
 </div>
@@ -359,11 +359,11 @@ The following example shows a simple schema without time attributes and one-to-o
 {% highlight yaml %}
 schema:
   - name: MyField1    # required: specify the fields of the table (in this order)
-    type: INT
+    data-type: INT
   - name: MyField2
-    type: VARCHAR
+    data-type: STRING
   - name: MyField3
-    type: BOOLEAN
+    data-type: BOOLEAN
 {% endhighlight %}
 </div>
 </div>
@@ -375,11 +375,11 @@ For *each field*, the following properties can be declared in addition to the co
 {% highlight java %}
 .withSchema(
   new Schema()
-    .field("MyField1", Types.SQL_TIMESTAMP)
+    .field("MyField1", DataTypes.TIMESTAMP(3))
       .proctime()      // optional: declares this field as a processing-time attribute
-    .field("MyField2", Types.SQL_TIMESTAMP)
+    .field("MyField2", DataTypes.TIMESTAMP(3))
       .rowtime(...)    // optional: declares this field as a event-time attribute
-    .field("MyField3", Types.BOOLEAN)
+    .field("MyField3", DataTypes.BOOLEAN())
       .from("mf3")     // optional: original field in the input that is referenced/aliased by this field
 )
 {% endhighlight %}
@@ -389,9 +389,9 @@ For *each field*, the following properties can be declared in addition to the co
 {% highlight python %}
 .with_schema(
     Schema()
-    .field("MyField1", DataTypes.TIMESTAMP())
+    .field("MyField1", DataTypes.TIMESTAMP(3))
     .proctime()  # optional: declares this field as a processing-time attribute
-    .field("MyField2", DataTypes.TIMESTAMP())
+    .field("MyField2", DataTypes.TIMESTAMP(3))
     .rowtime(...)  # optional: declares this field as a event-time attribute
     .field("MyField3", DataTypes.BOOLEAN())
     .from_origin_field("mf3")  # optional: original field in the input that is referenced/aliased by this field
@@ -403,13 +403,13 @@ For *each field*, the following properties can be declared in addition to the co
 {% highlight yaml %}
 schema:
   - name: MyField1
-    type: TIMESTAMP
+    data-type: TIMESTAMP(3)
     proctime: true    # optional: boolean flag whether this field should be a processing-time attribute
   - name: MyField2
-    type: TIMESTAMP
+    data-type: TIMESTAMP(3)
     rowtime: ...      # optional: wether this field should be a event-time attribute
   - name: MyField3
-    type: BOOLEAN
+    data-type: BOOLEAN
     from: mf3         # optional: original field in the input that is referenced/aliased by this field
 {% endhighlight %}
 </div>
@@ -578,34 +578,8 @@ Make sure to always declare both timestamps and watermarks. Watermarks are requi
 
 ### Type Strings
 
-Because type information is only available in a programming language, the following type strings are supported for being defined in a YAML file:
-
-{% highlight yaml %}
-VARCHAR
-BOOLEAN
-TINYINT
-SMALLINT
-INT
-BIGINT
-FLOAT
-DOUBLE
-DECIMAL
-DATE
-TIME
-TIMESTAMP
-MAP<fieldtype, fieldtype>        # generic map; e.g. MAP<VARCHAR, INT> that is mapped to Flink's MapTypeInfo
-MULTISET<fieldtype>              # multiset; e.g. MULTISET<VARCHAR> that is mapped to Flink's MultisetTypeInfo
-PRIMITIVE_ARRAY<fieldtype>       # primitive array; e.g. PRIMITIVE_ARRAY<INT> that is mapped to Flink's PrimitiveArrayTypeInfo
-OBJECT_ARRAY<fieldtype>          # object array; e.g. OBJECT_ARRAY<POJO(org.mycompany.MyPojoClass)> that is mapped to
-                                 #   Flink's ObjectArrayTypeInfo
-ROW<fieldtype, ...>              # unnamed row; e.g. ROW<VARCHAR, INT> that is mapped to Flink's RowTypeInfo
-                                 #   with indexed fields names f0, f1, ...
-ROW<fieldname fieldtype, ...>    # named row; e.g., ROW<myField VARCHAR, myOtherField INT> that
-                                 #   is mapped to Flink's RowTypeInfo
-POJO<class>                      # e.g., POJO<org.mycompany.MyPojoClass> that is mapped to Flink's PojoTypeInfo
-ANY<class>                       # e.g., ANY<org.mycompany.MyClass> that is mapped to Flink's GenericTypeInfo
-ANY<class, serialized>           # used for type information that is not supported by Flink's Table & SQL API
-{% endhighlight %}
+Because `DataType` is only available in a programming language, type strings are supported for being defined in a YAML file.
+The type strings are the same to type declaration in SQL, please see the [Data Types](types.html) page about how to declare a type in SQL.
 
 {% top %}
 
@@ -1433,9 +1407,9 @@ CREATE TABLE MyUserTable (
   'format.type' = 'csv',                  -- required: specify the schema type
 
   'format.fields.0.name' = 'lon',         -- required: define the schema either by using type information
-  'format.fields.0.type' = 'FLOAT',
+  'format.fields.0.data-type' = 'FLOAT',
   'format.fields.1.name' = 'rideTime',
-  'format.fields.1.type' = 'TIMESTAMP',
+  'format.fields.1.data-type' = 'TIMESTAMP(3)',
 
   'format.derive-schema' = 'true',        -- or use the table's schema
 
@@ -1618,9 +1592,9 @@ CREATE TABLE MyUserTable (
   'format.fail-on-missing-field' = 'true'   -- optional: flag whether to fail if a field is missing or not, false by default
 
   'format.fields.0.name' = 'lon',           -- required: define the schema either by using a type string which parses numbers to corresponding types
-  'format.fields.0.type' = 'FLOAT',
+  'format.fields.0.data-type' = 'FLOAT',
   'format.fields.1.name' = 'rideTime',
-  'format.fields.1.type' = 'TIMESTAMP',
+  'format.fields.1.data-type' = 'TIMESTAMP(3)',
 
   'format.json-schema' =                    -- or by using a JSON schema which parses to DECIMAL and TIMESTAMP
     '{
@@ -1855,8 +1829,8 @@ Use the old one for stream/batch filesystem operations for now.
 {% highlight java %}
 .withFormat(
   new OldCsv()
-    .field("field1", Types.STRING)    // required: ordered format fields
-    .field("field2", Types.TIMESTAMP)
+    .field("field1", DataTypes.STRING())    // required: ordered format fields
+    .field("field2", DataTypes.TIMESTAMP(3))
     .deriveSchema()                   // or use the table's schema
     .fieldDelimiter(",")              // optional: string delimiter "," by default
     .lineDelimiter("\n")              // optional: string delimiter "\n" by default
@@ -1890,9 +1864,9 @@ format:
   type: csv
   fields:                    # required: ordered format fields
     - name: field1
-      type: VARCHAR
+      data-type: STRING
     - name: field2
-      type: TIMESTAMP
+      data-type: TIMESTAMP(3)
   derive-schema: true        # or use the table's schema
   field-delimiter: ","       # optional: string delimiter "," by default
   line-delimiter: "\n"       # optional: string delimiter "\n" by default
@@ -1911,9 +1885,9 @@ CREATE TABLE MyUserTable (
   'format.type' = 'csv',                  -- required: specify the schema type
 
   'format.fields.0.name' = 'lon',         -- required: define the schema either by using type information
-  'format.fields.0.type' = 'FLOAT',
+  'format.fields.0.data-type' = 'STRING',
   'format.fields.1.name' = 'rideTime',
-  'format.fields.1.type' = 'TIMESTAMP',
+  'format.fields.1.data-type' = 'TIMESTAMP(3)',
 
   'format.derive-schema' = 'true',        -- or use the table's schema'
 

--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -330,13 +330,13 @@ tables:
       schema: "ROW<rideId LONG, lon FLOAT, lat FLOAT, rideTime TIMESTAMP>"
     schema:
       - name: rideId
-        type: LONG
+        data-type: BIGINT
       - name: lon
-        type: FLOAT
+        data-type: FLOAT
       - name: lat
-        type: FLOAT
+        data-type: FLOAT
       - name: rowTime
-        type: TIMESTAMP
+        data-type: TIMESTAMP(3)
         rowtime:
           timestamps:
             type: "from-field"
@@ -345,7 +345,7 @@ tables:
             type: "periodic-bounded"
             delay: "60000"
       - name: procTime
-        type: TIMESTAMP
+        data-type: TIMESTAMP(3)
         proctime: true
 {% endhighlight %}
 
@@ -500,13 +500,13 @@ tables:
       derive-schema: true
     schema:
       - name: rideId
-        type: LONG
+        data-type: BIGINT
       - name: lon
-        type: FLOAT
+        data-type: FLOAT
       - name: lat
-        type: FLOAT
+        data-type: FLOAT
       - name: rideTime
-        type: TIMESTAMP
+        data-type: TIMESTAMP(3)
 {% endhighlight %}
 
 The SQL Client makes sure that a statement is successfully submitted to the cluster. Once the query is submitted, the CLI will show information about the Flink job.
@@ -582,11 +582,11 @@ tables:
     format: # ...
     schema:
       - name: integerField
-        type: INT
+        data-type: INT
       - name: stringField
-        type: VARCHAR
+        data-type: STRING
       - name: rowtimeField
-        type: TIMESTAMP
+        data-type: TIMESTAMP(3)
         rowtime:
           timestamps:
             type: from-field

--- a/docs/dev/table/sqlClient.zh.md
+++ b/docs/dev/table/sqlClient.zh.md
@@ -330,13 +330,13 @@ tables:
       schema: "ROW<rideId LONG, lon FLOAT, lat FLOAT, rideTime TIMESTAMP>"
     schema:
       - name: rideId
-        type: LONG
+        data-type: BIGINT
       - name: lon
-        type: FLOAT
+        data-type: FLOAT
       - name: lat
-        type: FLOAT
+        data-type: FLOAT
       - name: rowTime
-        type: TIMESTAMP
+        data-type: TIMESTAMP(3)
         rowtime:
           timestamps:
             type: "from-field"
@@ -345,7 +345,7 @@ tables:
             type: "periodic-bounded"
             delay: "60000"
       - name: procTime
-        type: TIMESTAMP
+        data-type: TIMESTAMP(3)
         proctime: true
 {% endhighlight %}
 
@@ -500,13 +500,13 @@ tables:
       derive-schema: true
     schema:
       - name: rideId
-        type: LONG
+        data-type: BIGINT
       - name: lon
-        type: FLOAT
+        data-type: FLOAT
       - name: lat
-        type: FLOAT
+        data-type: FLOAT
       - name: rideTime
-        type: TIMESTAMP
+        data-type: TIMESTAMP(3)
 {% endhighlight %}
 
 The SQL Client makes sure that a statement is successfully submitted to the cluster. Once the query is submitted, the CLI will show information about the Flink job.
@@ -582,11 +582,11 @@ tables:
     format: # ...
     schema:
       - name: integerField
-        type: INT
+        data-type: INT
       - name: stringField
-        type: VARCHAR
+        data-type: STRING
       - name: rowtimeField
-        type: TIMESTAMP
+        data-type: TIMESTAMP(3)
         rowtime:
           timestamps:
             type: from-field

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkFactoryBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkFactoryBase.java
@@ -82,6 +82,7 @@ import static org.apache.flink.table.descriptors.ElasticsearchValidator.CONNECTO
 import static org.apache.flink.table.descriptors.FormatDescriptorValidator.FORMAT;
 import static org.apache.flink.table.descriptors.FormatDescriptorValidator.FORMAT_TYPE;
 import static org.apache.flink.table.descriptors.Schema.SCHEMA;
+import static org.apache.flink.table.descriptors.Schema.SCHEMA_DATA_TYPE;
 import static org.apache.flink.table.descriptors.Schema.SCHEMA_NAME;
 import static org.apache.flink.table.descriptors.Schema.SCHEMA_TYPE;
 import static org.apache.flink.table.descriptors.StreamTableDescriptorValidator.UPDATE_MODE;
@@ -136,6 +137,7 @@ public abstract class ElasticsearchUpsertTableSinkFactoryBase implements StreamT
 		properties.add(CONNECTOR_CONNECTION_PATH_PREFIX);
 
 		// schema
+		properties.add(SCHEMA + ".#." + SCHEMA_DATA_TYPE);
 		properties.add(SCHEMA + ".#." + SCHEMA_TYPE);
 		properties.add(SCHEMA + ".#." + SCHEMA_NAME);
 

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkFactoryTestBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkFactoryTestBase.java
@@ -22,8 +22,8 @@ import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.formats.json.JsonRowSerializationSchema;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchUpsertTableSinkBase.Host;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchUpsertTableSinkBase.SinkOption;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.api.Types;
 import org.apache.flink.table.descriptors.Elasticsearch;
 import org.apache.flink.table.descriptors.Json;
 import org.apache.flink.table.descriptors.Schema;
@@ -106,10 +106,10 @@ public abstract class ElasticsearchUpsertTableSinkFactoryTestBase extends TestLo
 					.deriveSchema())
 			.withSchema(
 				new Schema()
-					.field(FIELD_KEY, Types.LONG())
-					.field(FIELD_FRUIT_NAME, Types.STRING())
-					.field(FIELD_COUNT, Types.DECIMAL())
-					.field(FIELD_TS, Types.SQL_TIMESTAMP()))
+					.field(FIELD_KEY, DataTypes.BIGINT())
+					.field(FIELD_FRUIT_NAME, DataTypes.STRING())
+					.field(FIELD_COUNT, DataTypes.DECIMAL(10, 4))
+					.field(FIELD_TS, DataTypes.TIMESTAMP(3)))
 			.inUpsertMode();
 
 		final Map<String, String> propertiesMap = testDesc.toProperties();
@@ -121,10 +121,10 @@ public abstract class ElasticsearchUpsertTableSinkFactoryTestBase extends TestLo
 
 	protected TableSchema createTestSchema() {
 		return TableSchema.builder()
-			.field(FIELD_KEY, Types.LONG())
-			.field(FIELD_FRUIT_NAME, Types.STRING())
-			.field(FIELD_COUNT, Types.DECIMAL())
-			.field(FIELD_TS, Types.SQL_TIMESTAMP())
+			.field(FIELD_KEY, DataTypes.BIGINT())
+			.field(FIELD_FRUIT_NAME, DataTypes.STRING())
+			.field(FIELD_COUNT, DataTypes.DECIMAL(10, 4))
+			.field(FIELD_TS, DataTypes.TIMESTAMP(3))
 			.build();
 	}
 

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceBase.java
@@ -26,13 +26,14 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.api.Types;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.sources.DefinedFieldMapping;
 import org.apache.flink.table.sources.DefinedProctimeAttribute;
 import org.apache.flink.table.sources.DefinedRowtimeAttributes;
 import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.table.sources.StreamTableSource;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.utils.TableConnectorUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
@@ -286,11 +287,11 @@ public abstract class KafkaTableSourceBase implements
 	private Optional<String> validateProctimeAttribute(Optional<String> proctimeAttribute) {
 		return proctimeAttribute.map((attribute) -> {
 			// validate that field exists and is of correct type
-			Optional<TypeInformation<?>> tpe = schema.getFieldType(attribute);
+			Optional<DataType> tpe = schema.getFieldDataType(attribute);
 			if (!tpe.isPresent()) {
 				throw new ValidationException("Processing time attribute '" + attribute + "' is not present in TableSchema.");
-			} else if (tpe.get() != Types.SQL_TIMESTAMP()) {
-				throw new ValidationException("Processing time attribute '" + attribute + "' is not of type SQL_TIMESTAMP.");
+			} else if (tpe.get().getLogicalType().getTypeRoot() != LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) {
+				throw new ValidationException("Processing time attribute '" + attribute + "' is not of type TIMESTAMP.");
 			}
 			return attribute;
 		});
@@ -306,11 +307,11 @@ public abstract class KafkaTableSourceBase implements
 		// validate that all declared fields exist and are of correct type
 		for (RowtimeAttributeDescriptor desc : rowtimeAttributeDescriptors) {
 			String rowtimeAttribute = desc.getAttributeName();
-			Optional<TypeInformation<?>> tpe = schema.getFieldType(rowtimeAttribute);
+			Optional<DataType> tpe = schema.getFieldDataType(rowtimeAttribute);
 			if (!tpe.isPresent()) {
 				throw new ValidationException("Rowtime attribute '" + rowtimeAttribute + "' is not present in TableSchema.");
-			} else if (tpe.get() != Types.SQL_TIMESTAMP()) {
-				throw new ValidationException("Rowtime attribute '" + rowtimeAttribute + "' is not of type SQL_TIMESTAMP.");
+			} else if (tpe.get().getLogicalType().getTypeRoot() != LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) {
+				throw new ValidationException("Rowtime attribute '" + rowtimeAttribute + "' is not of type TIMESTAMP.");
 			}
 		}
 		return rowtimeAttributeDescriptors;

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
@@ -75,6 +75,7 @@ import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_WATERMARKS_DELA
 import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_WATERMARKS_SERIALIZED;
 import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_WATERMARKS_TYPE;
 import static org.apache.flink.table.descriptors.Schema.SCHEMA;
+import static org.apache.flink.table.descriptors.Schema.SCHEMA_DATA_TYPE;
 import static org.apache.flink.table.descriptors.Schema.SCHEMA_FROM;
 import static org.apache.flink.table.descriptors.Schema.SCHEMA_NAME;
 import static org.apache.flink.table.descriptors.Schema.SCHEMA_PROCTIME;
@@ -115,6 +116,7 @@ public abstract class KafkaTableSourceSinkFactoryBase implements
 		properties.add(CONNECTOR_SINK_PARTITIONER_CLASS);
 
 		// schema
+		properties.add(SCHEMA + ".#." + SCHEMA_DATA_TYPE);
 		properties.add(SCHEMA + ".#." + SCHEMA_TYPE);
 		properties.add(SCHEMA + ".#." + SCHEMA_NAME);
 		properties.add(SCHEMA + ".#." + SCHEMA_FROM);

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
@@ -34,8 +34,8 @@ import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkFixedPartitioner;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.api.Types;
 import org.apache.flink.table.descriptors.Kafka;
 import org.apache.flink.table.descriptors.Rowtime;
 import org.apache.flink.table.descriptors.Schema;
@@ -104,10 +104,10 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 		// prepare parameters for Kafka table source
 
 		final TableSchema schema = TableSchema.builder()
-			.field(FRUIT_NAME, Types.STRING())
-			.field(COUNT, Types.DECIMAL())
-			.field(EVENT_TIME, Types.SQL_TIMESTAMP())
-			.field(PROC_TIME, Types.SQL_TIMESTAMP())
+			.field(FRUIT_NAME, DataTypes.STRING())
+			.field(COUNT, DataTypes.DECIMAL(10, 3))
+			.field(EVENT_TIME, DataTypes.TIMESTAMP(3))
+			.field(PROC_TIME, DataTypes.TIMESTAMP(3))
 			.build();
 
 		final List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors = Collections.singletonList(
@@ -125,9 +125,9 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 
 		final TestDeserializationSchema deserializationSchema = new TestDeserializationSchema(
 			TableSchema.builder()
-				.field(NAME, Types.STRING())
-				.field(COUNT, Types.DECIMAL())
-				.field(TIME, Types.SQL_TIMESTAMP())
+				.field(NAME, DataTypes.STRING())
+				.field(COUNT, DataTypes.DECIMAL(10, 3))
+				.field(TIME, DataTypes.TIMESTAMP(3))
 				.build()
 				.toRowType()
 		);
@@ -157,11 +157,11 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 			.withFormat(new TestTableFormat())
 			.withSchema(
 				new Schema()
-					.field(FRUIT_NAME, Types.STRING()).from(NAME)
-					.field(COUNT, Types.DECIMAL()) // no from so it must match with the input
-					.field(EVENT_TIME, Types.SQL_TIMESTAMP()).rowtime(
+					.field(FRUIT_NAME, DataTypes.STRING()).from(NAME)
+					.field(COUNT, DataTypes.DECIMAL(10, 3)) // no from so it must match with the input
+					.field(EVENT_TIME, DataTypes.TIMESTAMP(3)).rowtime(
 						new Rowtime().timestampsFromField(TIME).watermarksPeriodicAscending())
-					.field(PROC_TIME, Types.SQL_TIMESTAMP()).proctime())
+					.field(PROC_TIME, DataTypes.TIMESTAMP(3)).proctime())
 			.inAppendMode();
 
 		final Map<String, String> propertiesMap = testDesc.toProperties();
@@ -185,9 +185,9 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 		// prepare parameters for Kafka table sink
 
 		final TableSchema schema = TableSchema.builder()
-			.field(FRUIT_NAME, Types.STRING())
-			.field(COUNT, Types.DECIMAL())
-			.field(EVENT_TIME, Types.SQL_TIMESTAMP())
+			.field(FRUIT_NAME, DataTypes.STRING())
+			.field(COUNT, DataTypes.DECIMAL(10, 4))
+			.field(EVENT_TIME, DataTypes.TIMESTAMP(3))
 			.build();
 
 		final KafkaTableSinkBase expected = getExpectedKafkaTableSink(
@@ -209,9 +209,9 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 			.withFormat(new TestTableFormat())
 			.withSchema(
 				new Schema()
-					.field(FRUIT_NAME, Types.STRING())
-					.field(COUNT, Types.DECIMAL())
-					.field(EVENT_TIME, Types.SQL_TIMESTAMP()))
+					.field(FRUIT_NAME, DataTypes.STRING())
+					.field(COUNT, DataTypes.DECIMAL(10, 4))
+					.field(EVENT_TIME, DataTypes.TIMESTAMP(3)))
 			.inAppendMode();
 
 		final Map<String, String> propertiesMap = testDesc.toProperties();

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
@@ -36,6 +36,7 @@ import org.apache.flink.types.Row;
 import java.util.Arrays;
 import java.util.Objects;
 
+import static org.apache.flink.api.java.io.jdbc.JDBCTypeUtil.normalizeTableSchema;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -219,7 +220,7 @@ public class JDBCTableSource implements
 		 * required, table schema of this table source.
 		 */
 		public Builder setSchema(TableSchema schema) {
-			this.schema = schema;
+			this.schema = normalizeTableSchema(schema);
 			return this;
 		}
 

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTypeUtil.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTypeUtil.java
@@ -22,7 +22,13 @@ import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Collections;
 import java.util.HashMap;
@@ -100,4 +106,31 @@ class JDBCTypeUtil {
 		return SQL_TYPE_NAMES.get(typeInformationToSqlType(type));
 	}
 
+	/**
+	 * The original table schema may contain generated columns which shouldn't be produced/consumed
+	 * by TableSource/TableSink. And the original TIMESTAMP/DATE/TIME types uses LocalDateTime/LocalDate/LocalTime
+	 * as the conversion classes, however, JDBC connector uses Timestamp/Date/Time classes. So that
+	 * we bridge them to the expected conversion classes.
+	 */
+	static TableSchema normalizeTableSchema(TableSchema schema) {
+		TableSchema.Builder physicalSchemaBuilder = TableSchema.builder();
+		schema.getTableColumns()
+			.forEach(c -> {
+				if (!c.isGenerated()) {
+					LogicalTypeRoot root = c.getType().getLogicalType().getTypeRoot();
+					final DataType type;
+					if (root == LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) {
+						type = c.getType().bridgedTo(Timestamp.class);
+					} else if (root == LogicalTypeRoot.DATE) {
+						type = c.getType().bridgedTo(Date.class);
+					} else if (root == LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE) {
+						type = c.getType().bridgedTo(Time.class);
+					} else {
+						type = c.getType();
+					}
+					physicalSchemaBuilder.field(c.getName(), type);
+				}
+			});
+		return physicalSchemaBuilder.build();
+	}
 }

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSink.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSink.java
@@ -37,6 +37,7 @@ import java.util.Objects;
 
 import static org.apache.flink.api.java.io.jdbc.AbstractJDBCOutputFormat.DEFAULT_FLUSH_INTERVAL_MILLS;
 import static org.apache.flink.api.java.io.jdbc.AbstractJDBCOutputFormat.DEFAULT_FLUSH_MAX_SIZE;
+import static org.apache.flink.api.java.io.jdbc.JDBCTypeUtil.normalizeTableSchema;
 import static org.apache.flink.api.java.io.jdbc.JDBCUpsertOutputFormat.DEFAULT_MAX_RETRY_TIMES;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -177,7 +178,7 @@ public class JDBCUpsertTableSink implements UpsertStreamTableSink<Row> {
 		 * required, table schema of this table source.
 		 */
 		public Builder setTableSchema(TableSchema schema) {
-			this.schema = schema;
+			this.schema = normalizeTableSchema(schema);
 			return this;
 		}
 

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceSinkFactoryTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceSinkFactoryTest.java
@@ -20,12 +20,14 @@ package org.apache.flink.api.java.io.jdbc;
 
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.factories.StreamTableSinkFactory;
 import org.apache.flink.table.factories.StreamTableSourceFactory;
 import org.apache.flink.table.factories.TableFactoryService;
 import org.apache.flink.table.sinks.StreamTableSink;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.table.sources.TableSource;
+import org.apache.flink.table.sources.TableSourceValidation;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.FieldsDataType;
 
@@ -44,6 +46,14 @@ import static org.junit.Assert.fail;
  */
 public class JDBCTableSourceSinkFactoryTest {
 
+	private static final TableSchema schema = TableSchema.builder()
+		.field("aaa", DataTypes.INT())
+		.field("bbb", DataTypes.STRING())
+		.field("ccc", DataTypes.DOUBLE())
+		.field("ddd", DataTypes.DECIMAL(24, 3))
+		.field("eee", DataTypes.TIMESTAMP(3))
+		.build();
+
 	@Test
 	public void testJDBCCommonProperties() {
 		Map<String, String> properties = getBasicProperties();
@@ -61,16 +71,13 @@ public class JDBCTableSourceSinkFactoryTest {
 			.setUsername("user")
 			.setPassword("pass")
 			.build();
-		final TableSchema schema = TableSchema.builder()
-			.field("aaa", DataTypes.INT())
-			.field("bbb", DataTypes.STRING())
-			.field("ccc", DataTypes.DOUBLE())
-			.build();
 		final JDBCTableSource expected = JDBCTableSource.builder()
 			.setOptions(options)
 			.setSchema(schema)
 			.build();
 
+		TableSourceValidation.validateTableSource(expected);
+		TableSourceValidation.validateTableSource(actual);
 		assertEquals(expected, actual);
 	}
 
@@ -96,11 +103,6 @@ public class JDBCTableSourceSinkFactoryTest {
 			.setPartitionUpperBound(100)
 			.setNumPartitions(10)
 			.setFetchSize(20)
-			.build();
-		final TableSchema schema = TableSchema.builder()
-			.field("aaa", DataTypes.INT())
-			.field("bbb", DataTypes.STRING())
-			.field("ccc", DataTypes.DOUBLE())
 			.build();
 		final JDBCTableSource expected = JDBCTableSource.builder()
 			.setOptions(options)
@@ -130,11 +132,6 @@ public class JDBCTableSourceSinkFactoryTest {
 			.setCacheExpireMs(10_000)
 			.setMaxRetryTimes(10)
 			.build();
-		final TableSchema schema = TableSchema.builder()
-			.field("aaa", DataTypes.INT())
-			.field("bbb", DataTypes.STRING())
-			.field("ccc", DataTypes.DOUBLE())
-			.build();
 		final JDBCTableSource expected = JDBCTableSource.builder()
 			.setOptions(options)
 			.setLookupOptions(lookupOptions)
@@ -157,11 +154,6 @@ public class JDBCTableSourceSinkFactoryTest {
 		final JDBCOptions options = JDBCOptions.builder()
 			.setDBUrl("jdbc:derby:memory:mydb")
 			.setTableName("mytable")
-			.build();
-		final TableSchema schema = TableSchema.builder()
-			.field("aaa", DataTypes.INT())
-			.field("bbb", DataTypes.STRING())
-			.field("ccc", DataTypes.DOUBLE())
 			.build();
 		final JDBCUpsertTableSink expected = JDBCUpsertTableSink.builder()
 			.setOptions(options)
@@ -264,13 +256,10 @@ public class JDBCTableSourceSinkFactoryTest {
 		properties.put("connector.url", "jdbc:derby:memory:mydb");
 		properties.put("connector.table", "mytable");
 
-		properties.put("schema.0.name", "aaa");
-		properties.put("schema.0.type", "INT");
-		properties.put("schema.1.name", "bbb");
-		properties.put("schema.1.type", "VARCHAR");
-		properties.put("schema.2.name", "ccc");
-		properties.put("schema.2.type", "DOUBLE");
+		DescriptorProperties descriptorProperties = new DescriptorProperties();
+		descriptorProperties.putProperties(properties);
+		descriptorProperties.putTableSchema("schema", schema);
 
-		return properties;
+		return new HashMap<>(descriptorProperties.asMap());
 	}
 }

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSinkITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSinkITCase.java
@@ -18,15 +18,13 @@
 
 package org.apache.flink.api.java.io.jdbc;
 
-import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.timestamps.AscendingTimestampExtractor;
 import org.apache.flink.table.api.Table;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
-import org.apache.flink.table.types.DataType;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
 
@@ -38,14 +36,13 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import static org.apache.flink.api.java.io.jdbc.JDBCTestBase.DRIVER_CLASS;
 import static org.apache.flink.api.java.io.jdbc.JDBCUpsertOutputFormatTest.check;
-import static org.apache.flink.table.api.DataTypes.BIGINT;
-import static org.apache.flink.table.api.DataTypes.INT;
 
 /**
  * IT case for {@link JDBCUpsertTableSink}.
@@ -68,11 +65,13 @@ public class JDBCUpsertTableSinkITCase extends AbstractTestBase {
 					"cnt BIGINT NOT NULL DEFAULT 0," +
 					"lencnt BIGINT NOT NULL DEFAULT 0," +
 					"cTag INT NOT NULL DEFAULT 0," +
+					"ts TIMESTAMP," +
 					"PRIMARY KEY (cnt, cTag))");
 
 			stat.executeUpdate("CREATE TABLE " + OUTPUT_TABLE2 + " (" +
 					"id INT NOT NULL DEFAULT 0," +
-					"num BIGINT NOT NULL DEFAULT 0)");
+					"num BIGINT NOT NULL DEFAULT 0," +
+					"ts TIMESTAMP)");
 		}
 	}
 
@@ -87,29 +86,29 @@ public class JDBCUpsertTableSinkITCase extends AbstractTestBase {
 		}
 	}
 
-	public static DataStream<Tuple3<Integer, Long, String>> get3TupleDataStream(StreamExecutionEnvironment env) {
-		List<Tuple3<Integer, Long, String>> data = new ArrayList<>();
-		data.add(new Tuple3<>(1, 1L, "Hi"));
-		data.add(new Tuple3<>(2, 2L, "Hello"));
-		data.add(new Tuple3<>(3, 2L, "Hello world"));
-		data.add(new Tuple3<>(4, 3L, "Hello world, how are you?"));
-		data.add(new Tuple3<>(5, 3L, "I am fine."));
-		data.add(new Tuple3<>(6, 3L, "Luke Skywalker"));
-		data.add(new Tuple3<>(7, 4L, "Comment#1"));
-		data.add(new Tuple3<>(8, 4L, "Comment#2"));
-		data.add(new Tuple3<>(9, 4L, "Comment#3"));
-		data.add(new Tuple3<>(10, 4L, "Comment#4"));
-		data.add(new Tuple3<>(11, 5L, "Comment#5"));
-		data.add(new Tuple3<>(12, 5L, "Comment#6"));
-		data.add(new Tuple3<>(13, 5L, "Comment#7"));
-		data.add(new Tuple3<>(14, 5L, "Comment#8"));
-		data.add(new Tuple3<>(15, 5L, "Comment#9"));
-		data.add(new Tuple3<>(16, 6L, "Comment#10"));
-		data.add(new Tuple3<>(17, 6L, "Comment#11"));
-		data.add(new Tuple3<>(18, 6L, "Comment#12"));
-		data.add(new Tuple3<>(19, 6L, "Comment#13"));
-		data.add(new Tuple3<>(20, 6L, "Comment#14"));
-		data.add(new Tuple3<>(21, 6L, "Comment#15"));
+	public static DataStream<Tuple4<Integer, Long, String, Timestamp>> get4TupleDataStream(StreamExecutionEnvironment env) {
+		List<Tuple4<Integer, Long, String, Timestamp>> data = new ArrayList<>();
+		data.add(new Tuple4<>(1, 1L, "Hi", Timestamp.valueOf("1970-01-01 00:00:00.001")));
+		data.add(new Tuple4<>(2, 2L, "Hello", Timestamp.valueOf("1970-01-01 00:00:00.002")));
+		data.add(new Tuple4<>(3, 2L, "Hello world", Timestamp.valueOf("1970-01-01 00:00:00.003")));
+		data.add(new Tuple4<>(4, 3L, "Hello world, how are you?", Timestamp.valueOf("1970-01-01 00:00:00.004")));
+		data.add(new Tuple4<>(5, 3L, "I am fine.", Timestamp.valueOf("1970-01-01 00:00:00.005")));
+		data.add(new Tuple4<>(6, 3L, "Luke Skywalker", Timestamp.valueOf("1970-01-01 00:00:00.006")));
+		data.add(new Tuple4<>(7, 4L, "Comment#1", Timestamp.valueOf("1970-01-01 00:00:00.007")));
+		data.add(new Tuple4<>(8, 4L, "Comment#2", Timestamp.valueOf("1970-01-01 00:00:00.008")));
+		data.add(new Tuple4<>(9, 4L, "Comment#3", Timestamp.valueOf("1970-01-01 00:00:00.009")));
+		data.add(new Tuple4<>(10, 4L, "Comment#4", Timestamp.valueOf("1970-01-01 00:00:00.010")));
+		data.add(new Tuple4<>(11, 5L, "Comment#5", Timestamp.valueOf("1970-01-01 00:00:00.011")));
+		data.add(new Tuple4<>(12, 5L, "Comment#6", Timestamp.valueOf("1970-01-01 00:00:00.012")));
+		data.add(new Tuple4<>(13, 5L, "Comment#7", Timestamp.valueOf("1970-01-01 00:00:00.013")));
+		data.add(new Tuple4<>(14, 5L, "Comment#8", Timestamp.valueOf("1970-01-01 00:00:00.014")));
+		data.add(new Tuple4<>(15, 5L, "Comment#9", Timestamp.valueOf("1970-01-01 00:00:00.015")));
+		data.add(new Tuple4<>(16, 6L, "Comment#10", Timestamp.valueOf("1970-01-01 00:00:00.016")));
+		data.add(new Tuple4<>(17, 6L, "Comment#11", Timestamp.valueOf("1970-01-01 00:00:00.017")));
+		data.add(new Tuple4<>(18, 6L, "Comment#12", Timestamp.valueOf("1970-01-01 00:00:00.018")));
+		data.add(new Tuple4<>(19, 6L, "Comment#13", Timestamp.valueOf("1970-01-01 00:00:00.019")));
+		data.add(new Tuple4<>(20, 6L, "Comment#14", Timestamp.valueOf("1970-01-01 00:00:00.020")));
+		data.add(new Tuple4<>(21, 6L, "Comment#15", Timestamp.valueOf("1970-01-01 00:00:00.021")));
 
 		Collections.shuffle(data);
 		return env.fromCollection(data);
@@ -122,36 +121,40 @@ public class JDBCUpsertTableSinkITCase extends AbstractTestBase {
 		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
 
-		Table t = tEnv.fromDataStream(get3TupleDataStream(env).assignTimestampsAndWatermarks(
-				new AscendingTimestampExtractor<Tuple3<Integer, Long, String>>() {
+		Table t = tEnv.fromDataStream(get4TupleDataStream(env).assignTimestampsAndWatermarks(
+				new AscendingTimestampExtractor<Tuple4<Integer, Long, String, Timestamp>>() {
 					@Override
-					public long extractAscendingTimestamp(Tuple3<Integer, Long, String> element) {
+					public long extractAscendingTimestamp(Tuple4<Integer, Long, String, Timestamp> element) {
 						return element.f0;
-					}}), "id, num, text");
+					}}), "id, num, text, ts");
 
-		tEnv.registerTable("T", t);
+		tEnv.createTemporaryView("T", t);
+		tEnv.sqlUpdate(
+			"CREATE TABLE upsertSink (" +
+				"  cnt BIGINT," +
+				"  lencnt BIGINT," +
+				"  cTag INT," +
+				"  ts TIMESTAMP(3)" +
+				") WITH (" +
+				"  'connector.type'='jdbc'," +
+				"  'connector.url'='" + DB_URL + "'," +
+				"  'connector.table'='" + OUTPUT_TABLE1 + "'" +
+				")");
 
-		String[] fields = {"cnt", "lencnt", "cTag"};
-		tEnv.registerTableSink("upsertSink", JDBCUpsertTableSink.builder()
-				.setOptions(JDBCOptions.builder()
-						.setDBUrl(DB_URL)
-						.setTableName(OUTPUT_TABLE1)
-						.build())
-				.setTableSchema(TableSchema.builder().fields(
-						fields, new DataType[] {BIGINT(), BIGINT(), INT()}).build())
-				.build());
-
-		tEnv.sqlUpdate("INSERT INTO upsertSink SELECT cnt, COUNT(len) AS lencnt, cTag FROM" +
-				" (SELECT len, COUNT(id) as cnt, cTag FROM" +
-				" (SELECT id, CHAR_LENGTH(text) AS len, (CASE WHEN id > 0 THEN 1 ELSE 0 END) cTag FROM T)" +
-				" GROUP BY len, cTag)" +
-				" GROUP BY cnt, cTag");
+		tEnv.sqlUpdate("INSERT INTO upsertSink \n" +
+			"SELECT cnt, COUNT(len) AS lencnt, cTag, MAX(ts) AS ts\n" +
+			"FROM (\n" +
+			"  SELECT len, COUNT(id) as cnt, cTag, MAX(ts) AS ts\n" +
+			"  FROM (SELECT id, CHAR_LENGTH(text) AS len, (CASE WHEN id > 0 THEN 1 ELSE 0 END) cTag, ts FROM T)\n" +
+			"  GROUP BY len, cTag\n" +
+			")\n" +
+			"GROUP BY cnt, cTag");
 		env.execute();
 		check(new Row[] {
-				Row.of(1, 5, 1),
-				Row.of(7, 1, 1),
-				Row.of(9, 1, 1)
-		}, DB_URL, OUTPUT_TABLE1, fields);
+				Row.of(1, 5, 1, Timestamp.valueOf("1970-01-01 00:00:00.006")),
+				Row.of(7, 1, 1, Timestamp.valueOf("1970-01-01 00:00:00.021")),
+				Row.of(9, 1, 1, Timestamp.valueOf("1970-01-01 00:00:00.015"))
+		}, DB_URL, OUTPUT_TABLE1, new String[]{"cnt", "lencnt", "cTag", "ts"});
 	}
 
 	@Test
@@ -161,26 +164,27 @@ public class JDBCUpsertTableSinkITCase extends AbstractTestBase {
 		env.getConfig().setParallelism(1);
 		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
 
-		Table t = tEnv.fromDataStream(get3TupleDataStream(env), "id, num, text");
+		Table t = tEnv.fromDataStream(get4TupleDataStream(env), "id, num, text, ts");
 
 		tEnv.registerTable("T", t);
 
-		String[] fields = {"id", "num"};
-		tEnv.registerTableSink("upsertSink", JDBCUpsertTableSink.builder()
-				.setOptions(JDBCOptions.builder()
-						.setDBUrl(DB_URL)
-						.setTableName(OUTPUT_TABLE2)
-						.build())
-				.setTableSchema(TableSchema.builder().fields(
-						fields, new DataType[] {INT(), BIGINT()}).build())
-				.build());
+		tEnv.sqlUpdate(
+			"CREATE TABLE upsertSink (" +
+				"  id INT," +
+				"  num BIGINT," +
+				"  ts TIMESTAMP(3)" +
+				") WITH (" +
+				"  'connector.type'='jdbc'," +
+				"  'connector.url'='" + DB_URL + "'," +
+				"  'connector.table'='" + OUTPUT_TABLE2 + "'" +
+				")");
 
-		tEnv.sqlUpdate("INSERT INTO upsertSink SELECT id, num FROM T WHERE id IN (2, 10, 20)");
+		tEnv.sqlUpdate("INSERT INTO upsertSink SELECT id, num, ts FROM T WHERE id IN (2, 10, 20)");
 		env.execute();
 		check(new Row[] {
-				Row.of(2, 2),
-				Row.of(10, 4),
-				Row.of(20, 6)
-		}, DB_URL, OUTPUT_TABLE2, fields);
+				Row.of(2, 2, Timestamp.valueOf("1970-01-01 00:00:00.002")),
+				Row.of(10, 4, Timestamp.valueOf("1970-01-01 00:00:00.01")),
+				Row.of(20, 6, Timestamp.valueOf("1970-01-01 00:00:00.02"))
+		}, DB_URL, OUTPUT_TABLE2, new String[]{"id", "num", "ts"});
 	}
 }

--- a/flink-end-to-end-tests/test-scripts/kafka_sql_common.sh
+++ b/flink-end-to-end-tests/test-scripts/kafka_sql_common.sh
@@ -50,7 +50,7 @@ function get_kafka_json_source_schema {
     update-mode: append
     schema:
       - name: rowtime
-        type: TIMESTAMP
+        data-type: TIMESTAMP(3)
         rowtime:
           timestamps:
             type: from-field
@@ -59,9 +59,9 @@ function get_kafka_json_source_schema {
             type: periodic-bounded
             delay: 2000
       - name: user
-        type: VARCHAR
+        data-type: STRING
       - name: event
-        type: ROW<type VARCHAR, message VARCHAR>
+        data-type: ROW<type STRING, message STRING>
     connector:
       type: kafka
       version: "$KAFKA_SQL_VERSION"

--- a/flink-end-to-end-tests/test-scripts/test_sql_client.sh
+++ b/flink-end-to-end-tests/test-scripts/test_sql_client.sh
@@ -139,11 +139,11 @@ cat >> $SQL_CONF << EOF
     update-mode: upsert
     schema:
       - name: user_id
-        type: INT
+        data-type: INT
       - name: user_name
-        type: VARCHAR
+        data-type: STRING
       - name: user_count
-        type: BIGINT
+        data-type: BIGINT
     connector:
       type: elasticsearch
       version: 6
@@ -163,11 +163,11 @@ cat >> $SQL_CONF << EOF
     update-mode: append
     schema:
       - name: user_id
-        type: INT
+        data-type: INT
       - name: user_name
-        type: VARCHAR
+        data-type: STRING
       - name: user_count
-        type: BIGINT
+        data-type: BIGINT
     connector:
       type: elasticsearch
       version: 6

--- a/flink-end-to-end-tests/test-scripts/test_sql_client_kafka_common.sh
+++ b/flink-end-to-end-tests/test-scripts/test_sql_client_kafka_common.sh
@@ -87,13 +87,13 @@ cat >> $SQL_CONF << EOF
     update-mode: append
     schema:
       - name: event_timestamp
-        type: VARCHAR
+        data-type: STRING
       - name: user
-        type: VARCHAR
+        data-type: STRING
       - name: message
-        type: VARCHAR
+        data-type: STRING
       - name: duplicate_count
-        type: BIGINT
+        data-type: BIGINT
     connector:
       type: kafka
       version: "$KAFKA_SQL_VERSION"
@@ -123,15 +123,15 @@ cat >> $SQL_CONF << EOF
     update-mode: append
     schema:
       - name: event_timestamp
-        type: VARCHAR
+        data-type: STRING
       - name: user
-        type: VARCHAR
+        data-type: STRING
       - name: message
-        type: VARCHAR
+        data-type: STRING
       - name: duplicate_count
-        type: BIGINT
+        data-type: BIGINT
       - name: constant
-        type: VARCHAR
+        data-type: STRING
     connector:
       type: filesystem
       path: $RESULT
@@ -139,15 +139,15 @@ cat >> $SQL_CONF << EOF
       type: csv
       fields:
         - name: event_timestamp
-          type: VARCHAR
+          data-type: STRING
         - name: user
-          type: VARCHAR
+          data-type: STRING
         - name: message
-          type: VARCHAR
+          data-type: STRING
         - name: duplicate_count
-          type: BIGINT
+          data-type: BIGINT
         - name: constant
-          type: VARCHAR
+          data-type: STRING
 
 functions:
   - name: RegReplace

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDeserializationSchema.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDeserializationSchema.java
@@ -311,6 +311,12 @@ public final class CsvRowDeserializationSchema implements DeserializationSchema<
 			return (node) -> Time.valueOf(node.asText());
 		} else if (info.equals(Types.SQL_TIMESTAMP)) {
 			return (node) -> Timestamp.valueOf(node.asText());
+		} else if (info.equals(Types.LOCAL_DATE)) {
+			return (node) -> Date.valueOf(node.asText()).toLocalDate();
+		} else if (info.equals(Types.LOCAL_TIME)) {
+			return (node) -> Time.valueOf(node.asText()).toLocalTime();
+		} else if (info.equals(Types.LOCAL_DATE_TIME)) {
+			return (node) -> Timestamp.valueOf(node.asText()).toLocalDateTime();
 		} else if (info instanceof RowTypeInfo) {
 			final RowTypeInfo rowTypeInfo = (RowTypeInfo) info;
 			return createRowRuntimeConverter(rowTypeInfo, ignoreParseErrors, false);

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowSchemaConverter.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowSchemaConverter.java
@@ -66,7 +66,9 @@ public final class CsvRowSchemaConverter {
 	 * and value is not trimmed.
 	 */
 	private static final HashSet<TypeInformation<?>> STRING_TYPES =
-		new HashSet<>(Arrays.asList(Types.STRING, Types.SQL_DATE, Types.SQL_TIME, Types.SQL_TIMESTAMP));
+		new HashSet<>(Arrays.asList(Types.STRING,
+			Types.SQL_DATE, Types.SQL_TIME, Types.SQL_TIMESTAMP,
+			Types.LOCAL_DATE, Types.LOCAL_TIME, Types.LOCAL_DATE_TIME));
 
 	/**
 	 * Types that can be converted to ColumnType.BOOLEAN.

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowSerializationSchema.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowSerializationSchema.java
@@ -40,8 +40,14 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.csv.Csv
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.util.Arrays;
 import java.util.Objects;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 
 /**
  * Serialization schema that serializes an object of Flink types into a CSV bytes.
@@ -199,6 +205,13 @@ public final class CsvRowSerializationSchema implements SerializationSchema<Row>
 
 	// --------------------------------------------------------------------------------------------
 
+	private static final DateTimeFormatter DATE_TIME_FORMATTER = new DateTimeFormatterBuilder()
+			.parseCaseInsensitive()
+			.append(ISO_LOCAL_DATE)
+			.appendLiteral(' ')
+			.append(ISO_LOCAL_TIME)
+			.toFormatter();
+
 	private interface RuntimeConverter extends Serializable {
 		JsonNode convert(CsvMapper csvMapper, ContainerNode<?> container, Object obj);
 	}
@@ -294,6 +307,12 @@ public final class CsvRowSerializationSchema implements SerializationSchema<Row>
 			return (csvMapper, container, obj) -> container.textNode(obj.toString());
 		} else if (info.equals(Types.SQL_TIMESTAMP)) {
 			return (csvMapper, container, obj) -> container.textNode(obj.toString());
+		} else if (info.equals(Types.LOCAL_DATE)) {
+			return (csvMapper, container, obj) -> container.textNode(obj.toString());
+		} else if (info.equals(Types.LOCAL_TIME)) {
+			return (csvMapper, container, obj) -> container.textNode(obj.toString());
+		} else if (info.equals(Types.LOCAL_DATE_TIME)) {
+			return (csvMapper, container, obj) -> container.textNode(DATE_TIME_FORMATTER.format((LocalDateTime) obj));
 		} else if (info instanceof RowTypeInfo){
 			return createRowRuntimeConverter((RowTypeInfo) info, false);
 		} else if (info instanceof BasicArrayTypeInfo) {

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDeSerializationSchemaTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDeSerializationSchemaTest.java
@@ -72,6 +72,12 @@ public class CsvRowDeSerializationSchemaTest {
 			Types.SQL_TIMESTAMP,
 			"\"2018-10-12 12:12:12.0\"",
 			Timestamp.valueOf("2018-10-12 12:12:12"));
+		testNullableField(Types.LOCAL_DATE, "2018-10-12", Date.valueOf("2018-10-12").toLocalDate());
+		testNullableField(Types.LOCAL_TIME, "12:12:12", Time.valueOf("12:12:12").toLocalTime());
+		testNullableField(
+			Types.LOCAL_DATE_TIME,
+			"\"2018-10-12 12:12:12\"",
+			Timestamp.valueOf("2018-10-12 12:12:12").toLocalDateTime());
 		testNullableField(
 			Types.ROW(Types.STRING, Types.INT, Types.BOOLEAN),
 			"Hello;42;false",

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDeserializationSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDeserializationSchemaTest.java
@@ -55,6 +55,10 @@ public class JsonRowDeserializationSchemaTest {
 		String name = "asdlkjasjkdla998y1122";
 		byte[] bytes = new byte[1024];
 		ThreadLocalRandom.current().nextBytes(bytes);
+		Timestamp timestamp = Timestamp.valueOf("1990-10-14 12:12:43");
+		Date date = Date.valueOf("1990-10-14");
+		Time time = Time.valueOf("12:12:43");
+
 		Map<String, Long> map = new HashMap<>();
 		map.put("flink", 123L);
 
@@ -70,6 +74,12 @@ public class JsonRowDeserializationSchemaTest {
 		root.put("id", id);
 		root.put("name", name);
 		root.put("bytes", bytes);
+		root.put("date1", "1990-10-14");
+		root.put("date2", "1990-10-14");
+		root.put("time1", "12:12:43Z");
+		root.put("time2", "12:12:43Z");
+		root.put("timestamp1", "1990-10-14T12:12:43Z");
+		root.put("timestamp2", "1990-10-14T12:12:43Z");
 		root.putObject("map").put("flink", 123);
 		root.putObject("map2map").putObject("inner_map").put("key", 234);
 
@@ -77,17 +87,27 @@ public class JsonRowDeserializationSchemaTest {
 
 		JsonRowDeserializationSchema deserializationSchema = new JsonRowDeserializationSchema.Builder(
 			Types.ROW_NAMED(
-				new String[]{"id", "name", "bytes", "map", "map2map"},
-				Types.LONG, Types.STRING, Types.PRIMITIVE_ARRAY(Types.BYTE), Types.MAP(Types.STRING, Types.LONG),
+				new String[]{"id", "name", "bytes", "date1", "date2",
+					"time1", "time2", "timestamp1", "timestamp2", "map", "map2map"},
+				Types.LONG, Types.STRING, Types.PRIMITIVE_ARRAY(Types.BYTE),
+				Types.SQL_DATE, Types.LOCAL_DATE, Types.SQL_TIME, Types.LOCAL_TIME,
+				Types.SQL_TIMESTAMP, Types.LOCAL_DATE_TIME,
+				Types.MAP(Types.STRING, Types.LONG),
 				Types.MAP(Types.STRING, Types.MAP(Types.STRING, Types.INT)))
 		).build();
 
-		Row row = new Row(5);
+		Row row = new Row(11);
 		row.setField(0, id);
 		row.setField(1, name);
 		row.setField(2, bytes);
-		row.setField(3, map);
-		row.setField(4, nestedMap);
+		row.setField(3, date);
+		row.setField(4, date.toLocalDate());
+		row.setField(5, time);
+		row.setField(6, time.toLocalTime());
+		row.setField(7, timestamp);
+		row.setField(8, timestamp.toLocalDateTime());
+		row.setField(9, map);
+		row.setField(10, nestedMap);
 
 		assertThat(serializedJson, whenDeserializedWith(deserializationSchema).equalsTo(row));
 	}

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowSerializationSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowSerializationSchemaTest.java
@@ -43,13 +43,15 @@ public class JsonRowSerializationSchemaTest {
 	@Test
 	public void testRowSerialization() {
 		final TypeInformation<Row> rowSchema = Types.ROW_NAMED(
-			new String[] {"f1", "f2", "f3"},
-			Types.INT, Types.BOOLEAN, Types.STRING);
+			new String[] {"f1", "f2", "f3", "f4", "f5"},
+			Types.INT, Types.BOOLEAN, Types.STRING, Types.SQL_TIMESTAMP, Types.LOCAL_DATE_TIME);
 
-		final Row row = new Row(3);
+		final Row row = new Row(5);
 		row.setField(0, 1);
 		row.setField(1, true);
 		row.setField(2, "str");
+		row.setField(3, Timestamp.valueOf("1990-10-14 12:12:43"));
+		row.setField(4, Timestamp.valueOf("1990-10-14 12:12:43").toLocalDateTime());
 
 		final JsonRowSerializationSchema serializationSchema = new JsonRowSerializationSchema.Builder(rowSchema)
 			.build();

--- a/flink-python/pyflink/table/tests/test_descriptor.py
+++ b/flink-python/pyflink/table/tests/test_descriptor.py
@@ -437,11 +437,11 @@ class OldCsvDescriptorTests(PyFlinkTestCase):
 
         properties = csv.to_properties()
         expected = {'format.fields.0.name': 'a',
-                    'format.fields.0.type': 'BIGINT',
+                    'format.fields.0.data-type': 'BIGINT',
                     'format.fields.1.name': 'b',
-                    'format.fields.1.type': 'VARCHAR',
+                    'format.fields.1.data-type': 'VARCHAR(2147483647)',
                     'format.fields.2.name': 'c',
-                    'format.fields.2.type': 'SQL_TIMESTAMP',
+                    'format.fields.2.data-type': 'TIMESTAMP(3)',
                     'format.type': 'csv',
                     'format.property-version': '1'}
         self.assertEqual(expected, properties)
@@ -454,9 +454,9 @@ class OldCsvDescriptorTests(PyFlinkTestCase):
 
         properties = csv.to_properties()
         expected = {'format.fields.0.name': 'a',
-                    'format.fields.0.type': 'INT',
+                    'format.fields.0.data-type': 'INT',
                     'format.fields.1.name': 'b',
-                    'format.fields.1.type': 'VARCHAR',
+                    'format.fields.1.data-type': 'VARCHAR(2147483647)',
                     'format.type': 'csv',
                     'format.property-version': '1'}
 
@@ -786,27 +786,27 @@ class SchemaDescriptorTests(PyFlinkTestCase):
 
         properties = schema.to_properties()
         expected = {'schema.0.name': 'int_field',
-                    'schema.0.type': 'INT',
+                    'schema.0.data-type': 'INT',
                     'schema.1.name': 'long_field',
-                    'schema.1.type': 'BIGINT',
+                    'schema.1.data-type': 'BIGINT',
                     'schema.2.name': 'string_field',
-                    'schema.2.type': 'VARCHAR',
+                    'schema.2.data-type': 'VARCHAR(2147483647)',
                     'schema.3.name': 'timestamp_field',
-                    'schema.3.type': 'TIMESTAMP',
+                    'schema.3.data-type': 'TIMESTAMP(3)',
                     'schema.4.name': 'time_field',
-                    'schema.4.type': 'TIME',
+                    'schema.4.data-type': 'TIME(0)',
                     'schema.5.name': 'date_field',
-                    'schema.5.type': 'DATE',
+                    'schema.5.data-type': 'DATE',
                     'schema.6.name': 'double_field',
-                    'schema.6.type': 'DOUBLE',
+                    'schema.6.data-type': 'DOUBLE',
                     'schema.7.name': 'float_field',
-                    'schema.7.type': 'FLOAT',
+                    'schema.7.data-type': 'FLOAT',
                     'schema.8.name': 'byte_field',
-                    'schema.8.type': 'TINYINT',
+                    'schema.8.data-type': 'TINYINT',
                     'schema.9.name': 'short_field',
-                    'schema.9.type': 'SMALLINT',
+                    'schema.9.data-type': 'SMALLINT',
                     'schema.10.name': 'boolean_field',
-                    'schema.10.type': 'BOOLEAN'}
+                    'schema.10.data-type': 'BOOLEAN'}
         self.assertEqual(expected, properties)
 
     def test_field_in_string(self):
@@ -825,27 +825,27 @@ class SchemaDescriptorTests(PyFlinkTestCase):
 
         properties = schema.to_properties()
         expected = {'schema.0.name': 'int_field',
-                    'schema.0.type': 'INT',
+                    'schema.0.data-type': 'INT',
                     'schema.1.name': 'long_field',
-                    'schema.1.type': 'BIGINT',
+                    'schema.1.data-type': 'BIGINT',
                     'schema.2.name': 'string_field',
-                    'schema.2.type': 'VARCHAR',
+                    'schema.2.data-type': 'VARCHAR',
                     'schema.3.name': 'timestamp_field',
-                    'schema.3.type': 'SQL_TIMESTAMP',
+                    'schema.3.data-type': 'TIMESTAMP(3)',
                     'schema.4.name': 'time_field',
-                    'schema.4.type': 'SQL_TIME',
+                    'schema.4.data-type': 'TIME(0)',
                     'schema.5.name': 'date_field',
-                    'schema.5.type': 'SQL_DATE',
+                    'schema.5.data-type': 'DATE',
                     'schema.6.name': 'double_field',
-                    'schema.6.type': 'DOUBLE',
+                    'schema.6.data-type': 'DOUBLE',
                     'schema.7.name': 'float_field',
-                    'schema.7.type': 'FLOAT',
+                    'schema.7.data-type': 'FLOAT',
                     'schema.8.name': 'byte_field',
-                    'schema.8.type': 'TINYINT',
+                    'schema.8.data-type': 'TINYINT',
                     'schema.9.name': 'short_field',
-                    'schema.9.type': 'SMALLINT',
+                    'schema.9.data-type': 'SMALLINT',
                     'schema.10.name': 'boolean_field',
-                    'schema.10.type': 'BOOLEAN'}
+                    'schema.10.data-type': 'BOOLEAN'}
         self.assertEqual(expected, properties)
 
     def test_from_origin_field(self):
@@ -856,12 +856,12 @@ class SchemaDescriptorTests(PyFlinkTestCase):
 
         properties = schema.to_properties()
         expected = {'schema.0.name': 'int_field',
-                    'schema.0.type': 'INT',
+                    'schema.0.data-type': 'INT',
                     'schema.1.name': 'long_field',
-                    'schema.1.type': 'BIGINT',
+                    'schema.1.data-type': 'BIGINT',
                     'schema.1.from': 'origin_field_a',
                     'schema.2.name': 'string_field',
-                    'schema.2.type': 'VARCHAR'}
+                    'schema.2.data-type': 'VARCHAR(2147483647)'}
         self.assertEqual(expected, properties)
 
     def test_proctime(self):
@@ -872,12 +872,12 @@ class SchemaDescriptorTests(PyFlinkTestCase):
 
         properties = schema.to_properties()
         expected = {'schema.0.name': 'int_field',
-                    'schema.0.type': 'INT',
+                    'schema.0.data-type': 'INT',
                     'schema.1.name': 'ptime',
-                    'schema.1.type': 'BIGINT',
+                    'schema.1.data-type': 'BIGINT',
                     'schema.1.proctime': 'true',
                     'schema.2.name': 'string_field',
-                    'schema.2.type': 'VARCHAR'}
+                    'schema.2.data-type': 'VARCHAR(2147483647)'}
         self.assertEqual(expected, properties)
 
     def test_rowtime(self):
@@ -892,17 +892,17 @@ class SchemaDescriptorTests(PyFlinkTestCase):
         properties = schema.to_properties()
         print(properties)
         expected = {'schema.0.name': 'int_field',
-                    'schema.0.type': 'INT',
+                    'schema.0.data-type': 'INT',
                     'schema.1.name': 'long_field',
-                    'schema.1.type': 'BIGINT',
+                    'schema.1.data-type': 'BIGINT',
                     'schema.2.name': 'rtime',
-                    'schema.2.type': 'BIGINT',
+                    'schema.2.data-type': 'BIGINT',
                     'schema.2.rowtime.timestamps.type': 'from-field',
                     'schema.2.rowtime.timestamps.from': 'long_field',
                     'schema.2.rowtime.watermarks.type': 'periodic-bounded',
                     'schema.2.rowtime.watermarks.delay': '5000',
                     'schema.3.name': 'string_field',
-                    'schema.3.type': 'VARCHAR'}
+                    'schema.3.data-type': 'VARCHAR(2147483647)'}
         self.assertEqual(expected, properties)
 
     def test_schema(self):
@@ -912,9 +912,9 @@ class SchemaDescriptorTests(PyFlinkTestCase):
 
         properties = schema.to_properties()
         expected = {'schema.0.name': 'a',
-                    'schema.0.type': 'INT',
+                    'schema.0.data-type': 'INT',
                     'schema.1.name': 'b',
-                    'schema.1.type': 'VARCHAR'}
+                    'schema.1.data-type': 'VARCHAR(2147483647)'}
         self.assertEqual(expected, properties)
 
 
@@ -930,7 +930,7 @@ class AbstractTableDescriptorTests(object):
         expected = {'format.type': 'csv',
                     'format.property-version': '1',
                     'format.fields.0.name': 'a',
-                    'format.fields.0.type': 'INT',
+                    'format.fields.0.data-type': 'INT',
                     'connector.property-version': '1',
                     'connector.type': 'filesystem'}
         assert properties == expected
@@ -942,7 +942,7 @@ class AbstractTableDescriptorTests(object):
 
         properties = descriptor.to_properties()
         expected = {'schema.0.name': 'a',
-                    'schema.0.type': 'INT',
+                    'schema.0.data-type': 'INT',
                     'format.type': 'csv',
                     'format.property-version': '1',
                     'connector.type': 'filesystem',

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSinkFactoryBase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSinkFactoryBase.java
@@ -40,6 +40,7 @@ import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_TIMESTAMPS_FROM
 import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_TIMESTAMPS_TYPE;
 import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_WATERMARKS_TYPE;
 import static org.apache.flink.table.descriptors.Schema.SCHEMA;
+import static org.apache.flink.table.descriptors.Schema.SCHEMA_DATA_TYPE;
 import static org.apache.flink.table.descriptors.Schema.SCHEMA_NAME;
 import static org.apache.flink.table.descriptors.Schema.SCHEMA_TYPE;
 import static org.apache.flink.table.descriptors.StreamTableDescriptorValidator.UPDATE_MODE;
@@ -70,6 +71,7 @@ public abstract class TestTableSinkFactoryBase implements StreamTableSinkFactory
 	public List<String> supportedProperties() {
 		final List<String> properties = new ArrayList<>();
 		properties.add("connector." + testProperty);
+		properties.add(SCHEMA + ".#." + SCHEMA_DATA_TYPE);
 		properties.add(SCHEMA + ".#." + SCHEMA_TYPE);
 		properties.add(SCHEMA + ".#." + SCHEMA_NAME);
 		properties.add(SCHEMA + ".#." + ROWTIME_TIMESTAMPS_TYPE);

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSourceFactoryBase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSourceFactoryBase.java
@@ -43,6 +43,7 @@ import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_TIMESTAMPS_FROM
 import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_TIMESTAMPS_TYPE;
 import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_WATERMARKS_TYPE;
 import static org.apache.flink.table.descriptors.Schema.SCHEMA;
+import static org.apache.flink.table.descriptors.Schema.SCHEMA_DATA_TYPE;
 import static org.apache.flink.table.descriptors.Schema.SCHEMA_NAME;
 import static org.apache.flink.table.descriptors.Schema.SCHEMA_TYPE;
 import static org.apache.flink.table.descriptors.StreamTableDescriptorValidator.UPDATE_MODE;
@@ -73,6 +74,7 @@ public abstract class TestTableSourceFactoryBase implements StreamTableSourceFac
 	public List<String> supportedProperties() {
 		final List<String> properties = new ArrayList<>();
 		properties.add("connector." + testProperty);
+		properties.add(SCHEMA + ".#." + SCHEMA_DATA_TYPE);
 		properties.add(SCHEMA + ".#." + SCHEMA_TYPE);
 		properties.add(SCHEMA + ".#." + SCHEMA_NAME);
 		properties.add(SCHEMA + ".#." + ROWTIME_TIMESTAMPS_TYPE);

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/descriptors/OldCsv.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/descriptors/OldCsv.java
@@ -22,6 +22,11 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.UnresolvedUserDefinedType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeParser;
+import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.table.utils.TypeStringUtils;
 
 import java.util.Arrays;
@@ -112,9 +117,25 @@ public class OldCsv extends FormatDescriptor {
 	 *
 	 * @param fieldName the field name
 	 * @param fieldType the type information of the field
+	 * @deprecated This method will be removed in future versions as it uses the old type system.
+	 * 			Please use {@link #field(String, DataType)} instead.
 	 */
+	@Deprecated
 	public OldCsv field(String fieldName, TypeInformation<?> fieldType) {
-		field(fieldName, TypeStringUtils.writeTypeInfo(fieldType));
+		field(fieldName, TypeConversions.fromLegacyInfoToDataType(fieldType));
+		return this;
+	}
+
+	/**
+	 * Adds a format field with the field name and the type information. Required.
+	 * This method can be called multiple times. The call order of this method defines
+	 * also the order of the fields in the format.
+	 *
+	 * @param fieldName the field name
+	 * @param fieldType the type information of the field
+	 */
+	public OldCsv field(String fieldName, DataType fieldType) {
+		addField(fieldName, fieldType.getLogicalType().asSerializableString());
 		return this;
 	}
 
@@ -123,15 +144,39 @@ public class OldCsv extends FormatDescriptor {
 	 * This method can be called multiple times. The call order of this method defines
 	 * also the order of the fields in the format.
 	 *
+	 * <p>NOTE: the fieldType string should follow the type string defined in {@link LogicalTypeParser}.
+	 * This method also keeps compatible with old type string defined in {@link TypeStringUtils} but
+	 * will be dropped in future versions as it uses the old type system.
+	 *
 	 * @param fieldName the field name
 	 * @param fieldType the type string of the field
 	 */
 	public OldCsv field(String fieldName, String fieldType) {
+		if (isLegacyTypeString(fieldType)) {
+			// fallback to legacy parser
+			TypeInformation<?> typeInfo = TypeStringUtils.readTypeInfo(fieldType);
+			return field(fieldName, TypeConversions.fromLegacyInfoToDataType(typeInfo));
+		} else {
+			return addField(fieldName, fieldType);
+		}
+	}
+
+	private OldCsv addField(String fieldName, String fieldType) {
 		if (schema.containsKey(fieldName)) {
 			throw new ValidationException("Duplicate field name " + fieldName + ".");
 		}
 		schema.put(fieldName, fieldType);
 		return this;
+	}
+
+	private static boolean isLegacyTypeString(String fieldType) {
+		try {
+			LogicalType type = LogicalTypeParser.parse(fieldType);
+			return type instanceof UnresolvedUserDefinedType;
+		} catch (Exception e) {
+			// if the parsing failed, fallback to the legacy parser
+			return true;
+		}
 	}
 
 	/**
@@ -195,7 +240,7 @@ public class OldCsv extends FormatDescriptor {
 		} else {
 			List<String> subKeys = Arrays.asList(
 				DescriptorProperties.TABLE_SCHEMA_NAME,
-				DescriptorProperties.TABLE_SCHEMA_TYPE);
+				DescriptorProperties.TABLE_SCHEMA_DATA_TYPE);
 
 			List<List<String>> subValues = schema.entrySet().stream()
 				.map(e -> Arrays.asList(e.getKey(), e.getValue()))

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/CsvTableSinkFactoryBase.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/CsvTableSinkFactoryBase.java
@@ -66,12 +66,14 @@ public abstract class CsvTableSinkFactoryBase implements TableFactory {
 		properties.add(CONNECTOR_PATH);
 		// format
 		properties.add(FORMAT_FIELDS + ".#." + DescriptorProperties.TABLE_SCHEMA_TYPE);
+		properties.add(FORMAT_FIELDS + ".#." + DescriptorProperties.TABLE_SCHEMA_DATA_TYPE);
 		properties.add(FORMAT_FIELDS + ".#." + DescriptorProperties.TABLE_SCHEMA_NAME);
 		properties.add(FormatDescriptorValidator.FORMAT_DERIVE_SCHEMA);
 		properties.add(FORMAT_FIELD_DELIMITER);
 		properties.add(CONNECTOR_PATH);
 		// schema
 		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_TYPE);
+		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_DATA_TYPE);
 		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_NAME);
 		return properties;
 	}

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/CsvTableSourceFactoryBase.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/CsvTableSourceFactoryBase.java
@@ -71,6 +71,7 @@ public abstract class CsvTableSourceFactoryBase implements TableFactory {
 		properties.add(CONNECTOR_PATH);
 		// format
 		properties.add(FORMAT_FIELDS + ".#." + DescriptorProperties.TABLE_SCHEMA_TYPE);
+		properties.add(FORMAT_FIELDS + ".#." + DescriptorProperties.TABLE_SCHEMA_DATA_TYPE);
 		properties.add(FORMAT_FIELDS + ".#." + DescriptorProperties.TABLE_SCHEMA_NAME);
 		properties.add(FormatDescriptorValidator.FORMAT_DERIVE_SCHEMA);
 		properties.add(FORMAT_FIELD_DELIMITER);
@@ -82,6 +83,7 @@ public abstract class CsvTableSourceFactoryBase implements TableFactory {
 		properties.add(CONNECTOR_PATH);
 		// schema
 		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_TYPE);
+		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_DATA_TYPE);
 		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_NAME);
 		return properties;
 	}

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/CsvTableSinkFactoryTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/CsvTableSinkFactoryTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.factories;
 
-import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.descriptors.DescriptorProperties;
@@ -50,7 +49,8 @@ public class CsvTableSinkFactoryTest {
 		.field("myfield2", DataTypes.INT())
 		.field("myfield3", DataTypes.MAP(DataTypes.STRING(), DataTypes.INT()))
 		.field("myfield4", DataTypes.ROW(DataTypes.FIELD("nested_f1", DataTypes.BIGINT())))
-		.field("myfield5", Types.PRIMITIVE_ARRAY(Types.SHORT))
+		// TODO: we can't declare the TINYINT as NOT NULL, because CSV connector will ignore the information
+		.field("myfield5", DataTypes.ARRAY(DataTypes.TINYINT()))
 		.build();
 
 	@Parameterized.Parameter

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/TableSourceFactoryMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/TableSourceFactoryMock.java
@@ -69,6 +69,7 @@ public class TableSourceFactoryMock implements TableSourceFactory<Row> {
 		supportedProperties.add(ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION);
 		supportedProperties.add(FormatDescriptorValidator.FORMAT + ".*");
 		supportedProperties.add(Schema.SCHEMA + ".#." + Schema.SCHEMA_NAME);
+		supportedProperties.add(Schema.SCHEMA + ".#." + Schema.SCHEMA_DATA_TYPE);
 		supportedProperties.add(Schema.SCHEMA + ".#." + Schema.SCHEMA_TYPE);
 		return supportedProperties;
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/Schema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/Schema.java
@@ -22,6 +22,11 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.UnresolvedUserDefinedType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeParser;
+import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.table.utils.TypeStringUtils;
 
 import java.util.ArrayList;
@@ -40,7 +45,13 @@ public class Schema implements Descriptor {
 
 	public static final String SCHEMA = "schema";
 	public static final String SCHEMA_NAME = "name";
+	/**
+	 * @deprecated {@link Schema} uses the legacy type key (e.g. schema.0.type = LONG) to store type information in
+	 * prior v1.9. Since v1.10, {@link Schema} uses data type key (e.g. schema.0.data-type = BIGINT) to store types.
+	 */
+	@Deprecated
 	public static final String SCHEMA_TYPE = "type";
+	public static final String SCHEMA_DATA_TYPE = "data-type";
 	public static final String SCHEMA_PROCTIME = "proctime";
 	public static final String SCHEMA_FROM = "from";
 
@@ -52,7 +63,7 @@ public class Schema implements Descriptor {
 	/**
 	 * Sets the schema with field names and the types. Required.
 	 *
-	 * <p>This method overwrites existing fields added with {@link #field(String, TypeInformation)}.
+	 * <p>This method overwrites existing fields added with {@link #field(String, DataType)}.
 	 *
 	 * @param schema the table schema
 	 */
@@ -60,10 +71,24 @@ public class Schema implements Descriptor {
 		tableSchema.clear();
 		lastField = null;
 		for (int i = 0; i < schema.getFieldCount(); i++) {
-			field(schema.getFieldName(i).get(), schema.getFieldType(i).get());
+			field(schema.getFieldName(i).get(), schema.getFieldDataType(i).get());
 		}
 		return this;
 	}
+
+	/**
+	 * Adds a field with the field name and the data type. Required.
+	 * This method can be called multiple times. The call order of this method defines
+	 * also the order of the fields in a row.
+	 *
+	 * @param fieldName the field name
+	 * @param fieldType the type information of the field
+	 */
+	public Schema field(String fieldName, DataType fieldType) {
+		addField(fieldName, fieldType.getLogicalType().asSerializableString());
+		return this;
+	}
+
 
 	/**
 	 * Adds a field with the field name and the type information. Required.
@@ -72,9 +97,12 @@ public class Schema implements Descriptor {
 	 *
 	 * @param fieldName the field name
 	 * @param fieldType the type information of the field
+	 * @deprecated This method will be removed in future versions as it uses the old type system.
+	 * 				Please use {@link #field(String, DataType)} instead.
 	 */
+	@Deprecated
 	public Schema field(String fieldName, TypeInformation<?> fieldType) {
-		field(fieldName, TypeStringUtils.writeTypeInfo(fieldType));
+		field(fieldName, TypeConversions.fromLegacyInfoToDataType(fieldType));
 		return this;
 	}
 
@@ -83,21 +111,45 @@ public class Schema implements Descriptor {
 	 * This method can be called multiple times. The call order of this method defines
 	 * also the order of the fields in a row.
 	 *
+	 * <p>NOTE: the fieldType string should follow the type string defined in {@link LogicalTypeParser}.
+	 * This method also keeps compatible with old type string defined in {@link TypeStringUtils}
+	 * but will be dropped in future versions as it uses the old type system.
+	 *
 	 * @param fieldName the field name
 	 * @param fieldType the type string of the field
 	 */
 	public Schema field(String fieldName, String fieldType) {
+		if (isLegacyTypeString(fieldType)) {
+			// fallback to legacy parser
+			TypeInformation<?> typeInfo = TypeStringUtils.readTypeInfo(fieldType);
+			return field(fieldName, TypeConversions.fromLegacyInfoToDataType(typeInfo));
+		} else {
+			return addField(fieldName, fieldType);
+		}
+	}
+
+	private Schema addField(String fieldName, String fieldType) {
 		if (tableSchema.containsKey(fieldName)) {
-			throw new ValidationException("Duplicate field name $fieldName.");
+			throw new ValidationException("Duplicate field name " + fieldName + ".");
 		}
 
 		LinkedHashMap<String, String> fieldProperties = new LinkedHashMap<>();
-		fieldProperties.put(SCHEMA_TYPE, fieldType);
+		fieldProperties.put(SCHEMA_DATA_TYPE, fieldType);
 
 		tableSchema.put(fieldName, fieldProperties);
 
 		lastField = fieldName;
 		return this;
+	}
+
+	private static boolean isLegacyTypeString(String fieldType) {
+		try {
+			LogicalType type = LogicalTypeParser.parse(fieldType);
+			return type instanceof UnresolvedUserDefinedType;
+		} catch (Exception e) {
+			// if the parsing failed, fallback to the legacy parser
+			return true;
+		}
 	}
 
 	/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableFormatFactoryBase.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableFormatFactoryBase.java
@@ -19,10 +19,10 @@
 package org.apache.flink.table.factories;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.descriptors.FormatDescriptorValidator;
+import org.apache.flink.table.types.DataType;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -42,6 +42,12 @@ public abstract class TableFormatFactoryBase<T> implements TableFormatFactory<T>
 	// TODO drop constants once SchemaValidator has been ported to flink-table-common
 	private static final String SCHEMA = "schema";
 	private static final String SCHEMA_NAME = "name";
+	private static final String SCHEMA_DATA_TYPE = "data-type";
+	/**
+	 * @deprecated {@link #SCHEMA_TYPE} will be removed in future version as it uses old type system.
+	 *  Please use {@link #SCHEMA_DATA_TYPE} instead.
+	 */
+	@Deprecated
 	private static final String SCHEMA_TYPE = "type";
 	private static final String SCHEMA_PROCTIME = "proctime";
 	private static final String SCHEMA_FROM = "from";
@@ -87,6 +93,7 @@ public abstract class TableFormatFactoryBase<T> implements TableFormatFactory<T>
 		if (supportsSchemaDerivation) {
 			properties.add(FormatDescriptorValidator.FORMAT_DERIVE_SCHEMA);
 			// schema
+			properties.add(SCHEMA + ".#." + SCHEMA_DATA_TYPE);
 			properties.add(SCHEMA + ".#." + SCHEMA_TYPE);
 			properties.add(SCHEMA + ".#." + SCHEMA_NAME);
 			properties.add(SCHEMA + ".#." + SCHEMA_FROM);
@@ -137,7 +144,7 @@ public abstract class TableFormatFactoryBase<T> implements TableFormatFactory<T>
 		final TableSchema baseSchema = descriptorProperties.getTableSchema(SCHEMA);
 		for (int i = 0; i < baseSchema.getFieldCount(); i++) {
 			final String fieldName = baseSchema.getFieldNames()[i];
-			final TypeInformation<?> fieldType = baseSchema.getFieldTypes()[i];
+			final DataType fieldType = baseSchema.getFieldDataTypes()[i];
 
 			final boolean isProctime = descriptorProperties
 				.getOptionalBoolean(SCHEMA + '.' + i + '.' + SCHEMA_PROCTIME)

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LegacyTypeInformationType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LegacyTypeInformationType.java
@@ -20,8 +20,9 @@ package org.apache.flink.table.types.logical;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.types.utils.LegacyTypeInfoDataTypeConverter;
+import org.apache.flink.table.utils.EncodingUtils;
+import org.apache.flink.table.utils.TypeStringUtils;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Collections;
@@ -45,7 +46,7 @@ import java.util.Objects;
 @Internal
 public final class LegacyTypeInformationType<T> extends LogicalType {
 
-	private static final String FORMAT = "LEGACY(%s)";
+	private static final String FORMAT = "LEGACY('%s', '%s')";
 
 	private final TypeInformation<T> typeInfo;
 
@@ -65,12 +66,15 @@ public final class LegacyTypeInformationType<T> extends LogicalType {
 
 	@Override
 	public String asSerializableString() {
-		throw new TableException("Legacy type information has no serializable string representation.");
+		return withNullability(
+			FORMAT,
+			getTypeRoot(),
+			EncodingUtils.escapeSingleQuotes(TypeStringUtils.writeTypeInfo(typeInfo)));
 	}
 
 	@Override
 	public String asSummaryString() {
-		return withNullability(FORMAT, typeInfo);
+		return asSerializableString();
 	}
 
 	@Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeParser.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeParser.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.types.logical.utils;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.table.api.ValidationException;
@@ -35,8 +36,10 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LegacyTypeInformationType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.NullType;
@@ -53,6 +56,7 @@ import org.apache.flink.table.types.logical.YearMonthIntervalType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType.YearMonthResolution;
 import org.apache.flink.table.types.logical.ZonedTimestampType;
 import org.apache.flink.table.utils.EncodingUtils;
+import org.apache.flink.table.utils.TypeStringUtils;
 
 import javax.annotation.Nullable;
 
@@ -302,6 +306,7 @@ public final class LogicalTypeParser {
 		ROW,
 		NULL,
 		RAW,
+		LEGACY,
 		NOT
 	}
 
@@ -540,6 +545,8 @@ public final class LogicalTypeParser {
 					return new NullType();
 				case RAW:
 					return parseRawType();
+				case LEGACY:
+					return parseLegacyType();
 				default:
 					throw parsingError("Unsupported type: " + token().value);
 			}
@@ -896,6 +903,28 @@ public final class LogicalTypeParser {
 				throw parsingError(
 					"Unable to restore the RAW type of class '" + className + "' with " +
 						"serializer snapshot '" + serializer + "'.", t);
+			}
+		}
+
+		@SuppressWarnings("unchecked")
+		private LogicalType parseLegacyType() {
+			nextToken(TokenType.BEGIN_PARAMETER);
+			nextToken(TokenType.LITERAL_STRING);
+			final String rootString = tokenAsString();
+
+			nextToken(TokenType.LIST_SEPARATOR);
+			nextToken(TokenType.LITERAL_STRING);
+			final String typeInfoString = tokenAsString();
+			nextToken(TokenType.END_PARAMETER);
+
+			try {
+				final LogicalTypeRoot root = LogicalTypeRoot.valueOf(rootString);
+				final TypeInformation typeInfo = TypeStringUtils.readTypeInfo(typeInfoString);
+				return new LegacyTypeInformationType<>(root, typeInfo);
+			} catch (Throwable t) {
+				throw parsingError(
+						"Unable to restore the Legacy type of '" + typeInfoString + "' with " +
+								"type root '" + rootString + "'.", t);
 			}
 		}
 	}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/descriptors/DescriptorPropertiesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/descriptors/DescriptorPropertiesTest.java
@@ -18,13 +18,14 @@
 
 package org.apache.flink.table.descriptors;
 
+import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.types.LogicalTypeParserTest;
 
 import org.junit.Test;
 
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -177,10 +178,10 @@ public class DescriptorPropertiesTest {
 			.field("f0", DataTypes.BIGINT())
 			.field("f1", DataTypes.ROW(
 				DataTypes.FIELD("q1", DataTypes.STRING()),
-				// the "bridgedTo" is a temporary solution because the type string format is based on TypeInformation.
-				DataTypes.FIELD("q2", DataTypes.TIMESTAMP(3).bridgedTo(Timestamp.class))))
+				DataTypes.FIELD("q2", DataTypes.TIMESTAMP(9))))
 			.field("f2", DataTypes.STRING())
 			.field("f3", DataTypes.BIGINT(), "f0 + 1")
+			.field("f4", DataTypes.DECIMAL(10, 3))
 			.watermark(
 				"f1.q2",
 				"`f1`.`q2` - INTERVAL '5' SECOND",
@@ -192,21 +193,66 @@ public class DescriptorPropertiesTest {
 		Map<String, String> actual = properties.asMap();
 		Map<String, String> expected = new HashMap<>();
 		expected.put("schema.0.name", "f0");
-		expected.put("schema.0.type", "BIGINT");
+		expected.put("schema.0.data-type", "BIGINT");
 		expected.put("schema.1.name", "f1");
-		expected.put("schema.1.type", "ROW<q1 VARCHAR, q2 TIMESTAMP>");
+		expected.put("schema.1.data-type", "ROW<`q1` VARCHAR(2147483647), `q2` TIMESTAMP(9)>");
 		expected.put("schema.2.name", "f2");
-		expected.put("schema.2.type", "VARCHAR");
+		expected.put("schema.2.data-type", "VARCHAR(2147483647)");
 		expected.put("schema.3.name", "f3");
-		expected.put("schema.3.type", "BIGINT");
+		expected.put("schema.3.data-type", "BIGINT");
 		expected.put("schema.3.expr", "f0 + 1");
+		expected.put("schema.4.name", "f4");
+		expected.put("schema.4.data-type", "DECIMAL(10, 3)");
 		expected.put("schema.watermark.0.rowtime", "f1.q2");
 		expected.put("schema.watermark.0.strategy.expr", "`f1`.`q2` - INTERVAL '5' SECOND");
-		expected.put("schema.watermark.0.strategy.datatype", "TIMESTAMP(3)");
+		expected.put("schema.watermark.0.strategy.data-type", "TIMESTAMP(3)");
 		assertEquals(expected, actual);
 
 		TableSchema restored = properties.getTableSchema("schema");
 		assertEquals(schema, restored);
+	}
+
+	@Test
+	public void testLegacyTableSchema() {
+		DescriptorProperties properties = new DescriptorProperties();
+		Map<String, String> map = new HashMap<>();
+		map.put("schema.0.name", "f0");
+		map.put("schema.0.type", "VARCHAR");
+		map.put("schema.1.name", "f1");
+		map.put("schema.1.type", "BIGINT");
+		map.put("schema.2.name", "f2");
+		map.put("schema.2.type", "DECIMAL");
+		map.put("schema.3.name", "f3");
+		map.put("schema.3.type", "TIMESTAMP");
+		map.put("schema.4.name", "f4");
+		map.put("schema.4.type", "MAP<TINYINT, SMALLINT>");
+		map.put("schema.5.name", "f5");
+		map.put("schema.5.type", "ANY<java.lang.Class>");
+		map.put("schema.6.name", "f6");
+		map.put("schema.6.type", "PRIMITIVE_ARRAY<DOUBLE>");
+		map.put("schema.7.name", "f7");
+		map.put("schema.7.type", "OBJECT_ARRAY<TIME>");
+		map.put("schema.8.name", "f8");
+		map.put("schema.8.type", "ROW<q1 VARCHAR, q2 DATE>");
+		map.put("schema.9.name", "f9");
+		map.put("schema.9.type", "POJO<org.apache.flink.table.types.LogicalTypeParserTest$MyPojo>");
+		properties.putProperties(map);
+		TableSchema restored = properties.getTableSchema("schema");
+
+		TableSchema expected = TableSchema.builder()
+			.field("f0", Types.STRING)
+			.field("f1", Types.LONG)
+			.field("f2", Types.BIG_DEC)
+			.field("f3", Types.SQL_TIMESTAMP)
+			.field("f4", Types.MAP(Types.BYTE, Types.SHORT))
+			.field("f5", Types.GENERIC(Class.class))
+			.field("f6", Types.PRIMITIVE_ARRAY(Types.DOUBLE))
+			.field("f7", Types.OBJECT_ARRAY(Types.SQL_TIME))
+			.field("f8", Types.ROW_NAMED(new String[]{"q1", "q2"}, Types.STRING, Types.SQL_DATE))
+			.field("f9", Types.POJO(LogicalTypeParserTest.MyPojo.class))
+			.build();
+
+		assertEquals(expected, restored);
 	}
 
 	private void testArrayValidation(

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -322,16 +322,16 @@ public class SqlToOperationConverterTest {
 		Map<String, String> properties = catalogTable.toProperties();
 		Map<String, String> expected = new HashMap<>();
 		expected.put("schema.0.name", "a");
-		expected.put("schema.0.type", "INT");
+		expected.put("schema.0.data-type", "INT");
 		expected.put("schema.1.name", "b");
-		expected.put("schema.1.type", "BIGINT");
+		expected.put("schema.1.data-type", "BIGINT");
 		expected.put("schema.2.name", "c");
-		expected.put("schema.2.type", "TIMESTAMP");
+		expected.put("schema.2.data-type", "TIMESTAMP(3)");
 		expected.put("schema.watermark.0.rowtime", "c");
 		expected.put(
 			"schema.watermark.0.strategy.expr",
 			"`builtin`.`default`.`myfunc`(`c`, 1) - INTERVAL '5' SECOND");
-		expected.put("schema.watermark.0.strategy.datatype", "TIMESTAMP(3)");
+		expected.put("schema.watermark.0.strategy.data-type", "TIMESTAMP(3)");
 		expected.put("connector.type", "kafka");
 		assertEquals(expected, properties);
 	}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
@@ -25,13 +25,13 @@ import org.apache.flink.table.catalog.{CatalogDatabaseImpl, CatalogFunctionImpl,
 import org.apache.flink.table.planner.expressions.utils.Func0
 import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.JavaFunc0
+import org.apache.flink.table.planner.utils.DateTimeTestUtil.localDateTime
 import org.apache.flink.types.Row
 import org.junit.Assert.{assertEquals, fail}
 import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.junit.{Before, Ignore, Rule, Test}
-import java.sql.Timestamp
 import java.util
 
 import scala.collection.JavaConversions._
@@ -283,11 +283,11 @@ class CatalogTableITCase(isStreamingMode: Boolean) {
       toRow(2, "2019-09-10 09:23:44")
     )
     val expected = List(
-      toRow(1, "1990-02-10 12:34:56", Timestamp.valueOf("1990-02-10 12:34:56")),
-      toRow(2, "2019-09-10 09:23:41", Timestamp.valueOf("2019-09-10 9:23:41")),
-      toRow(3, "2019-09-10 09:23:42", Timestamp.valueOf("2019-09-10 9:23:42")),
-      toRow(1, "2019-09-10 09:23:43", Timestamp.valueOf("2019-09-10 9:23:43")),
-      toRow(2, "2019-09-10 09:23:44", Timestamp.valueOf("2019-09-10 9:23:44"))
+      toRow(1, "1990-02-10 12:34:56", localDateTime("1990-02-10 12:34:56")),
+      toRow(2, "2019-09-10 09:23:41", localDateTime("2019-09-10 09:23:41")),
+      toRow(3, "2019-09-10 09:23:42", localDateTime("2019-09-10 09:23:42")),
+      toRow(1, "2019-09-10 09:23:43", localDateTime("2019-09-10 09:23:43")),
+      toRow(2, "2019-09-10 09:23:44", localDateTime("2019-09-10 09:23:44"))
     )
     TestCollectionTableFactory.initData(sourceData)
     val sourceDDL =

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableTest.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.catalog
+
+import org.apache.flink.table.api.{DataTypes, EnvironmentSettings, TableEnvironment, TableSchema}
+import org.apache.flink.table.api.internal.TableEnvironmentImpl
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+/**
+  * Unit tests around catalog table and DDL.
+  */
+class CatalogTableTest {
+
+  val tEnv: TableEnvironment = TableEnvironmentImpl.create(
+    EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build())
+
+  @Test
+  def testDDLSchema(): Unit = {
+    tEnv.sqlUpdate(
+      """
+        |CREATE TABLE t1 (
+        |  f1 INT,
+        |  f2 BIGINT NOT NULL,
+        |  f3 STRING,
+        |  f4 DECIMAL(10, 4),
+        |  f5 TIMESTAMP(2) NOT NULL,
+        |  f6 TIME,
+        |  f7 DATE,
+        |  f8 VARCHAR(10) NOT NULL
+        |) WITH (
+        |  'connector' = 'COLLECTION'
+        |)
+      """.stripMargin
+    )
+
+    val actual = tEnv.sqlQuery("SELECT * FROM t1").getSchema
+    val expected = TableSchema.builder()
+      .field("f1", DataTypes.INT())
+      .field("f2", DataTypes.BIGINT().notNull())
+      .field("f3", DataTypes.STRING())
+      .field("f4", DataTypes.DECIMAL(10, 4))
+      .field("f5", DataTypes.TIMESTAMP(2).notNull())
+      .field("f6", DataTypes.TIME())
+      .field("f7", DataTypes.DATE())
+      .field("f8", DataTypes.VARCHAR(10).notNull())
+      .build()
+
+    assertEquals(expected, actual)
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TimeAttributeITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TimeAttributeITCase.scala
@@ -29,6 +29,7 @@ import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.Test
 
 import java.sql.Timestamp
+import java.time.LocalDateTime
 import java.util.TimeZone
 
 import scala.collection.JavaConverters._
@@ -39,13 +40,13 @@ import scala.collection.JavaConverters._
 class TimeAttributeITCase extends StreamingTestBase {
 
   val data = List(
-    row("1970-01-01 00:00:00.001", utcTimestamp(1L), 1, 1d),
-    row("1970-01-01 00:00:00.002", utcTimestamp(2L), 1, 2d),
-    row("1970-01-01 00:00:00.003", utcTimestamp(3L), 1, 2d),
-    row("1970-01-01 00:00:00.004", utcTimestamp(4L), 1, 5d),
-    row("1970-01-01 00:00:00.007", utcTimestamp(7L), 1, 3d),
-    row("1970-01-01 00:00:00.008", utcTimestamp(8L), 1, 3d),
-    row("1970-01-01 00:00:00.016", utcTimestamp(16L), 1, 4d))
+    row("1970-01-01 00:00:00.001", localDateTime(1L), 1, 1d),
+    row("1970-01-01 00:00:00.002", localDateTime(2L), 1, 2d),
+    row("1970-01-01 00:00:00.003", localDateTime(3L), 1, 2d),
+    row("1970-01-01 00:00:00.004", localDateTime(4L), 1, 5d),
+    row("1970-01-01 00:00:00.007", localDateTime(7L), 1, 3d),
+    row("1970-01-01 00:00:00.008", localDateTime(8L), 1, 3d),
+    row("1970-01-01 00:00:00.016", localDateTime(16L), 1, 4d))
 
   TestCollectionTableFactory.reset()
   TestCollectionTableFactory.initData(data.asJava)
@@ -188,8 +189,8 @@ class TimeAttributeITCase extends StreamingTestBase {
 
   // ------------------------------------------------------------------------------------------
 
-  private def utcTimestamp(ts: Long): Timestamp = {
-    new Timestamp(ts - TimeZone.getDefault.getOffset(ts))
+  private def localDateTime(ts: Long): LocalDateTime = {
+    new Timestamp(ts - TimeZone.getDefault.getOffset(ts)).toLocalDateTime
   }
 
   private def row(args: Any*): Row = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/descriptors/OldCsvTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/descriptors/OldCsvTest.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.table.descriptors
 
 import java.util
-
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.table.api.{TableSchema, Types, ValidationException}
@@ -34,7 +33,7 @@ class OldCsvTest extends DescriptorTestBase {
 
   @Test(expected = classOf[ValidationException])
   def testInvalidType(): Unit = {
-    addPropertyAndVerify(descriptors().get(0), "format.fields.0.type", "WHATEVER")
+    addPropertyAndVerify(descriptors().get(0), "format.fields.0.data-type", "WHATEVER")
   }
 
   @Test(expected = classOf[ValidationException])
@@ -74,22 +73,22 @@ class OldCsvTest extends DescriptorTestBase {
       "format.type" -> "csv",
       "format.property-version" -> "1",
       "format.fields.0.name" -> "field1",
-      "format.fields.0.type" -> "STRING",
+      "format.fields.0.data-type" -> "STRING",
       "format.fields.1.name" -> "field2",
-      "format.fields.1.type" -> "TIMESTAMP",
+      "format.fields.1.data-type" -> "TIMESTAMP(3)",
       "format.fields.2.name" -> "field3",
-      "format.fields.2.type" -> "ANY<java.lang.Class>",
+      "format.fields.2.data-type" -> "LEGACY('RAW', 'ANY<java.lang.Class>')",
       "format.fields.3.name" -> "field4",
-      "format.fields.3.type" -> "ROW<test INT, row VARCHAR>",
+      "format.fields.3.data-type" -> "ROW<`test` INT, `row` VARCHAR(2147483647)>",
       "format.line-delimiter" -> "^")
 
     val props2 = Map(
       "format.type" -> "csv",
       "format.property-version" -> "1",
       "format.fields.0.name" -> "test",
-      "format.fields.0.type" -> "INT",
+      "format.fields.0.data-type" -> "INT",
       "format.fields.1.name" -> "row",
-      "format.fields.1.type" -> "VARCHAR",
+      "format.fields.1.data-type" -> "VARCHAR(2147483647)",
       "format.quote-character" -> "#",
       "format.ignore-first-line" -> "true")
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/descriptors/SchemaTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/descriptors/SchemaTest.scala
@@ -31,7 +31,7 @@ class SchemaTest extends DescriptorTestBase {
   def testInvalidType(): Unit = {
     addPropertyAndVerify(
       descriptors().get(0),
-      "schema.1.type", "dfghj")
+      "schema.1.data-type", "dfghj")
   }
 
   @Test(expected = classOf[ValidationException])
@@ -67,30 +67,30 @@ class SchemaTest extends DescriptorTestBase {
   override def properties(): util.List[util.Map[String, String]] = {
     val props1 = Map(
       "schema.0.name" -> "myField",
-      "schema.0.type" -> "BOOLEAN",
+      "schema.0.data-type" -> "BOOLEAN",
       "schema.1.name" -> "otherField",
-      "schema.1.type" -> "VARCHAR",
+      "schema.1.data-type" -> "VARCHAR",
       "schema.1.from" -> "csvField",
       "schema.2.name" -> "p",
-      "schema.2.type" -> "TIMESTAMP",
+      "schema.2.data-type" -> "TIMESTAMP(3)",
       "schema.2.proctime" -> "true",
       "schema.3.name" -> "r",
-      "schema.3.type" -> "TIMESTAMP",
+      "schema.3.data-type" -> "TIMESTAMP(3)",
       "schema.3.rowtime.watermarks.type" -> "from-source",
       "schema.3.rowtime.timestamps.type" -> "from-source"
     )
 
     val props2 = Map(
       "schema.0.name" -> "myField",
-      "schema.0.type" -> "BOOLEAN",
+      "schema.0.data-type" -> "BOOLEAN",
       "schema.1.name" -> "otherField",
-      "schema.1.type" -> "VARCHAR",
+      "schema.1.data-type" -> "VARCHAR",
       "schema.1.from" -> "csvField",
       "schema.2.name" -> "p",
-      "schema.2.type" -> "TIMESTAMP",
+      "schema.2.data-type" -> "TIMESTAMP(3)",
       "schema.2.proctime" -> "true",
       "schema.3.name" -> "r",
-      "schema.3.type" -> "TIMESTAMP"
+      "schema.3.data-type" -> "TIMESTAMP(3)"
     )
 
     util.Arrays.asList(props1.asJava, props2.asJava)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/descriptors/SchemaValidatorTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/descriptors/SchemaValidatorTest.scala
@@ -19,8 +19,7 @@
 package org.apache.flink.table.descriptors
 
 import java.util.Optional
-
-import org.apache.flink.table.api.{TableException, TableSchema, Types}
+import org.apache.flink.table.api.{DataTypes, TableException, TableSchema, Types}
 import org.apache.flink.table.descriptors.RowtimeTest.CustomExtractor
 import org.apache.flink.table.sources.tsextractors.{ExistingField, StreamRecordTimestamp}
 import org.apache.flink.table.sources.wmstrategies.{BoundedOutOfOrderTimestamps, PreserveWatermarks}
@@ -87,19 +86,21 @@ class SchemaValidatorTest {
 
   @Test
   def testDeriveTableSinkSchemaWithRowtimeFromField(): Unit = {
+    // we have to use DataTypes here because TypeInformation -> properties -> DataType
+    // loses information (conversion class)
     val desc1 = new Schema()
-      .field("otherField", Types.STRING).from("csvField")
-      .field("abcField", Types.STRING)
-      .field("p", Types.SQL_TIMESTAMP).proctime()
-      .field("r", Types.SQL_TIMESTAMP).rowtime(
+      .field("otherField", DataTypes.STRING()).from("csvField")
+      .field("abcField", DataTypes.STRING())
+      .field("p", DataTypes.TIMESTAMP(3)).proctime()
+      .field("r", DataTypes.TIMESTAMP(3)).rowtime(
       new Rowtime().timestampsFromField("myTime").watermarksFromSource())
     val props = new DescriptorProperties()
     props.putProperties(desc1.toProperties)
 
     val expectedTableSinkSchema = TableSchema.builder()
-      .field("csvField", Types.STRING) // aliased
-      .field("abcField", Types.STRING)
-      .field("myTime", Types.SQL_TIMESTAMP)
+      .field("csvField", DataTypes.STRING()) // aliased
+      .field("abcField", DataTypes.STRING())
+      .field("myTime", DataTypes.TIMESTAMP(3))
       .build()
 
     assertEquals(expectedTableSinkSchema, SchemaValidator.deriveTableSinkSchema(props))

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/descriptors/TableDescriptorTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/descriptors/TableDescriptorTest.scala
@@ -84,6 +84,9 @@ class TableDescriptorTest extends TableTestBase {
     // tests the table factory discovery and thus validates the result automatically
     descriptor.registerTableSourceAndSink("MyTable")
 
+    val personArrayString = "ARRAY<LEGACY('STRUCTURED_TYPE', " +
+      "'POJO<org.apache.flink.table.runtime.utils.CommonTestData$Person>')>"
+
     val expectedCommonProperties = Seq(
       "connector.property-version" -> "1",
       "connector.type" -> "filesystem",
@@ -91,38 +94,36 @@ class TableDescriptorTest extends TableTestBase {
       "format.property-version" -> "1",
       "format.type" -> "csv",
       "format.fields.0.name" -> "myfield",
-      "format.fields.0.type" -> "VARCHAR",
+      "format.fields.0.data-type" -> "VARCHAR(2147483647)",
       "format.fields.1.name" -> "myfield2",
-      "format.fields.1.type" -> "INT",
+      "format.fields.1.data-type" -> "INT",
       "format.fields.2.name" -> "myfield3",
-      "format.fields.2.type" -> "MAP<VARCHAR, INT>",
+      "format.fields.2.data-type" -> "MAP<VARCHAR(2147483647), INT>",
       "format.fields.3.name" -> "myfield4",
-      "format.fields.3.type" -> "MULTISET<BIGINT>",
+      "format.fields.3.data-type" -> "MULTISET<BIGINT>",
       "format.fields.4.name" -> "myfield5",
-      "format.fields.4.type" -> "PRIMITIVE_ARRAY<SMALLINT>",
+      "format.fields.4.data-type" -> "ARRAY<SMALLINT NOT NULL>",
       "format.fields.5.name" -> "myfield6",
-      "format.fields.5.type" ->
-        "OBJECT_ARRAY<POJO<org.apache.flink.table.runtime.utils.CommonTestData$Person>>",
+      "format.fields.5.data-type" -> personArrayString,
       "format.field-delimiter" -> "#",
       "schema.0.name" -> "myfield",
-      "schema.0.type" -> "VARCHAR",
+      "schema.0.data-type" -> "VARCHAR(2147483647)",
       "schema.1.name" -> "myfield2",
-      "schema.1.type" -> "INT",
+      "schema.1.data-type" -> "INT",
       "schema.2.name" -> "myfield3",
-      "schema.2.type" -> "MAP<VARCHAR, INT>",
+      "schema.2.data-type" -> "MAP<VARCHAR(2147483647), INT>",
       "schema.3.name" -> "myfield4",
-      "schema.3.type" -> "MULTISET<BIGINT>",
+      "schema.3.data-type" -> "MULTISET<BIGINT>",
       "schema.4.name" -> "myfield5",
-      "schema.4.type" -> "PRIMITIVE_ARRAY<SMALLINT>",
+      "schema.4.data-type" -> "ARRAY<SMALLINT NOT NULL>",
       "schema.5.name" -> "myfield6",
-      "schema.5.type" ->
-        "OBJECT_ARRAY<POJO<org.apache.flink.table.runtime.utils.CommonTestData$Person>>"
+      "schema.5.data-type" -> personArrayString
     )
 
     val expectedProperties = if (isStreaming) {
       expectedCommonProperties ++ Seq(
         //"schema.2.name" -> "proctime",
-        //"schema.2.type" -> "TIMESTAMP",
+        //"schema.2.data-type" -> "TIMESTAMP",
         //"schema.2.proctime" -> "true",
         "update-mode" -> "append"
       )

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/InMemoryTableFactory.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/InMemoryTableFactory.scala
@@ -19,8 +19,8 @@
 package org.apache.flink.table.utils
 
 import java.util
-
 import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.table.api.TableSchema
 import org.apache.flink.table.descriptors.ConnectorDescriptorValidator.{CONNECTOR_PROPERTY_VERSION, CONNECTOR_TYPE}
 import org.apache.flink.table.descriptors.Rowtime._
 import org.apache.flink.table.descriptors.Schema._
@@ -28,7 +28,11 @@ import org.apache.flink.table.descriptors.{DescriptorProperties, SchemaValidator
 import org.apache.flink.table.factories.{StreamTableSinkFactory, StreamTableSourceFactory, TableFactory}
 import org.apache.flink.table.sinks.StreamTableSink
 import org.apache.flink.table.sources.StreamTableSource
+import org.apache.flink.table.types.logical.LogicalTypeRoot
+import org.apache.flink.table.types.utils.TypeConversions.fromDataTypeToLegacyInfo
 import org.apache.flink.types.Row
+
+import java.sql.Timestamp
 
 /**
   * Factory for creating stream table sources and sinks.
@@ -54,9 +58,17 @@ class InMemoryTableFactory(terminationCount: Int)
     new SchemaValidator(true, true, true).validate(params)
 
     val tableSchema = SchemaValidator.deriveTableSinkSchema(params)
+    val fieldTypes = tableSchema.getFieldDataTypes.map(t => {
+      if (t.getLogicalType.getTypeRoot == LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) {
+        // force to use Timestamp because old planner only support Timestamp
+        t.bridgedTo(classOf[Timestamp])
+      } else {
+        t
+      }
+    })
 
     new MemoryTableSourceSinkUtil.UnsafeMemoryAppendTableSink()
-      .configure(tableSchema.getFieldNames, tableSchema.getFieldTypes)
+      .configure(tableSchema.getFieldNames, fromDataTypeToLegacyInfo(fieldTypes))
       .asInstanceOf[StreamTableSink[Row]]
   }
 
@@ -75,12 +87,20 @@ class InMemoryTableFactory(terminationCount: Int)
     // proctime
     val proctimeAttributeOpt = SchemaValidator.deriveProctimeAttribute(params)
 
-    val (names, types) = tableSchema.getFieldNames.zip(tableSchema.getFieldTypes)
+    val fieldTypes = tableSchema.getFieldDataTypes.map(t => {
+      if (t.getLogicalType.getTypeRoot == LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) {
+        // force to use Timestamp because old planner only support Timestamp
+        t.bridgedTo(classOf[Timestamp])
+      } else {
+        t
+      }
+    })
+    val (names, types) = tableSchema.getFieldNames.zip(fromDataTypeToLegacyInfo(fieldTypes))
       .filter(_._1 != proctimeAttributeOpt.get()).unzip
     // rowtime
     val rowtimeDescriptors = SchemaValidator.deriveRowtimeAttributes(params)
     new MemoryTableSourceSinkUtil.UnsafeMemoryTableSource(
-      tableSchema,
+      TableSchema.builder().fields(tableSchema.getFieldNames, fieldTypes).build(),
       new RowTypeInfo(types, names),
       rowtimeDescriptors,
       proctimeAttributeOpt.get(),
@@ -100,6 +120,7 @@ class InMemoryTableFactory(terminationCount: Int)
 
     // schema
     properties.add(SCHEMA + ".#." + SCHEMA_TYPE)
+    properties.add(SCHEMA + ".#." + SCHEMA_DATA_TYPE)
     properties.add(SCHEMA + ".#." + SCHEMA_NAME)
     properties.add(SCHEMA + ".#." + SCHEMA_FROM)
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Use the `LogicalType#asSerializableString` as the properties value string instead of using `TypeStringUtil`. This can keep the nullability and precision.

NOTE: However, this will lead to the default conversion class of `TIMESTAMP` declared in DDL will be `LocalDateTime`. In the previous versions, the default conversion class is `java.sql.Timestamp`. We have to update all the connectors to adapt this changes, otherwise it will fail to create the connector. We should also add this into release note. 

## Brief change log


82bae84e63e8e42447e75e097a32cc4f8d4f0618
 - Support to parse LegacyTypeInformationType, because user may pass in Types.BIG_DEC into TableSchema

423400c30bcf6a2c0f97d439db1e25fd76f7e01c
 - Use LogicalType.asSerializableString as the data type properties value string

f1f08640eca5f6980b51ecfecd318f36d3f6773e b3962df2b64140b0be9232449e93a213404e6ebb fb7f5e6fd44afb5c26c72ee579b4eb883b2dccfe d7ecec4f1d9e2857f461f82faee5a902224ccd0a e80446be9909bd9bcf1304aa0050c87c0bb37479 ab3e19f2ceea1cb1e60586b9781254609ab2b192
 - update connectors to adapt the properties changes, because the default TIMESTAMP conversion class is LocalDateTime now.

ac84bc121839537b858ed201c464d836f823c209
 - Use `data-type` as watermark expression type key too

038052c833940fbaef3111ed92525216f13edee2
 - Support to pass nullability and precision defined in DDL to planner


## Verifying this change

This change is already covered by existing tests and new added tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
