### PR TITLE
[FLINK-15086][client] Explictly close JobCluster in attach mode

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/AbstractJobClusterExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/AbstractJobClusterExecutor.java
@@ -75,7 +75,16 @@ public class AbstractJobClusterExecutor<ClusterID, ClientFactory extends Cluster
 				return CompletableFuture.completedFuture(new ClusterClientJobClientAdapter<ClusterID>(clusterClient, jobGraph.getJobID()) {
 					@Override
 					protected void doClose() {
+						clusterClient.shutDownCluster();
 						ShutdownHookUtil.removeShutdownHook(shutdownHook, clusterClient.getClass().getSimpleName(), LOG);
+						clusterClient.close();
+					}
+				});
+			} else if (!configAccessor.getDetachedMode()){
+				return CompletableFuture.completedFuture(new ClusterClientJobClientAdapter<ClusterID>(clusterClient, jobGraph.getJobID()) {
+					@Override
+					protected void doClose() {
+						clusterClient.shutDownCluster();
 						clusterClient.close();
 					}
 				});


### PR DESCRIPTION
## What is the purpose of the change

If a JobCluster started in attached execution mode, it will wait for a client requesting its result and shutdown itself. However, there is no permission that a user got `JobClient` from `executeAsync` must call `getJobExecutionResult` so the cluster may leak.

Since currently the choice detach or attach can be done by user itself, my opinion is that we doesn't close JobCluster in MiniDispatcher in attach mode, but let the client send a shutdown request on close.

## Verifying this change

Maybe an end-to-end test for resource leak? I don't have an idea to verify per-job resource leak in UT/IT framework.

## Does this pull request potentially affect one of the following parts:

N/A

## Documentation

N/A
