### PR TITLE
[FLINK-15114][SQL-CLIENT]Add execute result info for alter/create/drop database in sql-client

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -605,17 +605,32 @@ public class CliClient {
 
 	private void callCreateDatabase(SqlCommandCall cmdCall) {
 		final String createDatabaseStmt = cmdCall.operands[0];
-		executor.executeUpdate(sessionId, createDatabaseStmt);
+		try {
+			executor.executeUpdate(sessionId, createDatabaseStmt);
+			printInfo(CliStrings.MESSAGE_DATABASE_CREATED);
+		} catch (SqlExecutionException e) {
+			printExecutionException(e);
+		}
 	}
 
 	private void callDropDatabase(SqlCommandCall cmdCall) {
 		final String dropDatabaseStmt = cmdCall.operands[0];
-		executor.executeUpdate(sessionId, dropDatabaseStmt);
+		try {
+			executor.executeUpdate(sessionId, dropDatabaseStmt);
+			printInfo(CliStrings.MESSAGE_DATABASE_REMOVED);
+		} catch (SqlExecutionException e) {
+			printExecutionException(e);
+		}
 	}
 
 	private void callAlterDatabase(SqlCommandCall cmdCall) {
 		final String alterDatabaseStmt = cmdCall.operands[0];
-		executor.executeUpdate(sessionId, alterDatabaseStmt);
+		try {
+			executor.executeUpdate(sessionId, alterDatabaseStmt);
+			printInfo(CliStrings.MESSAGE_DATABASE_ALTER_SUCCEEDED);
+		} catch (SqlExecutionException e) {
+			printExecutionException(CliStrings.MESSAGE_DATABASE_ALTER_FAILED, e);
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
@@ -141,6 +141,14 @@ public final class CliStrings {
 
 	public static final String MESSAGE_VIEW_REMOVED = "View has been removed.";
 
+	public static final String MESSAGE_DATABASE_CREATED = "Database has been created.";
+
+	public static final String MESSAGE_DATABASE_REMOVED = "Database has been removed.";
+
+	public static final String MESSAGE_DATABASE_ALTER_SUCCEEDED = "Alter database succeeded!";
+
+	public static final String MESSAGE_DATABASE_ALTER_FAILED = "Alter database failed!";
+
 	public static final String MESSAGE_VIEW_ALREADY_EXISTS = "A view with this name has already been defined in the current CLI session.";
 
 	public static final String MESSAGE_VIEW_NOT_FOUND = "The given view does not exist in the current CLI session. " +


### PR DESCRIPTION
## What is the purpose of the change

*Add execute result info for alter/create/drop database in sql client*


## Brief change log
  - *Add execute result info for alter/create/drop database in sql client*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
