### PR TITLE
[FLINK-15044][e2e tests] Clean up TpcdsResultComparator

### DIFF
--- a/flink-end-to-end-tests/flink-tpcds-test/src/main/java/org/apache/flink/table/tpcds/utils/TpcdsResultComparator.java
+++ b/flink-end-to-end-tests/flink-tpcds-test/src/main/java/org/apache/flink/table/tpcds/utils/TpcdsResultComparator.java
@@ -20,20 +20,20 @@ package org.apache.flink.table.tpcds.utils;
 
 import org.apache.flink.api.java.utils.ParameterTool;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
-import java.util.ArrayList;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 /**
  * Result comparator for TPC-DS test according to the TPC-DS standard specification v2.11.0.
  * Query result in Flink for all TPC-DS queries is strictly matched with TPC-DS answer set.
  */
+@SuppressWarnings("UseOfSystemOutOrSystemErr")
 public class TpcdsResultComparator {
 
-	private static final int VALIDATE_QUERY_NUM = 103;
 	private static final List<String> VALIDATE_QUERIES = Arrays.asList(
 			"1", "2", "3", "4", "5", "6", "7", "8", "9", "10",
 			"11", "12", "13", "14a", "14b", "15", "16", "17", "18", "19", "20",
@@ -47,8 +47,9 @@ public class TpcdsResultComparator {
 			"91", "92", "93", "94", "95", "96", "97", "98", "99"
 	);
 
+	private static final HashSet<String> NULL_LITERALS = new HashSet<>(Arrays.asList("%", "-", "NULL", "[NULL]"));
+
 	private static final String REGEX_SPLIT_BAR = "\\|";
-	private static final String FILE_SEPARATOR = "/";
 	private static final String RESULT_SUFFIX = ".ans";
 	private static final double TOLERATED_DOUBLE_DEVIATION = 0.01d;
 
@@ -56,171 +57,178 @@ public class TpcdsResultComparator {
 		ParameterTool params = ParameterTool.fromArgs(args);
 		String expectedDir = params.getRequired("expectedDir");
 		String actualDir = params.getRequired("actualDir");
-		int passCnt = 0;
-		for (String queryId : VALIDATE_QUERIES) {
-			File expectedFile = new File(expectedDir + FILE_SEPARATOR + queryId + RESULT_SUFFIX);
-			File actualFile = new File(actualDir + FILE_SEPARATOR + queryId + RESULT_SUFFIX);
 
-			if (compareResult(expectedFile, actualFile)) {
+		int passCnt = 0;
+
+		for (String queryId : VALIDATE_QUERIES) {
+			File expectedFile = new File(expectedDir, queryId + RESULT_SUFFIX);
+			File actualFile = new File(actualDir, queryId + RESULT_SUFFIX);
+
+			if (compareResult(queryId, expectedFile, actualFile)) {
 				passCnt++;
-				System.out.println("[INFO] validate success, file: " + expectedFile.getName() + " total query:" + VALIDATE_QUERY_NUM + " passed query:" + passCnt);
+				System.out.println(String.format("[INFO] Validation succeeded for file: %s (%d/%d)",
+					expectedFile.getName(), passCnt, VALIDATE_QUERIES.size()));
 			} else {
-				System.out.println("[ERROR] validate fail, file: " + expectedFile.getName() + "\n");
+				System.out.println("[ERROR] Validation failed for file: " + expectedFile.getName() + '\n');
 			}
 		}
-		if (passCnt == VALIDATE_QUERY_NUM) {
+
+		if (passCnt == VALIDATE_QUERIES.size()) {
 			System.exit(0);
 		}
 		System.exit(1);
 	}
 
-	private static boolean compareResult(File expectedFile, File actualFile) throws Exception {
-		BufferedReader expectedReader = new BufferedReader(new FileReader(expectedFile));
-		BufferedReader actualReader = new BufferedReader(new FileReader(actualFile));
+	private static boolean compareResult(String queryId, File expectedFile, File actualFile) throws Exception {
+		final String[] expectedLines = Files.readAllLines(expectedFile.toPath(), StandardCharsets.UTF_8).toArray(new String[0]);
+		final String[] actualLines = Files.readAllLines(actualFile.toPath(), StandardCharsets.UTF_8).toArray(new String[0]);
 
-		int expectedLineNum = 0;
-		int actualLineNum = 0;
+		if (expectedLines.length != actualLines.length) {
+			System.out.println(String.format(
+				"[ERROR] Incorrect number of lines! Expecting %d lines, but found %d lines.",
+				expectedLines.length, actualLines.length));
 
-		String expectedLine, actualLine;
-		while ((expectedLine = expectedReader.readLine()) != null &&
-				(actualLine = actualReader.readLine()) != null) {
-			expectedLineNum++;
-			actualLineNum++;
+			return false;
+		}
 
-			// reslut top 8 line of query 34,
-			// result line  2、3  0f query 77
-			// result line 18、 19 of query 79
-			// have different order with answer set, because of Flink keep nulls last for DESC, nulls first for ASC.
-			// it's still up to TPC-DS standard.
-			if ("34.ans".equals(expectedFile.getName()) && expectedLineNum == 1) {
-				List<String> expectedTop8Line = new ArrayList<>(8);
-				List<String> actualTop8Line = new ArrayList<>(8);
+		if ("34".equals(queryId)) {
+			return compareQuery34(expectedLines, actualLines);
+		}
+		else if ("77".equals(queryId)) {
+			return compareQuery77(expectedLines, actualLines);
+		}
+		else if ("79".equals(queryId)) {
+			return compareQuery79(expectedLines, actualLines);
+		}
+		else {
+			return compareLinesPrintingErrors(expectedLines, actualLines, 0);
+		}
+	}
 
-				String expectedLine2 = expectedReader.readLine();
-				expectedLineNum++;
-				while (expectedLineNum < 8) {
-					expectedTop8Line.add(expectedReader.readLine());
-					expectedLineNum++;
-				}
-				expectedTop8Line.add(expectedLine);
-				expectedTop8Line.add(expectedLine2);
+	// ------------------------------------------------------------------------
 
-				actualTop8Line.add(actualLine);
-				while (actualLineNum < 8) {
-					actualTop8Line.add(actualReader.readLine());
-					actualLineNum++;
-				}
-				for (int i = 0; i < 8; i++) {
-					if (!isEqualLine(expectedTop8Line.get(i), actualTop8Line.get(i), i)) {
-						return false;
-					}
-				}
-				continue;
-			}
-			if ("77.ans".equals(expectedFile.getName()) && expectedLineNum == 2) {
-				String expectedLine3 = expectedReader.readLine();
-				String actualLine3 = actualReader.readLine();
-				expectedLineNum++;
-				actualLineNum++;
+	private static boolean compareQuery34(String[] expectedLines, String[] actualLines) {
+		// take the first two lines and move them back to lines 7 and 8
+		final String expected1 = expectedLines[0];
+		final String expected2 = expectedLines[1];
+		System.arraycopy(expectedLines, 2, expectedLines, 0, 6);
+		expectedLines[6] = expected1;
+		expectedLines[7] = expected2;
 
-				if (isEqualLine(expectedLine, actualLine3, 2) && isEqualLine(expectedLine3, actualLine, 3)) {
-					continue;
-				}
-				if (isEqualLine(expectedLine, actualLine, 2) && isEqualLine(expectedLine3, actualLine3, 3)) {
-					continue;
-				}
-				return false;
-			}
+		return compareLinesPrintingErrors(expectedLines, actualLines, 0);
+	}
 
-			if ("79.ans".equals(expectedFile.getName()) && expectedLineNum == 18) {
-				String expectedLine19 = expectedReader.readLine();
-				String actualLine19 = actualReader.readLine();
-				expectedLineNum++;
-				actualLineNum++;
+	private static boolean compareQuery77(String[] expectedLines, String[] actualLines) {
+		if (!compareLinePrintingErrors(expectedLines[0], actualLines[0], 1)) {
+			return false;
+		}
+		if (!comparePairOfLinesPrintingErrors(expectedLines[1], expectedLines[2], actualLines[1], actualLines[2], 2, 3)) {
+			return false;
+		}
+		return compareLinesPrintingErrors(expectedLines, actualLines, 3);
+	}
 
-				if (isEqualLine(expectedLine, actualLine, 18) && isEqualLine(expectedLine19, actualLine19, 19)) {
-					continue;
-				}
-				if (isEqualLine(expectedLine, actualLine19, 18) && isEqualLine(expectedLine19, actualLine, 19)) {
-					continue;
-				}
-				return false;
-			}
+	private static boolean compareQuery79(String[] expectedLines, String[] actualLines) {
+		if (!compareLinesPrintingErrors(expectedLines, actualLines, 0, 17)) {
+			return false;
+		}
+		if (!comparePairOfLinesPrintingErrors(expectedLines[17], expectedLines[18], actualLines[17], actualLines[18], 18, 19)) {
+			return false;
+		}
+		return compareLinesPrintingErrors(expectedLines, actualLines, 20);
+	}
 
-			if (!isEqualLine(expectedLine, actualLine, expectedLineNum)) {
+	// ------------------------------------------------------------------------
+
+	private static boolean compareLinesPrintingErrors(String[] expectedLines, String[] actualLines, int from, int num) {
+		for (int line = from; line < from + num; line++) {
+			if (!compareLinePrintingErrors(expectedLines[line], actualLines[line], line)) {
 				return false;
 			}
 		}
+		return true;
+	}
 
-		while (expectedReader.readLine() != null) {
-			expectedLineNum++;
-		}
-		while (actualReader.readLine() != null) {
-			actualLineNum++;
-		}
+	private static boolean compareLinesPrintingErrors(String[] expectedLines, String[] actualLines, int from) {
+		final int remaining = expectedLines.length - from;
+		return compareLinesPrintingErrors(expectedLines, actualLines, from, remaining);
+	}
 
-		if (expectedLineNum != actualLineNum) {
-			System.out.println(
-					"[ERROR] Incorrect number of lines! Expecting " + expectedLineNum +
-							" lines, but found " + actualLineNum + " lines.");
+	private static boolean comparePairOfLinesPrintingErrors(
+			String expected1, String expected2,
+			String actual1, String actual2,
+			int lineNum1, int lineNum2) {
+
+		final boolean matchesPair = compareLine(expected1, actual1) && compareLine(expected2, actual2);
+		final boolean matchesCross = compareLine(expected2, actual1) && compareLine(expected1, actual2);
+
+		if (!(matchesPair || matchesCross)) {
+			System.out.println(String.format("[ERROR] Lines %d/%d do not match in any pairing." +
+					"\n - Expected %d: %s\n - Expected %d: %s\n - Actual %d: %s\n - Actual %d: %s",
+				lineNum1, lineNum2, lineNum1, expected1, lineNum2, expected2,
+				lineNum1, actual1, lineNum2, actual2));
+
 			return false;
 		}
 
 		return true;
 	}
 
-	private static boolean isEqualLine(String expectedLine, String actualLine, int lineNum) {
-		String[] expected = expectedLine.split(REGEX_SPLIT_BAR, -1);
-		String[] actual = actualLine.split(REGEX_SPLIT_BAR, -1);
+	// ------------------------------------------------------------------------
+
+	private static boolean compareLine(String expectedLine, String actualLine) {
+		return compareLineInternal(expectedLine, actualLine, -1, false);
+	}
+
+	private static boolean compareLinePrintingErrors(String expectedLine, String actualLine, int lineNum) {
+		return compareLineInternal(expectedLine, actualLine, lineNum, true);
+	}
+
+	private static boolean compareLineInternal(String expectedLine, String actualLine, int lineNum, boolean printError) {
+		final String[] expected = expectedLine.split(REGEX_SPLIT_BAR, -1);
+		final String[] actual = actualLine.split(REGEX_SPLIT_BAR, -1);
+
 		if (expected.length != actual.length) {
-			System.out.println(
-					"[ERROR] Incorrect number of columns! Expecting " + expected.length +
-							" columns, but found " + actual.length + " columns.");
+			if (printError) {
+				System.out.println(String.format(
+					"[ERROR] Incorrect number of columns! Expecting %d columns, but found %d columns.",
+					expected.length, actual.length));
+			}
 			return false;
 		}
+
 		for (int i = 0; i < expected.length; i++) {
 			if (!isEqualCol(expected[i].trim(), actual[i].trim())) {
-				System.out.println("[ERROR] Incorrect result on line " + lineNum + " column " + (i + 1) +
-						"! Expecting " + expected[i] + ", but found " + actual[i] + ".");
+				if (printError) {
+					System.out.println(String.format(
+						"[ERROR] Incorrect result on line %d column %d! Expecting %s but found %s.",
+						lineNum, i + 1, expected[i], actual[i]));
+				}
 				return false;
 			}
 		}
+
 		return true;
 	}
 
+	// ------------------------------------------------------------------------
+
 	private static boolean isEqualCol(String expected, String actual) {
-		if (isEqualNumber(expected, actual)) {
-			return true;
-		} else if (isEqualNull(expected, actual)) {
-			return true;
-		} else {
-			return expected.equals(actual);
-		}
+		return isEqualNull(expected, actual) || isEqualNumber(expected, actual) || expected.equals(actual);
 	}
 
 	private static boolean isEqualNumber(String expected, String actual) {
 		try {
-			Double expectVal = new Double(expected);
-			Double actualVal = new Double(actual);
-			if (expectVal.equals(actualVal)) {
-				return true;
-			}
-			if (Math.abs(expectVal - actualVal) <= TOLERATED_DOUBLE_DEVIATION) {
-				return true;
-			}
+			double expectVal = Double.parseDouble(expected);
+			double actualVal = Double.parseDouble(actual);
+			return Math.abs(expectVal - actualVal) <= TOLERATED_DOUBLE_DEVIATION;
 		} catch (NumberFormatException e) {
-			// Column data can not convert to double, return false instead of throwing NumberFormatException.
+			// cannot parse, so column is not a numeric column
 			return false;
 		}
-		return false;
 	}
 
 	private static boolean isEqualNull(String expected, String actual) {
-		if (null == actual || "".equals(actual)) {
-			if ("%".equals(expected) || "-".equals(expected) || "NULL".equals(expected) || "[NULL]".equals(expected)) {
-				return true;
-			}
-		}
-		return false;
+		return (null == actual || actual.isEmpty()) && NULL_LITERALS.contains(expected);
 	}
 }

--- a/flink-end-to-end-tests/flink-tpcds-test/tpcds-tool/answer_set/46_NULLS_FIRST.ans
+++ b/flink-end-to-end-tests/flink-tpcds-test/tpcds-tool/answer_set/46_NULLS_FIRST.ans
@@ -100,4 +100,3 @@ NULL                           NULL                 Midway                      
 NULL                           NULL                 Milan                                                        Woodland                                                               226048                                  3239.64                                -13933.74
 NULL                           NULL                 Mount Pleasant                                               Clifton                                                                 33934                                  2089.09                                 -5930.92
 NULL                           NULL                 Mount Pleasant                                               Union                                                                  157956                                  7732.84                                -12103.02
-Warning: Null value is eliminated by an aggregate or other SET operation.


### PR DESCRIPTION
## Purpose / Changelog

This cleans up the code in the `TpcdsResultComparator`. The functionality is not changed.
The code cleanup fixed a bug, as a byproduct.

This uncovered some dirty trailing error message in the expected answer set, which is removed in the second commit.

## Verifying this change

This is a cleanup of a test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
