### PR TITLE
[FLINK-15036][yarn] Container startup error should be handled inside …

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -487,7 +487,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 	// ------------------------------------------------------------------------
 	@Override
 	public void onContainerStarted(ContainerId containerId, Map<String, ByteBuffer> map) {
-		log.debug("Succeed to call YARN Node Manager to start container", containerId);
+		log.debug("Succeeded to call YARN Node Manager to start container {}.", containerId);
 	}
 
 	@Override
@@ -497,7 +497,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 
 	@Override
 	public void onContainerStopped(ContainerId containerId) {
-		log.debug("Succeed to call YARN Node Manager to stop container", containerId);
+		log.debug("Succeeded to call YARN Node Manager to stop container {}.", containerId);
 	}
 
 	@Override
@@ -512,7 +512,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 
 	@Override
 	public void onStopContainerError(ContainerId containerId, Throwable throwable) {
-		log.warn("Error while calling YARN Node Manager to stop container {}", containerId, throwable);
+		log.warn("Error while calling YARN Node Manager to stop container {}.", containerId, throwable);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -422,6 +422,8 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 	}
 
 	private void releaseFailedContainerAndRequestNewContainerIfRequired(ContainerId containerId, Throwable throwable) {
+		validateRunsInMainThread();
+
 		log.error("Could not start TaskManager in container {}.", containerId, throwable);
 
 		final ResourceID resourceId = new ResourceID(containerId.toString());

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -89,6 +89,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.configuration.GlobalConfiguration.FLINK_CONF_FILENAME;
@@ -170,6 +171,11 @@ public class YarnResourceManagerTest extends TestLogger {
 	static class TestingYarnResourceManager extends YarnResourceManager {
 		AMRMClientAsync<AMRMClient.ContainerRequest> mockResourceManagerClient;
 		NMClientAsync mockNMClient;
+		/**
+		 * When runAsync is called, runAsyncCalledNum will increase one. This variable could be used to check whether
+		 * callback methods of AMRMClientAsync and NMClientAsync are executed in ResourceManager's main thread.
+		 */
+		int runAsyncCalledNum;
 
 		TestingYarnResourceManager(
 				RpcService rpcService,
@@ -203,6 +209,7 @@ public class YarnResourceManagerTest extends TestLogger {
 				resourceManagerMetricGroup);
 			this.mockNMClient = mockNMClient;
 			this.mockResourceManagerClient = mockResourceManagerClient;
+			this.runAsyncCalledNum = 0;
 		}
 
 		<T> CompletableFuture<T> runInMainThread(Callable<T> callable) {
@@ -228,6 +235,7 @@ public class YarnResourceManagerTest extends TestLogger {
 
 		@Override
 		protected void runAsync(final Runnable runnable) {
+			runAsyncCalledNum++;
 			runnable.run();
 		}
 
@@ -370,14 +378,7 @@ public class YarnResourceManagerTest extends TestLogger {
 		new Context() {{
 			runTest(() -> {
 				// Request slot from SlotManager.
-				CompletableFuture<?> registerSlotRequestFuture = resourceManager.runInMainThread(() -> {
-					rmServices.slotManager.registerSlotRequest(
-						new SlotRequest(new JobID(), new AllocationID(), resourceProfile1, taskHost));
-					return null;
-				});
-
-				// wait for the registerSlotRequest completion
-				registerSlotRequestFuture.get();
+				registerSlotRequest(resourceManager, rmServices, resourceProfile1, taskHost);
 
 				// Callback from YARN when container is allocated.
 				Container testingContainer = mockContainer("container", 1234, 1, resourceManager.getContainerResource());
@@ -473,14 +474,7 @@ public class YarnResourceManagerTest extends TestLogger {
 	public void testOnContainerCompleted() throws Exception {
 		new Context() {{
 			runTest(() -> {
-				CompletableFuture<?> registerSlotRequestFuture = resourceManager.runInMainThread(() -> {
-					rmServices.slotManager.registerSlotRequest(
-						new SlotRequest(new JobID(), new AllocationID(), resourceProfile1, taskHost));
-					return null;
-				});
-
-				// wait for the registerSlotRequest completion
-				registerSlotRequestFuture.get();
+				registerSlotRequest(resourceManager, rmServices, resourceProfile1, taskHost);
 
 				// Callback from YARN when container is allocated.
 				Container testingContainer = mockContainer("container", 1234, 1, resourceManager.getContainerResource());
@@ -504,7 +498,49 @@ public class YarnResourceManagerTest extends TestLogger {
 				// slot is already fulfilled by pending containers, no need to request new container.
 				resourceManager.onContainersCompleted(ImmutableList.of(testingContainerStatus));
 				verify(mockResourceManagerClient, times(2)).addContainerRequest(any(AMRMClient.ContainerRequest.class));
+
+				assertEquals(3, resourceManager.runAsyncCalledNum);
 			});
 		}};
+	}
+
+	@Test
+	public void testOnStartContainerError() throws Exception {
+		new Context() {{
+			runTest(() -> {
+				registerSlotRequest(resourceManager, rmServices, resourceProfile1, taskHost);
+				Container testingContainer = mockContainer("container", 1234, 1, resourceManager.getContainerResource());
+
+				doReturn(Collections.singletonList(Collections.singletonList(resourceManager.getContainerRequest())))
+					.when(mockResourceManagerClient).getMatchingRequests(any(Priority.class), anyString(), any(Resource.class));
+
+				resourceManager.onContainersAllocated(ImmutableList.of(testingContainer));
+				verify(mockResourceManagerClient).addContainerRequest(any(AMRMClient.ContainerRequest.class));
+				verify(mockResourceManagerClient).removeContainerRequest(any(AMRMClient.ContainerRequest.class));
+				verify(mockNMClient).startContainerAsync(eq(testingContainer), any(ContainerLaunchContext.class));
+
+				resourceManager.onStartContainerError(testingContainer.getId(), new Exception("start error"));
+				verify(mockResourceManagerClient).releaseAssignedContainer(testingContainer.getId());
+				verify(mockResourceManagerClient, times(2)).addContainerRequest(any(AMRMClient.ContainerRequest.class));
+
+				assertEquals(2, resourceManager.runAsyncCalledNum);
+			});
+		}};
+	}
+
+	private void registerSlotRequest(
+			TestingYarnResourceManager resourceManager,
+			MockResourceManagerRuntimeServices rmServices,
+			ResourceProfile resourceProfile,
+			String taskHost) throws ExecutionException, InterruptedException {
+
+		CompletableFuture<?> registerSlotRequestFuture = resourceManager.runInMainThread(() -> {
+			rmServices.slotManager.registerSlotRequest(
+				new SlotRequest(new JobID(), new AllocationID(), resourceProfile, taskHost));
+			return null;
+		});
+
+		// wait for the registerSlotRequest completion
+		registerSlotRequestFuture.get();
 	}
 }

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -78,6 +78,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.verification.VerificationWithTimeout;
 
 import javax.annotation.Nullable;
 
@@ -112,6 +113,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -122,6 +124,8 @@ import static org.mockito.Mockito.when;
 public class YarnResourceManagerTest extends TestLogger {
 
 	private static final Time TIMEOUT = Time.seconds(10L);
+
+	private static final VerificationWithTimeout VERIFICATION_TIMEOUT = timeout(TIMEOUT.toMilliseconds());
 
 	private Configuration flinkConfig;
 
@@ -171,11 +175,6 @@ public class YarnResourceManagerTest extends TestLogger {
 	static class TestingYarnResourceManager extends YarnResourceManager {
 		AMRMClientAsync<AMRMClient.ContainerRequest> mockResourceManagerClient;
 		NMClientAsync mockNMClient;
-		/**
-		 * When runAsync is called, runAsyncCalledNum will increase one. This variable could be used to check whether
-		 * callback methods of AMRMClientAsync and NMClientAsync are executed in ResourceManager's main thread.
-		 */
-		int runAsyncCalledNum;
 
 		TestingYarnResourceManager(
 				RpcService rpcService,
@@ -209,7 +208,6 @@ public class YarnResourceManagerTest extends TestLogger {
 				resourceManagerMetricGroup);
 			this.mockNMClient = mockNMClient;
 			this.mockResourceManagerClient = mockResourceManagerClient;
-			this.runAsyncCalledNum = 0;
 		}
 
 		<T> CompletableFuture<T> runInMainThread(Callable<T> callable) {
@@ -232,13 +230,6 @@ public class YarnResourceManagerTest extends TestLogger {
 		protected NMClientAsync createAndStartNodeManagerClient(YarnConfiguration yarnConfiguration) {
 			return mockNMClient;
 		}
-
-		@Override
-		protected void runAsync(final Runnable runnable) {
-			runAsyncCalledNum++;
-			runnable.run();
-		}
-
 	}
 
 	class Context {
@@ -325,6 +316,15 @@ public class YarnResourceManagerTest extends TestLogger {
 				stopResourceManager();
 			}
 		}
+
+		void verifyContainerHasBeenStarted(Container testingContainer) {
+			verify(mockResourceManagerClient, VERIFICATION_TIMEOUT).removeContainerRequest(any(AMRMClient.ContainerRequest.class));
+			verify(mockNMClient, VERIFICATION_TIMEOUT).startContainerAsync(eq(testingContainer), any(ContainerLaunchContext.class));
+		}
+
+		void verifyContainerHasBeenRequested() {
+			verify(mockResourceManagerClient, VERIFICATION_TIMEOUT).addContainerRequest(any(AMRMClient.ContainerRequest.class));
+		}
 	}
 
 	private static Container mockContainer(String host, int port, int containerId, Resource resource) {
@@ -387,8 +387,8 @@ public class YarnResourceManagerTest extends TestLogger {
 					.when(mockResourceManagerClient).getMatchingRequests(any(Priority.class), anyString(), any(Resource.class));
 
 				resourceManager.onContainersAllocated(ImmutableList.of(testingContainer));
-				verify(mockResourceManagerClient).addContainerRequest(any(AMRMClient.ContainerRequest.class));
-				verify(mockNMClient).startContainerAsync(eq(testingContainer), any(ContainerLaunchContext.class));
+				verifyContainerHasBeenRequested();
+				verifyContainerHasBeenStarted(testingContainer);
 
 				// Remote task executor registers with YarnResourceManager.
 				TaskExecutorGateway mockTaskExecutorGateway = mock(TaskExecutorGateway.class);
@@ -483,23 +483,20 @@ public class YarnResourceManagerTest extends TestLogger {
 					.when(mockResourceManagerClient).getMatchingRequests(any(Priority.class), anyString(), any(Resource.class));
 
 				resourceManager.onContainersAllocated(ImmutableList.of(testingContainer));
-				verify(mockResourceManagerClient).addContainerRequest(any(AMRMClient.ContainerRequest.class));
-				verify(mockResourceManagerClient).removeContainerRequest(any(AMRMClient.ContainerRequest.class));
-				verify(mockNMClient).startContainerAsync(eq(testingContainer), any(ContainerLaunchContext.class));
+				verifyContainerHasBeenRequested();
+				verifyContainerHasBeenStarted(testingContainer);
 
 				// Callback from YARN when container is Completed, pending request can not be fulfilled by pending
 				// containers, need to request new container.
 				ContainerStatus testingContainerStatus = mockContainerStatus(testingContainer.getId());
 
 				resourceManager.onContainersCompleted(ImmutableList.of(testingContainerStatus));
-				verify(mockResourceManagerClient, times(2)).addContainerRequest(any(AMRMClient.ContainerRequest.class));
+				verify(mockResourceManagerClient, VERIFICATION_TIMEOUT.times(2)).addContainerRequest(any(AMRMClient.ContainerRequest.class));
 
 				// Callback from YARN when container is Completed happened before global fail, pending request
 				// slot is already fulfilled by pending containers, no need to request new container.
 				resourceManager.onContainersCompleted(ImmutableList.of(testingContainerStatus));
 				verify(mockResourceManagerClient, times(2)).addContainerRequest(any(AMRMClient.ContainerRequest.class));
-
-				assertEquals(3, resourceManager.runAsyncCalledNum);
 			});
 		}};
 	}
@@ -515,15 +512,12 @@ public class YarnResourceManagerTest extends TestLogger {
 					.when(mockResourceManagerClient).getMatchingRequests(any(Priority.class), anyString(), any(Resource.class));
 
 				resourceManager.onContainersAllocated(ImmutableList.of(testingContainer));
-				verify(mockResourceManagerClient).addContainerRequest(any(AMRMClient.ContainerRequest.class));
-				verify(mockResourceManagerClient).removeContainerRequest(any(AMRMClient.ContainerRequest.class));
-				verify(mockNMClient).startContainerAsync(eq(testingContainer), any(ContainerLaunchContext.class));
+				verifyContainerHasBeenRequested();
+				verifyContainerHasBeenStarted(testingContainer);
 
 				resourceManager.onStartContainerError(testingContainer.getId(), new Exception("start error"));
-				verify(mockResourceManagerClient).releaseAssignedContainer(testingContainer.getId());
-				verify(mockResourceManagerClient, times(2)).addContainerRequest(any(AMRMClient.ContainerRequest.class));
-
-				assertEquals(2, resourceManager.runAsyncCalledNum);
+				verify(mockResourceManagerClient, VERIFICATION_TIMEOUT).releaseAssignedContainer(testingContainer.getId());
+				verify(mockResourceManagerClient, VERIFICATION_TIMEOUT.times(2)).addContainerRequest(any(AMRMClient.ContainerRequest.class));
 			});
 		}};
 	}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

With [FLINK-13184](https://issues.apache.org/jira/browse/FLINK-15036), we replaced the `NMClient` with the `NMClientAsync`. As part of this change, container start up errors are now handled by a callback to NMClientAsync.CallbackHandler. The implementation of `NMClientAsync.CallbackHandler#onStartContainerError` will be called by the `NMClientAsync`. Since the implementation does state changing operations, it needs to happen inside of the YarnResourceManager main thread.


## Brief change log

* Wrap all codes of `onStartContainerError` in `runAsync(() -> {xxxx})`


## Verifying this change

* The change could be covered by unit test `YarnResourceManagerTest#testOnStartContainerError`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
