### PR TITLE
[FLINK-15026][SQL-CLIENT]Support create/drop/alter database in sql client

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -305,6 +305,15 @@ public class CliClient {
 			case SOURCE:
 				callSource(cmdCall);
 				break;
+			case CREATE_DATABASE:
+				callCreateDatabase(cmdCall);
+				break;
+			case DROP_DATABASE:
+				callDropDatabase(cmdCall);
+				break;
+			case ALTER_DATABASE:
+				callAlterDatabase(cmdCall);
+				break;
 			default:
 				throw new SqlClientException("Unsupported command: " + cmdCall.command);
 		}
@@ -592,6 +601,21 @@ public class CliClient {
 		// try to run it
 		final Optional<SqlCommandCall> call = parseCommand(stmt);
 		call.ifPresent(this::callCommand);
+	}
+
+	private void callCreateDatabase(SqlCommandCall cmdCall) {
+		final String createDatabaseStmt = cmdCall.operands[0];
+		executor.executeUpdate(sessionId, createDatabaseStmt);
+	}
+
+	private void callDropDatabase(SqlCommandCall cmdCall) {
+		final String dropDatabaseStmt = cmdCall.operands[0];
+		executor.executeUpdate(sessionId, dropDatabaseStmt);
+	}
+
+	private void callAlterDatabase(SqlCommandCall cmdCall) {
+		final String alterDatabaseStmt = cmdCall.operands[0];
+		executor.executeUpdate(sessionId, alterDatabaseStmt);
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
@@ -136,9 +136,21 @@ public final class SqlCommandParser {
 				return Optional.of(new String[]{operands[0], operands[1]});
 			}),
 
+		CREATE_DATABASE(
+				"(CREATE\\s+DATABASE\\s+.*)",
+				SINGLE_OPERAND),
+
+		DROP_DATABASE(
+				"(DROP\\s+DATABASE\\s+.*)",
+				SINGLE_OPERAND),
+
 		DROP_VIEW(
 			"DROP\\s+VIEW\\s+(.*)",
 			SINGLE_OPERAND),
+
+		ALTER_DATABASE(
+				"(ALTER\\s+DATABASE\\s+.*)",
+				SINGLE_OPERAND),
 
 		SET(
 			"SET(\\s+(\\S+)\\s*=(.*))?", // whitespace is only ignored on the left side of '='

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -544,6 +544,11 @@ public class LocalExecutor implements Executor {
 			String statement) {
 		applyUpdate(context, context.getTableEnvironment(), context.getQueryConfig(), statement);
 
+		//Todo: we should refactor following condition after TableEnvironment has support submit job directly.
+		if (!statement.trim().matches("(INSERT\\s+INTO.*)")) {
+			return null;
+		}
+
 		// create job graph with dependencies
 		final String jobName = sessionId + ": " + statement;
 		final JobGraph jobGraph;

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
@@ -77,6 +77,12 @@ public class SqlCommandParserTest {
 		testValidSqlCommand("USE CATALOG default", new SqlCommandCall(SqlCommand.USE_CATALOG, new String[]{"default"}));
 		testValidSqlCommand("use default", new SqlCommandCall(SqlCommand.USE, new String[] {"default"}));
 		testInvalidSqlCommand("use catalog");
+		testValidSqlCommand("create database db1",
+				new SqlCommandCall(SqlCommand.CREATE_DATABASE, new String[] {"create database db1"}));
+		testValidSqlCommand("drop database db1",
+				new SqlCommandCall(SqlCommand.DROP_DATABASE, new String[] {"drop database db1"}));
+		testValidSqlCommand("alter database db1 set ('k1' = 'a')",
+				new SqlCommandCall(SqlCommand.ALTER_DATABASE, new String[] {"alter database db1 set ('k1' = 'a')"}));
 	}
 
 	private void testInvalidSqlCommand(String stmt) {

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -212,6 +212,63 @@ public class LocalExecutorITCase extends TestLogger {
 	}
 
 	@Test
+	public void testCreateDatabase() throws Exception {
+		final Executor executor = createDefaultExecutor(clusterClient);
+		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+		assertEquals("test-session", sessionId);
+
+		executor.executeUpdate(sessionId, "create database db1");
+
+		final List<String> actualDatabases = executor.listDatabases(sessionId);
+		final List<String> expectedDatabases = Arrays.asList("default_database", "db1");
+		assertEquals(expectedDatabases, actualDatabases);
+
+		executor.closeSession(sessionId);
+	}
+
+	@Test
+	public void testDropDatabase() throws Exception {
+		final Executor executor = createDefaultExecutor(clusterClient);
+		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+		assertEquals("test-session", sessionId);
+
+		executor.executeUpdate(sessionId, "create database db1");
+
+		List<String> actualDatabases = executor.listDatabases(sessionId);
+		List<String> expectedDatabases = Arrays.asList("default_database", "db1");
+		assertEquals(expectedDatabases, actualDatabases);
+
+		executor.executeUpdate(sessionId, "drop database if exists db1");
+
+		actualDatabases = executor.listDatabases(sessionId);
+		expectedDatabases = Arrays.asList("default_database");
+		assertEquals(expectedDatabases, actualDatabases);
+
+		executor.closeSession(sessionId);
+	}
+
+	@Test
+	public void testAlterDatabase() throws Exception {
+		final Executor executor = createDefaultExecutor(clusterClient);
+		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+		assertEquals("test-session", sessionId);
+
+		executor.executeUpdate(sessionId, "create database db1 comment 'db1_comment' with ('k1' = 'v1')");
+
+		executor.executeUpdate(sessionId, "alter database db1 set ('k1' = 'a', 'k2' = 'b')");
+
+		final List<String> actualDatabases = executor.listDatabases(sessionId);
+		final List<String> expectedDatabases = Arrays.asList("default_database", "db1");
+		assertEquals(expectedDatabases, actualDatabases);
+		//todo: we should compare the new db1 properties after we support describe database in LocalExecutor.
+
+		executor.closeSession(sessionId);
+	}
+
+	@Test
 	public void testListTables() throws Exception {
 		final Executor executor = createDefaultExecutor(clusterClient);
 		final SessionContext session = new SessionContext("test-session", new Environment());


### PR DESCRIPTION
## What is the purpose of the change

*Since we have support create/drop/alter database operation in TableEnvironment, it's natural and easy to hook up such operation in sql client too. This PR aims to bridge that.*


## Brief change log

  - [0433794](https://github.com/apache/flink/commit/043379493823c0ac38c05d355471079d6808d16a) Support create/drop/alter database in sql client


## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests for SqlParserCommand in SqlCommandParserTest#testCommands*
  - *Added test that validates create database in  LocalExecutorITCase#testCreateDatabase*
  - *Added test that validates drop database in LocalExecutorITCase#testDropDatabase*
  - *Added test that validates alter database in LocalExecutorITCase#alterDatabase*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
