### PR TITLE
[FLINK-14815][rest]Expose network metric in IOMetricsInfo

### DIFF
--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -984,7 +984,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           },
           "metrics" : {
             "type" : "object",
-            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:IOMetricsInfo",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:JobVertexIOMetricsInfo",
             "properties" : {
               "read-bytes" : {
                 "type" : "integer"
@@ -1008,6 +1008,30 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
                 "type" : "integer"
               },
               "write-records-complete" : {
+                "type" : "boolean"
+              },
+              "is-backpressed" : {
+                "type" : "boolean"
+              },
+              "is-backpressed-complete" : {
+                "type" : "boolean"
+              },
+              "out-pool-usage-avg" : {
+                "type" : "float"
+              },
+              "out-pool-usage-avg-complete" : {
+                "type" : "boolean"
+              },
+              "input-exclusive-buffers-avg-usage" : {
+                "type" : "float"
+              },
+              "input-exclusive-buffers-usage-avg-complete" : {
+                "type" : "boolean"
+              },
+              "input-floating-buffers-avg-usage" : {
+                "type" : "float"
+              },
+              "input-floating-buffers-usage-avg-complete" : {
                 "type" : "boolean"
               }
             }
@@ -2552,7 +2576,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           },
           "metrics" : {
             "type" : "object",
-            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:IOMetricsInfo",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:SubTaskIOMetricsInfo",
             "properties" : {
               "read-bytes" : {
                 "type" : "integer"
@@ -2576,6 +2600,30 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
                 "type" : "integer"
               },
               "write-records-complete" : {
+                "type" : "boolean"
+              },
+              "is-backpressed" : {
+                "type" : "boolean"
+              },
+              "is-backpressed-complete" : {
+                "type" : "boolean"
+              },
+              "out-pool-usage" : {
+                "type" : "float"
+              },
+              "out-pool-usage-complete" : {
+                "type" : "boolean"
+              },
+              "input-exclusive-buffers-usage" : {
+                "type" : "float"
+              },
+              "input-exclusive-buffers-usage-complete" : {
+                "type" : "boolean"
+              },
+              "input-floating-buffers-usage" : {
+                "type" : "float"
+              },
+              "input-floating-buffers-usage-complete" : {
                 "type" : "boolean"
               }
             }
@@ -3035,7 +3083,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     },
     "metrics" : {
       "type" : "object",
-      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:IOMetricsInfo",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:SubTaskIOMetricsInfo",
       "properties" : {
         "read-bytes" : {
           "type" : "integer"
@@ -3059,6 +3107,30 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           "type" : "integer"
         },
         "write-records-complete" : {
+          "type" : "boolean"
+        },
+        "is-backpressed" : {
+          "type" : "boolean"
+        },
+        "is-backpressed-complete" : {
+          "type" : "boolean"
+        },
+        "out-pool-usage" : {
+          "type" : "float"
+        },
+        "out-pool-usage-complete" : {
+          "type" : "boolean"
+        },
+        "input-exclusive-buffers-usage" : {
+          "type" : "float"
+        },
+        "input-exclusive-buffers-usage-complete" : {
+          "type" : "boolean"
+        },
+        "input-floating-buffers-usage" : {
+          "type" : "float"
+        },
+        "input-floating-buffers-usage-complete" : {
           "type" : "boolean"
         }
       }
@@ -3147,7 +3219,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     },
     "metrics" : {
       "type" : "object",
-      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:IOMetricsInfo",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:SubTaskIOMetricsInfo",
       "properties" : {
         "read-bytes" : {
           "type" : "integer"
@@ -3171,6 +3243,30 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           "type" : "integer"
         },
         "write-records-complete" : {
+          "type" : "boolean"
+        },
+        "is-backpressed" : {
+          "type" : "boolean"
+        },
+        "is-backpressed-complete" : {
+          "type" : "boolean"
+        },
+        "out-pool-usage" : {
+          "type" : "float"
+        },
+        "out-pool-usage-complete" : {
+          "type" : "boolean"
+        },
+        "input-exclusive-buffers-usage" : {
+          "type" : "float"
+        },
+        "input-exclusive-buffers-usage-complete" : {
+          "type" : "boolean"
+        },
+        "input-floating-buffers-usage" : {
+          "type" : "float"
+        },
+        "input-floating-buffers-usage-complete" : {
           "type" : "boolean"
         }
       }
@@ -3516,6 +3612,12 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
                 "type" : "integer"
               },
               "write-records-complete" : {
+                "type" : "boolean"
+              },
+              "is-backpressed" : {
+                "type" : "boolean"
+              },
+              "is-backpressed-complete" : {
                 "type" : "boolean"
               }
             }

--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -1010,18 +1010,6 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
               "write-records-complete" : {
                 "type" : "boolean"
               },
-              "is-backpressed" : {
-                "type" : "boolean"
-              },
-              "is-backpressed-complete" : {
-                "type" : "boolean"
-              },
-              "out-pool-usage-avg" : {
-                "type" : "number"
-              },
-              "out-pool-usage-avg-complete" : {
-                "type" : "boolean"
-              },
               "input-exclusive-buffers-usage-avg" : {
                 "type" : "number"
               },
@@ -1032,6 +1020,18 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
                 "type" : "number"
               },
               "input-floating-buffers-usage-avg-complete" : {
+                "type" : "boolean"
+              },
+              "out-pool-usage-avg" : {
+                "type" : "number"
+              },
+              "out-pool-usage-avg-complete" : {
+                "type" : "boolean"
+              },
+              "is-backpressed" : {
+                "type" : "boolean"
+              },
+              "is-backpressed-complete" : {
                 "type" : "boolean"
               }
             }
@@ -2602,18 +2602,6 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
               "write-records-complete" : {
                 "type" : "boolean"
               },
-              "is-backpressed" : {
-                "type" : "boolean"
-              },
-              "is-backpressed-complete" : {
-                "type" : "boolean"
-              },
-              "out-pool-usage" : {
-                "type" : "number"
-              },
-              "out-pool-usage-complete" : {
-                "type" : "boolean"
-              },
               "input-exclusive-buffers-usage" : {
                 "type" : "number"
               },
@@ -2624,6 +2612,18 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
                 "type" : "number"
               },
               "input-floating-buffers-usage-complete" : {
+                "type" : "boolean"
+              },
+              "out-pool-usage" : {
+                "type" : "number"
+              },
+              "out-pool-usage-complete" : {
+                "type" : "boolean"
+              },
+              "is-backpressed" : {
+                "type" : "boolean"
+              },
+              "is-backpressed-complete" : {
                 "type" : "boolean"
               }
             }
@@ -3109,18 +3109,6 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
         "write-records-complete" : {
           "type" : "boolean"
         },
-        "is-backpressed" : {
-          "type" : "boolean"
-        },
-        "is-backpressed-complete" : {
-          "type" : "boolean"
-        },
-        "out-pool-usage" : {
-          "type" : "number"
-        },
-        "out-pool-usage-complete" : {
-          "type" : "boolean"
-        },
         "input-exclusive-buffers-usage" : {
           "type" : "number"
         },
@@ -3131,6 +3119,18 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           "type" : "number"
         },
         "input-floating-buffers-usage-complete" : {
+          "type" : "boolean"
+        },
+        "out-pool-usage" : {
+          "type" : "number"
+        },
+        "out-pool-usage-complete" : {
+          "type" : "boolean"
+        },
+        "is-backpressed" : {
+          "type" : "boolean"
+        },
+        "is-backpressed-complete" : {
           "type" : "boolean"
         }
       }
@@ -3245,18 +3245,6 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
         "write-records-complete" : {
           "type" : "boolean"
         },
-        "is-backpressed" : {
-          "type" : "boolean"
-        },
-        "is-backpressed-complete" : {
-          "type" : "boolean"
-        },
-        "out-pool-usage" : {
-          "type" : "number"
-        },
-        "out-pool-usage-complete" : {
-          "type" : "boolean"
-        },
         "input-exclusive-buffers-usage" : {
           "type" : "number"
         },
@@ -3267,6 +3255,18 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           "type" : "number"
         },
         "input-floating-buffers-usage-complete" : {
+          "type" : "boolean"
+        },
+        "out-pool-usage" : {
+          "type" : "number"
+        },
+        "out-pool-usage-complete" : {
+          "type" : "boolean"
+        },
+        "is-backpressed" : {
+          "type" : "boolean"
+        },
+        "is-backpressed-complete" : {
           "type" : "boolean"
         }
       }

--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -1017,19 +1017,19 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
                 "type" : "boolean"
               },
               "out-pool-usage-avg" : {
-                "type" : "float"
+                "type" : "number"
               },
               "out-pool-usage-avg-complete" : {
                 "type" : "boolean"
               },
-              "input-exclusive-buffers-avg-usage" : {
-                "type" : "float"
+              "input-exclusive-buffers-usage-avg" : {
+                "type" : "number"
               },
               "input-exclusive-buffers-usage-avg-complete" : {
                 "type" : "boolean"
               },
-              "input-floating-buffers-avg-usage" : {
-                "type" : "float"
+              "input-floating-buffers-usage-avg" : {
+                "type" : "number"
               },
               "input-floating-buffers-usage-avg-complete" : {
                 "type" : "boolean"
@@ -2609,19 +2609,19 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
                 "type" : "boolean"
               },
               "out-pool-usage" : {
-                "type" : "float"
+                "type" : "number"
               },
               "out-pool-usage-complete" : {
                 "type" : "boolean"
               },
               "input-exclusive-buffers-usage" : {
-                "type" : "float"
+                "type" : "number"
               },
               "input-exclusive-buffers-usage-complete" : {
                 "type" : "boolean"
               },
               "input-floating-buffers-usage" : {
-                "type" : "float"
+                "type" : "number"
               },
               "input-floating-buffers-usage-complete" : {
                 "type" : "boolean"
@@ -3116,19 +3116,19 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           "type" : "boolean"
         },
         "out-pool-usage" : {
-          "type" : "float"
+          "type" : "number"
         },
         "out-pool-usage-complete" : {
           "type" : "boolean"
         },
         "input-exclusive-buffers-usage" : {
-          "type" : "float"
+          "type" : "number"
         },
         "input-exclusive-buffers-usage-complete" : {
           "type" : "boolean"
         },
         "input-floating-buffers-usage" : {
-          "type" : "float"
+          "type" : "number"
         },
         "input-floating-buffers-usage-complete" : {
           "type" : "boolean"
@@ -3252,19 +3252,19 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           "type" : "boolean"
         },
         "out-pool-usage" : {
-          "type" : "float"
+          "type" : "number"
         },
         "out-pool-usage-complete" : {
           "type" : "boolean"
         },
         "input-exclusive-buffers-usage" : {
-          "type" : "float"
+          "type" : "number"
         },
         "input-exclusive-buffers-usage-complete" : {
           "type" : "boolean"
         },
         "input-floating-buffers-usage" : {
-          "type" : "float"
+          "type" : "number"
         },
         "input-floating-buffers-usage-complete" : {
           "type" : "boolean"

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -622,7 +622,7 @@
               },
               "metrics" : {
                 "type" : "object",
-                "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:IOMetricsInfo",
+                "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:JobVertexIOMetricsInfo",
                 "properties" : {
                   "read-bytes" : {
                     "type" : "integer"
@@ -646,6 +646,30 @@
                     "type" : "integer"
                   },
                   "write-records-complete" : {
+                    "type" : "boolean"
+                  },
+                  "is-backpressed" : {
+                    "type" : "boolean"
+                  },
+                  "is-backpressed-complete" : {
+                    "type" : "boolean"
+                  },
+                  "out-pool-usage-avg" : {
+                    "type" : "number"
+                  },
+                  "out-pool-usage-avg-complete" : {
+                    "type" : "boolean"
+                  },
+                  "input-exclusive-buffers-usage-avg" : {
+                    "type" : "number"
+                  },
+                  "input-exclusive-buffers-usage-avg-complete" : {
+                    "type" : "boolean"
+                  },
+                  "input-floating-buffers-usage-avg" : {
+                    "type" : "number"
+                  },
+                  "input-floating-buffers-usage-avg-complete" : {
                     "type" : "boolean"
                   }
                 }
@@ -1666,7 +1690,7 @@
               },
               "metrics" : {
                 "type" : "object",
-                "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:IOMetricsInfo",
+                "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:SubTaskIOMetricsInfo",
                 "properties" : {
                   "read-bytes" : {
                     "type" : "integer"
@@ -1690,6 +1714,30 @@
                     "type" : "integer"
                   },
                   "write-records-complete" : {
+                    "type" : "boolean"
+                  },
+                  "is-backpressed" : {
+                    "type" : "boolean"
+                  },
+                  "is-backpressed-complete" : {
+                    "type" : "boolean"
+                  },
+                  "out-pool-usage" : {
+                    "type" : "number"
+                  },
+                  "out-pool-usage-complete" : {
+                    "type" : "boolean"
+                  },
+                  "input-exclusive-buffers-usage" : {
+                    "type" : "number"
+                  },
+                  "input-exclusive-buffers-usage-complete" : {
+                    "type" : "boolean"
+                  },
+                  "input-floating-buffers-usage" : {
+                    "type" : "number"
+                  },
+                  "input-floating-buffers-usage-complete" : {
                     "type" : "boolean"
                   }
                 }
@@ -1972,7 +2020,7 @@
         },
         "metrics" : {
           "type" : "object",
-          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:IOMetricsInfo",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:SubTaskIOMetricsInfo",
           "properties" : {
             "read-bytes" : {
               "type" : "integer"
@@ -1996,6 +2044,30 @@
               "type" : "integer"
             },
             "write-records-complete" : {
+              "type" : "boolean"
+            },
+            "is-backpressed" : {
+              "type" : "boolean"
+            },
+            "is-backpressed-complete" : {
+              "type" : "boolean"
+            },
+            "out-pool-usage" : {
+              "type" : "number"
+            },
+            "out-pool-usage-complete" : {
+              "type" : "boolean"
+            },
+            "input-exclusive-buffers-usage" : {
+              "type" : "number"
+            },
+            "input-exclusive-buffers-usage-complete" : {
+              "type" : "boolean"
+            },
+            "input-floating-buffers-usage" : {
+              "type" : "number"
+            },
+            "input-floating-buffers-usage-complete" : {
               "type" : "boolean"
             }
           }
@@ -2058,7 +2130,7 @@
         },
         "metrics" : {
           "type" : "object",
-          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:IOMetricsInfo",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:SubTaskIOMetricsInfo",
           "properties" : {
             "read-bytes" : {
               "type" : "integer"
@@ -2082,6 +2154,30 @@
               "type" : "integer"
             },
             "write-records-complete" : {
+              "type" : "boolean"
+            },
+            "is-backpressed" : {
+              "type" : "boolean"
+            },
+            "is-backpressed-complete" : {
+              "type" : "boolean"
+            },
+            "out-pool-usage" : {
+              "type" : "number"
+            },
+            "out-pool-usage-complete" : {
+              "type" : "boolean"
+            },
+            "input-exclusive-buffers-usage" : {
+              "type" : "number"
+            },
+            "input-exclusive-buffers-usage-complete" : {
+              "type" : "boolean"
+            },
+            "input-floating-buffers-usage" : {
+              "type" : "number"
+            },
+            "input-floating-buffers-usage-complete" : {
               "type" : "boolean"
             }
           }
@@ -2311,6 +2407,12 @@
                     "type" : "integer"
                   },
                   "write-records-complete" : {
+                    "type" : "boolean"
+                  },
+                  "is-backpressed" : {
+                    "type" : "boolean"
+                  },
+                  "is-backpressed-complete" : {
                     "type" : "boolean"
                   }
                 }

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -648,18 +648,6 @@
                   "write-records-complete" : {
                     "type" : "boolean"
                   },
-                  "is-backpressed" : {
-                    "type" : "boolean"
-                  },
-                  "is-backpressed-complete" : {
-                    "type" : "boolean"
-                  },
-                  "out-pool-usage-avg" : {
-                    "type" : "number"
-                  },
-                  "out-pool-usage-avg-complete" : {
-                    "type" : "boolean"
-                  },
                   "input-exclusive-buffers-usage-avg" : {
                     "type" : "number"
                   },
@@ -670,6 +658,18 @@
                     "type" : "number"
                   },
                   "input-floating-buffers-usage-avg-complete" : {
+                    "type" : "boolean"
+                  },
+                  "out-pool-usage-avg" : {
+                    "type" : "number"
+                  },
+                  "out-pool-usage-avg-complete" : {
+                    "type" : "boolean"
+                  },
+                  "is-backpressed" : {
+                    "type" : "boolean"
+                  },
+                  "is-backpressed-complete" : {
                     "type" : "boolean"
                   }
                 }
@@ -1716,18 +1716,6 @@
                   "write-records-complete" : {
                     "type" : "boolean"
                   },
-                  "is-backpressed" : {
-                    "type" : "boolean"
-                  },
-                  "is-backpressed-complete" : {
-                    "type" : "boolean"
-                  },
-                  "out-pool-usage" : {
-                    "type" : "number"
-                  },
-                  "out-pool-usage-complete" : {
-                    "type" : "boolean"
-                  },
                   "input-exclusive-buffers-usage" : {
                     "type" : "number"
                   },
@@ -1738,6 +1726,18 @@
                     "type" : "number"
                   },
                   "input-floating-buffers-usage-complete" : {
+                    "type" : "boolean"
+                  },
+                  "out-pool-usage" : {
+                    "type" : "number"
+                  },
+                  "out-pool-usage-complete" : {
+                    "type" : "boolean"
+                  },
+                  "is-backpressed" : {
+                    "type" : "boolean"
+                  },
+                  "is-backpressed-complete" : {
                     "type" : "boolean"
                   }
                 }
@@ -2046,18 +2046,6 @@
             "write-records-complete" : {
               "type" : "boolean"
             },
-            "is-backpressed" : {
-              "type" : "boolean"
-            },
-            "is-backpressed-complete" : {
-              "type" : "boolean"
-            },
-            "out-pool-usage" : {
-              "type" : "number"
-            },
-            "out-pool-usage-complete" : {
-              "type" : "boolean"
-            },
             "input-exclusive-buffers-usage" : {
               "type" : "number"
             },
@@ -2068,6 +2056,18 @@
               "type" : "number"
             },
             "input-floating-buffers-usage-complete" : {
+              "type" : "boolean"
+            },
+            "out-pool-usage" : {
+              "type" : "number"
+            },
+            "out-pool-usage-complete" : {
+              "type" : "boolean"
+            },
+            "is-backpressed" : {
+              "type" : "boolean"
+            },
+            "is-backpressed-complete" : {
               "type" : "boolean"
             }
           }
@@ -2156,18 +2156,6 @@
             "write-records-complete" : {
               "type" : "boolean"
             },
-            "is-backpressed" : {
-              "type" : "boolean"
-            },
-            "is-backpressed-complete" : {
-              "type" : "boolean"
-            },
-            "out-pool-usage" : {
-              "type" : "number"
-            },
-            "out-pool-usage-complete" : {
-              "type" : "boolean"
-            },
             "input-exclusive-buffers-usage" : {
               "type" : "number"
             },
@@ -2178,6 +2166,18 @@
               "type" : "number"
             },
             "input-floating-buffers-usage-complete" : {
+              "type" : "boolean"
+            },
+            "out-pool-usage" : {
+              "type" : "number"
+            },
+            "out-pool-usage-complete" : {
+              "type" : "boolean"
+            },
+            "is-backpressed" : {
+              "type" : "boolean"
+            },
+            "is-backpressed-complete" : {
               "type" : "boolean"
             }
           }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IOMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IOMetrics.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.executiongraph;
 
+import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Meter;
 
 import java.io.Serializable;
@@ -35,22 +36,40 @@ public class IOMetrics implements Serializable {
 	protected long numBytesIn;
 	protected long numBytesOut;
 
-	public IOMetrics(Meter recordsIn, Meter recordsOut, Meter bytesIn, Meter bytesOut) {
+	protected float usageInputFloatingBuffers;
+	protected float usageInputExclusiveBuffers;
+	protected float usageOutPool;
+	protected boolean isBackPressured;
+
+	public IOMetrics(Meter recordsIn, Meter recordsOut, Meter bytesIn, Meter bytesOut, Gauge<Float> inputFloatingBuffers,
+			Gauge<Float> inputExclusiveBuffers, Gauge<Float> outPool, Gauge<Boolean> backPressured) {
 		this.numRecordsIn = recordsIn.getCount();
 		this.numRecordsOut = recordsOut.getCount();
 		this.numBytesIn = bytesIn.getCount();
 		this.numBytesOut = bytesOut.getCount();
+		this.usageInputFloatingBuffers = inputFloatingBuffers.getValue();
+		this.usageInputExclusiveBuffers = inputExclusiveBuffers.getValue();
+		this.usageOutPool = outPool.getValue();
+		this.isBackPressured = backPressured.getValue();
 	}
 
 	public IOMetrics(
 			long numBytesIn,
 			long numBytesOut,
 			long numRecordsIn,
-			long numRecordsOut) {
+			long numRecordsOut,
+			float usageInputFloatingBuffers,
+			float usageInputExclusiveBuffers,
+			float usageOutPool,
+			boolean isBackPressured) {
 		this.numBytesIn = numBytesIn;
 		this.numBytesOut = numBytesOut;
 		this.numRecordsIn = numRecordsIn;
 		this.numRecordsOut = numRecordsOut;
+		this.usageInputFloatingBuffers = usageInputFloatingBuffers;
+		this.usageInputExclusiveBuffers = usageInputExclusiveBuffers;
+		this.usageOutPool = usageOutPool;
+		this.isBackPressured = isBackPressured;
 	}
 
 	public long getNumRecordsIn() {
@@ -67,5 +86,21 @@ public class IOMetrics implements Serializable {
 
 	public long getNumBytesOut() {
 		return numBytesOut;
+	}
+
+	public float getUsageInputFloatingBuffers() {
+		return usageInputFloatingBuffers;
+	}
+
+	public float getUsageInputExclusiveBuffers() {
+		return usageInputExclusiveBuffers;
+	}
+
+	public float getUsageOutPool() {
+		return usageOutPool;
+	}
+
+	public boolean isBackPressured() {
+		return isBackPressured;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IOMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IOMetrics.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.executiongraph;
 
-import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Meter;
 
 import java.io.Serializable;
@@ -41,16 +40,11 @@ public class IOMetrics implements Serializable {
 	protected float usageOutPool;
 	protected boolean isBackPressured;
 
-	public IOMetrics(Meter recordsIn, Meter recordsOut, Meter bytesIn, Meter bytesOut, Gauge<Float> inputFloatingBuffers,
-			Gauge<Float> inputExclusiveBuffers, Gauge<Float> outPool, Gauge<Boolean> backPressured) {
+	public IOMetrics(Meter recordsIn, Meter recordsOut, Meter bytesIn, Meter bytesOut) {
 		this.numRecordsIn = recordsIn.getCount();
 		this.numRecordsOut = recordsOut.getCount();
 		this.numBytesIn = bytesIn.getCount();
 		this.numBytesOut = bytesOut.getCount();
-		this.usageInputFloatingBuffers = inputFloatingBuffers.getValue();
-		this.usageInputExclusiveBuffers = inputExclusiveBuffers.getValue();
-		this.usageOutPool = outPool.getValue();
-		this.isBackPressured = backPressured.getValue();
 	}
 
 	public IOMetrics(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/NettyShuffleMetricFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/NettyShuffleMetricFactory.java
@@ -51,23 +51,23 @@ public class NettyShuffleMetricFactory {
 
 	// task level metric group structure: Shuffle.Netty.<Input|Output>.Buffers
 
-	private static final String METRIC_GROUP_SHUFFLE = "Shuffle";
-	private static final String METRIC_GROUP_NETTY = "Netty";
+	public static final String METRIC_GROUP_SHUFFLE = "Shuffle";
+	public static final String METRIC_GROUP_NETTY = "Netty";
 	public static final String METRIC_GROUP_OUTPUT = "Output";
 	public static final String METRIC_GROUP_INPUT = "Input";
-	private static final String METRIC_GROUP_BUFFERS = "Buffers";
+	public static final String METRIC_GROUP_BUFFERS = "Buffers";
 
 	// task level output metrics: Shuffle.Netty.Output.*
 
 	private static final String METRIC_OUTPUT_QUEUE_LENGTH = "outputQueueLength";
-	private static final String METRIC_OUTPUT_POOL_USAGE = "outPoolUsage";
+	public static final String METRIC_OUTPUT_POOL_USAGE = "outPoolUsage";
 
 	// task level input metrics: Shuffle.Netty.Input.*
 
 	private static final String METRIC_INPUT_QUEUE_LENGTH = "inputQueueLength";
 	private static final String METRIC_INPUT_POOL_USAGE = "inPoolUsage";
-	private static final String METRIC_INPUT_FLOATING_BUFFERS_USAGE = "inputFloatingBuffersUsage";
-	private static final String METRIC_INPUT_EXCLUSIVE_BUFFERS_USAGE = "inputExclusiveBuffersUsage";
+	public static final String METRIC_INPUT_FLOATING_BUFFERS_USAGE = "inputFloatingBuffersUsage";
+	public static final String METRIC_INPUT_EXCLUSIVE_BUFFERS_USAGE = "inputExclusiveBuffersUsage";
 
 	private NettyShuffleMetricFactory() {
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -18,6 +18,11 @@
 
 package org.apache.flink.runtime.metrics;
 
+import org.apache.flink.runtime.io.network.metrics.NettyShuffleMetricFactory;
+import org.apache.flink.runtime.metrics.scope.TaskManagerScopeFormat;
+
+import java.util.StringJoiner;
+
 /**
  * Collection of metric names.
  */
@@ -45,6 +50,28 @@ public class MetricNames {
 	public static final String IO_CURRENT_INPUT_1_WATERMARK = "currentInput1Watermark";
 	public static final String IO_CURRENT_INPUT_2_WATERMARK = "currentInput2Watermark";
 	public static final String IO_CURRENT_OUTPUT_WATERMARK = "currentOutputWatermark";
+
+	private static final String  SHUFFLE_NETTY_GROUP = new StringJoiner(TaskManagerScopeFormat.SCOPE_SEPARATOR)
+		.add(NettyShuffleMetricFactory.METRIC_GROUP_SHUFFLE)
+		.add(NettyShuffleMetricFactory.METRIC_GROUP_NETTY).toString();
+	private static final String SHUFFLE_NETTY_INPUT_GROUP = new StringJoiner(TaskManagerScopeFormat.SCOPE_SEPARATOR,
+		SHUFFLE_NETTY_GROUP, NettyShuffleMetricFactory.METRIC_GROUP_BUFFERS)
+		.add(NettyShuffleMetricFactory.METRIC_GROUP_INPUT).toString();
+	private static final String SHUFFLE_NETTY_OUPUT_GROUP = new StringJoiner(TaskManagerScopeFormat.SCOPE_SEPARATOR,
+		SHUFFLE_NETTY_GROUP, NettyShuffleMetricFactory.METRIC_GROUP_BUFFERS)
+		.add(NettyShuffleMetricFactory.METRIC_GROUP_OUTPUT).toString();
+	public static final String USAGE_SHUFFLE_NETTY_INPUT_FLOATING_BUFFERS = new StringJoiner(
+		TaskManagerScopeFormat.SCOPE_SEPARATOR,
+		SHUFFLE_NETTY_INPUT_GROUP,
+		NettyShuffleMetricFactory.METRIC_INPUT_FLOATING_BUFFERS_USAGE).toString();
+	public static final String USAGE_SHUFFLE_NETTY_INPUT_EXCLUSIVE_BUFFERS = new StringJoiner(
+		TaskManagerScopeFormat.SCOPE_SEPARATOR,
+		SHUFFLE_NETTY_INPUT_GROUP,
+		NettyShuffleMetricFactory.METRIC_INPUT_EXCLUSIVE_BUFFERS_USAGE).toString();
+	public static final String USAGE_SHUFFLE_NETTY_OUTPUT_POOL_USAGE = new StringJoiner(
+		TaskManagerScopeFormat.SCOPE_SEPARATOR,
+		SHUFFLE_NETTY_OUPUT_GROUP,
+		NettyShuffleMetricFactory.METRIC_OUTPUT_POOL_USAGE).toString();
 
 	public static final String NUM_RUNNING_JOBS = "numRunningJobs";
 	public static final String TASK_SLOTS_AVAILABLE = "taskSlotsAvailable";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.metrics;
 
 import org.apache.flink.runtime.io.network.metrics.NettyShuffleMetricFactory;
-import org.apache.flink.runtime.metrics.scope.TaskManagerScopeFormat;
+import org.apache.flink.runtime.metrics.scope.OperatorScopeFormat;
 
 import java.util.StringJoiner;
 
@@ -51,27 +51,25 @@ public class MetricNames {
 	public static final String IO_CURRENT_INPUT_2_WATERMARK = "currentInput2Watermark";
 	public static final String IO_CURRENT_OUTPUT_WATERMARK = "currentOutputWatermark";
 
-	private static final String  SHUFFLE_NETTY_GROUP = new StringJoiner(TaskManagerScopeFormat.SCOPE_SEPARATOR)
+	private static final String  SHUFFLE_NETTY_GROUP = new StringJoiner(OperatorScopeFormat.SCOPE_SEPARATOR)
 		.add(NettyShuffleMetricFactory.METRIC_GROUP_SHUFFLE)
-		.add(NettyShuffleMetricFactory.METRIC_GROUP_NETTY).toString();
-	private static final String SHUFFLE_NETTY_INPUT_GROUP = new StringJoiner(TaskManagerScopeFormat.SCOPE_SEPARATOR,
-		SHUFFLE_NETTY_GROUP, NettyShuffleMetricFactory.METRIC_GROUP_BUFFERS)
+		.add(NettyShuffleMetricFactory.METRIC_GROUP_NETTY)
+		.add(NettyShuffleMetricFactory.METRIC_GROUP_BUFFERS).toString();
+	private static final String SHUFFLE_NETTY_INPUT_GROUP = new StringJoiner(OperatorScopeFormat.SCOPE_SEPARATOR)
+		.add(SHUFFLE_NETTY_GROUP)
 		.add(NettyShuffleMetricFactory.METRIC_GROUP_INPUT).toString();
-	private static final String SHUFFLE_NETTY_OUPUT_GROUP = new StringJoiner(TaskManagerScopeFormat.SCOPE_SEPARATOR,
-		SHUFFLE_NETTY_GROUP, NettyShuffleMetricFactory.METRIC_GROUP_BUFFERS)
+	private static final String SHUFFLE_NETTY_OUPUT_GROUP = new StringJoiner(OperatorScopeFormat.SCOPE_SEPARATOR)
+		.add(SHUFFLE_NETTY_GROUP)
 		.add(NettyShuffleMetricFactory.METRIC_GROUP_OUTPUT).toString();
-	public static final String USAGE_SHUFFLE_NETTY_INPUT_FLOATING_BUFFERS = new StringJoiner(
-		TaskManagerScopeFormat.SCOPE_SEPARATOR,
-		SHUFFLE_NETTY_INPUT_GROUP,
-		NettyShuffleMetricFactory.METRIC_INPUT_FLOATING_BUFFERS_USAGE).toString();
-	public static final String USAGE_SHUFFLE_NETTY_INPUT_EXCLUSIVE_BUFFERS = new StringJoiner(
-		TaskManagerScopeFormat.SCOPE_SEPARATOR,
-		SHUFFLE_NETTY_INPUT_GROUP,
-		NettyShuffleMetricFactory.METRIC_INPUT_EXCLUSIVE_BUFFERS_USAGE).toString();
-	public static final String USAGE_SHUFFLE_NETTY_OUTPUT_POOL_USAGE = new StringJoiner(
-		TaskManagerScopeFormat.SCOPE_SEPARATOR,
-		SHUFFLE_NETTY_OUPUT_GROUP,
-		NettyShuffleMetricFactory.METRIC_OUTPUT_POOL_USAGE).toString();
+	public static final String USAGE_SHUFFLE_NETTY_INPUT_FLOATING_BUFFERS = new StringJoiner(OperatorScopeFormat.SCOPE_SEPARATOR)
+		.add(SHUFFLE_NETTY_INPUT_GROUP)
+		.add(NettyShuffleMetricFactory.METRIC_INPUT_FLOATING_BUFFERS_USAGE).toString();
+	public static final String USAGE_SHUFFLE_NETTY_INPUT_EXCLUSIVE_BUFFERS = new StringJoiner(OperatorScopeFormat.SCOPE_SEPARATOR)
+		.add(SHUFFLE_NETTY_INPUT_GROUP)
+		.add(NettyShuffleMetricFactory.METRIC_INPUT_EXCLUSIVE_BUFFERS_USAGE).toString();
+	public static final String USAGE_SHUFFLE_NETTY_OUTPUT_POOL_USAGE = new StringJoiner(OperatorScopeFormat.SCOPE_SEPARATOR)
+		.add(SHUFFLE_NETTY_OUPUT_GROUP)
+		.add(NettyShuffleMetricFactory.METRIC_OUTPUT_POOL_USAGE).toString();
 
 	public static final String NUM_RUNNING_JOBS = "numRunningJobs";
 	public static final String TASK_SLOTS_AVAILABLE = "taskSlotsAvailable";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -53,14 +53,15 @@ public class MetricNames {
 
 	private static final String  SHUFFLE_NETTY_GROUP = new StringJoiner(OperatorScopeFormat.SCOPE_SEPARATOR)
 		.add(NettyShuffleMetricFactory.METRIC_GROUP_SHUFFLE)
-		.add(NettyShuffleMetricFactory.METRIC_GROUP_NETTY)
-		.add(NettyShuffleMetricFactory.METRIC_GROUP_BUFFERS).toString();
+		.add(NettyShuffleMetricFactory.METRIC_GROUP_NETTY).toString();
 	private static final String SHUFFLE_NETTY_INPUT_GROUP = new StringJoiner(OperatorScopeFormat.SCOPE_SEPARATOR)
 		.add(SHUFFLE_NETTY_GROUP)
-		.add(NettyShuffleMetricFactory.METRIC_GROUP_INPUT).toString();
+		.add(NettyShuffleMetricFactory.METRIC_GROUP_INPUT)
+		.add(NettyShuffleMetricFactory.METRIC_GROUP_BUFFERS).toString();
 	private static final String SHUFFLE_NETTY_OUPUT_GROUP = new StringJoiner(OperatorScopeFormat.SCOPE_SEPARATOR)
 		.add(SHUFFLE_NETTY_GROUP)
-		.add(NettyShuffleMetricFactory.METRIC_GROUP_OUTPUT).toString();
+		.add(NettyShuffleMetricFactory.METRIC_GROUP_OUTPUT)
+		.add(NettyShuffleMetricFactory.METRIC_GROUP_BUFFERS).toString();
 	public static final String USAGE_SHUFFLE_NETTY_INPUT_FLOATING_BUFFERS = new StringJoiner(OperatorScopeFormat.SCOPE_SEPARATOR)
 		.add(SHUFFLE_NETTY_INPUT_GROUP)
 		.add(NettyShuffleMetricFactory.METRIC_INPUT_FLOATING_BUFFERS_USAGE).toString();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandler.java
@@ -210,7 +210,9 @@ public class JobDetailsHandler extends AbstractExecutionGraphHandler<JobDetailsI
 			counts.getNumRecordsIn(),
 			counts.isNumRecordsInComplete(),
 			counts.getNumRecordsOut(),
-			counts.isNumRecordsOutComplete());
+			counts.isNumRecordsOutComplete(),
+			counts.isBackPressured(),
+			counts.isBackPressuredComplete());
 
 		return new JobDetailsInfo.JobVertexDetailsInfo(
 			ejv.getJobVertexId(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandler.java
@@ -37,7 +37,7 @@ import org.apache.flink.runtime.rest.messages.JobMessageParameters;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
 import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
-import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
+import org.apache.flink.runtime.rest.messages.job.metrics.JobVertexIOMetricsInfo;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
 import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
@@ -201,8 +201,11 @@ public class JobDetailsHandler extends AbstractExecutionGraphHandler<JobDetailsI
 				jobId.toString(),
 				ejv.getJobVertexId().toString());
 		}
-
-		final IOMetricsInfo jobVertexMetrics = new IOMetricsInfo(
+		final int taskSize = ejv.getTaskVertices().length;
+		final float outPoolUsageAvg = counts.getUsageOutPool() / (taskSize * 1.0f);
+		final float inputExclusiveBuffersUsageAvg = counts.getUsageInputExclusiveBuffers() / (taskSize * 1.0f);
+		final float inputFloatingBuffersUsageAvg = counts.getUsageInputFloatingBuffers() / (taskSize * 1.0f);
+		final JobVertexIOMetricsInfo jobVertexMetrics = new JobVertexIOMetricsInfo(
 			counts.getNumBytesIn(),
 			counts.isNumBytesInComplete(),
 			counts.getNumBytesOut(),
@@ -212,7 +215,13 @@ public class JobDetailsHandler extends AbstractExecutionGraphHandler<JobDetailsI
 			counts.getNumRecordsOut(),
 			counts.isNumRecordsOutComplete(),
 			counts.isBackPressured(),
-			counts.isBackPressuredComplete());
+			counts.isBackPressuredComplete(),
+			outPoolUsageAvg,
+			counts.isUsageOutPoolComplete(),
+			inputExclusiveBuffersUsageAvg,
+			counts.isUsageInputExclusiveBuffersComplete(),
+			inputFloatingBuffersUsageAvg,
+			counts.isUsageInputFloatingBuffersComplete());
 
 		return new JobDetailsInfo.JobVertexDetailsInfo(
 			ejv.getJobVertexId(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandler.java
@@ -214,7 +214,13 @@ public class JobDetailsHandler extends AbstractExecutionGraphHandler<JobDetailsI
 			counts.isNumRecordsInComplete(),
 			counts.getNumRecordsOut(),
 			counts.isNumRecordsOutComplete(),
-			inputExclusiveBuffersUsageAvg, counts.isUsageInputExclusiveBuffersComplete(), inputFloatingBuffersUsageAvg, counts.isUsageInputFloatingBuffersComplete(), outPoolUsageAvg, counts.isUsageOutPoolComplete(), counts.isBackPressured(),
+			inputExclusiveBuffersUsageAvg,
+			counts.isUsageInputExclusiveBuffersComplete(),
+			inputFloatingBuffersUsageAvg,
+			counts.isUsageInputFloatingBuffersComplete(),
+			outPoolUsageAvg,
+			counts.isUsageOutPoolComplete(),
+			counts.isBackPressured(),
 			counts.isBackPressuredComplete()
 		);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandler.java
@@ -214,14 +214,9 @@ public class JobDetailsHandler extends AbstractExecutionGraphHandler<JobDetailsI
 			counts.isNumRecordsInComplete(),
 			counts.getNumRecordsOut(),
 			counts.isNumRecordsOutComplete(),
-			counts.isBackPressured(),
-			counts.isBackPressuredComplete(),
-			outPoolUsageAvg,
-			counts.isUsageOutPoolComplete(),
-			inputExclusiveBuffersUsageAvg,
-			counts.isUsageInputExclusiveBuffersComplete(),
-			inputFloatingBuffersUsageAvg,
-			counts.isUsageInputFloatingBuffersComplete());
+			inputExclusiveBuffersUsageAvg, counts.isUsageInputExclusiveBuffersComplete(), inputFloatingBuffersUsageAvg, counts.isUsageInputFloatingBuffersComplete(), outPoolUsageAvg, counts.isUsageOutPoolComplete(), counts.isBackPressured(),
+			counts.isBackPressuredComplete()
+		);
 
 		return new JobDetailsInfo.JobVertexDetailsInfo(
 			ejv.getJobVertexId(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexTaskManagersHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexTaskManagersHandler.java
@@ -184,7 +184,9 @@ public class JobVertexTaskManagersHandler extends AbstractExecutionGraphHandler<
 				counts.getNumRecordsIn(),
 				counts.isNumRecordsInComplete(),
 				counts.getNumRecordsOut(),
-				counts.isNumRecordsOutComplete());
+				counts.isNumRecordsOutComplete(),
+				counts.isBackPressured(),
+				counts.isBackPressuredComplete());
 
 			Map<ExecutionState, Integer> statusCounts = new HashMap<>(ExecutionState.values().length);
 			for (ExecutionState state : ExecutionState.values()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/util/MutableIOMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/util/MutableIOMetrics.java
@@ -18,9 +18,6 @@
 
 package org.apache.flink.runtime.rest.handler.util;
 
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Supplier;
 import org.apache.flink.runtime.executiongraph.AccessExecution;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.IOMetrics;
@@ -30,6 +27,8 @@ import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
 import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricStore;
 
 import javax.annotation.Nullable;
+
+import java.util.function.Consumer;
 
 /**
  * This class is a mutable version of the {@link IOMetrics} class that allows adding up IO-related metrics.
@@ -143,9 +142,24 @@ public class MutableIOMetrics extends IOMetrics {
 						(Long value) -> this.numRecordsOut += value
 					);
 
-					updateFloat(metrics, MetricNames.IO_NUM_RECORDS_OUT,
-						(String value) -> this.numRecordsOutComplete = false,
-						(Float value) -> this.numRecordsOut += value
+					updateFloat(metrics, MetricNames.USAGE_SHUFFLE_NETTY_INPUT_FLOATING_BUFFERS,
+						(String value) -> this.usageInputFloatingBuffersComplete = false,
+						(Float value) -> this.usageInputFloatingBuffers += value
+					);
+
+					updateFloat(metrics, MetricNames.USAGE_SHUFFLE_NETTY_INPUT_EXCLUSIVE_BUFFERS,
+						(String value) -> this.usageInputExclusiveBuffersComplete = false,
+						(Float value) -> this.usageInputExclusiveBuffers += value
+					);
+
+					updateFloat(metrics, MetricNames.USAGE_SHUFFLE_NETTY_OUTPUT_POOL_USAGE,
+						(String value) -> this.usageOutPoolComplete = false,
+						(Float value) -> this.usageOutPool += value
+					);
+
+					updateBoolean(metrics, MetricNames.IS_BACKPRESSURED,
+						(String value) -> this.isBackPressuredComplete = false,
+						(Boolean value) -> this.isBackPressured &= value
 					);
 				}
 				else {
@@ -153,6 +167,10 @@ public class MutableIOMetrics extends IOMetrics {
 					this.numBytesOutComplete = false;
 					this.numRecordsInComplete = false;
 					this.numRecordsOutComplete = false;
+					this.usageInputFloatingBuffersComplete = false;
+					this.usageInputExclusiveBuffersComplete = false;
+					this.usageOutPoolComplete = false;
+					this.isBackPressuredComplete = false;
 				}
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/util/MutableIOMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/util/MutableIOMetrics.java
@@ -108,7 +108,7 @@ public class MutableIOMetrics extends IOMetrics {
 				this.usageInputExclusiveBuffers += ioMetrics.getUsageInputExclusiveBuffers();
 				this.usageInputFloatingBuffers += ioMetrics.getUsageInputFloatingBuffers();
 				this.usageOutPool += ioMetrics.getUsageOutPool();
-				this.isBackPressured &= ioMetrics.isBackPressured();
+				this.isBackPressured |= ioMetrics.isBackPressured();
 			}
 		} else { // execAttempt is still running, use MetricQueryService instead
 			if (fetcher != null) {
@@ -159,7 +159,7 @@ public class MutableIOMetrics extends IOMetrics {
 
 					update(metrics, MetricNames.IS_BACKPRESSURED,
 						(String value) -> this.isBackPressuredComplete = false,
-						(String value) -> this.isBackPressured &= Boolean.valueOf(value)
+						(String value) -> this.isBackPressured |= Boolean.valueOf(value)
 					);
 				}
 				else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/util/MutableIOMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/util/MutableIOMetrics.java
@@ -122,44 +122,44 @@ public class MutableIOMetrics extends IOMetrics {
 					 * In case a metric is missing for a parallel instance of a task, we set the complete flag as
 					 * false.
 					 */
-					updateLong(metrics, MetricNames.IO_NUM_BYTES_IN,
+					update(metrics, MetricNames.IO_NUM_BYTES_IN,
 						(String value) -> this.numBytesInComplete = false,
-						(Long value) -> this.numBytesIn += value
+						(String value) -> this.numBytesIn += Long.valueOf(value)
 					);
 
-					updateLong(metrics, MetricNames.IO_NUM_BYTES_OUT,
+					update(metrics, MetricNames.IO_NUM_BYTES_OUT,
 						(String value) -> this.numBytesOutComplete = false,
-						(Long value) -> this.numBytesOut += value
+						(String value) -> this.numBytesOut += Long.valueOf(value)
 					);
 
-					updateLong(metrics, MetricNames.IO_NUM_RECORDS_IN,
+					update(metrics, MetricNames.IO_NUM_RECORDS_IN,
 						(String value) -> this.numRecordsInComplete = false,
-						(Long value) -> this.numRecordsIn += value
+						(String value) -> this.numRecordsIn += Long.valueOf(value)
 					);
 
-					updateLong(metrics, MetricNames.IO_NUM_RECORDS_OUT,
+					update(metrics, MetricNames.IO_NUM_RECORDS_OUT,
 						(String value) -> this.numRecordsOutComplete = false,
-						(Long value) -> this.numRecordsOut += value
+						(String value) -> this.numRecordsOut += Long.valueOf(value)
 					);
 
-					updateFloat(metrics, MetricNames.USAGE_SHUFFLE_NETTY_INPUT_FLOATING_BUFFERS,
+					update(metrics, MetricNames.USAGE_SHUFFLE_NETTY_INPUT_FLOATING_BUFFERS,
 						(String value) -> this.usageInputFloatingBuffersComplete = false,
-						(Float value) -> this.usageInputFloatingBuffers += value
+						(String value) -> this.usageInputFloatingBuffers += Float.valueOf(value)
 					);
 
-					updateFloat(metrics, MetricNames.USAGE_SHUFFLE_NETTY_INPUT_EXCLUSIVE_BUFFERS,
+					update(metrics, MetricNames.USAGE_SHUFFLE_NETTY_INPUT_EXCLUSIVE_BUFFERS,
 						(String value) -> this.usageInputExclusiveBuffersComplete = false,
-						(Float value) -> this.usageInputExclusiveBuffers += value
+						(String value) -> this.usageInputExclusiveBuffers += Float.valueOf(value)
 					);
 
-					updateFloat(metrics, MetricNames.USAGE_SHUFFLE_NETTY_OUTPUT_POOL_USAGE,
+					update(metrics, MetricNames.USAGE_SHUFFLE_NETTY_OUTPUT_POOL_USAGE,
 						(String value) -> this.usageOutPoolComplete = false,
-						(Float value) -> this.usageOutPool += value
+						(String value) -> this.usageOutPool += Float.valueOf(value)
 					);
 
-					updateBoolean(metrics, MetricNames.IS_BACKPRESSURED,
+					update(metrics, MetricNames.IS_BACKPRESSURED,
 						(String value) -> this.isBackPressuredComplete = false,
-						(Boolean value) -> this.isBackPressured &= value
+						(String value) -> this.isBackPressured &= Boolean.valueOf(value)
 					);
 				}
 				else {
@@ -176,33 +176,13 @@ public class MutableIOMetrics extends IOMetrics {
 		}
 	}
 
-	private void updateLong(MetricStore.ComponentMetricStore metrics, String metricKey, Consumer<String> emptyFunction, Consumer<Long> noEmptyFunction) {
+	private void update(MetricStore.ComponentMetricStore metrics, String metricKey, Consumer<String> emptyFunction, Consumer<String> noEmptyFunction) {
 		String value = metrics.getMetric(metricKey);
 		if (value == null){
 			emptyFunction.accept(value);
 		}
 		else {
-			noEmptyFunction.accept(Long.valueOf(value));
-		}
-	}
-
-	private void updateFloat(MetricStore.ComponentMetricStore metrics, String metricKey, Consumer<String> emptyFunction, Consumer<Float> noEmptyFunction) {
-		String value = metrics.getMetric(metricKey);
-		if (value == null){
-			emptyFunction.accept(value);
-		}
-		else {
-			noEmptyFunction.accept(Float.valueOf(value));
-		}
-	}
-
-	private void updateBoolean(MetricStore.ComponentMetricStore metrics, String metricKey, Consumer<String> emptyFunction, Consumer<Boolean> noEmptyFunction) {
-		String value = metrics.getMetric(metricKey);
-		if (value == null){
-			emptyFunction.accept(value);
-		}
-		else {
-			noEmptyFunction.accept(Boolean.valueOf(value));
+			noEmptyFunction.accept(value);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfo.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
-import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
+import org.apache.flink.runtime.rest.messages.job.metrics.JobVertexIOMetricsInfo;
 import org.apache.flink.runtime.rest.messages.json.JobIDDeserializer;
 import org.apache.flink.runtime.rest.messages.json.JobIDSerializer;
 import org.apache.flink.runtime.rest.messages.json.JobVertexIDDeserializer;
@@ -279,7 +279,7 @@ public class JobDetailsInfo implements ResponseBody {
 		private final Map<ExecutionState, Integer> tasksPerState;
 
 		@JsonProperty(FIELD_NAME_JOB_VERTEX_METRICS)
-		private final IOMetricsInfo jobVertexMetrics;
+		private final JobVertexIOMetricsInfo jobVertexMetrics;
 
 		@JsonCreator
 		public JobVertexDetailsInfo(
@@ -291,7 +291,7 @@ public class JobDetailsInfo implements ResponseBody {
 				@JsonProperty(FIELD_NAME_JOB_VERTEX_END_TIME) long endTime,
 				@JsonProperty(FIELD_NAME_JOB_VERTEX_DURATION) long duration,
 				@JsonProperty(FIELD_NAME_TASKS_PER_STATE) Map<ExecutionState, Integer> tasksPerState,
-				@JsonProperty(FIELD_NAME_JOB_VERTEX_METRICS) IOMetricsInfo jobVertexMetrics) {
+				@JsonProperty(FIELD_NAME_JOB_VERTEX_METRICS) JobVertexIOMetricsInfo jobVertexMetrics) {
 			this.jobVertexID = Preconditions.checkNotNull(jobVertexID);
 			this.name = Preconditions.checkNotNull(name);
 			this.parallelism = parallelism;
@@ -344,7 +344,7 @@ public class JobDetailsInfo implements ResponseBody {
 		}
 
 		@JsonIgnore
-		public IOMetricsInfo getJobVertexMetrics() {
+		public JobVertexIOMetricsInfo getJobVertexMetrics() {
 			return jobVertexMetrics;
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfo.java
@@ -25,7 +25,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
 import org.apache.flink.runtime.rest.handler.util.MutableIOMetrics;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
-import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
+import org.apache.flink.runtime.rest.messages.job.metrics.SubTaskIOMetricsInfo;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.Preconditions;
 
@@ -86,7 +86,7 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 	private final long duration;
 
 	@JsonProperty(FIELD_NAME_METRICS)
-	private final IOMetricsInfo ioMetricsInfo;
+	private final SubTaskIOMetricsInfo subTaskIOMetricsInfo;
 
 	@JsonProperty(FIELD_NAME_TASKMANAGER_ID)
 	private final String taskmanagerId;
@@ -100,7 +100,7 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 			@JsonProperty(FIELD_NAME_START_TIME) long startTime,
 			@JsonProperty(FIELD_NAME_END_TIME) long endTime,
 			@JsonProperty(FIELD_NAME_DURATION) long duration,
-			@JsonProperty(FIELD_NAME_METRICS) IOMetricsInfo ioMetricsInfo,
+			@JsonProperty(FIELD_NAME_METRICS) SubTaskIOMetricsInfo subTaskIOMetricsInfo,
 			@JsonProperty(FIELD_NAME_TASKMANAGER_ID) String taskmanagerId) {
 
 		this.subtaskIndex = subtaskIndex;
@@ -111,7 +111,7 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 		this.startTimeCompatible = startTime;
 		this.endTime = endTime;
 		this.duration = duration;
-		this.ioMetricsInfo = Preconditions.checkNotNull(ioMetricsInfo);
+		this.subTaskIOMetricsInfo = Preconditions.checkNotNull(subTaskIOMetricsInfo);
 		this.taskmanagerId = Preconditions.checkNotNull(taskmanagerId);
 	}
 
@@ -147,8 +147,8 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 		return duration;
 	}
 
-	public IOMetricsInfo getIoMetricsInfo() {
-		return ioMetricsInfo;
+	public SubTaskIOMetricsInfo getSubTaskIOMetricsInfo() {
+		return subTaskIOMetricsInfo;
 	}
 
 	public String getTaskmanagerId() {
@@ -174,13 +174,13 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 			startTimeCompatible == that.startTimeCompatible &&
 			endTime == that.endTime &&
 			duration == that.duration &&
-			Objects.equals(ioMetricsInfo, that.ioMetricsInfo) &&
+			Objects.equals(subTaskIOMetricsInfo, that.subTaskIOMetricsInfo) &&
 			Objects.equals(taskmanagerId, that.taskmanagerId);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(subtaskIndex, status, attempt, host, startTime, startTimeCompatible, endTime, duration, ioMetricsInfo, taskmanagerId);
+		return Objects.hash(subtaskIndex, status, attempt, host, startTime, startTimeCompatible, endTime, duration, subTaskIOMetricsInfo, taskmanagerId);
 	}
 
 	public static SubtaskExecutionAttemptDetailsInfo create(AccessExecution execution, @Nullable MetricFetcher metricFetcher, JobID jobID, JobVertexID jobVertexID) {
@@ -206,7 +206,7 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 			jobVertexID.toString()
 		);
 
-		final IOMetricsInfo ioMetricsInfo = new IOMetricsInfo(
+		final SubTaskIOMetricsInfo subTaskIOMetricsInfo = new SubTaskIOMetricsInfo(
 			ioMetrics.getNumBytesIn(),
 			ioMetrics.isNumBytesInComplete(),
 			ioMetrics.getNumBytesOut(),
@@ -214,7 +214,13 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 			ioMetrics.getNumRecordsIn(),
 			ioMetrics.isNumRecordsInComplete(),
 			ioMetrics.getNumRecordsOut(),
-			ioMetrics.isNumRecordsOutComplete());
+			ioMetrics.isNumRecordsOutComplete(),
+			ioMetrics.getUsageOutPool(),
+			ioMetrics.isUsageOutPoolComplete(),
+			ioMetrics.getUsageInputExclusiveBuffers(),
+			ioMetrics.isUsageInputExclusiveBuffersComplete(),
+			ioMetrics.getUsageInputFloatingBuffers(),
+			ioMetrics.isUsageInputFloatingBuffersComplete());
 
 		return new SubtaskExecutionAttemptDetailsInfo(
 			execution.getParallelSubtaskIndex(),
@@ -224,7 +230,7 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 			startTime,
 			endTime,
 			duration,
-			ioMetricsInfo,
+			subTaskIOMetricsInfo,
 			taskmanagerId
 		);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfo.java
@@ -215,6 +215,8 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 			ioMetrics.isNumRecordsInComplete(),
 			ioMetrics.getNumRecordsOut(),
 			ioMetrics.isNumRecordsOutComplete(),
+			ioMetrics.isBackPressured(),
+			ioMetrics.isBackPressuredComplete(),
 			ioMetrics.getUsageOutPool(),
 			ioMetrics.isUsageOutPoolComplete(),
 			ioMetrics.getUsageInputExclusiveBuffers(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfo.java
@@ -215,7 +215,13 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 			ioMetrics.isNumRecordsInComplete(),
 			ioMetrics.getNumRecordsOut(),
 			ioMetrics.isNumRecordsOutComplete(),
-			ioMetrics.getUsageInputExclusiveBuffers(), ioMetrics.isUsageInputExclusiveBuffersComplete(), ioMetrics.getUsageInputFloatingBuffers(), ioMetrics.isUsageInputFloatingBuffersComplete(), ioMetrics.getUsageOutPool(), ioMetrics.isUsageOutPoolComplete(), ioMetrics.isBackPressured(),
+			ioMetrics.getUsageInputExclusiveBuffers(),
+			ioMetrics.isUsageInputExclusiveBuffersComplete(),
+			ioMetrics.getUsageInputFloatingBuffers(),
+			ioMetrics.isUsageInputFloatingBuffersComplete(),
+			ioMetrics.getUsageOutPool(),
+			ioMetrics.isUsageOutPoolComplete(),
+			ioMetrics.isBackPressured(),
 			ioMetrics.isBackPressuredComplete()
 		);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfo.java
@@ -215,14 +215,9 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 			ioMetrics.isNumRecordsInComplete(),
 			ioMetrics.getNumRecordsOut(),
 			ioMetrics.isNumRecordsOutComplete(),
-			ioMetrics.isBackPressured(),
-			ioMetrics.isBackPressuredComplete(),
-			ioMetrics.getUsageOutPool(),
-			ioMetrics.isUsageOutPoolComplete(),
-			ioMetrics.getUsageInputExclusiveBuffers(),
-			ioMetrics.isUsageInputExclusiveBuffersComplete(),
-			ioMetrics.getUsageInputFloatingBuffers(),
-			ioMetrics.isUsageInputFloatingBuffersComplete());
+			ioMetrics.getUsageInputExclusiveBuffers(), ioMetrics.isUsageInputExclusiveBuffersComplete(), ioMetrics.getUsageInputFloatingBuffers(), ioMetrics.isUsageInputFloatingBuffersComplete(), ioMetrics.getUsageOutPool(), ioMetrics.isUsageOutPoolComplete(), ioMetrics.isBackPressured(),
+			ioMetrics.isBackPressuredComplete()
+		);
 
 		return new SubtaskExecutionAttemptDetailsInfo(
 			execution.getParallelSubtaskIndex(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/IOMetricsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/IOMetricsInfo.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest.messages.job.metrics;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
@@ -102,42 +103,52 @@ public class IOMetricsInfo {
 		this.isBackPressuredComplete = isBackPressuredComplete;
 	}
 
+	@JsonIgnore
 	public long getBytesRead() {
 		return bytesRead;
 	}
 
+	@JsonIgnore
 	public boolean isBytesReadComplete() {
 		return bytesReadComplete;
 	}
 
+	@JsonIgnore
 	public long getBytesWritten() {
 		return bytesWritten;
 	}
 
+	@JsonIgnore
 	public boolean isBytesWrittenComplete() {
 		return bytesWrittenComplete;
 	}
 
+	@JsonIgnore
 	public long getRecordsRead() {
 		return recordsRead;
 	}
 
+	@JsonIgnore
 	public boolean isRecordsReadComplete() {
 		return recordsReadComplete;
 	}
 
+	@JsonIgnore
 	public long getRecordsWritten() {
 		return recordsWritten;
 	}
 
+	@JsonIgnore
 	public boolean isRecordsWrittenComplete() {
 		return recordsWrittenComplete;
 	}
 
+	@JsonIgnore
 	public boolean isBackPressured() {
 		return isBackPressured;
 	}
 
+	@JsonIgnore
 	public boolean isBackPressuredComplete() {
 		return isBackPressuredComplete;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/IOMetricsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/IOMetricsInfo.java
@@ -26,23 +26,23 @@ import java.util.Objects;
 /**
  * IO metrics information.
  */
-public final class IOMetricsInfo {
+public class IOMetricsInfo {
 
-	private static final String FIELD_NAME_BYTES_READ = "read-bytes";
+	protected static final String FIELD_NAME_BYTES_READ = "read-bytes";
 
-	private static final String FIELD_NAME_BYTES_READ_COMPLETE = "read-bytes-complete";
+	protected static final String FIELD_NAME_BYTES_READ_COMPLETE = "read-bytes-complete";
 
-	private static final String FIELD_NAME_BYTES_WRITTEN = "write-bytes";
+	protected static final String FIELD_NAME_BYTES_WRITTEN = "write-bytes";
 
-	private static final String FIELD_NAME_BYTES_WRITTEN_COMPLETE = "write-bytes-complete";
+	protected static final String FIELD_NAME_BYTES_WRITTEN_COMPLETE = "write-bytes-complete";
 
-	private static final String FIELD_NAME_RECORDS_READ = "read-records";
+	protected static final String FIELD_NAME_RECORDS_READ = "read-records";
 
-	private static final String FIELD_NAME_RECORDS_READ_COMPLETE = "read-records-complete";
+	protected static final String FIELD_NAME_RECORDS_READ_COMPLETE = "read-records-complete";
 
-	private static final String FIELD_NAME_RECORDS_WRITTEN = "write-records";
+	protected static final String FIELD_NAME_RECORDS_WRITTEN = "write-records";
 
-	private static final String FIELD_NAME_RECORDS_WRITTEN_COMPLETE = "write-records-complete";
+	protected static final String FIELD_NAME_RECORDS_WRITTEN_COMPLETE = "write-records-complete";
 
 	@JsonProperty(FIELD_NAME_BYTES_READ)
 	private final long bytesRead;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/IOMetricsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/IOMetricsInfo.java
@@ -44,6 +44,10 @@ public class IOMetricsInfo {
 
 	protected static final String FIELD_NAME_RECORDS_WRITTEN_COMPLETE = "write-records-complete";
 
+	protected static final String FIELD_NAME_IS_BACKPRESSED = "is-backpressed";
+
+	protected static final String FIELD_NAME_IS_BACKPRESSED_COMPLETE = "is-backpressed-complete";
+
 	@JsonProperty(FIELD_NAME_BYTES_READ)
 	private final long bytesRead;
 
@@ -68,6 +72,12 @@ public class IOMetricsInfo {
 	@JsonProperty(FIELD_NAME_RECORDS_WRITTEN_COMPLETE)
 	private final boolean recordsWrittenComplete;
 
+	@JsonProperty(FIELD_NAME_IS_BACKPRESSED)
+	private final boolean isBackPressured;
+
+	@JsonProperty(FIELD_NAME_IS_BACKPRESSED_COMPLETE)
+	private final boolean isBackPressuredComplete;
+
 	@JsonCreator
 	public IOMetricsInfo(
 			@JsonProperty(FIELD_NAME_BYTES_READ) long bytesRead,
@@ -77,7 +87,9 @@ public class IOMetricsInfo {
 			@JsonProperty(FIELD_NAME_RECORDS_READ) long recordsRead,
 			@JsonProperty(FIELD_NAME_RECORDS_READ_COMPLETE) boolean recordsReadComplete,
 			@JsonProperty(FIELD_NAME_RECORDS_WRITTEN) long recordsWritten,
-			@JsonProperty(FIELD_NAME_RECORDS_WRITTEN_COMPLETE) boolean recordsWrittenComplete) {
+			@JsonProperty(FIELD_NAME_RECORDS_WRITTEN_COMPLETE) boolean recordsWrittenComplete,
+			@JsonProperty(FIELD_NAME_IS_BACKPRESSED) boolean isBackPressured,
+			@JsonProperty(FIELD_NAME_IS_BACKPRESSED_COMPLETE) boolean isBackPressuredComplete) {
 		this.bytesRead = bytesRead;
 		this.bytesReadComplete = bytesReadComplete;
 		this.bytesWritten = bytesWritten;
@@ -86,6 +98,8 @@ public class IOMetricsInfo {
 		this.recordsReadComplete = recordsReadComplete;
 		this.recordsWritten = recordsWritten;
 		this.recordsWrittenComplete = recordsWrittenComplete;
+		this.isBackPressured = isBackPressured;
+		this.isBackPressuredComplete = isBackPressuredComplete;
 	}
 
 	public long getBytesRead() {
@@ -120,6 +134,14 @@ public class IOMetricsInfo {
 		return recordsWrittenComplete;
 	}
 
+	public boolean isBackPressured() {
+		return isBackPressured;
+	}
+
+	public boolean isBackPressuredComplete() {
+		return isBackPressuredComplete;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -136,11 +158,14 @@ public class IOMetricsInfo {
 			recordsRead == that.recordsRead &&
 			recordsReadComplete == that.recordsReadComplete &&
 			recordsWritten == that.recordsWritten &&
-			recordsWrittenComplete == that.recordsWrittenComplete;
+			recordsWrittenComplete == that.recordsWrittenComplete &&
+			isBackPressured == that.isBackPressured &&
+			isBackPressuredComplete == that.isBackPressuredComplete;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(bytesRead, bytesReadComplete, bytesWritten, bytesWrittenComplete, recordsRead, recordsReadComplete, recordsWritten, recordsWrittenComplete);
+		return Objects.hash(bytesRead, bytesReadComplete, bytesWritten, bytesWrittenComplete, recordsRead,
+			recordsReadComplete, recordsWritten, recordsWrittenComplete, isBackPressured, isBackPressuredComplete);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/JobVertexIOMetricsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/JobVertexIOMetricsInfo.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest.messages.job.metrics;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
@@ -86,26 +87,32 @@ public final class JobVertexIOMetricsInfo extends IOMetricsInfo {
 		this.inputFloatingBuffersUsageAvgComplete = inputFloatingBuffersUsageAvgComplete;
 	}
 
+	@JsonIgnore
 	public float getOutPoolUsageAvg() {
 		return outPoolUsageAvg;
 	}
 
+	@JsonIgnore
 	public boolean isOutPoolUsageAvgComplete() {
 		return outPoolUsageAvgComplete;
 	}
 
+	@JsonIgnore
 	public float getInputExclusiveBuffersUsageAvg() {
 		return inputExclusiveBuffersUsageAvg;
 	}
 
+	@JsonIgnore
 	public boolean isInputExclusiveBuffersUsageAvgComplete() {
 		return inputExclusiveBuffersUsageAvgComplete;
 	}
 
+	@JsonIgnore
 	public float getInputFloatingBuffersUsageAvg() {
 		return inputFloatingBuffersUsageAvg;
 	}
 
+	@JsonIgnore
 	public boolean isInputFloatingBuffersUsageAvgComplete() {
 		return inputFloatingBuffersUsageAvgComplete;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/JobVertexIOMetricsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/JobVertexIOMetricsInfo.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.metrics;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/**
+ * JobVertex IO metrics information.
+ */
+public final class JobVertexIOMetricsInfo extends IOMetricsInfo {
+
+	private static final String FIELD_NAME_OUT_POOL_USAGE_AVG = "out-pool-usage-avg";
+
+	private static final String FIELD_NAME_OUT_POOL_USAGE_AVG_COMPLETE = "out-pool-usage-avg-complete";
+
+	private static final String FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_AVG = "input-exclusive-buffers-usage-avg";
+
+	private static final String FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_AVG_COMPLETE = "input-exclusive-buffers-usage-avg-complete";
+
+	private static final String FIELD_NAME_INPUT_FLOATING_BUFFERS_AVG_USAGE = "input-floating-buffers-usage-avg";
+
+	private static final String FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE_AVG_COMPLETE = "input-floating-buffers-usage-avg-complete";
+
+	@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_AVG)
+	private final float outPoolUsageAvg;
+
+	@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_AVG_COMPLETE)
+	private final boolean outPoolUsageAvgComplete;
+
+	@JsonProperty(FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_AVG)
+	private final float inputExclusiveBuffersUsageAvg;
+
+	@JsonProperty(FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_AVG_COMPLETE)
+	private final boolean inputExclusiveBuffersUsageAvgComplete;
+
+	@JsonProperty(FIELD_NAME_INPUT_FLOATING_BUFFERS_AVG_USAGE)
+	private final float inputFloatingBuffersUsageAvg;
+
+	@JsonProperty(FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE_AVG_COMPLETE)
+	private final boolean inputFloatingBuffersUsageAvgComplete;
+
+	@JsonCreator
+	public JobVertexIOMetricsInfo(
+		@JsonProperty(FIELD_NAME_BYTES_READ) long bytesRead,
+		@JsonProperty(FIELD_NAME_BYTES_READ_COMPLETE) boolean bytesReadComplete,
+		@JsonProperty(FIELD_NAME_BYTES_WRITTEN) long bytesWritten,
+		@JsonProperty(FIELD_NAME_BYTES_WRITTEN_COMPLETE) boolean bytesWrittenComplete,
+		@JsonProperty(FIELD_NAME_RECORDS_READ) long recordsRead,
+		@JsonProperty(FIELD_NAME_RECORDS_READ_COMPLETE) boolean recordsReadComplete,
+		@JsonProperty(FIELD_NAME_RECORDS_WRITTEN) long recordsWritten,
+		@JsonProperty(FIELD_NAME_RECORDS_WRITTEN_COMPLETE) boolean recordsWrittenComplete,
+		@JsonProperty(FIELD_NAME_IS_BACKPRESSED) boolean isBackPressured,
+		@JsonProperty(FIELD_NAME_IS_BACKPRESSED_COMPLETE) boolean isBackPressuredComplete,
+		@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_AVG) float outPoolUsageAvg,
+		@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_AVG_COMPLETE) boolean outPoolUsageAvgComplete,
+		@JsonProperty(FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_AVG) float inputExclusiveBuffersUsageAvg,
+		@JsonProperty(FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_AVG_COMPLETE) boolean inputExclusiveBuffersUsageAvgComplete,
+		@JsonProperty(FIELD_NAME_INPUT_FLOATING_BUFFERS_AVG_USAGE) float inputFloatingBuffersUsageAvg,
+		@JsonProperty(FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE_AVG_COMPLETE) boolean inputFloatingBuffersUsageAvgComplete) {
+		super(bytesRead, bytesReadComplete, bytesWritten, bytesWrittenComplete, recordsRead, recordsReadComplete,
+			recordsWritten, recordsWrittenComplete, isBackPressured, isBackPressuredComplete);
+		this.outPoolUsageAvg = outPoolUsageAvg;
+		this.outPoolUsageAvgComplete = outPoolUsageAvgComplete;
+		this.inputExclusiveBuffersUsageAvg = inputExclusiveBuffersUsageAvg;
+		this.inputExclusiveBuffersUsageAvgComplete = inputExclusiveBuffersUsageAvgComplete;
+		this.inputFloatingBuffersUsageAvg = inputFloatingBuffersUsageAvg;
+		this.inputFloatingBuffersUsageAvgComplete = inputFloatingBuffersUsageAvgComplete;
+	}
+
+	public float getOutPoolUsageAvg() {
+		return outPoolUsageAvg;
+	}
+
+	public boolean isOutPoolUsageAvgComplete() {
+		return outPoolUsageAvgComplete;
+	}
+
+	public float getInputExclusiveBuffersUsageAvg() {
+		return inputExclusiveBuffersUsageAvg;
+	}
+
+	public boolean isInputExclusiveBuffersUsageAvgComplete() {
+		return inputExclusiveBuffersUsageAvgComplete;
+	}
+
+	public float getInputFloatingBuffersUsageAvg() {
+		return inputFloatingBuffersUsageAvg;
+	}
+
+	public boolean isInputFloatingBuffersUsageAvgComplete() {
+		return inputFloatingBuffersUsageAvgComplete;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		JobVertexIOMetricsInfo that = (JobVertexIOMetricsInfo) o;
+		return this.getBytesRead() == that.getBytesRead() &&
+			this.isBytesReadComplete() == that.isBytesReadComplete() &&
+			this.getBytesWritten() == that.getBytesWritten() &&
+			this.isBytesWrittenComplete() == that.isBytesWrittenComplete() &&
+			this.getRecordsRead() == that.getRecordsRead() &&
+			this.isRecordsReadComplete() == that.isRecordsReadComplete() &&
+			this.getRecordsWritten() == that.getRecordsWritten() &&
+			this.isRecordsWrittenComplete() == that.isRecordsWrittenComplete() &&
+			this.isBackPressured() == that.isBackPressured() &&
+			that.isBackPressuredComplete() == that.isBackPressuredComplete() &&
+			this.getOutPoolUsageAvg() == that.getOutPoolUsageAvg() &&
+			this.isOutPoolUsageAvgComplete() == that.isOutPoolUsageAvgComplete() &&
+			this.getInputExclusiveBuffersUsageAvg() == that.getInputExclusiveBuffersUsageAvg() &&
+			this.isInputExclusiveBuffersUsageAvgComplete() == that.isInputExclusiveBuffersUsageAvgComplete() &&
+			this.getInputFloatingBuffersUsageAvg() == that.getInputFloatingBuffersUsageAvg() &&
+			this.isInputFloatingBuffersUsageAvgComplete() == that.isInputFloatingBuffersUsageAvgComplete();
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.getBytesRead(), this.isBytesReadComplete(), this.getBytesWritten(), this.isBytesWrittenComplete(),
+			this.getRecordsRead(), this.isRecordsReadComplete(), this.getRecordsWritten(), this.isRecordsWrittenComplete(),
+			this.isBackPressured(), this.isBackPressuredComplete(), this.getOutPoolUsageAvg(), this.isOutPoolUsageAvgComplete(),
+			this.getInputExclusiveBuffersUsageAvg(), this.isInputExclusiveBuffersUsageAvgComplete(), this.getInputFloatingBuffersUsageAvg(),
+			this.isInputFloatingBuffersUsageAvgComplete());
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/JobVertexIOMetricsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/JobVertexIOMetricsInfo.java
@@ -29,10 +29,6 @@ import java.util.Objects;
  */
 public final class JobVertexIOMetricsInfo extends IOMetricsInfo {
 
-	private static final String FIELD_NAME_OUT_POOL_USAGE_AVG = "out-pool-usage-avg";
-
-	private static final String FIELD_NAME_OUT_POOL_USAGE_AVG_COMPLETE = "out-pool-usage-avg-complete";
-
 	private static final String FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_AVG = "input-exclusive-buffers-usage-avg";
 
 	private static final String FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_AVG_COMPLETE = "input-exclusive-buffers-usage-avg-complete";
@@ -41,11 +37,9 @@ public final class JobVertexIOMetricsInfo extends IOMetricsInfo {
 
 	private static final String FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE_AVG_COMPLETE = "input-floating-buffers-usage-avg-complete";
 
-	@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_AVG)
-	private final float outPoolUsageAvg;
+	private static final String FIELD_NAME_OUT_POOL_USAGE_AVG = "out-pool-usage-avg";
 
-	@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_AVG_COMPLETE)
-	private final boolean outPoolUsageAvgComplete;
+	private static final String FIELD_NAME_OUT_POOL_USAGE_AVG_COMPLETE = "out-pool-usage-avg-complete";
 
 	@JsonProperty(FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_AVG)
 	private final float inputExclusiveBuffersUsageAvg;
@@ -58,6 +52,12 @@ public final class JobVertexIOMetricsInfo extends IOMetricsInfo {
 
 	@JsonProperty(FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE_AVG_COMPLETE)
 	private final boolean inputFloatingBuffersUsageAvgComplete;
+
+	@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_AVG)
+	private final float outPoolUsageAvg;
+
+	@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_AVG_COMPLETE)
+	private final boolean outPoolUsageAvgComplete;
 
 	@JsonCreator
 	public JobVertexIOMetricsInfo(
@@ -88,16 +88,6 @@ public final class JobVertexIOMetricsInfo extends IOMetricsInfo {
 	}
 
 	@JsonIgnore
-	public float getOutPoolUsageAvg() {
-		return outPoolUsageAvg;
-	}
-
-	@JsonIgnore
-	public boolean isOutPoolUsageAvgComplete() {
-		return outPoolUsageAvgComplete;
-	}
-
-	@JsonIgnore
 	public float getInputExclusiveBuffersUsageAvg() {
 		return inputExclusiveBuffersUsageAvg;
 	}
@@ -117,6 +107,16 @@ public final class JobVertexIOMetricsInfo extends IOMetricsInfo {
 		return inputFloatingBuffersUsageAvgComplete;
 	}
 
+	@JsonIgnore
+	public float getOutPoolUsageAvg() {
+		return outPoolUsageAvg;
+	}
+
+	@JsonIgnore
+	public boolean isOutPoolUsageAvgComplete() {
+		return outPoolUsageAvgComplete;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -134,23 +134,23 @@ public final class JobVertexIOMetricsInfo extends IOMetricsInfo {
 			this.isRecordsReadComplete() == that.isRecordsReadComplete() &&
 			this.getRecordsWritten() == that.getRecordsWritten() &&
 			this.isRecordsWrittenComplete() == that.isRecordsWrittenComplete() &&
-			this.isBackPressured() == that.isBackPressured() &&
-			that.isBackPressuredComplete() == that.isBackPressuredComplete() &&
-			this.getOutPoolUsageAvg() == that.getOutPoolUsageAvg() &&
-			this.isOutPoolUsageAvgComplete() == that.isOutPoolUsageAvgComplete() &&
 			this.getInputExclusiveBuffersUsageAvg() == that.getInputExclusiveBuffersUsageAvg() &&
 			this.isInputExclusiveBuffersUsageAvgComplete() == that.isInputExclusiveBuffersUsageAvgComplete() &&
 			this.getInputFloatingBuffersUsageAvg() == that.getInputFloatingBuffersUsageAvg() &&
-			this.isInputFloatingBuffersUsageAvgComplete() == that.isInputFloatingBuffersUsageAvgComplete();
+			this.isInputFloatingBuffersUsageAvgComplete() == that.isInputFloatingBuffersUsageAvgComplete() &&
+			this.getOutPoolUsageAvg() == that.getOutPoolUsageAvg() &&
+			this.isOutPoolUsageAvgComplete() == that.isOutPoolUsageAvgComplete() &&
+			this.isBackPressured() == that.isBackPressured() &&
+			this.isBackPressuredComplete() == that.isBackPressuredComplete();
 	}
 
 	@Override
 	public int hashCode() {
 		return Objects.hash(this.getBytesRead(), this.isBytesReadComplete(), this.getBytesWritten(), this.isBytesWrittenComplete(),
 			this.getRecordsRead(), this.isRecordsReadComplete(), this.getRecordsWritten(), this.isRecordsWrittenComplete(),
-			this.isBackPressured(), this.isBackPressuredComplete(), this.getOutPoolUsageAvg(), this.isOutPoolUsageAvgComplete(),
 			this.getInputExclusiveBuffersUsageAvg(), this.isInputExclusiveBuffersUsageAvgComplete(), this.getInputFloatingBuffersUsageAvg(),
-			this.isInputFloatingBuffersUsageAvgComplete());
+			this.isInputFloatingBuffersUsageAvgComplete(), this.getOutPoolUsageAvg(), this.isOutPoolUsageAvgComplete(),
+			this.isBackPressured(), this.isBackPressuredComplete());
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/JobVertexIOMetricsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/JobVertexIOMetricsInfo.java
@@ -69,14 +69,14 @@ public final class JobVertexIOMetricsInfo extends IOMetricsInfo {
 		@JsonProperty(FIELD_NAME_RECORDS_READ_COMPLETE) boolean recordsReadComplete,
 		@JsonProperty(FIELD_NAME_RECORDS_WRITTEN) long recordsWritten,
 		@JsonProperty(FIELD_NAME_RECORDS_WRITTEN_COMPLETE) boolean recordsWrittenComplete,
-		@JsonProperty(FIELD_NAME_IS_BACKPRESSED) boolean isBackPressured,
-		@JsonProperty(FIELD_NAME_IS_BACKPRESSED_COMPLETE) boolean isBackPressuredComplete,
-		@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_AVG) float outPoolUsageAvg,
-		@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_AVG_COMPLETE) boolean outPoolUsageAvgComplete,
 		@JsonProperty(FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_AVG) float inputExclusiveBuffersUsageAvg,
 		@JsonProperty(FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_AVG_COMPLETE) boolean inputExclusiveBuffersUsageAvgComplete,
 		@JsonProperty(FIELD_NAME_INPUT_FLOATING_BUFFERS_AVG_USAGE) float inputFloatingBuffersUsageAvg,
-		@JsonProperty(FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE_AVG_COMPLETE) boolean inputFloatingBuffersUsageAvgComplete) {
+		@JsonProperty(FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE_AVG_COMPLETE) boolean inputFloatingBuffersUsageAvgComplete,
+		@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_AVG) float outPoolUsageAvg,
+		@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_AVG_COMPLETE) boolean outPoolUsageAvgComplete,
+		@JsonProperty(FIELD_NAME_IS_BACKPRESSED) boolean isBackPressured,
+		@JsonProperty(FIELD_NAME_IS_BACKPRESSED_COMPLETE) boolean isBackPressuredComplete) {
 		super(bytesRead, bytesReadComplete, bytesWritten, bytesWrittenComplete, recordsRead, recordsReadComplete,
 			recordsWritten, recordsWrittenComplete, isBackPressured, isBackPressuredComplete);
 		this.outPoolUsageAvg = outPoolUsageAvg;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/SubTaskIOMetricsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/SubTaskIOMetricsInfo.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.metrics;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/**
+ * SubTask IO metrics information.
+ */
+public final class SubTaskIOMetricsInfo extends IOMetricsInfo {
+
+	private static final String FIELD_NAME_OUT_POOL_USAGE = "out-pool-usage";
+
+	private static final String FIELD_NAME_OUT_POOL_USAGE_COMPLETE = "out-pool-usage-complete";
+
+	private static final String FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE = "input-exclusive-buffers-usage";
+
+	private static final String FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_COMPLETE = "input-exclusive-buffers-usage-complete";
+
+	private static final String FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE = "input-floating-buffers-usage";
+
+	private static final String FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE_COMPLETE = "input-floating-buffers-usage-complete";
+
+	@JsonProperty(FIELD_NAME_OUT_POOL_USAGE)
+	private final float outPoolUsage;
+
+	@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_COMPLETE)
+	private final boolean outPoolUsageComplete;
+
+	@JsonProperty(FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE)
+	private final float inputExclusiveBuffersUsage;
+
+	@JsonProperty(FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_COMPLETE)
+	private final boolean inputExclusiveBuffersUsageComplete;
+
+	@JsonProperty(FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE)
+	private final float inputFloatingBuffersUsage;
+
+	@JsonProperty(FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE_COMPLETE)
+	private final boolean inputFloatingBuffersUsageComplete;
+
+	@JsonCreator
+	public SubTaskIOMetricsInfo(
+		@JsonProperty(FIELD_NAME_BYTES_READ) long bytesRead,
+		@JsonProperty(FIELD_NAME_BYTES_READ_COMPLETE) boolean bytesReadComplete,
+		@JsonProperty(FIELD_NAME_BYTES_WRITTEN) long bytesWritten,
+		@JsonProperty(FIELD_NAME_BYTES_WRITTEN_COMPLETE) boolean bytesWrittenComplete,
+		@JsonProperty(FIELD_NAME_RECORDS_READ) long recordsRead,
+		@JsonProperty(FIELD_NAME_RECORDS_READ_COMPLETE) boolean recordsReadComplete,
+		@JsonProperty(FIELD_NAME_RECORDS_WRITTEN) long recordsWritten,
+		@JsonProperty(FIELD_NAME_RECORDS_WRITTEN_COMPLETE) boolean recordsWrittenComplete,
+		@JsonProperty(FIELD_NAME_OUT_POOL_USAGE) float outPoolUsage,
+		@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_COMPLETE) boolean outPoolUsageComplete,
+		@JsonProperty(FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE) float inputExclusiveBuffersUsage,
+		@JsonProperty(FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_COMPLETE) boolean inputExclusiveBuffersUsageComplete,
+		@JsonProperty(FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE) float inputFloatingBuffersUsage,
+		@JsonProperty(FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE_COMPLETE) boolean inputFloatingBuffersUsageComplete) {
+		super(bytesRead, bytesReadComplete, bytesWritten, bytesWrittenComplete, recordsRead, recordsReadComplete, recordsWritten, recordsWrittenComplete);
+		this.outPoolUsage = outPoolUsage;
+		this.outPoolUsageComplete = outPoolUsageComplete;
+		this.inputExclusiveBuffersUsage = inputExclusiveBuffersUsage;
+		this.inputExclusiveBuffersUsageComplete = inputExclusiveBuffersUsageComplete;
+		this.inputFloatingBuffersUsage = inputFloatingBuffersUsage;
+		this.inputFloatingBuffersUsageComplete = inputFloatingBuffersUsageComplete;
+	}
+
+	public float getOutPoolUsage() {
+		return outPoolUsage;
+	}
+
+	public boolean isOutPoolUsageComplete() {
+		return outPoolUsageComplete;
+	}
+
+	public float getInputExclusiveBuffersUsage() {
+		return inputExclusiveBuffersUsage;
+	}
+
+	public boolean isInputExclusiveBuffersUsageComplete() {
+		return inputExclusiveBuffersUsageComplete;
+	}
+
+	public float getInputFloatingBuffersUsage() {
+		return inputFloatingBuffersUsage;
+	}
+
+	public boolean isInputFloatingBuffersUsageComplete() {
+		return inputFloatingBuffersUsageComplete;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		SubTaskIOMetricsInfo that = (SubTaskIOMetricsInfo) o;
+		return this.getBytesRead() == that.getBytesRead() &&
+			this.isBytesReadComplete() == that.isBytesReadComplete() &&
+			this.getBytesWritten() == that.getBytesWritten() &&
+			this.isBytesWrittenComplete() == that.isBytesWrittenComplete() &&
+			this.getRecordsRead() == that.getRecordsRead() &&
+			this.isRecordsReadComplete() == that.isRecordsReadComplete() &&
+			this.getRecordsWritten() == that.getRecordsWritten() &&
+			this.isRecordsWrittenComplete() == that.isRecordsWrittenComplete() &&
+			this.getOutPoolUsage() == that.getOutPoolUsage() &&
+			this.isOutPoolUsageComplete() == that.isOutPoolUsageComplete() &&
+			this.getInputExclusiveBuffersUsage() == that.getInputExclusiveBuffersUsage() &&
+			this.isInputExclusiveBuffersUsageComplete() == that.isInputExclusiveBuffersUsageComplete() &&
+			this.getInputFloatingBuffersUsage() == that.getInputFloatingBuffersUsage() &&
+			this.isInputFloatingBuffersUsageComplete() == that.isInputFloatingBuffersUsageComplete();
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.getBytesRead(), this.isBytesReadComplete(), this.getBytesWritten(), this.isBytesWrittenComplete(),
+			this.getRecordsRead(), this.isRecordsReadComplete(), this.getRecordsWritten(), this.isRecordsWrittenComplete(),
+			this.getOutPoolUsage(), this.isOutPoolUsageComplete(), this.getInputExclusiveBuffersUsage(), this.isInputExclusiveBuffersUsageComplete(),
+			this.getInputFloatingBuffersUsage(), this.isInputFloatingBuffersUsageComplete());
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/SubTaskIOMetricsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/SubTaskIOMetricsInfo.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest.messages.job.metrics;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
@@ -86,26 +87,32 @@ public final class SubTaskIOMetricsInfo extends IOMetricsInfo {
 		this.inputFloatingBuffersUsageComplete = inputFloatingBuffersUsageComplete;
 	}
 
+	@JsonIgnore
 	public float getOutPoolUsage() {
 		return outPoolUsage;
 	}
 
+	@JsonIgnore
 	public boolean isOutPoolUsageComplete() {
 		return outPoolUsageComplete;
 	}
 
+	@JsonIgnore
 	public float getInputExclusiveBuffersUsage() {
 		return inputExclusiveBuffersUsage;
 	}
 
+	@JsonIgnore
 	public boolean isInputExclusiveBuffersUsageComplete() {
 		return inputExclusiveBuffersUsageComplete;
 	}
 
+	@JsonIgnore
 	public float getInputFloatingBuffersUsage() {
 		return inputFloatingBuffersUsage;
 	}
 
+	@JsonIgnore
 	public boolean isInputFloatingBuffersUsageComplete() {
 		return inputFloatingBuffersUsageComplete;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/SubTaskIOMetricsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/SubTaskIOMetricsInfo.java
@@ -68,13 +68,16 @@ public final class SubTaskIOMetricsInfo extends IOMetricsInfo {
 		@JsonProperty(FIELD_NAME_RECORDS_READ_COMPLETE) boolean recordsReadComplete,
 		@JsonProperty(FIELD_NAME_RECORDS_WRITTEN) long recordsWritten,
 		@JsonProperty(FIELD_NAME_RECORDS_WRITTEN_COMPLETE) boolean recordsWrittenComplete,
+		@JsonProperty(FIELD_NAME_IS_BACKPRESSED) boolean isBackPressured,
+		@JsonProperty(FIELD_NAME_IS_BACKPRESSED_COMPLETE) boolean isBackPressuredComplete,
 		@JsonProperty(FIELD_NAME_OUT_POOL_USAGE) float outPoolUsage,
 		@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_COMPLETE) boolean outPoolUsageComplete,
 		@JsonProperty(FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE) float inputExclusiveBuffersUsage,
 		@JsonProperty(FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_COMPLETE) boolean inputExclusiveBuffersUsageComplete,
 		@JsonProperty(FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE) float inputFloatingBuffersUsage,
 		@JsonProperty(FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE_COMPLETE) boolean inputFloatingBuffersUsageComplete) {
-		super(bytesRead, bytesReadComplete, bytesWritten, bytesWrittenComplete, recordsRead, recordsReadComplete, recordsWritten, recordsWrittenComplete);
+		super(bytesRead, bytesReadComplete, bytesWritten, bytesWrittenComplete, recordsRead, recordsReadComplete,
+			recordsWritten, recordsWrittenComplete, isBackPressured, isBackPressuredComplete);
 		this.outPoolUsage = outPoolUsage;
 		this.outPoolUsageComplete = outPoolUsageComplete;
 		this.inputExclusiveBuffersUsage = inputExclusiveBuffersUsage;
@@ -124,6 +127,8 @@ public final class SubTaskIOMetricsInfo extends IOMetricsInfo {
 			this.isRecordsReadComplete() == that.isRecordsReadComplete() &&
 			this.getRecordsWritten() == that.getRecordsWritten() &&
 			this.isRecordsWrittenComplete() == that.isRecordsWrittenComplete() &&
+			this.isBackPressured() == that.isBackPressured() &&
+			that.isBackPressuredComplete() == that.isBackPressuredComplete() &&
 			this.getOutPoolUsage() == that.getOutPoolUsage() &&
 			this.isOutPoolUsageComplete() == that.isOutPoolUsageComplete() &&
 			this.getInputExclusiveBuffersUsage() == that.getInputExclusiveBuffersUsage() &&
@@ -136,8 +141,9 @@ public final class SubTaskIOMetricsInfo extends IOMetricsInfo {
 	public int hashCode() {
 		return Objects.hash(this.getBytesRead(), this.isBytesReadComplete(), this.getBytesWritten(), this.isBytesWrittenComplete(),
 			this.getRecordsRead(), this.isRecordsReadComplete(), this.getRecordsWritten(), this.isRecordsWrittenComplete(),
-			this.getOutPoolUsage(), this.isOutPoolUsageComplete(), this.getInputExclusiveBuffersUsage(), this.isInputExclusiveBuffersUsageComplete(),
-			this.getInputFloatingBuffersUsage(), this.isInputFloatingBuffersUsageComplete());
+			this.isBackPressured(), this.isBackPressuredComplete(), this.getOutPoolUsage(), this.isOutPoolUsageComplete(),
+			this.getInputExclusiveBuffersUsage(), this.isInputExclusiveBuffersUsageComplete(), this.getInputFloatingBuffersUsage(),
+			this.isInputFloatingBuffersUsageComplete());
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/SubTaskIOMetricsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/SubTaskIOMetricsInfo.java
@@ -29,10 +29,6 @@ import java.util.Objects;
  */
 public final class SubTaskIOMetricsInfo extends IOMetricsInfo {
 
-	private static final String FIELD_NAME_OUT_POOL_USAGE = "out-pool-usage";
-
-	private static final String FIELD_NAME_OUT_POOL_USAGE_COMPLETE = "out-pool-usage-complete";
-
 	private static final String FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE = "input-exclusive-buffers-usage";
 
 	private static final String FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_COMPLETE = "input-exclusive-buffers-usage-complete";
@@ -41,11 +37,9 @@ public final class SubTaskIOMetricsInfo extends IOMetricsInfo {
 
 	private static final String FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE_COMPLETE = "input-floating-buffers-usage-complete";
 
-	@JsonProperty(FIELD_NAME_OUT_POOL_USAGE)
-	private final float outPoolUsage;
+	private static final String FIELD_NAME_OUT_POOL_USAGE = "out-pool-usage";
 
-	@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_COMPLETE)
-	private final boolean outPoolUsageComplete;
+	private static final String FIELD_NAME_OUT_POOL_USAGE_COMPLETE = "out-pool-usage-complete";
 
 	@JsonProperty(FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE)
 	private final float inputExclusiveBuffersUsage;
@@ -58,6 +52,12 @@ public final class SubTaskIOMetricsInfo extends IOMetricsInfo {
 
 	@JsonProperty(FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE_COMPLETE)
 	private final boolean inputFloatingBuffersUsageComplete;
+
+	@JsonProperty(FIELD_NAME_OUT_POOL_USAGE)
+	private final float outPoolUsage;
+
+	@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_COMPLETE)
+	private final boolean outPoolUsageComplete;
 
 	@JsonCreator
 	public SubTaskIOMetricsInfo(
@@ -88,16 +88,6 @@ public final class SubTaskIOMetricsInfo extends IOMetricsInfo {
 	}
 
 	@JsonIgnore
-	public float getOutPoolUsage() {
-		return outPoolUsage;
-	}
-
-	@JsonIgnore
-	public boolean isOutPoolUsageComplete() {
-		return outPoolUsageComplete;
-	}
-
-	@JsonIgnore
 	public float getInputExclusiveBuffersUsage() {
 		return inputExclusiveBuffersUsage;
 	}
@@ -117,6 +107,16 @@ public final class SubTaskIOMetricsInfo extends IOMetricsInfo {
 		return inputFloatingBuffersUsageComplete;
 	}
 
+	@JsonIgnore
+	public float getOutPoolUsage() {
+		return outPoolUsage;
+	}
+
+	@JsonIgnore
+	public boolean isOutPoolUsageComplete() {
+		return outPoolUsageComplete;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -134,23 +134,23 @@ public final class SubTaskIOMetricsInfo extends IOMetricsInfo {
 			this.isRecordsReadComplete() == that.isRecordsReadComplete() &&
 			this.getRecordsWritten() == that.getRecordsWritten() &&
 			this.isRecordsWrittenComplete() == that.isRecordsWrittenComplete() &&
-			this.isBackPressured() == that.isBackPressured() &&
-			that.isBackPressuredComplete() == that.isBackPressuredComplete() &&
-			this.getOutPoolUsage() == that.getOutPoolUsage() &&
-			this.isOutPoolUsageComplete() == that.isOutPoolUsageComplete() &&
 			this.getInputExclusiveBuffersUsage() == that.getInputExclusiveBuffersUsage() &&
 			this.isInputExclusiveBuffersUsageComplete() == that.isInputExclusiveBuffersUsageComplete() &&
 			this.getInputFloatingBuffersUsage() == that.getInputFloatingBuffersUsage() &&
-			this.isInputFloatingBuffersUsageComplete() == that.isInputFloatingBuffersUsageComplete();
+			this.isInputFloatingBuffersUsageComplete() == that.isInputFloatingBuffersUsageComplete() &&
+			this.isBackPressured() == that.isBackPressured() &&
+			that.isBackPressuredComplete() == that.isBackPressuredComplete() &&
+			this.getOutPoolUsage() == that.getOutPoolUsage() &&
+			this.isOutPoolUsageComplete() == that.isOutPoolUsageComplete();
 	}
 
 	@Override
 	public int hashCode() {
 		return Objects.hash(this.getBytesRead(), this.isBytesReadComplete(), this.getBytesWritten(), this.isBytesWrittenComplete(),
 			this.getRecordsRead(), this.isRecordsReadComplete(), this.getRecordsWritten(), this.isRecordsWrittenComplete(),
-			this.isBackPressured(), this.isBackPressuredComplete(), this.getOutPoolUsage(), this.isOutPoolUsageComplete(),
 			this.getInputExclusiveBuffersUsage(), this.isInputExclusiveBuffersUsageComplete(), this.getInputFloatingBuffersUsage(),
-			this.isInputFloatingBuffersUsageComplete());
+			this.isInputFloatingBuffersUsageComplete(), this.getOutPoolUsage(), this.isOutPoolUsageComplete(),
+			this.isBackPressured(), this.isBackPressuredComplete());
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/SubTaskIOMetricsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/SubTaskIOMetricsInfo.java
@@ -69,14 +69,14 @@ public final class SubTaskIOMetricsInfo extends IOMetricsInfo {
 		@JsonProperty(FIELD_NAME_RECORDS_READ_COMPLETE) boolean recordsReadComplete,
 		@JsonProperty(FIELD_NAME_RECORDS_WRITTEN) long recordsWritten,
 		@JsonProperty(FIELD_NAME_RECORDS_WRITTEN_COMPLETE) boolean recordsWrittenComplete,
-		@JsonProperty(FIELD_NAME_IS_BACKPRESSED) boolean isBackPressured,
-		@JsonProperty(FIELD_NAME_IS_BACKPRESSED_COMPLETE) boolean isBackPressuredComplete,
-		@JsonProperty(FIELD_NAME_OUT_POOL_USAGE) float outPoolUsage,
-		@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_COMPLETE) boolean outPoolUsageComplete,
 		@JsonProperty(FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE) float inputExclusiveBuffersUsage,
 		@JsonProperty(FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_COMPLETE) boolean inputExclusiveBuffersUsageComplete,
 		@JsonProperty(FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE) float inputFloatingBuffersUsage,
-		@JsonProperty(FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE_COMPLETE) boolean inputFloatingBuffersUsageComplete) {
+		@JsonProperty(FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE_COMPLETE) boolean inputFloatingBuffersUsageComplete,
+		@JsonProperty(FIELD_NAME_OUT_POOL_USAGE) float outPoolUsage,
+		@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_COMPLETE) boolean outPoolUsageComplete,
+		@JsonProperty(FIELD_NAME_IS_BACKPRESSED) boolean isBackPressured,
+		@JsonProperty(FIELD_NAME_IS_BACKPRESSED_COMPLETE) boolean isBackPressuredComplete) {
 		super(bytesRead, bytesReadComplete, bytesWritten, bytesWrittenComplete, recordsRead, recordsReadComplete,
 			recordsWritten, recordsWrittenComplete, isBackPressured, isBackPressuredComplete);
 		this.outPoolUsage = outPoolUsage;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -334,7 +334,7 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 		// verify behavior for canceled executions
 		Execution execution1 = graphAndExecutions.f1.values().iterator().next();
 
-		IOMetrics ioMetrics = new IOMetrics(0, 0, 0, 0);
+		IOMetrics ioMetrics = new IOMetrics(0, 0, 0, 0, 0.0f, 0.0f, 0.0f, false);
 		Map<String, Accumulator<?, ?>> accumulators = new HashMap<>();
 		accumulators.put("acc", new IntCounter(4));
 		AccumulatorSnapshot accumulatorSnapshot = new AccumulatorSnapshot(graph.getJobID(), execution1.getAttemptId(), accumulators);
@@ -350,7 +350,7 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 		// verify behavior for failed executions
 		Execution execution2 = graphAndExecutions.f1.values().iterator().next();
 
-		IOMetrics ioMetrics2 = new IOMetrics(0, 0, 0, 0);
+		IOMetrics ioMetrics2 = new IOMetrics(0, 0, 0, 0, 0.0f, 0.0f, 0.0f, false);
 		Map<String, Accumulator<?, ?>> accumulators2 = new HashMap<>();
 		accumulators2.put("acc", new IntCounter(8));
 		AccumulatorSnapshot accumulatorSnapshot2 = new AccumulatorSnapshot(graph.getJobID(), execution2.getAttemptId(), accumulators2);
@@ -378,7 +378,7 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 
 		Map<ExecutionAttemptID, Execution> executions = setupExecution(v1, 1, v2, 1).f1;
 
-		IOMetrics ioMetrics = new IOMetrics(0, 0, 0, 0);
+		IOMetrics ioMetrics = new IOMetrics(0, 0, 0, 0, 0.0f, 0.0f, 0.0f, false);
 		Map<String, Accumulator<?, ?>> accumulators = Collections.emptyMap();
 
 		Execution execution1 = executions.values().iterator().next();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionPartitionLifecycleTest.java
@@ -152,7 +152,9 @@ public class ExecutionPartitionLifecycleTest extends TestLogger {
 		testPartitionTrackingForStateTransition(
 			execution -> {
 				execution.cancel();
-				execution.completeCancelling(Collections.emptyMap(), new IOMetrics(0, 0, 0, 0), false);
+				execution.completeCancelling(Collections.emptyMap(),
+					new IOMetrics(0, 0, 0, 0, 0.0f, 0.0f, 0.0f, false),
+					false);
 			},
 			PartitionReleaseResult.STOP_TRACKING);
 	}
@@ -173,7 +175,7 @@ public class ExecutionPartitionLifecycleTest extends TestLogger {
 			execution -> execution.markFailed(
 				new Exception("Test exception"),
 				Collections.emptyMap(),
-				new IOMetrics(0, 0, 0, 0)),
+				new IOMetrics(0, 0, 0, 0, 0.0f, 0.0f, 0.0f, false)),
 			PartitionReleaseResult.STOP_TRACKING);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandlerTest.java
@@ -41,7 +41,7 @@ import org.apache.flink.runtime.rest.messages.JobVertexIdPathParameter;
 import org.apache.flink.runtime.rest.messages.job.SubtaskCurrentAttemptDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptDetailsInfo;
 import org.apache.flink.runtime.rest.messages.job.SubtaskMessageParameters;
-import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
+import org.apache.flink.runtime.rest.messages.job.metrics.SubTaskIOMetricsInfo;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.util.EvictingBoundedList;
@@ -74,12 +74,20 @@ public class SubtaskCurrentAttemptDetailsHandlerTest extends TestLogger {
 		final long bytesOut = 10L;
 		final long recordsIn = 20L;
 		final long recordsOut = 30L;
+		final float usageInputFloatingBuffers = 0.1f;
+		final float usageInputExclusiveBuffers = 0.1f;
+		final float usageOutPool = 0.2f;
+		final boolean isBackPressured = false;
 
 		final IOMetrics ioMetrics = new IOMetrics(
 			bytesIn,
 			bytesOut,
 			recordsIn,
-			recordsOut);
+			recordsOut,
+			usageInputFloatingBuffers,
+			usageInputExclusiveBuffers,
+			usageOutPool,
+			isBackPressured);
 
 		final long[] timestamps = new long[ExecutionState.values().length];
 		timestamps[ExecutionState.DEPLOYING.ordinal()] = deployingTs;
@@ -145,7 +153,7 @@ public class SubtaskCurrentAttemptDetailsHandlerTest extends TestLogger {
 		final SubtaskExecutionAttemptDetailsInfo detailsInfo = handler.handleRequest(request, executionVertex);
 
 		// Verify
-		final IOMetricsInfo ioMetricsInfo = new IOMetricsInfo(
+		final SubTaskIOMetricsInfo subTaskIOMetricsInfo = new SubTaskIOMetricsInfo(
 			bytesIn,
 			true,
 			bytesOut,
@@ -153,6 +161,14 @@ public class SubtaskCurrentAttemptDetailsHandlerTest extends TestLogger {
 			recordsIn,
 			true,
 			recordsOut,
+			true,
+			isBackPressured,
+			true,
+			usageOutPool,
+			true,
+			usageInputExclusiveBuffers,
+			true,
+			usageInputFloatingBuffers,
 			true
 		);
 
@@ -164,7 +180,7 @@ public class SubtaskCurrentAttemptDetailsHandlerTest extends TestLogger {
 			deployingTs,
 			finishedTs,
 			finishedTs - deployingTs,
-			ioMetricsInfo,
+			subTaskIOMetricsInfo,
 			assignedResourceLocation.getResourceID().getResourceIdString()
 		);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandlerTest.java
@@ -162,13 +162,7 @@ public class SubtaskCurrentAttemptDetailsHandlerTest extends TestLogger {
 			true,
 			recordsOut,
 			true,
-			isBackPressured,
-			true,
-			usageOutPool,
-			true,
-			usageInputExclusiveBuffers,
-			true,
-			usageInputFloatingBuffers,
+			usageInputExclusiveBuffers, true, usageInputFloatingBuffers, true, usageOutPool, true, isBackPressured,
 			true
 		);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandlerTest.java
@@ -45,6 +45,7 @@ import org.apache.flink.runtime.rest.messages.job.SubtaskAttemptPathParameter;
 import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptDetailsInfo;
 import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
+import org.apache.flink.runtime.rest.messages.job.metrics.SubTaskIOMetricsInfo;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.util.EvictingBoundedList;
 import org.apache.flink.util.TestLogger;
@@ -78,12 +79,20 @@ public class SubtaskExecutionAttemptDetailsHandlerTest extends TestLogger {
 		final long bytesOut = 10L;
 		final long recordsIn = 20L;
 		final long recordsOut = 30L;
+		final float usageInputFloatingBuffers = 0.1f;
+		final float usageInputExclusiveBuffers = 0.1f;
+		final float usageOutPool = 0.2f;
+		final boolean isBackPressured = false;
 
 		final IOMetrics ioMetrics = new IOMetrics(
 			bytesIn,
 			bytesOut,
 			recordsIn,
-			recordsOut);
+			recordsOut,
+			usageInputFloatingBuffers,
+			usageInputExclusiveBuffers,
+			usageOutPool,
+			isBackPressured);
 
 		final ArchivedExecutionJobVertex archivedExecutionJobVertex = new ArchivedExecutionJobVertex(
 			new ArchivedExecutionVertex[]{
@@ -153,7 +162,7 @@ public class SubtaskExecutionAttemptDetailsHandlerTest extends TestLogger {
 			archivedExecutionJobVertex);
 
 		// Verify
-		final IOMetricsInfo ioMetricsInfo = new IOMetricsInfo(
+		final SubTaskIOMetricsInfo subTaskIOMetricsInfo = new SubTaskIOMetricsInfo(
 			bytesIn,
 			true,
 			bytesOut,
@@ -161,6 +170,14 @@ public class SubtaskExecutionAttemptDetailsHandlerTest extends TestLogger {
 			recordsIn,
 			true,
 			recordsOut,
+			true,
+			isBackPressured,
+			true,
+			usageOutPool,
+			true,
+			usageInputExclusiveBuffers,
+			true,
+			usageInputFloatingBuffers,
 			true
 		);
 
@@ -172,7 +189,7 @@ public class SubtaskExecutionAttemptDetailsHandlerTest extends TestLogger {
 			-1L,
 			0L,
 			-1L,
-			ioMetricsInfo,
+			subTaskIOMetricsInfo,
 			"(unassigned)"
 		);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandlerTest.java
@@ -44,7 +44,6 @@ import org.apache.flink.runtime.rest.messages.job.SubtaskAttemptMessageParameter
 import org.apache.flink.runtime.rest.messages.job.SubtaskAttemptPathParameter;
 import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptDetailsInfo;
-import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
 import org.apache.flink.runtime.rest.messages.job.metrics.SubTaskIOMetricsInfo;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.util.EvictingBoundedList;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandlerTest.java
@@ -170,13 +170,7 @@ public class SubtaskExecutionAttemptDetailsHandlerTest extends TestLogger {
 			true,
 			recordsOut,
 			true,
-			isBackPressured,
-			true,
-			usageOutPool,
-			true,
-			usageInputExclusiveBuffers,
-			true,
-			usageInputFloatingBuffers,
+			usageInputExclusiveBuffers, true, usageInputFloatingBuffers, true, usageOutPool, true, isBackPressured,
 			true
 		);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfoTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.rest.messages;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptDetailsInfo;
-import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
+import org.apache.flink.runtime.rest.messages.job.metrics.SubTaskIOMetricsInfo;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,15 +39,24 @@ public class JobVertexDetailsInfoTest extends RestResponseMarshallingTestBase<Jo
 	@Override
 	protected JobVertexDetailsInfo getTestResponseInstance() throws Exception {
 		final Random random = new Random();
-		final IOMetricsInfo jobVertexMetrics = new IOMetricsInfo(
-			random.nextLong(),
+		final SubTaskIOMetricsInfo subTaskIOMetricsInfo = new SubTaskIOMetricsInfo(
+			Math.abs(random.nextLong()),
 			random.nextBoolean(),
-			random.nextLong(),
+			Math.abs(random.nextLong()),
 			random.nextBoolean(),
-			random.nextLong(),
+			Math.abs(random.nextLong()),
 			random.nextBoolean(),
-			random.nextLong(),
-			random.nextBoolean());
+			Math.abs(random.nextLong()),
+			random.nextBoolean(),
+			random.nextBoolean(),
+			random.nextBoolean(),
+			Math.abs(random.nextFloat()),
+			random.nextBoolean(),
+			Math.abs(random.nextFloat()),
+			random.nextBoolean(),
+			Math.abs(random.nextFloat()),
+			random.nextBoolean()
+		);
 		List<SubtaskExecutionAttemptDetailsInfo> vertexTaskDetailList = new ArrayList<>();
 		vertexTaskDetailList.add(new SubtaskExecutionAttemptDetailsInfo(
 			0,
@@ -57,7 +66,7 @@ public class JobVertexDetailsInfoTest extends RestResponseMarshallingTestBase<Jo
 			System.currentTimeMillis(),
 			System.currentTimeMillis(),
 			1L,
-			jobVertexMetrics,
+			subTaskIOMetricsInfo,
 			"taskmanagerId1"));
 		vertexTaskDetailList.add(new SubtaskExecutionAttemptDetailsInfo(
 			1,
@@ -67,7 +76,7 @@ public class JobVertexDetailsInfoTest extends RestResponseMarshallingTestBase<Jo
 			System.currentTimeMillis(),
 			System.currentTimeMillis(),
 			1L,
-			jobVertexMetrics,
+			subTaskIOMetricsInfo,
 			"taskmanagerId2"));
 		vertexTaskDetailList.add(new SubtaskExecutionAttemptDetailsInfo(
 			2,
@@ -77,7 +86,7 @@ public class JobVertexDetailsInfoTest extends RestResponseMarshallingTestBase<Jo
 			System.currentTimeMillis(),
 			System.currentTimeMillis(),
 			1L,
-			jobVertexMetrics,
+			subTaskIOMetricsInfo,
 			"taskmanagerId3"));
 
 		return new JobVertexDetailsInfo(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfoTest.java
@@ -48,13 +48,7 @@ public class JobVertexDetailsInfoTest extends RestResponseMarshallingTestBase<Jo
 			random.nextBoolean(),
 			Math.abs(random.nextLong()),
 			random.nextBoolean(),
-			random.nextBoolean(),
-			random.nextBoolean(),
-			Math.abs(random.nextFloat()),
-			random.nextBoolean(),
-			Math.abs(random.nextFloat()),
-			random.nextBoolean(),
-			Math.abs(random.nextFloat()),
+			Math.abs(random.nextFloat()), random.nextBoolean(), Math.abs(random.nextFloat()), random.nextBoolean(), Math.abs(random.nextFloat()), random.nextBoolean(), random.nextBoolean(),
 			random.nextBoolean()
 		);
 		List<SubtaskExecutionAttemptDetailsInfo> vertexTaskDetailList = new ArrayList<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobVertexTaskManagersInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobVertexTaskManagersInfoTest.java
@@ -53,6 +53,8 @@ public class JobVertexTaskManagersInfoTest extends RestResponseMarshallingTestBa
 			random.nextLong(),
 			random.nextBoolean(),
 			random.nextLong(),
+			random.nextBoolean(),
+			random.nextBoolean(),
 			random.nextBoolean());
 		int count = 100;
 		for (ExecutionState executionState : ExecutionState.values()) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfoTest.java
@@ -88,6 +88,8 @@ public class JobDetailsInfoTest extends RestResponseMarshallingTestBase<JobDetai
 			random.nextLong(),
 			random.nextBoolean(),
 			random.nextLong(),
+			random.nextBoolean(),
+			random.nextBoolean(),
 			random.nextBoolean());
 
 		for (ExecutionState executionState : ExecutionState.values()) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfoTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.rest.messages.RestResponseMarshallingTestBase;
-import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
+import org.apache.flink.runtime.rest.messages.job.metrics.JobVertexIOMetricsInfo;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -80,7 +80,7 @@ public class JobDetailsInfoTest extends RestResponseMarshallingTestBase<JobDetai
 
 	private JobDetailsInfo.JobVertexDetailsInfo createJobVertexDetailsInfo(Random random) {
 		final Map<ExecutionState, Integer> tasksPerState = new HashMap<>(ExecutionState.values().length);
-		final IOMetricsInfo jobVertexMetrics = new IOMetricsInfo(
+		final JobVertexIOMetricsInfo jobVertexMetrics = new JobVertexIOMetricsInfo(
 			random.nextLong(),
 			random.nextBoolean(),
 			random.nextLong(),
@@ -90,6 +90,12 @@ public class JobDetailsInfoTest extends RestResponseMarshallingTestBase<JobDetai
 			random.nextLong(),
 			random.nextBoolean(),
 			random.nextBoolean(),
+			random.nextBoolean(),
+			random.nextFloat(),
+			random.nextBoolean(),
+			random.nextFloat(),
+			random.nextBoolean(),
+			random.nextFloat(),
 			random.nextBoolean());
 
 		for (ExecutionState executionState : ExecutionState.values()) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfoTest.java
@@ -89,14 +89,9 @@ public class JobDetailsInfoTest extends RestResponseMarshallingTestBase<JobDetai
 			random.nextBoolean(),
 			random.nextLong(),
 			random.nextBoolean(),
-			random.nextBoolean(),
-			random.nextBoolean(),
-			random.nextFloat(),
-			random.nextBoolean(),
-			random.nextFloat(),
-			random.nextBoolean(),
-			random.nextFloat(),
-			random.nextBoolean());
+			random.nextFloat(), random.nextBoolean(), random.nextFloat(), random.nextBoolean(), random.nextFloat(), random.nextBoolean(), random.nextBoolean(),
+			random.nextBoolean()
+		);
 
 		for (ExecutionState executionState : ExecutionState.values()) {
 			tasksPerState.put(executionState, random.nextInt());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfoTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.rest.messages.RestResponseMarshallingTestBase;
 import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
 
 import java.util.Random;
+import org.apache.flink.runtime.rest.messages.job.metrics.SubTaskIOMetricsInfo;
 
 /**
  * Tests (un)marshalling of the {@link SubtaskExecutionAttemptDetailsInfo}.
@@ -38,7 +39,7 @@ public class SubtaskExecutionAttemptDetailsInfoTest extends RestResponseMarshall
 	protected SubtaskExecutionAttemptDetailsInfo getTestResponseInstance() throws Exception {
 		final Random random = new Random();
 
-		final IOMetricsInfo ioMetricsInfo = new IOMetricsInfo(
+		final SubTaskIOMetricsInfo subTaskIOMetricsInfo = new SubTaskIOMetricsInfo(
 			Math.abs(random.nextLong()),
 			random.nextBoolean(),
 			Math.abs(random.nextLong()),
@@ -46,6 +47,14 @@ public class SubtaskExecutionAttemptDetailsInfoTest extends RestResponseMarshall
 			Math.abs(random.nextLong()),
 			random.nextBoolean(),
 			Math.abs(random.nextLong()),
+			random.nextBoolean(),
+			random.nextBoolean(),
+			random.nextBoolean(),
+			Math.abs(random.nextFloat()),
+			random.nextBoolean(),
+			Math.abs(random.nextFloat()),
+			random.nextBoolean(),
+			Math.abs(random.nextFloat()),
 			random.nextBoolean()
 		);
 
@@ -57,7 +66,7 @@ public class SubtaskExecutionAttemptDetailsInfoTest extends RestResponseMarshall
 			Math.abs(random.nextLong()),
 			Math.abs(random.nextLong()),
 			Math.abs(random.nextLong()),
-			ioMetricsInfo,
+			subTaskIOMetricsInfo,
 			"taskmanagerId"
 		);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfoTest.java
@@ -20,10 +20,9 @@ package org.apache.flink.runtime.rest.messages.job;
 
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.rest.messages.RestResponseMarshallingTestBase;
-import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
+import org.apache.flink.runtime.rest.messages.job.metrics.SubTaskIOMetricsInfo;
 
 import java.util.Random;
-import org.apache.flink.runtime.rest.messages.job.metrics.SubTaskIOMetricsInfo;
 
 /**
  * Tests (un)marshalling of the {@link SubtaskExecutionAttemptDetailsInfo}.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfoTest.java
@@ -47,13 +47,7 @@ public class SubtaskExecutionAttemptDetailsInfoTest extends RestResponseMarshall
 			random.nextBoolean(),
 			Math.abs(random.nextLong()),
 			random.nextBoolean(),
-			random.nextBoolean(),
-			random.nextBoolean(),
-			Math.abs(random.nextFloat()),
-			random.nextBoolean(),
-			Math.abs(random.nextFloat()),
-			random.nextBoolean(),
-			Math.abs(random.nextFloat()),
+			Math.abs(random.nextFloat()), random.nextBoolean(), Math.abs(random.nextFloat()), random.nextBoolean(), Math.abs(random.nextFloat()), random.nextBoolean(), random.nextBoolean(),
 			random.nextBoolean()
 		);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfoTest.java
@@ -47,7 +47,13 @@ public class SubtaskExecutionAttemptDetailsInfoTest extends RestResponseMarshall
 			random.nextBoolean(),
 			Math.abs(random.nextLong()),
 			random.nextBoolean(),
-			Math.abs(random.nextFloat()), random.nextBoolean(), Math.abs(random.nextFloat()), random.nextBoolean(), Math.abs(random.nextFloat()), random.nextBoolean(), random.nextBoolean(),
+			Math.abs(random.nextFloat()),
+			random.nextBoolean(),
+			Math.abs(random.nextFloat()),
+			random.nextBoolean(),
+			Math.abs(random.nextFloat()),
+			random.nextBoolean(),
+			random.nextBoolean(),
 			random.nextBoolean()
 		);
 


### PR DESCRIPTION


## What is the purpose of the change

- Expose network metric in IOMetricsInfo
    - JobVertex exposes is-backpressed、out-pool-usage-avg、input-exclusive-buffers-usage-avg、input-floating-buffers-usage-avg.
    - SubTask exposes is-backpressed、out-pool-usage、input-exclusive-buffers-usage、input-floating-buffers-usage.


## Brief change log

- calculate in MutableIOMetrics#addIOMetrics
- add SubTaskIOMetricsInfo for subtask's metrics in rest api.
- add JobVertexIOMetricsInfo for job vertex's metrics in rest api.


## Verifying this change



This change is already covered by existing tests, such as SubtaskCurrentAttemptDetailsHandlerTest、SubtaskExecutionAttemptDetailsHandlerTest、JobDetailsInfoTest、SubtaskExecutionAttemptDetailsInfoTest、JobVertexDetailsInfoTest.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)