### PR TITLE
[FLINK-14566] Enable to get/set whether an operator uses managed memory

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
@@ -65,6 +65,11 @@ public final class ResourceSpec implements Serializable {
 	 */
 	public static final ResourceSpec DEFAULT = UNKNOWN;
 
+	/**
+	 * A ResourceSpec that indicates zero amount of resources.
+	 */
+	public static final ResourceSpec ZERO = ResourceSpec.newBuilder(0.0, 0).build();
+
 	/** How many cpu cores are needed. Can be null only if it is unknown. */
 	@Nullable
 	private final Resource cpuCores;

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/util/OperatorValidationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/util/OperatorValidationUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.operators.util;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.operators.ResourceSpec;
+import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.util.Preconditions;
 
 /**
@@ -71,5 +72,20 @@ public class OperatorValidationUtils {
 		Preconditions.checkArgument(minResources.lessThanOrEqual(preferredResources),
 			"The resources must be either both UNKNOWN or both not UNKNOWN. If not UNKNOWN,"
 				+ " the preferred resources must be greater than or equal to the min resources.");
+	}
+
+	public static void validateResourceRequirements(
+			final ResourceSpec minResources,
+			final ResourceSpec preferredResources,
+			final int managedMemoryWeight) {
+
+		validateMinAndPreferredResources(minResources, preferredResources);
+		Preconditions.checkArgument(
+			managedMemoryWeight >= 0,
+			"managed memory weight must be no less than zero, was: " + managedMemoryWeight);
+		Preconditions.checkArgument(
+			minResources.equals(ResourceSpec.UNKNOWN) || managedMemoryWeight == Transformation.DEFAULT_MANAGED_MEMORY_WEIGHT,
+			"The resources and managed memory weight should not be specified at the same time. " +
+				"resources: " + minResources + ", managed memory weight: " + managedMemoryWeight);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
@@ -98,6 +98,8 @@ public abstract class Transformation<T> {
 	// Has to be equal to StreamGraphGenerator.UPPER_BOUND_MAX_PARALLELISM
 	public static final int UPPER_BOUND_MAX_PARALLELISM = 1 << 15;
 
+	public static final int DEFAULT_MANAGED_MEMORY_WEIGHT = 1;
+
 	// This is used to assign a unique ID to every Transformation
 	protected static Integer idCounter = 0;
 
@@ -135,6 +137,14 @@ public abstract class Transformation<T> {
 	 *  dynamic resource resize in future plan.
 	 */
 	private ResourceSpec preferredResources = ResourceSpec.DEFAULT;
+
+	/**
+	 * This weight indicates how much this transformation relies on managed memory, so that
+	 * transformation highly relies on managed memory would be able to acquire more managed
+	 * memory in runtime (linear association). Note that it only works in cases of UNKNOWN
+	 * resources.
+	 */
+	private int managedMemoryWeight = DEFAULT_MANAGED_MEMORY_WEIGHT;
 
 	/**
 	 * User-specified ID for this transformation. This is used to assign the
@@ -232,7 +242,7 @@ public abstract class Transformation<T> {
 	 * @param preferredResources The preferred resource of this transformation.
 	 */
 	public void setResources(ResourceSpec minResources, ResourceSpec preferredResources) {
-		OperatorValidationUtils.validateMinAndPreferredResources(minResources, preferredResources);
+		OperatorValidationUtils.validateResourceRequirements(minResources, preferredResources, managedMemoryWeight);
 		this.minResources = checkNotNull(minResources);
 		this.preferredResources = checkNotNull(preferredResources);
 	}
@@ -253,6 +263,34 @@ public abstract class Transformation<T> {
 	 */
 	public ResourceSpec getPreferredResources() {
 		return preferredResources;
+	}
+
+	/**
+	 * Set the managed memory weight which indicates how much this transformation relies
+	 * on managed memory, so that a transformation highly relies on managed memory would
+	 * be able to acquire more managed memory in runtime (linear association). The default
+	 * weight value is 1. Note that currently it's only allowed to set the weight in cases
+	 * of UNKNOWN resources.
+	 *
+	 * @param managedMemoryWeight The managed memory weight of this transformation
+	 *
+	 * @throws IllegalArgumentException Thrown, if non-UNKNOWN resources are already set to this transformation
+	 */
+	public void setManagedMemoryWeight(int managedMemoryWeight) {
+		OperatorValidationUtils.validateResourceRequirements(minResources, preferredResources, managedMemoryWeight);
+		this.managedMemoryWeight = managedMemoryWeight;
+	}
+
+	/**
+	 * Get the managed memory weight which indicates how much this transformation relies
+	 * on managed memory, so that a transformation highly relies on managed memory would
+	 * be able to acquire more managed memory in runtime (linear association). The default
+	 * weight value is 1. Note that it only works in cases of UNKNOWN resources.
+	 *
+	 * @return The managed memory weight of this transformation
+	 */
+	public int getManagedMemoryWeight() {
+		return managedMemoryWeight;
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
@@ -232,6 +232,7 @@ public abstract class Transformation<T> {
 	 * @param preferredResources The preferred resource of this transformation.
 	 */
 	public void setResources(ResourceSpec minResources, ResourceSpec preferredResources) {
+		OperatorValidationUtils.validateMinAndPreferredResources(minResources, preferredResources);
 		this.minResources = checkNotNull(minResources);
 		this.preferredResources = checkNotNull(preferredResources);
 	}

--- a/flink-core/src/test/java/org/apache/flink/api/dag/TransformationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/dag/TransformationTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.dag;
+
+import org.apache.flink.api.common.operators.ResourceSpec;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link Transformation}.
+ */
+public class TransformationTest extends TestLogger {
+
+	private Transformation<Void> transformation;
+
+	@Before
+	public void setUp() {
+		transformation = new TestTransformation<>("t", null, 1);
+	}
+
+	@Test
+	public void testSetManagedMemoryWeight() {
+		transformation.setManagedMemoryWeight(123);
+		assertEquals(123, transformation.getManagedMemoryWeight());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testSetManagedMemoryWeightFailIfResourcesIsSpecified() {
+		final ResourceSpec resources = ResourceSpec.newBuilder(1.0, 100).build();
+		transformation.setResources(resources, resources);
+
+		transformation.setManagedMemoryWeight(123);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testSetResourcesFailIfManagedMemoryWeightIsSpecified() {
+		transformation.setManagedMemoryWeight(123);
+
+		final ResourceSpec resources = ResourceSpec.newBuilder(1.0, 100).build();
+		transformation.setResources(resources, resources);
+	}
+
+	/**
+	 * A test implementation of {@link Transformation}.
+	 */
+	private class TestTransformation<T> extends Transformation<T> {
+
+		public TestTransformation(String name, TypeInformation<T> outputType, int parallelism) {
+			super(name, outputType, parallelism);
+		}
+
+		@Override
+		public Collection<Transformation<?>> getTransitivePredecessors() {
+			return Collections.EMPTY_LIST;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/SlotSharingGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/SlotSharingGroup.java
@@ -43,7 +43,7 @@ public class SlotSharingGroup implements java.io.Serializable {
 
 	/** Represents resources of all tasks in the group. Default to be zero.
 	 * Any task with UNKNOWN resources will turn it to be UNKNOWN. */
-	private ResourceSpec resourceSpec = ResourceSpec.newBuilder(0.0, 0).build();
+	private ResourceSpec resourceSpec = ResourceSpec.ZERO;
 
 	// --------------------------------------------------------------------------------------------
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
@@ -21,7 +21,6 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.operators.ResourceSpec;
-import org.apache.flink.api.common.operators.util.OperatorValidationUtils;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.api.transformations.SinkTransformation;
@@ -127,8 +126,6 @@ public class DataStreamSink<T> {
 	 * @return The sink with set minimum and preferred resources.
 	 */
 	private DataStreamSink<T> setResources(ResourceSpec minResources, ResourceSpec preferredResources) {
-		OperatorValidationUtils.validateMinAndPreferredResources(minResources, preferredResources);
-
 		transformation.setResources(minResources, preferredResources);
 
 		return this;
@@ -141,8 +138,6 @@ public class DataStreamSink<T> {
 	 * @return The sink with set minimum and preferred resources.
 	 */
 	private DataStreamSink<T> setResources(ResourceSpec resources) {
-		OperatorValidationUtils.validateResources(resources);
-
 		transformation.setResources(resources, resources);
 
 		return this;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
@@ -176,7 +176,6 @@ public class SingleOutputStreamOperator<T> extends DataStream<T> {
 	 * @return The operator with set minimum and preferred resources.
 	 */
 	private SingleOutputStreamOperator<T> setResources(ResourceSpec minResources, ResourceSpec preferredResources) {
-		OperatorValidationUtils.validateMinAndPreferredResources(minResources, preferredResources);
 		transformation.setResources(minResources, preferredResources);
 
 		return this;
@@ -189,7 +188,6 @@ public class SingleOutputStreamOperator<T> extends DataStream<T> {
 	 * @return The operator with set minimum and preferred resources.
 	 */
 	private SingleOutputStreamOperator<T> setResources(ResourceSpec resources) {
-		OperatorValidationUtils.validateResources(resources);
 		transformation.setResources(resources, resources);
 
 		return this;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -562,6 +562,12 @@ public class StreamGraph implements Pipeline {
 		}
 	}
 
+	public void setManagedMemoryWeight(int vertexID, int managedMemoryWeight) {
+		if (getStreamNode(vertexID) != null) {
+			getStreamNode(vertexID).setManagedMemoryWeight(managedMemoryWeight);
+		}
+	}
+
 	public void setOneInputStateKey(Integer vertexID, KeySelector<?, ?> keySelector, TypeSerializer<?> keySerializer) {
 		StreamNode node = getStreamNode(vertexID);
 		node.setStatePartitioner1(keySelector);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -707,6 +707,16 @@ public class StreamGraph implements Pipeline {
 		sinks.add(sink.getId());
 		setParallelism(sink.getId(), parallelism);
 		setMaxParallelism(sink.getId(), parallelism);
+		// The tail node is always in the same slot sharing group with the head node
+		// so that they can share resources (they do not use non-sharable resources,
+		// i.e. managed memory). There is no contract on how the resources should be
+		// divided for head and tail nodes at the moment. To be simple, we assign all
+		// resources to the head node and set the tail node resources to be zero if
+		// resources are specified.
+		final ResourceSpec tailResources = minResources.equals(ResourceSpec.UNKNOWN)
+			? ResourceSpec.UNKNOWN
+			: ResourceSpec.ZERO;
+		setResources(sink.getId(), tailResources, tailResources);
 
 		iterationSourceSinkPairs.add(new Tuple2<>(source, sink));
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -305,6 +305,8 @@ public class StreamGraphGenerator {
 			streamGraph.setResources(transform.getId(), transform.getMinResources(), transform.getPreferredResources());
 		}
 
+		streamGraph.setManagedMemoryWeight(transform.getId(), transform.getManagedMemoryWeight());
+
 		return transformedIds;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.streaming.api.collector.selector.OutputSelector;
@@ -53,6 +54,7 @@ public class StreamNode implements Serializable {
 	private int maxParallelism;
 	private ResourceSpec minResources = ResourceSpec.DEFAULT;
 	private ResourceSpec preferredResources = ResourceSpec.DEFAULT;
+	private int managedMemoryWeight = Transformation.DEFAULT_MANAGED_MEMORY_WEIGHT;
 	private long bufferTimeout;
 	private final String operatorName;
 	private @Nullable String slotSharingGroup;
@@ -194,6 +196,14 @@ public class StreamNode implements Serializable {
 	public void setResources(ResourceSpec minResources, ResourceSpec preferredResources) {
 		this.minResources = minResources;
 		this.preferredResources = preferredResources;
+	}
+
+	public void setManagedMemoryWeight(int managedMemoryWeight) {
+		this.managedMemoryWeight = managedMemoryWeight;
+	}
+
+	public int getManagedMemoryWeight() {
+		return managedMemoryWeight;
 	}
 
 	public long getBufferTimeout() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -82,7 +82,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import static org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration.MINIMAL_CHECKPOINT_TIME;
-import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
@@ -174,7 +173,8 @@ public class StreamingJobGraphGenerator {
 			Collections.unmodifiableMap(jobVertices),
 			Collections.unmodifiableMap(vertexConfigs),
 			Collections.unmodifiableMap(chainedConfigs),
-			id -> streamGraph.getStreamNode(id).getMinResources());
+			id -> streamGraph.getStreamNode(id).getMinResources(),
+			id -> streamGraph.getStreamNode(id).getManagedMemoryWeight());
 
 		configureCheckpointing();
 
@@ -701,7 +701,8 @@ public class StreamingJobGraphGenerator {
 			final Map<Integer, JobVertex> jobVertices,
 			final Map<Integer, StreamConfig> operatorConfigs,
 			final Map<Integer, Map<Integer, StreamConfig>> vertexChainedConfigs,
-			final java.util.function.Function<Integer, ResourceSpec> operatorResourceRetriever) {
+			final java.util.function.Function<Integer, ResourceSpec> operatorResourceRetriever,
+			final java.util.function.Function<Integer, Integer> operatorManagedMemoryWeightRetriever) {
 
 		// all slot sharing groups in this job
 		final Set<SlotSharingGroup> slotSharingGroups = Collections.newSetFromMap(new IdentityHashMap<>());
@@ -736,7 +737,8 @@ public class StreamingJobGraphGenerator {
 				vertexOperators,
 				operatorConfigs,
 				vertexChainedConfigs,
-				operatorResourceRetriever);
+				operatorResourceRetriever,
+				operatorManagedMemoryWeightRetriever);
 		}
 	}
 
@@ -746,21 +748,24 @@ public class StreamingJobGraphGenerator {
 			final Map<JobVertexID, Set<Integer>> vertexOperators,
 			final Map<Integer, StreamConfig> operatorConfigs,
 			final Map<Integer, Map<Integer, StreamConfig>> vertexChainedConfigs,
-			final java.util.function.Function<Integer, ResourceSpec> operatorResourceRetriever) {
+			final java.util.function.Function<Integer, ResourceSpec> operatorResourceRetriever,
+			final java.util.function.Function<Integer, Integer> operatorManagedMemoryWeightRetriever) {
 
-		final int groupOperatorCount = slotSharingGroup.getJobVertexIds().stream()
-			.map(vertexOperators::get)
-			.mapToInt(Collection::size)
+		final int groupManagedMemoryWeight = slotSharingGroup.getJobVertexIds().stream()
+			.flatMap(vid -> vertexOperators.get(vid).stream())
+			.mapToInt(operatorManagedMemoryWeightRetriever::apply)
 			.sum();
 
 		for (JobVertexID jobVertexID : slotSharingGroup.getJobVertexIds()) {
 			for (int operatorNodeId : vertexOperators.get(jobVertexID)) {
 				final StreamConfig operatorConfig = operatorConfigs.get(operatorNodeId);
 				final ResourceSpec operatorResourceSpec = operatorResourceRetriever.apply(operatorNodeId);
+				final int operatorManagedMemoryWeight = operatorManagedMemoryWeightRetriever.apply(operatorNodeId);
 				setManagedMemoryFractionForOperator(
 					operatorResourceSpec,
 					slotSharingGroup.getResourceSpec(),
-					groupOperatorCount,
+					operatorManagedMemoryWeight,
+					groupManagedMemoryWeight,
 					operatorConfig);
 			}
 
@@ -774,17 +779,19 @@ public class StreamingJobGraphGenerator {
 	private static void setManagedMemoryFractionForOperator(
 			final ResourceSpec operatorResourceSpec,
 			final ResourceSpec groupResourceSpec,
-			final int groupOperatorCount,
+			final int operatorManagedMemoryWeight,
+			final int groupManagedMemoryWeight,
 			final StreamConfig operatorConfig) {
 
 		final double managedMemoryFraction;
 
 		if (groupResourceSpec.equals(ResourceSpec.UNKNOWN)) {
-			checkArgument(groupOperatorCount > 0, "A slot sharing group must contain at least 1 operator");
-			managedMemoryFraction = getFractionRoundedDown(1, groupOperatorCount);
+			managedMemoryFraction = groupManagedMemoryWeight > 0
+				? getFractionRoundedDown(operatorManagedMemoryWeight, groupManagedMemoryWeight)
+				: 0.0;
 		} else {
 			final long groupManagedMemoryBytes = groupResourceSpec.getManagedMemory().getBytes();
-				managedMemoryFraction = groupManagedMemoryBytes > 0
+			managedMemoryFraction = groupManagedMemoryBytes > 0
 				? getFractionRoundedDown(operatorResourceSpec.getManagedMemory().getBytes(), groupManagedMemoryBytes)
 				: 0.0;
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -510,6 +510,22 @@ public class StreamGraphGeneratorTest {
 		}
 	}
 
+	@Test
+	public void testSetManagedMemoryWeight() {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		final DataStream<Integer> source = env.fromElements(1, 2, 3).name("source");
+		source.getTransformation().setManagedMemoryWeight(123);
+		source.print().name("sink");
+
+		final StreamGraph streamGraph = env.getStreamGraph();
+		for (StreamNode streamNode : streamGraph.getStreamNodes()) {
+			final int expectedWeight = streamNode.getOperatorName().contains("source")
+				? 123
+				: Transformation.DEFAULT_MANAGED_MEMORY_WEIGHT;
+			assertEquals(expectedWeight, streamNode.getManagedMemoryWeight());
+		}
+	}
+
 	private static class OutputTypeConfigurableOperationWithTwoInputs
 			extends AbstractStreamOperator<Integer>
 			implements TwoInputStreamOperator<Integer, Integer, Integer>, OutputTypeConfigurable<Integer> {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -51,6 +51,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.util.EvenOddOutputSelector;
 import org.apache.flink.streaming.util.NoOpIntMap;
+import org.apache.flink.util.TestLogger;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -74,7 +75,7 @@ import static org.junit.Assert.assertTrue;
  * specific tests.
  */
 @SuppressWarnings("serial")
-public class StreamGraphGeneratorTest {
+public class StreamGraphGeneratorTest extends TestLogger {
 
 	@Test
 	public void generatorForwardsSavepointRestoreSettings() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -67,8 +67,11 @@ import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 
 import org.junit.Test;
 
+import javax.annotation.Nullable;
+
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -672,9 +675,10 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 		final ResourceSpec resource4 = ResourceSpec.newBuilder(1, 100)
 			.setManagedMemory(new MemorySize(123))
 			.build();
+		final List<ResourceSpec> resourceSpecs = Arrays.asList(resource1, resource2, resource3, resource4);
 
 		// v1(source -> map1), v2(map2) are in the same slot sharing group, v3(map3) is in a different group
-		final JobGraph jobGraph = createJobGraphForManagedMemoryFractionTest(resource1, resource2, resource3, resource4);
+		final JobGraph jobGraph = createJobGraphForManagedMemoryFractionTest(resourceSpecs, null);
 		final JobVertex vertex1 = jobGraph.getVerticesSortedTopologicallyFromSources().get(0);
 		final JobVertex vertex2 = jobGraph.getVerticesSortedTopologicallyFromSources().get(1);
 		final JobVertex vertex3 = jobGraph.getVerticesSortedTopologicallyFromSources().get(2);
@@ -700,26 +704,25 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 
 	@Test
 	public void testManagedMemoryFractionForUnknownResourceSpec() throws Exception {
-		final ResourceSpec resource1 = ResourceSpec.UNKNOWN;
-		final ResourceSpec resource2 = ResourceSpec.UNKNOWN;
-		final ResourceSpec resource3 = ResourceSpec.UNKNOWN;
-		final ResourceSpec resource4 = ResourceSpec.UNKNOWN;
+		final ResourceSpec resource = ResourceSpec.UNKNOWN;
+		final List<ResourceSpec> resourceSpecs = Arrays.asList(resource, resource, resource, resource);
+		final List<Integer> managedMemoryWeights = Arrays.asList(1, 2, 3, 4);
 
 		// v1(source -> map1), v2(map2) are in the same slot sharing group, v3(map3) is in a different group
-		final JobGraph jobGraph = createJobGraphForManagedMemoryFractionTest(resource1, resource2, resource3, resource4);
+		final JobGraph jobGraph = createJobGraphForManagedMemoryFractionTest(resourceSpecs, managedMemoryWeights);
 		final JobVertex vertex1 = jobGraph.getVerticesSortedTopologicallyFromSources().get(0);
 		final JobVertex vertex2 = jobGraph.getVerticesSortedTopologicallyFromSources().get(1);
 		final JobVertex vertex3 = jobGraph.getVerticesSortedTopologicallyFromSources().get(2);
 
 		final StreamConfig sourceConfig = new StreamConfig(vertex1.getConfiguration());
-		assertEquals(1.0 / 3, sourceConfig.getManagedMemoryFraction(), 0.000001);
+		assertEquals(1.0 / 6, sourceConfig.getManagedMemoryFraction(), 0.000001);
 
 		final StreamConfig map1Config = Iterables.getOnlyElement(
 			sourceConfig.getTransitiveChainedTaskConfigs(StreamingJobGraphGeneratorTest.class.getClassLoader()).values());
-		assertEquals(1.0 / 3, map1Config.getManagedMemoryFraction(), 0.000001);
+		assertEquals(2.0 / 6, map1Config.getManagedMemoryFraction(), 0.000001);
 
 		final StreamConfig map2Config = new StreamConfig(vertex2.getConfiguration());
-		assertEquals(1.0 / 3, map2Config.getManagedMemoryFraction(), 0.000001);
+		assertEquals(3.0 / 6, map2Config.getManagedMemoryFraction(), 0.000001);
 
 		final StreamConfig map3Config = new StreamConfig(vertex3.getConfiguration());
 		assertEquals(1.0, map3Config.getManagedMemoryFraction(), 0.000001);
@@ -727,10 +730,8 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 	}
 
 	private JobGraph createJobGraphForManagedMemoryFractionTest(
-		final ResourceSpec resource1,
-		final ResourceSpec resource2,
-		final ResourceSpec resource3,
-		final ResourceSpec resource4) throws Exception {
+		final List<ResourceSpec> resourceSpecs,
+		@Nullable final List<Integer> managedMemoryWeights) throws Exception {
 
 		final Method opMethod = getSetResourcesMethodAndSetAccessible(SingleOutputStreamOperator.class);
 
@@ -745,19 +746,26 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 			public void cancel() {
 			}
 		});
-		opMethod.invoke(source, resource1);
+		opMethod.invoke(source, resourceSpecs.get(0));
 
 		// CHAIN(source -> map1) in default slot sharing group
 		final DataStream<Integer> map1 = source.map((MapFunction<Integer, Integer>) value -> value);
-		opMethod.invoke(map1, resource2);
+		opMethod.invoke(map1, resourceSpecs.get(1));
 
 		// CHAIN(map2) in default slot sharing group
 		final DataStream<Integer> map2 = map1.rebalance().map((MapFunction<Integer, Integer>) value -> value);
-		opMethod.invoke(map2, resource3);
+		opMethod.invoke(map2, resourceSpecs.get(2));
 
 		// CHAIN(map3) in test slot sharing group
 		final DataStream<Integer> map3 = map2.rebalance().map(value -> value).slotSharingGroup("test");
-		opMethod.invoke(map3, resource4);
+		opMethod.invoke(map3, resourceSpecs.get(3));
+
+		if (managedMemoryWeights != null) {
+			source.getTransformation().setManagedMemoryWeight(managedMemoryWeights.get(0));
+			map1.getTransformation().setManagedMemoryWeight(managedMemoryWeights.get(1));
+			map2.getTransformation().setManagedMemoryWeight(managedMemoryWeights.get(2));
+			map3.getTransformation().setManagedMemoryWeight(managedMemoryWeights.get(3));
+		}
 
 		return StreamingJobGraphGenerator.createJobGraph(env.getStreamGraph());
 	}


### PR DESCRIPTION
## What is the purpose of the change

To calculate managed memory fraction for an operator with UNKNOWN resources, we need to know whether the operator will use managed memory to better utilize memory memory for better performance, according to FLINK-14062.

To achieve this, we need an interface to set/get whether an operator uses managed memory.

## Brief change log

  - *Enable to get/set managed memory weight in Transformation*
  - *Set Transformation managed memory weight to corresponding StreamNode*
  - *Adjust managed memory fraction calculation regarding managed memory weights*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests for changes in Transformation*
  - *Added unit tests for changes in StreamGraph/StreamNode*
  - *Adjusted unit tests for managed memory fraction calculation changes*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
