### PR TITLE
[FLINK-15109][runtime] null out restored state ref in InternalTimerServiceImpl after use

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImpl.java
@@ -152,6 +152,8 @@ public class InternalTimerServiceImpl<K, N> implements InternalTimerService<N> {
 				TypeSerializerSchemaCompatibility<N> namespaceSerializerCompatibility =
 					restoredTimersSnapshot.getNamespaceSerializerSnapshot().resolveSchemaCompatibility(namespaceSerializer);
 
+				restoredTimersSnapshot = null;
+
 				if (namespaceSerializerCompatibility.isIncompatible() || namespaceSerializerCompatibility.isCompatibleAfterMigration()) {
 					throw new IllegalStateException(
 						"Tried to initialize restored TimerService with new namespace serializer that requires migration or is incompatible.");


### PR DESCRIPTION
## What is the purpose of the change

`InternalTimerServiceImpl` references restored state after use, taking up resources unnecessarily.
This PR just nullifies its restoredTimersSnapshot field in `startTimerService()`.

## Verifying this change

This change is already covered by existing tests, such as `InternalTimerServiceImplTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
