### PR TITLE
[FLINK-14912][Table] register, drop, and alter catalog functions from…

### DIFF
--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterFunction.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterFunction.java
@@ -40,7 +40,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class SqlAlterFunction extends SqlCall {
 
-	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("ALTER FUNCTION", SqlKind.OTHER);
+	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("ALTER FUNCTION", SqlKind.OTHER_DDL);
 
 	private final SqlIdentifier functionIdentifier;
 
@@ -106,8 +106,16 @@ public class SqlAlterFunction extends SqlCall {
 		return ImmutableNullableList.of(functionIdentifier, functionClassName);
 	}
 
-	public String getLanguage() {
+	public String getFunctionLanguage() {
 		return functionLanguage;
+	}
+
+	public SqlCharStringLiteral getFunctionClassName() {
+		return this.functionClassName;
+	}
+
+	public boolean isIfExists() {
+		return this.ifExists;
 	}
 
 	public String[] getFunctionIdentifier() {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterFunctionOperation.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.ddl;
+
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.OperationUtils;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Operation to describe a ALTER FUNCTION statement.
+ */
+public class AlterFunctionOperation implements AlterOperation  {
+	private final ObjectIdentifier functionIdentifier;
+	private CatalogFunction catalogFunction;
+	private boolean ifExists;
+
+	public AlterFunctionOperation(
+			ObjectIdentifier functionIdentifier,
+			CatalogFunction catalogFunction,
+			boolean ifExists) {
+		this.functionIdentifier = functionIdentifier;
+		this.catalogFunction = catalogFunction;
+		this.ifExists = ifExists;
+	}
+
+	public CatalogFunction getCatalogFunction() {
+		return this.catalogFunction;
+	}
+
+	public ObjectIdentifier getFunctionIdentifier() {
+		return this.functionIdentifier;
+	}
+
+	public boolean isIfExists() {
+		return this.ifExists;
+	}
+
+	@Override
+	public String asSummaryString() {
+		Map<String, Object> params = new LinkedHashMap<>();
+		params.put("catalogFunction", catalogFunction.getDetailedDescription());
+		params.put("identifier", functionIdentifier);
+		params.put("ifExists", ifExists);
+
+		return OperationUtils.formatWithChildren(
+			"ALTER FUNCTION",
+			params,
+			Collections.emptyList(),
+			Operation::asSummaryString);
+	}
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateFunctionOperation.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.ddl;
+
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.OperationUtils;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Operation to describe a CREATE FUNCTION statement.
+ */
+public class CreateFunctionOperation implements CreateOperation {
+	private final ObjectIdentifier functionIdentifier;
+	private CatalogFunction catalogFunction;
+	private boolean ignoreIfExists;
+
+	public CreateFunctionOperation(
+			ObjectIdentifier functionIdentifier,
+			CatalogFunction catalogFunction,
+			boolean ignoreIfExists) {
+		this.functionIdentifier = functionIdentifier;
+		this.catalogFunction = catalogFunction;
+		this.ignoreIfExists = ignoreIfExists;
+	}
+
+	public CatalogFunction getCatalogFunction() {
+		return this.catalogFunction;
+	}
+
+	public ObjectIdentifier getFunctionIdentifier() {
+		return this.functionIdentifier;
+	}
+
+	public boolean isIgnoreIfExists() {
+		return this.ignoreIfExists;
+	}
+
+	@Override
+	public String asSummaryString() {
+		Map<String, Object> params = new LinkedHashMap<>();
+		params.put("catalogFunction", catalogFunction.getDetailedDescription());
+		params.put("identifier", functionIdentifier);
+		params.put("ignoreIfExists", ignoreIfExists);
+
+		return OperationUtils.formatWithChildren(
+			"CREATE FUNCTION",
+			params,
+			Collections.emptyList(),
+			Operation::asSummaryString);
+	}
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropFunctionOperation.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.ddl;
+
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.OperationUtils;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ *  Operation to describe a DROP FUNCTION statement.
+ */
+public class DropFunctionOperation implements DropOperation {
+	private final ObjectIdentifier functionIdentifier;
+	private final boolean ifExists;
+
+	public DropFunctionOperation(
+			ObjectIdentifier functionIdentifier,
+			boolean ifExists) {
+		this.functionIdentifier = functionIdentifier;
+		this.ifExists = ifExists;
+	}
+
+	public ObjectIdentifier getFunctionIdentifier() {
+		return this.functionIdentifier;
+	}
+
+	public boolean isIfExists() {
+		return this.ifExists;
+	}
+
+	@Override
+	public String asSummaryString() {
+		Map<String, Object> params = new LinkedHashMap<>();
+		params.put("identifier", functionIdentifier);
+		params.put("IfExists", ifExists);
+
+		return OperationUtils.formatWithChildren(
+			"DROP FUNCTION",
+			params,
+			Collections.emptyList(),
+			Operation::asSummaryString);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -19,12 +19,15 @@
 package org.apache.flink.table.planner.operations;
 
 import org.apache.flink.sql.parser.ddl.SqlAlterDatabase;
+import org.apache.flink.sql.parser.ddl.SqlAlterFunction;
 import org.apache.flink.sql.parser.ddl.SqlAlterTable;
 import org.apache.flink.sql.parser.ddl.SqlAlterTableProperties;
 import org.apache.flink.sql.parser.ddl.SqlAlterTableRename;
 import org.apache.flink.sql.parser.ddl.SqlCreateDatabase;
+import org.apache.flink.sql.parser.ddl.SqlCreateFunction;
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
 import org.apache.flink.sql.parser.ddl.SqlDropDatabase;
+import org.apache.flink.sql.parser.ddl.SqlDropFunction;
 import org.apache.flink.sql.parser.ddl.SqlDropTable;
 import org.apache.flink.sql.parser.ddl.SqlTableColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableOption;
@@ -37,9 +40,12 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.CatalogDatabaseImpl;
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.CatalogFunctionImpl;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.catalog.FunctionLanguage;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
@@ -48,16 +54,20 @@ import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
+import org.apache.flink.table.operations.ddl.AlterFunctionOperation;
 import org.apache.flink.table.operations.ddl.AlterTablePropertiesOperation;
 import org.apache.flink.table.operations.ddl.AlterTableRenameOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
+import org.apache.flink.table.operations.ddl.CreateFunctionOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
+import org.apache.flink.table.operations.ddl.DropFunctionOperation;
 import org.apache.flink.table.operations.ddl.DropTableOperation;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.util.StringUtils;
 
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.type.RelDataType;
@@ -120,6 +130,12 @@ public class SqlToOperationConverter {
 			return Optional.of(converter.convertDropTable((SqlDropTable) validated));
 		} else if (validated instanceof SqlAlterTable) {
 			return Optional.of(converter.convertAlterTable((SqlAlterTable) validated));
+		} else if (validated instanceof SqlCreateFunction) {
+			return Optional.of(converter.convertCreateFunction((SqlCreateFunction) validated));
+		} else if (validated instanceof SqlAlterFunction) {
+			return Optional.of(converter.convertAlterFunction((SqlAlterFunction) validated));
+		} else if (validated instanceof SqlDropFunction) {
+			return Optional.of(converter.convertDropFunction((SqlDropFunction) validated));
 		} else if (validated instanceof RichSqlInsert) {
 			return Optional.of(converter.convertSqlInsert((RichSqlInsert) validated));
 		} else if (validated instanceof SqlUseCatalog) {
@@ -138,6 +154,8 @@ public class SqlToOperationConverter {
 			return Optional.empty();
 		}
 	}
+
+	//~ Tools ------------------------------------------------------------------
 
 	/**
 	 * Convert the {@link SqlCreateTable} node.
@@ -193,30 +211,98 @@ public class SqlToOperationConverter {
 		ObjectIdentifier tableIdentifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 		if (sqlAlterTable instanceof SqlAlterTableRename) {
 			UnresolvedIdentifier newUnresolvedIdentifier =
-					UnresolvedIdentifier.of(((SqlAlterTableRename) sqlAlterTable).fullNewTableName());
+				UnresolvedIdentifier.of(((SqlAlterTableRename) sqlAlterTable).fullNewTableName());
 			ObjectIdentifier newTableIdentifier = catalogManager.qualifyIdentifier(newUnresolvedIdentifier);
 			return new AlterTableRenameOperation(tableIdentifier, newTableIdentifier);
-		} else if (sqlAlterTable instanceof SqlAlterTableProperties){
+		} else if (sqlAlterTable instanceof SqlAlterTableProperties) {
 			Optional<CatalogManager.TableLookupResult> optionalCatalogTable = catalogManager.getTable(tableIdentifier);
 			if (optionalCatalogTable.isPresent() && !optionalCatalogTable.get().isTemporary()) {
 				CatalogTable originalCatalogTable = (CatalogTable) optionalCatalogTable.get().getTable();
 				Map<String, String> properties = new HashMap<>();
 				properties.putAll(originalCatalogTable.getProperties());
 				((SqlAlterTableProperties) sqlAlterTable).getPropertyList().getList().forEach(p ->
-						properties.put(((SqlTableOption) p).getKeyString().toLowerCase(),
-								((SqlTableOption) p).getValueString()));
+					properties.put(((SqlTableOption) p).getKeyString().toLowerCase(),
+						((SqlTableOption) p).getValueString()));
 				CatalogTable catalogTable = new CatalogTableImpl(
-						originalCatalogTable.getSchema(),
-						originalCatalogTable.getPartitionKeys(),
-						properties,
-						originalCatalogTable.getComment());
+					originalCatalogTable.getSchema(),
+					originalCatalogTable.getPartitionKeys(),
+					properties,
+					originalCatalogTable.getComment());
 				return new AlterTablePropertiesOperation(tableIdentifier, catalogTable);
 			} else {
 				throw new ValidationException(String.format("Table %s doesn't exist or is a temporary table.",
-						tableIdentifier.toString()));
+					tableIdentifier.toString()));
 			}
 		}
 		return null;
+	}
+
+	/** Convert CREATE FUNCTION statement. */
+	private Operation convertCreateFunction(SqlCreateFunction sqlCreateFunction) {
+		FunctionLanguage language = parseLanguage(sqlCreateFunction.getFunctionLanguage());
+		CatalogFunction catalogFunction = new CatalogFunctionImpl(
+			sqlCreateFunction.getFunctionClassName().getValueAs(String.class), language);
+
+		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlCreateFunction.getFunctionIdentifier());
+		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
+
+		return new CreateFunctionOperation(
+			identifier,
+			catalogFunction,
+			sqlCreateFunction.isIfNotExists()
+		);
+	}
+
+	/** Convert ALTER FUNCTION statement. */
+	private Operation convertAlterFunction(SqlAlterFunction sqlAlterFunction) {
+		FunctionLanguage language = parseLanguage(sqlAlterFunction.getFunctionLanguage());
+		CatalogFunction catalogFunction = new CatalogFunctionImpl(
+			sqlAlterFunction.getFunctionClassName().getValueAs(String.class), language);
+
+		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlAlterFunction.getFunctionIdentifier());
+		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
+		return new AlterFunctionOperation(
+			identifier,
+			catalogFunction,
+			sqlAlterFunction.isIfExists()
+		);
+	}
+
+	/** Convert DROP FUNCTION statement. */
+	private Operation convertDropFunction(SqlDropFunction sqlDropFunction) {
+		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlDropFunction.getFunctionIdentifier());
+		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
+
+		return new DropFunctionOperation(
+			identifier,
+			sqlDropFunction.getIfExists());
+	}
+
+	/**
+	 * Converts language string to the FunctionLanguage.
+	 *
+	 * @param languageString  the language string from SQL parser
+	 * @return supported FunctionLanguage otherwise raise UnsupportedOperationException.
+	 * @throws UnsupportedOperationException if the languageString is not parsable or language is not supported
+	 */
+	private FunctionLanguage parseLanguage(String languageString) {
+		if (StringUtils.isNullOrWhitespaceOnly(languageString)) {
+			return FunctionLanguage.JAVA;
+		}
+
+		FunctionLanguage language;
+		try {
+			language = FunctionLanguage.valueOf(languageString);
+		} catch (IllegalArgumentException e) {
+			throw new UnsupportedOperationException(
+				String.format("Unrecognized function language string %s", languageString), e);
+		}
+
+		if (language.equals(FunctionLanguage.PYTHON)) {
+			throw new UnsupportedOperationException("Only function language JAVA and SCALA are supported for now.");
+		}
+
+		return language;
 	}
 
 	/** Convert insert into statement. */
@@ -267,7 +353,7 @@ public class SqlToOperationConverter {
 		String databaseName = (fullDatabaseName.length == 1) ? fullDatabaseName[0] : fullDatabaseName[1];
 		boolean ignoreIfExists = sqlCreateDatabase.isIfNotExists();
 		String databaseComment = sqlCreateDatabase.getComment()
-								.map(comment -> comment.getNlsString().getValue()).orElse(null);
+			.map(comment -> comment.getNlsString().getValue()).orElse(null);
 		// set with properties
 		Map<String, String> properties = new HashMap<>();
 		sqlCreateDatabase.getPropertyList().getList().forEach(p ->
@@ -286,10 +372,10 @@ public class SqlToOperationConverter {
 		String catalogName = (fullDatabaseName.length == 1) ? catalogManager.getCurrentCatalog() : fullDatabaseName[0];
 		String databaseName = (fullDatabaseName.length == 1) ? fullDatabaseName[0] : fullDatabaseName[1];
 		return new DropDatabaseOperation(
-				catalogName,
-				databaseName,
-				sqlDropDatabase.getIfExists(),
-				sqlDropDatabase.isCascade());
+			catalogName,
+			databaseName,
+			sqlDropDatabase.getIfExists(),
+			sqlDropDatabase.isCascade());
 	}
 
 	/** Convert ALTER DATABASE statement. */
@@ -324,8 +410,6 @@ public class SqlToOperationConverter {
 	private Operation convertSqlQuery(SqlNode node) {
 		return toQueryOperation(flinkPlanner, node);
 	}
-
-	//~ Tools ------------------------------------------------------------------
 
 	/**
 	 * Create a table schema from {@link SqlCreateTable}. This schema may contains computed column

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
@@ -117,7 +117,10 @@ class FlinkPlannerImpl(
       }
       // no need to validate row type for DDL and insert nodes.
       if (sqlNode.getKind.belongsTo(SqlKind.DDL)
-        || sqlNode.getKind == SqlKind.INSERT) {
+        || sqlNode.getKind == SqlKind.INSERT
+        || sqlNode.getKind == SqlKind.CREATE_FUNCTION
+        || sqlNode.getKind == SqlKind.DROP_FUNCTION
+        || sqlNode.getKind == SqlKind.OTHER_DDL) {
         return sqlNode
       }
       validator.validate(sqlNode)

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/catalog/CatalogFunctionTestBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/catalog/CatalogFunctionTestBase.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.catalog;
+
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.types.Row;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link CatalogFunction}.
+ */
+public abstract class CatalogFunctionTestBase {
+	protected static TableEnvironment tableEnv;
+
+	@Test
+	public void testCreateCatalogFunctionInDefaultCatalog() {
+		String ddl1 = "create function f1 as 'org.apache.flink.function.TestFunction'";
+		tableEnv.sqlUpdate(ddl1);
+		assertTrue(Arrays.asList(tableEnv.listFunctions()).contains("f1"));
+
+		tableEnv.sqlUpdate("DROP FUNCTION IF EXISTS default_catalog.default_database.f1");
+		assertFalse(Arrays.asList(tableEnv.listFunctions()).contains("f1"));
+	}
+
+	@Test
+	public void testCreateFunctionWithFullPath() {
+		String ddl1 = "create function default_catalog.default_database.f2 as" +
+			" 'org.apache.flink.function.TestFunction'";
+		tableEnv.sqlUpdate(ddl1);
+		assertTrue(Arrays.asList(tableEnv.listFunctions()).contains("f2"));
+
+		tableEnv.sqlUpdate("DROP FUNCTION IF EXISTS default_catalog.default_database.f2");
+		assertFalse(Arrays.asList(tableEnv.listFunctions()).contains("f2"));
+	}
+
+	@Test
+	public void testCreateFunctionWithoutCatalogIdentifier() {
+		String ddl1 = "create function default_database.f3 as" +
+			" 'org.apache.flink.function.TestFunction'";
+		tableEnv.sqlUpdate(ddl1);
+		assertTrue(Arrays.asList(tableEnv.listFunctions()).contains("f3"));
+
+		tableEnv.sqlUpdate("DROP FUNCTION IF EXISTS default_catalog.default_database.f3");
+		assertFalse(Arrays.asList(tableEnv.listFunctions()).contains("f3"));
+	}
+
+	@Test
+	public void testCreateFunctionCatalogNotExists() {
+
+		String ddl1 = "create function catalog1.database1.f3 as 'org.apache.flink.function.TestFunction'";
+
+		try {
+			tableEnv.sqlUpdate(ddl1);
+		} catch (Exception e){
+			assertTrue(e.getMessage().equals("Catalog catalog1 does not exist"));
+		}
+	}
+
+	@Test
+	public void testCreateFunctionDBNotExists() {
+		String ddl1 = "create function default_catalog.database1.f3 as 'org.apache.flink.function.TestFunction'";
+
+		try {
+			tableEnv.sqlUpdate(ddl1);
+		} catch (Exception e){
+			assertEquals(e.getMessage(), "Could not execute CREATE FUNCTION:" +
+				" (catalogFunction: [Optional[This is a user-defined function]], identifier:" +
+				" [`default_catalog`.`database1`.`f3`], ignoreIfExists: [false])");
+		}
+	}
+
+	@Test
+	public void testAlterFunction() throws Exception {
+		String create = "create function f3 as 'org.apache.flink.function.TestFunction'";
+		String alter = "alter function f3 as 'org.apache.flink.function.TestFunction2'";
+
+		ObjectPath objectPath = new ObjectPath("default_database", "f3");
+		Catalog catalog = tableEnv.getCatalog("default_catalog").get();
+		tableEnv.sqlUpdate(create);
+		CatalogFunction beforeUpdate = catalog.getFunction(objectPath);
+		assertEquals("org.apache.flink.function.TestFunction", beforeUpdate.getClassName());
+
+		tableEnv.sqlUpdate(alter);
+		CatalogFunction afterUpdate = catalog.getFunction(objectPath);
+		assertEquals("org.apache.flink.function.TestFunction2", afterUpdate.getClassName());
+	}
+
+	@Test
+	public void testAlterFunctionNonExists() {
+		String alterUndefinedFunction = "ALTER FUNCTION default_catalog.default_database.f4" +
+			" as 'org.apache.flink.function.TestFunction'";
+
+		String alterFunctionInWrongCatalog = "ALTER FUNCTION catalog1.default_database.f4 " +
+			"as 'org.apache.flink.function.TestFunction'";
+
+		String alterFunctionInWrongDB = "ALTER FUNCTION default_catalog.db1.f4 " +
+			"as 'org.apache.flink.function.TestFunction'";
+
+		try {
+			tableEnv.sqlUpdate(alterUndefinedFunction);
+			fail();
+		} catch (Exception e){
+			assertEquals(e.getMessage(), "Could not execute ALTER FUNCTION: " +
+				"(catalogFunction: [Optional[This is a user-defined function]], " +
+				"identifier: [`default_catalog`.`default_database`.`f4`], ifExists: [false])");
+		}
+
+		try {
+			tableEnv.sqlUpdate(alterFunctionInWrongCatalog);
+			fail();
+		} catch (Exception e) {
+			assertTrue(e.getMessage().equals("Catalog catalog1 does not exist"));
+		}
+
+		try {
+			tableEnv.sqlUpdate(alterFunctionInWrongDB);
+			fail();
+		} catch (Exception e) {
+			assertEquals(e.getMessage(), "Could not execute ALTER FUNCTION: " +
+				"(catalogFunction: [Optional[This is a user-defined function]], " +
+				"identifier: [`default_catalog`.`db1`.`f4`], ifExists: [false])");
+		}
+	}
+
+	@Test
+	public void testDropFunctionNonExists() {
+		String dropUndefinedFunction = "DROP FUNCTION default_catalog.default_database.f4";
+
+		String dropFunctionInWrongCatalog = "DROP FUNCTION catalog1.default_database.f4";
+
+		String dropFunctionInWrongDB = "DROP FUNCTION default_catalog.db1.f4";
+
+		try {
+			tableEnv.sqlUpdate(dropUndefinedFunction);
+			fail();
+		} catch (Exception e){
+			assertEquals(e.getMessage(), "Could not execute DROP FUNCTION:" +
+				" (identifier: [`default_catalog`.`default_database`.`f4`], IfExists: [false])");
+		}
+
+		try {
+			tableEnv.sqlUpdate(dropFunctionInWrongCatalog);
+			fail();
+		} catch (Exception e) {
+			assertTrue(e.getMessage().equals("Catalog catalog1 does not exist"));
+		}
+
+		try {
+			tableEnv.sqlUpdate(dropFunctionInWrongDB);
+			fail();
+		} catch (Exception e) {
+			assertEquals(e.getMessage(), "Could not execute DROP FUNCTION:" +
+				" (identifier: [`default_catalog`.`db1`.`f4`], IfExists: [false])");
+		}
+	}
+
+	protected Row toRow(Object ... objects) {
+		Row row = new Row(objects.length);
+		for (int i = 0; i < objects.length; i++) {
+			row.setField(i, objects[i]);
+		}
+
+		return row;
+	}
+
+	/**
+	 * Test udf class.
+	 */
+	public static class TestUDF extends ScalarFunction {
+
+		public Integer eval(Integer a, Integer b) {
+			return a + b;
+		}
+	}
+}
+

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CatalogFunctionITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CatalogFunctionITCase.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.batch.sql;
+
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.planner.catalog.CatalogFunctionTestBase;
+import org.apache.flink.table.planner.utils.TestingTableEnvironment;
+
+import org.junit.BeforeClass;
+
+/**
+ * Tests for {@link CatalogFunction} in batch table environment.
+ */
+public class CatalogFunctionITCase extends CatalogFunctionTestBase {
+
+	@BeforeClass
+	public static void setup() {
+		EnvironmentSettings environmentSettings =
+			EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build();
+		tableEnv = TestingTableEnvironment.create(environmentSettings);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/CatalogFunctionITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/CatalogFunctionITCase.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.sql;
+
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.planner.catalog.CatalogFunctionTestBase;
+import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory;
+import org.apache.flink.table.planner.utils.TestingTableEnvironment;
+import org.apache.flink.types.Row;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Tests for {@link CatalogFunction} in stream table environment.
+ */
+public class CatalogFunctionITCase extends CatalogFunctionTestBase {
+
+	@BeforeClass
+	public static void setup() {
+		EnvironmentSettings environmentSettings =
+			EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
+		tableEnv = TestingTableEnvironment.create(environmentSettings);
+	}
+
+	@Test
+	// This test case only works for stream mode
+	public void testUseDefinedCatalogFunction() throws Exception {
+		List<Row> sourceData = Arrays.asList(
+			toRow(1, "1000", 2),
+			toRow(2, "1", 3),
+			toRow(3, "2000", 4),
+			toRow(1, "2", 2),
+			toRow(2, "3000", 3)
+		);
+
+		TestCollectionTableFactory.reset();
+		TestCollectionTableFactory.initData(sourceData, new ArrayList<Row>(), -1);
+
+		String sourceDDL = "create table t1(a int, b varchar, c int) with ('connector' = 'COLLECTION')";
+		String sinkDDL = "create table t2(a int, b varchar, c int) with ('connector' = 'COLLECTION')";
+
+		String functionDDL = "create function addOne as " +
+			"'org.apache.flink.table.planner.catalog.CatalogFunctionTestBase$TestUDF'";
+
+		String query = "select t1.a, t1.b, addOne(t1.a, 1) as c from t1";
+
+		tableEnv.sqlUpdate(sourceDDL);
+		tableEnv.sqlUpdate(sinkDDL);
+		tableEnv.sqlUpdate(functionDDL);
+		Table t2 = tableEnv.sqlQuery(query);
+		tableEnv.insertInto("t2", t2);
+		tableEnv.execute("job1");
+
+		Row[] result = TestCollectionTableFactory.RESULT().toArray(new Row[0]);
+		Row[] expected = sourceData.toArray(new Row[0]);
+		assertArrayEquals(expected, result);
+	}
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -23,13 +23,13 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.table.api._
 import org.apache.flink.table.calcite.{CalciteParser, FlinkPlannerImpl, FlinkRelBuilder}
 import org.apache.flink.table.catalog._
+import org.apache.flink.table.catalog.exceptions.{DatabaseAlreadyExistException, DatabaseNotEmptyException, DatabaseNotExistException, FunctionAlreadyExistException, FunctionNotExistException}
 import org.apache.flink.table.delegation.Parser
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.expressions.resolver.lookups.TableReferenceLookup
 import org.apache.flink.table.factories.{TableFactoryService, TableFactoryUtil, TableSinkFactory}
 import org.apache.flink.table.functions.{AggregateFunction, ScalarFunction, TableFunction, UserDefinedAggregateFunction, _}
 import org.apache.flink.table.module.{Module, ModuleManager}
-import org.apache.flink.table.operations.ddl.{CreateTableOperation, DropTableOperation}
 import org.apache.flink.table.operations.ddl._
 import org.apache.flink.table.operations.utils.OperationTreeBuilder
 import org.apache.flink.table.operations.{CatalogQueryOperation, TableSourceQueryOperation, _}
@@ -42,8 +42,6 @@ import org.apache.calcite.sql.parser.SqlParser
 import org.apache.calcite.tools.FrameworkConfig
 import _root_.java.util.function.{Supplier => JSupplier}
 import _root_.java.util.{Optional, HashMap => JHashMap, Map => JMap}
-
-import org.apache.flink.table.catalog.exceptions.{DatabaseAlreadyExistException, DatabaseNotEmptyException, DatabaseNotExistException}
 
 import _root_.scala.collection.JavaConverters._
 import _root_.scala.collection.JavaConversions._
@@ -548,6 +546,12 @@ abstract class TableEnvImpl(
           case ex: DatabaseNotExistException => throw new ValidationException(exMsg, ex)
           case ex: Exception => throw new TableException(exMsg, ex)
         }
+      case createFunctionOperation: CreateFunctionOperation =>
+        createCatalogFunction(createFunctionOperation)
+      case alterFunctionOperation: AlterFunctionOperation =>
+        alterCatalogFunction(alterFunctionOperation)
+      case dropFunctionOperation: DropFunctionOperation =>
+        dropCatalogFunction(dropFunctionOperation)
       case useCatalogOperation: UseCatalogOperation =>
         catalogManager.setCurrentCatalog(useCatalogOperation.getCatalogName)
       case useDatabaseOperation: UseDatabaseOperation =>
@@ -689,6 +693,52 @@ abstract class TableEnvImpl(
     JavaScalaConversionUtil.toScala(catalogManager.getTable(identifier))
       .filter(_.isTemporary)
       .map(_.getTable)
+  }
+
+  private def createCatalogFunction(createFunctionOperation: CreateFunctionOperation)= {
+    val catalog = getCatalogOrThrowException(
+      createFunctionOperation.getFunctionIdentifier.getCatalogName)
+    val exMsg = getDDLOpExecuteErrorMsg(createFunctionOperation.asSummaryString)
+    try {
+      catalog.createFunction(
+        createFunctionOperation.getFunctionIdentifier.toObjectPath,
+        createFunctionOperation.getCatalogFunction,
+        createFunctionOperation.isIgnoreIfExists)
+    } catch {
+      case ex: FunctionAlreadyExistException => throw new ValidationException(exMsg, ex)
+      case ex: Exception => throw new TableException(exMsg, ex)
+    }
+  }
+
+  private def alterCatalogFunction(alterFunctionOperation: AlterFunctionOperation) = {
+    val catalog = getCatalogOrThrowException(
+      alterFunctionOperation.getFunctionIdentifier.getCatalogName)
+    val exMsg = getDDLOpExecuteErrorMsg(alterFunctionOperation.asSummaryString)
+
+    try {
+      catalog.alterFunction(
+        alterFunctionOperation.getFunctionIdentifier.toObjectPath,
+        alterFunctionOperation.getCatalogFunction,
+        alterFunctionOperation.isIfExists)
+    } catch {
+      case ex: FunctionNotExistException => throw new ValidationException(exMsg, ex)
+      case ex: Exception => throw new TableException(exMsg, ex)
+    }
+  }
+
+  private def dropCatalogFunction(dropFunctionOperation: DropFunctionOperation) = {
+    val catalog = getCatalogOrThrowException(
+      dropFunctionOperation.getFunctionIdentifier.getCatalogName)
+    val exMsg = getDDLOpExecuteErrorMsg(dropFunctionOperation.asSummaryString)
+
+    try {
+      catalog.dropFunction(
+        dropFunctionOperation.getFunctionIdentifier.toObjectPath,
+        dropFunctionOperation.isIfExists)
+    } catch {
+      case ex: FunctionNotExistException => throw new ValidationException(exMsg, ex)
+      case ex: Exception => throw new TableException(exMsg, ex)
+    }
   }
 
   /** Returns the [[FlinkRelBuilder]] of this TableEnvironment. */

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/FlinkPlannerImpl.scala
@@ -117,7 +117,10 @@ class FlinkPlannerImpl(
       }
       // no need to validate row type for DDL and insert nodes.
       if (sqlNode.getKind.belongsTo(SqlKind.DDL)
-        || sqlNode.getKind == SqlKind.INSERT) {
+        || sqlNode.getKind == SqlKind.INSERT
+        || sqlNode.getKind == SqlKind.CREATE_FUNCTION
+        || sqlNode.getKind == SqlKind.DROP_FUNCTION
+        || sqlNode.getKind == SqlKind.OTHER_DDL) {
         return sqlNode
       }
       validator.validate(sqlNode)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/CatalogFunctionTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/CatalogFunctionTestBase.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.factories.utils.TestCollectionTableFactory;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.types.Row;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link CatalogFunction}.
+ */
+public abstract class CatalogFunctionTestBase {
+	private static TableEnvironment tableEnv;
+
+	public static void setTableEnv(TableEnvironment e) {
+		tableEnv = e;
+	}
+
+	public abstract void execute() throws Exception;
+
+	@Test
+	public void testCreateCatalogFunctionInDefaultCatalog() {
+		String ddl1 = "create function f1 as 'org.apache.flink.function.TestFunction'";
+		tableEnv.sqlUpdate(ddl1);
+		assertTrue(Arrays.asList(tableEnv.listFunctions()).contains("f1"));
+
+		tableEnv.sqlUpdate("DROP FUNCTION IF EXISTS default_catalog.default_database.f1");
+		assertFalse(Arrays.asList(tableEnv.listFunctions()).contains("f1"));
+	}
+
+	@Test
+	public void testCreateFunctionWithFullPath() {
+		String ddl1 = "create function default_catalog.default_database.f2 as" +
+			" 'org.apache.flink.function.TestFunction'";
+		tableEnv.sqlUpdate(ddl1);
+		assertTrue(Arrays.asList(tableEnv.listFunctions()).contains("f2"));
+
+		tableEnv.sqlUpdate("DROP FUNCTION IF EXISTS default_catalog.default_database.f2");
+		assertFalse(Arrays.asList(tableEnv.listFunctions()).contains("f2"));
+	}
+
+	@Test
+	public void testCreateFunctionWithoutCatalogIdentifier() {
+		String ddl1 = "create function default_database.f3 as" +
+			" 'org.apache.flink.function.TestFunction'";
+		tableEnv.sqlUpdate(ddl1);
+		assertTrue(Arrays.asList(tableEnv.listFunctions()).contains("f3"));
+
+		tableEnv.sqlUpdate("DROP FUNCTION IF EXISTS default_catalog.default_database.f3");
+		assertFalse(Arrays.asList(tableEnv.listFunctions()).contains("f3"));
+	}
+
+	@Test
+	public void testCreateFunctionCatalogNotExists() {
+
+		String ddl1 = "create function catalog1.database1.f3 as 'org.apache.flink.function.TestFunction'";
+
+		try {
+			tableEnv.sqlUpdate(ddl1);
+		} catch (Exception e){
+			assertTrue(e.getMessage().equals("Catalog catalog1 does not exist"));
+		}
+	}
+
+	@Test
+	public void testCreateFunctionDBNotExists() {
+		String ddl1 = "create function default_catalog.database1.f3 as 'org.apache.flink.function.TestFunction'";
+
+		try {
+			tableEnv.sqlUpdate(ddl1);
+		} catch (Exception e){
+			assertEquals(e.getMessage(), "Could not execute CREATE FUNCTION:" +
+				" (catalogFunction: [Optional[This is a user-defined function]], identifier:" +
+				" [`default_catalog`.`database1`.`f3`], ignoreIfExists: [false])");
+		}
+	}
+
+	@Test
+	public void testAlterFunction() throws Exception {
+		String create = "create function f3 as 'org.apache.flink.function.TestFunction'";
+		String alter = "alter function f3 as 'org.apache.flink.function.TestFunction2'";
+
+		ObjectPath objectPath = new ObjectPath("default_database", "f3");
+		Catalog catalog = tableEnv.getCatalog("default_catalog").get();
+		tableEnv.sqlUpdate(create);
+		CatalogFunction beforeUpdate = catalog.getFunction(objectPath);
+		assertEquals("org.apache.flink.function.TestFunction", beforeUpdate.getClassName());
+
+		tableEnv.sqlUpdate(alter);
+		CatalogFunction afterUpdate = catalog.getFunction(objectPath);
+		assertEquals("org.apache.flink.function.TestFunction2", afterUpdate.getClassName());
+	}
+
+	@Test
+	public void testAlterFunctionNonExists() {
+		String alterUndefinedFunction = "ALTER FUNCTION default_catalog.default_database.f4" +
+			" as 'org.apache.flink.function.TestFunction'";
+
+		String alterFunctionInWrongCatalog = "ALTER FUNCTION catalog1.default_database.f4 " +
+			"as 'org.apache.flink.function.TestFunction'";
+
+		String alterFunctionInWrongDB = "ALTER FUNCTION default_catalog.db1.f4 " +
+			"as 'org.apache.flink.function.TestFunction'";
+
+		try {
+			tableEnv.sqlUpdate(alterUndefinedFunction);
+			fail();
+		} catch (Exception e){
+			assertEquals(e.getMessage(), "Could not execute ALTER FUNCTION: " +
+				"(catalogFunction: [Optional[This is a user-defined function]], " +
+				"identifier: [`default_catalog`.`default_database`.`f4`], ifExists: [false])");
+		}
+
+		try {
+			tableEnv.sqlUpdate(alterFunctionInWrongCatalog);
+			fail();
+		} catch (Exception e) {
+			assertTrue(e.getMessage().equals("Catalog catalog1 does not exist"));
+		}
+
+		try {
+			tableEnv.sqlUpdate(alterFunctionInWrongDB);
+			fail();
+		} catch (Exception e) {
+			assertEquals(e.getMessage(), "Could not execute ALTER FUNCTION: " +
+				"(catalogFunction: [Optional[This is a user-defined function]], " +
+				"identifier: [`default_catalog`.`db1`.`f4`], ifExists: [false])");
+		}
+	}
+
+	@Test
+	public void testDropFunctionNonExists() {
+		String dropUndefinedFunction = "DROP FUNCTION default_catalog.default_database.f4";
+
+		String dropFunctionInWrongCatalog = "DROP FUNCTION catalog1.default_database.f4";
+
+		String dropFunctionInWrongDB = "DROP FUNCTION default_catalog.db1.f4";
+
+		try {
+			tableEnv.sqlUpdate(dropUndefinedFunction);
+			fail();
+		} catch (Exception e){
+			assertEquals(e.getMessage(), "Could not execute DROP FUNCTION:" +
+				" (identifier: [`default_catalog`.`default_database`.`f4`], IfExists: [false])");
+		}
+
+		try {
+			tableEnv.sqlUpdate(dropFunctionInWrongCatalog);
+			fail();
+		} catch (Exception e) {
+			assertTrue(e.getMessage().equals("Catalog catalog1 does not exist"));
+		}
+
+		try {
+			tableEnv.sqlUpdate(dropFunctionInWrongDB);
+			fail();
+		} catch (Exception e) {
+			assertEquals(e.getMessage(), "Could not execute DROP FUNCTION:" +
+				" (identifier: [`default_catalog`.`db1`.`f4`], IfExists: [false])");
+		}
+	}
+
+	@Test
+	public void testUseDefinedCatalogFunction() throws Exception {
+		List<Row> sourceData = Arrays.asList(
+			toRow(1, "1000", 2),
+			toRow(2, "1", 3),
+			toRow(3, "2000", 4),
+			toRow(1, "2", 2),
+			toRow(2, "3000", 3)
+		);
+
+		TestCollectionTableFactory.reset();
+		TestCollectionTableFactory.initData(sourceData, new ArrayList<Row>(), -1);
+
+		String sourceDDL = "create table t1(a int, b varchar, c int) with ('connector' = 'COLLECTION')";
+		String sinkDDL = "create table t2(a int, b varchar, c int) with ('connector' = 'COLLECTION')";
+
+		String functionDDL = "create function addOne as " +
+			"'org.apache.flink.table.catalog.CatalogFunctionTestBase$TestUDF'";
+
+		String query = " insert into t2 select t1.a, t1.b, addOne(t1.a, 1) as c from t1";
+
+		tableEnv.sqlUpdate(sourceDDL);
+		tableEnv.sqlUpdate(sinkDDL);
+		tableEnv.sqlUpdate(functionDDL);
+		tableEnv.sqlUpdate(query);
+		execute();
+
+		Row[] result = TestCollectionTableFactory.RESULT().toArray(new Row[0]);
+		Row[] expected = sourceData.toArray(new Row[0]);
+		assertArrayEquals(expected, result);
+	}
+
+	private Row toRow(Object ... objects) {
+		Row row = new Row(objects.length);
+		for (int i = 0; i < objects.length; i++) {
+			row.setField(i, objects[i]);
+		}
+
+		return row;
+	}
+
+	/**
+	 * Test udf class.
+	 */
+	public static class TestUDF extends ScalarFunction {
+
+		public Integer eval(Integer a, Integer b) {
+			return a + b;
+		}
+	}
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/sql/CatalogFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/sql/CatalogFunctionITCase.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.batch.sql;
+
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.table.api.java.BatchTableEnvironment;
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.CatalogFunctionTestBase;
+
+import org.junit.BeforeClass;
+
+/**
+ * Tests for {@link CatalogFunction} in batch table environment.
+ */
+public class CatalogFunctionITCase extends CatalogFunctionTestBase {
+	private static ExecutionEnvironment executionEnvironment = ExecutionEnvironment.getExecutionEnvironment();
+
+	@BeforeClass
+	public static void setup() {
+		BatchTableEnvironment batchTableEnvironment = BatchTableEnvironment.create(executionEnvironment);
+		setTableEnv(batchTableEnvironment);
+	}
+
+	@Override
+	public void execute() throws Exception {
+		executionEnvironment.execute();
+	}
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/stream/sql/CatalogFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/stream/sql/CatalogFunctionITCase.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.stream.sql;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.CatalogFunctionTestBase;
+
+import org.junit.BeforeClass;
+
+/**
+ * Tests for {@link CatalogFunction} in stream table environment.
+ */
+public class CatalogFunctionITCase extends CatalogFunctionTestBase {
+	private static StreamExecutionEnvironment streamExecEnvironment;
+
+	@BeforeClass
+	public static void setup() {
+		streamExecEnvironment = StreamExecutionEnvironment.getExecutionEnvironment();
+		StreamTableEnvironment streamTableEnvironment = StreamTableEnvironment.create(streamExecEnvironment);
+		setTableEnv(streamTableEnvironment);
+	}
+
+	@Override
+	public void execute() throws Exception {
+		streamExecEnvironment.execute();
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Create, drop and alter catalog functions through catalog manager.

## Brief change log

Add create, drop, alter function operation
Add SqlNode to Operation conversion logic SqlToOperationConverter
Add the catalog function registration and drop logic in table environments
Add CatalogFunctionITCase for end to end testing function DDL to create and drop catalog function in both Planner and Blink Planner

## Verifying this change

It is end to end tested in new added CatalogFunctionITCase for both planners.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
