### PR TITLE
[FLINK-14857][runtime] Remove checkpoint lock usage from AsyncWaitOperator.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
@@ -89,8 +89,6 @@ public class AsyncWaitOperator<IN, OUT>
 	/** Timeout for the async collectors. */
 	private final long timeout;
 
-	private transient Object checkpointingLock;
-
 	/** {@link TypeSerializer} for inputs while making snapshots. */
 	private transient StreamElementSerializer<IN> inStreamElementSerializer;
 
@@ -130,8 +128,6 @@ public class AsyncWaitOperator<IN, OUT>
 	@Override
 	public void setup(StreamTask<?, ?> containingTask, StreamConfig config, Output<StreamRecord<OUT>> output) {
 		super.setup(containingTask, config, output);
-
-		this.checkpointingLock = getContainingTask().getCheckpointLock();
 
 		this.inStreamElementSerializer = new StreamElementSerializer<>(
 			getOperatorConfig().<IN>getTypeSerializerIn1(getUserCodeClassloader()));
@@ -255,7 +251,6 @@ public class AsyncWaitOperator<IN, OUT>
 	 * @return a handle that allows to set the result of the async computation for the given element.
 	 */
 	private ResultFuture<OUT> addToWorkQueue(StreamElement streamElement) throws InterruptedException {
-		assert(Thread.holdsLock(checkpointingLock));
 
 		Optional<ResultFuture<OUT>> queueEntry;
 		while (!(queueEntry = queue.tryPut(streamElement)).isPresent()) {
@@ -266,7 +261,6 @@ public class AsyncWaitOperator<IN, OUT>
 	}
 
 	private void waitInFlightInputsFinished() throws InterruptedException {
-		assert(Thread.holdsLock(checkpointingLock));
 
 		while (!queue.isEmpty()) {
 			mailboxExecutor.yield();
@@ -282,9 +276,7 @@ public class AsyncWaitOperator<IN, OUT>
 	private void outputCompletedElement() {
 		if (queue.hasCompletedElements()) {
 			// emit only one element to not block the mailbox thread unnecessarily
-			synchronized (checkpointingLock) {
-				queue.emitCompletedElement(timestampedCollector);
-			}
+			queue.emitCompletedElement(timestampedCollector);
 			// if there are more completed elements, emit them with subsequent mails
 			if (queue.hasCompletedElements()) {
 				mailboxExecutor.execute(this::outputCompletedElement, "AsyncWaitOperator#outputCompletedElement");


### PR DESCRIPTION
## What is the purpose of the change

This PR removes remaining `checkpoint lock` usages from `AsyncWaitOperator`.
After 9b3a0b54e2eb2d29805365a3a6c2c9bd9330fd1c every Mail action
acquires checkpoint lock automatically and all state-modifying actions
in `AsyncWaitOperator` are already executed as mails.

## Verifying this change

This change is already covered by existing tests, such as *`AsyncWaitOperatorTest`*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
