### PR TITLE
[FLINK-15039][FLINK-15041] Remove default ClusterClient and JobClient close() implementations

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -41,9 +41,7 @@ import java.util.concurrent.CompletableFuture;
 public interface ClusterClient<T> extends AutoCloseable {
 
 	@Override
-	default void close() {
-
-	}
+	void close();
 
 	/**
 	 * Returns the cluster id identifying the cluster to which the client is connected.

--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -123,6 +123,11 @@ public class MiniClusterClient implements ClusterClient<MiniClusterClient.MiniCl
 	}
 
 	@Override
+	public void close() {
+
+	}
+
+	@Override
 	public MiniClusterClient.MiniClusterId getClusterId() {
 		return MiniClusterId.INSTANCE;
 	}

--- a/flink-clients/src/test/java/org/apache/flink/client/program/TestingClusterClient.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/TestingClusterClient.java
@@ -131,4 +131,9 @@ public class TestingClusterClient<T> implements ClusterClient<T> {
 	public CompletableFuture<String> triggerSavepoint(JobID jobId, @Nullable String savepointDirectory) {
 		return triggerSavepointFunction.apply(jobId, savepointDirectory);
 	}
+
+	@Override
+	public void close() {
+
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/core/execution/JobClient.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/JobClient.java
@@ -85,7 +85,5 @@ public interface JobClient extends AutoCloseable {
 	CompletableFuture<JobExecutionResult> getJobExecutionResult(final ClassLoader userClassloader);
 
 	@Override
-	default void close() {
-
-	}
+	void close();
 }

--- a/flink-java/src/test/java/org/apache/flink/api/java/TestingJobClient.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/TestingJobClient.java
@@ -69,4 +69,8 @@ public class TestingJobClient implements JobClient {
 		return CompletableFuture.completedFuture(Collections.emptyMap());
 	}
 
+	@Override
+	public void close() {
+
+	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/environment/TestingJobClient.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/environment/TestingJobClient.java
@@ -69,4 +69,8 @@ public class TestingJobClient implements JobClient {
 		return CompletableFuture.completedFuture(Collections.emptyMap());
 	}
 
+	@Override
+	public void close() {
+
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR removes the default implementations of the `close()` method in the `ClusterClient` and the `JobClient`. The reason is that having a default implementation may lead to subclass implementers not even thinking about providing a proper `close()` implementation, which can lead to difficult bugs related to resource leaks.

## Verifying this change

This change is a trivial rework / code cleanup covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
