### PR TITLE
[FLINK-14872][runtime] Temporary fix for potential deadlock problem when tasks read from blocking ResultPartitions.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -224,8 +224,7 @@ public class SingleInputGateFactory {
 			int floatingNetworkBuffersPerGate,
 			int size,
 			ResultPartitionType type) {
-		int maxNumberOfMemorySegments = type.isBounded() ? floatingNetworkBuffersPerGate : Integer.MAX_VALUE;
-		return () -> bufferPoolFactory.createBufferPool(0, maxNumberOfMemorySegments);
+		return () -> bufferPoolFactory.createBufferPool(0, floatingNetworkBuffersPerGate);
 	}
 
 	private static class ChannelStatistics {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentTest.java
@@ -163,8 +163,8 @@ public class NettyShuffleEnvironmentTest extends TestLogger {
 		assertEquals(0, ig3.getBufferPool().getNumberOfRequiredMemorySegments());
 		assertEquals(0, ig4.getBufferPool().getNumberOfRequiredMemorySegments());
 
-		assertEquals(Integer.MAX_VALUE, ig1.getBufferPool().getMaxNumberOfMemorySegments());
-		assertEquals(Integer.MAX_VALUE, ig2.getBufferPool().getMaxNumberOfMemorySegments());
+		assertEquals(floatingBuffers, ig1.getBufferPool().getMaxNumberOfMemorySegments());
+		assertEquals(floatingBuffers, ig2.getBufferPool().getMaxNumberOfMemorySegments());
 		assertEquals(floatingBuffers, ig3.getBufferPool().getMaxNumberOfMemorySegments());
 		assertEquals(floatingBuffers, ig4.getBufferPool().getMaxNumberOfMemorySegments());
 


### PR DESCRIPTION
## What is the purpose of the change

This commit implements a temporary fix for the potential deadlock problem reported in FLINK-14872. The problem itself is not solved completely, however the possibility of deadlock is largely reduced. We leave the proper fix of this problem to the future version. Because the fix does not solve the deadlock problem completely and the fix is trivial, so no new test is attached.


## Brief change log

  - Reduce the max size of local buffer pool from ```Integer.MAX_VALUE``` to ```floatingNetworkBuffersPerGate``` for InputGates reading from blocking result partition.


## Verifying this change

Because the fix does not solve the deadlock problem completely and the fix is trivial, so no new test is attached.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
