### PR TITLE
[FLINK-15051][state-backends] Fix typo in RocksDBStateBackend.getNumberOfTransferingThreads

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricMonitor.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricMonitor.java
@@ -74,7 +74,7 @@ public class RocksDBNativeMetricMonitor implements Closeable {
 	 */
 	void registerColumnFamily(String columnFamilyName, ColumnFamilyHandle handle) {
 
-		boolean columnFamilyAsVariable = options.isColumnFaminlyAsVariable();
+		boolean columnFamilyAsVariable = options.isColumnFamilyAsVariable();
 		MetricGroup group = columnFamilyAsVariable
 			? metricGroup.addGroup(COLUMN_FAMILY_KEY, columnFamilyName)
 			: metricGroup.addGroup(columnFamilyName);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricOptions.java
@@ -437,11 +437,19 @@ public class RocksDBNativeMetricOptions implements Serializable {
 	}
 
 	/**
+	 * @deprecated Typo in the method name, use {@link #isColumnFamilyAsVariable()}.
+	 */
+	@Deprecated
+	public boolean isColumnFaminlyAsVariable() {
+		return isColumnFamilyAsVariable();
+	}
+
+	/**
 	 *  {{@link RocksDBNativeMetricMonitor}} Whether to expose the column family as a variable..
 	 *
 	 * @return true is column family to expose variable, false otherwise.
 	 */
-	public boolean isColumnFaminlyAsVariable() {
+	public boolean isColumnFamilyAsVariable() {
 		return this.columnFamilyAsVariable;
 	}
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -109,7 +109,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	/** Flag whether the native library has been loaded. */
 	private static boolean rocksDbInitialized = false;
 
-	private static final int UNDEFINED_NUMBER_OF_TRANSFERING_THREADS = -1;
+	private static final int UNDEFINED_NUMBER_OF_TRANSFER_THREADS = -1;
 
 	// ------------------------------------------------------------------------
 
@@ -136,7 +136,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	private final TernaryBoolean enableIncrementalCheckpointing;
 
 	/** Thread number used to transfer (download and upload) state, default value: 1. */
-	private int numberOfTransferingThreads;
+	private int numberOfTransferThreads;
 
 	/**
 	 * This determines if compaction filter to cleanup state with TTL is enabled.
@@ -264,7 +264,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	public RocksDBStateBackend(StateBackend checkpointStreamBackend, TernaryBoolean enableIncrementalCheckpointing) {
 		this.checkpointStreamBackend = checkNotNull(checkpointStreamBackend);
 		this.enableIncrementalCheckpointing = enableIncrementalCheckpointing;
-		this.numberOfTransferingThreads = UNDEFINED_NUMBER_OF_TRANSFERING_THREADS;
+		this.numberOfTransferThreads = UNDEFINED_NUMBER_OF_TRANSFER_THREADS;
 		// for now, we use still the heap-based implementation as default
 		this.priorityQueueStateType = PriorityQueueStateType.HEAP;
 		this.defaultMetricOptions = new RocksDBNativeMetricOptions();
@@ -305,10 +305,10 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 		this.enableIncrementalCheckpointing = original.enableIncrementalCheckpointing.resolveUndefined(
 			config.getBoolean(CheckpointingOptions.INCREMENTAL_CHECKPOINTS));
 
-		if (original.numberOfTransferingThreads == UNDEFINED_NUMBER_OF_TRANSFERING_THREADS) {
-			this.numberOfTransferingThreads = config.getInteger(CHECKPOINT_TRANSFER_THREAD_NUM);
+		if (original.numberOfTransferThreads == UNDEFINED_NUMBER_OF_TRANSFER_THREADS) {
+			this.numberOfTransferThreads = config.getInteger(CHECKPOINT_TRANSFER_THREAD_NUM);
 		} else {
-			this.numberOfTransferingThreads = original.numberOfTransferingThreads;
+			this.numberOfTransferThreads = original.numberOfTransferThreads;
 		}
 
 		this.enableTtlCompactionFilter = original.enableTtlCompactionFilter
@@ -515,7 +515,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 			cancelStreamRegistry
 		).setEnableIncrementalCheckpointing(isIncrementalCheckpointsEnabled())
 			.setEnableTtlCompactionFilter(isTtlCompactionFilterEnabled())
-			.setNumberOfTransferingThreads(getNumberOfTransferingThreads())
+			.setNumberOfTransferingThreads(getNumberOfTransferThreads())
 			.setNativeMetricOptions(getMemoryWatcherOptions());
 		return builder.build();
 	}
@@ -823,20 +823,36 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	/**
 	 * Gets the number of threads used to transfer files while snapshotting/restoring.
 	 */
-	public int getNumberOfTransferingThreads() {
-		return numberOfTransferingThreads == UNDEFINED_NUMBER_OF_TRANSFERING_THREADS ?
-			CHECKPOINT_TRANSFER_THREAD_NUM.defaultValue() : numberOfTransferingThreads;
+	public int getNumberOfTransferThreads() {
+		return numberOfTransferThreads == UNDEFINED_NUMBER_OF_TRANSFER_THREADS ?
+			CHECKPOINT_TRANSFER_THREAD_NUM.defaultValue() : numberOfTransferThreads;
 	}
 
 	/**
 	 * Sets the number of threads used to transfer files while snapshotting/restoring.
 	 *
-	 * @param numberOfTransferingThreads The number of threads used to transfer files while snapshotting/restoring.
+	 * @param numberOfTransferThreads The number of threads used to transfer files while snapshotting/restoring.
 	 */
-	public void setNumberOfTransferingThreads(int numberOfTransferingThreads) {
-		Preconditions.checkArgument(numberOfTransferingThreads > 0,
+	public void setNumberOfTransferThreads(int numberOfTransferThreads) {
+		Preconditions.checkArgument(numberOfTransferThreads > 0,
 			"The number of threads used to transfer files in RocksDBStateBackend should be greater than zero.");
-		this.numberOfTransferingThreads = numberOfTransferingThreads;
+		this.numberOfTransferThreads = numberOfTransferThreads;
+	}
+
+	/**
+	 * @deprecated Typo in method name. Use {@link #getNumberOfTransferThreads} instead.
+	 */
+	@Deprecated
+	public int getNumberOfTransferingThreads() {
+		return getNumberOfTransferThreads();
+	}
+
+	/**
+	 * @deprecated Typo in method name. Use {@link #setNumberOfTransferThreads(int)} instead.
+	 */
+	@Deprecated
+	public void setNumberOfTransferingThreads(int numberOfTransferingThreads) {
+		setNumberOfTransferThreads(numberOfTransferingThreads);
 	}
 
 	// ------------------------------------------------------------------------
@@ -849,7 +865,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 				"checkpointStreamBackend=" + checkpointStreamBackend +
 				", localRocksDbDirectories=" + Arrays.toString(localRocksDbDirectories) +
 				", enableIncrementalCheckpointing=" + enableIncrementalCheckpointing +
-				", numberOfTransferingThreads=" + numberOfTransferingThreads +
+				", numberOfTransferThreads=" + numberOfTransferThreads +
 				'}';
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This fixes a simple typo in the `RocksDBStateBackend.getNumberOfTransferingThreads()` changing to `RocksDBStateBackend.getNumberOfTransferThreads()`.

The original method is retained and deprecated.