### PR TITLE
[FLINK-15027][SQL-CLINET]Support alter table DDLs in SQL CLI

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -622,10 +622,9 @@ public class CliClient {
 	}
 
 	private void callAlterTable(SqlCommandCall cmdCall) {
-		final String alterDatabaseStmt = cmdCall.operands[0];
+		final String alterTableStmt = cmdCall.operands[0];
 		try {
-			// perform and validate change
-			executor.executeUpdate(sessionId, alterDatabaseStmt);
+			executor.executeUpdate(sessionId, alterTableStmt);
 			printInfo(CliStrings.MESSAGE_ALTER_TABLE_SUCCEEDED);
 		} catch (SqlExecutionException e) {
 			printExecutionException(CliStrings.MESSAGE_ALTER_TABLE_FAILED, e);

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -314,6 +314,9 @@ public class CliClient {
 			case ALTER_DATABASE:
 				callAlterDatabase(cmdCall);
 				break;
+			case ALTER_TABLE:
+				callAlterTable(cmdCall);
+				break;
 			default:
 				throw new SqlClientException("Unsupported command: " + cmdCall.command);
 		}
@@ -616,6 +619,17 @@ public class CliClient {
 	private void callAlterDatabase(SqlCommandCall cmdCall) {
 		final String alterDatabaseStmt = cmdCall.operands[0];
 		executor.executeUpdate(sessionId, alterDatabaseStmt);
+	}
+
+	private void callAlterTable(SqlCommandCall cmdCall) {
+		final String alterDatabaseStmt = cmdCall.operands[0];
+		try {
+			// perform and validate change
+			executor.executeUpdate(sessionId, alterDatabaseStmt);
+			printInfo(CliStrings.MESSAGE_ALTER_TABLE_SUCCEEDED);
+		} catch (SqlExecutionException e) {
+			printExecutionException(CliStrings.MESSAGE_ALTER_TABLE_FAILED, e);
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
@@ -137,6 +137,10 @@ public final class CliStrings {
 
 	public static final String MESSAGE_UNSUPPORTED_SQL = "Unsupported SQL statement.";
 
+	public static final String MESSAGE_ALTER_TABLE_SUCCEEDED = "Alter table succeeded!";
+
+	public static final String MESSAGE_ALTER_TABLE_FAILED = "Alter table failed!";
+
 	public static final String MESSAGE_VIEW_CREATED = "View has been created.";
 
 	public static final String MESSAGE_VIEW_REMOVED = "View has been removed.";

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
@@ -152,6 +152,10 @@ public final class SqlCommandParser {
 				"(ALTER\\s+DATABASE\\s+.*)",
 				SINGLE_OPERAND),
 
+		ALTER_TABLE(
+				"(ALTER\\s+TABLE\\s+.*)",
+				SINGLE_OPERAND),
+
 		SET(
 			"SET(\\s+(\\S+)\\s*=(.*))?", // whitespace is only ignored on the left side of '='
 			(operands) -> {

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
@@ -83,6 +83,11 @@ public class SqlCommandParserTest {
 				new SqlCommandCall(SqlCommand.DROP_DATABASE, new String[] {"drop database db1"}));
 		testValidSqlCommand("alter database db1 set ('k1' = 'a')",
 				new SqlCommandCall(SqlCommand.ALTER_DATABASE, new String[] {"alter database db1 set ('k1' = 'a')"}));
+		testValidSqlCommand("alter table cat1.db1.tb1 rename to tb2",
+				new SqlCommandCall(SqlCommand.ALTER_TABLE, new String[]{"alter table cat1.db1.tb1 rename to tb2"}));
+		testValidSqlCommand("alter table cat1.db1.tb1 set ('k1'='v1', 'k2'='v2')",
+				new SqlCommandCall(SqlCommand.ALTER_TABLE,
+						new String[]{"alter table cat1.db1.tb1 set ('k1'='v1', 'k2'='v2')"}));
 	}
 
 	private void testInvalidSqlCommand(String stmt) {

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -269,6 +269,26 @@ public class LocalExecutorITCase extends TestLogger {
 	}
 
 	@Test
+	public void testAlterTable() throws Exception {
+		final Executor executor = createDefaultExecutor(clusterClient);
+		final LocalExecutor localExecutor = (LocalExecutor) executor;
+		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+		assertEquals("test-session", sessionId);
+		executor.useCatalog(sessionId, "simple-catalog");
+		executor.useDatabase(sessionId, "default_database");
+		List<String> actualTables = executor.listTables(sessionId);
+		List<String> expectedTables = Arrays.asList("test-table");
+		assertEquals(expectedTables, actualTables);
+		executor.executeUpdate(sessionId, "alter table `test-table` rename to t1");
+		actualTables = executor.listTables(sessionId);
+		expectedTables = Arrays.asList("t1");
+		assertEquals(expectedTables, actualTables);
+		//todo: we should add alter table set test when we support create table in executor.
+		executor.closeSession(sessionId);
+	}
+
+	@Test
 	public void testListTables() throws Exception {
 		final Executor executor = createDefaultExecutor(clusterClient);
 		final SessionContext session = new SessionContext("test-session", new Environment());


### PR DESCRIPTION
## What is the purpose of the change

Support syntax as following through TableEnvironment in Sql Client:

ALTER TABLE [[catalogName.] dataBasesName].tableName RENAME TO newTableName

ALTER TABLE [[catalogName.] dataBasesName].tableName SET ( name=value [, name=value]*)


## Brief change log

  - [0c46873](https://github.com/apache/flink/commit/0c468730a76437b5792129eeea184cefa66949fe)Support alter table DDLs in SQL CLI


## Verifying this change

This change added tests and can be verified as follows:
  - *Added integration tests LocalExecutorITCase#testAlterTable*
  - *Added SqlParserTest in SqlCommandParserTest#testCommands*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
