### PR TITLE
[FLINK-14407][yarn] Retry S3 tests on failure

### DIFF
--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTestS3ITCase.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTestS3ITCase.java
@@ -23,6 +23,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.fs.hdfs.HadoopFileSystem;
+import org.apache.flink.testutils.junit.RetryOnFailure;
+import org.apache.flink.testutils.junit.RetryRule;
 import org.apache.flink.testutils.s3.S3TestCredentials;
 import org.apache.flink.util.TestLogger;
 
@@ -60,6 +62,9 @@ public class YarnFileStageTestS3ITCase extends TestLogger {
 
 	@Rule
 	public final TemporaryFolder tempFolder = new TemporaryFolder();
+
+	@Rule
+	public final RetryRule retryRule = new RetryRule();
 
 	/**
 	 * Number of tests executed.
@@ -165,6 +170,7 @@ public class YarnFileStageTestS3ITCase extends TestLogger {
 	}
 
 	@Test
+	@RetryOnFailure(times = 3)
 	public void testRecursiveUploadForYarnS3n() throws Exception {
 		try {
 			Class.forName("org.apache.hadoop.fs.s3native.NativeS3FileSystem");
@@ -178,6 +184,7 @@ public class YarnFileStageTestS3ITCase extends TestLogger {
 	}
 
 	@Test
+	@RetryOnFailure(times = 3)
 	public void testRecursiveUploadForYarnS3a() throws Exception {
 		try {
 			Class.forName("org.apache.hadoop.fs.s3a.S3AFileSystem");


### PR DESCRIPTION
Adds a `RetryRule` to the `YarnFileStageTestS3ITCase` to alleviate issues when read-after-write operations aren't as reliable as we'd like them to be.