### PR TITLE
 [FLINK-15067][table] Pass configuration to the underlying ExecutionEnvironment from TableEnvironment

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -757,7 +757,7 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	}
 
 	@Override
-	public <T> WritableConfig set(ConfigOption<T> option, T value) {
+	public <T> Configuration set(ConfigOption<T> option, T value) {
 		setValueInternal(option.key(), value);
 		return this;
 	}

--- a/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
@@ -344,7 +344,7 @@ public final class DelegatingConfiguration extends Configuration {
 	}
 
 	@Override
-	public <T> WritableConfig set(ConfigOption<T> option, T value) {
+	public <T> Configuration set(ConfigOption<T> option, T value) {
 		return backingConfig.set(prefixOption(option, prefix), value);
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ReadableConfigToConfigurationAdapter.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ReadableConfigToConfigurationAdapter.java
@@ -223,7 +223,7 @@ public class ReadableConfigToConfigurationAdapter extends Configuration {
 	}
 
 	@Override
-	public <T> WritableConfig set(ConfigOption<T> option, T value) {
+	public <T> Configuration set(ConfigOption<T> option, T value) {
 		throw new UnsupportedOperationException("The configuration is read only");
 	}
 

--- a/flink-python/pyflink/table/tests/test_table_config_completeness.py
+++ b/flink-python/pyflink/table/tests/test_table_config_completeness.py
@@ -39,7 +39,7 @@ class TableConfigCompletenessTests(PythonAPICompletenessTestCase, unittest.TestC
     @classmethod
     def excluded_methods(cls):
         # internal interfaces, no need to expose to users.
-        return {'getPlannerConfig', 'setPlannerConfig'}
+        return {'getPlannerConfig', 'setPlannerConfig', 'addJobParameter'}
 
     @classmethod
     def java_method_name(cls, python_method_name):

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
@@ -36,6 +36,18 @@ import java.time.ZoneId;
  *
  * <p>For more advanced configuration, users can directly access the underlying key-value map via
  * {@link #getConfiguration()}. Currently, key-value options are only supported for the Blink planner.
+ * Users can configure also underlying execution parameters via this object. E.g.
+ *
+ * <pre>
+ * {@code
+ * tEnv.getConfig().addConfiguration(
+ *          new Configuration()
+ *              .set(CoreOptions.DEFAULT_PARALLELISM, 128)
+ *              .set(PipelineOptions.AUTO_WATERMARK_INTERVAL, Duration.ofMillis(800))
+ *              .set(ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL, Duration.ofSeconds(30))
+ *      );
+ * }
+ * </pre>
  *
  * <p>Note: Because options are read at different point in time when performing operations, it is
  * recommended to set configuration options early after instantiating a table environment.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
@@ -18,15 +18,19 @@
 
 package org.apache.flink.table.api;
 
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.api.config.OptimizerConfigOptions;
 import org.apache.flink.util.Preconditions;
 
 import java.math.MathContext;
 import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Configuration for the current {@link TableEnvironment} session to adjust Table & SQL API programs.
@@ -260,6 +264,32 @@ public class TableConfig {
 	 */
 	public long getMaxIdleStateRetentionTime() {
 		return maxIdleStateRetentionTime;
+	}
+
+	/**
+	 * Sets a custom user parameter that can be accessed via
+	 * {@link org.apache.flink.table.functions.FunctionContext#getJobParameter(String, String)}.
+	 *
+	 * <p>This will add an entry to the current value of {@link PipelineOptions#GLOBAL_JOB_PARAMETERS}.
+	 *
+	 * <p>It is also possible to set multiple parameters at once, which will override any previously set
+	 * parameters:
+	 * <pre>
+	 * {@code
+	 * Map<String, String> params = ...
+	 * TableConfig config = tEnv.getConfig;
+	 * config.getConfiguration().set(PipelineOptions.GLOBAL_JOB_PARAMETERS, params);
+	 * }
+	 * </pre>
+	 */
+	@Experimental
+	public void addJobParameter(String key, String value) {
+		Map<String, String> params = getConfiguration()
+			.getOptional(PipelineOptions.GLOBAL_JOB_PARAMETERS)
+			.map(HashMap::new)
+			.orElseGet(HashMap::new);
+		params.put(key, value);
+		getConfiguration().set(PipelineOptions.GLOBAL_JOB_PARAMETERS, params);
 	}
 
 	public static TableConfig getDefault() {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -141,7 +141,9 @@ abstract class PlannerBase(
       return List.empty[Transformation[_]]
     }
     // prepare the execEnv before translating
-    mergeParameters()
+    getExecEnv.configure(
+      getTableConfig.getConfiguration,
+      Thread.currentThread().getContextClassLoader)
     overrideEnvParallelism()
 
     val relNodes = modifyOperations.map(translateToRel)
@@ -284,28 +286,6 @@ abstract class PlannerBase(
           .createTableSink(sinkProperties))
 
       case _ => None
-    }
-  }
-
-  /**
-    * Merge global job parameters and table config parameters,
-    * and set the merged result to GlobalJobParameters
-    */
-  private def mergeParameters(): Unit = {
-    val execEnv = getExecEnv
-    if (execEnv != null && execEnv.getConfig != null) {
-      val parameters = new Configuration()
-      if (config != null && config.getConfiguration != null) {
-        parameters.addAll(config.getConfiguration)
-      }
-
-      if (execEnv.getConfig.getGlobalJobParameters != null) {
-        execEnv.getConfig.getGlobalJobParameters.toMap.foreach {
-          kv => parameters.setString(kv._1, kv._2)
-        }
-      }
-
-      execEnv.getConfig.setGlobalJobParameters(parameters)
     }
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/api/EnvironmentTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/api/EnvironmentTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link TableEnvironment} that require a planner.
+ */
+public class EnvironmentTest {
+
+	@Test
+	public void testPassingExecutionParameters() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		StreamTableEnvironment tEnv = StreamTableEnvironment.create(
+			env,
+			EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build());
+
+		tEnv.getConfig().addConfiguration(
+			new Configuration()
+				.set(CoreOptions.DEFAULT_PARALLELISM, 128)
+				.set(PipelineOptions.AUTO_WATERMARK_INTERVAL, Duration.ofMillis(800))
+				.set(ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL, Duration.ofSeconds(30))
+		);
+
+		tEnv.createTemporaryView("test", env.fromElements(1, 2, 3));
+
+		// trigger translation
+		Table table = tEnv.sqlQuery("SELECT * FROM test");
+		tEnv.toAppendStream(table, Row.class);
+
+		assertEquals(128, env.getParallelism());
+		assertEquals(800, env.getConfig().getAutoWatermarkInterval());
+		assertEquals(30000, env.getCheckpointConfig().getCheckpointInterval());
+	}
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/StreamPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/StreamPlanner.scala
@@ -245,6 +245,9 @@ class StreamPlanner(
 
     logicalPlan match {
       case node: DataStreamRel =>
+        getExecutionEnvironment.configure(
+          config.getConfiguration,
+          Thread.currentThread().getContextClassLoader)
         node.translateToPlan(this, queryConfig)
       case _ =>
         throw new TableException("Cannot generate DataStream due to an invalid logical plan. " +

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/StreamTableEnvironmentTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/StreamTableEnvironmentTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link StreamTableEnvironment} that require a planner.
+ */
+public class StreamTableEnvironmentTest {
+
+	@Test
+	public void testPassingExecutionParameters() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+		tEnv.getConfig().addConfiguration(
+			new Configuration()
+				.set(CoreOptions.DEFAULT_PARALLELISM, 128)
+				.set(PipelineOptions.AUTO_WATERMARK_INTERVAL, Duration.ofMillis(800))
+				.set(ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL, Duration.ofSeconds(30))
+		);
+
+		tEnv.createTemporaryView("test", env.fromElements(1, 2, 3));
+
+		// trigger translation
+		Table table = tEnv.sqlQuery("SELECT * FROM test");
+		tEnv.toAppendStream(table, Row.class);
+
+		assertEquals(128, env.getParallelism());
+		assertEquals(800, env.getConfig().getAutoWatermarkInterval());
+		assertEquals(30000, env.getCheckpointConfig().getCheckpointInterval());
+	}
+}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/ExpressionReductionRulesTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/ExpressionReductionRulesTest.scala
@@ -552,8 +552,7 @@ class ExpressionReductionRulesTest extends TableTestBase {
     util.addFunction("MyUdf", new RichFunc1)
     util.tableEnv
       .getConfig
-      .getConfiguration
-      .set(PipelineOptions.GLOBAL_JOB_PARAMETERS, Map("int.value" -> "10").asJava)
+      .addJobParameter("int.value", "10")
 
     val expected = unaryNode(
       "DataStreamCalc",

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/ExpressionReductionRulesTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/ExpressionReductionRulesTest.scala
@@ -19,14 +19,18 @@
 package org.apache.flink.table.plan
 
 import org.apache.flink.api.scala._
+import org.apache.flink.configuration.PipelineOptions
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.utils.{Func1, RichFunc1}
-import org.apache.flink.table.functions.python.{PythonEnv, PythonFunction}
 import org.apache.flink.table.functions.ScalarFunction
+import org.apache.flink.table.functions.python.{PythonEnv, PythonFunction}
 import org.apache.flink.table.utils.TableTestBase
 import org.apache.flink.table.utils.TableTestUtil._
+
 import org.junit.{Ignore, Test}
+
+import scala.collection.JavaConverters._
 
 class ExpressionReductionRulesTest extends TableTestBase {
 
@@ -546,7 +550,10 @@ class ExpressionReductionRulesTest extends TableTestBase {
     val table = util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
 
     util.addFunction("MyUdf", new RichFunc1)
-    util.tableEnv.getConfig.getConfiguration.setString("int.value", "10")
+    util.tableEnv
+      .getConfig
+      .getConfiguration
+      .set(PipelineOptions.GLOBAL_JOB_PARAMETERS, Map("int.value" -> "10").asJava)
 
     val expected = unaryNode(
       "DataStreamCalc",


### PR DESCRIPTION
## What is the purpose of the change

After this PR the `TableEnvironment` passes configuration to the underlying `StreamExecutionEnvironment`. It allows configuring options such as e.g. autoWatermarkInterval, globalJobParameters etc.

It is possible to do it as follows:

```
StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
	tEnv.getConfig().addConfiguration(
		new Configuration()
			.set(CoreOptions.DEFAULT_PARALLELISM, 128)
			.set(PipelineOptions.AUTO_WATERMARK_INTERVAL, Duration.ofMillis(800))
			.set(ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL, Duration.ofSeconds(30))
	);
```

## Verifying this change
Added tests for blink and flink planners

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
