### PR TITLE
[FLINK-12283] In Table API, allow non-static inner class as UDF

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/functions/UserFunctionsTypeHelper.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/functions/UserFunctionsTypeHelper.java
@@ -152,9 +152,6 @@ public class UserFunctionsTypeHelper {
 			throw new ValidationException(String.format(
 				"Function class %s is no proper class," +
 					" it is either abstract, an interface, or a primitive type.", clazz.getCanonicalName()));
-		} else if (InstantiationUtil.isNonStaticInnerClass(clazz)) {
-			throw new ValidationException(String.format(
-				"The class %s is an inner class, but not statically accessible.", clazz.getCanonicalName()));
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This relaxes a check in the Table API to allow more types of functions. Specifically, this allows to use UDFs as defined in the Scala Shell.

This might lead to cases where a user specifies a function that then is not serializable, but I think it's worth it to enable the above use case.