### PR TITLE
[FLINK-15057][tests] Set JM and TM memory config in flink-conf.yaml

### DIFF
--- a/flink-jepsen/src/jepsen/flink/db.clj
+++ b/flink-jepsen/src/jepsen/flink/db.clj
@@ -38,19 +38,21 @@
 
 (defn- default-flink-configuration
   [test node]
-  {:high-availability                  "zookeeper"
-   :high-availability.zookeeper.quorum (zookeeper-quorum test)
-   :high-availability.storageDir       "hdfs:///flink/ha"
-   :jobmanager.rpc.address             node
-   :state.savepoints.dir               "hdfs:///flink/savepoints"
-   :rest.address                       node
-   :rest.port                          8081
-   :rest.bind-address                  "0.0.0.0"
-   :taskmanager.numberOfTaskSlots      taskmanager-slots
-   :yarn.application-attempts          99999
-   :slotmanager.taskmanager-timeout    10000
-   :state.backend.local-recovery       "true"
-   :taskmanager.registration.timeout   "30 s"})
+  {:high-availability                     "zookeeper"
+   :high-availability.zookeeper.quorum    (zookeeper-quorum test)
+   :high-availability.storageDir          "hdfs:///flink/ha"
+   :jobmanager.heap.size                  "2048m"
+   :jobmanager.rpc.address                node
+   :state.savepoints.dir                  "hdfs:///flink/savepoints"
+   :rest.address                          node
+   :rest.port                             8081
+   :rest.bind-address                     "0.0.0.0"
+   :taskmanager.numberOfTaskSlots         taskmanager-slots
+   :yarn.application-attempts             99999
+   :slotmanager.taskmanager-timeout       10000
+   :state.backend.local-recovery          "true"
+   :taskmanager.memory.total-process.size "2048m"
+   :taskmanager.registration.timeout      "30 s"})
 
 (defn flink-configuration
   [test node]
@@ -254,9 +256,7 @@
   []
   (fu/join-space (hadoop-env-vars)
                  (str install-dir "/bin/yarn-session.sh")
-                 "-d"
-                 "-jm 2048m"
-                 "-tm 2048m"))
+                 "-d"))
 
 (defn- start-yarn-session!
   []
@@ -281,7 +281,7 @@
 (defn- start-yarn-job!
   [test]
   (c/su
-    (submit-job-with-retry! test ["-m yarn-cluster" "-yjm 2048m" "-ytm 2048m"])))
+    (submit-job-with-retry! test ["-m yarn-cluster"])))
 
 (defn yarn-job-db
   []
@@ -301,11 +301,9 @@
     (str install-dir "/bin/mesos-appmaster.sh")
     (str "-Dmesos.master=" (zookeeper-uri test mesos/zk-namespace))
     "-Djobmanager.rpc.address=$(hostname -f)"
-    "-Djobmanager.heap.size=2048m"
     "-Djobmanager.rpc.port=6123"
-    "-Dmesos.resourcemanager.tasks.mem=2048"
-    "-Dtaskmanager.memory.total-process.size=2048m"
     "-Dmesos.resourcemanager.tasks.cpus=1"
+    "-Dmesos.resourcemanager.tasks.mem=2048" ;; FLINK-15082: this option must be set instead of taskmanager.memory.total-process.size
     "-Drest.bind-address=$(hostname -f)"))
 
 (defn- start-mesos-session!


### PR DESCRIPTION
## What is the purpose of the change

*This sets the JM and TM memory configuration in flink-conf.yaml used in Jepsen tests.*


## Brief change log

  - *Set JM and TM memory config in flink-conf.yaml*

## Verifying this change


This change is already covered by existing tests, such as *the test that is being changed*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
