### PR TITLE
[FLINK-15050][table-planner-blink] DataFormatConverters should suppor…

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
@@ -19,8 +19,6 @@ package org.apache.flink.table.dataformat;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
-import org.apache.flink.api.common.typeinfo.LocalTimeTypeInfo;
-import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.CompositeType;
 import org.apache.flink.api.common.typeutils.TypeSerializer;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
@@ -167,22 +167,22 @@ public class DataFormatConverters {
 					return new DecimalConverter(ps.f0, ps.f1);
 				}
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
-				int precision = getDateTimePrecision(logicalType);
+				int precisionOfTS = getDateTimePrecision(logicalType);
 				if (clazz == Timestamp.class) {
-					return new TimestampConverter(precision);
+					return new TimestampConverter(precisionOfTS);
 				} else if (clazz == LocalDateTime.class) {
-					return new LocalDateTimeConverter(precision);
+					return new LocalDateTimeConverter(precisionOfTS);
 				} else {
-					return new SqlTimestampConverter(precision);
+					return new SqlTimestampConverter(precisionOfTS);
 				}
 			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-				int precision = getDateTimePrecision(logicalType);
+				int precisionOfLZTS = getDateTimePrecision(logicalType);
 				if (clazz == Instant.class) {
-					return new InstantConverter(precision);
+					return new InstantConverter(precisionOfLZTS);
 				} else if (clazz == Long.class || clazz == long.class) {
-					return new LongSqlTimestampConverter(precision);
+					return new LongSqlTimestampConverter(precisionOfLZTS);
 				} else {
-					return new SqlTimestampConverter(precision);
+					return new SqlTimestampConverter(precisionOfLZTS);
 				}
 			case ARRAY:
 				if (clazz == BinaryArray.class) {
@@ -303,7 +303,7 @@ public class DataFormatConverters {
 		if (logicalType instanceof LocalZonedTimestampType) {
 			return ((LocalZonedTimestampType) logicalType).getPrecision();
 		} else if (logicalType instanceof TimestampType) {
-			return ((TimestampType) logicalType).getPrecision()
+			return ((TimestampType) logicalType).getPrecision();
 		} else {
 			TypeInformation typeInfo = ((LegacyTypeInformationType) logicalType).getTypeInformation();
 			if (typeInfo instanceof LegacyInstantTypeInfo) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
@@ -19,6 +19,8 @@ package org.apache.flink.table.dataformat;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.LocalTimeTypeInfo;
+import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.CompositeType;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -121,9 +123,6 @@ public class DataFormatConverters {
 		t2C.put(DataTypes.TIME().bridgedTo(Integer.class), IntConverter.INSTANCE);
 		t2C.put(DataTypes.TIME().bridgedTo(int.class), IntConverter.INSTANCE);
 
-		t2C.put(DataTypes.TIMESTAMP(3).bridgedTo(Timestamp.class), new TimestampConverter(3));
-		t2C.put(DataTypes.TIMESTAMP(3).bridgedTo(LocalDateTime.class), new LocalDateTimeConverter(3));
-
 		t2C.put(DataTypes.INTERVAL(DataTypes.MONTH()).bridgedTo(Integer.class), IntConverter.INSTANCE);
 		t2C.put(DataTypes.INTERVAL(DataTypes.MONTH()).bridgedTo(int.class), IntConverter.INSTANCE);
 
@@ -168,6 +167,15 @@ public class DataFormatConverters {
 					return new BigDecimalConverter(ps.f0, ps.f1);
 				} else {
 					return new DecimalConverter(ps.f0, ps.f1);
+				}
+			case TIMESTAMP_WITHOUT_TIME_ZONE:
+				int precision = getDateTimePrecision(logicalType);
+				if (clazz == Timestamp.class) {
+					return new TimestampConverter(precision);
+				} else if (clazz == LocalDateTime.class) {
+					return new LocalDateTimeConverter(precision);
+				} else {
+					return new SqlTimestampConverter(precision);
 				}
 			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
 				int precision = getDateTimePrecision(logicalType);
@@ -264,11 +272,6 @@ public class DataFormatConverters {
 					return BinaryGenericConverter.INSTANCE;
 				}
 				return new GenericConverter(typeInfo.createSerializer(new ExecutionConfig()));
-			case TIMESTAMP_WITHOUT_TIME_ZONE:
-				if (dataType.getConversionClass().equals(LocalDateTime.class)) {
-					return new LocalDateTimeConverter(((TimestampType) logicalType).getPrecision());
-				}
-				return new TimestampConverter(((TimestampType) logicalType).getPrecision());
 			default:
 				throw new RuntimeException("Not support dataType: " + dataType);
 		}
@@ -301,12 +304,17 @@ public class DataFormatConverters {
 	private static int getDateTimePrecision(LogicalType logicalType) {
 		if (logicalType instanceof LocalZonedTimestampType) {
 			return ((LocalZonedTimestampType) logicalType).getPrecision();
+		} else if (logicalType instanceof TimestampType) {
+			return ((TimestampType) logicalType).getPrecision()
 		} else {
 			TypeInformation typeInfo = ((LegacyTypeInformationType) logicalType).getTypeInformation();
 			if (typeInfo instanceof LegacyInstantTypeInfo) {
 				return ((LegacyInstantTypeInfo) typeInfo).getPrecision();
+			} else if (typeInfo instanceof LegacyLocalDateTimeTypeInfo) {
+				return ((LegacyLocalDateTimeTypeInfo) typeInfo).getPrecision();
 			} else {
-				return LocalZonedTimestampType.DEFAULT_PRECISION;
+				// TimestampType.DEFAULT_PRECISION == LocalZonedTimestampType.DEFAULT_PRECISION == 6
+				return TimestampType.DEFAULT_PRECISION;
 			}
 		}
 	}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/DataFormatConvertersTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/DataFormatConvertersTest.java
@@ -128,7 +128,8 @@ public class DataFormatConvertersTest {
 		new AtomicDataType(
 			new LegacyTypeInformationType<>(
 				LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE,
-				new LegacyTimestampTypeInfo(7)))
+				new LegacyTimestampTypeInfo(7))),
+		DataTypes.TIMESTAMP(3).bridgedTo(SqlTimestamp.class)
 	};
 
 	private Object[] dataValues = new Object[] {
@@ -136,7 +137,8 @@ public class DataFormatConvertersTest {
 		Timestamp.valueOf("1970-01-01 00:00:00.123456789"),
 		LocalDateTime.of(1970, 1, 1, 0, 0, 0, 123),
 		Timestamp.valueOf("1970-01-01 00:00:00.123"),
-		Timestamp.valueOf("1970-01-01 00:00:00.1234567")
+		Timestamp.valueOf("1970-01-01 00:00:00.1234567"),
+		SqlTimestamp.fromEpochMillis(1000L)
 	};
 
 	private static DataFormatConverter getConverter(TypeInformation typeInfo) {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/DataFormatConvertersTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/DataFormatConvertersTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.LocalTimeTypeInfo;
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -31,12 +32,18 @@ import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.dataformat.DataFormatConverters.DataFormatConverter;
 import org.apache.flink.table.runtime.functions.SqlDateTimeUtils;
 import org.apache.flink.table.runtime.typeutils.BaseRowTypeInfo;
 import org.apache.flink.table.runtime.typeutils.BinaryStringTypeInfo;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
+import org.apache.flink.table.runtime.typeutils.LegacyTimestampTypeInfo;
+import org.apache.flink.table.types.AtomicDataType;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LegacyTypeInformationType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.types.Row;
@@ -44,6 +51,8 @@ import org.apache.flink.types.Row;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HashMap;
 
@@ -108,6 +117,28 @@ public class DataFormatConvertersTest {
 			BinaryString.fromString("hahah")
 	};
 
+	private DataType[] dataTypes = new DataType[] {
+		DataTypes.TIMESTAMP(9).bridgedTo(LocalDateTime.class),
+		DataTypes.TIMESTAMP(9).bridgedTo(Timestamp.class),
+		DataTypes.TIMESTAMP(3),
+		new AtomicDataType(
+			new LegacyTypeInformationType<>(
+				LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE,
+				SqlTimeTypeInfo.TIMESTAMP)),
+		new AtomicDataType(
+			new LegacyTypeInformationType<>(
+				LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE,
+				new LegacyTimestampTypeInfo(7)))
+	};
+
+	private Object[] dataValues = new Object[] {
+		LocalDateTime.of(1970, 1, 1, 0, 0, 0, 123456789),
+		Timestamp.valueOf("1970-01-01 00:00:00.123456789"),
+		LocalDateTime.of(1970, 1, 1, 0, 0, 0, 123),
+		Timestamp.valueOf("1970-01-01 00:00:00.123"),
+		Timestamp.valueOf("1970-01-01 00:00:00.1234567")
+	};
+
 	private static DataFormatConverter getConverter(TypeInformation typeInfo) {
 		return getConverterForDataType(TypeConversions.fromLegacyInfoToDataType(typeInfo));
 	}
@@ -116,6 +147,17 @@ public class DataFormatConvertersTest {
 		DataFormatConverter converter = getConverter(typeInfo);
 		Assert.assertTrue(Arrays.deepEquals(
 				new Object[] {converter.toExternal(converter.toInternal(value))}, new Object[] {value}));
+	}
+
+	private static DataFormatConverter getConverter(DataType dataType) {
+		return getConverterForDataType(dataType);
+	}
+
+	private static void testDataType(DataType dataType, Object value) {
+		DataFormatConverter converter = getConverter(dataType);
+		Assert.assertTrue(Arrays.deepEquals(
+			new Object[] {converter.toExternal(converter.toInternal(value))}, new Object[]{value}
+		));
 	}
 
 	@Test
@@ -160,6 +202,13 @@ public class DataFormatConvertersTest {
 		test(tupleTypeInfo, tuple2);
 
 		test(TypeExtractor.createTypeInfo(MyPojo.class), new MyPojo(1, 3));
+	}
+
+	@Test
+	public void testDataTypes() {
+		for (int i = 0; i < dataTypes.length; i++) {
+			testDataType(dataTypes[i], dataValues[i]);
+		}
 	}
 
 	/**


### PR DESCRIPTION
…t any TIMESTAMP WITHOUT TIME ZONE types


## What is the purpose of the change

User may pass any TIMESTAMP WITHOUT TIME ZONE in, e.g.:
```
DataTypes.TIMESTAMP(9).bridgedTo(LocalDateTime.class),
DataTypes.TIMESTAMP(9).bridgedTo(Timestamp.class),
DataTypes.TIMESTAMP(3),
new AtomicDataType(
  new LegacyTypeInformationType<>(
    LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE,
    SqlTimeTypeInfo.TIMESTAMP))
,
new AtomicDataType(
  new LegacyTypeInformationType<>(
    LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE,
    new LegacyTimestampTypeInfo(7)))
```
In such situations, we should return proper converters.

## Brief change log

- Let DataFormatConverters support any TIMESTAMP_WITHOUT_TIME_ZONE types
- Add tests to verify

## Verifying this change

This change is already covered by existing tests, such as *DataFormatConvertersTest)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
