### PR TITLE
[FLINK-15113][config] add fs.azure.account.key to list of sensitive configs

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
@@ -44,7 +44,7 @@ public final class GlobalConfiguration {
 	public static final String FLINK_CONF_FILENAME = "flink-conf.yaml";
 
 	// the keys whose values should be hidden
-	private static final String[] SENSITIVE_KEYS = new String[] {"password", "secret"};
+	private static final String[] SENSITIVE_KEYS = new String[] {"password", "secret", "fs.azure.account.key"};
 
 	// the hidden content to be displayed
 	public static final String HIDDEN_CONTENT = "******";

--- a/flink-core/src/test/java/org/apache/flink/configuration/GlobalConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/GlobalConfigurationTest.java
@@ -128,6 +128,7 @@ public class GlobalConfigurationTest extends TestLogger {
 		assertTrue(GlobalConfiguration.isSensitive("123pasSword"));
 		assertTrue(GlobalConfiguration.isSensitive("PasSword"));
 		assertTrue(GlobalConfiguration.isSensitive("Secret"));
+		assertTrue(GlobalConfiguration.isSensitive("fs.azure.account.key.storageaccount123456.core.windows.net"));
 		assertFalse(GlobalConfiguration.isSensitive("Hello"));
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

For access to Azure's Blob Storage, you need to provide the (secret) key with `fs.azure.account.key.<storageaccount>.core.windows.net`. This value, however, is not hidden from the global configuration which only specifies configurations with keys containing "password" or "secret" as sensitive.

We should add fs.azure.account.key to that list as well.

## Brief change log

- add `fs.azure.account.key` to the list of patterns for sensitive keys

## Verifying this change

This change added tests and can be verified by starting a Flink cluster with a config key `fs.azure.account.key.<storageaccount>.core.windows.net` and looking at the log file (which prints config values by default as well.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/flink/10470)
<!-- Reviewable:end -->
