### PR TITLE
[FLINK-15008][tests] Fix ClassNotFoundException of flink-yarn-tests module under JDK11

### DIFF
--- a/flink-yarn-tests/pom.xml
+++ b/flink-yarn-tests/pom.xml
@@ -190,6 +190,14 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<!-- Refer to HADOOP-15775 to fix broken tests under JDK11 -->
+			<groupId>javax.activation</groupId>
+			<artifactId>javax.activation-api</artifactId>
+			<version>1.2.0</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
##  What is the purpose of the change

Refer to [HADOOP-15775](https://issues.apache.org/jira/browse/HADOOP-15775) to add missing  javax.activation-api dependency to fix broken tests under JDK11

## Brief change log
Add missing  javax.activation-api dependency.

## Verifying this change
This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **yes**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
