### PR TITLE
[FLINK-14960][e2e] Fix failed dependency shading test of table modules

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_table_shaded_dependencies.sh
+++ b/flink-end-to-end-tests/test-scripts/test_table_shaded_dependencies.sh
@@ -39,6 +39,8 @@ function checkCodeDependencies {
       grep -v "^\s*\-> scala" |\
       `# flink dependencies` \
       grep -v "^\s*\-> org.apache.flink" |\
+      `# flink-core dependencies` \
+      grep -v "^\s*\-> com.esotericsoftware.kryo" |\
       `# janino dependencies` \
       grep -v "^\s*\-> org.codehaus.janino" |\
       grep -v "^\s*\-> org.codehaus.commons" |\

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/DummyStreamExecutionEnvironment.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/DummyStreamExecutionEnvironment.java
@@ -57,6 +57,9 @@ import java.util.List;
  *
  * <p>This class could be removed once the {@link TableSource} interface and {@link StreamTableSink} interface
  * are reworked.
+ *
+ * <p>NOTE: Please remove {@code com.esotericsoftware.kryo} item in the whitelist of checkCodeDependencies()
+ * method in {@code test_table_shaded_dependencies.sh} end-to-end test when this class is removed.
  */
 public class DummyStreamExecutionEnvironment extends StreamExecutionEnvironment {
 


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The `com.esotericsoftware.kryo.Serializer` import in `DummyStreamExecutionEnvironment` fails the `test_table_shaded_dependencies.sh`. As discussed in the JIRA, it's safe to add it to the whilelist of `checkCodeDependencies()` method as it is from flink-core. 

## Brief change log

- Exclude `com.esotericsoftware.kryo` in `checkCodeDependencies()`
- Add note in `DummyStreamExecutionEnvironment` to remove the check back when removing `DummyStreamExecutionEnvironment`.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
