### PR TITLE
[FLINK-15116] Make JobClient stateless, remove AutoCloseable

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -210,6 +210,8 @@ public class CliFrontend {
 		final Configuration effectiveConfiguration =
 				getEffectiveConfiguration(commandLine, programOptions, jobJars);
 
+		LOG.debug("Effective executor configuration: {}", effectiveConfiguration);
+
 		try {
 			executeProgram(effectiveConfiguration, program);
 		} finally {
@@ -1089,7 +1091,9 @@ public class CliFrontend {
 	 * @return custom command-line which is active (may only be one at a time)
 	 */
 	public CustomCommandLine getActiveCustomCommandLine(CommandLine commandLine) {
+		LOG.debug("Custom commandlines: {}", customCommandLines);
 		for (CustomCommandLine cli : customCommandLines) {
+			LOG.debug("Checking custom commandline {}, isActive: {}", cli, cli.isActive(commandLine));
 			if (cli.isActive(commandLine)) {
 				return cli;
 			}

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -862,7 +862,7 @@ public class CliFrontend {
 				"you would like to connect.");
 		} else {
 			try {
-				final ClusterClient<ClusterID> clusterClient = clusterDescriptor.retrieve(clusterId);
+				final ClusterClient<ClusterID> clusterClient = clusterDescriptor.retrieve(clusterId).getClusterClient();
 
 				try {
 					clusterAction.runAction(clusterClient);

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/AbstractJobClusterExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/AbstractJobClusterExecutor.java
@@ -63,7 +63,9 @@ public class AbstractJobClusterExecutor<ClusterID, ClientFactory extends Cluster
 
 			final ClusterSpecification clusterSpecification = clusterClientFactory.getClusterSpecification(configuration);
 
-			final ClusterClient<ClusterID> clusterClient = clusterDescriptor.deployJobCluster(clusterSpecification, jobGraph, configAccessor.getDetachedMode());
+			final ClusterClient<ClusterID> clusterClient = clusterDescriptor
+					.deployJobCluster(clusterSpecification, jobGraph, configAccessor.getDetachedMode())
+					.getClusterClient();
 			LOG.info("Job has been submitted with JobID " + jobGraph.getJobID());
 
 			final boolean withShutdownHook = !configAccessor.getDetachedMode() && configAccessor.isShutdownOnAttachedExit();

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/AbstractSessionClusterExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/AbstractSessionClusterExecutor.java
@@ -56,7 +56,10 @@ public class AbstractSessionClusterExecutor<ClusterID, ClientFactory extends Clu
 			final ClusterID clusterID = clusterClientFactory.getClusterId(configuration);
 			checkState(clusterID != null);
 
-			final ClusterClient<ClusterID> clusterClient = clusterDescriptor.retrieve(clusterID);
+			final ClusterClient<ClusterID> clusterClient = clusterDescriptor
+					.retrieve(clusterID)
+					.getClusterClient();
+
 			return clusterClient
 					.submitJob(jobGraph)
 					.thenApply(jobID -> new ClusterClientJobClientAdapter<ClusterID>(clusterClient, jobID) {

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/AbstractSessionClusterExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/AbstractSessionClusterExecutor.java
@@ -21,6 +21,7 @@ package org.apache.flink.client.deployment;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.client.program.ClusterClientProvider;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.Executor;
 import org.apache.flink.core.execution.JobClient;
@@ -56,18 +57,14 @@ public class AbstractSessionClusterExecutor<ClusterID, ClientFactory extends Clu
 			final ClusterID clusterID = clusterClientFactory.getClusterId(configuration);
 			checkState(clusterID != null);
 
-			final ClusterClient<ClusterID> clusterClient = clusterDescriptor
-					.retrieve(clusterID)
-					.getClusterClient();
-
+			final ClusterClientProvider<ClusterID> clusterClientProvider = clusterDescriptor.retrieve(clusterID);
+			ClusterClient<ClusterID> clusterClient = clusterClientProvider.getClusterClient();
 			return clusterClient
 					.submitJob(jobGraph)
-					.thenApply(jobID -> new ClusterClientJobClientAdapter<ClusterID>(clusterClient, jobID) {
-						@Override
-						protected void doClose() {
-							clusterClient.close();
-						}
-					});
+					.thenApplyAsync(jobID -> (JobClient) new ClusterClientJobClientAdapter<>(
+							clusterClientProvider,
+							jobID))
+					.whenComplete((ignored1, ignored2) -> clusterClient.close());
 		}
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterDescriptor.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.client.deployment;
 
-import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.client.program.ClusterClientProvider;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.util.FlinkException;
 
@@ -41,7 +41,7 @@ public interface ClusterDescriptor<T> extends AutoCloseable {
 	 * @return Client for the cluster
 	 * @throws ClusterRetrieveException if the cluster client could not be retrieved
 	 */
-	ClusterClient<T> retrieve(T clusterId) throws ClusterRetrieveException;
+	ClusterClientProvider<T> retrieve(T clusterId) throws ClusterRetrieveException;
 
 	/**
 	 * Triggers deployment of a cluster.
@@ -49,7 +49,7 @@ public interface ClusterDescriptor<T> extends AutoCloseable {
 	 * @return Client for the cluster
 	 * @throws ClusterDeploymentException if the cluster could not be deployed
 	 */
-	ClusterClient<T> deploySessionCluster(ClusterSpecification clusterSpecification) throws ClusterDeploymentException;
+	ClusterClientProvider<T> deploySessionCluster(ClusterSpecification clusterSpecification) throws ClusterDeploymentException;
 
 	/**
 	 * Deploys a per-job cluster with the given job on the cluster.
@@ -61,7 +61,7 @@ public interface ClusterDescriptor<T> extends AutoCloseable {
 	 * @return Cluster client to talk to the Flink cluster
 	 * @throws ClusterDeploymentException if the cluster could not be deployed
 	 */
-	ClusterClient<T> deployJobCluster(
+	ClusterClientProvider<T> deployJobCluster(
 		final ClusterSpecification clusterSpecification,
 		final JobGraph jobGraph,
 		final boolean detached) throws ClusterDeploymentException;

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterDescriptor.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.client.deployment;
 
+import org.apache.flink.client.program.ClusterClientProvider;
 import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
@@ -44,21 +45,23 @@ public class StandaloneClusterDescriptor implements ClusterDescriptor<Standalone
 	}
 
 	@Override
-	public RestClusterClient<StandaloneClusterId> retrieve(StandaloneClusterId standaloneClusterId) throws ClusterRetrieveException {
-		try {
-			return new RestClusterClient<>(config, standaloneClusterId);
-		} catch (Exception e) {
-			throw new ClusterRetrieveException("Couldn't retrieve standalone cluster", e);
-		}
+	public ClusterClientProvider<StandaloneClusterId> retrieve(StandaloneClusterId standaloneClusterId) throws ClusterRetrieveException {
+		return () -> {
+			try {
+				return new RestClusterClient<>(config, standaloneClusterId);
+			} catch (Exception e) {
+				throw new RuntimeException("Couldn't retrieve standalone cluster", e);
+			}
+		};
 	}
 
 	@Override
-	public RestClusterClient<StandaloneClusterId> deploySessionCluster(ClusterSpecification clusterSpecification) {
+	public ClusterClientProvider<StandaloneClusterId> deploySessionCluster(ClusterSpecification clusterSpecification) {
 		throw new UnsupportedOperationException("Can't deploy a standalone cluster.");
 	}
 
 	@Override
-	public RestClusterClient<StandaloneClusterId> deployJobCluster(
+	public ClusterClientProvider<StandaloneClusterId> deployJobCluster(
 			ClusterSpecification clusterSpecification,
 			JobGraph jobGraph,
 			boolean detached) {

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/LocalExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/LocalExecutor.java
@@ -19,6 +19,7 @@
 package org.apache.flink.client.deployment.executors;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.client.FlinkPipelineTranslationUtil;
@@ -62,15 +63,14 @@ public class LocalExecutor implements Executor {
 		final MiniCluster miniCluster = startMiniCluster(jobGraph, configuration);
 		final MiniClusterClient clusterClient = new MiniClusterClient(configuration, miniCluster);
 
-		return clusterClient
-				.submitJob(jobGraph)
-				.thenApply(jobID -> new ClusterClientJobClientAdapter<MiniClusterClient.MiniClusterId>(clusterClient, jobID) {
-					@Override
-					protected void doClose() {
-						clusterClient.close();
-						shutdownMiniCluster(miniCluster);
-					}
-				});
+		CompletableFuture<JobID> jobIdFuture = clusterClient.submitJob(jobGraph);
+
+		jobIdFuture
+				.thenCompose(clusterClient::requestJobResult)
+				.thenAccept((jobResult) -> clusterClient.shutDownCluster());
+
+		return jobIdFuture.thenApply(jobID ->
+				new ClusterClientJobClientAdapter<>(() -> clusterClient, jobID));
 	}
 
 	private JobGraph getJobGraph(Pipeline pipeline, Configuration configuration) {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClientProvider.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClientProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.flink.client.program;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * Factory for {@link ClusterClient ClusterClients}.
+ */
+@Internal
+public interface ClusterClientProvider<T> {
+
+	/**
+	 * Creates and returns a new {@link ClusterClient}. The returned client needs to be closed via
+	 * {@link ClusterClient#close()} after use.
+	 */
+	ClusterClient<T> getClusterClient();
+}

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
@@ -109,6 +109,6 @@ public class DefaultCLITest extends CliFrontendTestBase {
 		checkState(clusterFactory != null);
 
 		final ClusterDescriptor<StandaloneClusterId> clusterDescriptor = clusterFactory.createClusterDescriptor(executorConfig);
-		return clusterDescriptor.retrieve(clusterFactory.getClusterId(executorConfig));
+		return clusterDescriptor.retrieve(clusterFactory.getClusterId(executorConfig)).getClusterClient();
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyClusterDescriptor.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyClusterDescriptor.java
@@ -21,6 +21,7 @@ package org.apache.flink.client.cli.util;
 import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.client.program.ClusterClientProvider;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.util.Preconditions;
 
@@ -41,21 +42,21 @@ public class DummyClusterDescriptor<T> implements ClusterDescriptor<T> {
 	}
 
 	@Override
-	public ClusterClient<T> retrieve(T clusterId) {
-		return clusterClient;
+	public ClusterClientProvider<T> retrieve(T clusterId) {
+		return () -> clusterClient;
 	}
 
 	@Override
-	public ClusterClient<T> deploySessionCluster(ClusterSpecification clusterSpecification) {
-		return clusterClient;
+	public ClusterClientProvider<T> deploySessionCluster(ClusterSpecification clusterSpecification) {
+		return () -> clusterClient;
 	}
 
 	@Override
-	public ClusterClient<T> deployJobCluster(
+	public ClusterClientProvider<T> deployJobCluster(
 			ClusterSpecification clusterSpecification,
 			JobGraph jobGraph,
 			boolean detached) {
-		return clusterClient;
+		return () -> clusterClient;
 	}
 
 	@Override

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -396,7 +396,7 @@ public class ClientTest extends TestLogger {
 						jobGraph.setClasspaths(accessor.getClasspaths());
 
 						final JobID jobID = ClientUtils.submitJob(clusterClient, jobGraph).getJobID();
-						return CompletableFuture.completedFuture(new ClusterClientJobClientAdapter<>(clusterClient, jobID));
+						return CompletableFuture.completedFuture(new ClusterClientJobClientAdapter<>(() -> clusterClient, jobID));
 					};
 				}
 			};

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -555,7 +555,9 @@ public class RestClusterClientTest extends TestLogger {
 		checkState(clusterFactory != null);
 
 		final ClusterDescriptor<StandaloneClusterId> clusterDescriptor = clusterFactory.createClusterDescriptor(executorConfig);
-		final RestClusterClient<?> clusterClient = (RestClusterClient<?>) clusterDescriptor.retrieve(clusterFactory.getClusterId(executorConfig));
+		final RestClusterClient<?> clusterClient = (RestClusterClient<?>) clusterDescriptor
+				.retrieve(clusterFactory.getClusterId(executorConfig))
+				.getClusterClient();
 
 		URL webMonitorBaseUrl = clusterClient.getWebMonitorBaseUrl().get();
 		assertThat(webMonitorBaseUrl.getHost(), equalTo(manualHostname));

--- a/flink-core/src/main/java/org/apache/flink/core/execution/JobClient.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/JobClient.java
@@ -32,7 +32,7 @@ import java.util.concurrent.CompletableFuture;
  * A client that is scoped to a specific job.
  */
 @PublicEvolving
-public interface JobClient extends AutoCloseable {
+public interface JobClient {
 
 	/**
 	 * Returns the {@link JobID} that uniquely identifies the job this client is scoped to.
@@ -83,7 +83,4 @@ public interface JobClient extends AutoCloseable {
 	 * @param userClassloader the classloader used to de-serialize the accumulators of the job.
 	 */
 	CompletableFuture<JobExecutionResult> getJobExecutionResult(final ClassLoader userClassloader);
-
-	@Override
-	void close();
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -804,13 +804,15 @@ public class ExecutionEnvironment {
 	 * @throws Exception Thrown, if the program executions fails.
 	 */
 	public JobExecutionResult execute(String jobName) throws Exception {
-		try (final JobClient jobClient = executeAsync(jobName).get()) {
-			lastJobExecutionResult = configuration.getBoolean(DeploymentOptions.ATTACHED)
-					? jobClient.getJobExecutionResult(userClassloader).get()
-					: new DetachedJobExecutionResult(jobClient.getJobID());
+		final JobClient jobClient = executeAsync(jobName).get();
 
-			return lastJobExecutionResult;
+		if (configuration.getBoolean(DeploymentOptions.ATTACHED)) {
+			lastJobExecutionResult = jobClient.getJobExecutionResult(userClassloader).get();
+		} else {
+			lastJobExecutionResult = new DetachedJobExecutionResult(jobClient.getJobID());
 		}
+
+		return lastJobExecutionResult;
 	}
 
 	/**
@@ -821,10 +823,6 @@ public class ExecutionEnvironment {
 	 * data sinks created with {@link DataSet#output(org.apache.flink.api.common.io.OutputFormat)}.
 	 *
 	 * <p>The program execution will be logged and displayed with a generated default name.
-	 *
-	 * <p><b>ATTENTION:</b> The caller of this method is responsible for managing the lifecycle of
-	 * the returned {@link JobClient}. This means calling {@link JobClient#close()} at the end of
-	 * its usage. In other case, there may be resource leaks depending on the JobClient implementation.
 	 *
 	 * @return A future of {@link JobClient} that can be used to communicate with the submitted job, completed on submission succeeded.
 	 * @throws Exception Thrown, if the program submission fails.
@@ -842,10 +840,6 @@ public class ExecutionEnvironment {
 	 * data sinks created with {@link DataSet#output(org.apache.flink.api.common.io.OutputFormat)}.
 	 *
 	 * <p>The program execution will be logged and displayed with the given job name.
-	 *
-	 * <p><b>ATTENTION:</b> The caller of this method is responsible for managing the lifecycle of
-	 * the returned {@link JobClient}. This means calling {@link JobClient#close()} at the end of
-	 * its usage. In other case, there may be resource leaks depending on the JobClient implementation.
 	 *
 	 * @return A future of {@link JobClient} that can be used to communicate with the submitted job, completed on submission succeeded.
 	 * @throws Exception Thrown, if the program submission fails.

--- a/flink-java/src/test/java/org/apache/flink/api/java/TestingJobClient.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/TestingJobClient.java
@@ -68,9 +68,4 @@ public class TestingJobClient implements JobClient {
 	public CompletableFuture<Map<String, Object>> getAccumulators(ClassLoader classLoader) {
 		return CompletableFuture.completedFuture(Collections.emptyMap());
 	}
-
-	@Override
-	public void close() {
-
-	}
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
@@ -55,7 +55,8 @@ public class KubernetesClusterDescriptorTest extends KubernetesTestBase {
 			.setSlotsPerTaskManager(1)
 			.createClusterSpecification();
 
-		final ClusterClient<String> clusterClient = descriptor.deploySessionCluster(clusterSpecification);
+		final ClusterClient<String> clusterClient =
+				descriptor.deploySessionCluster(clusterSpecification).getClusterClient();
 
 		assertEquals(CLUSTER_ID, clusterClient.getClusterId());
 		assertEquals(String.format("http://%s:8081", MOCK_SERVICE_IP), clusterClient.getWebInterfaceURL());
@@ -91,6 +92,8 @@ public class KubernetesClusterDescriptorTest extends KubernetesTestBase {
 		assertEquals(
 			clusterSpecification.getMasterMemoryMB() + Constants.RESOURCE_UNIT_MB,
 			jmContainer.getResources().getLimits().get(Constants.RESOURCE_NAME_MEMORY).getAmount());
+
+		clusterClient.close();
 	}
 
 	@Test

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -149,7 +149,7 @@ public class RestClient implements AutoCloseableAsync {
 			.channel(NioSocketChannel.class)
 			.handler(initializer);
 
-		LOG.info("Rest client endpoint started.");
+		LOG.debug("Rest client endpoint started.");
 	}
 
 	@Override
@@ -162,7 +162,7 @@ public class RestClient implements AutoCloseableAsync {
 
 		try {
 			shutDownFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-			LOG.info("Rest endpoint shutdown complete.");
+			LOG.debug("Rest endpoint shutdown complete.");
 		} catch (Exception e) {
 			LOG.warn("Rest endpoint shutdown failed.", e);
 		}
@@ -170,7 +170,7 @@ public class RestClient implements AutoCloseableAsync {
 
 	private CompletableFuture<Void> shutdownInternally(Time timeout) {
 		if (isRunning.compareAndSet(true, false)) {
-			LOG.info("Shutting down rest endpoint.");
+			LOG.debug("Shutting down rest endpoint.");
 
 			if (bootstrap != null) {
 				if (bootstrap.group() != null) {

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -251,7 +251,9 @@ object FlinkShell {
     val clusterSpecification = clientFactory.getClusterSpecification(executorConfig)
 
     val clusterClient = try {
-      clusterDescriptor.deploySessionCluster(clusterSpecification)
+      clusterDescriptor
+        .deploySessionCluster(clusterSpecification)
+        .getClusterClient
     } finally {
       clusterDescriptor.close()
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -1619,10 +1619,12 @@ public class StreamExecutionEnvironment {
 	 */
 	@Internal
 	public JobExecutionResult execute(StreamGraph streamGraph) throws Exception {
-		try (final JobClient jobClient = executeAsync(streamGraph).get()) {
-			return configuration.getBoolean(DeploymentOptions.ATTACHED)
-					? jobClient.getJobExecutionResult(userClassloader).get()
-					: new DetachedJobExecutionResult(jobClient.getJobID());
+		final JobClient jobClient = executeAsync(streamGraph).get();
+
+		if (configuration.getBoolean(DeploymentOptions.ATTACHED)) {
+			return jobClient.getJobExecutionResult(userClassloader).get();
+		} else {
+			return new DetachedJobExecutionResult(jobClient.getJobID());
 		}
 	}
 
@@ -1633,10 +1635,6 @@ public class StreamExecutionEnvironment {
 	 *
 	 * <p>The program execution will be logged and displayed with a generated
 	 * default name.
-	 *
-	 * <p><b>ATTENTION:</b> The caller of this method is responsible for managing the lifecycle of
-	 * the returned {@link JobClient}. This means calling {@link JobClient#close()} at the end of
-	 * its usage. In other case, there may be resource leaks depending on the JobClient implementation.
 	 *
 	 * @return A future of {@link JobClient} that can be used to communicate with the submitted job, completed on submission succeeded.
 	 * @throws Exception which occurs during job execution.
@@ -1652,10 +1650,6 @@ public class StreamExecutionEnvironment {
 	 * for example printing results or forwarding them to a message queue.
 	 *
 	 * <p>The program execution will be logged and displayed with the provided name
-	 *
-	 * <p><b>ATTENTION:</b> The caller of this method is responsible for managing the lifecycle of
-	 * the returned {@link JobClient}. This means calling {@link JobClient#close()} at the end of
-	 * its usage. In other case, there may be resource leaks depending on the JobClient implementation.
 	 *
 	 * @param jobName desired name of the job
 	 * @return A future of {@link JobClient} that can be used to communicate with the submitted job, completed on submission succeeded.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -1671,10 +1671,6 @@ public class StreamExecutionEnvironment {
 	 * the program that have resulted in a "sink" operation. Sink operations are
 	 * for example printing results or forwarding them to a message queue.
 	 *
-	 * <p><b>ATTENTION:</b> The caller of this method is responsible for managing the lifecycle of
-	 * the returned {@link JobClient}. This means calling {@link JobClient#close()} at the end of
-	 * its usage. In other case, there may be resource leaks depending on the JobClient implementation.
-	 *
 	 * @param streamGraph the stream graph representing the transformations
 	 * @return A future of {@link JobClient} that can be used to communicate with the submitted job, completed on submission succeeded.
 	 * @throws Exception which occurs during job execution.

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
@@ -149,7 +149,7 @@ public class RemoteStreamExecutionEnvironmentTest extends TestLogger {
 						clusterClient = new TestClusterClient(configuration, jobID);
 
 						return CompletableFuture.completedFuture(
-								new ClusterClientJobClientAdapter<>(clusterClient, jobID));
+								new ClusterClientJobClientAdapter<>(() -> clusterClient, jobID));
 					};
 				}
 			};

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/environment/TestingJobClient.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/environment/TestingJobClient.java
@@ -68,9 +68,4 @@ public class TestingJobClient implements JobClient {
 	public CompletableFuture<Map<String, Object>> getAccumulators(ClassLoader classLoader) {
 		return CompletableFuture.completedFuture(Collections.emptyMap());
 	}
-
-	@Override
-	public void close() {
-
-	}
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -547,7 +547,7 @@ public class LocalExecutor implements Executor {
 			ClusterClient<T> clusterClient = null;
 			try {
 				// retrieve existing cluster
-				clusterClient = clusterDescriptor.retrieve(context.getClusterId());
+				clusterClient = clusterDescriptor.retrieve(context.getClusterId()).getClusterClient();
 				try {
 					clusterClient.cancel(new JobID(StringUtils.hexStringToByte(resultId))).get();
 				} catch (Throwable t) {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -601,7 +601,8 @@ public class LocalExecutor implements Executor {
 		final ProgramDeployer deployer = new ProgramDeployer(configuration, jobName, pipeline);
 
 		// blocking deployment
-		try (JobClient jobClient = deployer.deploy().get()) {
+		try {
+			JobClient jobClient = deployer.deploy().get();
 			return ProgramTargetDescriptor.of(jobClient.getJobID());
 		} catch (Exception e) {
 			throw new RuntimeException("Error running SQL job.", e);

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
@@ -289,12 +289,13 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
 	private RestClusterClient<ApplicationId> deploySessionCluster(YarnClusterDescriptor yarnClusterDescriptor) throws ClusterDeploymentException {
 		final int masterMemory = 256;
 		final int taskManagerMemory = 1024;
-		final ClusterClient<ApplicationId> yarnClusterClient = yarnClusterDescriptor.deploySessionCluster(
-			new ClusterSpecification.ClusterSpecificationBuilder()
-				.setMasterMemoryMB(masterMemory)
-				.setTaskManagerMemoryMB(taskManagerMemory)
-				.setSlotsPerTaskManager(1)
-				.createClusterSpecification());
+		final ClusterClient<ApplicationId> yarnClusterClient = yarnClusterDescriptor
+				.deploySessionCluster(new ClusterSpecification.ClusterSpecificationBuilder()
+						.setMasterMemoryMB(masterMemory)
+						.setTaskManagerMemoryMB(taskManagerMemory)
+						.setSlotsPerTaskManager(1)
+						.createClusterSpecification())
+				.getClusterClient();
 
 		assertThat(yarnClusterClient, is(instanceOf(RestClusterClient.class)));
 		return (RestClusterClient<ApplicationId>) yarnClusterClient;

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -112,10 +112,12 @@ public class YARNITCase extends YarnTestBase {
 			File testingJar = YarnTestBase.findFile("..", new YarnTestUtils.TestJarFinder("flink-yarn-tests"));
 
 			jobGraph.addJar(new org.apache.flink.core.fs.Path(testingJar.toURI()));
-			try (ClusterClient<ApplicationId> clusterClient = yarnClusterDescriptor.deployJobCluster(
-				clusterSpecification,
-				jobGraph,
-				false)) {
+			try (ClusterClient<ApplicationId> clusterClient = yarnClusterDescriptor
+					.deployJobCluster(
+							clusterSpecification,
+							jobGraph,
+							false)
+					.getClusterClient()) {
 
 				ApplicationId applicationId = clusterClient.getClusterId();
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
@@ -114,7 +114,9 @@ public class YarnConfigurationITCase extends YarnTestBase {
 					.setSlotsPerTaskManager(slotsPerTaskManager)
 					.createClusterSpecification();
 
-				final ClusterClient<ApplicationId> clusterClient = clusterDescriptor.deployJobCluster(clusterSpecification, jobGraph, true);
+				final ClusterClient<ApplicationId> clusterClient = clusterDescriptor
+						.deployJobCluster(clusterSpecification, jobGraph, true)
+						.getClusterClient();
 
 				final ApplicationId clusterId = clusterClient.getClusterId();
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnDistributedCacheITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnDistributedCacheITCase.java
@@ -87,10 +87,12 @@ public class YarnDistributedCacheITCase extends YarnTestBase {
 
 				jobGraph.addJar(new org.apache.flink.core.fs.Path(testingJar.toURI()));
 
-				try (ClusterClient<ApplicationId> clusterClient = yarnClusterDescriptor.deployJobCluster(
-					clusterSpecification,
-					jobGraph,
-					false)) {
+				try (ClusterClient<ApplicationId> clusterClient = yarnClusterDescriptor
+						.deployJobCluster(
+								clusterSpecification,
+								jobGraph,
+								false)
+						.getClusterClient()) {
 
 					ApplicationId applicationId = clusterClient.getClusterId();
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -86,7 +86,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import static org.apache.flink.client.cli.CliFrontendParser.DETACHED_OPTION;
-import static org.apache.flink.client.cli.CliFrontendParser.SHUTDOWN_IF_ATTACHED_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.YARN_DETACHED_OPTION;
 import static org.apache.flink.configuration.HighAvailabilityOptions.HA_CLUSTER_ID;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -218,7 +217,6 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 		allOptions.addOption(slots);
 		allOptions.addOption(dynamicproperties);
 		allOptions.addOption(DETACHED_OPTION);
-		allOptions.addOption(SHUTDOWN_IF_ATTACHED_OPTION);
 		allOptions.addOption(YARN_DETACHED_OPTION);
 		allOptions.addOption(name);
 		allOptions.addOption(applicationId);


### PR DESCRIPTION
## What is the purpose of the change

*Right now this is a proposal to show others what it looks like. If we agree on this changed behaviour I should add tests for it. Currently we don't have tests for `JobClient`, though.*

With this change, the JobClient acquires the required ClusterClient for
each method call. This means that the users no longer have the burden of
managing the JobClient lifecycle, i.e. they can freely ignore the result
of executeAsync().

I also modified the `SocketWindowWordCount` to play around and show how the API works. **(This will be reverted)**.

## Brief change log

  - The first commit changes `ClusterDescriptor` to return a `ClusterClientProvider` so that consumers of the method can create a new `ClusterClient` whenever needed
  - The second commit changes `JobClient` to create a new `ClusterClient` from the provider for every method call. It therefore does not need to hold any resources that need to be cleaned up

## Verifying this change

Same test coverage as before, we don't test the `JobClient` yet.

## Documentation

  - `JobClient` is not yet documented and this PR also doesn't add any documentation.

