### PR TITLE
[FLINK-15068][rocksdb] stop writing to RocksDB logs by default

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/DefaultConfigurableOptionsFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/DefaultConfigurableOptionsFactory.java
@@ -51,10 +51,8 @@ import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOption
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.WRITE_BUFFER_SIZE;
 
 /**
- * An implementation of {@link ConfigurableOptionsFactory} using options provided by {@link RocksDBConfigurableOptions}
- * and acted as the default options factory within {@link RocksDBStateBackend} if user not defined a {@link OptionsFactory}.
- *
- * <p>This implementation also provide some setters to let user could create a {@link OptionsFactory} conveniently。
+ * An implementation of {@link ConfigurableOptionsFactory} using options provided by {@link RocksDBConfigurableOptions}.
+ * It acts as the default options factory within {@link RocksDBStateBackend} if the user did not define a {@link OptionsFactory}.
  */
 public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFactory {
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
@@ -23,6 +23,7 @@ import org.rocksdb.BloomFilter;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.CompactionStyle;
 import org.rocksdb.DBOptions;
+import org.rocksdb.InfoLogLevel;
 
 /**
  * The {@code PredefinedOptions} are configuration settings for the {@link RocksDBStateBackend}.
@@ -31,6 +32,9 @@ import org.rocksdb.DBOptions;
  *
  * <p>Some of these settings are based on experiments by the Flink community, some follow
  * guides from the RocksDB project.
+ *
+ * <p>All of them effectively disable the RocksDB log by default because this file would grow
+ * indefinitely and will be deleted with the TM anyway.
  */
 public enum PredefinedOptions {
 
@@ -40,13 +44,22 @@ public enum PredefinedOptions {
 	 *
 	 * <p>Note: Because Flink does not rely on RocksDB data on disk for recovery,
 	 * there is no need to sync data to stable storage.
+	 *
+	 * <p>The following options are set:
+	 * <ul>
+	 *     <li>setUseFsync(false)</li>
+	 *     <li>setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)</li>
+	 *     <li>setStatsDumpPeriodSec(0)</li>
+	 * </ul>
 	 */
 	DEFAULT {
 
 		@Override
 		public DBOptions createDBOptions() {
 			return new DBOptions()
-					.setUseFsync(false);
+					.setUseFsync(false)
+					.setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)
+					.setStatsDumpPeriodSec(0);
 		}
 
 		@Override
@@ -71,6 +84,8 @@ public enum PredefinedOptions {
 	 *     <li>setUseFsync(false)</li>
 	 *     <li>setDisableDataSync(true)</li>
 	 *     <li>setMaxOpenFiles(-1)</li>
+	 *     <li>setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)</li>
+	 *     <li>setStatsDumpPeriodSec(0)</li>
 	 * </ul>
 	 *
 	 * <p>Note: Because Flink does not rely on RocksDB data on disk for recovery,
@@ -84,7 +99,9 @@ public enum PredefinedOptions {
 			return new DBOptions()
 					.setIncreaseParallelism(4)
 					.setUseFsync(false)
-					.setMaxOpenFiles(-1);
+					.setMaxOpenFiles(-1)
+					.setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)
+					.setStatsDumpPeriodSec(0);
 		}
 
 		@Override
@@ -114,6 +131,8 @@ public enum PredefinedOptions {
 	 *     <li>setMaxWriteBufferNumber(4)</li>
 	 *     <li>setUseFsync(false)</li>
 	 *     <li>setMaxOpenFiles(-1)</li>
+	 *     <li>setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)</li>
+	 *     <li>setStatsDumpPeriodSec(0)</li>
 	 *     <li>BlockBasedTableConfig.setBlockCacheSize(256 MBytes)</li>
 	 *     <li>BlockBasedTableConfigsetBlockSize(128 KBytes)</li>
 	 * </ul>
@@ -129,7 +148,9 @@ public enum PredefinedOptions {
 			return new DBOptions()
 					.setIncreaseParallelism(4)
 					.setUseFsync(false)
-					.setMaxOpenFiles(-1);
+					.setMaxOpenFiles(-1)
+					.setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)
+					.setStatsDumpPeriodSec(0);
 		}
 
 		@Override
@@ -169,6 +190,8 @@ public enum PredefinedOptions {
 	 *     <li>setUseFsync(false)</li>
 	 *     <li>setDisableDataSync(true)</li>
 	 *     <li>setMaxOpenFiles(-1)</li>
+	 *     <li>setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)</li>
+	 *     <li>setStatsDumpPeriodSec(0)</li>
 	 * </ul>
 	 *
 	 * <p>Note: Because Flink does not rely on RocksDB data on disk for recovery,
@@ -181,7 +204,9 @@ public enum PredefinedOptions {
 			return new DBOptions()
 					.setIncreaseParallelism(4)
 					.setUseFsync(false)
-					.setMaxOpenFiles(-1);
+					.setMaxOpenFiles(-1)
+					.setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)
+					.setStatsDumpPeriodSec(0);
 		}
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change

With Flink's default settings for RocksDB, it will write a `LOG` file (not the WAL, but pure logging statements) into the data folder. Besides periodic statistics, it will log compaction attempts, new memtable creations, flushes, etc. This file grows indefinitely and may fill the disk without this log being actually used anywhere (it will be deleted with the job anway).

With this PR, we are effectively disabling the log by default. If anyone wants to retain it, it can be re-configured at will providing an own `OptionsFactory`.

## Brief change log

- change the default RocksDB configuration for all `PredefinedOptions`
so that they use log level `HEADER_LEVEL`
- disable periodic statistics dumps to the `LOG` file
- hotfix the description of the `DefaultConfigurableOptionsFactory`

## Verifying this change

I ran a Flink cluster with these changes and the `LOG` file now only contains some headers and is then never written to again. Normal behaviour is otherwise covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **JavaDocs**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/flink/10437)
<!-- Reviewable:end -->
