### PR TITLE
[FLINK-13450][table api] Use StrictMath instead of Math for exp

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
@@ -45,7 +45,7 @@ object BuiltInMethods {
 
   val LOG2 = Types.lookupMethod(classOf[ScalarFunctions], "log2", classOf[Double])
 
-  val EXP = Types.lookupMethod(classOf[Math], "exp", classOf[Double])
+  val EXP = Types.lookupMethod(classOf[ScalarFunctions], "exp", classOf[Double])
 
   val POWER = Types.lookupMethod(classOf[Math], "pow", classOf[Double], classOf[Double])
   val POWER_DEC = Types.lookupMethod(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
@@ -116,6 +116,17 @@ object ScalarFunctions {
   }
 
   /**
+   * Returns exp(x).
+   */
+  def exp(x: Double): Double = {
+    if (x <= 0.0) {
+      throw new IllegalArgumentException(s"x of 'exp(x)' must be > 0, but x = $x")
+    } else {
+      StrictMath.exp(x)
+    }
+  }
+
+  /**
     * Calculates the hyperbolic tangent of a big decimal number.
     */
   def tanh(x: JBigDecimal): Double = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/SqlExpressionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/SqlExpressionTest.scala
@@ -104,7 +104,7 @@ class SqlExpressionTest extends ExpressionTestBase {
     testSqlApi("LOG2(8)", "3.0")
     testSqlApi("LOG(E())", "1.0")
     testSqlApi("LOG(3,27)", "3.0000000000000004")
-    testSqlApi("EXP(1)", "2.718281828459045")
+    testSqlApi("EXP(1)", "2.7182818284590455")
     testSqlApi("CEIL(2.5)", "3")
     testSqlApi("CEILING(2.5)", "3")
     testSqlApi("FLOOR(2.5)", "2")


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Some math calculation result is different between x86 and aarch64 because of hardware optimizations.

For exmaple, the `Math.exp(1)`
```
on X86 is      2.718281828459045
on aarch64 is  2.7182818284590455 
```  

Use StrictMath can keep the result the same.


## Brief change log

Add a new `exp` functino to use StrictMath instead.

## Verifying this change

This change is already covered by existing tests, such as *testArithmeticFunctions*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
