### PR TITLE
[FLINK-15089][connectors] Puslar catalog

### DIFF
--- a/flink-connectors/flink-connector-pulsar/pom.xml
+++ b/flink-connectors/flink-connector-pulsar/pom.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-connectors</artifactId>
+		<version>1.10-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-connector-pulsar_${scala.binary.version}</artifactId>
+	<name>flink-connector-pulsar</name>
+
+	<packaging>jar</packaging>
+
+	<!-- Allow users to pass custom connector versions -->
+	<properties>
+		<pulsar.version>2.4.1</pulsar.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.pulsar</groupId>
+			<artifactId>pulsar-client-all</artifactId>
+			<version>${pulsar.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Table ecosystem -->
+		<!-- Projects depending on this project won't depend on flink-table-*. -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-api-java-bridge_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+		<!-- A planner dependency won't be necessary once FLIP-32 has been completed. -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- test dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-tests</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Pulsar table descriptor testing -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-common</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Pulsar catalog testing -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-sql-client_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/flink-connectors/flink-connector-pulsar/pom.xml
+++ b/flink-connectors/flink-connector-pulsar/pom.xml
@@ -37,7 +37,9 @@ under the License.
 
 	<!-- Allow users to pass custom connector versions -->
 	<properties>
-		<pulsar.version>2.4.1</pulsar.version>
+		<pulsar.version>2.4.2</pulsar.version>
+		<streamnative-tests.version>2.4.2</streamnative-tests.version>
+		<testcontainers.version>1.10.6</testcontainers.version>
 	</properties>
 
 	<dependencies>
@@ -80,6 +82,13 @@ under the License.
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-metrics-jmx_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>
@@ -138,6 +147,48 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>io.streamnative.tests</groupId>
+			<artifactId>framework-common</artifactId>
+			<version>${streamnative-tests.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>io.netty</groupId>
+					<artifactId>netty-common</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>io.streamnative.tests</groupId>
+			<artifactId>framework-pulsar</artifactId>
+			<version>${streamnative-tests.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.pulsar</groupId>
+					<artifactId>pulsar-client-original</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.pulsar</groupId>
+					<artifactId>pulsar-client-admin-original</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 	</dependencies>
+
+	<repositories>
+		<repository>
+			<id>central</id>
+			<layout>default</layout>
+			<url>https://repo1.maven.org/maven2</url>
+		</repository>
+		<repository>
+			<id>bintray-streamnative-maven</id>
+			<name>bintray</name>
+			<url>https://dl.bintray.com/streamnative/maven</url>
+		</repository>
+	</repositories>
 
 </project>

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarMetadataReader.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarMetadataReader.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar.internal;
+
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.types.FieldsDataType;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.schema.BytesSchema;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicDomain;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.schema.SchemaInfo;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class PulsarMetadataReader implements Closeable {
+
+	private PulsarAdmin admin;
+
+	private volatile boolean closed = false;
+
+	public PulsarMetadataReader(String adminUrl) throws PulsarClientException {
+		this.admin = PulsarAdmin.builder().serviceHttpUrl(adminUrl).build();
+	}
+
+	@Override
+	public void close() {
+		closed = true;
+		if (admin != null) {
+			admin.close();
+			admin = null;
+		}
+	}
+	
+	public List<String> listNamespaces() throws PulsarAdminException {
+		List<String> tenants = admin.tenants().getTenants();
+		List<String> namespaces = new ArrayList<>();
+		for (String tenant : tenants) {
+			namespaces.addAll(admin.namespaces().getNamespaces(tenant));
+		}
+		return namespaces;
+	}
+
+	public boolean namespaceExists(String ns) throws PulsarAdminException {
+		try {
+			admin.namespaces().getTopics(ns);
+		} catch (PulsarAdminException.NotFoundException e) {
+			return false;
+		}
+		return true;
+	}
+
+	public void createNamespace(String ns) throws PulsarAdminException {
+		String nsName = NamespaceName.get(ns).toString();
+		admin.namespaces().createNamespace(nsName);
+	}
+
+	public void deleteNamespace(String ns) throws PulsarAdminException {
+		String nsName = NamespaceName.get(ns).toString();
+		admin.namespaces().deleteNamespace(nsName);
+	}
+
+	public List<String> getTopics(String ns) throws PulsarAdminException {
+		List<String> nonPartitionedTopics = getNonPartitionedTopics(ns);
+		List<String> partitionedTopics = admin.topics().getPartitionedTopicList(ns);
+		List<String> allTopics = new ArrayList<>();
+		Stream.of(partitionedTopics, nonPartitionedTopics).forEach(allTopics::addAll);
+		return allTopics.stream().map(t -> TopicName.get(t).getLocalName()).collect(Collectors.toList());
+	}
+
+	private List<String> getNonPartitionedTopics(String databaseName) throws PulsarAdminException {
+		return admin
+			.topics()
+			.getList(databaseName)
+			.stream()
+			.filter(t -> !TopicName.get(t).isPartitioned()).collect(Collectors.toList());
+	}
+
+	public TableSchema getTableSchema(ObjectPath objectPath) throws PulsarAdminException {
+		String topicName = objectPath2TopicName(objectPath);
+		FieldsDataType fieldsDataType = getSchema(topicName);
+		return SchemaUtils.toTableSchema(fieldsDataType);
+	}
+
+	public boolean topicExists(ObjectPath objectPath) throws PulsarAdminException {
+		String topicName = objectPath2TopicName(objectPath);
+		int partitionNum = admin.topics().getPartitionedTopicMetadata(topicName).partitions;
+		if (partitionNum > 0) {
+			return true;
+		} else {
+			admin.topics().getStats(topicName);
+		}
+		return true;
+	}
+
+	public void deleteTopic(ObjectPath objectPath) throws PulsarAdminException {
+		String topicName = objectPath2TopicName(objectPath);
+		int partitionNum = admin.topics().getPartitionedTopicMetadata(topicName).partitions;
+		if (partitionNum > 0) {
+			admin.topics().deletePartitionedTopic(topicName, true);
+		} else {
+			admin.topics().delete(topicName, true);
+		}
+	}
+
+	public void createTopic(ObjectPath objectPath, int defaultPartitionNum, CatalogBaseTable table) throws PulsarAdminException, SchemaUtils.IncompatibleSchemaException {
+		String topicName = objectPath2TopicName(objectPath);
+		admin.topics().createPartitionedTopic(topicName, defaultPartitionNum);
+		SchemaInfo si = SchemaUtils.sqlType2PulsarSchema(table.getSchema().toRowDataType()).getSchemaInfo();
+	}
+
+	private FieldsDataType getSchema(String topic) throws PulsarAdminException {
+		SchemaInfo si = getPulsarSchema(topic);
+		try {
+			return SchemaUtils.pulsarSourceSchema(si);
+		} catch (SchemaUtils.IncompatibleSchemaException e) {
+			throw new PulsarAdminException(e);
+		}
+	}
+
+	private SchemaInfo getPulsarSchema(String topic) throws PulsarAdminException {
+		try {
+			return admin.schemas().getSchemaInfo(TopicName.get(topic).toString());
+		} catch (PulsarAdminException e) {
+			if (e.getStatusCode() == 404) {
+				return BytesSchema.of().getSchemaInfo();
+			} else {
+				throw e;
+			}
+		}
+	}
+
+	private static String objectPath2TopicName(ObjectPath objectPath) {
+		NamespaceName ns = NamespaceName.get(objectPath.getDatabaseName());
+		String topic = objectPath.getObjectName();
+		TopicName fullName = TopicName.get(TopicDomain.persistent.toString(), ns, topic);
+		return fullName.toString();
+	}
+
+
+
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarMetadataReader.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarMetadataReader.java
@@ -15,12 +15,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.streaming.connectors.pulsar.internal;
 
+import com.google.common.collect.Iterables;
+import org.apache.commons.collections.ListUtils;
+import org.apache.flink.streaming.connectors.pulsar.internal.SchemaUtils.IncompatibleSchemaException;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.FieldsDataType;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -30,35 +34,65 @@ import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.schema.SchemaInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.Closeable;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class PulsarMetadataReader implements Closeable {
+/**
+ * A Helper class that responsible for catalog administration.
+ */
+public class PulsarMetadataReader implements AutoCloseable {
 
-	private PulsarAdmin admin;
+	protected static final Logger LOG = LoggerFactory.getLogger(PulsarMetadataReader.class);
+
+	private final String adminUrl;
+
+	private final String driverGroupIdPrefix;
+
+	private final Map<String, String> caseInsensitiveParams;
+
+	private final int indexOfThisSubtask;
+
+	private final int numParallelSubtasks;
+
+	private final PulsarAdmin admin;
 
 	private volatile boolean closed = false;
 
-	public PulsarMetadataReader(String adminUrl) throws PulsarClientException {
+	public PulsarMetadataReader(
+		String adminUrl,
+		String driverGroupIdPrefix,
+		Map<String, String> caseInsensitiveParams,
+		int indexOfThisSubtask,
+		int numParallelSubtasks) throws PulsarClientException {
+
+		this.adminUrl = adminUrl;
+		this.driverGroupIdPrefix = driverGroupIdPrefix;
+		this.caseInsensitiveParams = caseInsensitiveParams;
+		this.indexOfThisSubtask = indexOfThisSubtask;
+		this.numParallelSubtasks = numParallelSubtasks;
 		this.admin = PulsarAdmin.builder().serviceHttpUrl(adminUrl).build();
 	}
 
 	@Override
 	public void close() {
 		closed = true;
-		if (admin != null) {
-			admin.close();
-			admin = null;
-		}
+		admin.close();
 	}
-	
+
 	public List<String> listNamespaces() throws PulsarAdminException {
 		List<String> tenants = admin.tenants().getTenants();
-		List<String> namespaces = new ArrayList<>();
+		List<String> namespaces = new ArrayList<String>();
 		for (String tenant : tenants) {
 			namespaces.addAll(admin.namespaces().getNamespaces(tenant));
 		}
@@ -92,17 +126,14 @@ public class PulsarMetadataReader implements Closeable {
 		return allTopics.stream().map(t -> TopicName.get(t).getLocalName()).collect(Collectors.toList());
 	}
 
-	private List<String> getNonPartitionedTopics(String databaseName) throws PulsarAdminException {
-		return admin
-			.topics()
-			.getList(databaseName)
-			.stream()
-			.filter(t -> !TopicName.get(t).isPartitioned()).collect(Collectors.toList());
-	}
-
 	public TableSchema getTableSchema(ObjectPath objectPath) throws PulsarAdminException {
 		String topicName = objectPath2TopicName(objectPath);
-		FieldsDataType fieldsDataType = getSchema(topicName);
+		FieldsDataType fieldsDataType = null;
+		try {
+			fieldsDataType = getSchema(Collections.singletonList(topicName));
+		} catch (IncompatibleSchemaException e) {
+			throw new PulsarAdminException(e);
+		}
 		return SchemaUtils.toTableSchema(fieldsDataType);
 	}
 
@@ -127,40 +158,139 @@ public class PulsarMetadataReader implements Closeable {
 		}
 	}
 
-	public void createTopic(ObjectPath objectPath, int defaultPartitionNum, CatalogBaseTable table) throws PulsarAdminException, SchemaUtils.IncompatibleSchemaException {
+	public void createTopic(ObjectPath objectPath, int defaultPartitionNum, CatalogBaseTable table) throws PulsarAdminException, IncompatibleSchemaException {
 		String topicName = objectPath2TopicName(objectPath);
 		admin.topics().createPartitionedTopic(topicName, defaultPartitionNum);
-		SchemaInfo si = SchemaUtils.sqlType2PulsarSchema(table.getSchema().toRowDataType()).getSchemaInfo();
 	}
 
-	private FieldsDataType getSchema(String topic) throws PulsarAdminException {
-		SchemaInfo si = getPulsarSchema(topic);
-		try {
-			return SchemaUtils.pulsarSourceSchema(si);
-		} catch (SchemaUtils.IncompatibleSchemaException e) {
-			throw new PulsarAdminException(e);
+	public void putSchema(ObjectPath tablePath, CatalogBaseTable table) throws IncompatibleSchemaException {
+		String topic = objectPath2TopicName(tablePath);
+		TableSchema tableSchema = table.getSchema();
+		List<String> fieldsRemaining = new ArrayList<>(tableSchema.getFieldCount());
+		for (String fieldName : tableSchema.getFieldNames()) {
+			if (!PulsarOptions.META_FIELD_NAMES.contains(fieldName)) {
+				fieldsRemaining.add(fieldName);
+			}
+		}
+
+		DataType dataType;
+
+		if (fieldsRemaining.size() == 1) {
+			dataType = tableSchema.getFieldDataType(fieldsRemaining.get(0)).get();
+		} else {
+			List<DataTypes.Field> fieldList = fieldsRemaining.stream()
+				.map(f -> DataTypes.FIELD(f, tableSchema.getFieldDataType(f).get()))
+				.collect(Collectors.toList());
+			dataType = DataTypes.ROW(fieldList.toArray(new DataTypes.Field[0]));
+		}
+
+		SchemaInfo si = SchemaUtils.sqlType2PulsarSchema(dataType).getSchemaInfo();
+		SchemaUtils.uploadPulsarSchema(admin, topic, si);
+	}
+
+	public FieldsDataType getSchema(List<String> topics) throws IncompatibleSchemaException {
+		SchemaInfo si = getPulsarSchema(topics);
+		return SchemaUtils.pulsarSourceSchema(si);
+	}
+
+	public SchemaInfo getPulsarSchema(List<String> topics) throws IncompatibleSchemaException {
+		Set<SchemaInfo> schemas = new HashSet<>();
+		if (topics.size() > 0) {
+			topics.forEach(t -> schemas.add(getPulsarSchema(t)));
+
+			if (schemas.size() != 1) {
+				throw new IncompatibleSchemaException(
+					String.format("Topics to read must share identical schema, however we got %d distinct schemas [%s]",
+						schemas.size(),
+						String.join(",", schemas.stream().map(SchemaInfo::toString).collect(Collectors.toList()))),
+					null);
+			}
+			return Iterables.getFirst(schemas, SchemaUtils.emptySchemaInfo());
+		} else {
+			return SchemaUtils.emptySchemaInfo();
 		}
 	}
 
-	private SchemaInfo getPulsarSchema(String topic) throws PulsarAdminException {
+	public SchemaInfo getPulsarSchema(String topic) {
 		try {
 			return admin.schemas().getSchemaInfo(TopicName.get(topic).toString());
-		} catch (PulsarAdminException e) {
-			if (e.getStatusCode() == 404) {
+		} catch (Throwable e) {
+			if (e instanceof PulsarAdminException && ((PulsarAdminException) e).getStatusCode() == 404) {
 				return BytesSchema.of().getSchemaInfo();
 			} else {
-				throw e;
+				throw new RuntimeException(
+					String.format("Failed to get schema information for %s", TopicName.get(topic).toString()), e);
 			}
 		}
 	}
 
-	private static String objectPath2TopicName(ObjectPath objectPath) {
+	public Set<String> getTopicPartitionsAll() throws PulsarAdminException {
+		List<String> topics = getTopics();
+		HashSet<String> allTopics = new HashSet<>();
+		for (String topic : topics) {
+			int partNum = admin.topics().getPartitionedTopicMetadata(topic).partitions;
+			if (partNum == 0) {
+				allTopics.add(topic);
+			} else {
+				for (int i = 0; i < partNum; i++) {
+					allTopics.add(topic + PulsarOptions.PARTITION_SUFFIX + i);
+				}
+			}
+		}
+		return allTopics;
+	}
+
+	public List<String> getTopics() throws PulsarAdminException {
+		for (Map.Entry<String, String> e : caseInsensitiveParams.entrySet()) {
+			if (PulsarOptions.TOPIC_OPTION_KEYS.contains(e.getKey())) {
+				String key = e.getKey();
+				if (key.equals("topic")) {
+					return Collections.singletonList(TopicName.get(e.getValue()).toString());
+				} else if (key.equals("topics")) {
+					return Arrays.asList(e.getValue().split(",")).stream()
+						.filter(s -> !s.isEmpty())
+						.map(t -> TopicName.get(t).toString())
+						.collect(Collectors.toList());
+				} else { // topicspattern
+					return getTopicsWithPattern(e.getValue());
+				}
+			}
+		}
+		return null;
+	}
+
+	private List<String> getTopicsWithPattern(String topicsPattern) throws PulsarAdminException {
+		TopicName dest = TopicName.get(topicsPattern);
+		List<String> allNonPartitionedTopics = getNonPartitionedTopics(dest.getNamespace());
+		List<String> nonPartitionedMatch = topicsPatternFilter(allNonPartitionedTopics, dest.toString());
+
+		List<String> allPartitionedTopics = admin.topics().getPartitionedTopicList(dest.getNamespace());
+		List<String> partitionedMatch = topicsPatternFilter(allPartitionedTopics, dest.toString());
+
+		return ListUtils.union(nonPartitionedMatch, partitionedMatch);
+	}
+
+	private List<String> getNonPartitionedTopics(String namespace) throws PulsarAdminException {
+		return admin.topics().getList(namespace).stream()
+			.filter(t -> !TopicName.get(t).isPartitioned())
+			.collect(Collectors.toList());
+	}
+
+	private List<String> topicsPatternFilter(List<String> allTopics, String topicsPattern) {
+		Pattern shortenedTopicsPattern = Pattern.compile(topicsPattern.split("\\:\\/\\/")[1]);
+		return allTopics.stream().map(t -> TopicName.get(t).toString())
+			.filter(t -> shortenedTopicsPattern.matcher(t.split("\\:\\/\\/")[1]).matches())
+			.collect(Collectors.toList());
+	}
+
+	public static String objectPath2TopicName(ObjectPath objectPath) {
 		NamespaceName ns = NamespaceName.get(objectPath.getDatabaseName());
 		String topic = objectPath.getObjectName();
 		TopicName fullName = TopicName.get(TopicDomain.persistent.toString(), ns, topic);
 		return fullName.toString();
 	}
 
+	public static class ClosedException extends Exception {
 
-
+	}
 }

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarOptions.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarOptions.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar.internal;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+public class PulsarOptions {
+
+	public static final String TOPIC_ATTRIBUTE_NAME = "__topic";
+	public static final String KEY_ATTRIBUTE_NAME = "__key";
+	public static final String MESSAGE_ID_NAME = "__messageId";
+	public static final String PUBLISH_TIME_NAME = "__publishTime";
+	public static final String EVENT_TIME_NAME = "__eventTime";
+
+	public static final List<String> META_FIELD_NAMES = ImmutableList.of(
+		TOPIC_ATTRIBUTE_NAME,
+		KEY_ATTRIBUTE_NAME,
+		MESSAGE_ID_NAME,
+		PUBLISH_TIME_NAME,
+		EVENT_TIME_NAME);
+
+	public static final String DEFAULT_PARTITIONS = "tableDefaultPartitions";
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarOptions.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarOptions.java
@@ -19,10 +19,39 @@
 package org.apache.flink.streaming.connectors.pulsar.internal;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.shade.com.google.common.collect.ImmutableSet;
 
 import java.util.List;
+import java.util.Set;
 
+/**
+ * Multiple options keys to work with the Pulsar connector.
+ */
 public class PulsarOptions {
+
+	// topic options
+	public static final String TOPIC_SINGLE_OPTION_KEY = "topic";
+	public static final String TOPIC_MULTI_OPTION_KEY = "topics";
+	public static final String TOPIC_PATTERN_OPTION_KEY = "topicspattern";
+
+	public static final String PARTITION_SUFFIX = TopicName.PARTITIONED_TOPIC_SUFFIX;
+
+	public static final Set<String> TOPIC_OPTION_KEYS = ImmutableSet.of(
+		TOPIC_SINGLE_OPTION_KEY,
+		TOPIC_MULTI_OPTION_KEY,
+		TOPIC_PATTERN_OPTION_KEY);
+
+	public static final String SERVICE_URL_OPTION_KEY = "service-url";
+	public static final String ADMIN_URL_OPTION_KEY = "admin-url";
+	public static final String STARTUP_MODE_OPTION_KEY = "startup-mode";
+
+	public static final String PARTITION_DISCOVERY_INTERVAL_MS_OPTION_KEY = "partitiondiscoveryintervalmillis";
+	public static final String CLIENT_CACHE_SIZE_OPTION_KEY = "clientcachesize";
+	public static final String FLUSH_ON_CHECKPOINT_OPTION_KEY = "flushoncheckpoint";
+	public static final String FAIL_ON_WRITE_OPTION_KEY = "failonwrite";
+	public static final String POLL_TIMEOUT_MS_OPTION_KEY = "polltimeoutms";
+	public static final String FAIL_ON_DATA_LOSS_OPTION_KEY = "failondataloss";
 
 	public static final String TOPIC_ATTRIBUTE_NAME = "__topic";
 	public static final String KEY_ATTRIBUTE_NAME = "__key";
@@ -37,5 +66,5 @@ public class PulsarOptions {
 		PUBLISH_TIME_NAME,
 		EVENT_TIME_NAME);
 
-	public static final String DEFAULT_PARTITIONS = "tableDefaultPartitions";
+	public static final String DEFAULT_PARTITIONS = "table-default-partitions";
 }

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/SchemaUtils.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/SchemaUtils.java
@@ -1,0 +1,399 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar.internal;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.types.AtomicDataType;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.FieldsDataType;
+import org.apache.flink.table.types.KeyValueDataType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.impl.schema.BooleanSchema;
+import org.apache.pulsar.client.impl.schema.ByteSchema;
+import org.apache.pulsar.client.impl.schema.BytesSchema;
+import org.apache.pulsar.client.impl.schema.DateSchema;
+import org.apache.pulsar.client.impl.schema.DoubleSchema;
+import org.apache.pulsar.client.impl.schema.FloatSchema;
+import org.apache.pulsar.client.impl.schema.IntSchema;
+import org.apache.pulsar.client.impl.schema.LongSchema;
+import org.apache.pulsar.client.impl.schema.ShortSchema;
+import org.apache.pulsar.client.impl.schema.TimestampSchema;
+import org.apache.pulsar.common.schema.SchemaInfo;
+
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.shade.org.apache.avro.LogicalType;
+import org.apache.pulsar.shade.org.apache.avro.LogicalTypes;
+import org.apache.pulsar.shade.org.apache.avro.Schema;
+import org.apache.pulsar.shade.org.apache.avro.SchemaBuilder;
+import scala.NotImplementedError;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions.TOPIC_ATTRIBUTE_NAME;
+import static org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions.KEY_ATTRIBUTE_NAME;
+import static org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions.MESSAGE_ID_NAME;
+import static org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions.PUBLISH_TIME_NAME;
+import static org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions.EVENT_TIME_NAME;
+
+public class SchemaUtils {
+
+	public static TableSchema toTableSchema(FieldsDataType schema) {
+		RowType rt = (RowType) schema.getLogicalType();
+		List<DataType> fieldTypes = rt.getFieldNames().stream().map(fn -> schema.getFieldDataTypes().get(fn)).collect(Collectors.toList());
+
+		return TableSchema.builder().fields(
+			rt.getFieldNames().toArray(new String[0]), fieldTypes.toArray(new DataType[0])).build();
+	}
+
+	public static FieldsDataType pulsarSourceSchema(SchemaInfo si) throws IncompatibleSchemaException {
+		List<DataTypes.Field> mainSchema = new ArrayList<>();
+		DataType dataType = si2SqlType(si);
+		if (dataType instanceof FieldsDataType) {
+			FieldsDataType fieldsDataType = (FieldsDataType) dataType;
+			RowType rowType = (RowType) fieldsDataType.getLogicalType();
+			rowType.getFieldNames().stream()
+				.map(fieldName -> DataTypes.FIELD(fieldName, fieldsDataType.getFieldDataTypes().get(fieldName)))
+				.forEach(mainSchema::add);
+		} else {
+			mainSchema.add(DataTypes.FIELD("value", dataType));
+		}
+
+		mainSchema.addAll(metadataFields);
+		return (FieldsDataType) DataTypes.ROW(mainSchema.toArray(new DataTypes.Field[0]));
+	}
+
+	public static List<DataTypes.Field> metadataFields = ImmutableList.of(
+		DataTypes.FIELD(
+			KEY_ATTRIBUTE_NAME,
+			DataTypes.BYTES()),
+		DataTypes.FIELD(
+			TOPIC_ATTRIBUTE_NAME,
+			DataTypes.STRING()),
+		DataTypes.FIELD(
+			MESSAGE_ID_NAME,
+			DataTypes.BYTES()),
+		DataTypes.FIELD(
+			PUBLISH_TIME_NAME,
+			DataTypes.TIMESTAMP(3).bridgedTo(java.sql.Timestamp.class)),
+		DataTypes.FIELD(
+			EVENT_TIME_NAME,
+			DataTypes.TIMESTAMP(3).bridgedTo(java.sql.Timestamp.class)));
+
+	public static DataType si2SqlType(SchemaInfo si) throws IncompatibleSchemaException, NotImplementedError {
+		switch (si.getType()) {
+			case NONE:
+			case BYTES:
+				return DataTypes.BYTES();
+			case BOOLEAN:
+				return DataTypes.BOOLEAN();
+			case DATE:
+				return DataTypes.DATE();
+			case STRING:
+				return DataTypes.STRING();
+			case TIMESTAMP:
+				return DataTypes.TIMESTAMP(3).bridgedTo(java.sql.Timestamp.class);
+			case INT8:
+				return DataTypes.TINYINT();
+			case DOUBLE:
+				return DataTypes.DOUBLE();
+			case FLOAT:
+				return DataTypes.FLOAT();
+			case INT32:
+				return DataTypes.INT();
+			case INT64:
+				return DataTypes.BIGINT();
+			case INT16:
+				return DataTypes.SMALLINT();
+			case AVRO:
+			case JSON:
+				Schema avroSchema =
+					new Schema.Parser().parse(new String(si.getSchema(), StandardCharsets.UTF_8));
+				return avro2SqlType(avroSchema, Collections.emptySet());
+			default:
+				throw new NotImplementedError(String.format("We do not support %s currently.", si.getType()));
+		}
+	}
+
+	private static DataType avro2SqlType(Schema avroSchema, Set<String> existingRecordNames) throws IncompatibleSchemaException {
+		LogicalType logicalType = avroSchema.getLogicalType();
+		switch (avroSchema.getType()) {
+			case INT:
+				if (logicalType instanceof LogicalTypes.Date) {
+					return DataTypes.DATE();
+				} else {
+					return DataTypes.INT();
+				}
+
+			case STRING:
+			case ENUM:
+				return DataTypes.STRING();
+
+			case BOOLEAN:
+				return DataTypes.BOOLEAN();
+
+			case BYTES:
+			case FIXED:
+				// For FIXED type, if the precision requires more bytes than fixed size, the logical
+				// type will be null, which is handled by Avro library.
+				if (logicalType instanceof LogicalTypes.Decimal) {
+					LogicalTypes.Decimal d = (LogicalTypes.Decimal) logicalType;
+					return DataTypes.DECIMAL(d.getPrecision(), d.getScale());
+				} else {
+					return DataTypes.BYTES();
+				}
+
+			case DOUBLE:
+				return DataTypes.DOUBLE();
+
+			case FLOAT:
+				return DataTypes.FLOAT();
+
+			case LONG:
+				if (logicalType instanceof LogicalTypes.TimestampMillis ||
+					logicalType instanceof LogicalTypes.TimestampMicros) {
+					return DataTypes.TIMESTAMP(3).bridgedTo(java.sql.Timestamp.class);
+				} else {
+					return DataTypes.BIGINT();
+				}
+
+			case RECORD:
+				if (existingRecordNames.contains(avroSchema.getFullName())) {
+					throw new IncompatibleSchemaException(
+						String.format("Found recursive reference in Avro schema, which can not be processed by Flink: %s", avroSchema.toString(true)), null);
+				}
+
+				Set<String> newRecordName = ImmutableSet.<String>builder()
+					.addAll(existingRecordNames).add(avroSchema.getFullName()).build();
+				List<DataTypes.Field> fields = new ArrayList<>();
+				for (Schema.Field f: avroSchema.getFields()) {
+					DataType fieldType = avro2SqlType(f.schema(), newRecordName);
+					fields.add(DataTypes.FIELD(f.name(), fieldType));
+				}
+				return DataTypes.ROW(fields.toArray(new DataTypes.Field[0]));
+
+			case ARRAY:
+				DataType elementType = avro2SqlType(avroSchema.getElementType(), existingRecordNames);
+				return DataTypes.ARRAY(elementType);
+
+			case MAP:
+				DataType valueType = avro2SqlType(avroSchema.getValueType(), existingRecordNames);
+				return DataTypes.MAP(DataTypes.STRING(), valueType);
+
+			case UNION:
+				if (avroSchema.getTypes().stream().anyMatch(f -> f.getType() == Schema.Type.NULL)) {
+					// In case of a union with null, eliminate it and make a recursive call
+					List<Schema> remainingUnionTypes =
+						avroSchema.getTypes().stream().filter(f -> f.getType() != Schema.Type.NULL).collect(Collectors.toList());
+					if (remainingUnionTypes.size() == 1) {
+						return avro2SqlType(remainingUnionTypes.get(0), existingRecordNames).nullable();
+					} else {
+						return avro2SqlType(Schema.createUnion(remainingUnionTypes), existingRecordNames).nullable();
+					}
+				} else {
+					List<Schema.Type> types = avroSchema.getTypes().stream().map(Schema::getType).collect(Collectors.toList());
+					if (types.size() == 1) {
+						return avro2SqlType(avroSchema.getTypes().get(0), existingRecordNames);
+					} else if (types.size() == 2 && types.contains(Schema.Type.INT) && types.contains(Schema.Type.LONG)) {
+						return DataTypes.BIGINT();
+					} else if (types.size() == 2 && types.contains(Schema.Type.FLOAT) && types.contains(Schema.Type.DOUBLE)) {
+						return DataTypes.DOUBLE();
+					} else {
+						// Convert complex unions to struct types where field names are member0, member1, etc.
+						// This is consistent with the behavior when converting between Avro and Parquet.
+						List<DataTypes.Field> memberFields = new ArrayList<>();
+						List<Schema> schemas = avroSchema.getTypes();
+						for (int i = 0; i < schemas.size(); i++) {
+							DataType memberType = avro2SqlType(schemas.get(i), existingRecordNames);
+							memberFields.add(DataTypes.FIELD("member" + i, memberType));
+						}
+						return DataTypes.ROW(memberFields.toArray(new DataTypes.Field[0]));
+					}
+				}
+
+			default:
+				throw new IncompatibleSchemaException(String.format("Unsupported type %s", avroSchema.toString(true)), null);
+		}
+	}
+
+	public static org.apache.pulsar.client.api.Schema sqlType2PulsarSchema(DataType flinkType) throws IncompatibleSchemaException {
+		if (flinkType instanceof AtomicDataType) {
+			LogicalTypeRoot type = flinkType.getLogicalType().getTypeRoot();
+			switch (type) {
+				case BOOLEAN: return BooleanSchema.of();
+				case VARBINARY: return BytesSchema.of();
+				case DATE: return DateSchema.of();
+				case VARCHAR: return org.apache.pulsar.client.api.Schema.STRING;
+				case TIMESTAMP_WITHOUT_TIME_ZONE: return TimestampSchema.of();
+				case TINYINT: return ByteSchema.of();
+				case DOUBLE: return DoubleSchema.of();
+				case FLOAT: return FloatSchema.of();
+				case INTEGER: return IntSchema.of();
+				case BIGINT: return LongSchema.of();
+				case SMALLINT: return ShortSchema.of();
+				default:
+					throw new IncompatibleSchemaException(String.format("%s is not supported by Pulsar yet", flinkType.toString()), null);
+			}
+		} else if (flinkType instanceof FieldsDataType) {
+			return avroSchema2PulsarSchema(sqlType2AvroSchema(flinkType));
+		}
+		throw new IncompatibleSchemaException(String.format("%s is not supported by Pulsar yet", flinkType.toString()), null);
+	}
+
+	private static GenericSchema<GenericRecord> avroSchema2PulsarSchema(Schema avroSchema) {
+		byte[] schemaBytes = avroSchema.toString().getBytes(StandardCharsets.UTF_8);
+		SchemaInfo si = new SchemaInfo();
+		si.setName("Avro");
+		si.setSchema(schemaBytes);
+		si.setType(SchemaType.AVRO);
+		return org.apache.pulsar.client.api.Schema.generic(si);
+	}
+
+	public static Schema sqlType2AvroSchema(DataType flinkType) throws IncompatibleSchemaException {
+		return sqlType2AvroSchema(flinkType, false, "topLevelRecord", "");
+	}
+
+	private static Schema sqlType2AvroSchema(DataType flinkType, boolean nullable, String recordName, String namespace) throws IncompatibleSchemaException {
+		SchemaBuilder.TypeBuilder<Schema> builder = SchemaBuilder.builder();
+		LogicalTypeRoot type = flinkType.getLogicalType().getTypeRoot();
+		Schema schema = null;
+
+		if (flinkType instanceof AtomicDataType) {
+			switch (type) {
+				case BOOLEAN:
+					schema = builder.booleanType();
+					break;
+				case TINYINT:
+				case SMALLINT:
+				case INTEGER:
+					schema = builder.intType();
+					break;
+				case BIGINT:
+					schema = builder.longType();
+					break;
+				case DATE:
+					schema = LogicalTypes.date().addToSchema(builder.intType());
+					break;
+				case TIMESTAMP_WITHOUT_TIME_ZONE:
+					schema = LogicalTypes.timestampMicros().addToSchema(builder.longType());
+					break;
+				case FLOAT:
+					schema = builder.floatType();
+					break;
+				case DOUBLE:
+					schema = builder.doubleType();
+					break;
+				case VARCHAR:
+					schema = builder.stringType();
+					break;
+				case BINARY:
+				case VARBINARY:
+					schema = builder.bytesType();
+					break;
+				case DECIMAL:
+					DecimalType dt = (DecimalType) flinkType.getLogicalType();
+					LogicalTypes.Decimal avroType = LogicalTypes.decimal(dt.getPrecision(), dt.getScale());
+					int fixedSize = minBytesForPrecision[dt.getPrecision()];
+					// Need to avoid naming conflict for the fixed fields
+					String name;
+					if (namespace.equals("")) {
+						name = recordName + ".fixed";
+					} else {
+						name = namespace + recordName + ".fixed";
+					}
+					schema = avroType.addToSchema(SchemaBuilder.fixed(name).size(fixedSize));
+					break;
+				default:
+					throw new IncompatibleSchemaException(String.format("Unsupported type %s", flinkType.toString()),null);
+			}
+		} else if (flinkType instanceof CollectionDataType) {
+			if (type == LogicalTypeRoot.ARRAY) {
+				CollectionDataType cdt = (CollectionDataType) flinkType;
+				DataType elementType = cdt.getElementDataType();
+				schema = builder.array().items(sqlType2AvroSchema(elementType, elementType.getLogicalType().isNullable(), recordName, namespace));
+			} else {
+				throw new IncompatibleSchemaException("Pulsar only support collection as array", null);
+			}
+		} else if (flinkType instanceof KeyValueDataType) {
+			KeyValueDataType kvType = (KeyValueDataType) flinkType;
+			DataType keyType = kvType.getKeyDataType();
+			DataType valueType = kvType.getValueDataType();
+			if (!(keyType instanceof AtomicDataType) || keyType.getLogicalType().getTypeRoot() != LogicalTypeRoot.VARCHAR) {
+				throw new IncompatibleSchemaException("Pulsar only support string key map", null);
+			}
+			schema = builder.map().values(sqlType2AvroSchema(valueType, valueType.getLogicalType().isNullable(), recordName, namespace));
+		} else if (flinkType instanceof FieldsDataType) {
+			FieldsDataType fieldsDataType = (FieldsDataType) flinkType;
+			String childNamespace = namespace.equals("") ? recordName : namespace + "." + recordName;
+			SchemaBuilder.FieldAssembler<Schema> fieldsAssembler = builder.record(recordName).namespace(namespace).fields();
+			RowType rowType = (RowType) fieldsDataType.getLogicalType();
+
+			for (String fieldName : rowType.getFieldNames()) {
+				DataType ftype = fieldsDataType.getFieldDataTypes().get(fieldName);
+				Schema fieldAvroSchema = sqlType2AvroSchema(ftype, ftype.getLogicalType().isNullable(), fieldName, childNamespace);
+				fieldsAssembler.name(fieldName).type(fieldAvroSchema).noDefault();
+			}
+			schema = fieldsAssembler.endRecord();
+		} else {
+			throw new IncompatibleSchemaException(String.format("Unexpected type %s", flinkType.toString()),null);
+		}
+
+		if (nullable) {
+			return Schema.createUnion(schema, NULL_SCHEMA);
+		} else {
+			return schema;
+		}
+	}
+
+	private static Schema NULL_SCHEMA = Schema.create(Schema.Type.NULL);
+
+	private static int[] minBytesForPrecision = new int[39];
+
+	static {
+		for (int i = 0; i < minBytesForPrecision.length; i++) {
+			minBytesForPrecision[i] = computeMinBytesForPrecision(i);
+		}
+	}
+
+	private static int computeMinBytesForPrecision(int precision) {
+		int numBytes = 1;
+		while (Math.pow(2.0, 8 * numBytes - 1) < Math.pow(10.0, precision)) {
+			numBytes += 1;
+		}
+		return numBytes;
+	}
+
+	public static class IncompatibleSchemaException extends Exception {
+		public IncompatibleSchemaException(String message, Throwable e) {
+			super(message, e);
+		}
+	}
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/PulsarCatalog.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/PulsarCatalog.java
@@ -1,0 +1,356 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.pulsar;
+
+import org.apache.flink.streaming.connectors.pulsar.internal.PulsarMetadataReader;
+import org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions;
+import org.apache.flink.streaming.connectors.pulsar.internal.SchemaUtils;
+import org.apache.flink.table.catalog.AbstractCatalog;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.catalog.CatalogDatabaseImpl;
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.CatalogPartition;
+import org.apache.flink.table.catalog.CatalogPartitionSpec;
+import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.catalog.exceptions.FunctionAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.FunctionNotExistException;
+import org.apache.flink.table.catalog.exceptions.PartitionAlreadyExistsException;
+import org.apache.flink.table.catalog.exceptions.PartitionNotExistException;
+import org.apache.flink.table.catalog.exceptions.PartitionSpecInvalidException;
+import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
+import org.apache.flink.table.catalog.exceptions.TablePartitionedException;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
+import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
+import org.apache.flink.table.factories.TableFactory;
+
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class PulsarCatalog extends AbstractCatalog {
+
+	private static final Logger LOG = LoggerFactory.getLogger(PulsarCatalog.class);
+
+	private String adminUrl;
+	private Map<String, String> properties;
+
+	private PulsarMetadataReader metadataReader;
+
+	public PulsarCatalog(String adminUrl, String catalogName, Map<String, String> properties, String defaultDatabase) {
+		super(catalogName, defaultDatabase);
+
+		this.adminUrl = adminUrl;
+		this.properties = properties;
+
+		LOG.info("Created PulsarCatalog '{}'", catalogName);
+	}
+
+	@Override
+	public void open() throws CatalogException {
+		if (metadataReader == null) {
+			try {
+				metadataReader = new PulsarMetadataReader(adminUrl);
+			} catch (PulsarClientException e) {
+				throw new CatalogException("Failed to create Pulsar admin using " + adminUrl, e);
+			}
+		}
+	}
+
+	@Override
+	public void close() throws CatalogException {
+		if (metadataReader != null) {
+			metadataReader.close();
+			metadataReader = null;
+			LOG.info("Close connection to Pulsar");
+		}
+	}
+
+	@Override
+	public Optional<TableFactory> getTableFactory() {
+		// TODO
+		return Optional.empty();
+	}
+
+	@Override
+	public List<String> listDatabases() throws CatalogException {
+		try {
+			return metadataReader.listNamespaces();
+		} catch (PulsarAdminException e) {
+			throw new CatalogException(String.format("Failed to list all databases in %s", getName()), e);
+		}
+	}
+
+	@Override
+	public CatalogDatabase getDatabase(String databaseName) throws DatabaseNotExistException, CatalogException {
+		Map<String, String> properties = new HashMap<>();
+		return new CatalogDatabaseImpl(properties, databaseName);
+	}
+
+	@Override
+	public boolean databaseExists(String databaseName) throws CatalogException {
+		try {
+			return metadataReader.namespaceExists(databaseName);
+		} catch (PulsarAdminException e) {
+			throw new CatalogException(String.format("Failed to check existence of databases %s", databaseName), e);
+		}
+	}
+
+	@Override
+	public void createDatabase(String name, CatalogDatabase database, boolean ignoreIfExists) throws DatabaseAlreadyExistException, CatalogException {
+		try {
+			metadataReader.createNamespace(name);
+		} catch (PulsarAdminException.ConflictException e) {
+			if (!ignoreIfExists) {
+				throw new DatabaseAlreadyExistException(getName(), name, e);
+			}
+		} catch (PulsarAdminException e) {
+			throw new CatalogException(String.format("Failed to create database %s", name), e);
+		}
+	}
+
+	@Override
+	public void dropDatabase(String name, boolean ignoreIfNotExists, boolean cascade) throws DatabaseNotExistException, DatabaseNotEmptyException, CatalogException {
+		try {
+			metadataReader.deleteNamespace(name);
+		} catch (PulsarAdminException.NotFoundException e) {
+			if (!ignoreIfNotExists) {
+				throw new DatabaseNotExistException(getName(), name);
+			}
+		} catch (PulsarAdminException e) {
+			throw new CatalogException(String.format("Failed to drop database %s", name), e);
+		}
+	}
+
+	@Override
+	public List<String> listTables(String databaseName) throws DatabaseNotExistException, CatalogException {
+		try {
+			return metadataReader.getTopics(databaseName);
+		} catch (PulsarAdminException.NotFoundException e) {
+			throw new DatabaseNotExistException(getName(), databaseName, e);
+		} catch (PulsarAdminException e) {
+			throw new CatalogException(String.format("Failed to list tables in database %s", databaseName), e);
+		}
+	}
+
+	@Override
+	public CatalogBaseTable getTable(ObjectPath tablePath) throws TableNotExistException, CatalogException {
+		try {
+			return new CatalogTableImpl(metadataReader.getTableSchema(tablePath), properties, "");
+		} catch (PulsarAdminException.NotFoundException e) {
+			throw new TableNotExistException(getName(), tablePath, e);
+		} catch (PulsarAdminException e) {
+			throw new CatalogException(String.format("Failed to get table %s schema", tablePath.getFullName()), e);
+		}
+	}
+
+	@Override
+	public boolean tableExists(ObjectPath tablePath) throws CatalogException {
+		try {
+			return metadataReader.topicExists(tablePath);
+		} catch (PulsarAdminException.NotFoundException e) {
+			return false;
+		} catch (PulsarAdminException e) {
+			throw new CatalogException(String.format("Failed to check table %s existence", tablePath.getFullName()), e);
+		}
+	}
+
+	@Override
+	public void dropTable(ObjectPath tablePath, boolean ignoreIfNotExists) throws TableNotExistException, CatalogException {
+		try {
+			metadataReader.deleteTopic(tablePath);
+		} catch (PulsarAdminException.NotFoundException e) {
+			if (!ignoreIfNotExists) {
+				throw new TableNotExistException(getName(), tablePath, e);
+			}
+		} catch (PulsarAdminException e) {
+			throw new CatalogException(String.format("Failed to drop table %s", tablePath.getFullName()), e);
+		}
+	}
+
+	@Override
+	public void createTable(ObjectPath tablePath, CatalogBaseTable table, boolean ignoreIfExists) throws TableAlreadyExistException, DatabaseNotExistException, CatalogException {
+		int defaultNumPartitions = Integer.parseInt(properties.getOrDefault(PulsarOptions.DEFAULT_PARTITIONS, "5"));
+		String databaseName = tablePath.getDatabaseName();
+		Boolean databaseExists;
+		try {
+			databaseExists = metadataReader.namespaceExists(databaseName);
+		} catch (PulsarAdminException e) {
+			throw new CatalogException(String.format("Failed to check existence of databases %s", databaseName), e);
+		}
+
+		if (!databaseExists) {
+			throw new DatabaseNotExistException(getName(), databaseName);
+		}
+
+		try {
+			metadataReader.createTopic(tablePath, defaultNumPartitions, table);
+		} catch (PulsarAdminException e) {
+			if (e.getStatusCode() == 409) {
+				throw new TableAlreadyExistException(getName(), tablePath, e);
+			} else {
+				throw new CatalogException(String.format("Failed to create table %s", tablePath.getFullName()), e);
+			}
+		} catch (SchemaUtils.IncompatibleSchemaException e) {
+			throw new CatalogException("Failed to translate Flink type to Pulsar", e);
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	// Unsupported catalog operations for Pulsar
+	// ------------------------------------------------------------------------
+
+	@Override
+	public void alterDatabase(String name, CatalogDatabase newDatabase, boolean ignoreIfNotExists) throws DatabaseNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<String> listViews(String databaseName) throws DatabaseNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void alterTable(ObjectPath tablePath, CatalogBaseTable newTable, boolean ignoreIfNotExists) throws TableNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void renameTable(ObjectPath tablePath, String newTableName, boolean ignoreIfNotExists) throws TableNotExistException, TableAlreadyExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath) throws TableNotExistException, TableNotPartitionedException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws TableNotExistException, TableNotPartitionedException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CatalogPartition getPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws PartitionNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean partitionExists(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void createPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, CatalogPartition partition, boolean ignoreIfExists) throws TableNotExistException, TableNotPartitionedException, PartitionSpecInvalidException, PartitionAlreadyExistsException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void dropPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, boolean ignoreIfNotExists) throws PartitionNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void alterPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, CatalogPartition newPartition, boolean ignoreIfNotExists) throws PartitionNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<String> listFunctions(String dbName) throws DatabaseNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CatalogFunction getFunction(ObjectPath functionPath) throws FunctionNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean functionExists(ObjectPath functionPath) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void createFunction(ObjectPath functionPath, CatalogFunction function, boolean ignoreIfExists) throws FunctionAlreadyExistException, DatabaseNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void alterFunction(ObjectPath functionPath, CatalogFunction newFunction, boolean ignoreIfNotExists) throws FunctionNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void dropFunction(ObjectPath functionPath, boolean ignoreIfNotExists) throws FunctionNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CatalogTableStatistics getTableStatistics(ObjectPath tablePath) throws TableNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CatalogColumnStatistics getTableColumnStatistics(ObjectPath tablePath) throws TableNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CatalogTableStatistics getPartitionStatistics(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws PartitionNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CatalogColumnStatistics getPartitionColumnStatistics(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws PartitionNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void alterTableStatistics(ObjectPath tablePath, CatalogTableStatistics tableStatistics, boolean ignoreIfNotExists) throws TableNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void alterTableColumnStatistics(ObjectPath tablePath, CatalogColumnStatistics columnStatistics, boolean ignoreIfNotExists) throws TableNotExistException, CatalogException, TablePartitionedException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void alterPartitionStatistics(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, CatalogTableStatistics partitionStatistics, boolean ignoreIfNotExists) throws PartitionNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void alterPartitionColumnStatistics(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, CatalogColumnStatistics columnStatistics, boolean ignoreIfNotExists) throws PartitionNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/descriptors/PulsarCatalogDescriptor.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/descriptors/PulsarCatalogDescriptor.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.pulsar.descriptors;
+
+import org.apache.flink.table.catalog.pulsar.PulsarCatalog;
+import org.apache.flink.table.descriptors.CatalogDescriptor;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.StringUtils;
+
+import java.util.Map;
+
+import static org.apache.flink.table.catalog.pulsar.descriptors.PulsarCatalogValidator.CATALOG_TYPE_VALUE_PULSAR;
+import static org.apache.flink.table.catalog.pulsar.descriptors.PulsarCatalogValidator.CATALOG_PULSAR_VERSION;
+
+/**
+ * Catalog descriptor for {@link PulsarCatalog}.
+ */
+public class PulsarCatalogDescriptor extends CatalogDescriptor {
+
+	private String pulsarVersion;
+
+	public PulsarCatalogDescriptor() {
+		super(CATALOG_TYPE_VALUE_PULSAR, 1, "public/default");
+	}
+
+	public PulsarCatalogDescriptor pulsarVersion(String version) {
+		Preconditions.checkArgument(!StringUtils.isNullOrWhitespaceOnly(version));
+		this.pulsarVersion = version;
+		return this;
+	}
+
+	@Override
+	protected Map<String, String> toCatalogProperties() {
+		final DescriptorProperties properties = new DescriptorProperties();
+
+		if (pulsarVersion != null) {
+			properties.putString(CATALOG_PULSAR_VERSION, pulsarVersion);
+		}
+
+		return properties.asMap();
+	}
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/descriptors/PulsarCatalogDescriptor.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/descriptors/PulsarCatalogDescriptor.java
@@ -40,20 +40,21 @@ public class PulsarCatalogDescriptor extends CatalogDescriptor {
 		super(CATALOG_TYPE_VALUE_PULSAR, 1, "public/default");
 	}
 
-	public PulsarCatalogDescriptor pulsarVersion(String version) {
-		Preconditions.checkArgument(!StringUtils.isNullOrWhitespaceOnly(version));
-		this.pulsarVersion = version;
+	public PulsarCatalogDescriptor pulsarVersion(String pulsarVersion) {
+		Preconditions.checkArgument(!StringUtils.isNullOrWhitespaceOnly(pulsarVersion));
+		this.pulsarVersion = pulsarVersion;
+
 		return this;
 	}
 
 	@Override
 	protected Map<String, String> toCatalogProperties() {
-		final DescriptorProperties properties = new DescriptorProperties();
+		DescriptorProperties props = new DescriptorProperties();
 
 		if (pulsarVersion != null) {
-			properties.putString(CATALOG_PULSAR_VERSION, pulsarVersion);
+			props.putString(CATALOG_PULSAR_VERSION, pulsarVersion);
 		}
 
-		return properties.asMap();
+		return props.asMap();
 	}
 }

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/descriptors/PulsarCatalogValidator.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/descriptors/PulsarCatalogValidator.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.pulsar.descriptors;
+
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.descriptors.CatalogDescriptorValidator;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+
+import static org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions.DEFAULT_PARTITIONS;
+
+/**
+ * Validator for {@link PulsarCatalogDescriptor}.
+ */
+public class PulsarCatalogValidator extends CatalogDescriptorValidator {
+	public static final String CATALOG_TYPE_VALUE_PULSAR = "pulsar";
+	public static final String CATALOG_PULSAR_VERSION = "pulsar-version";
+	public static final String CATALOG_SERVICE_URL = "serviceUrl";
+	public static final String CATALOG_ADMIN_URL = "adminUrl";
+	public static final String CATALOG_STARTING_POS = "startingOffsets";
+	public static final String CATALOG_DEFAULT_PARTITIONS = DEFAULT_PARTITIONS;
+
+	@Override
+	public void validate(DescriptorProperties properties) {
+		super.validate(properties);
+		properties.validateValue(CATALOG_TYPE, CATALOG_TYPE_VALUE_PULSAR, false);
+		properties.validateString(CATALOG_PULSAR_VERSION, true, 1);
+		properties.validateString(CATALOG_SERVICE_URL, false, 1);
+		properties.validateString(CATALOG_ADMIN_URL, false, 1);
+		properties.validateInt(CATALOG_DEFAULT_PARTITIONS, true, 1);
+		validateStartingOffsets(properties);
+	}
+
+	private void validateStartingOffsets(DescriptorProperties properties) {
+		if (properties.containsKey(CATALOG_STARTING_POS)) {
+			String v = properties.getString(CATALOG_STARTING_POS);
+			if (v != "earliest" && v != "latest") {
+				throw new ValidationException(CATALOG_STARTING_POS + " should be either earliest or latest");
+			}
+		}
+	}
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/descriptors/PulsarCatalogValidator.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/descriptors/PulsarCatalogValidator.java
@@ -18,22 +18,22 @@
 
 package org.apache.flink.table.catalog.pulsar.descriptors;
 
+import org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.descriptors.CatalogDescriptorValidator;
 import org.apache.flink.table.descriptors.DescriptorProperties;
-
-import static org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions.DEFAULT_PARTITIONS;
 
 /**
  * Validator for {@link PulsarCatalogDescriptor}.
  */
 public class PulsarCatalogValidator extends CatalogDescriptorValidator {
+
 	public static final String CATALOG_TYPE_VALUE_PULSAR = "pulsar";
 	public static final String CATALOG_PULSAR_VERSION = "pulsar-version";
-	public static final String CATALOG_SERVICE_URL = "serviceUrl";
-	public static final String CATALOG_ADMIN_URL = "adminUrl";
-	public static final String CATALOG_STARTING_POS = "startingOffsets";
-	public static final String CATALOG_DEFAULT_PARTITIONS = DEFAULT_PARTITIONS;
+	public static final String CATALOG_SERVICE_URL = PulsarOptions.SERVICE_URL_OPTION_KEY;
+	public static final String CATALOG_ADMIN_URL = PulsarOptions.ADMIN_URL_OPTION_KEY;
+	public static final String CATALOG_STARTUP_MODE = PulsarOptions.STARTUP_MODE_OPTION_KEY;
+	public static final String CATALOG_DEFAULT_PARTITIONS = PulsarOptions.DEFAULT_PARTITIONS;
 
 	@Override
 	public void validate(DescriptorProperties properties) {
@@ -47,10 +47,10 @@ public class PulsarCatalogValidator extends CatalogDescriptorValidator {
 	}
 
 	private void validateStartingOffsets(DescriptorProperties properties) {
-		if (properties.containsKey(CATALOG_STARTING_POS)) {
-			String v = properties.getString(CATALOG_STARTING_POS);
-			if (v != "earliest" && v != "latest") {
-				throw new ValidationException(CATALOG_STARTING_POS + " should be either earliest or latest");
+		if (properties.containsKey(CATALOG_STARTUP_MODE)) {
+			String v = properties.getString(CATALOG_STARTUP_MODE);
+			if (!v.equals("earliest") && !v.equals("latest")) {
+				throw new ValidationException(CATALOG_STARTUP_MODE + " should be either earliest or latest");
 			}
 		}
 	}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/factories/PulsarCatalogFactory.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/factories/PulsarCatalogFactory.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.pulsar.factories;
+
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.pulsar.PulsarCatalog;
+import org.apache.flink.table.catalog.pulsar.descriptors.PulsarCatalogValidator;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.factories.CatalogFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.table.catalog.pulsar.descriptors.PulsarCatalogValidator.CATALOG_DEFAULT_DATABASE;
+import static org.apache.flink.table.catalog.pulsar.descriptors.PulsarCatalogValidator.CATALOG_PULSAR_VERSION;
+import static org.apache.flink.table.catalog.pulsar.descriptors.PulsarCatalogValidator.CATALOG_SERVICE_URL;
+import static org.apache.flink.table.catalog.pulsar.descriptors.PulsarCatalogValidator.CATALOG_ADMIN_URL;
+import static org.apache.flink.table.catalog.pulsar.descriptors.PulsarCatalogValidator.CATALOG_STARTING_POS;
+import static org.apache.flink.table.catalog.pulsar.descriptors.PulsarCatalogValidator.CATALOG_DEFAULT_PARTITIONS;
+import static org.apache.flink.table.catalog.pulsar.descriptors.PulsarCatalogValidator.CATALOG_TYPE_VALUE_PULSAR;
+import static org.apache.flink.table.descriptors.CatalogDescriptorValidator.CATALOG_PROPERTY_VERSION;
+import static org.apache.flink.table.descriptors.CatalogDescriptorValidator.CATALOG_TYPE;
+
+
+public class PulsarCatalogFactory implements CatalogFactory {
+
+	@Override
+	public Catalog createCatalog(String name, Map<String, String> properties) {
+		final DescriptorProperties descriptorProperties = getValidatedProperties(properties);
+
+		final String defaultDatabase =
+			descriptorProperties.getOptionalString(CATALOG_DEFAULT_DATABASE)
+				.orElse("public/default");
+
+		String adminUrl = descriptorProperties.getString(CATALOG_ADMIN_URL);
+
+		return new PulsarCatalog(adminUrl, name, descriptorProperties.asMap(), defaultDatabase);
+	}
+
+	@Override
+	public Map<String, String> requiredContext() {
+		Map<String, String> context = new HashMap<>();
+		context.put(CATALOG_TYPE, CATALOG_TYPE_VALUE_PULSAR);
+		context.put(CATALOG_PROPERTY_VERSION, "1");
+		return context;
+	}
+
+	@Override
+	public List<String> supportedProperties() {
+		List<String> properties = new ArrayList<>();
+		properties.add(CATALOG_DEFAULT_DATABASE);
+		properties.add(CATALOG_PULSAR_VERSION);
+		properties.add(CATALOG_SERVICE_URL);
+		properties.add(CATALOG_ADMIN_URL);
+		properties.add(CATALOG_STARTING_POS);
+		properties.add(CATALOG_DEFAULT_PARTITIONS);
+		return properties;
+	}
+
+	private static DescriptorProperties getValidatedProperties(Map<String, String> properties) {
+		final DescriptorProperties descriptorProperties = new DescriptorProperties(true);
+		descriptorProperties.putProperties(properties);
+		new PulsarCatalogValidator().validate(descriptorProperties);
+		return descriptorProperties;
+	}
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/package-info.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/package-info.java
@@ -1,0 +1,1 @@
+package org.apache.flink.table;

--- a/flink-connectors/flink-connector-pulsar/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink-connectors/flink-connector-pulsar/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -1,0 +1,15 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.flink.table.catalog.pulsar.factories.PulsarCatalogFactory

--- a/flink-connectors/flink-connector-pulsar/src/main/resources/log4j.properties
+++ b/flink-connectors/flink-connector-pulsar/src/main/resources/log4j.properties
@@ -1,0 +1,22 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+log4j.rootLogger=INFO, testlogger
+log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
+log4j.appender.testlogger.target=System.err
+log4j.appender.testlogger.layout=org.apache.log4j.PatternLayout
+log4j.appender.testlogger.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+# suppress the irrelevant (wrong) warnings from the netty channel handler
+log4j.logger.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, testlogger
+

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/streaming/connectors/pulsar/CatalogITest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/streaming/connectors/pulsar/CatalogITest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import org.apache.commons.cli.Options;
+import org.apache.flink.client.cli.DefaultCLI;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.connectors.pulsar.testutils.EnvironmentFileUtil;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.pulsar.PulsarCatalog;
+import org.apache.flink.table.client.config.Environment;
+import org.apache.flink.table.client.gateway.SessionContext;
+import org.apache.flink.table.client.gateway.local.ExecutionContext;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class CatalogITest extends PulsarTestBaseWithFlink {
+
+	private static final String CATALOGS_ENVIRONMENT_FILE = "test-sql-client-pulsar-catalog.yaml";
+	private static final String CATALOGS_ENVIRONMENT_FILE_START = "test-sql-client-pulsar-start-catalog.yaml";
+
+	@Test
+	public void testCatalogs() throws Exception {
+		String inmemoryCatalog = "inmemorycatalog";
+		String pulsarCatalog1 = "pulsarcatalog1";
+		String pulsarCatalog2 = "pulsarcatalog2";
+
+		ExecutionContext context = createExecutionContext(CATALOGS_ENVIRONMENT_FILE, getStreamingConfs());
+		TableEnvironment tableEnv = context.getTableEnvironment();
+
+		assertEquals(tableEnv.getCurrentCatalog(), inmemoryCatalog);
+		assertEquals(tableEnv.getCurrentDatabase(), "mydatabase");
+
+		Catalog catalog = tableEnv.getCatalog(pulsarCatalog1).orElse(null);
+		assertNotNull(catalog);
+		assertTrue(catalog instanceof PulsarCatalog);
+		tableEnv.useCatalog(pulsarCatalog1);
+		assertEquals(tableEnv.getCurrentDatabase(), "public/default");
+
+		catalog = tableEnv.getCatalog(pulsarCatalog2).orElse(null);
+		assertNotNull(catalog);
+		assertTrue(catalog instanceof PulsarCatalog);
+		tableEnv.useCatalog(pulsarCatalog2);
+		assertEquals(tableEnv.getCurrentDatabase(), "tn/ns");
+	}
+
+	@Test
+	public void testDatabases() throws Exception {
+		String pulsarCatalog1 = "pulsarcatalog1";
+		List<String> namespaces = Arrays.asList("tn1/ns1", "tn1/ns2");
+		List<String> topics = Arrays.asList("tp1", "tp2");
+		List<String> topicsFullName = topics.stream().map(a -> "tn1/ns1/" + a).collect(Collectors.toList());
+		List<String> partitionedTopics = Arrays.asList("ptp1", "ptp2");
+		List<String> partitionedTopicsFullName = partitionedTopics.stream().map(a -> "tn1/ns1/" + a).collect(Collectors.toList());
+
+		ExecutionContext context = createExecutionContext(CATALOGS_ENVIRONMENT_FILE, getStreamingConfs());
+		TableEnvironment tableEnv = context.getTableEnvironment();
+
+		tableEnv.useCatalog(pulsarCatalog1);
+		assertEquals(tableEnv.getCurrentDatabase(), "public/default");
+
+		try (PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(getAdminUrl()).build()) {
+			admin.tenants().createTenant("tn1",
+				new TenantInfo(Sets.newHashSet(), Sets.newHashSet("standalone")));
+			for (String ns : namespaces) {
+				admin.namespaces().createNamespace(ns);
+			}
+
+			for (String tp : topicsFullName) {
+				admin.topics().createNonPartitionedTopic(tp);
+			}
+
+			for (String tp : partitionedTopicsFullName) {
+				admin.topics().createPartitionedTopic(tp, 5);
+			}
+
+			assertTrue(Sets.newHashSet(tableEnv.listDatabases()).containsAll(namespaces));
+
+			tableEnv.useDatabase("tn1/ns1");
+
+			assertTrue(
+				Sets.symmetricDifference(
+					Sets.newHashSet(tableEnv.listTables()),
+					Sets.newHashSet(Iterables.concat(topics, partitionedTopics)))
+					.isEmpty());
+
+			for (String tp : topicsFullName) {
+				admin.topics().delete(tp);
+			}
+
+			for (String tp : partitionedTopicsFullName) {
+				admin.topics().deletePartitionedTopic(tp);
+			}
+
+			for (String ns : namespaces) {
+				admin.namespaces().deleteNamespace(ns);
+			}
+		}
+	}
+
+	private <T> ExecutionContext<T> createExecutionContext(String file, Map<String, String> replaceVars) throws Exception {
+		final Environment env = EnvironmentFileUtil.parseModified(
+			file,
+			replaceVars);
+		final Configuration flinkConfig = new Configuration();
+		return new ExecutionContext<>(
+			env,
+			new SessionContext("test-session", new Environment()),
+			Collections.emptyList(),
+			flinkConfig,
+			new Options(),
+			Collections.singletonList(new DefaultCLI(flinkConfig)));
+	}
+
+	private Map<String, String> getStreamingConfs() {
+		Map<String, String> replaceVars = new HashMap<>();
+		replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
+		replaceVars.put("$VAR_RESULT_MODE", "changelog");
+		replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
+		replaceVars.put("$VAR_MAX_ROWS", "100");
+		replaceVars.put("$VAR_SERVICEURL", getServiceUrl());
+		replaceVars.put("$VAR_ADMINURL", getAdminUrl());
+		return replaceVars;
+	}
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarTestBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarTestBase.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar;
+
+import com.google.common.collect.Sets;
+import io.streamnative.tests.pulsar.service.PulsarService;
+import io.streamnative.tests.pulsar.service.PulsarServiceFactory;
+import io.streamnative.tests.pulsar.service.PulsarServiceSpec;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.metrics.jmx.JMXReporter;
+import org.apache.flink.streaming.connectors.pulsar.internal.PulsarMetadataReader;
+import org.apache.flink.streaming.util.TestStreamEnvironment;
+import org.apache.flink.util.TestLogger;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.util.UUID;
+
+public abstract class PulsarTestBase extends TestLogger {
+
+	protected static final Logger LOG = LoggerFactory.getLogger(PulsarMetadataReader.class);
+
+    protected static PulsarService pulsarService;
+
+    protected static String serviceUrl;
+
+    protected static String adminUrl;
+
+    public static String getServiceUrl() {
+        return serviceUrl;
+    }
+
+    public static String getAdminUrl() {
+        return adminUrl;
+    }
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+
+        LOG.info("-------------------------------------------------------------------------");
+		LOG.info("    Starting PulsarTestBase ");
+		LOG.info("-------------------------------------------------------------------------");
+
+        PulsarServiceSpec spec = PulsarServiceSpec.builder()
+                .clusterName("standalone-" + UUID.randomUUID())
+                .enableContainerLogging(false)
+                .build();
+
+        pulsarService = PulsarServiceFactory.createPulsarService(spec);
+        pulsarService.start();
+
+        for (URI uri : pulsarService.getServiceUris()) {
+            if (uri != null && uri.getScheme().equals("pulsar")) {
+                serviceUrl = uri.toString();
+            } else if (uri != null && !uri.getScheme().equals("pulsar")) {
+                adminUrl = uri.toString();
+            }
+        }
+
+        try (PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(adminUrl).build()) {
+            admin.namespaces().createNamespace("public/default", Sets.newHashSet("standalone"));
+        }
+
+		LOG.info("-------------------------------------------------------------------------");
+		LOG.info("Successfully started pulsar service at cluster " + spec.clusterName());
+		LOG.info("-------------------------------------------------------------------------");
+
+    }
+
+
+    @AfterClass
+    public static void shutDownServices() throws Exception {
+		LOG.info("-------------------------------------------------------------------------");
+		LOG.info("    Shut down PulsarTestBase ");
+		LOG.info("-------------------------------------------------------------------------");
+
+        TestStreamEnvironment.unsetAsContext();
+
+        if (pulsarService != null) {
+            pulsarService.stop();
+        }
+
+		LOG.info("-------------------------------------------------------------------------");
+		LOG.info("    PulsarTestBase finished");
+		LOG.info("-------------------------------------------------------------------------");
+    }
+
+    protected static Configuration getFlinkConfiguration() {
+        Configuration flinkConfig = new Configuration();
+        flinkConfig.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "16m");
+        flinkConfig.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "my_reporter." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, JMXReporter.class.getName());
+        return flinkConfig;
+    }
+
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarTestBaseWithFlink.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarTestBaseWithFlink.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.runtime.client.JobStatusMessage;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.pulsar.common.naming.TopicName;
+import org.junit.Before;
+import org.junit.ClassRule;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+public abstract class PulsarTestBaseWithFlink extends PulsarTestBase {
+
+    protected static final int NUM_TMS = 1;
+
+    protected static final int TM_SLOTS = 8;
+
+    protected ClusterClient<?> client;
+
+    @ClassRule
+    public static MiniClusterWithClientResource flink = new MiniClusterWithClientResource(
+            new MiniClusterResourceConfiguration.Builder()
+                    .setConfiguration(getFlinkConfiguration())
+                    .setNumberTaskManagers(NUM_TMS)
+                    .setNumberSlotsPerTaskManager(TM_SLOTS)
+                    .build());
+
+    @Before
+    public void noJobIsRunning() throws Exception {
+        client = flink.getClusterClient();
+        waitUntilNoJobIsRunning(client);
+    }
+
+    public static void waitUntilJobIsRunning(ClusterClient<?> client) throws Exception {
+        while (getRunningJobs(client).isEmpty()) {
+            Thread.sleep(50);
+        }
+    }
+
+    public static void waitUntilNoJobIsRunning(ClusterClient<?> client) throws Exception {
+        while (!getRunningJobs(client).isEmpty()) {
+            Thread.sleep(50);
+            cancelRunningJobs(client);
+        }
+    }
+
+    public static List<JobID> getRunningJobs(ClusterClient<?> client) throws Exception {
+        Collection<JobStatusMessage> statusMessages = client.listJobs().get();
+        return statusMessages.stream()
+                .filter(status -> !status.getJobState().isGloballyTerminalState())
+                .map(JobStatusMessage::getJobId)
+                .collect(Collectors.toList());
+    }
+
+    public static void cancelRunningJobs(ClusterClient<?> client) throws Exception {
+        List<JobID> runningJobs = getRunningJobs(client);
+        for (JobID runningJob : runningJobs) {
+            client.cancel(runningJob);
+        }
+    }
+
+    public static final AtomicInteger topicId = new AtomicInteger(0);
+
+    public static String newTopic() {
+        synchronized (topicId) {
+            int i = topicId.getAndIncrement();
+            return TopicName.get("topic-" + i).toString();
+        }
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/streaming/connectors/pulsar/testutils/EnvironmentFileUtil.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/streaming/connectors/pulsar/testutils/EnvironmentFileUtil.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar.testutils;
+
+import org.apache.flink.table.client.config.Environment;
+import org.apache.flink.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Utilities for reading an environment file.
+ */
+public final class EnvironmentFileUtil {
+
+    private EnvironmentFileUtil() {
+        // private
+    }
+
+    public static Environment parseUnmodified(String fileName) throws IOException {
+        final URL url = EnvironmentFileUtil.class.getClassLoader().getResource(fileName);
+        Objects.requireNonNull(url);
+        return Environment.parse(url);
+    }
+
+    public static Environment parseModified(String fileName, Map<String, String> replaceVars) throws IOException {
+        final URL url = EnvironmentFileUtil.class.getClassLoader().getResource(fileName);
+        Objects.requireNonNull(url);
+        String schema = FileUtils.readFileUtf8(new File(url.getFile()));
+
+        for (Map.Entry<String, String> replaceVar : replaceVars.entrySet()) {
+            schema = schema.replace(replaceVar.getKey(), replaceVar.getValue());
+        }
+
+        return Environment.parse(schema);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/resources/test-sql-client-pulsar-catalog.yaml
+++ b/flink-connectors/flink-connector-pulsar/src/test/resources/test-sql-client-pulsar-catalog.yaml
@@ -1,0 +1,45 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+execution:
+  type: "$VAR_EXECUTION_TYPE"
+  time-characteristic: event-time
+  periodic-watermarks-interval: 99
+  parallelism: 1
+  max-parallelism: 16
+  min-idle-state-retention: 0
+  max-idle-state-retention: 0
+  result-mode: "$VAR_RESULT_MODE"
+  max-table-result-rows: "$VAR_MAX_ROWS"
+  restart-strategy:
+    type: none
+  current-catalog: inmemorycatalog
+  current-database: mydatabase
+
+deployment:
+  response-timeout: 5000
+
+catalogs:
+  - name: pulsarcatalog1
+    type: pulsar
+    service-url: "$VAR_SERVICEURL"
+    admin-url: "$VAR_ADMINURL"
+  - name: pulsarcatalog2
+    type: pulsar
+    default-database: tn/ns
+    service-url: "$VAR_SERVICEURL"
+    admin-url: "$VAR_ADMINURL"
+  - name: inmemorycatalog
+    type: generic_in_memory
+    default-database: mydatabase

--- a/flink-connectors/flink-connector-pulsar/src/test/resources/test-sql-client-pulsar-start-catalog.yaml
+++ b/flink-connectors/flink-connector-pulsar/src/test/resources/test-sql-client-pulsar-start-catalog.yaml
@@ -1,0 +1,48 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+execution:
+  type: "$VAR_EXECUTION_TYPE"
+  time-characteristic: event-time
+  periodic-watermarks-interval: 99
+  parallelism: 1
+  max-parallelism: 16
+  min-idle-state-retention: 0
+  max-idle-state-retention: 0
+  result-mode: "$VAR_RESULT_MODE"
+  max-table-result-rows: "$VAR_MAX_ROWS"
+  restart-strategy:
+    type: none
+  current-catalog: inmemorycatalog
+  current-database: mydatabase
+
+deployment:
+  response-timeout: 5000
+
+catalogs:
+  - name: pulsarcatalog1
+    type: pulsar
+    service-url: "$VAR_SERVICEURL"
+    admin-url: "$VAR_ADMINURL"
+    startup-mode: "$VAR_STARTING"
+    table-default-partitions: 5
+  - name: pulsarcatalog2
+    type: pulsar
+    default-database: tn/ns
+    service-url: "$VAR_SERVICEURL"
+    admin-url: "$VAR_ADMINURL"
+    startup-mode: "$VAR_STARTING"
+  - name: inmemorycatalog
+    type: generic_in_memory
+    default-database: mydatabase

--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -53,6 +53,7 @@ under the License.
 		<module>flink-connector-rabbitmq</module>
 		<module>flink-connector-twitter</module>
 		<module>flink-connector-nifi</module>
+		<module>flink-connector-pulsar</module>
 		<module>flink-connector-cassandra</module>
 		<module>flink-connector-filesystem</module>
 		<module>flink-connector-kafka</module>


### PR DESCRIPTION
## What is the purpose of the change

This PR implements Pulsar catalog which is part of [FLIP-72](https://cwiki.apache.org/confluence/display/FLINK/FLIP-72%3A+Introduce+Pulsar+Connector).

The Pulsar catalog supports the following features by extending `AbstractCatalog` API:
- Open and close the catalog
- Database operations: list, get, exists, create, drop (create and drop should first check if the user has sufficient permissions)
- Table operations: list, get, exist, create, drop (create and drop should first check if the user has sufficient permissions)

## Brief change log

- The main functionality of Catalog exists in `PulsarCatalog` and `PulsarMetadataReader`.
- Pulsar Schema <-> Flink type conversion exists in `SchemaUtils`.

## Verifying this change

This PR will be tested by unit tests and integration tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes) . Add Pulsar dependencies.
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (https://docs.google.com/document/d/1LMnABtXn-wQedsmWv8hopvx-B-jbdr8-jHbIiDhdsoE/edit?usp=sharing)

