### PR TITLE
[FLINK-11524][tests] Print failure cause if job failed

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobResultUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobResultUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.utils;
+
+import org.apache.flink.runtime.jobmaster.JobResult;
+
+/**
+ * Testing utils surrounding the {@link JobResult}.
+ */
+public final class JobResultUtils {
+	public static void assertSuccess(final JobResult result) {
+		if (!result.isSuccess()) {
+			if (result.getSerializedThrowable().isPresent()) {
+				throw new AssertionError("Job failed.", result.getSerializedThrowable().get().deserializeError(JobResultUtils.class.getClassLoader()));
+			} else {
+				throw new AssertionError("Job was not successful but did not fail with an error.");
+			}
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderChangeClusterComponentsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderChangeClusterComponentsTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmaster.JobNotFinishedException;
 import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.jobmaster.utils.JobResultUtils;
 import org.apache.flink.runtime.minicluster.TestingMiniCluster;
 import org.apache.flink.runtime.minicluster.TestingMiniClusterConfiguration;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
@@ -128,7 +129,7 @@ public class LeaderChangeClusterComponentsTest extends TestLogger {
 
 		JobResult jobResult = jobResultFuture2.get();
 
-		assertThat(jobResult.isSuccess(), is(true));
+		JobResultUtils.assertSuccess(jobResult);
 	}
 
 	@Test
@@ -148,7 +149,7 @@ public class LeaderChangeClusterComponentsTest extends TestLogger {
 
 		JobResult jobResult = jobResultFuture.get();
 
-		assertThat(jobResult.isSuccess(), is(true));
+		JobResultUtils.assertSuccess(jobResult);
 	}
 
 	@Test


### PR DESCRIPTION
Enhances the `LeaderChangeClusterComponentsTest` to re-throw the returned exception if the job failed.