### PR TITLE
[hotfix] wrap root exception when instantiating catalog functions

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/functions/FunctionDefinitionUtil.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/functions/FunctionDefinitionUtil.java
@@ -32,8 +32,7 @@ public class FunctionDefinitionUtil {
 			func = Thread.currentThread().getContextClassLoader().loadClass(catalogFunction.getClassName()).newInstance();
 		} catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
 			throw new IllegalStateException(
-				String.format("Failed instantiating '%s'", catalogFunction.getClassName())
-			);
+				String.format("Failed instantiating '%s'", catalogFunction.getClassName()), e);
 		}
 
 		UserDefinedFunction udf = (UserDefinedFunction) func;


### PR DESCRIPTION
## What is the purpose of the change

wrap root exception when instantiating catalog functions. Found this issue when debugging function related tests with @HuangZhenQiu 

## Brief change log

wrap root exception when instantiating catalog functions

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

n/a

## Documentation

n/a