### PR TITLE
[FLINK-14965] [table-planner-blink] correct the logic of convertToTableStats method in CatalogTableStatisticsConverter

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/CatalogTableStatisticsConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/CatalogTableStatisticsConverter.java
@@ -38,23 +38,24 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Utility class for converting {@link CatalogTableStatistics} to {@link TableStats}.
+ * Utility class for converting {@link CatalogTableStatistics} and {@link CatalogColumnStatistics} to {@link TableStats}.
  */
 public class CatalogTableStatisticsConverter {
 
 	public static TableStats convertToTableStats(
 			CatalogTableStatistics tableStatistics,
 			CatalogColumnStatistics columnStatistics) {
-		if (tableStatistics == null || tableStatistics.equals(CatalogTableStatistics.UNKNOWN)) {
-			return TableStats.UNKNOWN;
+		long rowCount;
+		if (tableStatistics != null && tableStatistics.getRowCount() >= 0) {
+			rowCount = tableStatistics.getRowCount();
+		} else {
+			rowCount = TableStats.UNKNOWN.getRowCount();
 		}
 
-		long rowCount = tableStatistics.getRowCount();
-		Map<String, ColumnStats> columnStatsMap = null;
-		if (columnStatistics != null && !columnStatistics.equals(CatalogColumnStatistics.UNKNOWN)) {
+		Map<String, ColumnStats> columnStatsMap;
+		if (columnStatistics != null) {
 			columnStatsMap = convertToColumnStatsMap(columnStatistics.getColumnStatisticsData());
-		}
-		if (columnStatsMap == null) {
+		} else {
 			columnStatsMap = new HashMap<>();
 		}
 		return new TableStats(rowCount, columnStatsMap);

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/catalog/CatalogStatisticsTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/catalog/CatalogStatisticsTest.java
@@ -137,7 +137,7 @@ public class CatalogStatisticsTest {
 			String tableName) throws TableNotExistException, TablePartitionedException {
 		catalog.alterTableStatistics(new ObjectPath(databaseName, tableName),
 				new CatalogTableStatistics(100, 10, 1000L, 2000L), true);
-		catalog.alterTableColumnStatistics(new ObjectPath(databaseName, "T1"), createColumnStats(), true);
+		catalog.alterTableColumnStatistics(new ObjectPath(databaseName, tableName), createColumnStats(), true);
 	}
 
 	private CatalogColumnStatistics createColumnStats() {


### PR DESCRIPTION
## What is the purpose of the change

*[FLINK-14662](https://issues.apache.org/jira/browse/FLINK-14662) had let CatalogTableStatistics.UNKNOWN be consistent with TableStats.UNKNOWN.
however, the logic in CatalogTableStatisticsConverter#convertToTableStats method is also not correct:
1. HiveCatalog will create a new instance even if all attributes in CatalogTableStatistics is unknown instead of using CatalogTableStatistics.UNKNOWN. And CatalogTableStatistics does not override equals method. So tableStatistics.equals(CatalogTableStatistics.UNKNOWN) is always false.
2. similar logic about equals on CatalogColumnStatistics
3. even if tableStatistics is null or tableStatistics is CatalogTableStatistics.UNKNOWN, the columnStatistics may be not UNKNOWN. It also needs to be convert to column stats.

the pr mainly fixes the above incorrect logic. *


## Brief change log

  - *correct the logic of convertToTableStats method in CatalogTableStatisticsConverter*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests for unknown row count with known column stats*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no)**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no)**
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no)**
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
