### PR TITLE
[FLINK-15091][table-planner-blink] Fix memory overused in SortMergeJoinOperator

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/SortMergeJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/SortMergeJoinOperator.java
@@ -139,7 +139,8 @@ public class SortMergeJoinOperator extends TableStreamOperator<BaseRow>
 		this.ioManager = this.getContainingTask().getEnvironment().getIOManager();
 
 		long totalMemory = computeMemorySize();
-		long totalSortMem = totalMemory - externalBufferMemory;
+		long totalSortMem = totalMemory -
+				(type.equals(FlinkJoinType.FULL) ? externalBufferMemory * 2 : externalBufferMemory);
 		if (totalSortMem < 0) {
 			throw new TableException("Memory size is too small: " +
 					totalMemory + ", please increase manage memory of task manager.");


### PR DESCRIPTION

## What is the purpose of the change

In SortMergeJoinOperator, we should check if it is a full join, then will use two externalBufferMemory.

## Brief change log

Using two externalBufferMemory when SortMergeJoinOperator is full join.

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no