### PR TITLE
[FLINK-15072][client] executeAsync in ContextEnvironment from CliFrontend cause unexpected exception

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
@@ -19,13 +19,11 @@
 package org.apache.flink.client;
 
 import org.apache.flink.api.common.JobExecutionResult;
-import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.ContextEnvironment;
 import org.apache.flink.client.program.ContextEnvironmentFactory;
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.client.program.ProgramInvocationException;
-import org.apache.flink.client.program.ProgramMissingJobException;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.DeploymentOptions;
@@ -44,7 +42,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -119,42 +116,30 @@ public enum ClientUtils {
 		}
 	}
 
-	public static JobSubmissionResult executeProgram(
+	public static void executeProgram(
 			ExecutorServiceLoader executorServiceLoader,
 			Configuration configuration,
-			PackagedProgram program) throws ProgramMissingJobException, ProgramInvocationException {
-
+			PackagedProgram program) throws ProgramInvocationException {
 		checkNotNull(executorServiceLoader);
 		final ClassLoader userCodeClassLoader = program.getUserCodeClassLoader();
-
 		final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
 		try {
 			Thread.currentThread().setContextClassLoader(userCodeClassLoader);
 
 			LOG.info("Starting program (detached: {})", !configuration.getBoolean(DeploymentOptions.ATTACHED));
 
-			final AtomicReference<JobExecutionResult> jobExecutionResult = new AtomicReference<>();
-
 			ContextEnvironmentFactory factory = new ContextEnvironmentFactory(
 					executorServiceLoader,
 					configuration,
-					userCodeClassLoader,
-					jobExecutionResult);
+					userCodeClassLoader);
 			ContextEnvironment.setAsContext(factory);
 
 			try {
 				program.invokeInteractiveModeForExecution();
-
-				JobExecutionResult result = jobExecutionResult.get();
-				if (result == null) {
-					throw new ProgramMissingJobException("The program didn't contain a Flink job.");
-				}
-				return result;
 			} finally {
 				ContextEnvironment.unsetContext();
 			}
-		}
-		finally {
+		} finally {
 			Thread.currentThread().setContextClassLoader(contextClassLoader);
 		}
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -20,11 +20,8 @@ package org.apache.flink.client.cli;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
-import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
-import org.apache.flink.api.common.JobSubmissionResult;
-import org.apache.flink.api.common.accumulators.AccumulatorHelper;
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.client.ClientUtils;
 import org.apache.flink.client.FlinkPipelineTranslationUtil;
@@ -663,26 +660,8 @@ public class CliFrontend {
 	//  Interaction with programs and JobManager
 	// --------------------------------------------------------------------------------------------
 
-	protected void executeProgram(
-			final Configuration configuration,
-			final PackagedProgram program) throws ProgramMissingJobException, ProgramInvocationException {
-		logAndSysout("Starting execution of program");
-
-		JobSubmissionResult result = ClientUtils.executeProgram(DefaultExecutorServiceLoader.INSTANCE, configuration, program);
-
-		if (result.isJobExecutionResult()) {
-			logAndSysout("Program execution finished");
-			JobExecutionResult execResult = result.getJobExecutionResult();
-			System.out.println("Job with JobID " + execResult.getJobID() + " has finished.");
-			System.out.println("Job Runtime: " + execResult.getNetRuntime() + " ms");
-			Map<String, Object> accumulatorsResult = execResult.getAllAccumulatorResults();
-			if (accumulatorsResult.size() > 0) {
-				System.out.println("Accumulator Results: ");
-				System.out.println(AccumulatorHelper.getResultsFormatted(accumulatorsResult));
-			}
-		} else {
-			logAndSysout("Job has been submitted with JobID " + result.getJobID());
-		}
+	protected void executeProgram(final Configuration configuration, final PackagedProgram program) throws ProgramInvocationException {
+		ClientUtils.executeProgram(DefaultExecutorServiceLoader.INSTANCE, configuration, program);
 	}
 
 	/**

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -91,12 +91,22 @@ public class ContextEnvironment extends ExecutionEnvironment {
 			}
 
 			jobExecutionResult = jobExecutionResultFuture.get();
+			System.out.println(jobExecutionResult);
 		} else {
 			jobExecutionResult = new DetachedJobExecutionResult(jobClient.getJobID());
 		}
 
 		setJobExecutionResult(jobExecutionResult);
 		return jobExecutionResult;
+	}
+
+	@Override
+	public JobClient executeAsync(String jobName) throws Exception {
+		final JobClient jobClient = super.executeAsync(jobName);
+
+		System.out.println("Job has been submitted with JobID " + jobClient.getJobID());
+
+		return jobClient;
 	}
 
 	private void verifyExecuteIsCalledOnceWhenInDetachedMode() {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -19,7 +19,6 @@
 package org.apache.flink.client.program;
 
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.configuration.Configuration;
@@ -43,8 +42,6 @@ public class ContextEnvironment extends ExecutionEnvironment {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ExecutionEnvironment.class);
 
-	private boolean alreadyCalled;
-
 	ContextEnvironment(
 			final ExecutorServiceLoader executorServiceLoader,
 			final Configuration configuration,
@@ -55,14 +52,10 @@ public class ContextEnvironment extends ExecutionEnvironment {
 		if (parallelism > 0) {
 			setParallelism(parallelism);
 		}
-
-		this.alreadyCalled = false;
 	}
 
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
-		verifyExecuteIsCalledOnceWhenInDetachedMode();
-
 		JobClient jobClient = executeAsync(jobName);
 
 		JobExecutionResult jobExecutionResult;
@@ -99,13 +92,6 @@ public class ContextEnvironment extends ExecutionEnvironment {
 		System.out.println("Job has been submitted with JobID " + jobClient.getJobID());
 
 		return jobClient;
-	}
-
-	private void verifyExecuteIsCalledOnceWhenInDetachedMode() {
-		if (alreadyCalled && !getConfiguration().getBoolean(DeploymentOptions.ATTACHED)) {
-			throw new InvalidProgramException(DetachedJobExecutionResult.DETACHED_MESSAGE + DetachedJobExecutionResult.EXECUTE_TWICE_MESSAGE);
-		}
-		alreadyCalled = true;
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -35,9 +35,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-
-import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Execution Environment for remote execution with the Client.
@@ -46,17 +43,13 @@ public class ContextEnvironment extends ExecutionEnvironment {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ExecutionEnvironment.class);
 
-	private final AtomicReference<JobExecutionResult> jobExecutionResult;
-
 	private boolean alreadyCalled;
 
 	ContextEnvironment(
 			final ExecutorServiceLoader executorServiceLoader,
 			final Configuration configuration,
-			final ClassLoader userCodeClassLoader,
-			final AtomicReference<JobExecutionResult> jobExecutionResult) {
+			final ClassLoader userCodeClassLoader) {
 		super(executorServiceLoader, configuration, userCodeClassLoader);
-		this.jobExecutionResult = checkNotNull(jobExecutionResult);
 
 		final int parallelism = configuration.getInteger(CoreOptions.DEFAULT_PARALLELISM);
 		if (parallelism > 0) {
@@ -96,7 +89,6 @@ public class ContextEnvironment extends ExecutionEnvironment {
 			jobExecutionResult = new DetachedJobExecutionResult(jobClient.getJobID());
 		}
 
-		setJobExecutionResult(jobExecutionResult);
 		return jobExecutionResult;
 	}
 
@@ -114,10 +106,6 @@ public class ContextEnvironment extends ExecutionEnvironment {
 			throw new InvalidProgramException(DetachedJobExecutionResult.DETACHED_MESSAGE + DetachedJobExecutionResult.EXECUTE_TWICE_MESSAGE);
 		}
 		alreadyCalled = true;
-	}
-
-	public void setJobExecutionResult(JobExecutionResult jobExecutionResult) {
-		this.jobExecutionResult.set(jobExecutionResult);
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironmentFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironmentFactory.java
@@ -19,14 +19,11 @@
 package org.apache.flink.client.program;
 
 import org.apache.flink.api.common.InvalidProgramException;
-import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironmentFactory;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.core.execution.ExecutorServiceLoader;
-
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -43,19 +40,15 @@ public class ContextEnvironmentFactory implements ExecutionEnvironmentFactory {
 
 	private final ClassLoader userCodeClassLoader;
 
-	private final AtomicReference<JobExecutionResult> jobExecutionResult;
-
 	private boolean alreadyCalled;
 
 	public ContextEnvironmentFactory(
 			final ExecutorServiceLoader executorServiceLoader,
 			final Configuration configuration,
-			final ClassLoader userCodeClassLoader,
-			final AtomicReference<JobExecutionResult> jobExecutionResult) {
+			final ClassLoader userCodeClassLoader) {
 		this.executorServiceLoader = checkNotNull(executorServiceLoader);
 		this.configuration = checkNotNull(configuration);
 		this.userCodeClassLoader = checkNotNull(userCodeClassLoader);
-		this.jobExecutionResult = checkNotNull(jobExecutionResult);
 
 		this.alreadyCalled = false;
 	}
@@ -66,8 +59,7 @@ public class ContextEnvironmentFactory implements ExecutionEnvironmentFactory {
 		return new ContextEnvironment(
 				executorServiceLoader,
 				configuration,
-				userCodeClassLoader,
-				jobExecutionResult);
+				userCodeClassLoader);
 	}
 
 	private void verifyCreateIsCalledOnceWhenInDetachedMode() {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironmentFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironmentFactory.java
@@ -18,11 +18,9 @@
 
 package org.apache.flink.client.program;
 
-import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironmentFactory;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.core.execution.ExecutorServiceLoader;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -40,8 +38,6 @@ public class ContextEnvironmentFactory implements ExecutionEnvironmentFactory {
 
 	private final ClassLoader userCodeClassLoader;
 
-	private boolean alreadyCalled;
-
 	public ContextEnvironmentFactory(
 			final ExecutorServiceLoader executorServiceLoader,
 			final Configuration configuration,
@@ -49,23 +45,13 @@ public class ContextEnvironmentFactory implements ExecutionEnvironmentFactory {
 		this.executorServiceLoader = checkNotNull(executorServiceLoader);
 		this.configuration = checkNotNull(configuration);
 		this.userCodeClassLoader = checkNotNull(userCodeClassLoader);
-
-		this.alreadyCalled = false;
 	}
 
 	@Override
 	public ExecutionEnvironment createExecutionEnvironment() {
-		verifyCreateIsCalledOnceWhenInDetachedMode();
 		return new ContextEnvironment(
 				executorServiceLoader,
 				configuration,
 				userCodeClassLoader);
-	}
-
-	private void verifyCreateIsCalledOnceWhenInDetachedMode() {
-		if (!configuration.getBoolean(DeploymentOptions.ATTACHED) && alreadyCalled) {
-			throw new InvalidProgramException("Multiple environments cannot be created in detached mode");
-		}
-		alreadyCalled = true;
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/OptimizerPlanEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/OptimizerPlanEnvironment.java
@@ -18,10 +18,10 @@
 
 package org.apache.flink.client.program;
 
-import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironmentFactory;
+import org.apache.flink.core.execution.JobClient;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -39,7 +39,7 @@ public class OptimizerPlanEnvironment extends ExecutionEnvironment {
 	// ------------------------------------------------------------------------
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
+	public JobClient executeAsync(String jobName) throws Exception {
 		this.pipeline = createProgramPlan();
 
 		// do not go on with anything now!

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -127,17 +127,6 @@ public class ClientTest extends TestLogger {
 	@Test
 	public void testDetachedMode() throws Exception{
 		final ClusterClient<?> clusterClient = new MiniClusterClient(new Configuration(), MINI_CLUSTER_RESOURCE.getMiniCluster());
-		try {
-			PackagedProgram prg = PackagedProgram.newBuilder().setEntryPointClassName(TestExecuteTwice.class.getName()).build();
-			final Configuration configuration = fromPackagedProgram(prg, 1, true);
-
-			ClientUtils.executeProgram(new TestExecutorServiceLoader(clusterClient, plan), configuration, prg);
-			fail(FAIL_MESSAGE);
-		} catch (ProgramInvocationException e) {
-			assertEquals(
-					DetachedJobExecutionResult.DETACHED_MESSAGE + DetachedJobExecutionResult.EXECUTE_TWICE_MESSAGE,
-					e.getCause().getMessage());
-		}
 
 		try {
 			PackagedProgram prg = PackagedProgram.newBuilder().setEntryPointClassName(TestEager.class.getName()).build();
@@ -291,19 +280,6 @@ public class ClientTest extends TestLogger {
 		@Override
 		public String getDescription() {
 			return "TestOptimizerPlan <input-file-path> <output-file-path>";
-		}
-	}
-
-	/**
-	 * Test job that calls {@link ExecutionEnvironment#execute()} twice.
-	 */
-	public static final class TestExecuteTwice {
-
-		public static void main(String[] args) throws Exception {
-			final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-			env.fromElements(1, 2).output(new DiscardingOutputFormat<Integer>());
-			env.execute();
-			env.fromElements(1, 2).collect();
 		}
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/JobExecutionResult.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/JobExecutionResult.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.accumulators.AccumulatorHelper;
 import org.apache.flink.util.OptionalFailure;
 
 import java.util.Collections;
@@ -110,6 +111,22 @@ public class JobExecutionResult extends JobSubmissionResult {
 		return accumulatorResults.entrySet()
 			.stream()
 			.collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().getUnchecked()));
+	}
+
+	@Override
+	public String toString() {
+		final StringBuilder result = new StringBuilder();
+		result.append("Program execution finished").append("\n");
+		result.append("Job with JobID ").append(getJobID()).append(" has finished.").append("\n");
+		result.append("Job Runtime: ").append(getNetRuntime()).append(" ms").append("\n");
+
+		final Map<String, Object> accumulatorsResult = getAllAccumulatorResults();
+		if (accumulatorsResult.size() > 0) {
+			result.append("Accumulator Results: ").append("\n");
+			result.append(AccumulatorHelper.getResultsFormatted(accumulatorsResult)).append("\n");
+		}
+
+		return result.toString();
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/core/execution/DetachedJobExecutionResult.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/DetachedJobExecutionResult.java
@@ -34,8 +34,6 @@ public final class DetachedJobExecutionResult extends JobExecutionResult {
 
 	public static final String DETACHED_MESSAGE = "Job was submitted in detached mode. ";
 
-	public static final String EXECUTE_TWICE_MESSAGE = "Only one call to execute is allowed. ";
-
 	public static final String EAGER_FUNCTION_MESSAGE = "Please make sure your program doesn't call " +
 			"an eager execution function [collect, print, printToErr, count]. ";
 

--- a/flink-core/src/main/java/org/apache/flink/core/execution/DetachedJobExecutionResult.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/DetachedJobExecutionResult.java
@@ -80,4 +80,9 @@ public final class DetachedJobExecutionResult extends JobExecutionResult {
 	public JobExecutionResult getJobExecutionResult() {
 		return this;
 	}
+
+	@Override
+	public String toString() {
+		return "Job has been submitted with JobID " + getJobID();
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamContextEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamContextEnvironment.java
@@ -81,11 +81,21 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
 			}
 
 			jobExecutionResult = jobExecutionResultFuture.get();
+			System.out.println(jobExecutionResult);
 		} else {
 			jobExecutionResult = new DetachedJobExecutionResult(jobClient.getJobID());
 		}
 
 		ctx.setJobExecutionResult(jobExecutionResult);
 		return jobExecutionResult;
+	}
+
+	@Override
+	public JobClient executeAsync(StreamGraph streamGraph) throws Exception {
+		final JobClient jobClient = super.executeAsync(streamGraph);
+
+		System.out.println("Job has been submitted with JobID " + jobClient.getJobID());
+
+		return jobClient;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamContextEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamContextEnvironment.java
@@ -86,7 +86,6 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
 			jobExecutionResult = new DetachedJobExecutionResult(jobClient.getJobID());
 		}
 
-		ctx.setJobExecutionResult(jobExecutionResult);
 		return jobExecutionResult;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -1642,13 +1642,15 @@ public class StreamExecutionEnvironment {
 		final JobClient jobClient = executeAsync(streamGraph);
 
 		try {
-			JobExecutionResult jobExecutionResult =
-					configuration.getBoolean(DeploymentOptions.ATTACHED) ?
-							jobClient.getJobExecutionResult(userClassloader).get()
-							: new DetachedJobExecutionResult(jobClient.getJobID());
+			final JobExecutionResult jobExecutionResult;
 
-			jobListeners
-					.forEach(jobListener -> jobListener.onJobExecuted(jobExecutionResult, null));
+			if (configuration.getBoolean(DeploymentOptions.ATTACHED)) {
+				jobExecutionResult = jobClient.getJobExecutionResult(userClassloader).get();
+			} else {
+				jobExecutionResult = new DetachedJobExecutionResult(jobClient.getJobID());
+			}
+
+			jobListeners.forEach(jobListener -> jobListener.onJobExecuted(jobExecutionResult, null));
 
 			return jobExecutionResult;
 		} catch (Throwable t) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamPlanEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamPlanEnvironment.java
@@ -18,11 +18,11 @@
 package org.apache.flink.streaming.api.environment;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.client.program.OptimizerPlanEnvironment;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 
 /**
@@ -35,7 +35,6 @@ public class StreamPlanEnvironment extends StreamExecutionEnvironment {
 	private ExecutionEnvironment env;
 
 	protected StreamPlanEnvironment(ExecutionEnvironment env) {
-		super();
 		this.env = env;
 
 		int parallelism = env.getParallelism();
@@ -48,7 +47,7 @@ public class StreamPlanEnvironment extends StreamExecutionEnvironment {
 	}
 
 	@Override
-	public JobExecutionResult execute(StreamGraph streamGraph) throws Exception {
+	public JobClient executeAsync(StreamGraph streamGraph) throws Exception {
 		if (env instanceof OptimizerPlanEnvironment) {
 			((OptimizerPlanEnvironment) env).setPipeline(streamGraph);
 		}


### PR DESCRIPTION
## What is the purpose of the change

Currently, if users write program using `executeAsync`, it doesn't work if context environment get into use(JarRun endpoint, CLI Frontend). This is because we don't hijack `executeAsync` 

## Brief change log

- bugfix: call `verifyExecuteIsCalledOnceWhenInDetachedMode` in `StreamContextEnvironment` so that we prevent call twice in streaming context env.
- refactor: `StreamExecutionEnvironment#executeAsync(StreamGraph)` clear transformation by default, so that local/remote subclasses doesn't need to override it any more.
- bugfix: override `executeAsync` instead of `execute` in context environment so that we properly handle user program calls `executeAsync` instead of `execute`
- refactor: `ClientUtils#executeProgram` doesn't return `JobSubmissionResult`. If we try to get it into an `AtomicReference` container, it is hard to handle synchronization in execute/executeAsync(what result should we set?) Also I notice that result is used for print useless information. It should be discussed since user experience changed but I remove it at first.

## Verifying this change

Existing tests guarded for current behavior, `ClientTest#testExecuteAsync` tests for `executeAsync` with context environment.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes, change codes in envs)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
