### PR TITLE
[FLINK-13955][runtime] migrate ContinuousFileReaderOperator to the mailbox execution model

### DIFF
--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingMigrationTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingMigrationTest.java
@@ -135,8 +135,7 @@ public class ContinuousFileProcessingMigrationTest {
 		BlockingFileInputFormat format = new BlockingFileInputFormat(blockingLatch, new Path(testFolder.getAbsolutePath()));
 
 		TypeInformation<FileInputSplit> typeInfo = TypeExtractor.getInputFormatTypes(format);
-		ContinuousFileReaderOperator<FileInputSplit> initReader = new ContinuousFileReaderOperator<>(
-				format);
+		ContinuousFileReaderOperator<FileInputSplit> initReader = new ContinuousFileReaderOperator<>(format);
 		initReader.setOutputType(typeInfo, new ExecutionConfig());
 		OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, FileInputSplit> testHarness =
 				new OneInputStreamOperatorTestHarness<>(initReader);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -71,6 +71,7 @@ import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.functions.source.ContinuousFileMonitoringFunction;
 import org.apache.flink.streaming.api.functions.source.ContinuousFileReaderOperator;
+import org.apache.flink.streaming.api.functions.source.ContinuousFileReaderOperatorFactory;
 import org.apache.flink.streaming.api.functions.source.FileMonitoringFunction;
 import org.apache.flink.streaming.api.functions.source.FileProcessingMode;
 import org.apache.flink.streaming.api.functions.source.FileReadFunction;
@@ -1483,11 +1484,10 @@ public class StreamExecutionEnvironment {
 		ContinuousFileMonitoringFunction<OUT> monitoringFunction =
 			new ContinuousFileMonitoringFunction<>(inputFormat, monitoringMode, getParallelism(), interval);
 
-		ContinuousFileReaderOperator<OUT> reader =
-			new ContinuousFileReaderOperator<>(inputFormat);
+		ContinuousFileReaderOperatorFactory<OUT> factory = new ContinuousFileReaderOperatorFactory<>(inputFormat);
 
 		SingleOutputStreamOperator<OUT> source = addSource(monitoringFunction, sourceName)
-				.transform("Split Reader: " + sourceName, typeInfo, reader);
+				.transform("Split Reader: " + sourceName, typeInfo, factory);
 
 		return new DataStreamSource<>(source);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.api.functions.source;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.io.CheckpointableInputFormat;
 import org.apache.flink.api.common.io.FileInputFormat;
@@ -28,13 +29,17 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.MailboxExecutor;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.OutputTypeConfigurable;
 import org.apache.flink.streaming.api.operators.StreamSourceContexts;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.function.RunnableWithException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,9 +47,13 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.PriorityQueue;
-import java.util.Queue;
+import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -54,10 +63,23 @@ import static org.apache.flink.util.Preconditions.checkState;
  * {@link ContinuousFileMonitoringFunction}. Contrary to the {@link ContinuousFileMonitoringFunction}
  * which has a parallelism of 1, this operator can have DOP > 1.
  *
- * <p>As soon as a split descriptor is received, it is put in a queue, and have another
- * thread read the actual data of the split. This architecture allows the separation of the
- * reading thread from the one emitting the checkpoint barriers, thus removing any potential
- * back-pressure.
+ * <p>This implementation uses {@link MailboxExecutor} to execute each action and state machine approach. The workflow is the following :<ol>
+ *     <li>start in {@link ReaderState#IDLE IDLE}</li>
+ *     <li>upon receiving a split add it to the queue, switch to {@link ReaderState#OPENING OPENING} and enqueue a
+ *     {@link org.apache.flink.streaming.runtime.tasks.mailbox.Mail mail} to process it</li>
+ *     <li>open file, switch to {@link ReaderState#READING READING}, read one record, re-enqueue self</li>
+ *     <li>if no more records or splits available, switch back to {@link ReaderState#IDLE IDLE}</li>
+ *     </ol>
+ *     On close:
+ *     <ol>
+ *     <li>if {@link ReaderState#IDLE IDLE} then close immediately</li>
+ *     <li>otherwise switch to {@link ReaderState#CLOSING CLOSING}, call {@link MailboxExecutor#yield() yield} in a loop
+ *     until state is {@link ReaderState#CLOSED CLOSED}</li>
+ *     <li>{@link MailboxExecutor#yield() yield()} causes remaining records (and splits) to be processed in the same way as above</li>
+ * </ol></p>
+ * <p>Using {@link MailboxExecutor} allows to avoid explicit synchronization. At most one mail should be enqueued at any
+ * given time.</p>
+ * <p>Using FSM approach allows to explicitly define states and enforce {@link ReaderState#TRANSITIONS transitions} between them.</p>
  */
 @Internal
 public class ContinuousFileReaderOperator<OUT> extends AbstractStreamOperator<OUT>
@@ -67,51 +89,166 @@ public class ContinuousFileReaderOperator<OUT> extends AbstractStreamOperator<OU
 
 	private static final Logger LOG = LoggerFactory.getLogger(ContinuousFileReaderOperator.class);
 
-	private FileInputFormat<OUT> format;
+	private enum ReaderState {
+		IDLE {
+			@Override
+			public boolean prepareToProcessRecord(ContinuousFileReaderOperator<?> op) {
+				throw new IllegalStateException("not processing any records in IDLE state");
+			}
+		},
+		/**
+		 * A message is enqueued to process split, but no split is opened.
+		 */
+		OPENING { // the split was added and message to itself was enqueued to process it
+			@Override
+			public boolean prepareToProcessRecord(ContinuousFileReaderOperator<?> op) throws IOException {
+				if (op.splits.isEmpty()) {
+					op.switchState(ReaderState.IDLE);
+					return false;
+				} else {
+					op.loadSplit(op.splits.poll());
+					op.switchState(ReaderState.READING);
+					return true;
+				}
+			}
+		},
+		/**
+		 * A message is enqueued to process split and its processing was started.
+		 */
+		READING {
+			@Override
+			public boolean prepareToProcessRecord(ContinuousFileReaderOperator<?> op) {
+				return true;
+			}
+
+			@Override
+			public void onNoMoreData(ContinuousFileReaderOperator<?> op) {
+				op.switchState(ReaderState.IDLE);
+			}
+		},
+		/**
+		 * {@link #close()} was called but unprocessed data (records and splits) remains and needs to be processed.
+		 * {@link #close()} caller is blocked.
+		 */
+		CLOSING {
+			@Override
+			public boolean prepareToProcessRecord(ContinuousFileReaderOperator<?> op) throws IOException {
+				if (op.currentSplit == null && !op.splits.isEmpty()) {
+					op.loadSplit(op.splits.poll());
+				}
+				return true;
+			}
+
+			@Override
+			public void onNoMoreData(ContinuousFileReaderOperator<?> op) {
+				// need one more mail to unblock possible yield() in close() method (todo: wait with timeout in yield)
+				op.enqueueProcessRecord();
+				op.switchState(CLOSED);
+			}
+		},
+		CLOSED {
+			@Override
+			public boolean prepareToProcessRecord(ContinuousFileReaderOperator<?> op) {
+				LOG.warn("not processing any records while closed");
+				return false;
+			}
+		};
+
+		private static final Set<ReaderState> ACCEPT_SPLITS = EnumSet.of(IDLE, OPENING, READING);
+		/**
+		 * Possible transition FROM each state.
+		 */
+		private static final Map<ReaderState, Set<ReaderState>> TRANSITIONS;
+		static {
+			Map<ReaderState, Set<ReaderState>> tmpTransitions = new HashMap<>();
+			tmpTransitions.put(IDLE, EnumSet.of(OPENING, CLOSED));
+			tmpTransitions.put(OPENING, EnumSet.of(READING, CLOSING));
+			tmpTransitions.put(READING, EnumSet.of(IDLE, OPENING, CLOSING));
+			tmpTransitions.put(CLOSING, EnumSet.of(CLOSED));
+			tmpTransitions.put(CLOSED, EnumSet.noneOf(ReaderState.class));
+			TRANSITIONS = new EnumMap<>(tmpTransitions);
+		}
+
+		public boolean isAcceptingSplits() {
+			return ACCEPT_SPLITS.contains(this);
+		}
+
+		public final boolean isTerminal() {
+			return this == CLOSED;
+		}
+
+		public boolean canSwitchTo(ReaderState next) {
+			return TRANSITIONS
+					.getOrDefault(this, EnumSet.noneOf(ReaderState.class))
+					.contains(next);
+		}
+
+		/**
+		 * Prepare to process new record OR split.
+		 * @return true if should read the record
+		 */
+		public abstract boolean prepareToProcessRecord(ContinuousFileReaderOperator<?> op) throws IOException;
+
+		public void onNoMoreData(ContinuousFileReaderOperator<?> op) {
+		}
+	}
+
+	private transient FileInputFormat<OUT> format;
 	private TypeSerializer<OUT> serializer;
-
-	private transient Object checkpointLock;
-
-	private transient SplitReader<OUT> reader;
-	private transient SourceFunction.SourceContext<OUT> readerContext;
-
+	private transient MailboxExecutor executor;
+	private transient OUT reusedRecord;
+	private transient SourceFunction.SourceContext<OUT> sourceContext;
 	private transient ListState<TimestampedFileInputSplit> checkpointedState;
-	private transient List<TimestampedFileInputSplit> restoredReaderState;
+	/**
+	 * MUST only be changed via {@link #switchState(ReaderState) switchState}.
+	 */
+	private transient ReaderState state = ReaderState.IDLE;
+	private transient PriorityQueue<TimestampedFileInputSplit> splits;
+	private transient TimestampedFileInputSplit currentSplit; // can't work just on queue tail because it can change because it's PQ
+	private transient Counter completedSplitsCounter;
 
+	private final transient RunnableWithException processRecordAction = () -> {
+		try {
+			processRecord();
+		} catch (Exception e) {
+			switchState(ReaderState.CLOSED);
+			throw e;
+		}
+	};
+
+	@VisibleForTesting
 	public ContinuousFileReaderOperator(FileInputFormat<OUT> format) {
 		this.format = checkNotNull(format);
 	}
 
-	@Override
-	public void setOutputType(TypeInformation<OUT> outTypeInfo, ExecutionConfig executionConfig) {
-		this.serializer = outTypeInfo.createSerializer(executionConfig);
+	public ContinuousFileReaderOperator(FileInputFormat<OUT> format, MailboxExecutor mailboxExecutor) {
+		this.format = checkNotNull(format);
+		this.executor = checkNotNull(mailboxExecutor);
 	}
 
 	@Override
 	public void initializeState(StateInitializationContext context) throws Exception {
 		super.initializeState(context);
 
-		checkState(checkpointedState == null,	"The reader state has already been initialized.");
+		checkState(checkpointedState == null, "The reader state has already been initialized.");
 
 		checkpointedState = context.getOperatorStateStore().getSerializableListState("splits");
 
 		int subtaskIdx = getRuntimeContext().getIndexOfThisSubtask();
-		if (context.isRestored()) {
-			LOG.info("Restoring state for the {} (taskIdx={}).", getClass().getSimpleName(), subtaskIdx);
-
-			// this may not be null in case we migrate from a previous Flink version.
-			if (restoredReaderState == null) {
-				restoredReaderState = new ArrayList<>();
-				for (TimestampedFileInputSplit split : checkpointedState.get()) {
-					restoredReaderState.add(split);
-				}
-
-				if (LOG.isDebugEnabled()) {
-					LOG.debug("{} (taskIdx={}) restored {}.", getClass().getSimpleName(), subtaskIdx, restoredReaderState);
-				}
-			}
-		} else {
+		if (!context.isRestored()) {
 			LOG.info("No state to restore for the {} (taskIdx={}).", getClass().getSimpleName(), subtaskIdx);
+			return;
+		}
+
+		LOG.info("Restoring state for the {} (taskIdx={}).", getClass().getSimpleName(), subtaskIdx);
+
+		splits = splits == null ? new PriorityQueue<>() : splits;
+		for (TimestampedFileInputSplit split : checkpointedState.get()) {
+			splits.add(split);
+		}
+
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("{} (taskIdx={}) restored {}.", getClass().getSimpleName(), subtaskIdx, splits);
 		}
 	}
 
@@ -119,35 +256,119 @@ public class ContinuousFileReaderOperator<OUT> extends AbstractStreamOperator<OU
 	public void open() throws Exception {
 		super.open();
 
-		checkState(this.reader == null, "The reader is already initialized.");
 		checkState(this.serializer != null, "The serializer has not been set. " +
 			"Probably the setOutputType() was not called. Please report it.");
 
+		this.state = ReaderState.IDLE;
 		this.format.setRuntimeContext(getRuntimeContext());
 		this.format.configure(new Configuration());
-		this.checkpointLock = getContainingTask().getCheckpointLock();
 
-		// set the reader context based on the time characteristic
-		final TimeCharacteristic timeCharacteristic = getOperatorConfig().getTimeCharacteristic();
-		final long watermarkInterval = getRuntimeContext().getExecutionConfig().getAutoWatermarkInterval();
-		this.readerContext = StreamSourceContexts.getSourceContext(
-			timeCharacteristic,
+		this.sourceContext = StreamSourceContexts.getSourceContext(
+			getOperatorConfig().getTimeCharacteristic(),
 			getProcessingTimeService(),
-			checkpointLock,
+			new Object(), // no actual locking needed
 			getContainingTask().getStreamStatusMaintainer(),
 			output,
-			watermarkInterval,
+			getRuntimeContext().getExecutionConfig().getAutoWatermarkInterval(),
 			-1);
 
-		// and initialize the split reading thread
-		this.reader = new SplitReader<>(format, serializer, readerContext, checkpointLock, restoredReaderState);
-		this.restoredReaderState = null;
-		this.reader.start();
+		this.reusedRecord = serializer.createInstance();
+		this.completedSplitsCounter = getMetricGroup().counter("numSplitsProcessed");
+		this.executor = executor != null ? executor : getContainingTask().getMailboxExecutorFactory().createExecutor(getOperatorConfig().getChainIndex());
+		this.splits = this.splits == null ? new PriorityQueue<>() : this.splits;
+
+		if (!splits.isEmpty()) {
+			enqueueProcessRecord();
+		}
 	}
 
 	@Override
 	public void processElement(StreamRecord<TimestampedFileInputSplit> element) throws Exception {
-		reader.addSplit(element.getValue());
+		Preconditions.checkState(state.isAcceptingSplits());
+		splits.offer(element.getValue());
+		if (state == ReaderState.IDLE) {
+			enqueueProcessRecord();
+		}
+	}
+
+	private void enqueueProcessRecord() {
+		Preconditions.checkState(!state.isTerminal(), "can't enqueue mail in terminal state %s", state);
+		executor.execute(processRecordAction, "ContinuousFileReaderOperator");
+		if (state == ReaderState.IDLE) {
+			switchState(ReaderState.OPENING);
+		}
+	}
+
+	private void processRecord() throws IOException {
+		if (!state.prepareToProcessRecord(this)) {
+			return;
+		}
+
+		readAndCollectRecord();
+
+		if (format.reachedEnd()) {
+			onSplitProcessed();
+		} else {
+			enqueueProcessRecord();
+		}
+	}
+
+	private void onSplitProcessed() throws IOException {
+		completedSplitsCounter.inc();
+		LOG.debug("split {} processed: {}", completedSplitsCounter.getCount(), currentSplit);
+		format.close();
+		currentSplit = null;
+
+		if (splits.isEmpty()) {
+			state.onNoMoreData(this);
+			return;
+		}
+
+		if (state == ReaderState.READING) {
+			switchState(ReaderState.OPENING);
+		}
+
+		enqueueProcessRecord();
+	}
+
+	private void readAndCollectRecord() throws IOException {
+		Preconditions.checkState(state == ReaderState.READING || state == ReaderState.CLOSING, "can't process record in state %s", state);
+		if (format.reachedEnd()) {
+			return;
+		}
+		OUT out = format.nextRecord(this.reusedRecord);
+		if (out != null) {
+			sourceContext.collect(out);
+		}
+	}
+
+	private void loadSplit(TimestampedFileInputSplit split) throws IOException {
+		Preconditions.checkState(state != ReaderState.READING && state != ReaderState.CLOSED, "can't load split in state %s", state);
+		Preconditions.checkNotNull(split, "split is null");
+		LOG.debug("load split: {}", split);
+		currentSplit = split;
+		format.openInputFormat();
+		if (format instanceof CheckpointableInputFormat && currentSplit.getSplitState() != null) {
+			// recovering after a node failure with an input
+			// format that supports resetting the offset
+			((CheckpointableInputFormat<TimestampedFileInputSplit, Serializable>) format).
+					reopen(currentSplit, currentSplit.getSplitState());
+		} else {
+			// we either have a new split, or we recovered from a node
+			// failure but the input format does not support resetting the offset.
+			format.open(currentSplit);
+		}
+
+		// reset the restored state to null for the next iteration
+		currentSplit.resetSplitState();
+	}
+
+	private void switchState(ReaderState newState) {
+		if (state != newState) {
+			Preconditions.checkState(state.canSwitchTo(newState), "can't switch state from terminal state %s to %s", state, newState);
+			LOG.debug("switch state: {} -> {}", state, newState);
+			state = newState;
+		}
 	}
 
 	@Override
@@ -157,242 +378,85 @@ public class ContinuousFileReaderOperator<OUT> extends AbstractStreamOperator<OU
 
 	@Override
 	public void dispose() throws Exception {
-		super.dispose();
-
-		// first try to cancel it properly and
-		// give it some time until it finishes
-		reader.cancel();
-		try {
-			reader.join(200);
-		} catch (InterruptedException e) {
-			// we can ignore this
-		}
-
-		// if the above did not work, then interrupt the thread repeatedly
-		while (reader.isAlive()) {
-
-			StringBuilder bld = new StringBuilder();
-			StackTraceElement[] stack = reader.getStackTrace();
-			for (StackTraceElement e : stack) {
-				bld.append(e).append('\n');
-			}
-			LOG.warn("The reader is stuck in method:\n {}", bld.toString());
-
-			reader.interrupt();
+		Exception e = null;
+		if (state != ReaderState.CLOSED) {
 			try {
-				reader.join(50);
-			} catch (InterruptedException e) {
-				// we can ignore this
+				cleanUp();
+			} catch (Exception ex) {
+				e = ExceptionUtils.firstOrSuppressed(ex, e);
 			}
 		}
-		reader = null;
-		readerContext = null;
-		restoredReaderState = null;
-		format = null;
-		serializer = null;
+		{
+			checkpointedState = null;
+			completedSplitsCounter = null;
+			currentSplit = null;
+			executor = null;
+			format = null;
+			sourceContext = null;
+			reusedRecord = null;
+			serializer = null;
+			splits = null;
+		}
+		try {
+			super.dispose();
+		} catch (Exception ex) {
+			e = ExceptionUtils.firstOrSuppressed(ex, e);
+		}
+		if (e != null) {
+			throw e;
+		}
 	}
 
 	@Override
 	public void close() throws Exception {
+		LOG.debug("closing");
 		super.close();
 
-		waitSplitReaderFinished();
+		switch (state) {
+			case IDLE:
+				switchState(ReaderState.CLOSED);
+				break;
+			case CLOSED:
+				LOG.warn("operator is already closed, doing nothing");
+				return;
+			default:
+				switchState(ReaderState.CLOSING);
+				while (!state.isTerminal()) {
+					executor.yield();
+				}
+		}
 
-		output.close();
+		try {
+			sourceContext.emitWatermark(Watermark.MAX_WATERMARK);
+		} catch (Exception e) {
+			LOG.warn("unable to emit watermark while closing", e);
+		}
+
+		cleanUp();
 	}
 
-	private void waitSplitReaderFinished() throws InterruptedException {
-		// make sure that we hold the checkpointing lock
-		assert Thread.holdsLock(checkpointLock);
+	private void cleanUp() {
+		LOG.debug("cleanup, state={}", state);
 
-		// close the reader to signal that no more splits will come. By doing this,
-		// the reader will exit as soon as it finishes processing the already pending splits.
-		// This method will wait until then. Further cleaning up is handled by the dispose().
+		RunnableWithException[] runClose = {
+				() -> sourceContext.close(),
+				() -> output.close(),
+				() -> format.close(),
+				() -> format.closeInputFormat()};
+		Exception firstException = null;
 
-		while (reader != null && reader.isAlive() && reader.isRunning()) {
-			reader.close();
-			checkpointLock.wait();
-		}
-
-		// finally if we are operating on event or ingestion time,
-		// emit the long-max watermark indicating the end of the stream,
-		// like a normal source would do.
-
-		if (readerContext != null) {
-			readerContext.emitWatermark(Watermark.MAX_WATERMARK);
-			readerContext.close();
-			readerContext = null;
-		}
-	}
-
-	private class SplitReader<OT> extends Thread {
-
-		private volatile boolean shouldClose;
-
-		private volatile boolean isRunning;
-
-		private final FileInputFormat<OT> format;
-		private final TypeSerializer<OT> serializer;
-
-		private final Object checkpointLock;
-		private final SourceFunction.SourceContext<OT> readerContext;
-
-		private final Queue<TimestampedFileInputSplit> pendingSplits;
-
-		private TimestampedFileInputSplit currentSplit;
-
-		private volatile boolean isSplitOpen;
-
-		private SplitReader(FileInputFormat<OT> format,
-					TypeSerializer<OT> serializer,
-					SourceFunction.SourceContext<OT> readerContext,
-					Object checkpointLock,
-					List<TimestampedFileInputSplit> restoredState) {
-
-			this.format = checkNotNull(format, "Unspecified FileInputFormat.");
-			this.serializer = checkNotNull(serializer, "Unspecified Serializer.");
-			this.readerContext = checkNotNull(readerContext, "Unspecified Reader Context.");
-			this.checkpointLock = checkNotNull(checkpointLock, "Unspecified checkpoint lock.");
-
-			this.shouldClose = false;
-			this.isRunning = true;
-
-			this.pendingSplits = new PriorityQueue<>();
-
-			// this is the case where a task recovers from a previous failed attempt
-			if (restoredState != null) {
-				this.pendingSplits.addAll(restoredState);
-			}
-		}
-
-		private void addSplit(TimestampedFileInputSplit split) {
-			checkNotNull(split, "Cannot insert a null value in the pending splits queue.");
-			synchronized (checkpointLock) {
-				this.pendingSplits.add(split);
-			}
-		}
-
-		public boolean isRunning() {
-			return this.isRunning;
-		}
-
-		@Override
-		public void run() {
+		for (RunnableWithException r : runClose) {
 			try {
-
-				Counter completedSplitsCounter = getMetricGroup().counter("numSplitsProcessed");
-				this.format.openInputFormat();
-
-				while (this.isRunning) {
-
-					synchronized (checkpointLock) {
-
-						if (currentSplit == null) {
-							currentSplit = this.pendingSplits.poll();
-
-							// if the list of pending splits is empty (currentSplit == null) then:
-							//   1) if close() was called on the operator then exit the while loop
-							//   2) if not wait 50 ms and try again to fetch a new split to read
-
-							if (currentSplit == null) {
-								if (this.shouldClose) {
-									isRunning = false;
-								} else {
-									checkpointLock.wait(50);
-								}
-								continue;
-							}
-						}
-
-						if (this.format instanceof CheckpointableInputFormat && currentSplit.getSplitState() != null) {
-							// recovering after a node failure with an input
-							// format that supports resetting the offset
-							((CheckpointableInputFormat<TimestampedFileInputSplit, Serializable>) this.format).
-								reopen(currentSplit, currentSplit.getSplitState());
-						} else {
-							// we either have a new split, or we recovered from a node
-							// failure but the input format does not support resetting the offset.
-							this.format.open(currentSplit);
-						}
-
-						// reset the restored state to null for the next iteration
-						this.currentSplit.resetSplitState();
-						this.isSplitOpen = true;
-					}
-
-					LOG.debug("Reading split: " + currentSplit);
-
-					try {
-						OT nextElement = serializer.createInstance();
-						while (!format.reachedEnd()) {
-							synchronized (checkpointLock) {
-								nextElement = format.nextRecord(nextElement);
-								if (nextElement != null) {
-									readerContext.collect(nextElement);
-								} else {
-									break;
-								}
-							}
-						}
-						completedSplitsCounter.inc();
-
-					} finally {
-						// close and prepare for the next iteration
-						synchronized (checkpointLock) {
-							this.format.close();
-							this.isSplitOpen = false;
-							this.currentSplit = null;
-						}
-					}
-				}
-
-			} catch (Throwable e) {
-
-				getContainingTask().handleAsyncException("Caught exception when processing split: " + currentSplit, e);
-
-			} finally {
-				synchronized (checkpointLock) {
-					LOG.debug("Reader terminated, and exiting...");
-
-					try {
-						this.format.closeInputFormat();
-					} catch (IOException e) {
-						getContainingTask().handleAsyncException(
-							"Caught exception from " + this.format.getClass().getName() + ".closeInputFormat() : " + e.getMessage(), e);
-					}
-					this.isSplitOpen = false;
-					this.currentSplit = null;
-					this.isRunning = false;
-
-					checkpointLock.notifyAll();
-				}
+				r.run();
+			} catch (Exception e) {
+				firstException = ExceptionUtils.firstOrSuppressed(firstException, e);
 			}
 		}
-
-		private List<TimestampedFileInputSplit> getReaderState() throws IOException {
-			List<TimestampedFileInputSplit> snapshot = new ArrayList<>(this.pendingSplits.size());
-			if (currentSplit != null) {
-				if (this.format instanceof CheckpointableInputFormat && this.isSplitOpen) {
-					Serializable formatState =
-						((CheckpointableInputFormat<TimestampedFileInputSplit, Serializable>) this.format).getCurrentState();
-					this.currentSplit.setSplitState(formatState);
-				}
-				snapshot.add(this.currentSplit);
-			}
-			snapshot.addAll(this.pendingSplits);
-			return snapshot;
-		}
-
-		public void cancel() {
-			this.isRunning = false;
-		}
-
-		public void close() {
-			this.shouldClose = true;
+		currentSplit = null;
+		if (firstException != null) {
+			throw new FlinkRuntimeException("Unable to properly cleanup ContinuousFileReaderOperator", firstException);
 		}
 	}
-
-	//	---------------------			Checkpointing			--------------------------
 
 	@Override
 	public void snapshotState(StateSnapshotContext context) throws Exception {
@@ -405,23 +469,42 @@ public class ContinuousFileReaderOperator<OUT> extends AbstractStreamOperator<OU
 
 		checkpointedState.clear();
 
-		List<TimestampedFileInputSplit> readerState = reader.getReaderState();
+		List<TimestampedFileInputSplit> readerState = getReaderState();
 
 		try {
 			for (TimestampedFileInputSplit split : readerState) {
-				// create a new partition for each entry.
 				checkpointedState.add(split);
 			}
 		} catch (Exception e) {
 			checkpointedState.clear();
 
 			throw new Exception("Could not add timestamped file input splits to to operator " +
-				"state backend of operator " + getOperatorName() + '.', e);
+					"state backend of operator " + getOperatorName() + '.', e);
 		}
 
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("{} (taskIdx={}) checkpointed {} splits: {}.",
-				getClass().getSimpleName(), subtaskIdx, readerState.size(), readerState);
+					getClass().getSimpleName(), subtaskIdx, readerState.size(), readerState);
 		}
 	}
+
+	private List<TimestampedFileInputSplit> getReaderState() throws IOException {
+		List<TimestampedFileInputSplit> snapshot = new ArrayList<>(splits.size());
+		if (currentSplit != null) {
+			if (this.format instanceof CheckpointableInputFormat && state == ReaderState.READING) {
+				Serializable formatState =
+						((CheckpointableInputFormat<TimestampedFileInputSplit, Serializable>) this.format).getCurrentState();
+				this.currentSplit.setSplitState(formatState);
+			}
+			snapshot.add(this.currentSplit);
+		}
+		snapshot.addAll(splits);
+		return snapshot;
+	}
+
+	@Override
+	public void setOutputType(TypeInformation<OUT> outTypeInfo, ExecutionConfig executionConfig) {
+		this.serializer = outTypeInfo.createSerializer(executionConfig);
+	}
+
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperatorFactory.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.source;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.io.FileInputFormat;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.MailboxExecutor;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.YieldingOperatorFactory;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+
+/**
+ * {@link ContinuousFileReaderOperator} factory.
+ */
+public class ContinuousFileReaderOperatorFactory<OUT> implements YieldingOperatorFactory<OUT>, OneInputStreamOperatorFactory<TimestampedFileInputSplit, OUT> {
+
+	private ChainingStrategy strategy;
+	private final FileInputFormat<OUT> inputFormat;
+	private TypeInformation<OUT> type;
+	private ExecutionConfig executionConfig;
+	private transient MailboxExecutor mailboxExecutor;
+
+	public ContinuousFileReaderOperatorFactory(FileInputFormat<OUT> inputFormat) {
+		this.inputFormat = inputFormat;
+	}
+
+	@Override
+	public void setMailboxExecutor(MailboxExecutor mailboxExecutor) {
+		this.mailboxExecutor = mailboxExecutor;
+	}
+
+	@Override
+	public StreamOperator createStreamOperator(StreamTask containingTask, StreamConfig config, Output output) {
+		ContinuousFileReaderOperator<OUT> operator = new ContinuousFileReaderOperator<>(inputFormat, mailboxExecutor);
+		operator.setup(containingTask, config, output);
+		operator.setOutputType(type, executionConfig);
+		return operator;
+	}
+
+	@Override
+	public void setOutputType(TypeInformation<OUT> type, ExecutionConfig executionConfig) {
+		this.type = type;
+		this.executionConfig = executionConfig;
+	}
+
+	@Override
+	public void setChainingStrategy(ChainingStrategy strategy) {
+		this.strategy = strategy;
+	}
+
+	@Override
+	public ChainingStrategy getChainingStrategy() {
+		return strategy;
+	}
+
+	@Override
+	public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+		return ContinuousFileReaderOperator.class;
+	}
+
+	@Override
+	public boolean isOutputTypeConfigurable() {
+		return true;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
@@ -62,10 +62,10 @@ public class MailboxProcessor implements Closeable {
 	private static final Logger LOG = LoggerFactory.getLogger(MailboxProcessor.class);
 
 	/** The mailbox data-structure that manages request for special actions, like timers, checkpoints, ... */
-	private final TaskMailbox mailbox;
+	protected final TaskMailbox mailbox;
 
 	/** Action that is repeatedly executed if no action request is in the mailbox. Typically record processing. */
-	private final MailboxDefaultAction mailboxDefaultAction;
+	protected final MailboxDefaultAction mailboxDefaultAction;
 
 	/** A pre-created instance of mailbox executor that executes all mails. */
 	private final MailboxExecutor mainMailboxExecutor;
@@ -285,7 +285,7 @@ public class MailboxProcessor implements Closeable {
 		return suspendedDefaultAction != null;
 	}
 
-	private boolean isMailboxLoopRunning() {
+	protected boolean isMailboxLoopRunning() {
 		return mailboxLoopRunning;
 	}
 
@@ -303,11 +303,11 @@ public class MailboxProcessor implements Closeable {
 	 * Implementation of {@link MailboxDefaultAction.Controller} that is connected to a {@link MailboxProcessor}
 	 * instance.
 	 */
-	private static final class MailboxController implements MailboxDefaultAction.Controller {
+	protected static final class MailboxController implements MailboxDefaultAction.Controller {
 
 		private final MailboxProcessor mailboxProcessor;
 
-		private MailboxController(MailboxProcessor mailboxProcessor) {
+		protected MailboxController(MailboxProcessor mailboxProcessor) {
 			this.mailboxProcessor = mailboxProcessor;
 		}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/SteppingMailboxProcessor.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/SteppingMailboxProcessor.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.mailbox;
+
+import org.apache.flink.streaming.api.operators.MailboxExecutor;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
+
+import java.util.Optional;
+
+import static org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox.MIN_PRIORITY;
+
+/**
+ * A {@link MailboxProcessor} that allows to execute one mail at a time.
+ */
+public class SteppingMailboxProcessor extends MailboxProcessor {
+	public SteppingMailboxProcessor(MailboxDefaultAction mailboxDefaultAction) {
+		super(mailboxDefaultAction);
+	}
+
+	public SteppingMailboxProcessor(MailboxDefaultAction mailboxDefaultAction, StreamTaskActionExecutor actionExecutor) {
+		super(mailboxDefaultAction, actionExecutor);
+	}
+
+	public SteppingMailboxProcessor(MailboxDefaultAction mailboxDefaultAction, TaskMailbox mailbox, StreamTaskActionExecutor actionExecutor) {
+		super(mailboxDefaultAction, mailbox, actionExecutor);
+	}
+
+	public SteppingMailboxProcessor(MailboxDefaultAction mailboxDefaultAction, StreamTaskActionExecutor actionExecutor, TaskMailbox mailbox, MailboxExecutor mainMailboxExecutor) {
+		super(mailboxDefaultAction, actionExecutor, mailbox, mainMailboxExecutor);
+	}
+
+	public void runMailboxStep() throws Exception {
+		assert mailbox.getState() == TaskMailbox.State.OPEN : "Mailbox must be opened!";
+		final MailboxController defaultActionContext = new MailboxController(this);
+
+		Optional<Mail> maybeMail;
+		if (isMailboxLoopRunning() && (maybeMail = mailbox.tryTake(MIN_PRIORITY)).isPresent()) {
+			maybeMail.get().run();
+			return;
+		}
+		mailboxDefaultAction.runDefaultAction(defaultActionContext);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -66,6 +66,8 @@ import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox;
+import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxImpl;
 import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.Preconditions;
 
@@ -114,6 +116,8 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 	protected StreamTaskStateInitializer streamTaskStateInitializer;
 
 	CloseableRegistry closableRegistry;
+
+	private final TaskMailbox taskMailbox;
 
 	// use this as default for tests
 	protected StateBackend stateBackend = new MemoryStateBackend();
@@ -247,6 +251,8 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 			wasFailedExternally = true;
 		};
 
+		this.taskMailbox = new TaskMailboxImpl();
+
 		mockTask = new MockStreamTaskBuilder(env)
 			.setCheckpointLock(checkpointLock)
 			.setConfig(config)
@@ -256,6 +262,7 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 			.setCheckpointStorage(checkpointStorage)
 			.setTimerService(processingTimeService)
 			.setHandleAsyncException(handleAsyncException)
+			.setTaskMailbox(taskMailbox)
 			.build();
 	}
 
@@ -652,6 +659,11 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 	@VisibleForTesting
 	public StreamStatus getStreamStatus() {
 		return mockTask.getStreamStatusMaintainer().getStreamStatus();
+	}
+
+	@VisibleForTesting
+	public TaskMailbox getTaskMailbox() {
+		return taskMailbox;
 	}
 
 	private class MockOutput implements Output<StreamRecord<OUT>> {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
@@ -23,14 +23,17 @@ import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.state.CheckpointStorageWorkerView;
+import org.apache.flink.runtime.util.FatalExitExceptionHandler;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
 import org.apache.flink.streaming.runtime.tasks.TimerService;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxDefaultAction;
+import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox;
 
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -64,9 +67,11 @@ public class MockStreamTask<OUT, OP extends StreamOperator<OUT>> extends StreamT
 		CheckpointStorageWorkerView checkpointStorage,
 		TimerService timerService,
 		BiConsumer<String, Throwable> handleAsyncException,
-		Map<String, Accumulator<?, ?>> accumulatorMap
+		Map<String, Accumulator<?, ?>> accumulatorMap,
+		TaskMailbox taskMailbox,
+		StreamTaskActionExecutor.SynchronizedStreamTaskActionExecutor taskActionExecutor
 	) {
-		super(environment, timerService);
+		super(environment, timerService, FatalExitExceptionHandler.INSTANCE, taskActionExecutor, taskMailbox);
 		this.name = name;
 		this.checkpointLock = checkpointLock;
 		this.config = config;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTaskBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTaskBuilder.java
@@ -33,8 +33,11 @@ import org.apache.flink.streaming.api.operators.MockStreamStatusMaintainer;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializerImpl;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.TimerService;
+import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox;
+import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxImpl;
 
 import java.util.Collections;
 import java.util.Map;
@@ -56,6 +59,8 @@ public class MockStreamTaskBuilder {
 	private StreamTaskStateInitializer streamTaskStateInitializer;
 	private BiConsumer<String, Throwable> handleAsyncException = (message, throwable) -> { };
 	private Map<String, Accumulator<?, ?>> accumulatorMap = Collections.emptyMap();
+	private TaskMailbox taskMailbox = new TaskMailboxImpl();
+	private StreamTaskActionExecutor.SynchronizedStreamTaskActionExecutor taskActionExecutor = StreamTaskActionExecutor.synchronizedExecutor();
 
 	public MockStreamTaskBuilder(Environment environment) throws Exception {
 		this.environment = environment;
@@ -115,6 +120,16 @@ public class MockStreamTaskBuilder {
 		return this;
 	}
 
+	public MockStreamTaskBuilder setTaskMailbox(TaskMailbox taskMailbox) {
+		this.taskMailbox = taskMailbox;
+		return this;
+	}
+
+	public MockStreamTaskBuilder setTaskActionExecutor(StreamTaskActionExecutor.SynchronizedStreamTaskActionExecutor taskActionExecutor) {
+		this.taskActionExecutor = taskActionExecutor;
+		return this;
+	}
+
 	public MockStreamTask build() {
 		return new MockStreamTask(
 			environment,
@@ -128,6 +143,8 @@ public class MockStreamTaskBuilder {
 			checkpointStorage,
 			timerService,
 			handleAsyncException,
-			accumulatorMap);
+			accumulatorMap,
+			taskMailbox,
+			taskActionExecutor);
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
@@ -169,4 +169,5 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
 	public long getCurrentWatermark() {
 		return currentWatermark;
 	}
+
 }


### PR DESCRIPTION
## What is the purpose of the change

Use mailbox execution model in `ContinuousFileReaderOperator`.
This allows to avoid explicit synchronization and eventually to remove `StreamTask.getCheckpointLock()`.

ContinuousFileReaderOperator was changed significantly to avoid
having an unnecessary now separate thread
and extra synchronization between blocking and non-blocking code (e.g.
format.reachedEnd and nextRecord)

Performance is lower by ~15% because of the overhead of enqueueing and processing each mail (instead of just loop).


## Brief change log

  - *Currently, `ContinuousFileReaderOperator` spawn a thread to process file contents and acquires checkpoiint lock to process each record*
  - *The new implementation enqueues a `Mail` to be executed by `MailboxProcessor` - one record at a time, until end of split is reached*
  - *ContinuousFileProcessingRescalingTest refactored and updated to work with the new model*

## Verifying this change

This change is already covered by existing tests, such as *ContinuousFileProcessingRescalingTest, ContinuousFileProcessingTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **yes, for ContinuousFileReaderOperator**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **yes, ContinuousFileReaderOperator state** (no user-visible changes)
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
