### PR TITLE
[FLINK-14911] [table] register and drop temp catalog functions from D…

### DIFF
--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -797,6 +797,13 @@ class CatalogFunction(object):
         """
         return self._j_catalog_function.isGeneric()
 
+    def is_temporary(self):
+        """
+        Wheter or not the function is a temporary function.
+        :return: Wheter is a temporary function.
+        """
+        return self._j_catalog_function.isTemporary()
+
     def get_function_language(self):
         """
         Get the language used for the function definition.

--- a/flink-python/pyflink/table/tests/test_catalog.py
+++ b/flink-python/pyflink/table/tests/test_catalog.py
@@ -68,6 +68,7 @@ class CatalogTestBase(PyFlinkTestCase):
     def check_catalog_function_equals(self, f1, f2):
         self.assertEqual(f1.get_class_name(), f2.get_class_name())
         self.assertEqual(f1.is_generic(), f2.is_generic())
+        self.assertEqual(f1.is_temporary(), f2.is_temporary())
         self.assertEqual(f1.get_function_language(), f2.get_function_language())
 
     def check_catalog_partition_equals(self, p1, p2):

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterFunction.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterFunction.java
@@ -114,6 +114,10 @@ public class SqlAlterFunction extends SqlCall {
 		return this.functionClassName;
 	}
 
+	public boolean isTemporary() {
+		return isTemporary;
+	}
+
 	public boolean isIfExists() {
 		return this.ifExists;
 	}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateFunction.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateFunction.java
@@ -117,6 +117,10 @@ public class SqlCreateFunction extends SqlCreate implements ExtendedSqlNode {
 		return isSystemFunction;
 	}
 
+	public boolean isTemporary() {
+		return isTemporary;
+	}
+
 	public SqlCharStringLiteral getFunctionClassName() {
 		return this.functionClassName;
 	}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropFunction.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropFunction.java
@@ -92,6 +92,10 @@ public class SqlDropFunction extends SqlDrop implements ExtendedSqlNode {
 		return functionIdentifier.names.toArray(new String[0]);
 	}
 
+	public boolean isTemporary() {
+		return isTemporary;
+	}
+
 	public boolean getIfExists() {
 		return this.ifExists;
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogFunctionImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogFunctionImpl.java
@@ -32,15 +32,17 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class CatalogFunctionImpl implements CatalogFunction {
 	private final String className; // Fully qualified class name of the function
 	private final FunctionLanguage functionLanguage;
+	private final boolean isTemporary;
 
 	public CatalogFunctionImpl(String className) {
-		this(className, FunctionLanguage.JAVA);
+		this(className, FunctionLanguage.JAVA, false);
 	}
 
-	public CatalogFunctionImpl(String className, FunctionLanguage functionLanguage) {
+	public CatalogFunctionImpl(String className, FunctionLanguage functionLanguage, boolean isTemporary) {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(className), "className cannot be null or empty");
 		this.className = className;
 		this.functionLanguage = checkNotNull(functionLanguage, "functionLanguage cannot be null");
+		this.isTemporary = isTemporary;
 	}
 
 	@Override
@@ -50,7 +52,7 @@ public class CatalogFunctionImpl implements CatalogFunction {
 
 	@Override
 	public CatalogFunction copy() {
-		return new CatalogFunctionImpl(getClassName(), functionLanguage);
+		return new CatalogFunctionImpl(getClassName(), functionLanguage, isTemporary);
 	}
 
 	@Override
@@ -77,6 +79,11 @@ public class CatalogFunctionImpl implements CatalogFunction {
 	}
 
 	@Override
+	public boolean isTemporary() {
+		return isTemporary;
+	}
+
+	@Override
 	public FunctionLanguage getFunctionLanguage() {
 		return functionLanguage;
 	}
@@ -86,6 +93,8 @@ public class CatalogFunctionImpl implements CatalogFunction {
 		return "CatalogFunctionImpl{" +
 			"className='" + getClassName() + "', " +
 			"functionLanguage='" + getFunctionLanguage() +
+			"isGeneric='" + isGeneric() +
+			"isTemporary='" + isTemporary() +
 			"'}";
 	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -55,7 +55,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 @Internal
 public class FunctionCatalog implements FunctionLookup {
-
 	private final CatalogManager catalogManager;
 	private final ModuleManager moduleManager;
 
@@ -192,6 +191,17 @@ public class FunctionCatalog implements FunctionLookup {
 			oi,
 			definition
 		);
+	}
+
+	/**
+	 * Check whether a temporary catalog function is already registered.
+	 * @param functionIdentifier the object identifier of function
+	 * @return whether the temporary catalog function exists in the function catalog
+	 */
+	public boolean hasTemporaryCatalogFunction(ObjectIdentifier functionIdentifier) {
+		ObjectIdentifier normalizedIdentifier =
+			FunctionIdentifier.normalizeObjectIdentifier(functionIdentifier);
+		return tempCatalogFunctions.containsKey(normalizedIdentifier);
 	}
 
 	/**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterFunctionOperation.java
@@ -69,4 +69,8 @@ public class AlterFunctionOperation implements AlterOperation  {
 			Collections.emptyList(),
 			Operation::asSummaryString);
 	}
+
+	public String getFunctionName() {
+		return this.functionIdentifier.getObjectName();
+	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateFunctionOperation.java
@@ -69,4 +69,8 @@ public class CreateFunctionOperation implements CreateOperation {
 			Collections.emptyList(),
 			Operation::asSummaryString);
 	}
+
+	public String getFunctionName() {
+		return this.functionIdentifier.getObjectName();
+	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropFunctionOperation.java
@@ -32,12 +32,15 @@ import java.util.Map;
 public class DropFunctionOperation implements DropOperation {
 	private final ObjectIdentifier functionIdentifier;
 	private final boolean ifExists;
+	private final boolean isTemporary;
 
 	public DropFunctionOperation(
 			ObjectIdentifier functionIdentifier,
+			boolean isTemporary,
 			boolean ifExists) {
 		this.functionIdentifier = functionIdentifier;
 		this.ifExists = ifExists;
+		this.isTemporary = isTemporary;
 	}
 
 	public ObjectIdentifier getFunctionIdentifier() {
@@ -52,12 +55,21 @@ public class DropFunctionOperation implements DropOperation {
 	public String asSummaryString() {
 		Map<String, Object> params = new LinkedHashMap<>();
 		params.put("identifier", functionIdentifier);
-		params.put("IfExists", ifExists);
+		params.put("ifExists", ifExists);
+		params.put("isTemporary", isTemporary);
 
 		return OperationUtils.formatWithChildren(
 			"DROP FUNCTION",
 			params,
 			Collections.emptyList(),
 			Operation::asSummaryString);
+	}
+
+	public boolean isTemporary() {
+		return isTemporary;
+	}
+
+	public String getFunctionName() {
+		return this.functionIdentifier.getObjectName();
 	}
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
@@ -162,6 +162,6 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 
 	@Override
 	protected CatalogFunction createAnotherFunction() {
-		return new CatalogFunctionImpl(TestSimpleUDF.class.getCanonicalName(), FunctionLanguage.SCALA);
+		return new CatalogFunctionImpl(TestSimpleUDF.class.getCanonicalName(), FunctionLanguage.SCALA, false);
 	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogFunction.java
@@ -54,11 +54,18 @@ public interface CatalogFunction {
 	Optional<String> getDetailedDescription();
 
 	/**
-	 * Distinguish if the function is a generic Flink function.
+	 * Distinguish if the function is a generic function.
 	 *
-	 * @return whether the function is a generic Flink function
+	 * @return whether the function is a generic function
 	 */
 	boolean isGeneric();
+
+	/**
+	 * Distinguish if the function is a temporary function.
+	 *
+	 * @return whether the function is a generic function
+	 */
+	boolean isTemporary();
 
 	/**
 	 * Get the language used for the definition of function.

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -241,7 +241,7 @@ public class SqlToOperationConverter {
 	private Operation convertCreateFunction(SqlCreateFunction sqlCreateFunction) {
 		FunctionLanguage language = parseLanguage(sqlCreateFunction.getFunctionLanguage());
 		CatalogFunction catalogFunction = new CatalogFunctionImpl(
-			sqlCreateFunction.getFunctionClassName().getValueAs(String.class), language);
+			sqlCreateFunction.getFunctionClassName().getValueAs(String.class), language, sqlCreateFunction.isTemporary());
 
 		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlCreateFunction.getFunctionIdentifier());
 		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
@@ -257,7 +257,7 @@ public class SqlToOperationConverter {
 	private Operation convertAlterFunction(SqlAlterFunction sqlAlterFunction) {
 		FunctionLanguage language = parseLanguage(sqlAlterFunction.getFunctionLanguage());
 		CatalogFunction catalogFunction = new CatalogFunctionImpl(
-			sqlAlterFunction.getFunctionClassName().getValueAs(String.class), language);
+			sqlAlterFunction.getFunctionClassName().getValueAs(String.class), language, sqlAlterFunction.isTemporary());
 
 		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlAlterFunction.getFunctionIdentifier());
 		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
@@ -275,7 +275,9 @@ public class SqlToOperationConverter {
 
 		return new DropFunctionOperation(
 			identifier,
-			sqlDropFunction.getIfExists());
+			sqlDropFunction.isTemporary(),
+			sqlDropFunction.getIfExists()
+		);
 	}
 
 	/**

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CatalogFunctionITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CatalogFunctionITCase.java
@@ -28,7 +28,8 @@ import org.junit.BeforeClass;
 /**
  * Tests for {@link CatalogFunction} in batch table environment.
  */
-public class CatalogFunctionITCase extends CatalogFunctionTestBase {
+public class
+CatalogFunctionITCase extends CatalogFunctionTestBase {
 
 	@BeforeClass
 	public static void setup() {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -247,7 +247,9 @@ public class SqlToOperationConverter {
 	private Operation convertCreateFunction(SqlCreateFunction sqlCreateFunction) {
 		FunctionLanguage language = parseLanguage(sqlCreateFunction.getFunctionLanguage());
 		CatalogFunction catalogFunction = new CatalogFunctionImpl(
-			sqlCreateFunction.getFunctionClassName().getValueAs(String.class), language);
+			sqlCreateFunction.getFunctionClassName().getValueAs(String.class),
+			language,
+			sqlCreateFunction.isTemporary());
 
 		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlCreateFunction.getFunctionIdentifier());
 		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
@@ -263,7 +265,9 @@ public class SqlToOperationConverter {
 	private Operation convertAlterFunction(SqlAlterFunction sqlAlterFunction) {
 		FunctionLanguage language = parseLanguage(sqlAlterFunction.getFunctionLanguage());
 		CatalogFunction catalogFunction = new CatalogFunctionImpl(
-			sqlAlterFunction.getFunctionClassName().getValueAs(String.class), language);
+			sqlAlterFunction.getFunctionClassName().getValueAs(String.class),
+			language,
+			sqlAlterFunction.isTemporary());
 
 		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlAlterFunction.getFunctionIdentifier());
 		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
@@ -281,6 +285,7 @@ public class SqlToOperationConverter {
 
 		return new DropFunctionOperation(
 			identifier,
+			sqlDropFunction.isTemporary(),
 			sqlDropFunction.getIfExists());
 	}
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -696,48 +696,114 @@ abstract class TableEnvImpl(
   }
 
   private def createCatalogFunction(createFunctionOperation: CreateFunctionOperation)= {
-    val catalog = getCatalogOrThrowException(
-      createFunctionOperation.getFunctionIdentifier.getCatalogName)
     val exMsg = getDDLOpExecuteErrorMsg(createFunctionOperation.asSummaryString)
     try {
-      catalog.createFunction(
-        createFunctionOperation.getFunctionIdentifier.toObjectPath,
-        createFunctionOperation.getCatalogFunction,
-        createFunctionOperation.isIgnoreIfExists)
+      val function = createFunctionOperation.getCatalogFunction
+      if (function.isTemporary) {
+        val exist = functionCatalog.hasTemporaryCatalogFunction(
+          createFunctionOperation.getFunctionIdentifier);
+        if (!exist) {
+          val functionDefinition = FunctionDefinitionUtil.createFunctionDefinition(
+            createFunctionOperation.getFunctionName, function)
+          registerFunctionInFunctionCatalog(
+            createFunctionOperation.getFunctionIdentifier,
+            functionDefinition)
+        } else if (!createFunctionOperation.isIgnoreIfExists) {
+          throw new ValidationException(
+            String.format("Temporary catalog function %s is already defined",
+            createFunctionOperation.getFunctionIdentifier.asSerializableString))
+        }
+      } else {
+        val catalog = getCatalogOrThrowException(
+          createFunctionOperation.getFunctionIdentifier.getCatalogName)
+        catalog.createFunction(
+          createFunctionOperation.getFunctionIdentifier.toObjectPath,
+          createFunctionOperation.getCatalogFunction,
+          createFunctionOperation.isIgnoreIfExists)
+      }
     } catch {
-      case ex: FunctionAlreadyExistException => throw new ValidationException(exMsg, ex)
+      case ex: ValidationException => throw ex
+      case ex: FunctionAlreadyExistException => throw new ValidationException(ex.getMessage, ex)
       case ex: Exception => throw new TableException(exMsg, ex)
     }
   }
 
   private def alterCatalogFunction(alterFunctionOperation: AlterFunctionOperation) = {
-    val catalog = getCatalogOrThrowException(
-      alterFunctionOperation.getFunctionIdentifier.getCatalogName)
     val exMsg = getDDLOpExecuteErrorMsg(alterFunctionOperation.asSummaryString)
-
     try {
-      catalog.alterFunction(
-        alterFunctionOperation.getFunctionIdentifier.toObjectPath,
-        alterFunctionOperation.getCatalogFunction,
-        alterFunctionOperation.isIfExists)
+      val function = alterFunctionOperation.getCatalogFunction
+      if (function.isTemporary) {
+        throw new ValidationException("Alter temporary catalog function is not supported")
+      } else {
+        val catalog = getCatalogOrThrowException(
+          alterFunctionOperation.getFunctionIdentifier.getCatalogName)
+        catalog.alterFunction(
+          alterFunctionOperation.getFunctionIdentifier.toObjectPath,
+          alterFunctionOperation.getCatalogFunction,
+          alterFunctionOperation.isIfExists)
+      }
     } catch {
-      case ex: FunctionNotExistException => throw new ValidationException(exMsg, ex)
+      case ex: ValidationException => throw ex
+      case ex: FunctionNotExistException => throw new ValidationException(ex.getMessage, ex)
       case ex: Exception => throw new TableException(exMsg, ex)
     }
   }
 
   private def dropCatalogFunction(dropFunctionOperation: DropFunctionOperation) = {
-    val catalog = getCatalogOrThrowException(
-      dropFunctionOperation.getFunctionIdentifier.getCatalogName)
     val exMsg = getDDLOpExecuteErrorMsg(dropFunctionOperation.asSummaryString)
-
     try {
-      catalog.dropFunction(
-        dropFunctionOperation.getFunctionIdentifier.toObjectPath,
-        dropFunctionOperation.isIfExists)
+      if (dropFunctionOperation.isTemporary)  {
+
+        val exist = functionCatalog.hasTemporaryCatalogFunction(
+          dropFunctionOperation.getFunctionIdentifier)
+        if (exist) {
+          functionCatalog.dropTempCatalogFunction(
+            dropFunctionOperation.getFunctionIdentifier, dropFunctionOperation.isIfExists)
+        } else if (!dropFunctionOperation.isIfExists) {
+          throw new ValidationException(String.format("Temporary catalog function %s is not found",
+            dropFunctionOperation.getFunctionIdentifier.asSerializableString))
+        }
+      } else  {
+        val catalog = getCatalogOrThrowException(
+          dropFunctionOperation.getFunctionIdentifier.getCatalogName)
+        catalog.dropFunction(
+          dropFunctionOperation.getFunctionIdentifier.toObjectPath,
+          dropFunctionOperation.isIfExists)
+      }
     } catch {
-      case ex: FunctionNotExistException => throw new ValidationException(exMsg, ex)
+      case ex: ValidationException => throw ex
+      case ex: FunctionNotExistException => throw new ValidationException(ex.getMessage, ex)
       case ex: Exception => throw new TableException(exMsg, ex)
+    }
+  }
+
+  private def registerFunctionInFunctionCatalog[T, ACC](
+      functionIdentifier: ObjectIdentifier,
+      functionDefinition: FunctionDefinition): Unit = {
+    if (functionDefinition.isInstanceOf[ScalarFunctionDefinition]) {
+      val scalarFunctionDefinition = functionDefinition.asInstanceOf[ScalarFunctionDefinition]
+      functionCatalog.registerTempCatalogScalarFunction(
+        functionIdentifier,
+        scalarFunctionDefinition.getScalarFunction)
+    }
+    else if (functionDefinition.isInstanceOf[AggregateFunctionDefinition]) {
+      val aggregateFunctionDefinition = functionDefinition.asInstanceOf[AggregateFunctionDefinition]
+      val aggregateFunction = aggregateFunctionDefinition
+        .getAggregateFunction.asInstanceOf[AggregateFunction[T, ACC]]
+      val typeInfo = UserFunctionsTypeHelper.getReturnTypeOfAggregateFunction(aggregateFunction)
+      val accTypeInfo = UserFunctionsTypeHelper
+        .getAccumulatorTypeOfAggregateFunction(aggregateFunction)
+      functionCatalog.registerTempCatalogAggregateFunction(
+        functionIdentifier,
+        aggregateFunction,
+        typeInfo,
+        accTypeInfo)
+    }
+    else if (functionDefinition.isInstanceOf[TableFunctionDefinition]) {
+      val tableFunctionDefinition = functionDefinition.asInstanceOf[TableFunctionDefinition]
+      val tableFunction = tableFunctionDefinition.getTableFunction.asInstanceOf[TableFunction[T]]
+      val typeInfo = UserFunctionsTypeHelper.getReturnTypeOfTableFunction(tableFunction)
+      functionCatalog.registerTempCatalogTableFunction(functionIdentifier, tableFunction, typeInfo)
     }
   }
 


### PR DESCRIPTION
## What is the purpose of the change
Create and drop temp catalog functions from DDL to FunctionCatalog

## Brief change log

  - Create and drop temporary catalog function to FunctionCatalog by using function DDL.
  - And test cases for temporary catalog function operation.

## Verifying this change
It is tested in CatalogFunctionITCase for both flink/blink planner

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (o)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
