### PR TITLE
[FLINK-14649][table sql / api] Flatten all the connector properties keys to make it easy to configure in DDL

### DIFF
--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -247,10 +247,8 @@ tables:
       topic: test-input
       startup-mode: earliest-offset
       properties:
-        - key: zookeeper.connect
-          value: localhost:2181
-        - key: bootstrap.servers
-          value: localhost:9092
+        zookeeper.connect: localhost:2181,localhost:2182
+        bootstrap.servers: localhost:9092,localhost:9093
 
     # declare a format for this system
     format:
@@ -297,10 +295,8 @@ CREATE TABLE MyUserTable (
   'connector.version' = '0.10',
   'connector.topic' = 'topic_name',
   'connector.startup-mode' = 'earliest-offset',
-  'connector.properties.0.key' = 'zookeeper.connect',
-  'connector.properties.0.value' = 'localhost:2181',
-  'connector.properties.1.key' = 'bootstrap.servers',
-  'connector.properties.1.value' = 'localhost:9092',
+  'connector.properties.zookeeper.connect' = 'localhost:2181,localhost:2182',
+  'connector.properties.bootstrap.servers' = 'localhost:9092,localhost:9093',
   'update-mode' = 'append',
   -- declare a format for this system
   'format.type' = 'avro',
@@ -766,22 +762,15 @@ connector:
                       #   "0.8", "0.9", "0.10", "0.11", and "universal"
   topic: ...          # required: topic name from which the table is read
 
-  properties:         # optional: connector specific properties
-    - key: zookeeper.connect
-      value: localhost:2181
-    - key: bootstrap.servers
-      value: localhost:9092
-    - key: group.id
-      value: testGroup
+  properties:
+    zookeeper.connect: localhost:2181,localhost:2182  # required: specify the ZooKeeper connection string
+    bootstrap.servers: localhost:9092,localhost:9093  # required: specify the Kafka server connection string
+    group.id: testGroup                               # optional: required in Kafka consumer, specify consumer group
 
-  startup-mode: ...   # optional: valid modes are "earliest-offset", "latest-offset",
-                      # "group-offsets", or "specific-offsets"
-  specific-offsets:   # optional: used in case of startup mode with specific offsets
-    - partition: 0
-      offset: 42
-    - partition: 1
-      offset: 300
-
+  startup-mode: ...                                               # optional: valid modes are "earliest-offset", "latest-offset",
+                                                                  # "group-offsets", or "specific-offsets"
+  specific-offsets: partition:0,offset:42;partition:1,offset:300  # optional: used in case of startup mode with specific offsets
+  
   sink-partitioner: ...    # optional: output partitioning from Flink's partitions into Kafka's partitions
                            # valid are "fixed" (each Flink partition ends up in at most one Kafka partition),
                            # "round-robin" (a Flink partition is distributed to Kafka partitions round-robin)
@@ -805,21 +794,15 @@ CREATE TABLE MyUserTable (
   'update-mode' = 'append',         -- required: update mode when used as table sink, 
                                     -- only support append mode now.
 
-  'connector.properties.0.key' = 'zookeeper.connect', -- optional: connector specific properties
-  'connector.properties.0.value' = 'localhost:2181',
-  'connector.properties.1.key' = 'bootstrap.servers',
-  'connector.properties.1.value' = 'localhost:9092',
-  'connector.properties.2.key' = 'group.id',
-  'connector.properties.2.value' = 'testGroup',
+  'connector.properties.zookeeper.connect' = 'localhost:2181,localhost:2182', -- required: specify the ZooKeeper connection string
+  'connector.properties.bootstrap.servers' = 'localhost:9092,localhost:9093', -- required: specify the Kafka server connection string
+  'connector.properties.group.id' = 'testGroup', --optional: required in Kafka consumer, specify consumer group
   'connector.startup-mode' = 'earliest-offset',    -- optional: valid modes are "earliest-offset", 
                                                    -- "latest-offset", "group-offsets", 
                                                    -- or "specific-offsets"
 
   -- optional: used in case of startup mode with specific offsets
-  'connector.specific-offsets.0.partition' = '0',
-  'connector.specific-offsets.0.offset' = '42',
-  'connector.specific-offsets.1.partition' = '1',
-  'connector.specific-offsets.1.offset' = '300',
+  'connector.specific-offsets' = 'partition:0,offset:42;partition:1,offset:300',
 
   'connector.sink-partitioner' = '...',  -- optional: output partitioning from Flink's partitions 
                                          -- into Kafka's partitions valid are "fixed" 
@@ -943,11 +926,8 @@ The connector can be defined as follows:
 {% highlight yaml %}
 connector:
   type: elasticsearch
-  version: 6                # required: valid connector versions are "6"
-    hosts:                  # required: one or more Elasticsearch hosts to connect to
-      - hostname: "localhost"
-        port: 9200
-        protocol: "http"
+  version: 6                                            # required: valid connector versions are "6"
+    hosts: http://host_name:9092;http://host_name:9093  # required: one or more Elasticsearch hosts to connect to
     index: "MyUsers"        # required: Elasticsearch index
     document-type: "user"   # required: Elasticsearch document type
 
@@ -989,9 +969,7 @@ CREATE TABLE MyUserTable (
   
   'connector.version' = '6',          -- required: valid connector versions are "6"
   
-  'connector.hosts.0.hostname' = 'host_name',  -- required: one or more Elasticsearch hosts to connect to
-  'connector.hosts.0.port' = '9092',
-  'connector.hosts.0.protocol' = 'http',
+  'connector.hosts' = 'http://host_name:9092;http://host_name:9093',  -- required: one or more Elasticsearch hosts to connect to
 
   'connector.index' = 'MyUsers',       -- required: Elasticsearch index
 

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -247,8 +247,8 @@ tables:
       topic: test-input
       startup-mode: earliest-offset
       properties:
-        zookeeper.connect: localhost:2181,localhost:2182
-        bootstrap.servers: localhost:9092,localhost:9093
+        zookeeper.connect: localhost:2181
+        bootstrap.servers: localhost:9092
 
     # declare a format for this system
     format:
@@ -295,8 +295,8 @@ CREATE TABLE MyUserTable (
   'connector.version' = '0.10',
   'connector.topic' = 'topic_name',
   'connector.startup-mode' = 'earliest-offset',
-  'connector.properties.zookeeper.connect' = 'localhost:2181,localhost:2182',
-  'connector.properties.bootstrap.servers' = 'localhost:9092,localhost:9093',
+  'connector.properties.zookeeper.connect' = 'localhost:2181',
+  'connector.properties.bootstrap.servers' = 'localhost:9092',
   'update-mode' = 'append',
   -- declare a format for this system
   'format.type' = 'avro',
@@ -763,9 +763,9 @@ connector:
   topic: ...          # required: topic name from which the table is read
 
   properties:
-    zookeeper.connect: localhost:2181,localhost:2182  # required: specify the ZooKeeper connection string
-    bootstrap.servers: localhost:9092,localhost:9093  # required: specify the Kafka server connection string
-    group.id: testGroup                               # optional: required in Kafka consumer, specify consumer group
+    zookeeper.connect: localhost:2181  # required: specify the ZooKeeper connection string
+    bootstrap.servers: localhost:9092  # required: specify the Kafka server connection string
+    group.id: testGroup                # optional: required in Kafka consumer, specify consumer group
 
   startup-mode: ...                                               # optional: valid modes are "earliest-offset", "latest-offset",
                                                                   # "group-offsets", or "specific-offsets"
@@ -794,8 +794,8 @@ CREATE TABLE MyUserTable (
   'update-mode' = 'append',         -- required: update mode when used as table sink, 
                                     -- only support append mode now.
 
-  'connector.properties.zookeeper.connect' = 'localhost:2181,localhost:2182', -- required: specify the ZooKeeper connection string
-  'connector.properties.bootstrap.servers' = 'localhost:9092,localhost:9093', -- required: specify the Kafka server connection string
+  'connector.properties.zookeeper.connect' = 'localhost:2181', -- required: specify the ZooKeeper connection string
+  'connector.properties.bootstrap.servers' = 'localhost:9092', -- required: specify the Kafka server connection string
   'connector.properties.group.id' = 'testGroup', --optional: required in Kafka consumer, specify consumer group
   'connector.startup-mode' = 'earliest-offset',    -- optional: valid modes are "earliest-offset", 
                                                    -- "latest-offset", "group-offsets", 

--- a/docs/dev/table/connect.zh.md
+++ b/docs/dev/table/connect.zh.md
@@ -247,10 +247,8 @@ tables:
       topic: test-input
       startup-mode: earliest-offset
       properties:
-        - key: zookeeper.connect
-          value: localhost:2181
-        - key: bootstrap.servers
-          value: localhost:9092
+        zookeeper.connect: localhost:2181,localhost:2182
+        bootstrap.servers: localhost:9092,localhost:9093
 
     # declare a format for this system
     format:
@@ -297,10 +295,8 @@ CREATE TABLE MyUserTable (
   'connector.version' = '0.10',
   'connector.topic' = 'topic_name',
   'connector.startup-mode' = 'earliest-offset',
-  'connector.properties.0.key' = 'zookeeper.connect',
-  'connector.properties.0.value' = 'localhost:2181',
-  'connector.properties.1.key' = 'bootstrap.servers',
-  'connector.properties.1.value' = 'localhost:9092',
+  'connector.properties.zookeeper.connect' = 'localhost:2181,localhost:2182',
+  'connector.properties.bootstrap.servers' = 'localhost:9092,localhost:9093',
   'update-mode' = 'append',
   -- declare a format for this system
   'format.type' = 'avro',
@@ -766,22 +762,15 @@ connector:
                       #   "0.8", "0.9", "0.10", "0.11", and "universal"
   topic: ...          # required: topic name from which the table is read
 
-  properties:         # optional: connector specific properties
-    - key: zookeeper.connect
-      value: localhost:2181
-    - key: bootstrap.servers
-      value: localhost:9092
-    - key: group.id
-      value: testGroup
+  properties:          
+    zookeeper.connect: localhost:2181,localhost:2182  # required: specify the ZooKeeper connection string
+    bootstrap.servers: localhost:9092,localhost:9093  # required: specify the Kafka server connection string
+    group.id: testGroup                               # optional: required in Kafka consumer, specify consumer group
 
-  startup-mode: ...   # optional: valid modes are "earliest-offset", "latest-offset",
-                      # "group-offsets", or "specific-offsets"
-  specific-offsets:   # optional: used in case of startup mode with specific offsets
-    - partition: 0
-      offset: 42
-    - partition: 1
-      offset: 300
-
+  startup-mode: ...                                               # optional: valid modes are "earliest-offset", "latest-offset",
+                                                                  # "group-offsets", or "specific-offsets"
+  specific-offsets: partition:0,offset:42;partition:1,offset:300  # optional: used in case of startup mode with specific offsets
+  
   sink-partitioner: ...    # optional: output partitioning from Flink's partitions into Kafka's partitions
                            # valid are "fixed" (each Flink partition ends up in at most one Kafka partition),
                            # "round-robin" (a Flink partition is distributed to Kafka partitions round-robin)
@@ -805,21 +794,15 @@ CREATE TABLE MyUserTable (
   'update-mode' = 'append',         -- required: update mode when used as table sink,
                                     -- only support append mode now.
 
-  'connector.properties.0.key' = 'zookeeper.connect', -- optional: connector specific properties
-  'connector.properties.0.value' = 'localhost:2181',
-  'connector.properties.1.key' = 'bootstrap.servers',
-  'connector.properties.1.value' = 'localhost:9092',
-  'connector.properties.2.key' = 'group.id',
-  'connector.properties.2.value' = 'testGroup',
+  'connector.properties.zookeeper.connect' = 'localhost:2181,localhost:2182', -- required: specifies the ZooKeeper connection string
+  'connector.properties.bootstrap.servers' = 'localhost:9092,localhost:9093', -- required: specifies the Kafka server connection string
+  'connector.properties.group.id' = 'testGroup', --optional: required in Kafka consumer, specifies consumer group
   'connector.startup-mode' = 'earliest-offset',    -- optional: valid modes are "earliest-offset",
                                                    -- "latest-offset", "group-offsets",
                                                    -- or "specific-offsets"
 
   -- optional: used in case of startup mode with specific offsets
-  'connector.specific-offsets.0.partition' = '0',
-  'connector.specific-offsets.0.offset' = '42',
-  'connector.specific-offsets.1.partition' = '1',
-  'connector.specific-offsets.1.offset' = '300',
+  'connector.specific-offsets' = 'partition:0,offset:42,partition:1,offset:300',
 
   'connector.sink-partitioner' = '...',  -- optional: output partitioning from Flink's partitions
                                          -- into Kafka's partitions valid are "fixed"
@@ -943,11 +926,8 @@ The connector can be defined as follows:
 {% highlight yaml %}
 connector:
   type: elasticsearch
-  version: 6                # required: valid connector versions are "6"
-    hosts:                  # required: one or more Elasticsearch hosts to connect to
-      - hostname: "localhost"
-        port: 9200
-        protocol: "http"
+  version: 6                                            # required: valid connector versions are "6"
+    hosts: http://host_name:9092;http://host_name:9093  # required: one or more Elasticsearch hosts to connect to
     index: "MyUsers"        # required: Elasticsearch index
     document-type: "user"   # required: Elasticsearch document type
 
@@ -989,9 +969,7 @@ CREATE TABLE MyUserTable (
 
   'connector.version' = '6',          -- required: valid connector versions are "6"
 
-  'connector.hosts.0.hostname' = 'host_name',  -- required: one or more Elasticsearch hosts to connect to
-  'connector.hosts.0.port' = '9092',
-  'connector.hosts.0.protocol' = 'http',
+  'connector.hosts' = 'http://host_name:9092;http://host_name:9093',  -- required: one or more Elasticsearch hosts to connect to
 
   'connector.index' = 'MyUsers',       -- required: Elasticsearch index
 

--- a/docs/dev/table/connect.zh.md
+++ b/docs/dev/table/connect.zh.md
@@ -247,8 +247,8 @@ tables:
       topic: test-input
       startup-mode: earliest-offset
       properties:
-        zookeeper.connect: localhost:2181,localhost:2182
-        bootstrap.servers: localhost:9092,localhost:9093
+        zookeeper.connect: localhost:2181
+        bootstrap.servers: localhost:9092
 
     # declare a format for this system
     format:
@@ -295,8 +295,8 @@ CREATE TABLE MyUserTable (
   'connector.version' = '0.10',
   'connector.topic' = 'topic_name',
   'connector.startup-mode' = 'earliest-offset',
-  'connector.properties.zookeeper.connect' = 'localhost:2181,localhost:2182',
-  'connector.properties.bootstrap.servers' = 'localhost:9092,localhost:9093',
+  'connector.properties.zookeeper.connect' = 'localhost:2181',
+  'connector.properties.bootstrap.servers' = 'localhost:9092',
   'update-mode' = 'append',
   -- declare a format for this system
   'format.type' = 'avro',
@@ -763,9 +763,9 @@ connector:
   topic: ...          # required: topic name from which the table is read
 
   properties:          
-    zookeeper.connect: localhost:2181,localhost:2182  # required: specify the ZooKeeper connection string
-    bootstrap.servers: localhost:9092,localhost:9093  # required: specify the Kafka server connection string
-    group.id: testGroup                               # optional: required in Kafka consumer, specify consumer group
+    zookeeper.connect: localhost:2181  # required: specify the ZooKeeper connection string
+    bootstrap.servers: localhost:9092  # required: specify the Kafka server connection string
+    group.id: testGroup                # optional: required in Kafka consumer, specify consumer group
 
   startup-mode: ...                                               # optional: valid modes are "earliest-offset", "latest-offset",
                                                                   # "group-offsets", or "specific-offsets"
@@ -794,8 +794,8 @@ CREATE TABLE MyUserTable (
   'update-mode' = 'append',         -- required: update mode when used as table sink,
                                     -- only support append mode now.
 
-  'connector.properties.zookeeper.connect' = 'localhost:2181,localhost:2182', -- required: specifies the ZooKeeper connection string
-  'connector.properties.bootstrap.servers' = 'localhost:9092,localhost:9093', -- required: specifies the Kafka server connection string
+  'connector.properties.zookeeper.connect' = 'localhost:2181', -- required: specifies the ZooKeeper connection string
+  'connector.properties.bootstrap.servers' = 'localhost:9092', -- required: specifies the Kafka server connection string
   'connector.properties.group.id' = 'testGroup', --optional: required in Kafka consumer, specifies consumer group
   'connector.startup-mode' = 'earliest-offset',    -- optional: valid modes are "earliest-offset",
                                                    -- "latest-offset", "group-offsets",

--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -318,12 +318,9 @@ tables:
       topic: TaxiRides
       startup-mode: earliest-offset
       properties:
-        - key: zookeeper.connect
-          value: localhost:2181
-        - key: bootstrap.servers
-          value: localhost:9092
-        - key: group.id
-          value: testGroup
+        zookeeper.connect: localhost:2181
+        bootstrap.servers: localhost:9092
+        group.id: testGroup
     format:
       property-version: 1
       type: json
@@ -488,12 +485,9 @@ tables:
       version: "0.11"
       topic: OutputTopic
       properties:
-        - key: zookeeper.connect
-          value: localhost:2181
-        - key: bootstrap.servers
-          value: localhost:9092
-        - key: group.id
-          value: testGroup
+        zookeeper.connect: localhost:2181
+        bootstrap.servers: localhost:9092
+        group.id: testGroup
     format:
       property-version: 1
       type: json

--- a/docs/dev/table/sqlClient.zh.md
+++ b/docs/dev/table/sqlClient.zh.md
@@ -318,12 +318,9 @@ tables:
       topic: TaxiRides
       startup-mode: earliest-offset
       properties:
-        - key: zookeeper.connect
-          value: localhost:2181
-        - key: bootstrap.servers
-          value: localhost:9092
-        - key: group.id
-          value: testGroup
+        zookeeper.connect: localhost:2181
+        bootstrap.servers: localhost:9092
+        group.id: testGroup
     format:
       property-version: 1
       type: json
@@ -488,12 +485,9 @@ tables:
       version: "0.11"
       topic: OutputTopic
       properties:
-        - key: zookeeper.connect
-          value: localhost:2181
-        - key: bootstrap.servers
-          value: localhost:9092
-        - key: group.id
-          value: testGroup
+        zookeeper.connect: localhost:2181
+        bootstrap.servers: localhost:9092
+        group.id: testGroup
     format:
       property-version: 1
       type: json

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkBase.java
@@ -368,6 +368,13 @@ public abstract class ElasticsearchUpsertTableSinkBase implements UpsertStreamTa
 				port,
 				protocol);
 		}
+
+		@Override
+		public String toString() {
+			return protocol + "://"
+					+ hostname + ":"
+					+ port;
+		}
 	}
 
 	/**

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkBase.java
@@ -372,8 +372,8 @@ public abstract class ElasticsearchUpsertTableSinkBase implements UpsertStreamTa
 		@Override
 		public String toString() {
 			return protocol + "://"
-					+ hostname + ":"
-					+ port;
+				+ hostname + ":"
+				+ port;
 		}
 	}
 

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkFactoryBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkFactoryBase.java
@@ -47,6 +47,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
@@ -78,7 +79,7 @@ import static org.apache.flink.table.descriptors.ElasticsearchValidator.CONNECTO
 import static org.apache.flink.table.descriptors.ElasticsearchValidator.CONNECTOR_KEY_DELIMITER;
 import static org.apache.flink.table.descriptors.ElasticsearchValidator.CONNECTOR_KEY_NULL_LITERAL;
 import static org.apache.flink.table.descriptors.ElasticsearchValidator.CONNECTOR_TYPE_VALUE_ELASTICSEARCH;
-import static org.apache.flink.table.descriptors.ElasticsearchValidator.validateAndGetHostsStr;
+import static org.apache.flink.table.descriptors.ElasticsearchValidator.validateAndParseHostsString;
 import static org.apache.flink.table.descriptors.FormatDescriptorValidator.FORMAT;
 import static org.apache.flink.table.descriptors.FormatDescriptorValidator.FORMAT_TYPE;
 import static org.apache.flink.table.descriptors.Schema.SCHEMA;
@@ -201,21 +202,19 @@ public abstract class ElasticsearchUpsertTableSinkFactoryBase implements StreamT
 	}
 
 	private List<Host> getHosts(DescriptorProperties descriptorProperties) {
-		final List<Host> hostList = new ArrayList<>();
 		if (descriptorProperties.containsKey(CONNECTOR_HOSTS)) {
-			return validateAndGetHostsStr(descriptorProperties);
+			return validateAndParseHostsString(descriptorProperties);
 		} else {
 			final List<Map<String, String>> hosts = descriptorProperties.getFixedIndexedProperties(
-					CONNECTOR_HOSTS,
-					Arrays.asList(CONNECTOR_HOSTS_HOSTNAME, CONNECTOR_HOSTS_PORT, CONNECTOR_HOSTS_PROTOCOL));
-			hosts.stream()
-					.forEach(host -> hostList.add(new Host(
-							descriptorProperties.getString(host.get(CONNECTOR_HOSTS_HOSTNAME)),
-							descriptorProperties.getInt(host.get(CONNECTOR_HOSTS_PORT)),
-							descriptorProperties.getString(host.get(CONNECTOR_HOSTS_PROTOCOL)))
-					));
+				CONNECTOR_HOSTS,
+				Arrays.asList(CONNECTOR_HOSTS_HOSTNAME, CONNECTOR_HOSTS_PORT, CONNECTOR_HOSTS_PROTOCOL));
+			return hosts.stream()
+				.map(host -> new Host(
+					descriptorProperties.getString(host.get(CONNECTOR_HOSTS_HOSTNAME)),
+					descriptorProperties.getInt(host.get(CONNECTOR_HOSTS_PORT)),
+					descriptorProperties.getString(host.get(CONNECTOR_HOSTS_PROTOCOL))))
+				.collect(Collectors.toList());
 		}
-		return hostList;
 	}
 
 	private SerializationSchema<Row> getSerializationSchema(Map<String, String> properties) {

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/table/descriptors/Elasticsearch.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/table/descriptors/Elasticsearch.java
@@ -25,7 +25,6 @@ import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchUpsertTa
 import org.apache.flink.util.Preconditions;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -44,9 +43,6 @@ import static org.apache.flink.table.descriptors.ElasticsearchValidator.CONNECTO
 import static org.apache.flink.table.descriptors.ElasticsearchValidator.CONNECTOR_FAILURE_HANDLER_CLASS;
 import static org.apache.flink.table.descriptors.ElasticsearchValidator.CONNECTOR_FLUSH_ON_CHECKPOINT;
 import static org.apache.flink.table.descriptors.ElasticsearchValidator.CONNECTOR_HOSTS;
-import static org.apache.flink.table.descriptors.ElasticsearchValidator.CONNECTOR_HOSTS_HOSTNAME;
-import static org.apache.flink.table.descriptors.ElasticsearchValidator.CONNECTOR_HOSTS_PORT;
-import static org.apache.flink.table.descriptors.ElasticsearchValidator.CONNECTOR_HOSTS_PROTOCOL;
 import static org.apache.flink.table.descriptors.ElasticsearchValidator.CONNECTOR_INDEX;
 import static org.apache.flink.table.descriptors.ElasticsearchValidator.CONNECTOR_KEY_DELIMITER;
 import static org.apache.flink.table.descriptors.ElasticsearchValidator.CONNECTOR_KEY_NULL_LITERAL;
@@ -308,13 +304,7 @@ public class Elasticsearch extends ConnectorDescriptor {
 		final DescriptorProperties properties = new DescriptorProperties();
 		properties.putProperties(internalProperties);
 
-		final List<List<String>> hostValues = hosts.stream()
-			.map(host -> Arrays.asList(host.hostname, String.valueOf(host.port), host.protocol))
-			.collect(Collectors.toList());
-		properties.putIndexedFixedProperties(
-			CONNECTOR_HOSTS,
-			Arrays.asList(CONNECTOR_HOSTS_HOSTNAME, CONNECTOR_HOSTS_PORT, CONNECTOR_HOSTS_PROTOCOL),
-			hostValues);
+		properties.putString(CONNECTOR_HOSTS, hosts.stream().map(Host::toString).collect(Collectors.joining(";")));
 
 		return properties.asMap();
 	}

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/table/descriptors/Elasticsearch.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/table/descriptors/Elasticsearch.java
@@ -304,12 +304,13 @@ public class Elasticsearch extends ConnectorDescriptor {
 		final DescriptorProperties properties = new DescriptorProperties();
 		properties.putProperties(internalProperties);
 
-		properties.putString(
-			CONNECTOR_HOSTS,
-			hosts.stream()
-				.map(Host::toString)
-				.collect(Collectors.joining(";")));
-
+		if (hosts.size() > 0) {
+			properties.putString(
+				CONNECTOR_HOSTS,
+				hosts.stream()
+					.map(Host::toString)
+					.collect(Collectors.joining(";")));
+		}
 		return properties.asMap();
 	}
 }

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/table/descriptors/Elasticsearch.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/table/descriptors/Elasticsearch.java
@@ -304,7 +304,11 @@ public class Elasticsearch extends ConnectorDescriptor {
 		final DescriptorProperties properties = new DescriptorProperties();
 		properties.putProperties(internalProperties);
 
-		properties.putString(CONNECTOR_HOSTS, hosts.stream().map(Host::toString).collect(Collectors.joining(";")));
+		properties.putString(
+			CONNECTOR_HOSTS,
+			hosts.stream()
+				.map(Host::toString)
+				.collect(Collectors.joining(";")));
 
 		return properties.asMap();
 	}

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/table/descriptors/ElasticsearchValidator.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/table/descriptors/ElasticsearchValidator.java
@@ -156,7 +156,7 @@ public class ElasticsearchValidator extends ConnectorDescriptorValidator {
 
 		final String[] hosts = hostsStr.split(";");
 		final String validationExceptionMessage = "Properties '" + CONNECTOR_HOSTS + "' format should " +
-			"follow the format 'http://host_name:port', but is '" + hosts + "'.";
+			"follow the format 'http://host_name:port', but is '" + hostsStr + "'.";
 
 		if (hosts.length == 0) {
 			throw new ValidationException(validationExceptionMessage);

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/table/descriptors/ElasticsearchValidator.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/table/descriptors/ElasticsearchValidator.java
@@ -158,7 +158,7 @@ public class ElasticsearchValidator extends ConnectorDescriptorValidator {
 		}
 
 		final String[] hosts = hostsStr.split(";");
-		for (String host: hosts) {
+		for (String host : hosts) {
 			try {
 				final URL url = new URL(host);
 				final String protocol = url.getProtocol();

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/table/descriptors/ElasticsearchValidator.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/table/descriptors/ElasticsearchValidator.java
@@ -19,9 +19,9 @@
 package org.apache.flink.table.descriptors;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchUpsertTableSinkBase;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchUpsertTableSinkBase.Host;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.util.StringUtils;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -155,18 +155,22 @@ public class ElasticsearchValidator extends ConnectorDescriptorValidator {
 		final String hostsStr = descriptorProperties.getString(CONNECTOR_HOSTS);
 
 		final String[] hosts = hostsStr.split(";");
+		final String validationExceptionMessage = "Properties '" + CONNECTOR_HOSTS + "' format should " +
+			"follow the format 'http://host_name:port', but is '" + hosts + "'.";
+
+		if (hosts.length == 0) {
+			throw new ValidationException(validationExceptionMessage);
+		}
 		for (String host : hosts) {
-			final String validationExceptionMessage = "Properties '" + CONNECTOR_HOSTS + "' format should " +
-					"follow the format 'http://host_name:port', but is '" + host + "'.";
 			try {
 				final URL url = new URL(host);
 				final String protocol = url.getProtocol();
 				final String hostName = url.getHost();
 				final int hostPort = url.getPort();
 
-				if (null == protocol || protocol.isEmpty()
-					|| null == hostName || hostName.isEmpty()
-					|| -1 == hostPort ) {
+				if (StringUtils.isNullOrWhitespaceOnly(protocol) ||
+					StringUtils.isNullOrWhitespaceOnly(hostName) ||
+					-1 == hostPort ) {
 					throw new ValidationException(validationExceptionMessage);
 				}
 

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/table/descriptors/ElasticsearchValidator.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/table/descriptors/ElasticsearchValidator.java
@@ -170,7 +170,7 @@ public class ElasticsearchValidator extends ConnectorDescriptorValidator {
 
 				if (StringUtils.isNullOrWhitespaceOnly(protocol) ||
 					StringUtils.isNullOrWhitespaceOnly(hostName) ||
-					-1 == hostPort ) {
+					-1 == hostPort) {
 					throw new ValidationException(validationExceptionMessage);
 				}
 

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/table/descriptors/ElasticsearchValidator.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/table/descriptors/ElasticsearchValidator.java
@@ -153,8 +153,8 @@ public class ElasticsearchValidator extends ConnectorDescriptorValidator {
 		final List<ElasticsearchUpsertTableSinkBase.Host> hostList = new ArrayList<>();
 
 		final String hostsStr = descriptorProperties.getString(CONNECTOR_HOSTS);
-		if (null == hostsStr || hostsStr.length() == 0) {
-			throw new ValidationException("Properties '" + CONNECTOR_HOSTS + "' can not be empty, but is:" + hostsStr);
+		if (hostsStr.isEmpty()) {
+			throw new ValidationException("Properties '" + CONNECTOR_HOSTS + "' can not be empty.");
 		}
 
 		final String[] hosts = hostsStr.split(";");
@@ -165,9 +165,9 @@ public class ElasticsearchValidator extends ConnectorDescriptorValidator {
 				final String hostNmae = url.getHost();
 				final int hostPort = url.getPort();
 				hostList.add(new ElasticsearchUpsertTableSinkBase.Host(hostNmae, hostPort, protocol));
-			}
-			catch (MalformedURLException e) {
-				throw new ValidationException("Host format '" + CONNECTOR_HOSTS + "' should keep: protocol://host:port, but is:" + host , e);
+			} catch (MalformedURLException e) {
+				throw new ValidationException("Properties '" + CONNECTOR_HOSTS + "' format should follow the " +
+						"format 'http://host_name:9092', but is:" + host , e);
 			}
 		}
 		return hostList;

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkFactoryTestBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkFactoryTestBase.java
@@ -83,38 +83,46 @@ public abstract class ElasticsearchUpsertTableSinkFactoryTestBase extends TestLo
 			createTestSinkOptions());
 
 		// construct table sink using descriptors and table sink factory
+		final Map<String, String> elasticSearchProperties = createElasticSearchProperties();
+		final TableSink<?> actualSink = TableFactoryService.find(StreamTableSinkFactory.class, elasticSearchProperties)
+			.createStreamTableSink(elasticSearchProperties);
 
-		final TestTableDescriptor testDesc = new TestTableDescriptor(
-				new Elasticsearch()
-					.version(getElasticsearchVersion())
-					.host(HOSTNAME, PORT, SCHEMA)
-					.index(INDEX)
-					.documentType(DOC_TYPE)
-					.keyDelimiter(KEY_DELIMITER)
-					.keyNullLiteral(KEY_NULL_LITERAL)
-					.bulkFlushBackoffExponential()
-					.bulkFlushBackoffDelay(123L)
-					.bulkFlushBackoffMaxRetries(3)
-					.bulkFlushInterval(100L)
-					.bulkFlushMaxActions(1000)
-					.bulkFlushMaxSize("1 MB")
-					.failureHandlerCustom(DummyFailureHandler.class)
-					.connectionMaxRetryTimeout(100)
-					.connectionPathPrefix("/myapp"))
-			.withFormat(
-				new Json()
-					.deriveSchema())
-			.withSchema(
-				new Schema()
-					.field(FIELD_KEY, DataTypes.BIGINT())
-					.field(FIELD_FRUIT_NAME, DataTypes.STRING())
-					.field(FIELD_COUNT, DataTypes.DECIMAL(10, 4))
-					.field(FIELD_TS, DataTypes.TIMESTAMP(3)))
-			.inUpsertMode();
+		assertEquals(expectedSink, actualSink);
+	}
 
-		final Map<String, String> propertiesMap = testDesc.toProperties();
-		final TableSink<?> actualSink = TableFactoryService.find(StreamTableSinkFactory.class, propertiesMap)
-			.createStreamTableSink(propertiesMap);
+	@Test
+	public void testTableSinkWithLegacyProperties(){
+		// prepare parameters for Elasticsearch table sink
+
+		final TableSchema schema = createTestSchema();
+
+		final ElasticsearchUpsertTableSinkBase expectedSink = getExpectedTableSink(
+				false,
+				schema,
+				Collections.singletonList(new Host(HOSTNAME, PORT, SCHEMA)),
+				INDEX,
+				DOC_TYPE,
+				KEY_DELIMITER,
+				KEY_NULL_LITERAL,
+				new JsonRowSerializationSchema(schema.toRowType()),
+				XContentType.JSON,
+				new DummyFailureHandler(),
+				createTestSinkOptions());
+
+		// construct table sink using descriptors and table sink factory
+		final Map<String, String> elasticSearchProperties = createElasticSearchProperties();
+
+		final Map<String, String> legacyPropertiesMap = new HashMap<>();
+		legacyPropertiesMap.putAll(elasticSearchProperties);
+		// use legacy properties
+		legacyPropertiesMap.remove("connector.hosts");
+
+		legacyPropertiesMap.put("connector.hosts.0.hostname", "host1");
+		legacyPropertiesMap.put("connector.hosts.0.port", "1234");
+		legacyPropertiesMap.put("connector.hosts.0.protocol", "https");
+
+		final TableSink<?> actualSink = TableFactoryService.find(StreamTableSinkFactory.class, legacyPropertiesMap)
+				.createStreamTableSink(legacyPropertiesMap);
 
 		assertEquals(expectedSink, actualSink);
 	}
@@ -140,6 +148,37 @@ public abstract class ElasticsearchUpsertTableSinkFactoryTestBase extends TestLo
 		sinkOptions.put(SinkOption.REST_MAX_RETRY_TIMEOUT, "100");
 		sinkOptions.put(SinkOption.REST_PATH_PREFIX, "/myapp");
 		return sinkOptions;
+	}
+
+	protected Map<String, String> createElasticSearchProperties() {
+		return new TestTableDescriptor(
+				new Elasticsearch()
+						.version(getElasticsearchVersion())
+						.host(HOSTNAME, PORT, SCHEMA)
+						.index(INDEX)
+						.documentType(DOC_TYPE)
+						.keyDelimiter(KEY_DELIMITER)
+						.keyNullLiteral(KEY_NULL_LITERAL)
+						.bulkFlushBackoffExponential()
+						.bulkFlushBackoffDelay(123L)
+						.bulkFlushBackoffMaxRetries(3)
+						.bulkFlushInterval(100L)
+						.bulkFlushMaxActions(1000)
+						.bulkFlushMaxSize("1 MB")
+						.failureHandlerCustom(DummyFailureHandler.class)
+						.connectionMaxRetryTimeout(100)
+						.connectionPathPrefix("/myapp"))
+				.withFormat(
+						new Json()
+								.deriveSchema())
+				.withSchema(
+						new Schema()
+								.field(FIELD_KEY, DataTypes.BIGINT())
+								.field(FIELD_FRUIT_NAME, DataTypes.STRING())
+								.field(FIELD_COUNT, DataTypes.DECIMAL(10, 4))
+								.field(FIELD_TS, DataTypes.TIMESTAMP(3)))
+				.inUpsertMode()
+				.toProperties();
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkFactoryTestBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkFactoryTestBase.java
@@ -91,23 +91,22 @@ public abstract class ElasticsearchUpsertTableSinkFactoryTestBase extends TestLo
 	}
 
 	@Test
-	public void testTableSinkWithLegacyProperties(){
+	public void testTableSinkWithLegacyProperties() {
 		// prepare parameters for Elasticsearch table sink
-
 		final TableSchema schema = createTestSchema();
 
 		final ElasticsearchUpsertTableSinkBase expectedSink = getExpectedTableSink(
-				false,
-				schema,
-				Collections.singletonList(new Host(HOSTNAME, PORT, SCHEMA)),
-				INDEX,
-				DOC_TYPE,
-				KEY_DELIMITER,
-				KEY_NULL_LITERAL,
-				new JsonRowSerializationSchema(schema.toRowType()),
-				XContentType.JSON,
-				new DummyFailureHandler(),
-				createTestSinkOptions());
+			false,
+			schema,
+			Collections.singletonList(new Host(HOSTNAME, PORT, SCHEMA)),
+			INDEX,
+			DOC_TYPE,
+			KEY_DELIMITER,
+			KEY_NULL_LITERAL,
+			new JsonRowSerializationSchema(schema.toRowType()),
+			XContentType.JSON,
+			new DummyFailureHandler(),
+			createTestSinkOptions());
 
 		// construct table sink using descriptors and table sink factory
 		final Map<String, String> elasticSearchProperties = createElasticSearchProperties();
@@ -122,7 +121,7 @@ public abstract class ElasticsearchUpsertTableSinkFactoryTestBase extends TestLo
 		legacyPropertiesMap.put("connector.hosts.0.protocol", "https");
 
 		final TableSink<?> actualSink = TableFactoryService.find(StreamTableSinkFactory.class, legacyPropertiesMap)
-				.createStreamTableSink(legacyPropertiesMap);
+			.createStreamTableSink(legacyPropertiesMap);
 
 		assertEquals(expectedSink, actualSink);
 	}
@@ -152,33 +151,33 @@ public abstract class ElasticsearchUpsertTableSinkFactoryTestBase extends TestLo
 
 	protected Map<String, String> createElasticSearchProperties() {
 		return new TestTableDescriptor(
-				new Elasticsearch()
-						.version(getElasticsearchVersion())
-						.host(HOSTNAME, PORT, SCHEMA)
-						.index(INDEX)
-						.documentType(DOC_TYPE)
-						.keyDelimiter(KEY_DELIMITER)
-						.keyNullLiteral(KEY_NULL_LITERAL)
-						.bulkFlushBackoffExponential()
-						.bulkFlushBackoffDelay(123L)
-						.bulkFlushBackoffMaxRetries(3)
-						.bulkFlushInterval(100L)
-						.bulkFlushMaxActions(1000)
-						.bulkFlushMaxSize("1 MB")
-						.failureHandlerCustom(DummyFailureHandler.class)
-						.connectionMaxRetryTimeout(100)
-						.connectionPathPrefix("/myapp"))
-				.withFormat(
-						new Json()
-								.deriveSchema())
-				.withSchema(
-						new Schema()
-								.field(FIELD_KEY, DataTypes.BIGINT())
-								.field(FIELD_FRUIT_NAME, DataTypes.STRING())
-								.field(FIELD_COUNT, DataTypes.DECIMAL(10, 4))
-								.field(FIELD_TS, DataTypes.TIMESTAMP(3)))
-				.inUpsertMode()
-				.toProperties();
+			new Elasticsearch()
+				.version(getElasticsearchVersion())
+				.host(HOSTNAME, PORT, SCHEMA)
+				.index(INDEX)
+				.documentType(DOC_TYPE)
+				.keyDelimiter(KEY_DELIMITER)
+				.keyNullLiteral(KEY_NULL_LITERAL)
+				.bulkFlushBackoffExponential()
+				.bulkFlushBackoffDelay(123L)
+				.bulkFlushBackoffMaxRetries(3)
+				.bulkFlushInterval(100L)
+				.bulkFlushMaxActions(1000)
+				.bulkFlushMaxSize("1 MB")
+				.failureHandlerCustom(DummyFailureHandler.class)
+				.connectionMaxRetryTimeout(100)
+				.connectionPathPrefix("/myapp"))
+			.withFormat(
+				new Json()
+					.deriveSchema())
+			.withSchema(
+				new Schema()
+					.field(FIELD_KEY, DataTypes.BIGINT())
+					.field(FIELD_FRUIT_NAME, DataTypes.STRING())
+					.field(FIELD_COUNT, DataTypes.DECIMAL(10, 4))
+					.field(FIELD_TS, DataTypes.TIMESTAMP(3)))
+			.inUpsertMode()
+			.toProperties();
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/table/descriptors/ElasticsearchTest.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/table/descriptors/ElasticsearchTest.java
@@ -94,9 +94,7 @@ public class ElasticsearchTest extends DescriptorTestBase {
 		minimumDesc.put("connector.property-version", "1");
 		minimumDesc.put("connector.type", "elasticsearch");
 		minimumDesc.put("connector.version", "6");
-		minimumDesc.put("connector.hosts.0.hostname", "localhost");
-		minimumDesc.put("connector.hosts.0.port", "1234");
-		minimumDesc.put("connector.hosts.0.protocol", "http");
+		minimumDesc.put("connector.hosts", "http://localhost:1234");
 		minimumDesc.put("connector.index", "MyIndex");
 		minimumDesc.put("connector.document-type", "MyType");
 
@@ -104,12 +102,7 @@ public class ElasticsearchTest extends DescriptorTestBase {
 		maximumDesc.put("connector.property-version", "1");
 		maximumDesc.put("connector.type", "elasticsearch");
 		maximumDesc.put("connector.version", "6");
-		maximumDesc.put("connector.hosts.0.hostname", "host1");
-		maximumDesc.put("connector.hosts.0.port", "1234");
-		maximumDesc.put("connector.hosts.0.protocol", "https");
-		maximumDesc.put("connector.hosts.1.hostname", "host2");
-		maximumDesc.put("connector.hosts.1.port", "1234");
-		maximumDesc.put("connector.hosts.1.protocol", "https");
+		maximumDesc.put("connector.hosts", "https://host1:1234;https://host2:1234");
 		maximumDesc.put("connector.index", "MyIndex");
 		maximumDesc.put("connector.document-type", "MyType");
 		maximumDesc.put("connector.key-delimiter", "#");
@@ -128,9 +121,7 @@ public class ElasticsearchTest extends DescriptorTestBase {
 		customDesc.put("connector.property-version", "1");
 		customDesc.put("connector.type", "elasticsearch");
 		customDesc.put("connector.version", "6");
-		customDesc.put("connector.hosts.0.hostname", "localhost");
-		customDesc.put("connector.hosts.0.port", "1234");
-		customDesc.put("connector.hosts.0.protocol", "http");
+		customDesc.put("connector.hosts", "http://localhost:1234");
 		customDesc.put("connector.index", "MyIndex");
 		customDesc.put("connector.document-type", "MyType");
 		customDesc.put("connector.flush-on-checkpoint", "false");

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/table/descriptors/ElasticsearchTest.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/table/descriptors/ElasticsearchTest.java
@@ -28,6 +28,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.table.descriptors.ElasticsearchValidator.CONNECTOR_HOSTS;
+
 /**
  * Tests for the {@link Elasticsearch} descriptor.
  */
@@ -48,10 +50,30 @@ public class ElasticsearchTest extends DescriptorTestBase {
 		addPropertyAndVerify(descriptors().get(1), "connector.bulk-flush.max-size", "12 bytes");
 	}
 
+	@Test(expected = ValidationException.class)
+	public void testInvalidProtocolInHosts() {
+		final DescriptorProperties descriptorProperties = new DescriptorProperties();
+		descriptorProperties.putString(CONNECTOR_HOSTS, "localhost:90");
+		ElasticsearchValidator.validateAndParseHostsString(descriptorProperties);
+	}
+
+	@Test(expected = ValidationException.class)
+	public void testInvalidHostNameInHosts() {
+		final DescriptorProperties descriptorProperties = new DescriptorProperties();
+		descriptorProperties.putString(CONNECTOR_HOSTS, "http://:90");
+		ElasticsearchValidator.validateAndParseHostsString(descriptorProperties);
+	}
+
+	@Test(expected = ValidationException.class)
+	public void testInvalidHostPortInHosts() {
+		final DescriptorProperties descriptorProperties = new DescriptorProperties();
+		descriptorProperties.putString(CONNECTOR_HOSTS, "http://localhost");
+		ElasticsearchValidator.validateAndParseHostsString(descriptorProperties);
+	}
+
 	@Override
 	public List<Descriptor> descriptors() {
-		final Descriptor minimumDesc =
-			new Elasticsearch()
+		final Descriptor minimumDesc = new Elasticsearch()
 				.version("6")
 				.host("localhost", 1234, "http")
 				.index("MyIndex")

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
@@ -282,15 +282,13 @@ public abstract class KafkaTableSourceSinkFactoryBase implements
 	private Properties getKafkaProperties(DescriptorProperties descriptorProperties) {
 		final Properties kafkaProperties = new Properties();
 
-		if (descriptorProperties.containsKey(CONNECTOR_PROPERTIES_ZOOKEEPER_CONNECT)
-				|| descriptorProperties.containsKey(CONNECTOR_PROPERTIES_BOOTSTRAP_SERVER)
-				|| descriptorProperties.containsKey(CONNECTOR_PROPERTIES_GROUP_ID)) {
+		if (hasConciseKafkaProperties(descriptorProperties)) {
 			descriptorProperties.asMap().keySet()
 					.stream()
 					.filter(key -> key.startsWith(CONNECTOR_PROPERTIES))
 					.forEach(key -> {
 						final String value = descriptorProperties.getString(key);
-						final String subKey = key.replaceFirst(CONNECTOR_PROPERTIES + '.', "");
+						final String subKey = key.substring((CONNECTOR_PROPERTIES + '.').length());
 						kafkaProperties.put(subKey, value);
 					});
 		} else {
@@ -303,6 +301,12 @@ public abstract class KafkaTableSourceSinkFactoryBase implements
 			));
 		}
 		return kafkaProperties;
+	}
+
+	private boolean hasConciseKafkaProperties(DescriptorProperties descriptorProperties) {
+		return descriptorProperties.containsKey(CONNECTOR_PROPERTIES_ZOOKEEPER_CONNECT) ||
+				descriptorProperties.containsKey(CONNECTOR_PROPERTIES_BOOTSTRAP_SERVER) ||
+				descriptorProperties.containsKey(CONNECTOR_PROPERTIES_GROUP_ID);
 	}
 
 	private StartupOptions getStartupOptions(

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
@@ -53,11 +53,8 @@ import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CO
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_VERSION;
 import static org.apache.flink.table.descriptors.FormatDescriptorValidator.FORMAT;
 import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_PROPERTIES;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_PROPERTIES_BOOTSTRAP_SERVER;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_PROPERTIES_GROUP_ID;
 import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_PROPERTIES_KEY;
 import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_PROPERTIES_VALUE;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_PROPERTIES_ZOOKEEPER_CONNECT;
 import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER;
 import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER_CLASS;
 import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER_VALUE_CUSTOM;

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
@@ -282,31 +282,25 @@ public abstract class KafkaTableSourceSinkFactoryBase implements
 	private Properties getKafkaProperties(DescriptorProperties descriptorProperties) {
 		final Properties kafkaProperties = new Properties();
 
-		if (hasConciseKafkaProperties(descriptorProperties)) {
+		if (KafkaValidator.hasConciseKafkaProperties(descriptorProperties)) {
 			descriptorProperties.asMap().keySet()
-					.stream()
-					.filter(key -> key.startsWith(CONNECTOR_PROPERTIES))
-					.forEach(key -> {
-						final String value = descriptorProperties.getString(key);
-						final String subKey = key.substring((CONNECTOR_PROPERTIES + '.').length());
-						kafkaProperties.put(subKey, value);
-					});
+				.stream()
+				.filter(key -> key.startsWith(CONNECTOR_PROPERTIES))
+				.forEach(key -> {
+					final String value = descriptorProperties.getString(key);
+					final String subKey = key.substring((CONNECTOR_PROPERTIES + '.').length());
+					kafkaProperties.put(subKey, value);
+				});
 		} else {
 			final List<Map<String, String>> propsList = descriptorProperties.getFixedIndexedProperties(
-					CONNECTOR_PROPERTIES,
-					Arrays.asList(CONNECTOR_PROPERTIES_KEY, CONNECTOR_PROPERTIES_VALUE));
+				CONNECTOR_PROPERTIES,
+				Arrays.asList(CONNECTOR_PROPERTIES_KEY, CONNECTOR_PROPERTIES_VALUE));
 			propsList.forEach(kv -> kafkaProperties.put(
-					descriptorProperties.getString(kv.get(CONNECTOR_PROPERTIES_KEY)),
-					descriptorProperties.getString(kv.get(CONNECTOR_PROPERTIES_VALUE))
+				descriptorProperties.getString(kv.get(CONNECTOR_PROPERTIES_KEY)),
+				descriptorProperties.getString(kv.get(CONNECTOR_PROPERTIES_VALUE))
 			));
 		}
 		return kafkaProperties;
-	}
-
-	private boolean hasConciseKafkaProperties(DescriptorProperties descriptorProperties) {
-		return descriptorProperties.containsKey(CONNECTOR_PROPERTIES_ZOOKEEPER_CONNECT) ||
-				descriptorProperties.containsKey(CONNECTOR_PROPERTIES_BOOTSTRAP_SERVER) ||
-				descriptorProperties.containsKey(CONNECTOR_PROPERTIES_GROUP_ID);
 	}
 
 	private StartupOptions getStartupOptions(
@@ -341,7 +335,7 @@ public abstract class KafkaTableSourceSinkFactoryBase implements
 
 	private void buildSpecificOffsets(DescriptorProperties descriptorProperties, String topic, Map<KafkaTopicPartition, Long> specificOffsets) {
 		if (descriptorProperties.containsKey(CONNECTOR_SPECIFIC_OFFSETS)) {
-			final Map<Integer, Long> offsetMap = KafkaValidator.validateAndGetSpecificOffsetsStr(descriptorProperties);
+			final Map<Integer, Long> offsetMap = KafkaValidator.validateAndParseSpecificOffsetsString(descriptorProperties);
 			offsetMap.forEach((partition, offset) -> {
 				final KafkaTopicPartition topicPartition = new KafkaTopicPartition(topic, partition);
 				specificOffsets.put(topicPartition, offset);

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/Kafka.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/Kafka.java
@@ -24,18 +24,12 @@ import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.util.Preconditions;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_VERSION;
 import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_PROPERTIES;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_PROPERTIES_KEY;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_PROPERTIES_VALUE;
 import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER;
 import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER_CLASS;
 import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SINK_PARTITIONER_VALUE_CUSTOM;
@@ -265,24 +259,24 @@ public class Kafka extends ConnectorDescriptor {
 		}
 
 		if (specificOffsets != null) {
-			final List<List<String>> values = new ArrayList<>();
+			final StringBuilder stringBuilder = new StringBuilder();
+			int i = 0;
 			for (Map.Entry<Integer, Long> specificOffset : specificOffsets.entrySet()) {
-				values.add(Arrays.asList(specificOffset.getKey().toString(), specificOffset.getValue().toString()));
+				if (i != 0) {
+					stringBuilder.append(';');
+				}
+				stringBuilder.append(CONNECTOR_SPECIFIC_OFFSETS_PARTITION).append(':').append(specificOffset.getKey()).append(',');
+				stringBuilder.append(CONNECTOR_SPECIFIC_OFFSETS_OFFSET).append(':').append(specificOffset.getValue());
+				i++;
 			}
-			properties.putIndexedFixedProperties(
-				CONNECTOR_SPECIFIC_OFFSETS,
-				Arrays.asList(CONNECTOR_SPECIFIC_OFFSETS_PARTITION, CONNECTOR_SPECIFIC_OFFSETS_OFFSET),
-				values);
+			properties.putString(CONNECTOR_SPECIFIC_OFFSETS, stringBuilder.toString());
 		}
 
 		if (kafkaProperties != null) {
-			properties.putIndexedFixedProperties(
-				CONNECTOR_PROPERTIES,
-				Arrays.asList(CONNECTOR_PROPERTIES_KEY, CONNECTOR_PROPERTIES_VALUE),
-				this.kafkaProperties.entrySet().stream()
-					.map(e -> Arrays.asList(e.getKey(), e.getValue()))
-					.collect(Collectors.toList())
-				);
+			this.kafkaProperties.entrySet()
+					.forEach(
+							entry -> properties.putString(CONNECTOR_PROPERTIES + '.' + entry.getKey(), entry.getValue())
+					);
 		}
 
 		if (sinkPartitionerType != null) {

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/Kafka.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/Kafka.java
@@ -273,10 +273,8 @@ public class Kafka extends ConnectorDescriptor {
 		}
 
 		if (kafkaProperties != null) {
-			this.kafkaProperties.entrySet()
-					.forEach(
-							entry -> properties.putString(CONNECTOR_PROPERTIES + '.' + entry.getKey(), entry.getValue())
-					);
+			this.kafkaProperties.entrySet().forEach(entry ->
+							properties.putString(CONNECTOR_PROPERTIES + '.' + entry.getKey(), entry.getValue()));
 		}
 
 		if (sinkPartitionerType != null) {

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/Kafka.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/Kafka.java
@@ -265,16 +265,21 @@ public class Kafka extends ConnectorDescriptor {
 				if (i != 0) {
 					stringBuilder.append(';');
 				}
-				stringBuilder.append(CONNECTOR_SPECIFIC_OFFSETS_PARTITION).append(':').append(specificOffset.getKey()).append(',');
-				stringBuilder.append(CONNECTOR_SPECIFIC_OFFSETS_OFFSET).append(':').append(specificOffset.getValue());
+				stringBuilder.append(CONNECTOR_SPECIFIC_OFFSETS_PARTITION)
+					.append(':')
+					.append(specificOffset.getKey())
+					.append(',')
+					.append(CONNECTOR_SPECIFIC_OFFSETS_OFFSET)
+					.append(':')
+					.append(specificOffset.getValue());
 				i++;
 			}
 			properties.putString(CONNECTOR_SPECIFIC_OFFSETS, stringBuilder.toString());
 		}
 
 		if (kafkaProperties != null) {
-			this.kafkaProperties.entrySet().forEach(entry ->
-							properties.putString(CONNECTOR_PROPERTIES + '.' + entry.getKey(), entry.getValue()));
+			this.kafkaProperties.forEach((key, value) ->
+				properties.putString(CONNECTOR_PROPERTIES + '.' + key, value));
 		}
 
 		if (sinkPartitionerType != null) {

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaValidator.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaValidator.java
@@ -78,19 +78,19 @@ public class KafkaValidator extends ConnectorDescriptorValidator {
 	private void validateStartupMode(DescriptorProperties properties) {
 		final Map<String, Consumer<String>> specificOffsetValidators = new HashMap<>();
 		specificOffsetValidators.put(
-				CONNECTOR_SPECIFIC_OFFSETS_PARTITION,
-				(key) -> properties.validateInt(
-						key,
-						false,
-						0,
-						Integer.MAX_VALUE));
+			CONNECTOR_SPECIFIC_OFFSETS_PARTITION,
+			(key) -> properties.validateInt(
+				key,
+				false,
+				0,
+				Integer.MAX_VALUE));
 		specificOffsetValidators.put(
-				CONNECTOR_SPECIFIC_OFFSETS_OFFSET,
-				(key) -> properties.validateLong(
-						key,
-						false,
-						0,
-						Long.MAX_VALUE));
+			CONNECTOR_SPECIFIC_OFFSETS_OFFSET,
+			(key) -> properties.validateLong(
+				key,
+				false,
+				0,
+				Long.MAX_VALUE));
 
 		final Map<String, Consumer<String>> startupModeValidation = new HashMap<>();
 		startupModeValidation.put(CONNECTOR_STARTUP_MODE_VALUE_GROUP_OFFSETS, noValidation());

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaValidator.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaValidator.java
@@ -163,30 +163,30 @@ public class KafkaValidator extends ConnectorDescriptorValidator {
 	 *     connector.specific-offsets = partition:0,offset:42;partition:1,offset:300
 	 * </pre>
 	 * @param descriptorProperties
-	 * @return
+	 * @return SpecificOffsets with map format, key is partition, and value is offset.
 	 */
 	public static Map<Integer, Long> validateAndGetSpecificOffsetsStr(DescriptorProperties descriptorProperties) {
 		final Map<Integer, Long> offsetMap = new HashMap<>();
 
 		final String parseSpecificOffsetsStr = descriptorProperties.getString(CONNECTOR_SPECIFIC_OFFSETS);
-		if (null == parseSpecificOffsetsStr || parseSpecificOffsetsStr.length() == 0) {
+		if (parseSpecificOffsetsStr.isEmpty()) {
 			throw new ValidationException("Properties connector.specific-offsets can not be empty, but is:" + parseSpecificOffsetsStr);
 		}
 
 		final String[] pairs = parseSpecificOffsetsStr.split(";");
-		for (String pair: pairs) {
+		final String validationExceptionMessage = "Invalid properties '" + CONNECTOR_SPECIFIC_OFFSETS +
+				"' should in the format 'partition:0,offset:42;partition:1,offset:300', " +
+				"but is '" + parseSpecificOffsetsStr + "'.";
+		for (String pair : pairs) {
 			if (null == pair || pair.length() == 0 || !pair.contains(",")) {
-				throw new ValidationException("Invalid properties '" + CONNECTOR_SPECIFIC_OFFSETS + "'" +
-						"should in the format 'partition:0,offset:42;partition:1,offset:300', " +
-						"but is '" + parseSpecificOffsetsStr + "'.");			}
+				throw new ValidationException(validationExceptionMessage);
+			}
 
 			final String[] kv = pair.split(",");
 			if (kv.length != 2 ||
 					!kv[0].startsWith(CONNECTOR_SPECIFIC_OFFSETS_PARTITION + ':') ||
 					!kv[1].startsWith(CONNECTOR_SPECIFIC_OFFSETS_OFFSET + ':')) {
-				throw new ValidationException("Invalid properties '" + CONNECTOR_SPECIFIC_OFFSETS + "'" +
-						"should in the format 'partition:0,offset:42;partition:1,offset:300', " +
-						"but is '" + parseSpecificOffsetsStr + "'.");
+				throw new ValidationException(validationExceptionMessage);
 			}
 
 			String partitionValue = kv[0].substring(kv[0].indexOf(":") + 1);
@@ -197,9 +197,7 @@ public class KafkaValidator extends ConnectorDescriptorValidator {
 				offsetMap.put(parttion, offset);
 			}
 			catch (NumberFormatException e) {
-				throw new ValidationException("Invalid properties '" + CONNECTOR_SPECIFIC_OFFSETS + "'" +
-						"should in the format 'partition:0,offset:42;partition:1,offset:300', " +
-						"but is '" + parseSpecificOffsetsStr + "'.", e);
+				throw new ValidationException(validationExceptionMessage, e);
 			}
 		}
 		return offsetMap;

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaValidator.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaValidator.java
@@ -170,12 +170,12 @@ public class KafkaValidator extends ConnectorDescriptorValidator {
 
 		final String parseSpecificOffsetsStr = descriptorProperties.getString(CONNECTOR_SPECIFIC_OFFSETS);
 		if (parseSpecificOffsetsStr.isEmpty()) {
-			throw new ValidationException("Properties connector.specific-offsets can not be empty, but is:" + parseSpecificOffsetsStr);
+			throw new ValidationException("Properties '" + CONNECTOR_SPECIFIC_OFFSETS + "' can not be empty.");
 		}
 
 		final String[] pairs = parseSpecificOffsetsStr.split(";");
 		final String validationExceptionMessage = "Invalid properties '" + CONNECTOR_SPECIFIC_OFFSETS +
-				"' should in the format 'partition:0,offset:42;partition:1,offset:300', " +
+				"' should follow the format 'partition:0,offset:42;partition:1,offset:300', " +
 				"but is '" + parseSpecificOffsetsStr + "'.";
 		for (String pair : pairs) {
 			if (null == pair || pair.length() == 0 || !pair.contains(",")) {
@@ -195,8 +195,7 @@ public class KafkaValidator extends ConnectorDescriptorValidator {
 				final Integer parttion = Integer.valueOf(partitionValue);
 				final Long offset = Long.valueOf(offsetValue);
 				offsetMap.put(parttion, offset);
-			}
-			catch (NumberFormatException e) {
+			} catch (NumberFormatException e) {
 				throw new ValidationException(validationExceptionMessage, e);
 			}
 		}

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaValidator.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaValidator.java
@@ -175,6 +175,11 @@ public class KafkaValidator extends ConnectorDescriptorValidator {
 		final String validationExceptionMessage = "Invalid properties '" + CONNECTOR_SPECIFIC_OFFSETS +
 			"' should follow the format 'partition:0,offset:42;partition:1,offset:300', " +
 			"but is '" + parseSpecificOffsetsStr + "'.";
+
+		if (pairs.length == 0) {
+			throw new ValidationException(validationExceptionMessage);
+		}
+
 		for (String pair : pairs) {
 			if (null == pair || pair.length() == 0 || !pair.contains(",")) {
 				throw new ValidationException(validationExceptionMessage);

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
@@ -146,25 +146,7 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 		TableSourceValidation.validateTableSource(expected);
 
 		// construct table source using descriptors and table source factory
-
-		final TestTableDescriptor testDesc = new TestTableDescriptor(
-				new Kafka()
-					.version(getKafkaVersion())
-					.topic(TOPIC)
-					.properties(KAFKA_PROPERTIES)
-					.sinkPartitionerRoundRobin() // test if accepted although not needed
-					.startFromSpecificOffsets(OFFSETS))
-			.withFormat(new TestTableFormat())
-			.withSchema(
-				new Schema()
-					.field(FRUIT_NAME, DataTypes.STRING()).from(NAME)
-					.field(COUNT, DataTypes.DECIMAL(10, 3)) // no from so it must match with the input
-					.field(EVENT_TIME, DataTypes.TIMESTAMP(3)).rowtime(
-						new Rowtime().timestampsFromField(TIME).watermarksPeriodicAscending())
-					.field(PROC_TIME, DataTypes.TIMESTAMP(3)).proctime())
-			.inAppendMode();
-
-		final Map<String, String> propertiesMap = testDesc.toProperties();
+		final Map<String, String> propertiesMap = createKafkaSourceProperties();
 		final TableSource<?> actualSource = TableFactoryService.find(StreamTableSourceFactory.class, propertiesMap)
 			.createStreamTableSource(propertiesMap);
 
@@ -176,6 +158,108 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 		actualKafkaSource.getDataStream(mock);
 		assertTrue(getExpectedFlinkKafkaConsumer().isAssignableFrom(mock.sourceFunction.getClass()));
 	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testTableSourceWithLegacyProperties() {
+
+		// prepare parameters for Kafka table source
+
+		final TableSchema schema = TableSchema.builder()
+				.field(FRUIT_NAME, DataTypes.STRING())
+				.field(COUNT, DataTypes.DECIMAL(10, 3))
+				.field(EVENT_TIME, DataTypes.TIMESTAMP(3))
+				.field(PROC_TIME, DataTypes.TIMESTAMP(3))
+				.build();
+
+		final List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors = Collections.singletonList(
+				new RowtimeAttributeDescriptor(EVENT_TIME, new ExistingField(TIME), new AscendingTimestamps()));
+
+		final Map<String, String> fieldMapping = new HashMap<>();
+		fieldMapping.put(FRUIT_NAME, NAME);
+		fieldMapping.put(NAME, NAME);
+		fieldMapping.put(COUNT, COUNT);
+		fieldMapping.put(TIME, TIME);
+
+		final Map<KafkaTopicPartition, Long> specificOffsets = new HashMap<>();
+		specificOffsets.put(new KafkaTopicPartition(TOPIC, PARTITION_0), OFFSET_0);
+		specificOffsets.put(new KafkaTopicPartition(TOPIC, PARTITION_1), OFFSET_1);
+
+		final TestDeserializationSchema deserializationSchema = new TestDeserializationSchema(
+				TableSchema.builder()
+						.field(NAME, DataTypes.STRING())
+						.field(COUNT, DataTypes.DECIMAL(10, 3))
+						.field(TIME, DataTypes.TIMESTAMP(3))
+						.build()
+						.toRowType()
+		);
+
+		final KafkaTableSourceBase expected = getExpectedKafkaTableSource(
+				schema,
+				Optional.of(PROC_TIME),
+				rowtimeAttributeDescriptors,
+				fieldMapping,
+				TOPIC,
+				KAFKA_PROPERTIES,
+				deserializationSchema,
+				StartupMode.SPECIFIC_OFFSETS,
+				specificOffsets);
+
+		TableSourceValidation.validateTableSource(expected);
+
+		// construct table source using descriptors and table source factory
+		final Map<String, String> legacyPropertiesMap = new HashMap<>();
+		legacyPropertiesMap.putAll(createKafkaSourceProperties());
+
+		// use legacy properties
+		legacyPropertiesMap.remove("connector.specific-offsets");
+		legacyPropertiesMap.remove("connector.properties.zookeeper.connect");
+		legacyPropertiesMap.remove("connector.properties.bootstrap.servers");
+		legacyPropertiesMap.remove("connector.properties.group.id");
+
+		legacyPropertiesMap.put("connector.specific-offsets.0.partition", "0");
+		legacyPropertiesMap.put("connector.specific-offsets.0.offset", "100");
+		legacyPropertiesMap.put("connector.specific-offsets.1.partition", "1");
+		legacyPropertiesMap.put("connector.specific-offsets.1.offset", "123");
+		legacyPropertiesMap.put("connector.properties.0.key", "zookeeper.connect");
+		legacyPropertiesMap.put("connector.properties.0.value", "dummy");
+		legacyPropertiesMap.put("connector.properties.1.key", "bootstrap.servers");
+		legacyPropertiesMap.put("connector.properties.1.value", "dummy");
+		legacyPropertiesMap.put("connector.properties.2.key", "group.id");
+		legacyPropertiesMap.put("connector.properties.2.value", "dummy");
+
+		final TableSource<?> actualSource = TableFactoryService.find(StreamTableSourceFactory.class, legacyPropertiesMap)
+				.createStreamTableSource(legacyPropertiesMap);
+
+		assertEquals(expected, actualSource);
+
+		// test Kafka consumer
+		final KafkaTableSourceBase actualKafkaSource = (KafkaTableSourceBase) actualSource;
+		final StreamExecutionEnvironmentMock mock = new StreamExecutionEnvironmentMock();
+		actualKafkaSource.getDataStream(mock);
+		assertTrue(getExpectedFlinkKafkaConsumer().isAssignableFrom(mock.sourceFunction.getClass()));
+	}
+
+	protected Map<String, String> createKafkaSourceProperties() {
+		return new TestTableDescriptor(
+				new Kafka()
+						.version(getKafkaVersion())
+						.topic(TOPIC)
+						.properties(KAFKA_PROPERTIES)
+						.sinkPartitionerRoundRobin() // test if accepted although not needed
+						.startFromSpecificOffsets(OFFSETS))
+				.withFormat(new TestTableFormat())
+				.withSchema(
+						new Schema()
+								.field(FRUIT_NAME, DataTypes.STRING()).from(NAME)
+								.field(COUNT, DataTypes.DECIMAL(10, 3)) // no from so it must match with the input
+								.field(EVENT_TIME, DataTypes.TIMESTAMP(3)).rowtime(
+								new Rowtime().timestampsFromField(TIME).watermarksPeriodicAscending())
+								.field(PROC_TIME, DataTypes.TIMESTAMP(3)).proctime())
+				.inAppendMode()
+				.toProperties();
+	}
+
 
 	/**
 	 * This test can be unified with the corresponding source test once we have fixed FLINK-9870.
@@ -198,23 +282,7 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 			new TestSerializationSchema(schema.toRowType()));
 
 		// construct table sink using descriptors and table sink factory
-
-		final TestTableDescriptor testDesc = new TestTableDescriptor(
-				new Kafka()
-					.version(getKafkaVersion())
-					.topic(TOPIC)
-					.properties(KAFKA_PROPERTIES)
-					.sinkPartitionerFixed()
-					.startFromSpecificOffsets(OFFSETS)) // test if they accepted although not needed
-			.withFormat(new TestTableFormat())
-			.withSchema(
-				new Schema()
-					.field(FRUIT_NAME, DataTypes.STRING())
-					.field(COUNT, DataTypes.DECIMAL(10, 4))
-					.field(EVENT_TIME, DataTypes.TIMESTAMP(3)))
-			.inAppendMode();
-
-		final Map<String, String> propertiesMap = testDesc.toProperties();
+		final Map<String, String> propertiesMap = createKafkaSinkProperties();
 		final TableSink<?> actualSink = TableFactoryService.find(StreamTableSinkFactory.class, propertiesMap)
 			.createStreamTableSink(propertiesMap);
 
@@ -225,6 +293,74 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 		final DataStreamMock streamMock = new DataStreamMock(new StreamExecutionEnvironmentMock(), schema.toRowType());
 		actualKafkaSink.emitDataStream(streamMock);
 		assertTrue(getExpectedFlinkKafkaProducer().isAssignableFrom(streamMock.sinkFunction.getClass()));
+	}
+
+	@Test
+	public void testTableSinkWithLegacyProperties() {
+		// prepare parameters for Kafka table sink
+
+		final TableSchema schema = TableSchema.builder()
+				.field(FRUIT_NAME, DataTypes.STRING())
+				.field(COUNT, DataTypes.DECIMAL(10, 4))
+				.field(EVENT_TIME, DataTypes.TIMESTAMP(3))
+				.build();
+
+		final KafkaTableSinkBase expected = getExpectedKafkaTableSink(
+				schema,
+				TOPIC,
+				KAFKA_PROPERTIES,
+				Optional.of(new FlinkFixedPartitioner<>()),
+				new TestSerializationSchema(schema.toRowType()));
+
+		// construct table sink using descriptors and table sink factory
+		final Map<String, String> legacyPropertiesMap = new HashMap<>();
+		legacyPropertiesMap.putAll(createKafkaSinkProperties());
+
+		// use legacy properties
+		legacyPropertiesMap.remove("connector.specific-offsets");
+		legacyPropertiesMap.remove("connector.properties.zookeeper.connect");
+		legacyPropertiesMap.remove("connector.properties.bootstrap.servers");
+		legacyPropertiesMap.remove("connector.properties.group.id");
+
+		legacyPropertiesMap.put("connector.specific-offsets.0.partition", "0");
+		legacyPropertiesMap.put("connector.specific-offsets.0.offset", "100");
+		legacyPropertiesMap.put("connector.specific-offsets.1.partition", "1");
+		legacyPropertiesMap.put("connector.specific-offsets.1.offset", "123");
+		legacyPropertiesMap.put("connector.properties.0.key", "zookeeper.connect");
+		legacyPropertiesMap.put("connector.properties.0.value", "dummy");
+		legacyPropertiesMap.put("connector.properties.1.key", "bootstrap.servers");
+		legacyPropertiesMap.put("connector.properties.1.value", "dummy");
+		legacyPropertiesMap.put("connector.properties.2.key", "group.id");
+		legacyPropertiesMap.put("connector.properties.2.value", "dummy");
+
+		final TableSink<?> actualSink = TableFactoryService.find(StreamTableSinkFactory.class, legacyPropertiesMap)
+				.createStreamTableSink(legacyPropertiesMap);
+
+		assertEquals(expected, actualSink);
+
+		// test Kafka producer
+		final KafkaTableSinkBase actualKafkaSink = (KafkaTableSinkBase) actualSink;
+		final DataStreamMock streamMock = new DataStreamMock(new StreamExecutionEnvironmentMock(), schema.toRowType());
+		actualKafkaSink.emitDataStream(streamMock);
+		assertTrue(getExpectedFlinkKafkaProducer().isAssignableFrom(streamMock.sinkFunction.getClass()));
+	}
+
+	protected Map<String, String> createKafkaSinkProperties() {
+		return new TestTableDescriptor(
+				new Kafka()
+						.version(getKafkaVersion())
+						.topic(TOPIC)
+						.properties(KAFKA_PROPERTIES)
+						.sinkPartitionerFixed()
+						.startFromSpecificOffsets(OFFSETS)) // test if they accepted although not needed
+				.withFormat(new TestTableFormat())
+				.withSchema(
+						new Schema()
+								.field(FRUIT_NAME, DataTypes.STRING())
+								.field(COUNT, DataTypes.DECIMAL(10, 4))
+								.field(EVENT_TIME, DataTypes.TIMESTAMP(3)))
+				.inAppendMode()
+				.toProperties();
 	}
 
 	private static class StreamExecutionEnvironmentMock extends StreamExecutionEnvironment {

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
@@ -162,14 +162,14 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 	public void testTableSourceWithLegacyProperties() {
 		// prepare parameters for Kafka table source
 		final TableSchema schema = TableSchema.builder()
-				.field(FRUIT_NAME, DataTypes.STRING())
-				.field(COUNT, DataTypes.DECIMAL(10, 3))
-				.field(EVENT_TIME, DataTypes.TIMESTAMP(3))
-				.field(PROC_TIME, DataTypes.TIMESTAMP(3))
-				.build();
+			.field(FRUIT_NAME, DataTypes.STRING())
+			.field(COUNT, DataTypes.DECIMAL(10, 3))
+			.field(EVENT_TIME, DataTypes.TIMESTAMP(3))
+			.field(PROC_TIME, DataTypes.TIMESTAMP(3))
+			.build();
 
 		final List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors = Collections.singletonList(
-				new RowtimeAttributeDescriptor(EVENT_TIME, new ExistingField(TIME), new AscendingTimestamps()));
+			new RowtimeAttributeDescriptor(EVENT_TIME, new ExistingField(TIME), new AscendingTimestamps()));
 
 		final Map<String, String> fieldMapping = new HashMap<>();
 		fieldMapping.put(FRUIT_NAME, NAME);
@@ -182,24 +182,24 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 		specificOffsets.put(new KafkaTopicPartition(TOPIC, PARTITION_1), OFFSET_1);
 
 		final TestDeserializationSchema deserializationSchema = new TestDeserializationSchema(
-				TableSchema.builder()
-						.field(NAME, DataTypes.STRING())
-						.field(COUNT, DataTypes.DECIMAL(10, 3))
-						.field(TIME, DataTypes.TIMESTAMP(3))
-						.build()
-						.toRowType()
+			TableSchema.builder()
+				.field(NAME, DataTypes.STRING())
+				.field(COUNT, DataTypes.DECIMAL(10, 3))
+				.field(TIME, DataTypes.TIMESTAMP(3))
+				.build()
+				.toRowType()
 		);
 
 		final KafkaTableSourceBase expected = getExpectedKafkaTableSource(
-				schema,
-				Optional.of(PROC_TIME),
-				rowtimeAttributeDescriptors,
-				fieldMapping,
-				TOPIC,
-				KAFKA_PROPERTIES,
-				deserializationSchema,
-				StartupMode.SPECIFIC_OFFSETS,
-				specificOffsets);
+			schema,
+			Optional.of(PROC_TIME),
+			rowtimeAttributeDescriptors,
+			fieldMapping,
+			TOPIC,
+			KAFKA_PROPERTIES,
+			deserializationSchema,
+			StartupMode.SPECIFIC_OFFSETS,
+			specificOffsets);
 
 		TableSourceValidation.validateTableSource(expected);
 
@@ -225,7 +225,7 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 		legacyPropertiesMap.put("connector.properties.2.value", "dummy");
 
 		final TableSource<?> actualSource = TableFactoryService.find(StreamTableSourceFactory.class, legacyPropertiesMap)
-				.createStreamTableSource(legacyPropertiesMap);
+			.createStreamTableSource(legacyPropertiesMap);
 
 		assertEquals(expected, actualSource);
 
@@ -239,19 +239,19 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 	protected Map<String, String> createKafkaSourceProperties() {
 		return new TestTableDescriptor(
 				new Kafka()
-						.version(getKafkaVersion())
-						.topic(TOPIC)
-						.properties(KAFKA_PROPERTIES)
-						.sinkPartitionerRoundRobin() // test if accepted although not needed
-						.startFromSpecificOffsets(OFFSETS))
+					.version(getKafkaVersion())
+					.topic(TOPIC)
+					.properties(KAFKA_PROPERTIES)
+					.sinkPartitionerRoundRobin() // test if accepted although not needed
+					.startFromSpecificOffsets(OFFSETS))
 				.withFormat(new TestTableFormat())
 				.withSchema(
-						new Schema()
-								.field(FRUIT_NAME, DataTypes.STRING()).from(NAME)
-								.field(COUNT, DataTypes.DECIMAL(10, 3)) // no from so it must match with the input
-								.field(EVENT_TIME, DataTypes.TIMESTAMP(3)).rowtime(
-								new Rowtime().timestampsFromField(TIME).watermarksPeriodicAscending())
-								.field(PROC_TIME, DataTypes.TIMESTAMP(3)).proctime())
+					new Schema()
+						.field(FRUIT_NAME, DataTypes.STRING()).from(NAME)
+						.field(COUNT, DataTypes.DECIMAL(10, 3)) // no from so it must match with the input
+						.field(EVENT_TIME, DataTypes.TIMESTAMP(3)).rowtime(
+							new Rowtime().timestampsFromField(TIME).watermarksPeriodicAscending())
+							.field(PROC_TIME, DataTypes.TIMESTAMP(3)).proctime())
 				.inAppendMode()
 				.toProperties();
 	}
@@ -294,17 +294,17 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 	public void testTableSinkWithLegacyProperties() {
 		// prepare parameters for Kafka table sink
 		final TableSchema schema = TableSchema.builder()
-				.field(FRUIT_NAME, DataTypes.STRING())
-				.field(COUNT, DataTypes.DECIMAL(10, 4))
-				.field(EVENT_TIME, DataTypes.TIMESTAMP(3))
-				.build();
+			.field(FRUIT_NAME, DataTypes.STRING())
+			.field(COUNT, DataTypes.DECIMAL(10, 4))
+			.field(EVENT_TIME, DataTypes.TIMESTAMP(3))
+			.build();
 
 		final KafkaTableSinkBase expected = getExpectedKafkaTableSink(
-				schema,
-				TOPIC,
-				KAFKA_PROPERTIES,
-				Optional.of(new FlinkFixedPartitioner<>()),
-				new TestSerializationSchema(schema.toRowType()));
+			schema,
+			TOPIC,
+			KAFKA_PROPERTIES,
+			Optional.of(new FlinkFixedPartitioner<>()),
+			new TestSerializationSchema(schema.toRowType()));
 
 		// construct table sink using descriptors and table sink factory
 		final Map<String, String> legacyPropertiesMap = new HashMap<>();
@@ -328,7 +328,7 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 		legacyPropertiesMap.put("connector.properties.2.value", "dummy");
 
 		final TableSink<?> actualSink = TableFactoryService.find(StreamTableSinkFactory.class, legacyPropertiesMap)
-				.createStreamTableSink(legacyPropertiesMap);
+			.createStreamTableSink(legacyPropertiesMap);
 
 		assertEquals(expected, actualSink);
 
@@ -341,20 +341,20 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 
 	protected Map<String, String> createKafkaSinkProperties() {
 		return new TestTableDescriptor(
-				new Kafka()
-						.version(getKafkaVersion())
-						.topic(TOPIC)
-						.properties(KAFKA_PROPERTIES)
-						.sinkPartitionerFixed()
-						.startFromSpecificOffsets(OFFSETS)) // test if they accepted although not needed
-				.withFormat(new TestTableFormat())
-				.withSchema(
-						new Schema()
-								.field(FRUIT_NAME, DataTypes.STRING())
-								.field(COUNT, DataTypes.DECIMAL(10, 4))
-								.field(EVENT_TIME, DataTypes.TIMESTAMP(3)))
-				.inAppendMode()
-				.toProperties();
+			new Kafka()
+				.version(getKafkaVersion())
+				.topic(TOPIC)
+				.properties(KAFKA_PROPERTIES)
+				.sinkPartitionerFixed()
+				.startFromSpecificOffsets(OFFSETS)) // test if they accepted although not needed
+			.withFormat(new TestTableFormat())
+			.withSchema(
+				new Schema()
+					.field(FRUIT_NAME, DataTypes.STRING())
+					.field(COUNT, DataTypes.DECIMAL(10, 4))
+					.field(EVENT_TIME, DataTypes.TIMESTAMP(3)))
+			.inAppendMode()
+			.toProperties();
 	}
 
 	private static class StreamExecutionEnvironmentMock extends StreamExecutionEnvironment {

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
@@ -100,9 +100,7 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testTableSource() {
-
 		// prepare parameters for Kafka table source
-
 		final TableSchema schema = TableSchema.builder()
 			.field(FRUIT_NAME, DataTypes.STRING())
 			.field(COUNT, DataTypes.DECIMAL(10, 3))
@@ -162,9 +160,7 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testTableSourceWithLegacyProperties() {
-
 		// prepare parameters for Kafka table source
-
 		final TableSchema schema = TableSchema.builder()
 				.field(FRUIT_NAME, DataTypes.STRING())
 				.field(COUNT, DataTypes.DECIMAL(10, 3))
@@ -267,7 +263,6 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 	@Test
 	public void testTableSink() {
 		// prepare parameters for Kafka table sink
-
 		final TableSchema schema = TableSchema.builder()
 			.field(FRUIT_NAME, DataTypes.STRING())
 			.field(COUNT, DataTypes.DECIMAL(10, 4))
@@ -298,7 +293,6 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 	@Test
 	public void testTableSinkWithLegacyProperties() {
 		// prepare parameters for Kafka table sink
-
 		final TableSchema schema = TableSchema.builder()
 				.field(FRUIT_NAME, DataTypes.STRING())
 				.field(COUNT, DataTypes.DECIMAL(10, 4))

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/table/descriptors/KafkaTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/table/descriptors/KafkaTest.java
@@ -82,14 +82,9 @@ public class KafkaTest extends DescriptorTestBase {
 		props2.put("connector.version", "0.11");
 		props2.put("connector.topic", "MyTable");
 		props2.put("connector.startup-mode", "specific-offsets");
-		props2.put("connector.specific-offsets.0.partition", "0");
-		props2.put("connector.specific-offsets.0.offset", "42");
-		props2.put("connector.specific-offsets.1.partition", "1");
-		props2.put("connector.specific-offsets.1.offset", "300");
-		props2.put("connector.properties.0.key", "zookeeper.stuff");
-		props2.put("connector.properties.0.value", "12");
-		props2.put("connector.properties.1.key", "kafka.stuff");
-		props2.put("connector.properties.1.value", "42");
+		props2.put("connector.specific-offsets", "partition:0,offset:42;partition:1,offset:300");
+		props2.put("connector.properties.zookeeper.stuff", "12");
+		props2.put("connector.properties.kafka.stuff", "42");
 
 		final Map<String, String> props3 = new HashMap<>();
 		props3.put("connector.property-version", "1");
@@ -97,14 +92,9 @@ public class KafkaTest extends DescriptorTestBase {
 		props3.put("connector.version", "0.11");
 		props3.put("connector.topic", "MyTable");
 		props3.put("connector.startup-mode", "specific-offsets");
-		props3.put("connector.specific-offsets.0.partition", "0");
-		props3.put("connector.specific-offsets.0.offset", "42");
-		props3.put("connector.specific-offsets.1.partition", "1");
-		props3.put("connector.specific-offsets.1.offset", "300");
-		props3.put("connector.properties.0.key", "zookeeper.stuff");
-		props3.put("connector.properties.0.value", "12");
-		props3.put("connector.properties.1.key", "kafka.stuff");
-		props3.put("connector.properties.1.value", "42");
+		props3.put("connector.specific-offsets", "partition:0,offset:42;partition:1,offset:300");
+		props3.put("connector.properties.zookeeper.stuff", "12");
+		props3.put("connector.properties.kafka.stuff", "42");
 		props3.put("connector.sink-partitioner", "custom");
 		props3.put("connector.sink-partitioner-class", FlinkFixedPartitioner.class.getName());
 

--- a/flink-end-to-end-tests/test-scripts/kafka_sql_common.sh
+++ b/flink-end-to-end-tests/test-scripts/kafka_sql_common.sh
@@ -68,10 +68,8 @@ function get_kafka_json_source_schema {
       topic: $topicName
       startup-mode: earliest-offset
       properties:
-        - key: zookeeper.connect
-          value: localhost:2181
-        - key: bootstrap.servers
-          value: localhost:9092
+        zookeeper.connect: localhost:2181
+        bootstrap.servers: localhost:9092
     format:
       type: json
       json-schema: >

--- a/flink-end-to-end-tests/test-scripts/test_sql_client.sh
+++ b/flink-end-to-end-tests/test-scripts/test_sql_client.sh
@@ -147,10 +147,7 @@ cat >> $SQL_CONF << EOF
     connector:
       type: elasticsearch
       version: 6
-      hosts:
-        - hostname: "localhost"
-          port: 9200
-          protocol: "http"
+      hosts: "http://localhost:9200"
       index: "$ELASTICSEARCH_INDEX"
       document-type: "user"
       bulk-flush:
@@ -171,10 +168,7 @@ cat >> $SQL_CONF << EOF
     connector:
       type: elasticsearch
       version: 6
-      hosts:
-        - hostname: "localhost"
-          port: 9200
-          protocol: "http"
+      hosts: "http://localhost:9200"
       index: "$ELASTICSEARCH_INDEX"
       document-type: "user"
       bulk-flush:

--- a/flink-end-to-end-tests/test-scripts/test_sql_client_kafka_common.sh
+++ b/flink-end-to-end-tests/test-scripts/test_sql_client_kafka_common.sh
@@ -100,10 +100,8 @@ cat >> $SQL_CONF << EOF
       topic: test-avro
       startup-mode: earliest-offset
       properties:
-        - key: zookeeper.connect
-          value: localhost:2181
-        - key: bootstrap.servers
-          value: localhost:9092
+        zookeeper.connect: localhost:2181
+        bootstrap.servers: localhost:9092
     format:
       type: avro
       avro-schema: >

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -497,8 +497,8 @@ class TableEnvironment(object):
             ...     'connector.type' = 'kafka',
             ...     'update-mode' = 'append',
             ...     'connector.topic' = 'xxx',
-            ...     'connector.properties.0.key' = 'k0',
-            ...     'connector.properties.0.value' = 'v0'
+            ...     'connector.properties.zookeeper.connect' = 'localhost:2181',
+            ...     'connector.properties.bootstrap.servers' = 'localhost:9092'
             ... )
             ... '''
 

--- a/flink-python/pyflink/table/tests/test_descriptor.py
+++ b/flink-python/pyflink/table/tests/test_descriptor.py
@@ -66,10 +66,8 @@ class KafkaDescriptorTests(PyFlinkTestCase):
 
         properties = kafka.to_properties()
         expected = {'connector.type': 'kafka',
-                    'connector.properties.0.key': 'zookeeper.connect',
-                    'connector.properties.0.value': 'localhost:2181',
-                    'connector.properties.1.key': 'bootstrap.servers',
-                    'connector.properties.1.value': 'localhost:9092',
+                    'connector.properties.zookeeper.connect': 'localhost:2181',
+                    'connector.properties.bootstrap.servers': 'localhost:9092',
                     'connector.property-version': '1'}
         self.assertEqual(expected, properties)
 
@@ -78,8 +76,7 @@ class KafkaDescriptorTests(PyFlinkTestCase):
 
         properties = kafka.to_properties()
         expected = {'connector.type': 'kafka',
-                    'connector.properties.0.key': 'group.id',
-                    'connector.properties.0.value': 'testGroup',
+                    'connector.properties.group.id': 'testGroup',
                     'connector.property-version': '1'}
         self.assertEqual(expected, properties)
 
@@ -115,10 +112,7 @@ class KafkaDescriptorTests(PyFlinkTestCase):
 
         properties = kafka.to_properties()
         expected = {'connector.startup-mode': 'specific-offsets',
-                    'connector.specific-offsets.0.partition': '1',
-                    'connector.specific-offsets.0.offset': '220',
-                    'connector.specific-offsets.1.partition': '3',
-                    'connector.specific-offsets.1.offset': '400',
+                    'connector.specific-offsets.0.': 'partition:1,offset:220;partition:3,offset:400',
                     'connector.type': 'kafka',
                     'connector.property-version': '1'}
         self.assertEqual(expected, properties)
@@ -128,8 +122,7 @@ class KafkaDescriptorTests(PyFlinkTestCase):
 
         properties = kafka.to_properties()
         expected = {'connector.startup-mode': 'specific-offsets',
-                    'connector.specific-offsets.0.partition': '3',
-                    'connector.specific-offsets.0.offset': '300',
+                    'connector.specific-offsets': 'partition:3,offset:300',
                     'connector.type': 'kafka',
                     'connector.property-version': '1'}
         self.assertEqual(expected, properties)
@@ -181,9 +174,7 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
         elasticsearch = Elasticsearch().host("localhost", 9200, "http")
 
         properties = elasticsearch.to_properties()
-        expected = {'connector.hosts.0.hostname': 'localhost',
-                    'connector.hosts.0.port': '9200',
-                    'connector.hosts.0.protocol': 'http',
+        expected = {'connector.hosts.': 'http://localhost:9200',
                     'connector.type': 'elasticsearch',
                     'connector.property-version': '1'}
         self.assertEqual(expected, properties)

--- a/flink-python/pyflink/table/tests/test_descriptor.py
+++ b/flink-python/pyflink/table/tests/test_descriptor.py
@@ -112,7 +112,7 @@ class KafkaDescriptorTests(PyFlinkTestCase):
 
         properties = kafka.to_properties()
         expected = {'connector.startup-mode': 'specific-offsets',
-                    'connector.specific-offsets.0.': 'partition:1,offset:220;partition:3,offset:400',
+                    'connector.specific-offsets': 'partition:1,offset:220;partition:3,offset:400',
                     'connector.type': 'kafka',
                     'connector.property-version': '1'}
         self.assertEqual(expected, properties)
@@ -174,7 +174,7 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
         elasticsearch = Elasticsearch().host("localhost", 9200, "http")
 
         properties = elasticsearch.to_properties()
-        expected = {'connector.hosts.': 'http://localhost:9200',
+        expected = {'connector.hosts': 'http://localhost:9200',
                     'connector.type': 'elasticsearch',
                     'connector.property-version': '1'}
         self.assertEqual(expected, properties)

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -541,8 +541,8 @@ public interface TableEnvironment {
 	 *                        'connector.type' = 'kafka',
 	 *                        'update-mode' = 'append',
 	 *                        'connector.topic' = 'xxx',
-	 *                        'connector.properties.0.key' = 'k0',
-	 *                        'connector.properties.0.value' = 'v0',
+	 *                        'connector.properties.zookeeper.connect' = 'localhost:2181',
+	 *                        'connector.properties.bootstrap.servers' = 'localhost:9092',
 	 *                        ...
 	 *                      )";
 	 *


### PR DESCRIPTION
Flatten all the connector properties keys to make it easy to configure in DDL

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.

  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

* This pull request flatten all the special connector properties keys to make it easy to configure in DDL. And all  properties keys can find in FLIP86 *


## Brief change log

  - *Import new Properties in `KafkaValidator` and `ElasticSearchValidator`*
  - *Support  new Properties  in `Kafka Descriptor` and `ElasticSearch Descriptor`*
  - *Adopt  new Properties `ElasticsearchUpsertTableSinkFactoryBase` and `KafkaTableSourceSinkFactoryBase` and fallback logic*
  - *Add related tests to cover code path*
  - *Update docs*


## Verifying this change

* DescriptorTest `KafkaTest` and `ElasticSearchTest` passed.
* All subclasses extends from `ElasticsearchUpsertTableSinkFactoryTestBase` test passed.
* All subclasses extends from `KafkaTableSourceSinkFactoryTestBase` test passed.
* Add legacy properties test in `ElasticsearchUpsertTableSinkFactoryTestBase`  and `KafkaTableSourceSinkFactoryTestBase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
 
* docs, update connect.md and connect_zh.md.
