### PR TITLE
[FLINK-15076][task] Fix SourceStreamTask cancellation

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -131,8 +131,13 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 
 	@Override
 	protected void cancelTask() {
-		if (headOperator != null) {
-			headOperator.cancel();
+		try {
+			if (headOperator != null) {
+				headOperator.cancel();
+			}
+		}
+		finally {
+			sourceThread.interrupt();
 		}
 	}
 
@@ -191,6 +196,7 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 				headOperator.run(getCheckpointLock(), getStreamStatusMaintainer(), operatorChain);
 				completionFuture.complete(null);
 			} catch (Throwable t) {
+				// Note, t can be also an InterruptedException
 				completionFuture.completeExceptionally(t);
 			}
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/Mail.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/Mail.java
@@ -19,7 +19,6 @@ package org.apache.flink.streaming.runtime.tasks.mailbox;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
-import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.function.RunnableWithException;
 
@@ -76,10 +75,6 @@ public class Mail {
 	}
 
 	public void run() throws Exception {
-		try {
-			actionExecutor.run(runnable);
-		} catch (Exception e) {
-			throw new FlinkException("Cannot process mail " + toString(), e);
-		}
+		actionExecutor.run(runnable);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
@@ -198,6 +198,9 @@ public class MailboxProcessor implements Closeable {
 				if (throwable instanceof Exception) {
 					throw (Exception) throwable;
 				}
+				else if (throwable instanceof Error) {
+					throw (Error) throwable;
+				}
 				else {
 					throw WrappingRuntimeException.wrapIfNecessary(throwable);
 				}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
@@ -195,7 +195,12 @@ public class MailboxProcessor implements Closeable {
 	public void reportThrowable(Throwable throwable) {
 		sendControlMail(
 			() -> {
-				throw WrappingRuntimeException.wrapIfNecessary(throwable);
+				if (throwable instanceof Exception) {
+					throw (Exception) throwable;
+				}
+				else {
+					throw WrappingRuntimeException.wrapIfNecessary(throwable);
+				}
 			},
 			"Report throwable %s", throwable);
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -229,7 +229,9 @@ public class SourceStreamTaskTest {
 		try {
 			testHarness.waitForTaskCompletion();
 		} catch (Throwable t) {
-			assertTrue(ExceptionUtils.findThrowable(t, CancelTaskException.class).isPresent());
+			if (!ExceptionUtils.findThrowable(t, CancelTaskException.class).isPresent()) {
+				throw t;
+			}
 		}
 
 		expectedOutput.add(new StreamRecord<>("Hello"));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.operators.testutils.ExpectedTestException;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
 import org.apache.flink.streaming.api.functions.source.FromElementsFunction;
@@ -54,6 +55,7 @@ import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -62,6 +64,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.flink.util.Preconditions.checkState;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -239,6 +242,191 @@ public class SourceStreamTaskTest {
 		TestHarnessUtil.assertOutputEquals("Output was not correct.",
 			expectedOutput,
 			testHarness.getOutput());
+	}
+
+	@Test
+	public void testCancellationWithSourceBlockedOnLock() throws Exception {
+		testCancellationWithSourceBlockedOnLock(false, false);
+	}
+
+	@Test
+	public void testCancellationWithSourceBlockedOnLockWithPendingMail() throws Exception {
+		testCancellationWithSourceBlockedOnLock(true, false);
+	}
+
+	@Test
+	public void testCancellationWithSourceBlockedOnLockAndThrowingOnError() throws Exception {
+		testCancellationWithSourceBlockedOnLock(false, true);
+	}
+
+	@Test
+	public void testCancellationWithSourceBlockedOnLockWithPendingMailAndThrowingOnError() throws Exception {
+		testCancellationWithSourceBlockedOnLock(true, true);
+	}
+
+	/**
+	 * Note that this test is testing also for the shared cancellation logic inside {@link StreamTask}
+	 * which, as of the time this test is being written, is not tested anywhere else
+	 * (like {@link StreamTaskTest} or {@link OneInputStreamTaskTest}).
+	 */
+	public void testCancellationWithSourceBlockedOnLock(boolean withPendingMail, boolean throwInCancel) throws Exception {
+		final StreamTaskTestHarness<String> testHarness = new StreamTaskTestHarness<>(
+			SourceStreamTask::new,
+			BasicTypeInfo.STRING_TYPE_INFO);
+
+		CancelLockingSource.reset();
+		testHarness
+			.setupOperatorChain(
+				new OperatorID(),
+				new StreamSource<>(new CancelLockingSource(throwInCancel)))
+			.chain(
+				new OperatorID(),
+				new TestBoundedOneInputStreamOperator("Operator1"),
+				BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()))
+			.finish();
+
+		StreamConfig streamConfig = testHarness.getStreamConfig();
+		streamConfig.setTimeCharacteristic(TimeCharacteristic.ProcessingTime);
+
+		testHarness.invoke();
+		CancelLockingSource.awaitRunning();
+		if (withPendingMail) {
+			// This pending mail should be blocked on checkpointLock acquisition, blocking the
+			// mailbox (task) thread.
+			testHarness.getTask().getMailboxExecutorFactory().createExecutor(0).execute(
+				() -> assertFalse(
+					"This should never execute before task cancelation",
+					testHarness.getTask().isRunning()),
+				"Test");
+		}
+
+		try {
+			testHarness.getTask().cancel();
+		}
+		catch (ExpectedTestException e) {
+			checkState(throwInCancel);
+		}
+
+		try {
+			testHarness.waitForTaskCompletion();
+		} catch (Throwable t) {
+			if (!ExceptionUtils.findThrowable(t, CancelTaskException.class).isPresent()) {
+				throw t;
+			}
+		}
+	}
+
+	/**
+	 * A source that locks if cancellation attempts to cleanly shut down.
+	 */
+	public static class CancelLockingSource implements SourceFunction<String> {
+		private static final long serialVersionUID = 8713065281092996042L;
+
+		private static CompletableFuture<Void> isRunning = new CompletableFuture<>();
+
+		private final boolean throwOnCancel;
+
+		private volatile boolean cancelled = false;
+
+		public CancelLockingSource(boolean throwOnCancel) {
+			this.throwOnCancel = throwOnCancel;
+		}
+
+		public static void reset() {
+			isRunning = new CompletableFuture<>();
+		}
+
+		public static void awaitRunning() throws ExecutionException, InterruptedException {
+			isRunning.get();
+		}
+
+		@Override
+		public void run(SourceContext<String> ctx) throws Exception {
+			synchronized (ctx.getCheckpointLock()) {
+				while (!cancelled) {
+					isRunning.complete(null);
+
+					if (throwOnCancel) {
+						Thread.sleep(1000000000);
+					}
+					else {
+						try {
+							//noinspection SleepWhileHoldingLock
+							Thread.sleep(1000000000);
+						} catch (InterruptedException ignored) {
+						}
+					}
+				}
+			}
+		}
+
+		@Override
+		public void cancel() {
+			if (throwOnCancel) {
+				throw new ExpectedTestException();
+			}
+			cancelled = true;
+		}
+	}
+
+	@Test
+	public void testInterruptedNotSwallowed() throws Exception {
+		final StreamTaskTestHarness<String> testHarness = new StreamTaskTestHarness<>(
+			SourceStreamTask::new,
+			BasicTypeInfo.STRING_TYPE_INFO);
+
+		CancelLockingSource.reset();
+		testHarness
+			.setupOperatorChain(
+				new OperatorID(),
+				new StreamSource<>(new InterruptedSource()))
+			.chain(
+				new OperatorID(),
+				new TestBoundedOneInputStreamOperator("Operator1"),
+				BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()))
+			.finish();
+
+		StreamConfig streamConfig = testHarness.getStreamConfig();
+		streamConfig.setTimeCharacteristic(TimeCharacteristic.ProcessingTime);
+
+		testHarness.invoke();
+		try {
+			testHarness.waitForTaskCompletion();
+		} catch (Exception e) {
+			if (!(e.getCause() instanceof InterruptedException)) {
+				throw e;
+			}
+		}
+	}
+
+	/**
+	 * A source that locks if cancellation attempts to cleanly shut down.
+	 */
+	public static class InterruptedSource implements SourceFunction<String> {
+		private static final long serialVersionUID = 8713065281092996042L;
+
+		private static CompletableFuture<Void> isRunning = new CompletableFuture<>();
+
+		public static void reset() {
+			isRunning = new CompletableFuture<>();
+		}
+
+		public static void awaitRunning() throws ExecutionException, InterruptedException {
+			isRunning.get();
+		}
+
+		@Override
+		public void run(SourceContext<String> ctx) throws Exception {
+			synchronized (ctx.getCheckpointLock()) {
+				isRunning.complete(null);
+				Thread.currentThread().interrupt();
+				throw new InterruptedException();
+			}
+		}
+
+		@Override
+		public void cancel() {
+		}
 	}
 
 	/**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -315,7 +315,7 @@ public class StreamTaskTest extends TestLogger {
 	}
 
 	@Test
-	public void testCancellationFailsWithBlockingLock() throws Exception {
+	public void testCanceleablesCanceledOnCancelTaskError() throws Exception {
 		syncLatch = new OneShotLatch();
 
 		StreamConfig cfg = new StreamConfig(new Configuration());
@@ -332,6 +332,99 @@ public class StreamTaskTest extends TestLogger {
 		task.getExecutingThread().join();
 
 		assertEquals(ExecutionState.CANCELED, task.getExecutionState());
+	}
+
+	/**
+	 * A task that locks for ever, fail in {@link #cancelTask()}. It can be only shut down cleanly
+	 * if {@link StreamTask#getCancelables()} are closed properly.
+	 */
+	public static class CancelFailingTask extends StreamTask<String, AbstractStreamOperator<String>> {
+
+		public CancelFailingTask(Environment env) {
+			super(env);
+		}
+
+		@Override
+		protected void init() {}
+
+		@Override
+		protected void processInput(MailboxDefaultAction.Controller controller) throws Exception {
+			final OneShotLatch latch = new OneShotLatch();
+			final Object lock = new Object();
+
+			LockHolder holder = new LockHolder(lock, latch);
+			holder.start();
+			try {
+				// cancellation should try and cancel this
+				getCancelables().registerCloseable(holder);
+
+				// wait till the lock holder has the lock
+				latch.await();
+
+				// we are at the point where cancelling can happen
+				syncLatch.trigger();
+
+				// try to acquire the lock - this is not possible as long as the lock holder
+				// thread lives
+				//noinspection SynchronizationOnLocalVariableOrMethodParameter
+				synchronized (lock) {
+					// nothing
+				}
+			}
+			finally {
+				holder.close();
+			}
+			controller.allActionsCompleted();
+		}
+
+		@Override
+		protected void cleanup() {}
+
+		@Override
+		protected void cancelTask() throws Exception {
+			throw new Exception("test exception");
+		}
+
+		/**
+		 * A thread that holds a lock as long as it lives.
+		 */
+		private static final class LockHolder extends Thread implements Closeable {
+
+			private final OneShotLatch trigger;
+			private final Object lock;
+			private volatile boolean canceled;
+
+			private LockHolder(Object lock, OneShotLatch trigger) {
+				this.lock = lock;
+				this.trigger = trigger;
+			}
+
+			@Override
+			public void run() {
+				synchronized (lock) {
+					while (!canceled) {
+						// signal that we grabbed the lock
+						trigger.trigger();
+
+						// basically freeze this thread
+						try {
+							//noinspection SleepWhileHoldingLock
+							Thread.sleep(1000000000);
+						} catch (InterruptedException ignored) {}
+					}
+				}
+			}
+
+			public void cancel() {
+				canceled = true;
+			}
+
+			@Override
+			public void close() {
+				canceled = true;
+				interrupt();
+			}
+		}
 	}
 
 	@Test
@@ -1360,58 +1453,6 @@ public class StreamTaskTest extends TestLogger {
 		}
 	}
 
-	/**
-	 * A task that locks if cancellation attempts to cleanly shut down.
-	 */
-	public static class CancelFailingTask extends StreamTask<String, AbstractStreamOperator<String>> {
-
-		public CancelFailingTask(Environment env) {
-			super(env);
-		}
-
-		@Override
-		protected void init() {}
-
-		@Override
-		protected void processInput(MailboxDefaultAction.Controller controller) throws Exception {
-			final OneShotLatch latch = new OneShotLatch();
-			final Object lock = new Object();
-
-			LockHolder holder = new LockHolder(lock, latch);
-			holder.start();
-			try {
-				// cancellation should try and cancel this
-				getCancelables().registerCloseable(holder);
-
-				// wait till the lock holder has the lock
-				latch.await();
-
-				// we are at the point where cancelling can happen
-				syncLatch.trigger();
-
-				// try to acquire the lock - this is not possible as long as the lock holder
-				// thread lives
-				//noinspection SynchronizationOnLocalVariableOrMethodParameter
-				synchronized (lock) {
-					// nothing
-				}
-			}
-			finally {
-				holder.close();
-			}
-			controller.allActionsCompleted();
-		}
-
-		@Override
-		protected void cleanup() {}
-
-		@Override
-		protected void cancelTask() throws Exception {
-			throw new Exception("test exception");
-		}
-
-	}
-
 	private static class ThreadInspectingTask extends StreamTask<String, AbstractStreamOperator<String>> {
 
 		private final long taskThreadId;
@@ -1481,47 +1522,6 @@ public class StreamTaskTest extends TestLogger {
 
 	// ------------------------------------------------------------------------
 	// ------------------------------------------------------------------------
-
-	/**
-	 * A thread that holds a lock as long as it lives.
-	 */
-	private static final class LockHolder extends Thread implements Closeable {
-
-		private final OneShotLatch trigger;
-		private final Object lock;
-		private volatile boolean canceled;
-
-		private LockHolder(Object lock, OneShotLatch trigger) {
-			this.lock = lock;
-			this.trigger = trigger;
-		}
-
-		@Override
-		public void run() {
-			synchronized (lock) {
-				while (!canceled) {
-					// signal that we grabbed the lock
-					trigger.trigger();
-
-					// basically freeze this thread
-					try {
-						//noinspection SleepWhileHoldingLock
-						Thread.sleep(1000000000);
-					} catch (InterruptedException ignored) {}
-				}
-			}
-		}
-
-		public void cancel() {
-			canceled = true;
-		}
-
-		@Override
-		public void close() {
-			canceled = true;
-			interrupt();
-		}
-	}
 
 	static class TestStreamSource<OUT, SRC extends SourceFunction<OUT>> extends StreamSource<OUT, SRC> {
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImplTest.java
@@ -37,7 +37,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -150,18 +149,6 @@ public class MailboxExecutorImplTest {
 
 		Assert.assertNull(exceptionReference.get());
 		Assert.assertEquals(Thread.currentThread(), testRunnable.wasExecutedBy());
-	}
-
-	@Test
-	public void testPrettyExceptionMessage() {
-		final String description = "Pretty command description";
-		mailboxExecutor.execute(
-			() -> {
-				throw new RuntimeException("Some random exception");
-			},
-			description);
-		expectedException.expectMessage(containsString(description));
-		mailboxExecutor.tryYield();
 	}
 
 	/**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxProcessorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxProcessorTest.java
@@ -33,9 +33,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
-
 /**
  * Unit tests for {@link MailboxProcessor}.
  */
@@ -59,7 +56,7 @@ public class TaskMailboxProcessorTest {
 
 	@Test
 	public void testSubmittingRunnableWithException() throws Exception {
-		expectedException.expectCause(hasMessage(containsString("Expected")));
+		expectedException.expectMessage("Expected");
 		try (MailboxProcessor mailboxProcessor = new MailboxProcessor(controller -> {})) {
 			final Thread submitThread = new Thread(() -> {
 				mailboxProcessor.getMainMailboxExecutor().execute(


### PR DESCRIPTION
Source thread should be interrupted more or less the same way how task thread is being interrupted. This is important for example as in the scenario presented in the `SourceStreamTaskTest#testCancellationWithSourceBlockedOnLock()`. `SourceFunction` is blocked while holding checkpointLock, which might prevent task thread from cancelling properly if the `SourceFunction` is not interrupted.

## Verifying this change

This change is adding a couple of new test cases in `SourceStreamTask` which supersede an old very similar test from `StreamTask` the a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
