### PR TITLE
[FLINK-15045][runtime] Only log RestartStrategy in legacy scheduling mode

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartBackoffTimeStrategyFactoryLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartBackoffTimeStrategyFactoryLoader.java
@@ -59,7 +59,7 @@ public final class RestartBackoffTimeStrategyFactoryLoader {
 	 * @param isCheckpointingEnabled if checkpointing is enabled for the job
 	 * @return new version restart strategy factory
 	 */
-	public static RestartBackoffTimeStrategy.Factory createRestartStrategyFactory(
+	public static RestartBackoffTimeStrategy.Factory createRestartBackoffTimeStrategyFactory(
 			final RestartStrategies.RestartStrategyConfiguration jobRestartStrategyConfiguration,
 			final Configuration clusterConfiguration,
 			final boolean isCheckpointingEnabled) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -166,7 +166,7 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 
 	@Override
 	protected void startSchedulingInternal() {
-		log.debug("Starting scheduling with scheduling strategy [{}]", schedulingStrategy.getClass().getName());
+		log.info("Starting scheduling with scheduling strategy [{}]", schedulingStrategy.getClass().getName());
 		prepareExecutionGraphForNgScheduling();
 		schedulingStrategy.startScheduling();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -77,6 +77,7 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
 				jobMasterConfiguration,
 				jobGraph.isCheckpointingEnabled())
 			.create();
+		log.info("Using restart back off time strategy {} for {} ({}).", restartBackoffTimeStrategy, jobGraph.getName(), jobGraph.getJobID());
 
 		final SlotProviderStrategy slotProviderStrategy = SlotProviderStrategy.from(
 			jobGraph.getScheduleMode(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -69,7 +69,7 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
 
 		final SchedulingStrategyFactory schedulingStrategyFactory = createSchedulingStrategyFactory(jobGraph.getScheduleMode());
 		final RestartBackoffTimeStrategy restartBackoffTimeStrategy = RestartBackoffTimeStrategyFactoryLoader
-			.createRestartStrategyFactory(
+			.createRestartBackoffTimeStrategyFactory(
 				jobGraph
 					.getSerializedExecutionConfig()
 					.deserializeValue(userCodeLoader)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -193,7 +193,9 @@ public abstract class SchedulerBase implements SchedulerNG {
 			restartStrategyFactory,
 			jobGraph.isCheckpointingEnabled());
 
-		log.info("Using restart strategy {} for {} ({}).", this.restartStrategy, jobGraph.getName(), jobGraph.getJobID());
+		if (legacyScheduling) {
+			log.info("Using restart strategy {} for {} ({}).", this.restartStrategy, jobGraph.getName(), jobGraph.getJobID());
+		}
 
 		this.blobWriter = checkNotNull(blobWriter);
 		this.jobManagerJobMetricGroup = checkNotNull(jobManagerJobMetricGroup);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartBackoffTimeStrategyFactoryLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartBackoffTimeStrategyFactoryLoaderTest.java
@@ -45,7 +45,7 @@ public class RestartBackoffTimeStrategyFactoryLoaderTest extends TestLogger {
 		conf.setString(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
 
 		final RestartBackoffTimeStrategy.Factory factory =
-			RestartBackoffTimeStrategyFactoryLoader.createRestartStrategyFactory(
+			RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
 				RestartStrategies.noRestart(),
 				conf,
 				false);
@@ -59,7 +59,7 @@ public class RestartBackoffTimeStrategyFactoryLoaderTest extends TestLogger {
 		conf.setString(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
 
 		final RestartBackoffTimeStrategy.Factory factory =
-			RestartBackoffTimeStrategyFactoryLoader.createRestartStrategyFactory(
+			RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
 				RestartStrategies.fixedDelayRestart(1, Time.milliseconds(1000)),
 				conf,
 				false);
@@ -75,7 +75,7 @@ public class RestartBackoffTimeStrategyFactoryLoaderTest extends TestLogger {
 		conf.setString(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
 
 		final RestartBackoffTimeStrategy.Factory factory =
-			RestartBackoffTimeStrategyFactoryLoader.createRestartStrategyFactory(
+			RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
 				RestartStrategies.failureRateRestart(1, Time.milliseconds(1000), Time.milliseconds(1000)),
 				conf,
 				false);
@@ -91,7 +91,7 @@ public class RestartBackoffTimeStrategyFactoryLoaderTest extends TestLogger {
 		conf.setString(RestartStrategyOptions.RESTART_STRATEGY, "none");
 
 		final RestartBackoffTimeStrategy.Factory factory =
-			RestartBackoffTimeStrategyFactoryLoader.createRestartStrategyFactory(
+			RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
 				DEFAULT_JOB_LEVEL_RESTART_CONFIGURATION,
 				conf,
 				false);
@@ -105,7 +105,7 @@ public class RestartBackoffTimeStrategyFactoryLoaderTest extends TestLogger {
 		conf.setString(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
 
 		final RestartBackoffTimeStrategy.Factory factory =
-			RestartBackoffTimeStrategyFactoryLoader.createRestartStrategyFactory(
+			RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
 				DEFAULT_JOB_LEVEL_RESTART_CONFIGURATION,
 				conf,
 				false);
@@ -121,7 +121,7 @@ public class RestartBackoffTimeStrategyFactoryLoaderTest extends TestLogger {
 		conf.setString(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
 
 		final RestartBackoffTimeStrategy.Factory factory =
-			RestartBackoffTimeStrategyFactoryLoader.createRestartStrategyFactory(
+			RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
 				DEFAULT_JOB_LEVEL_RESTART_CONFIGURATION,
 				conf,
 				false);
@@ -136,7 +136,7 @@ public class RestartBackoffTimeStrategyFactoryLoaderTest extends TestLogger {
 		final Configuration conf = new Configuration();
 		conf.setString(RestartStrategyOptions.RESTART_STRATEGY, "invalid-strategy");
 
-		RestartBackoffTimeStrategyFactoryLoader.createRestartStrategyFactory(
+		RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
 			DEFAULT_JOB_LEVEL_RESTART_CONFIGURATION,
 			conf,
 			false);
@@ -145,7 +145,7 @@ public class RestartBackoffTimeStrategyFactoryLoaderTest extends TestLogger {
 	@Test
 	public void testNoStrategySpecifiedWhenCheckpointingEnabled() {
 		final RestartBackoffTimeStrategy.Factory factory =
-			RestartBackoffTimeStrategyFactoryLoader.createRestartStrategyFactory(
+			RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
 				DEFAULT_JOB_LEVEL_RESTART_CONFIGURATION,
 				new Configuration(),
 				true);
@@ -167,7 +167,7 @@ public class RestartBackoffTimeStrategyFactoryLoaderTest extends TestLogger {
 	@Test
 	public void testNoStrategySpecifiedWhenCheckpointingDisabled() {
 		final RestartBackoffTimeStrategy.Factory factory =
-			RestartBackoffTimeStrategyFactoryLoader.createRestartStrategyFactory(
+			RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
 				DEFAULT_JOB_LEVEL_RESTART_CONFIGURATION,
 				new Configuration(),
 				false);


### PR DESCRIPTION
## What is the purpose of the change

*This PR removes an obsolete log message that appeared when scheduling in `ng` scheduling mode.*


## Brief change log

  - *Only log RestartStrategy in legacy scheduling mode*
  - *Log RestartBackoffTimeStrategy*
  - *Several hotfixes (see commits)*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
