### PR TITLE
[FLINK-14026][python] Manage the resource of Python worker properly

### DIFF
--- a/docs/_includes/generated/python_configuration.html
+++ b/docs/_includes/generated/python_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>python.fn-execution.buffer.memory.size</h5></td>
+            <td style="word-wrap: break-word;">"15mb"</td>
+            <td>String</td>
+            <td>The amount of memory to be allocated by the input buffer and output buffer of the Python worker. The memory will be accounted as managed memory.</td>
+        </tr>
+        <tr>
             <td><h5>python.fn-execution.bundle.size</h5></td>
             <td style="word-wrap: break-word;">1000</td>
             <td>Integer</td>
@@ -19,6 +25,12 @@
             <td style="word-wrap: break-word;">1000</td>
             <td>Long</td>
             <td>Sets the waiting timeout(in milliseconds) before processing a bundle for Python user-defined function execution. The timeout defines how long the elements of a bundle will be buffered before being processed. Lower timeouts lead to lower tail latencies, but may affect throughput.</td>
+        </tr>
+        <tr>
+            <td><h5>python.fn-execution.framework.memory.size</h5></td>
+            <td style="word-wrap: break-word;">"64mb"</td>
+            <td>String</td>
+            <td>The amount of memory to be allocated by the Python framework. The memory will be accounted as managed memory. The sum of the value of this configuration and "python.fn-execution.buffer.memory.size" represents the total memory of the Python worker.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/_includes/generated/python_configuration.html
+++ b/docs/_includes/generated/python_configuration.html
@@ -12,7 +12,7 @@
             <td><h5>python.fn-execution.buffer.memory.size</h5></td>
             <td style="word-wrap: break-word;">"15mb"</td>
             <td>String</td>
-            <td>The amount of memory to be allocated by the input buffer and output buffer of the Python worker. The memory will be accounted as managed memory.</td>
+            <td>The amount of memory to be allocated by the input buffer and output buffer of a Python worker. The memory will be accounted as managed memory if the actual memory allocated to an operator is no less than the total memory of a Python worker. Otherwise, this configuration takes no effect.</td>
         </tr>
         <tr>
             <td><h5>python.fn-execution.bundle.size</h5></td>
@@ -30,7 +30,7 @@
             <td><h5>python.fn-execution.framework.memory.size</h5></td>
             <td style="word-wrap: break-word;">"64mb"</td>
             <td>String</td>
-            <td>The amount of memory to be allocated by the Python framework. The memory will be accounted as managed memory. The sum of the value of this configuration and "python.fn-execution.buffer.memory.size" represents the total memory of the Python worker.</td>
+            <td>The amount of memory to be allocated by the Python framework. The sum of the value of this configuration and "python.fn-execution.buffer.memory.size" represents the total memory of a Python worker. The memory will be accounted as managed memory if the actual memory allocated to an operator is no less than the total memory of a Python worker. Otherwise, this configuration takes no effect.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
+++ b/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
@@ -48,4 +48,24 @@ public class PythonOptions {
 		.withDescription("Sets the waiting timeout(in milliseconds) before processing a bundle for " +
 			"Python user-defined function execution. The timeout defines how long the elements of a bundle will be " +
 			"buffered before being processed. Lower timeouts lead to lower tail latencies, but may affect throughput.");
+
+	/**
+	 * The amount of memory to be allocated by the Python framework.
+	 */
+	public static final ConfigOption<String> PYTHON_FRAMEWORK_MEMORY_SIZE = ConfigOptions
+		.key("python.fn-execution.framework.memory.size")
+		.defaultValue("64mb")
+		.withDescription("The amount of memory to be allocated by the Python framework. The" +
+			" memory will be accounted as managed memory. The sum of the value of this" +
+			" configuration and \"python.fn-execution.buffer.memory.size\" represents the total" +
+			" memory of the Python worker.");
+
+	/**
+	 * The amount of memory to be allocated by the input/output buffer of the Python worker.
+	 */
+	public static final ConfigOption<String> PYTHON_DATA_BUFFER_MEMORY_SIZE = ConfigOptions
+		.key("python.fn-execution.buffer.memory.size")
+		.defaultValue("15mb")
+		.withDescription("The amount of memory to be allocated by the input buffer and output" +
+			" buffer of the Python worker. The memory will be accounted as managed memory.");
 }

--- a/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
+++ b/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
@@ -55,17 +55,20 @@ public class PythonOptions {
 	public static final ConfigOption<String> PYTHON_FRAMEWORK_MEMORY_SIZE = ConfigOptions
 		.key("python.fn-execution.framework.memory.size")
 		.defaultValue("64mb")
-		.withDescription("The amount of memory to be allocated by the Python framework. The" +
-			" memory will be accounted as managed memory. The sum of the value of this" +
-			" configuration and \"python.fn-execution.buffer.memory.size\" represents the total" +
-			" memory of the Python worker.");
+		.withDescription("The amount of memory to be allocated by the Python framework. The sum " +
+			"of the value of this configuration and \"python.fn-execution.buffer.memory.size\" " +
+			"represents the total memory of a Python worker. The memory will be accounted as " +
+			"managed memory if the actual memory allocated to an operator is no less than the " +
+			"total memory of a Python worker. Otherwise, this configuration takes no effect.");
 
 	/**
-	 * The amount of memory to be allocated by the input/output buffer of the Python worker.
+	 * The amount of memory to be allocated by the input/output buffer of a Python worker.
 	 */
 	public static final ConfigOption<String> PYTHON_DATA_BUFFER_MEMORY_SIZE = ConfigOptions
 		.key("python.fn-execution.buffer.memory.size")
 		.defaultValue("15mb")
-		.withDescription("The amount of memory to be allocated by the input buffer and output" +
-			" buffer of the Python worker. The memory will be accounted as managed memory.");
+		.withDescription("The amount of memory to be allocated by the input buffer and output " +
+			"buffer of a Python worker. The memory will be accounted as managed memory if the " +
+			"actual memory allocated to an operator is no less than the total memory of a Python " +
+			"worker. Otherwise, this configuration takes no effect.");
 }

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractPythonFunctionOperator.java
@@ -20,11 +20,14 @@ package org.apache.flink.streaming.api.operators.python;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.python.PythonOptions;
 import org.apache.flink.python.env.ProcessPythonEnvironmentManager;
 import org.apache.flink.python.env.PythonDependencyInfo;
 import org.apache.flink.python.env.PythonEnvironmentManager;
+import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
@@ -89,6 +92,11 @@ public abstract class AbstractPythonFunctionOperator<IN, OUT>
 	 */
 	private transient Runnable bundleFinishedCallback;
 
+	/**
+	 * The size of the reserved memory from the MemoryManager.
+	 */
+	private transient long reservedMemory;
+
 	public AbstractPythonFunctionOperator() {
 		this.chainingStrategy = ChainingStrategy.ALWAYS;
 	}
@@ -99,6 +107,30 @@ public abstract class AbstractPythonFunctionOperator<IN, OUT>
 			this.bundleStarted = new AtomicBoolean(false);
 
 			Map<String, String> jobParams = getExecutionConfig().getGlobalJobParameters().toMap();
+
+			long requiredPythonWorkerMemory =
+				MemorySize.parse(
+					jobParams.getOrDefault(PythonOptions.PYTHON_FRAMEWORK_MEMORY_SIZE.key(),
+						String.valueOf(PythonOptions.PYTHON_FRAMEWORK_MEMORY_SIZE.defaultValue())))
+					.add(MemorySize.parse(jobParams.getOrDefault(PythonOptions.PYTHON_DATA_BUFFER_MEMORY_SIZE.key(),
+						String.valueOf(PythonOptions.PYTHON_DATA_BUFFER_MEMORY_SIZE.defaultValue()))))
+					.getBytes();
+			MemoryManager memoryManager = getContainingTask().getEnvironment().getMemoryManager();
+			long availableManagedMemory = memoryManager.computeMemorySize(
+				getOperatorConfig().getManagedMemoryFraction());
+			if (requiredPythonWorkerMemory <= availableManagedMemory) {
+				memoryManager.reserveMemory(this, MemoryType.OFF_HEAP, requiredPythonWorkerMemory);
+				LOG.info("Reserved memory {} for Python worker.", requiredPythonWorkerMemory);
+				this.reservedMemory = requiredPythonWorkerMemory;
+				// TODO enforce the memory limit of Python worker
+			} else {
+				LOG.warn("Required Python worker memory {} exceeds the available managed off-heap " +
+					"memory {}. Skipping reserving off-heap memory from the MemoryManager. This does " +
+					"not affect the functionality. However, it may affect the stability of a job as " +
+					"the memory used by the Python worker is not managed by Flink.",
+					requiredPythonWorkerMemory, availableManagedMemory);
+				this.reservedMemory = -1;
+			}
 
 			this.maxBundleSize = Integer.valueOf(jobParams.getOrDefault(
 				PythonOptions.MAX_BUNDLE_SIZE.key(),
@@ -159,6 +191,11 @@ public abstract class AbstractPythonFunctionOperator<IN, OUT>
 			if (pythonFunctionRunner != null) {
 				pythonFunctionRunner.close();
 				pythonFunctionRunner = null;
+			}
+			if (reservedMemory > 0) {
+				getContainingTask().getEnvironment().getMemoryManager().releaseMemory(
+					this, MemoryType.OFF_HEAP, reservedMemory);
+				reservedMemory = -1;
 			}
 		} finally {
 			super.dispose();

--- a/flink-python/src/test/java/org/apache/flink/python/PythonOptionsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/PythonOptionsTest.java
@@ -56,4 +56,30 @@ public class PythonOptionsTest {
 		final long actualBundleSize = configuration.getLong(PythonOptions.MAX_BUNDLE_TIME_MILLS);
 		assertThat(actualBundleSize, is(equalTo(expectedBundleTime)));
 	}
+
+	@Test
+	public void testPythonFrameworkMemorySize() {
+		final Configuration configuration = new Configuration();
+		final String defaultPythonFrameworkMemorySize = configuration.getString(PythonOptions.PYTHON_FRAMEWORK_MEMORY_SIZE);
+		assertThat(defaultPythonFrameworkMemorySize, is(equalTo(PythonOptions.PYTHON_FRAMEWORK_MEMORY_SIZE.defaultValue())));
+
+		final String expectedPythonFrameworkMemorySize = "100mb";
+		configuration.setString(PythonOptions.PYTHON_FRAMEWORK_MEMORY_SIZE, expectedPythonFrameworkMemorySize);
+
+		final String actualPythonFrameworkMemorySize = configuration.getString(PythonOptions.PYTHON_FRAMEWORK_MEMORY_SIZE);
+		assertThat(actualPythonFrameworkMemorySize, is(equalTo(expectedPythonFrameworkMemorySize)));
+	}
+
+	@Test
+	public void testPythonBufferMemorySize() {
+		final Configuration configuration = new Configuration();
+		final String defaultPythonBufferMemorySize = configuration.getString(PythonOptions.PYTHON_DATA_BUFFER_MEMORY_SIZE);
+		assertThat(defaultPythonBufferMemorySize, is(equalTo(PythonOptions.PYTHON_DATA_BUFFER_MEMORY_SIZE.defaultValue())));
+
+		final String expectedPythonBufferMemorySize = "100mb";
+		configuration.setString(PythonOptions.PYTHON_DATA_BUFFER_MEMORY_SIZE, expectedPythonBufferMemorySize);
+
+		final String actualPythonBufferMemorySize = configuration.getString(PythonOptions.PYTHON_DATA_BUFFER_MEMORY_SIZE);
+		assertThat(actualPythonBufferMemorySize, is(equalTo(expectedPythonBufferMemorySize)));
+	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperatorTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperatorTestBase.java
@@ -233,7 +233,10 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN, UDFOU
 			new int[]{0, 1}
 		);
 
-		return new OneInputStreamOperatorTestHarness<>(operator);
+		OneInputStreamOperatorTestHarness<IN, OUT> testHarness =
+			new OneInputStreamOperatorTestHarness<>(operator);
+		testHarness.getStreamConfig().setManagedMemoryFraction(0.5);
+		return testHarness;
 	}
 
 	public abstract AbstractPythonScalarFunctionOperator<IN, OUT, UDFIN, UDFOUT> getTestOperator(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -290,6 +290,10 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 		return executionConfig;
 	}
 
+	public StreamConfig getStreamConfig() {
+		return config;
+	}
+
 	/**
 	 * Get all the output from the task. This contains StreamRecords and Events interleaved.
 	 */

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCalc.scala
@@ -37,7 +37,7 @@ import scala.collection.mutable
 
 trait CommonPythonCalc {
 
-  private def loadClass(className: String): Class[_] = {
+  def loadClass(className: String): Class[_] = {
     try {
       Class.forName(className, false, Thread.currentThread.getContextClassLoader)
     } catch {


### PR DESCRIPTION
## What is the purpose of the change

*This pull request add support to manage the resource of the Python worker. The memory of the Python worker will be accounted as the managed memory and managed by Flink.*

## Brief change log

  - *Introduce configuration python.fn-execution.framework.memory.size and python.fn-execution.buffer.memory.size*
  - *At compile phase, request the required amount of memory for the Python worker*
  - *At runtime phase, reserve the required amount of memory for the Python worker from MemoryManager*

## Verifying this change

This change added tests and can be verified as follows:
  - *Added test in PythonOptionsTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes, added configuration python.fn-execution.framework.memory.size and python.fn-execution.buffer.memory.size)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
