### PR TITLE
[FLINK-15080][fs][oss] Enable deployment

### DIFF
--- a/flink-filesystems/flink-oss-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-oss-fs-hadoop/pom.xml
@@ -98,16 +98,6 @@ under the License.
 	<build>
 		<plugins>
 
-			<!-- this is merely an intermediate build artifact and should not be -->
-			<!-- deployed to maven central                                       -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-deploy-plugin</artifactId>
-				<configuration>
-					<skip>true</skip>
-				</configuration>
-			</plugin>
-
 			<!-- Relocate all OSS related classes -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Enables the deployment of the OSS filesystem.

I see no reason why it shouldn't be deployed like all other filesystems.