### PR TITLE
[FLINK-15084][runtime] Add shared resources tracking to MemoryManager

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/function/LongFunctionWithException.java
+++ b/flink-core/src/main/java/org/apache/flink/util/function/LongFunctionWithException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util.function;
+
+import org.apache.flink.annotation.Public;
+
+/**
+ * Similar to {@link java.util.function.LongFunction} but can throw {@link Exception}.
+ */
+@Public
+@FunctionalInterface
+public interface LongFunctionWithException<R, E extends Throwable> {
+
+	/**
+	 * Applies this function to the given argument.
+	 *
+	 * @param value the function argument
+	 * @return the function result
+	 */
+	R apply(long value) throws E;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -26,6 +26,8 @@ import org.apache.flink.runtime.util.KeyedBudgetManager;
 import org.apache.flink.runtime.util.KeyedBudgetManager.AcquisitionResult;
 import org.apache.flink.util.MathUtils;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.function.LongFunctionWithException;
+import org.apache.flink.util.function.ThrowingRunnable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +40,7 @@ import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.EnumMap;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -83,6 +86,8 @@ public class MemoryManager {
 
 	private final KeyedBudgetManager<MemoryType> budgetByType;
 
+	private final SharedResources sharedResources;
+
 	/** Flag whether the close() has already been invoked. */
 	private volatile boolean isShutDown;
 
@@ -100,6 +105,7 @@ public class MemoryManager {
 		this.allocatedSegments = new ConcurrentHashMap<>();
 		this.reservedMemory = new ConcurrentHashMap<>();
 		this.budgetByType = new KeyedBudgetManager<>(memorySizeByType, pageSize);
+		this.sharedResources = new SharedResources();
 		verifyIntTotalNumberOfPages(memorySizeByType, budgetByType.maxTotalNumberOfPages());
 
 		LOG.debug(
@@ -536,6 +542,103 @@ public class MemoryManager {
 	}
 
 	// ------------------------------------------------------------------------
+	//  Shared opaque memory resources
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Acquires a shared memory resource, that uses all the memory of this memory manager.
+	 * This method behaves otherwise exactly as {@link #getSharedMemoryResourceForManagedMemory(String, LongFunctionWithException, double)}.
+	 */
+	public <T extends AutoCloseable> OpaqueMemoryResource<T> getSharedMemoryResourceForManagedMemory(
+			String type,
+			LongFunctionWithException<T, Exception> initializer) throws Exception {
+
+		return getSharedMemoryResourceForManagedMemory(type, initializer, 1.0);
+	}
+
+	/**
+	 * Acquires a shared memory resource, identified by a type string. If the resource already exists, this
+	 * returns a descriptor to the resource. If the resource does not yet exist, the given memory fraction
+	 * is reserved and the resource is initialized with that size.
+	 *
+	 * <p>The memory for the resource is reserved from the memory budget of this memory manager (thus
+	 * determining the size of the resource), but resource itself is opaque, meaning the memory manager
+	 * does not understand its structure.
+	 *
+	 * <p>The OpaqueMemoryResource object returned from this method must be closed once not used any further.
+	 * Once all acquisitions have closed the object, the resource itself is closed.
+	 */
+	public <T extends AutoCloseable> OpaqueMemoryResource<T> getSharedMemoryResourceForManagedMemory(
+			String type,
+			LongFunctionWithException<T, Exception> initializer,
+			double fractionToInitializeWith) throws Exception {
+
+		// if we need to allocate the resource (no shared resource allocated, yet), this would be the size to use
+		final long numBytes = computeMemorySize(fractionToInitializeWith);
+
+		// the initializer attempt to reserve the memory before actual initialization
+		final LongFunctionWithException<T, Exception> reserveAndInitialize = (size) -> {
+			try {
+				reserveMemory(type, MemoryType.OFF_HEAP, size);
+			} catch (MemoryReservationException e) {
+				throw new MemoryAllocationException("Could not created the shared memory resource of size " + size +
+					". Not enough memory left to reserve from the slot's managed memory.", e);
+			}
+
+			return initializer.apply(size);
+		};
+
+		// This object identifies the lease in this request. It is used only to identify the release operation.
+		// Using the object to represent the lease is a bit nicer safer than just using a reference counter.
+		final Object leaseHolder = new Object();
+
+		final SharedResources.ResourceAndSize<T> resource =
+				sharedResources.getOrAllocateSharedResource(type, leaseHolder, reserveAndInitialize, numBytes);
+
+		// the actual size may theoretically be different from what we requested, if allocated it was by
+		// someone else before with a different value for fraction (should not happen in practice, though).
+		final long size = resource.size();
+
+		final ThrowingRunnable<Exception> disposer = () -> {
+				final boolean allDisposed = sharedResources.release(type, leaseHolder);
+				if (allDisposed) {
+					releaseMemory(type, MemoryType.OFF_HEAP, size);
+				}
+			};
+
+		return new OpaqueMemoryResource<>(resource.resourceHandle(), size, disposer);
+	}
+
+	/**
+	 * Acquires a shared memory resource, identified by a type string. If the resource already exists, this
+	 * returns a descriptor to the resource. If the resource does not yet exist, the given memory fraction
+	 * is reserved and the resource is initialized with that size.
+	 *
+	 * <p>The memory for the resource is reserved from the memory budget of this memory manager (thus
+	 * determining the size of the resource), but resource itself is opaque, meaning the memory manager
+	 * does not understand its structure.
+	 *
+	 * <p>The OpaqueMemoryResource object returned from this method must be closed once not used any further.
+	 * Once all acquisitions have closed the object, the resource itself is closed.
+	 */
+	public <T extends AutoCloseable> OpaqueMemoryResource<T> getExternalSharedMemoryResource(
+			String type,
+			LongFunctionWithException<T, Exception> initializer,
+			long numBytes) throws Exception {
+
+		// This object identifies the lease in this request. It is used only to identify the release operation.
+		// Using the object to represent the lease is a bit nicer safer than just using a reference counter.
+		final Object leaseHolder = new Object();
+
+		final SharedResources.ResourceAndSize<T> resource =
+				sharedResources.getOrAllocateSharedResource(type, leaseHolder, initializer, numBytes);
+
+		final ThrowingRunnable<Exception> disposer = () -> sharedResources.release(type, leaseHolder);
+
+		return new OpaqueMemoryResource<>(resource.resourceHandle(), resource.size(), disposer);
+	}
+
+	// ------------------------------------------------------------------------
 	//  Properties, sizes and size conversions
 	// ------------------------------------------------------------------------
 
@@ -566,6 +669,16 @@ public class MemoryManager {
 	 */
 	public long getMemorySizeByType(MemoryType memoryType) {
 		return budgetByType.maxTotalBudgetForKey(memoryType);
+	}
+
+	/**
+	 * Returns the total size of the certain type of memory handled by this memory manager.
+	 *
+	 * @param memoryType The type of memory.
+	 * @return The total size of memory.
+	 */
+	public long availableMemory(MemoryType memoryType) {
+		return budgetByType.availableBudgetForKey(memoryType);
 	}
 
 	/**
@@ -705,5 +818,15 @@ public class MemoryManager {
 		public AllocationRequest build() {
 			return new AllocationRequest(owner, output, numberOfPages, types);
 		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  factories for testing
+	// ------------------------------------------------------------------------
+
+	public static MemoryManager forDefaultPageSize(long size) {
+		final Map<MemoryType, Long> memorySizes = new HashMap<>();
+		memorySizes.put(MemoryType.OFF_HEAP, size);
+		return new MemoryManager(memorySizes, DEFAULT_PAGE_SIZE);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/OpaqueMemoryResource.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/OpaqueMemoryResource.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.memory;
+
+import org.apache.flink.util.function.ThrowingRunnable;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * An opaque memory resource, meaning a memory resource not understood by Flink or the JVM.
+ * An example for this is a native resource, like RocksDB's block cache memory pool.
+ *
+ * <p>The resource must be closed after it is not used any more.
+ */
+public final class OpaqueMemoryResource<T> implements AutoCloseable {
+
+	private final T resourceHandle;
+
+	private final long size;
+
+	private final ThrowingRunnable<Exception> disposer;
+
+	private final AtomicBoolean closed = new AtomicBoolean();
+
+	public OpaqueMemoryResource(T resourceHandle, long size, ThrowingRunnable<Exception> disposer) {
+		checkArgument(size >= 0, "size must be >= 0");
+		this.resourceHandle = checkNotNull(resourceHandle, "resourceHandle");
+		this.disposer = checkNotNull(disposer, "disposer");
+		this.size = size;
+	}
+
+	/**
+	 * Gets the handle to the resource.
+	 */
+	public T getResourceHandle() {
+		return resourceHandle;
+	}
+
+	/**
+	 * Gets the size, in bytes.
+	 */
+	public long getSize() {
+		return size;
+	}
+
+	/**
+	 * Releases this resource.
+	 * This method is idempotent.
+	 */
+	@Override
+	public void close() throws Exception {
+		if (closed.compareAndSet(false, true)) {
+			disposer.run();
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "OpaqueMemoryResource (" + size + " bytes) @ " + resourceHandle + (closed.get() ? " (disposed)" : "");
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/SharedResources.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/SharedResources.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.memory;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.util.function.LongFunctionWithException;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * A map that keeps track of acquired shared resources and handles their allocation disposal.
+ */
+final class SharedResources {
+
+	private final ReentrantLock lock = new ReentrantLock();
+
+	private final HashMap<String, LeasedResource<?>> reservedResources = new HashMap<>();
+
+	/**
+	 * Gets the shared memory resource for the given owner and registers a lease. If the resource
+	 * does not yet exist, it will be created via the given initializer function.
+	 *
+	 * <p>The resource must be released when no longer used. That releases the lease. When all leases are
+	 * released, the resource is disposed.
+	 */
+	<T extends AutoCloseable> ResourceAndSize<T> getOrAllocateSharedResource(
+			String type,
+			Object leaseHolder,
+			LongFunctionWithException<T, Exception> initializer,
+			long sizeForInitialization) throws Exception {
+
+		// We could be stuck on this lock for a while, in cases where another initialization is currently
+		// happening and the initialization is expensive.
+		// We lock interruptibly here to allow for faster exit in case of cancellation errors.
+		try {
+			lock.lockInterruptibly();
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new MemoryAllocationException("Interrupted while acquiring memory");
+		}
+
+		try {
+			// we cannot use "computeIfAbsent()" here because the computing function may throw an exception.
+			@SuppressWarnings("unchecked")
+			LeasedResource<T> resource = (LeasedResource<T>) reservedResources.get(type);
+			if (resource == null) {
+				resource = createResource(initializer, sizeForInitialization);
+				reservedResources.put(type, resource);
+			}
+
+			resource.addLeaseHolder(leaseHolder);
+			return resource;
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Releases a lease (identified by the lease holder object) for the given type.
+	 * If no further leases exist, the resource is disposed.
+	 *
+	 * @return True, if this was the last lease holder and the resource was disposed.
+	 */
+	boolean release(String type, Object leaseHolder) throws Exception {
+		lock.lock();
+		try {
+			final LeasedResource resource = reservedResources.get(type);
+			if (resource == null) {
+				return false;
+			}
+
+			if (resource.removeLeaseHolder(leaseHolder)) {
+				reservedResources.remove(type);
+				resource.dispose();
+				return true;
+			}
+
+			return false;
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	@VisibleForTesting
+	int getNumResources() {
+		return reservedResources.size();
+	}
+
+	private static <T extends AutoCloseable> LeasedResource<T> createResource(
+			LongFunctionWithException<T, Exception> initializer,
+			long size) throws Exception {
+
+		final T resource = initializer.apply(size);
+		return new LeasedResource<>(resource, size);
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * A resource handle with size.
+	 */
+	interface ResourceAndSize<T extends AutoCloseable> {
+
+		T resourceHandle();
+
+		long size();
+	}
+
+	// ------------------------------------------------------------------------
+
+	private static final class LeasedResource<T extends AutoCloseable> implements ResourceAndSize<T> {
+
+		private final HashSet<Object> leaseHolders = new HashSet<>();
+
+		private final T resourceHandle;
+
+		private final long size;
+
+		private boolean disposed;
+
+		private LeasedResource(T resourceHandle, long size) {
+			this.resourceHandle = resourceHandle;
+			this.size = size;
+		}
+
+		public T resourceHandle() {
+			return resourceHandle;
+		}
+
+		public long size() {
+			return size;
+		}
+
+		void addLeaseHolder(Object leaseHolder) {
+			assert !disposed;
+			leaseHolders.add(leaseHolder);
+		}
+
+		boolean removeLeaseHolder(Object leaseHolder) {
+			assert !disposed;
+			leaseHolders.remove(leaseHolder);
+			return  leaseHolders.isEmpty();
+		}
+
+		void dispose() throws Exception {
+			assert !disposed;
+			disposed = true;
+			resourceHandle.close();
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/KeyedBudgetManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/KeyedBudgetManager.java
@@ -223,7 +223,7 @@ public class KeyedBudgetManager<K> {
 		}
 	}
 
-	long availableBudgetForKey(K key) {
+	public long availableBudgetForKey(K key) {
 		Preconditions.checkNotNull(key);
 		synchronized (lock) {
 			return availableBudgetByKey.getOrDefault(key, 0L);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerSharedResourcesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerSharedResourcesTest.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.memory;
+
+import org.apache.flink.core.memory.MemoryType;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the shared resource acquisition and initialization through the {@link MemoryManager}.
+ */
+public class MemoryManagerSharedResourcesTest {
+
+	@Test
+	public void getSameTypeGetsSameHandle() throws Exception {
+		final MemoryManager memoryManager = createMemoryManager();
+
+		final OpaqueMemoryResource<TestResource> resource1 = memoryManager.getSharedMemoryResourceForManagedMemory(
+			"type", TestResource::new, 0.1);
+		final OpaqueMemoryResource<TestResource> resource2 = memoryManager.getSharedMemoryResourceForManagedMemory(
+			"type", TestResource::new, 0.1);
+
+		assertNotSame(resource1, resource2);
+		assertSame(resource1.getResourceHandle(), resource2.getResourceHandle());
+	}
+
+	@Test
+	public void getDifferentTypeGetsDifferentResources() throws Exception {
+		final MemoryManager memoryManager = createMemoryManager();
+
+		final OpaqueMemoryResource<TestResource> resource1 = memoryManager.getSharedMemoryResourceForManagedMemory(
+			"type1", TestResource::new, 0.1);
+		final OpaqueMemoryResource<TestResource> resource2 = memoryManager.getSharedMemoryResourceForManagedMemory(
+			"type2", TestResource::new, 0.1);
+
+		assertNotSame(resource1, resource2);
+		assertNotSame(resource1.getResourceHandle(), resource2.getResourceHandle());
+	}
+
+	@Test
+	public void testAllocatesFractionOfTotalMemory() throws Exception {
+		final MemoryManager memoryManager = createMemoryManager();
+		final double fraction = 0.2;
+
+		final OpaqueMemoryResource<TestResource> resource = memoryManager.getSharedMemoryResourceForManagedMemory(
+			"type", TestResource::new, fraction);
+
+		assertEquals((long) (0.2 * memoryManager.getMemorySize()), resource.getSize());
+	}
+
+	@Test
+	public void getAllocateNewReservesMemory() throws Exception {
+		final MemoryManager memoryManager = createMemoryManager();
+
+		memoryManager.getSharedMemoryResourceForManagedMemory("type", TestResource::new, 0.5);
+
+		assertEquals(memoryManager.getMemorySize() / 2, memoryManager.availableMemory(MemoryType.OFF_HEAP));
+	}
+
+	@Test
+	public void getExistingDoesNotAllocateAdditionalMemory() throws Exception {
+		final MemoryManager memoryManager = createMemoryManager();
+		memoryManager.getSharedMemoryResourceForManagedMemory("type", TestResource::new, 0.8);
+		final long freeMemory = memoryManager.availableMemory(MemoryType.OFF_HEAP);
+
+		memoryManager.getSharedMemoryResourceForManagedMemory("type", TestResource::new, 0.8);
+
+		assertEquals(freeMemory, memoryManager.availableMemory(MemoryType.OFF_HEAP));
+	}
+
+	@Test
+	public void testFailReservation() throws Exception {
+		final MemoryManager memoryManager = createMemoryManager();
+		memoryManager.getSharedMemoryResourceForManagedMemory("type", TestResource::new, 0.8);
+
+		try {
+			memoryManager.getSharedMemoryResourceForManagedMemory("type2", TestResource::new, 0.8);
+			fail("exception expected");
+		}
+		catch (MemoryAllocationException e) {
+			// expected
+		}
+	}
+
+	@Test
+	public void testPartialReleaseDoesNotReleaseMemory() throws Exception {
+		final MemoryManager memoryManager = createMemoryManager();
+		final OpaqueMemoryResource<TestResource> resource1 = memoryManager.getSharedMemoryResourceForManagedMemory(
+			"type", TestResource::new, 0.1);
+		memoryManager.getSharedMemoryResourceForManagedMemory(
+			"type", TestResource::new, 0.1);
+		assertFalse(memoryManager.verifyEmpty());
+
+		resource1.close();
+
+		assertFalse(resource1.getResourceHandle().closed);
+	}
+
+	@Test
+	public void testLastReleaseReleasesMemory() throws Exception {
+		final MemoryManager memoryManager = createMemoryManager();
+		final OpaqueMemoryResource<TestResource> resource1 = memoryManager.getSharedMemoryResourceForManagedMemory(
+			"type", TestResource::new, 0.1);
+		final OpaqueMemoryResource<TestResource> resource2 = memoryManager.getSharedMemoryResourceForManagedMemory(
+			"type", TestResource::new, 0.1);
+		assertFalse(memoryManager.verifyEmpty());
+
+		resource1.close();
+		resource2.close();
+
+		assertTrue(resource1.getResourceHandle().closed);
+	}
+
+	@Test
+	public void testPartialReleaseDoesNotDisposeResource() throws Exception {
+		final MemoryManager memoryManager = createMemoryManager();
+		final OpaqueMemoryResource<TestResource> resource1 = memoryManager.getSharedMemoryResourceForManagedMemory(
+			"type", TestResource::new, 0.1);
+		memoryManager.getSharedMemoryResourceForManagedMemory(
+			"type", TestResource::new, 0.1);
+
+		resource1.close();
+
+		assertFalse(resource1.getResourceHandle().closed);
+	}
+
+	@Test
+	public void testLastReleaseDisposesResource() throws Exception {
+		final MemoryManager memoryManager = createMemoryManager();
+		final OpaqueMemoryResource<TestResource> resource1 = memoryManager.getSharedMemoryResourceForManagedMemory(
+			"type", TestResource::new, 0.1);
+		final OpaqueMemoryResource<TestResource> resource2 = memoryManager.getSharedMemoryResourceForManagedMemory(
+			"type", TestResource::new, 0.1);
+
+		resource1.close();
+		resource2.close();
+
+		assertTrue(resource1.getResourceHandle().closed);
+		assertTrue(resource2.getResourceHandle().closed);
+	}
+
+	@Test
+	public void getAllocateExternalResource() throws Exception {
+		final MemoryManager memoryManager = createMemoryManager();
+		final OpaqueMemoryResource<TestResource> resource = memoryManager.getExternalSharedMemoryResource(
+			"external-type", TestResource::new, 1337);
+
+		assertEquals(1337, resource.getSize());
+	}
+
+	@Test
+	public void getExistingExternalResource() throws Exception {
+		final MemoryManager memoryManager = createMemoryManager();
+		final OpaqueMemoryResource<TestResource> resource1 = memoryManager.getExternalSharedMemoryResource(
+			"external-type", TestResource::new, 1337);
+
+		final OpaqueMemoryResource<TestResource> resource2 = memoryManager.getExternalSharedMemoryResource(
+			"external-type", TestResource::new, 1337);
+
+		assertNotSame(resource1, resource2);
+		assertSame(resource1.getResourceHandle(), resource2.getResourceHandle());
+	}
+
+	@Test
+	public void getDifferentExternalResources() throws Exception {
+		final MemoryManager memoryManager = createMemoryManager();
+		final OpaqueMemoryResource<TestResource> resource1 = memoryManager.getExternalSharedMemoryResource(
+			"external-type-1", TestResource::new, 1337);
+
+		final OpaqueMemoryResource<TestResource> resource2 = memoryManager.getExternalSharedMemoryResource(
+			"external-type-2", TestResource::new, 1337);
+
+		assertNotSame(resource1, resource2);
+		assertNotSame(resource1.getResourceHandle(), resource2.getResourceHandle());
+	}
+
+	@Test
+	public void testReleaseDisposesExternalResource() throws Exception {
+		final MemoryManager memoryManager = createMemoryManager();
+		final OpaqueMemoryResource<TestResource> resource = memoryManager.getExternalSharedMemoryResource(
+			"external-type", TestResource::new, 1337);
+
+		resource.close();
+
+		assertTrue(resource.getResourceHandle().closed);
+	}
+
+	// ------------------------------------------------------------------------
+	//  Utils
+	// ------------------------------------------------------------------------
+
+	private static MemoryManager createMemoryManager() {
+		final long size = 128 * 1024 * 1024;
+		final MemoryManager mm = MemoryManager.forDefaultPageSize(size);
+
+		// this is to guard test assumptions
+		assertEquals(size, mm.getMemorySize());
+		assertEquals(size, mm.availableMemory(MemoryType.OFF_HEAP));
+
+		return mm;
+	}
+
+	private static final class TestResource implements AutoCloseable {
+
+		final long size;
+		boolean closed;
+
+		TestResource(long size) {
+			this.size = size;
+		}
+
+		@Override
+		public void close() {
+			closed = true;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/OpaqueMemoryResourceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/OpaqueMemoryResourceTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.memory;
+
+import org.apache.flink.util.function.ThrowingRunnable;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for the {@link OpaqueMemoryResource}.
+ */
+public class OpaqueMemoryResourceTest {
+
+	@Test
+	public void testCloseIsIdempotent() throws Exception {
+		final CountingCloseable disposer = new CountingCloseable();
+		final OpaqueMemoryResource<Object> resource = new OpaqueMemoryResource<>(new Object(), 10, disposer);
+
+		resource.close();
+		resource.close();
+
+		assertEquals(1, disposer.count);
+	}
+
+	private static final class CountingCloseable implements ThrowingRunnable<Exception> {
+
+		int count = 0;
+
+		@Override
+		public void run() throws Exception {
+			count++;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/SharedResourcesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/SharedResourcesTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.memory;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the {@link SharedResources} class.
+ */
+public class SharedResourcesTest {
+
+	@Test
+	public void testAllocatedResourcesInMap() throws Exception {
+		final SharedResources resources = new SharedResources();
+
+		final TestResource tr = resources
+				.getOrAllocateSharedResource("theType", new Object(), TestResource::new, 100)
+				.resourceHandle();
+
+		assertEquals(1, resources.getNumResources());
+		assertFalse(tr.closed);
+	}
+
+	@Test
+	public void testLastReleaseRemovesFromMap() throws Exception {
+		final SharedResources resources = new SharedResources();
+		final String type = "theType";
+		final Object leaseHolder = new Object();
+		resources.getOrAllocateSharedResource(type, leaseHolder, TestResource::new, 100);
+
+		resources.release(type, leaseHolder);
+
+		assertEquals(0, resources.getNumResources());
+	}
+
+	@Test
+	public void testLastReleaseDisposesResource() throws Exception {
+		final SharedResources resources = new SharedResources();
+		final String type = "theType";
+		final Object leaseHolder = new Object();
+
+		final TestResource tr = resources
+				.getOrAllocateSharedResource(type, leaseHolder, TestResource::new, 100)
+				.resourceHandle();
+
+		resources.release(type, leaseHolder);
+
+		assertTrue(tr.closed);
+	}
+
+	// ------------------------------------------------------------------------
+
+	private static final class TestResource implements AutoCloseable {
+
+		final long size;
+		boolean closed;
+
+		TestResource(long size) {
+			this.size = size;
+		}
+
+		@Override
+		public void close() {
+			closed = true;
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This change allows the memory manager to track shared opaque resources form other components, like for example block caches from RocksDB. The memory manager is responsible for allocating and releasing those resources, as well as for assigning the memory budget from of the managed memory budget.

The core is the `getSharedMemoryResourceForManagedMemory(type, initializer, fraction)` method.
It looks up if a resource identified by `type` already exists. If not, it reserves `fraction` amount of the managed memory and uses `initializer` to create the resource.

Every acquisition of the resource creates a new `OpaqueMemoryResource` objects which the users close. Once all are closed, the resource is disposed internally and the reserved memory is returned.

## Verifying this change

This change adds new unit test classes for the memory manager: 
  - [MemoryManagerSharedResourcesTest](https://github.com/StephanEwen/flink/blob/fba7ae37fda85dbac2cd235e5c1c049fe33df3df/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerSharedResourcesTest.java)
  - [SharedResourcesTest](https://github.com/StephanEwen/flink/blob/fba7ae37fda85dbac2cd235e5c1c049fe33df3df/flink-runtime/src/test/java/org/apache/flink/runtime/memory/SharedResourcesTest.java)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? (**only internal, not user facing**)
  - If yes, how is the feature documented? **not applicable**
