### PR TITLE
[FLINK-15063][metric]fix input group and output group of the task met…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironment.java
@@ -178,8 +178,8 @@ public class NettyShuffleEnvironment implements ShuffleEnvironment<ResultPartiti
 			checkNotNull(ownerName),
 			checkNotNull(executionAttemptID),
 			parentGroup,
-			nettyGroup.addGroup(METRIC_GROUP_INPUT),
-			nettyGroup.addGroup(METRIC_GROUP_OUTPUT));
+			nettyGroup.addGroup(METRIC_GROUP_OUTPUT),
+			nettyGroup.addGroup(METRIC_GROUP_INPUT));
 	}
 
 	@Override


### PR DESCRIPTION


## What is the purpose of the change


This pull request is for fix bug which input group and output group of the task metric are reversed


## Brief change log

- fix it in org.apache.flink.runtime.io.network.NettyShuffleEnvironment#createShuffleIOOwnerContext


## Verifying this change



This change is a hotfix.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)

