### PR TITLE
[FLINK-14692][table]support rename/alter table in tableEnvironment in both flink/blink planner

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -41,6 +41,8 @@
     "org.apache.flink.sql.parser.ddl.SqlCreateFunction",
     "org.apache.flink.sql.parser.ddl.SqlDropFunction",
     "org.apache.flink.sql.parser.ddl.SqlAlterTable",
+    "org.apache.flink.sql.parser.ddl.SqlAlterTableRename",
+    "org.apache.flink.sql.parser.ddl.SqlAlterTableProperties",
     "org.apache.flink.sql.parser.dml.RichSqlInsert",
     "org.apache.flink.sql.parser.dml.RichSqlInsertKeyword",
     "org.apache.flink.sql.parser.dql.SqlShowCatalogs",

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -331,25 +331,29 @@ SqlAlterTable SqlAlterTable() :
     SqlIdentifier tableIdentifier;
     SqlIdentifier newTableIdentifier = null;
     SqlNodeList propertyList = SqlNodeList.EMPTY;
-    boolean isRename = true;
 }
 {
     <ALTER> <TABLE> { startPos = getPos(); }
         tableIdentifier = CompoundIdentifier()
     (
-        <RENAME> <TO> { isRename = true; }
+        <RENAME> <TO>
         newTableIdentifier = CompoundIdentifier()
+        {
+            return new SqlAlterTableRename(
+                        startPos.plus(getPos()),
+                        tableIdentifier,
+                        newTableIdentifier);
+        }
     |
-        <SET>   { isRename = false; }
+        <SET>
         propertyList = TableProperties()
+        {
+            return new SqlAlterTableProperties(
+                        startPos.plus(getPos()),
+                        tableIdentifier,
+                        propertyList);
+        }
     )
-    {
-        return new SqlAlterTable(startPos.plus(getPos()),
-            tableIdentifier,
-            newTableIdentifier,
-            propertyList,
-            isRename);
-    }
 }
 
 void TableColumn(TableCreationContext context) :

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterTableRename.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterTableRename.java
@@ -18,48 +18,41 @@
 
 package org.apache.flink.sql.parser.ddl;
 
-import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
-import org.apache.calcite.sql.SqlKind;
-import org.apache.calcite.sql.SqlOperator;
-import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
 /**
- * Abstract class to describe statements like ALTER TABLE [[catalogName.] dataBasesName].tableName ...
+ * ALTER TABLE [[catalogName.] dataBasesName].tableName RENAME TO [[catalogName.] dataBasesName].newTableName.
  */
-public abstract class SqlAlterTable extends SqlCall {
+public class SqlAlterTableRename extends SqlAlterTable {
 
-	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("ALTER TABLE", SqlKind.ALTER_TABLE);
+	private final SqlIdentifier newTableIdentifier;
 
-	protected final SqlIdentifier tableIdentifier;
-
-	public SqlAlterTable(
-			SqlParserPos pos,
-			SqlIdentifier tableName) {
-		super(pos);
-		this.tableIdentifier = requireNonNull(tableName, "tableName should not be null");
+	public SqlAlterTableRename(SqlParserPos pos, SqlIdentifier tableName, SqlIdentifier newTableName) {
+		super(pos, tableName);
+		this.newTableIdentifier = requireNonNull(newTableName, "new tableName should not be null");
 	}
 
 	@Override
-	public SqlOperator getOperator() {
-		return OPERATOR;
-	}
-
-	public SqlIdentifier getTableName() {
-		return tableIdentifier;
+	public List<SqlNode> getOperandList() {
+		return ImmutableNullableList.of(tableIdentifier, newTableIdentifier);
 	}
 
 	@Override
 	public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
-		writer.keyword("ALTER TABLE");
-		tableIdentifier.unparse(writer, leftPrec, rightPrec);
+		super.unparse(writer, leftPrec, rightPrec);
+		writer.keyword("RENAME TO");
+		newTableIdentifier.unparse(writer, leftPrec, rightPrec);
 	}
 
-	public String[] fullTableName() {
-		return tableIdentifier.names.toArray(new String[0]);
+	public String[] fullNewTableName() {
+		return newTableIdentifier.names.toArray(new String[0]);
 	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -42,6 +42,8 @@ import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.delegation.Executor;
 import org.apache.flink.table.delegation.ExecutorFactory;
 import org.apache.flink.table.delegation.Parser;
@@ -64,6 +66,7 @@ import org.apache.flink.table.operations.TableSourceQueryOperation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
+import org.apache.flink.table.operations.ddl.AlterTableOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
@@ -103,7 +106,7 @@ public class TableEnvironmentImpl implements TableEnvironment {
 	protected final Parser parser;
 	private static final String UNSUPPORTED_QUERY_IN_SQL_UPDATE_MSG =
 			"Unsupported SQL query! sqlUpdate() only accepts a single SQL statement of type " +
-			"INSERT, CREATE TABLE, DROP TABLE, USE CATALOG, USE [CATALOG.]DATABASE, " +
+			"INSERT, CREATE TABLE, DROP TABLE, ALTER TABLE, USE CATALOG, USE [CATALOG.]DATABASE, " +
 			"CREATE DATABASE, DROP DATABASE, ALTER DATABASE";
 
 	/**
@@ -497,6 +500,27 @@ public class TableEnvironmentImpl implements TableEnvironment {
 			catalogManager.dropTable(
 				dropTableOperation.getTableIdentifier(),
 				dropTableOperation.isIfExists());
+		} else if (operation instanceof AlterTableOperation) {
+			AlterTableOperation alterTableOperation = (AlterTableOperation) operation;
+			Catalog catalog = getCatalogOrThrowException(alterTableOperation.getTableIdentifier().getCatalogName());
+			String exMsg = getDDLOpExecuteErrorMsg(alterTableOperation.asSummaryString());
+			try {
+				if (alterTableOperation.isRename()) {
+					catalog.renameTable(
+							alterTableOperation.getTableIdentifier().toObjectPath(),
+							alterTableOperation.getNewTableIdentifier().getObjectName(),
+							false);
+				} else {
+					catalog.alterTable(
+							alterTableOperation.getTableIdentifier().toObjectPath(),
+							alterTableOperation.getCatalogTable(),
+							false);
+				}
+			} catch (TableAlreadyExistException | TableNotExistException e) {
+				throw new ValidationException(exMsg, e);
+			} catch (Exception e) {
+				throw new TableException(exMsg, e);
+			}
 		} else if (operation instanceof DropDatabaseOperation) {
 			DropDatabaseOperation dropDatabaseOperation = (DropDatabaseOperation) operation;
 			Catalog catalog = getCatalogOrThrowException(dropDatabaseOperation.getCatalogName());

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -67,6 +67,8 @@ import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
 import org.apache.flink.table.operations.ddl.AlterTableOperation;
+import org.apache.flink.table.operations.ddl.AlterTablePropertiesOperation;
+import org.apache.flink.table.operations.ddl.AlterTableRenameOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
@@ -505,15 +507,17 @@ public class TableEnvironmentImpl implements TableEnvironment {
 			Catalog catalog = getCatalogOrThrowException(alterTableOperation.getTableIdentifier().getCatalogName());
 			String exMsg = getDDLOpExecuteErrorMsg(alterTableOperation.asSummaryString());
 			try {
-				if (alterTableOperation.isRename()) {
+				if (alterTableOperation instanceof AlterTableRenameOperation) {
+					AlterTableRenameOperation alterTableRenameOp = (AlterTableRenameOperation) operation;
 					catalog.renameTable(
-							alterTableOperation.getTableIdentifier().toObjectPath(),
-							alterTableOperation.getNewTableIdentifier().getObjectName(),
+							alterTableRenameOp.getTableIdentifier().toObjectPath(),
+							alterTableRenameOp.getNewTableIdentifier().getObjectName(),
 							false);
-				} else {
+				} else if (alterTableOperation instanceof AlterTablePropertiesOperation){
+					AlterTablePropertiesOperation alterTablePropertiesOp = (AlterTablePropertiesOperation) operation;
 					catalog.alterTable(
-							alterTableOperation.getTableIdentifier().toObjectPath(),
-							alterTableOperation.getCatalogTable(),
+							alterTablePropertiesOp.getTableIdentifier().toObjectPath(),
+							alterTablePropertiesOp.getCatalogTable(),
 							false);
 				}
 			} catch (TableAlreadyExistException | TableNotExistException e) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/OperationUtils.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/OperationUtils.java
@@ -94,7 +94,7 @@ public class OperationUtils {
 		return stringBuilder.append(childrenDescription).toString();
 	}
 
-	private static String formatParameter(String name, Object value) {
+	public static String formatParameter(String name, Object value) {
 		final StringBuilder stringBuilder = new StringBuilder();
 		stringBuilder.append(name);
 		stringBuilder.append(": ");

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterTableOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterTableOperation.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.ddl;
+
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.OperationUtils;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Operation to describe a ALTER TABLE statement.
+ */
+public class AlterTableOperation implements AlterOperation {
+	private final ObjectIdentifier tableIdentifier;
+	private final ObjectIdentifier newTableIdentifier;
+	private final CatalogTable catalogTable;
+	private boolean isRename;
+
+	public AlterTableOperation(
+			ObjectIdentifier tableIdentifier,
+			ObjectIdentifier newTableIdentifier,
+			boolean isRename,
+			CatalogTable catalogTable) {
+		this.tableIdentifier = tableIdentifier;
+		this.newTableIdentifier = newTableIdentifier;
+		this.isRename = isRename;
+		this.catalogTable = catalogTable;
+	}
+
+	public ObjectIdentifier getTableIdentifier() {
+		return tableIdentifier;
+	}
+
+	public ObjectIdentifier getNewTableIdentifier() {
+		return newTableIdentifier;
+	}
+
+	public CatalogTable getCatalogTable() {
+		return catalogTable;
+	}
+
+	public boolean isRename() {
+		return isRename;
+	}
+
+	@Override
+	public String asSummaryString() {
+		Map<String, Object> params = new LinkedHashMap<>();
+		params.put("AlterTable", tableIdentifier.toString());
+		params.put("identifier", tableIdentifier);
+		if (isRename) {
+			params.put("newIdentifier", newTableIdentifier.toString());
+		} else {
+			params.putAll(catalogTable.toProperties());
+		}
+
+		return OperationUtils.formatWithChildren(
+			"Alter TABLE",
+			params,
+			Collections.emptyList(),
+			Operation::asSummaryString);
+	}
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterTablePropertiesOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterTablePropertiesOperation.java
@@ -18,20 +18,35 @@
 
 package org.apache.flink.table.operations.ddl;
 
+import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.operations.OperationUtils;
+
+import java.util.stream.Collectors;
+
 
 /**
- * Abstract Operation to describe all ALTER TABLE statements such as rename table /set properties.
+ * Operation to describe a ALTER TABLE .. SET .. statement.
  */
-public abstract class AlterTableOperation implements AlterOperation {
-	protected final ObjectIdentifier tableIdentifier;
+public class AlterTablePropertiesOperation extends AlterTableOperation {
+	private final CatalogTable catalogTable;
 
-	public AlterTableOperation(ObjectIdentifier tableIdentifier) {
-		this.tableIdentifier = tableIdentifier;
+	public AlterTablePropertiesOperation(
+			ObjectIdentifier tableIdentifier,
+			CatalogTable catalogTable) {
+		super(tableIdentifier);
+		this.catalogTable = catalogTable;
 	}
 
-	public ObjectIdentifier getTableIdentifier() {
-		return tableIdentifier;
+	public CatalogTable getCatalogTable() {
+		return catalogTable;
 	}
 
+	@Override
+	public String asSummaryString() {
+		String description = catalogTable.getProperties().entrySet().stream()
+				.map(entry -> OperationUtils.formatParameter(entry.getKey(), entry.getValue()))
+				.collect(Collectors.joining(", "));
+		return String.format("ALTER TABLE %s SET (%s)", tableIdentifier.asSummaryString(), description);
+	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterTableRenameOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterTableRenameOperation.java
@@ -21,17 +21,23 @@ package org.apache.flink.table.operations.ddl;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 
 /**
- * Abstract Operation to describe all ALTER TABLE statements such as rename table /set properties.
+ * Operation to describe a ALTER TABLE .. RENAME to .. statement.
  */
-public abstract class AlterTableOperation implements AlterOperation {
-	protected final ObjectIdentifier tableIdentifier;
+public class AlterTableRenameOperation extends AlterTableOperation {
+	private final ObjectIdentifier newTableIdentifier;
 
-	public AlterTableOperation(ObjectIdentifier tableIdentifier) {
-		this.tableIdentifier = tableIdentifier;
+	public AlterTableRenameOperation(ObjectIdentifier tableIdentifier, ObjectIdentifier newTableIdentifier) {
+		super(tableIdentifier);
+		this.newTableIdentifier = newTableIdentifier;
 	}
 
-	public ObjectIdentifier getTableIdentifier() {
-		return tableIdentifier;
+	public ObjectIdentifier getNewTableIdentifier() {
+		return newTableIdentifier;
 	}
 
+	@Override
+	public String asSummaryString() {
+		return String.format("ALTER TABLE %s RENAME TO %s",
+				tableIdentifier.asSummaryString(), newTableIdentifier.asSummaryString());
+	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -46,7 +46,8 @@ import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
-import org.apache.flink.table.operations.ddl.AlterTableOperation;
+import org.apache.flink.table.operations.ddl.AlterTablePropertiesOperation;
+import org.apache.flink.table.operations.ddl.AlterTableRenameOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
@@ -188,31 +189,30 @@ public class SqlToOperationConverter {
 	private Operation convertAlterTable(SqlAlterTable sqlAlterTable) {
 		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlAlterTable.fullTableName());
 		ObjectIdentifier tableIdentifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
-		ObjectIdentifier newTableIdentifer = null;
-		Map<String, String> properties = new HashMap<>();
-		CatalogTable catalogTable = null;
 		if (sqlAlterTable.isRename()) {
 			UnresolvedIdentifier newUnresolvedIdentifier = UnresolvedIdentifier.of(sqlAlterTable.fullNewTableName());
-			newTableIdentifer = catalogManager.qualifyIdentifier(newUnresolvedIdentifier);
+			ObjectIdentifier newTableIdentifier = catalogManager.qualifyIdentifier(newUnresolvedIdentifier);
+			return new AlterTableRenameOperation(tableIdentifier, newTableIdentifier);
 		} else {
 			Optional<CatalogManager.TableLookupResult> optionalCatalogTable = catalogManager.getTable(tableIdentifier);
 			if (optionalCatalogTable.isPresent() && !optionalCatalogTable.get().isTemporary()) {
 				CatalogTable originalCatalogTable = (CatalogTable) optionalCatalogTable.get().getTable();
+				Map<String, String> properties = new HashMap<>();
 				properties.putAll(originalCatalogTable.getProperties());
 				sqlAlterTable.getPropertyList().getList().forEach(p ->
-								properties.put(((SqlTableOption) p).getKeyString().toLowerCase(),
+						properties.put(((SqlTableOption) p).getKeyString().toLowerCase(),
 								((SqlTableOption) p).getValueString()));
-				catalogTable = new CatalogTableImpl(
+				CatalogTable catalogTable = new CatalogTableImpl(
 						originalCatalogTable.getSchema(),
 						originalCatalogTable.getPartitionKeys(),
 						properties,
 						originalCatalogTable.getComment());
+				return new AlterTablePropertiesOperation(tableIdentifier, catalogTable);
 			} else {
 				throw new ValidationException(String.format("Table %s doesn't exist or is a temporary table.",
 						tableIdentifier.toString()));
 			}
 		}
-		return new AlterTableOperation(tableIdentifier, newTableIdentifer, sqlAlterTable.isRename(), catalogTable);
 	}
 
 	/** Convert insert into statement. */

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -45,6 +45,7 @@ import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
+import org.apache.flink.table.operations.ddl.AlterTableOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
@@ -541,6 +542,46 @@ public class SqlToOperationConverterTest {
 		assertArrayEquals(
 			expected,
 			columnExpressions);
+	}
+
+	@Test
+	public void testAlterTable() throws Exception {
+		Catalog catalog = new GenericInMemoryCatalog("default", "default");
+		catalogManager.registerCatalog("cat1", catalog);
+		catalog.createDatabase("db1",
+				new CatalogDatabaseImpl(new HashMap<>(), null),
+				true);
+		CatalogTable catalogTable = new CatalogTableImpl(
+				TableSchema.builder().field("a", DataTypes.STRING()).build(),
+				new HashMap<>(),
+				"tb1");
+		catalogManager.setCurrentCatalog("cat1");
+		catalogManager.setCurrentDatabase("db1");
+		catalogManager.createTable(catalogTable,
+				ObjectIdentifier.of("cat1", "db1", "tb1"),
+				true);
+		final String[] alterTableSqls = new String[] {
+				"alter table cat1.db1.tb1 rename to tb2",
+				"alter table db1.tb1 rename to tb2",
+				"alter table tb1 rename to cat1.db1.tb2",
+				"alter table cat1.db1.tb1 set ('k1' = 'v1', 'k2' = 'v2')"
+		};
+		final ObjectIdentifier expectedIdentifier =
+				ObjectIdentifier.of("cat1", "db1", "tb1");
+
+		final boolean[] expectedIsRename = new boolean[] {true, true, true, false};
+		final int expectedPropertySize = 2;
+
+		for (int i = 0; i < alterTableSqls.length; i++) {
+			Operation operation = parse(alterTableSqls[i], SqlDialect.DEFAULT);
+			assert operation instanceof AlterTableOperation;
+			final AlterTableOperation alterTableOperation = (AlterTableOperation) operation;
+			assertEquals(expectedIdentifier, alterTableOperation.getTableIdentifier());
+			assertEquals(expectedIsRename[i], alterTableOperation.isRename());
+			if (!alterTableOperation.isRename()) {
+				assertEquals(expectedPropertySize, alterTableOperation.getCatalogTable().getProperties().size());
+			}
+		}
 	}
 
 	//~ Tool Methods ----------------------------------------------------------

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
@@ -827,6 +827,33 @@ class CatalogTableITCase(isStreamingMode: Boolean) {
   }
 
   @Test
+  def testAlterTable(): Unit = {
+    val ddl1 =
+      """
+        |create table t1(
+        |  a bigint,
+        |  b bigint,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'k1' = 'v1'
+        |)
+      """.stripMargin
+    tableEnv.sqlUpdate(ddl1)
+    tableEnv.sqlUpdate("alter table t1 rename to t2")
+    assert(tableEnv.listTables().sameElements(Array[String]("t2")))
+    tableEnv.sqlUpdate("alter table t2 set ('k1' = 'a', 'k2' = 'b')")
+    val expectedProperties = new util.HashMap[String, String]()
+    expectedProperties.put("connector", "COLLECTION")
+    expectedProperties.put("k1", "a")
+    expectedProperties.put("k2", "b")
+    val properties = tableEnv.getCatalog(tableEnv.getCurrentCatalog).get()
+      .getTable(new ObjectPath(tableEnv.getCurrentDatabase, "t2"))
+      .getProperties
+    assertEquals(expectedProperties, properties)
+  }
+
+  @Test
   def testUseCatalog(): Unit = {
     tableEnv.registerCatalog("cat1", new GenericInMemoryCatalog("cat1"))
     tableEnv.registerCatalog("cat2", new GenericInMemoryCatalog("cat2"))

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -20,6 +20,8 @@ package org.apache.flink.table.sqlexec;
 
 import org.apache.flink.sql.parser.ddl.SqlAlterDatabase;
 import org.apache.flink.sql.parser.ddl.SqlAlterTable;
+import org.apache.flink.sql.parser.ddl.SqlAlterTableProperties;
+import org.apache.flink.sql.parser.ddl.SqlAlterTableRename;
 import org.apache.flink.sql.parser.ddl.SqlCreateDatabase;
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
 import org.apache.flink.sql.parser.ddl.SqlDropDatabase;
@@ -195,17 +197,18 @@ public class SqlToOperationConverter {
 	private Operation convertAlterTable(SqlAlterTable sqlAlterTable) {
 		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlAlterTable.fullTableName());
 		ObjectIdentifier tableIdentifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
-		if (sqlAlterTable.isRename()) {
-			UnresolvedIdentifier newUnresolvedIdentifier = UnresolvedIdentifier.of(sqlAlterTable.fullNewTableName());
+		if (sqlAlterTable instanceof SqlAlterTableRename) {
+			UnresolvedIdentifier newUnresolvedIdentifier =
+					UnresolvedIdentifier.of(((SqlAlterTableRename) sqlAlterTable).fullNewTableName());
 			ObjectIdentifier newTableIdentifier = catalogManager.qualifyIdentifier(newUnresolvedIdentifier);
 			return new AlterTableRenameOperation(tableIdentifier, newTableIdentifier);
-		} else {
+		} else if (sqlAlterTable instanceof SqlAlterTableProperties){
 			Optional<CatalogManager.TableLookupResult> optionalCatalogTable = catalogManager.getTable(tableIdentifier);
 			if (optionalCatalogTable.isPresent() && !optionalCatalogTable.get().isTemporary()) {
 				CatalogTable originalCatalogTable = (CatalogTable) optionalCatalogTable.get().getTable();
 				Map<String, String> properties = new HashMap<>();
 				properties.putAll(originalCatalogTable.getProperties());
-				sqlAlterTable.getPropertyList().getList().forEach(p ->
+				((SqlAlterTableProperties) sqlAlterTable).getPropertyList().getList().forEach(p ->
 						properties.put(((SqlTableOption) p).getKeyString().toLowerCase(),
 								((SqlTableOption) p).getValueString()));
 				CatalogTable catalogTable = new CatalogTableImpl(
@@ -219,6 +222,7 @@ public class SqlToOperationConverter {
 						tableIdentifier.toString()));
 			}
 		}
+		return null;
 	}
 
 	/** Fallback method for sql query. */

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.sqlexec;
 
 import org.apache.flink.sql.parser.ddl.SqlAlterDatabase;
+import org.apache.flink.sql.parser.ddl.SqlAlterTable;
 import org.apache.flink.sql.parser.ddl.SqlCreateDatabase;
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
 import org.apache.flink.sql.parser.ddl.SqlDropDatabase;
@@ -48,6 +49,7 @@ import org.apache.flink.table.operations.PlannerQueryOperation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
+import org.apache.flink.table.operations.ddl.AlterTableOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
@@ -110,6 +112,8 @@ public class SqlToOperationConverter {
 			return Optional.of(converter.convertCreateTable((SqlCreateTable) validated));
 		} else if (validated instanceof SqlDropTable) {
 			return Optional.of(converter.convertDropTable((SqlDropTable) validated));
+		} else if (validated instanceof SqlAlterTable) {
+			return Optional.of(converter.convertAlterTable((SqlAlterTable) validated));
 		} else if (validated instanceof RichSqlInsert) {
 			SqlNodeList targetColumnList = ((RichSqlInsert) validated).getTargetColumnList();
 			if (targetColumnList != null && targetColumnList.size() != 0) {
@@ -184,6 +188,37 @@ public class SqlToOperationConverter {
 		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
 		return new DropTableOperation(identifier, sqlDropTable.getIfExists());
+	}
+
+	/** convert ALTER TABLE statement. */
+	private Operation convertAlterTable(SqlAlterTable sqlAlterTable) {
+		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlAlterTable.fullTableName());
+		ObjectIdentifier tableIdentifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
+		ObjectIdentifier newTableIdentifer = null;
+		Map<String, String> properties = new HashMap<>();
+		CatalogTable catalogTable = null;
+		if (sqlAlterTable.isRename()) {
+			UnresolvedIdentifier newUnresolvedIdentifier = UnresolvedIdentifier.of(sqlAlterTable.fullNewTableName());
+			newTableIdentifer = catalogManager.qualifyIdentifier(newUnresolvedIdentifier);
+		} else {
+			Optional<CatalogManager.TableLookupResult> optionalCatalogTable = catalogManager.getTable(tableIdentifier);
+			if (optionalCatalogTable.isPresent() && !optionalCatalogTable.get().isTemporary()) {
+				CatalogTable originalCatalogTable = (CatalogTable) optionalCatalogTable.get().getTable();
+				properties.putAll(originalCatalogTable.getProperties());
+				sqlAlterTable.getPropertyList().getList().forEach(p ->
+								properties.put(((SqlTableOption) p).getKeyString().toLowerCase(),
+								((SqlTableOption) p).getValueString()));
+				catalogTable = new CatalogTableImpl(
+						originalCatalogTable.getSchema(),
+						originalCatalogTable.getPartitionKeys(),
+						properties,
+						originalCatalogTable.getComment());
+			} else {
+				throw new ValidationException(String.format("Table %s doesn't exist or is a temporary table.",
+															tableIdentifier.toString()));
+			}
+		}
+		return new AlterTableOperation(tableIdentifier, newTableIdentifer, sqlAlterTable.isRename(), catalogTable);
 	}
 
 	/** Fallback method for sql query. */

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -120,7 +120,7 @@ abstract class TableEnvImpl(
 
   private val UNSUPPORTED_QUERY_IN_SQL_UPDATE_MSG =
     "Unsupported SQL query! sqlUpdate() only accepts a single SQL statement of type " +
-      "INSERT, CREATE TABLE, DROP TABLE, USE CATALOG, USE [CATALOG.]DATABASE, " +
+      "INSERT, CREATE TABLE, DROP TABLE, ALTER TABLE, USE CATALOG, USE [CATALOG.]DATABASE, " +
       "CREATE DATABASE, DROP DATABASE, ALTER DATABASE"
 
   private def isStreamingMode: Boolean = this match {
@@ -501,6 +501,27 @@ abstract class TableEnvImpl(
         catalogManager.dropTable(
           dropTableOperation.getTableIdentifier,
           dropTableOperation.isIfExists)
+      case alterTableOperation: AlterTableOperation => {
+        val catalog = getCatalogOrThrowException(
+          alterTableOperation.getTableIdentifier.getCatalogName)
+        val exMsg = getDDLOpExecuteErrorMsg(alterTableOperation.asSummaryString)
+        try {
+          if (alterTableOperation.isRename) {
+            catalog.renameTable(
+              alterTableOperation.getTableIdentifier.toObjectPath,
+              alterTableOperation.getNewTableIdentifier.getObjectName,
+              false)
+          } else {
+            catalog.alterTable(
+              alterTableOperation.getTableIdentifier.toObjectPath,
+              alterTableOperation.getCatalogTable,
+              false)
+          }
+        } catch {
+          case ex: TableNotExistException => throw new ValidationException(exMsg, ex)
+          case ex: Exception => throw new TableException(exMsg, ex)
+        }
+      }
       case dropDatabaseOperation: DropDatabaseOperation =>
         val catalog = getCatalogOrThrowException(dropDatabaseOperation.getCatalogName)
         val exMsg = getDDLOpExecuteErrorMsg(dropDatabaseOperation.asSummaryString)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -506,16 +506,17 @@ abstract class TableEnvImpl(
           alterTableOperation.getTableIdentifier.getCatalogName)
         val exMsg = getDDLOpExecuteErrorMsg(alterTableOperation.asSummaryString)
         try {
-          if (alterTableOperation.isRename) {
-            catalog.renameTable(
-              alterTableOperation.getTableIdentifier.toObjectPath,
-              alterTableOperation.getNewTableIdentifier.getObjectName,
-              false)
-          } else {
-            catalog.alterTable(
-              alterTableOperation.getTableIdentifier.toObjectPath,
-              alterTableOperation.getCatalogTable,
-              false)
+          alterTableOperation match {
+            case alterTableRenameOp: AlterTableRenameOperation =>
+              catalog.renameTable(
+                alterTableRenameOp.getTableIdentifier.toObjectPath,
+                alterTableRenameOp.getNewTableIdentifier.getObjectName,
+                false)
+            case alterTablePropertiesOp: AlterTablePropertiesOperation =>
+              catalog.alterTable(
+                alterTablePropertiesOp.getTableIdentifier.toObjectPath,
+                alterTablePropertiesOp.getCatalogTable,
+                false)
           }
         } catch {
           case ex: TableNotExistException => throw new ValidationException(exMsg, ex)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.FunctionCatalog;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
+import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
@@ -48,6 +49,7 @@ import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
+import org.apache.flink.table.operations.ddl.AlterTableOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
@@ -504,6 +506,46 @@ public class SqlToOperationConverterTest {
 			expectedEx.expect(TableException.class);
 			expectedEx.expectMessage(item.expectedError);
 			SqlToOperationConverter.convert(planner, catalogManager, node);
+		}
+	}
+
+	@Test
+	public void testAlterTable() throws Exception {
+		Catalog catalog = new GenericInMemoryCatalog("default", "default");
+		catalogManager.registerCatalog("cat1", catalog);
+		catalog.createDatabase("db1",
+				new CatalogDatabaseImpl(new HashMap<>(), null),
+				true);
+		CatalogTable catalogTable = new CatalogTableImpl(
+				TableSchema.builder().field("a", DataTypes.STRING()).build(),
+				new HashMap<>(),
+				"tb1");
+		catalogManager.setCurrentCatalog("cat1");
+		catalogManager.setCurrentDatabase("db1");
+		catalogManager.createTable(catalogTable,
+				ObjectIdentifier.of("cat1", "db1", "tb1"),
+				true);
+		final String[] alterTableSqls = new String[] {
+				"alter table cat1.db1.tb1 rename to tb2",
+				"alter table db1.tb1 rename to tb2",
+				"alter table tb1 rename to cat1.db1.tb2",
+				"alter table cat1.db1.tb1 set ('k1' = 'v1', 'k2' = 'v2')"
+		};
+		final ObjectIdentifier expectedIdentifier =
+				ObjectIdentifier.of("cat1", "db1", "tb1");
+
+		final boolean[] expectedIsRename = new boolean[] {true, true, true, false};
+		final int expectedPropertySize = 2;
+
+		for (int i = 0; i < alterTableSqls.length; i++) {
+			Operation operation = parse(alterTableSqls[i], SqlDialect.DEFAULT);
+			assert operation instanceof AlterTableOperation;
+			final AlterTableOperation alterTableOperation = (AlterTableOperation) operation;
+			assertEquals(expectedIdentifier, alterTableOperation.getTableIdentifier());
+			assertEquals(expectedIsRename[i], alterTableOperation.isRename());
+			if (!alterTableOperation.isRename()) {
+				assertEquals(expectedPropertySize, alterTableOperation.getCatalogTable().getProperties().size());
+			}
 		}
 	}
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
@@ -49,7 +49,8 @@ import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
-import org.apache.flink.table.operations.ddl.AlterTableOperation;
+import org.apache.flink.table.operations.ddl.AlterTablePropertiesOperation;
+import org.apache.flink.table.operations.ddl.AlterTableRenameOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
@@ -513,40 +514,37 @@ public class SqlToOperationConverterTest {
 	public void testAlterTable() throws Exception {
 		Catalog catalog = new GenericInMemoryCatalog("default", "default");
 		catalogManager.registerCatalog("cat1", catalog);
-		catalog.createDatabase("db1",
-				new CatalogDatabaseImpl(new HashMap<>(), null),
-				true);
+		catalog.createDatabase("db1", new CatalogDatabaseImpl(new HashMap<>(), null), true);
 		CatalogTable catalogTable = new CatalogTableImpl(
 				TableSchema.builder().field("a", DataTypes.STRING()).build(),
 				new HashMap<>(),
 				"tb1");
 		catalogManager.setCurrentCatalog("cat1");
 		catalogManager.setCurrentDatabase("db1");
-		catalogManager.createTable(catalogTable,
-				ObjectIdentifier.of("cat1", "db1", "tb1"),
-				true);
-		final String[] alterTableSqls = new String[] {
+		catalog.createTable(new ObjectPath("db1", "tb1"), catalogTable, true);
+		final String[] renameTableSqls = new String[] {
 				"alter table cat1.db1.tb1 rename to tb2",
 				"alter table db1.tb1 rename to tb2",
 				"alter table tb1 rename to cat1.db1.tb2",
-				"alter table cat1.db1.tb1 set ('k1' = 'v1', 'k2' = 'v2')"
 		};
 		final ObjectIdentifier expectedIdentifier =
 				ObjectIdentifier.of("cat1", "db1", "tb1");
-
-		final boolean[] expectedIsRename = new boolean[] {true, true, true, false};
-		final int expectedPropertySize = 2;
-
-		for (int i = 0; i < alterTableSqls.length; i++) {
-			Operation operation = parse(alterTableSqls[i], SqlDialect.DEFAULT);
-			assert operation instanceof AlterTableOperation;
-			final AlterTableOperation alterTableOperation = (AlterTableOperation) operation;
-			assertEquals(expectedIdentifier, alterTableOperation.getTableIdentifier());
-			assertEquals(expectedIsRename[i], alterTableOperation.isRename());
-			if (!alterTableOperation.isRename()) {
-				assertEquals(expectedPropertySize, alterTableOperation.getCatalogTable().getProperties().size());
-			}
+		final ObjectIdentifier expectedNewIdentifier =
+				ObjectIdentifier.of("cat1", "db1", "tb2");
+		//test rename table converter
+		for (int i = 0; i < renameTableSqls.length; i++) {
+			Operation operation = parse(renameTableSqls[i], SqlDialect.DEFAULT);
+			assert operation instanceof AlterTableRenameOperation;
+			final AlterTableRenameOperation alterTableRenameOperation = (AlterTableRenameOperation) operation;
+			assertEquals(expectedIdentifier, alterTableRenameOperation.getTableIdentifier());
+			assertEquals(expectedNewIdentifier, alterTableRenameOperation.getNewTableIdentifier());
 		}
+		// test alter table properties
+		Operation operation = parse("alter table cat1.db1.tb1 set ('k1' = 'v1', 'k2' = 'v2')", SqlDialect.DEFAULT);
+		assert operation instanceof AlterTablePropertiesOperation;
+		final AlterTablePropertiesOperation alterTablePropertiesOperation = (AlterTablePropertiesOperation) operation;
+		assertEquals(expectedIdentifier, alterTablePropertiesOperation.getTableIdentifier());
+		assertEquals(2, alterTablePropertiesOperation.getCatalogTable().getProperties().size());
 	}
 
 	//~ Tool Methods ----------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

Support alterTableStatement as following:
1. ALTER TABLE  [[catalogName.] dataBasesName].tableName RENAME TO newTableName
2. ALTER TABLE  [[catalogName.] dataBasesName].tableName SET  ( name=value [, name=value]*)


## Brief change log
- [de0b373](https://github.com/apache/flink/commit/de0b3736069c62629a17afb60190abaa251ba33e) support rename/alter table operation


## Verifying this change

This change added tests and can be verified as follows:

  - *SqlToOperationConverterTest#testAlterTable*
  - *CatalogTableITCase.scala#testAlterTable*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? (not documented)
