### PR TITLE
[FLINK-15085][hs] Simplify dashboard config generation

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
@@ -29,7 +29,6 @@ import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.history.FsJobArchivist;
 import org.apache.flink.runtime.io.network.netty.SSLHandlerFactory;
 import org.apache.flink.runtime.net.SSLUtils;
-import org.apache.flink.runtime.rest.handler.legacy.JsonFactory;
 import org.apache.flink.runtime.rest.handler.router.Router;
 import org.apache.flink.runtime.rest.messages.DashboardConfiguration;
 import org.apache.flink.runtime.security.SecurityConfiguration;
@@ -42,7 +41,7 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.ShutdownHookUtil;
 
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +51,6 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.nio.file.Files;
 import java.time.ZonedDateTime;
@@ -86,6 +84,7 @@ import java.util.function.Consumer;
 public class HistoryServer {
 
 	private static final Logger LOG = LoggerFactory.getLogger(HistoryServer.class);
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
 	private final Configuration config;
 
@@ -300,21 +299,7 @@ public class HistoryServer {
 	}
 
 	private static String createConfigJson(DashboardConfiguration dashboardConfiguration) throws IOException {
-		StringWriter writer = new StringWriter();
-		JsonGenerator gen = JsonFactory.JACKSON_FACTORY.createGenerator(writer);
-
-		gen.writeStartObject();
-		gen.writeNumberField(DashboardConfiguration.FIELD_NAME_REFRESH_INTERVAL, dashboardConfiguration.getRefreshInterval());
-		gen.writeNumberField(DashboardConfiguration.FIELD_NAME_TIMEZONE_OFFSET, dashboardConfiguration.getTimeZoneOffset());
-		gen.writeStringField(DashboardConfiguration.FIELD_NAME_TIMEZONE_NAME, dashboardConfiguration.getTimeZoneName());
-		gen.writeStringField(DashboardConfiguration.FIELD_NAME_FLINK_VERSION, dashboardConfiguration.getFlinkVersion());
-		gen.writeStringField(DashboardConfiguration.FIELD_NAME_FLINK_REVISION, dashboardConfiguration.getFlinkRevision());
-
-		gen.writeEndObject();
-
-		gen.close();
-
-		return writer.toString();
+		return OBJECT_MAPPER.writeValueAsString(dashboardConfiguration);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/DashboardConfigurationHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/DashboardConfigurationHeaders.java
@@ -28,7 +28,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseSt
  */
 public final class DashboardConfigurationHeaders implements MessageHeaders<EmptyRequestBody, DashboardConfiguration, EmptyMessageParameters> {
 
-	private static final DashboardConfigurationHeaders INSTANCE = new DashboardConfigurationHeaders();
+	public static final DashboardConfigurationHeaders INSTANCE = new DashboardConfigurationHeaders();
 
 	// make the constructor private since we want it to be a singleton
 	private DashboardConfigurationHeaders() {}


### PR DESCRIPTION
Fixes an issue in the HistoryServer where the dashboard configuration JSON was generated manually, resulting in it being out-of-sync with the actual representation.

Instead we now use an `ObjectMapper` to directly map the object to json, just like how the REST handlers work.