### PR TITLE
[FLINK-15062][orc] Orc reader should use java.sql.Timestamp to read for respecting time zone

### DIFF
--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/AbstractOrcColumnVector.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/AbstractOrcColumnVector.java
@@ -113,7 +113,7 @@ public abstract class AbstractOrcColumnVector implements
 			case DATE:
 				return createLongVector(batchSize, dateToInternal((Date) value));
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
-				return createTimestampVector(batchSize, (LocalDateTime) value);
+				return createTimestampVector(batchSize, value);
 			default:
 				throw new UnsupportedOperationException("Unsupported type: " + type);
 		}
@@ -176,20 +176,15 @@ public abstract class AbstractOrcColumnVector implements
 		return dcv;
 	}
 
-	private static TimestampColumnVector createTimestampVector(int batchSize, LocalDateTime value) {
+	private static TimestampColumnVector createTimestampVector(int batchSize, Object value) {
 		TimestampColumnVector lcv = new TimestampColumnVector(batchSize);
 		if (value == null) {
 			lcv.noNulls = false;
 			lcv.isNull[0] = true;
 			lcv.isRepeating = true;
 		} else {
-			long epochDay = value.toLocalDate().toEpochDay();
-			long nanoOfDay = value.toLocalTime().toNanoOfDay();
-
-			long millisecond = epochDay * 24 * 60 * 60 * 1000 + nanoOfDay / 1_000_000;
-			int nanoOfSecond = (int) (nanoOfDay % 1_000_000_000);
-			Timestamp timestamp = new Timestamp(millisecond);
-			timestamp.setNanos(nanoOfSecond);
+			Timestamp timestamp = value instanceof LocalDateTime ?
+				Timestamp.valueOf((LocalDateTime) value) : (Timestamp) value;
 			lcv.fill(timestamp);
 			lcv.isNull[0] = false;
 		}

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/OrcTimestampColumnVector.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/OrcTimestampColumnVector.java
@@ -22,6 +22,8 @@ import org.apache.flink.table.dataformat.SqlTimestamp;
 
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
 
+import java.sql.Timestamp;
+
 /**
  * This column vector is used to adapt hive's TimestampColumnVector to
  * Flink's TimestampColumnVector.
@@ -39,8 +41,8 @@ public class OrcTimestampColumnVector extends AbstractOrcColumnVector implements
 	@Override
 	public SqlTimestamp getTimestamp(int i, int precision) {
 		int index = vector.isRepeating ? 0 : i;
-		return SqlTimestamp.fromEpochMillis(
-				vector.time[index],
-				SqlTimestamp.isCompact(precision) ? 0 : vector.nanos[index] % 1_000_000);
+		Timestamp timestamp = new Timestamp(vector.time[index]);
+		timestamp.setNanos(vector.nanos[index]);
+		return SqlTimestamp.fromTimestamp(timestamp);
 	}
 }

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcColumnarRowSplitReaderTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcColumnarRowSplitReaderTest.java
@@ -285,8 +285,7 @@ public class OrcColumnarRowSplitReaderTest {
 				col0.vector[i] = i;
 				col1.vector[i] = i;
 
-				Timestamp timestamp = Timestamp.valueOf(
-						padZero(4, i + 1000) + "-01-01 00:00:00." + i);
+				Timestamp timestamp = toTimestamp(i);
 				col2.time[i] = timestamp.getTime();
 				col2.nanos[i] = timestamp.getNanos();
 
@@ -309,7 +308,7 @@ public class OrcColumnarRowSplitReaderTest {
 		// second test read.
 		FileInputSplit split = createSplits(new Path(file), 1)[0];
 
-		long cnt = 0;
+		int cnt = 0;
 		Map<String, Object> partSpec = new HashMap<>();
 		partSpec.put("f5", true);
 		partSpec.put("f6", new Date(562423));
@@ -357,8 +356,7 @@ public class OrcColumnarRowSplitReaderTest {
 					Assert.assertFalse(row.isNullAt(3));
 					Assert.assertFalse(row.isNullAt(4));
 					Assert.assertEquals(
-							SqlTimestamp.fromTimestamp(
-									Timestamp.valueOf(padZero(4, cnt + 1000) + "-01-01 00:00:00." + cnt)),
+							SqlTimestamp.fromTimestamp(toTimestamp(cnt)),
 							row.getTimestamp(0, 9));
 					Assert.assertEquals(cnt, row.getFloat(1), 0);
 					Assert.assertEquals(cnt, row.getDouble(2), 0);
@@ -387,19 +385,15 @@ public class OrcColumnarRowSplitReaderTest {
 		assertEquals(rowSize, cnt);
 	}
 
-	private static String padZero(int len, Object o) {
-		String str = o.toString();
-		int strLen = str.length();
-		if (strLen == len) {
-			return str;
-		} else if (strLen > len) {
-			throw new IllegalArgumentException();
-		}
-		StringBuilder builder = new StringBuilder(len);
-		for (int i = 0; i < len - strLen; i++) {
-			builder.append("0");
-		}
-		return builder.append(str).toString();
+	private static Timestamp toTimestamp(int i) {
+		return new Timestamp(
+						i + 1000,
+						(i % 12) + 1,
+						(i % 28) + 1,
+						i % 24,
+						i % 60,
+						i % 60,
+						i * 1_000 + i);
 	}
 
 	private OrcColumnarRowSplitReader createReader(


### PR DESCRIPTION

## What is the purpose of the change

Hive orc use java.sql.Timestamp to read and write orc files... default, timestamp will consider time zone to adjust seconds.
Our vector Orc reader should use java.sql.Timestamp to read for respecting time zone

## Brief change log

- OrcTimestampColumnVector should get SqlTimestamp from java.sql.Timestamp.
- AbstractOrcColumnVector.createTimestampVector should fill data with java.sql.Timestamp.

## Verifying this change

OrcColumnarRowSplitReaderTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no