### PR TITLE
[FLINK-15049][table-planner-blink] Compile error when hash join with …

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/LongHashJoinGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/LongHashJoinGenerator.scala
@@ -73,6 +73,7 @@ object LongHashJoinGenerator {
     val term = singleType.getTypeRoot match {
       case FLOAT => s"Float.floatToIntBits($getCode)"
       case DOUBLE => s"Double.doubleToLongBits($getCode)"
+      case TIMESTAMP_WITHOUT_TIME_ZONE => s"$getCode.getMillisecond()"
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE => s"$getCode.getMillisecond()"
       case _ => getCode
     }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TimestampITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TimestampITCase.scala
@@ -25,6 +25,7 @@ import org.apache.flink.table.planner.utils.DateTimeTestUtil._
 import org.apache.flink.table.planner.utils.TestDataTypeTableSource
 import org.apache.flink.types.Row
 import org.junit.Test
+
 import java.sql.Timestamp
 import java.time.{Instant, LocalDateTime, ZoneId}
 
@@ -36,12 +37,14 @@ class TimestampITCase extends BatchTestBase {
     super.before()
 
     val tableSchema = TableSchema.builder().fields(
-      Array("a", "b", "c", "d", "e", "f"),
+      Array("a", "b", "c", "d", "e", "f", "g", "h"),
       Array(
         DataTypes.INT(),
         DataTypes.BIGINT(),
         DataTypes.TIMESTAMP(9).bridgedTo(classOf[LocalDateTime]),
         DataTypes.TIMESTAMP(9).bridgedTo(classOf[Timestamp]),
+        DataTypes.TIMESTAMP(3).bridgedTo(classOf[LocalDateTime]),
+        DataTypes.TIMESTAMP(3).bridgedTo(classOf[Timestamp])
         DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(9).bridgedTo(classOf[Instant]),
         DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(9).bridgedTo(classOf[Instant])
       )
@@ -62,6 +65,21 @@ class TimestampITCase extends BatchTestBase {
       Timestamp.valueOf("1969-01-01 00:00:00.123456789"),
       Timestamp.valueOf("1970-01-01 00:00:00.123456"),
       Timestamp.valueOf("1970-01-01 00:00:00.123"),
+      Timestamp.valueOf("1972-01-01 00:00:00"),
+      null
+    )
+
+    val datetimesWithMilli = List(
+      localDateTime("1969-01-01 00:00:00.123"),
+      localDateTime("1970-01-01 00:00:00.12"),
+      localDateTime("1970-01-01 00:00:00.12"),
+      localDateTime("1970-01-01 00:00:00.1"),
+      null)
+
+    val timestampsWithMilli = List(
+      Timestamp.valueOf("1969-01-01 00:00:00.123"),
+      Timestamp.valueOf("1970-01-01 00:00:00.12"),
+      Timestamp.valueOf("1970-01-01 00:00:00.1"),
       Timestamp.valueOf("1972-01-01 00:00:00"),
       null
     )
@@ -92,8 +110,8 @@ class TimestampITCase extends BatchTestBase {
     val data = new mutable.MutableList[Row]
 
     for (i <- ints.indices) {
-      data += row(ints(i), longs(i), datetimes(i), timestamps(i), instantsOfDateTime(i),
-        instantsOfTimestamp(i))
+      data += row(ints(i), longs(i), datetimes(i), timestamps(i), datetimesWithMilli(i),
+        timestampsWithMilli(i), instantsOfDateTime(i), instantsOfTimestamp(i))
     }
 
     val tableSource = new TestDataTypeTableSource(
@@ -111,18 +129,27 @@ class TimestampITCase extends BatchTestBase {
         row(1, 1, "1969-01-01T00:00:00.123456789"),
         row(3, 2, "1970-01-01T00:00:00.123456"),
         row(4, 4, "1970-01-01T00:00:00.123"),
-        row(null, null, null))
-    )
+        row(null, null, null)))
+
+    // group by TIMESTAMP(3)
+    checkResult(
+      "SELECT MAX(a), MIN(a), e FROM T GROUP BY e",
+      Seq(
+        row(1, 1, "1969-01-01T00:00:00.123"),
+        row(3, 2, "1970-01-01T00:00:00.120"),
+        row(4, 4, "1970-01-01T00:00:00.100"),
+        row(null, null, null)))
 
     // group by TIMESTAMP(9) WITH LOCAL TIME ZONE
     checkResult(
-      "SELECT MAX(a), MIN(a), e FROM T GROUP BY e",
+      "SELECT MAX(a), MIN(a), g FROM T GROUP BY g",
       Seq(
         row(1, 1, "1969-01-01T00:00:00.123456789Z"),
         row(3, 2, "1970-01-01T00:00:00.123456Z"),
         row(4, 4, "1970-01-01T00:00:00.123Z"),
         row(null, null, null))
     )
+
   }
 
   @Test
@@ -155,8 +182,8 @@ class TimestampITCase extends BatchTestBase {
   def testJoinOn(): Unit = {
     // Join On TIMESTAMP(9)
     checkResult(
-      "SELECT T1.a, T1.b, T1.c, T1.d, T2.a, T2.b, T2.c, T2.d " +
-        "FROM T as T1 JOIN T as T2 ON T1.c = T2.d",
+      "SELECT T1.a, T1.b, T1.c, T1.d, T2.a, T2.b, T2.c, T2.d FROM T as T1 " +
+        "JOIN T as T2 ON T1.c = T2.d",
       Seq(
         row(1, 1, "1969-01-01T00:00:00.123456789", "1969-01-01T00:00:00.123456789",
           1, 1, "1969-01-01T00:00:00.123456789", "1969-01-01T00:00:00.123456789"),
@@ -168,10 +195,25 @@ class TimestampITCase extends BatchTestBase {
           3, 2, "1970-01-01T00:00:00.123456", "1970-01-01T00:00:00.123")
       ))
 
+    // Join on TIMESTAMP(3)
+    checkResult(
+      "SELECT T1.a, T1.b, T1.e, T1.f, T2.a, T2.b, T2.e, T2.f FROM T as T1 " +
+        "JOIN T as T2 ON T1.e = T2.f",
+      Seq(
+        row(1, 1, "1969-01-01T00:00:00.123", "1969-01-01T00:00:00.123",
+          1, 1, "1969-01-01T00:00:00.123", "1969-01-01T00:00:00.123"),
+        row(2, 2, "1970-01-01T00:00:00.120", "1970-01-01T00:00:00.120",
+          2, 2, "1970-01-01T00:00:00.120", "1970-01-01T00:00:00.120"),
+        row(3, 2, "1970-01-01T00:00:00.120", "1970-01-01T00:00:00.100",
+          2, 2, "1970-01-01T00:00:00.120", "1970-01-01T00:00:00.120"),
+        row(4, 4, "1970-01-01T00:00:00.100", "1972-01-01T00:00",
+          3, 2, "1970-01-01T00:00:00.120", "1970-01-01T00:00:00.100")
+      ))
+
     // Join on TIMESTAMP(9) WITH LOCAL TIME ZONE
     checkResult(
-      "SELECT T1.a, T1.b, T1.e, T1.f, T2.a, T2.b, T2.e, T2.f " +
-        "FROM T as T1 JOIN T as T2 ON T1.e = T2.f",
+      "SELECT T1.a, T1.b, T1.g, T1.h, T2.a, T2.b, T2.g, T2.h " +
+        "FROM T as T1 JOIN T as T2 ON T1.g = T2.h",
       Seq(
         row(1, 1, "1969-01-01T00:00:00.123456789Z", "1969-01-01T00:00:00.123456789Z",
           1, 1, "1969-01-01T00:00:00.123456789Z", "1969-01-01T00:00:00.123456789Z"),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TimestampITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TimestampITCase.scala
@@ -44,10 +44,9 @@ class TimestampITCase extends BatchTestBase {
         DataTypes.TIMESTAMP(9).bridgedTo(classOf[LocalDateTime]),
         DataTypes.TIMESTAMP(9).bridgedTo(classOf[Timestamp]),
         DataTypes.TIMESTAMP(3).bridgedTo(classOf[LocalDateTime]),
-        DataTypes.TIMESTAMP(3).bridgedTo(classOf[Timestamp])
+        DataTypes.TIMESTAMP(3).bridgedTo(classOf[Timestamp]),
         DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(9).bridgedTo(classOf[Instant]),
-        DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(9).bridgedTo(classOf[Instant])
-      )
+        DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(9).bridgedTo(classOf[Instant]))
     ).build()
 
     val ints = List(1, 2, 3, 4, null)


### PR DESCRIPTION
…timestamp type key


## What is the purpose of the change

LongHashJoinGenerator should convert SqlTimestamp to long by genGetLongKey when precision of TimestampType is less than  or equals to 3.

## Brief change log

- Convert SqlTimestamp to long in genGetLongKey when precision of Timestamp <= 3
- Add JoinOn Timestmap(3) case to verify

## Verifying this change

This change is already covered by tests, such as *(TimestampITCase)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
