### PR TITLE
[FLINK-15096][python] Pass python configuration to the python operators via table config instead of global job parameters.

### DIFF
--- a/flink-python/pyflink/common/tests/test_dependency_manager.py
+++ b/flink-python/pyflink/common/tests/test_dependency_manager.py
@@ -107,15 +107,15 @@ class DependencyManagerTests(PyFlinkTestCase):
             table_config.get_python_executable())
 
     def test_constant_consistency(self):
-        JDependencyInfo = get_gateway().jvm.org.apache.flink.python.env.PythonDependencyInfo
+        JPythonConfig = get_gateway().jvm.org.apache.flink.python.PythonConfig
         self.assertEqual(DependencyManager.PYTHON_REQUIREMENTS_CACHE,
-                         JDependencyInfo.PYTHON_REQUIREMENTS_CACHE)
+                         JPythonConfig.PYTHON_REQUIREMENTS_CACHE)
         self.assertEqual(DependencyManager.PYTHON_REQUIREMENTS_FILE,
-                         JDependencyInfo.PYTHON_REQUIREMENTS_FILE)
+                         JPythonConfig.PYTHON_REQUIREMENTS_FILE)
         self.assertEqual(DependencyManager.PYTHON_ARCHIVES,
-                         JDependencyInfo.PYTHON_ARCHIVES)
-        self.assertEqual(DependencyManager.PYTHON_FILES, JDependencyInfo.PYTHON_FILES)
-        self.assertEqual(DependencyManager.PYTHON_EXEC, JDependencyInfo.PYTHON_EXEC)
+                         JPythonConfig.PYTHON_ARCHIVES)
+        self.assertEqual(DependencyManager.PYTHON_FILES, JPythonConfig.PYTHON_FILES)
+        self.assertEqual(DependencyManager.PYTHON_EXEC, JPythonConfig.PYTHON_EXEC)
 
 
 class Tuple2(object):

--- a/flink-python/pyflink/table/tests/test_dependency.py
+++ b/flink-python/pyflink/table/tests/test_dependency.py
@@ -26,10 +26,11 @@ from pyflink.table import DataTypes
 from pyflink.table.udf import udf
 from pyflink.testing import source_sink_utils
 from pyflink.testing.test_case_utils import (PyFlinkBlinkStreamTableTestCase,
-                                             PyFlinkBlinkBatchTableTestCase)
+                                             PyFlinkBlinkBatchTableTestCase,
+                                             PyFlinkStreamTableTestCase)
 
 
-class PyFlinkDependencyTests(object):
+class DependencyTests(object):
 
     def test_add_python_file(self):
         python_file_dir = os.path.join(self.tempdir, "python_file_dir_" + str(uuid.uuid4()))
@@ -56,12 +57,17 @@ class PyFlinkDependencyTests(object):
         self.assert_equals(actual, ["3,1", "4,2", "5,3"])
 
 
-class PyFlinkBatchDependencyTests(PyFlinkDependencyTests, PyFlinkBlinkBatchTableTestCase):
+class FlinkStreamDependencyTests(DependencyTests, PyFlinkStreamTableTestCase):
 
     pass
 
 
-class PyFlinkStreamDependencyTests(PyFlinkDependencyTests, PyFlinkBlinkStreamTableTestCase):
+class BlinkBatchDependencyTests(DependencyTests, PyFlinkBlinkBatchTableTestCase):
+
+    pass
+
+
+class BlinkStreamDependencyTests(DependencyTests, PyFlinkBlinkStreamTableTestCase):
 
     def test_set_requirements_without_cached_directory(self):
         requirements_txt_path = os.path.join(self.tempdir, str(uuid.uuid4()))

--- a/flink-python/src/main/java/org/apache/flink/python/PythonConfig.java
+++ b/flink-python/src/main/java/org/apache/flink/python/PythonConfig.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.python;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.Configuration;
+
+import java.io.Serializable;
+import java.util.Optional;
+
+/**
+ * Configuration for the Python job.
+ */
+@Internal
+public class PythonConfig implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	public static final String PYTHON_FILES = "python.files";
+	public static final String PYTHON_REQUIREMENTS_FILE = "python.requirements-file";
+	public static final String PYTHON_REQUIREMENTS_CACHE = "python.requirements-cache";
+	public static final String PYTHON_ARCHIVES = "python.archives";
+	public static final String PYTHON_EXEC = "python.exec";
+
+	/**
+	 * Max number of elements to include in a bundle.
+	 */
+	private final int maxBundleSize;
+
+	/**
+	 * Max duration of a bundle.
+	 */
+	private final long maxBundleTimeMills;
+
+	/**
+	 * The amount of memory to be allocated by the Python framework.
+	 */
+	private final String pythonFrameworkMemorySize;
+
+	/**
+	 * The amount of memory to be allocated by the input/output buffer of a Python worker.
+	 */
+	private final String pythonDataBufferMemorySize;
+
+	/**
+	 * The python files uploaded by TableEnvironment#add_python_file() or command line option "-pyfs". It is a json
+	 * string. The key is the file key in distribute cache and the value is the corresponding origin file name.
+	 */
+	private final String pythonFilesInfo;
+
+	/**
+	 * The file key of the requirements file in distribute cache. It is specified by
+	 * TableEnvironment#set_python_requirements() or command line option "-pyreq".
+	 */
+	private final String pythonRequirementsFileInfo;
+
+	/**
+	 * The file key of the requirements cached directory in distribute cache. It is specified by
+	 * TableEnvironment#set_python_requirements() or command line option "-pyreq". It is used to
+	 * support installing python packages offline.
+	 */
+	private final String pythonRequirementsCacheDirInfo;
+
+	/**
+	 * The python archives uploaded by TableEnvironment#add_python_archive() or command line option "-pyarch". It is a
+	 * json string. The key is the file key of the archives in distribute cache and the value is the name of the
+	 * directory to extract to.
+	 */
+	private final String pythonArchivesInfo;
+
+	/**
+	 * The path of the python interpreter (e.g. /usr/local/bin/python) specified by
+	 * pyflink.table.TableConfig#set_python_executable() or command line option "-pyexec".
+	 */
+	private final String pythonExec;
+
+	public PythonConfig(Configuration config) {
+		maxBundleSize = config.get(PythonOptions.MAX_BUNDLE_SIZE);
+		maxBundleTimeMills = config.get(PythonOptions.MAX_BUNDLE_TIME_MILLS);
+		pythonFrameworkMemorySize = config.get(PythonOptions.PYTHON_FRAMEWORK_MEMORY_SIZE);
+		pythonDataBufferMemorySize = config.get(PythonOptions.PYTHON_DATA_BUFFER_MEMORY_SIZE);
+		pythonFilesInfo = config.getString(PYTHON_FILES, null);
+		pythonRequirementsFileInfo = config.getString(PYTHON_REQUIREMENTS_FILE, null);
+		pythonRequirementsCacheDirInfo = config.getString(PYTHON_REQUIREMENTS_CACHE, null);
+		pythonArchivesInfo = config.getString(PYTHON_ARCHIVES, null);
+		pythonExec = config.getString(PYTHON_EXEC, null);
+	}
+
+	public int getMaxBundleSize() {
+		return maxBundleSize;
+	}
+
+	public long getMaxBundleTimeMills() {
+		return maxBundleTimeMills;
+	}
+
+	public String getPythonFrameworkMemorySize() {
+		return pythonFrameworkMemorySize;
+	}
+
+	public String getPythonDataBufferMemorySize() {
+		return pythonDataBufferMemorySize;
+	}
+
+	public Optional<String> getPythonFilesInfo() {
+		return Optional.ofNullable(pythonFilesInfo);
+	}
+
+	public Optional<String> getPythonRequirementsFileInfo() {
+		return Optional.ofNullable(pythonRequirementsFileInfo);
+	}
+
+	public Optional<String> getPythonRequirementsCacheDirInfo() {
+		return Optional.ofNullable(pythonRequirementsCacheDirInfo);
+	}
+
+	public Optional<String> getPythonArchivesInfo() {
+		return Optional.ofNullable(pythonArchivesInfo);
+	}
+
+	public Optional<String> getPythonExec() {
+		return Optional.ofNullable(pythonExec);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/AbstractPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/AbstractPythonScalarFunctionOperator.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.operators.python;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.streaming.api.operators.python.AbstractPythonFunctionOperator;
@@ -116,12 +117,13 @@ public abstract class AbstractPythonScalarFunctionOperator<IN, OUT, UDFIN, UDFOU
 	protected transient LinkedBlockingQueue<UDFOUT> udfResultQueue;
 
 	AbstractPythonScalarFunctionOperator(
+		Configuration config,
 		PythonFunctionInfo[] scalarFunctions,
 		RowType inputType,
 		RowType outputType,
 		int[] udfInputOffsets,
 		int[] forwardedFields) {
-		super();
+		super(config);
 		this.scalarFunctions = Preconditions.checkNotNull(scalarFunctions);
 		this.inputType = Preconditions.checkNotNull(inputType);
 		this.outputType = Preconditions.checkNotNull(outputType);

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonScalarFunctionOperator.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.operators.python;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -71,12 +72,13 @@ public class BaseRowPythonScalarFunctionOperator
 	private transient Projection<BaseRow, BinaryRow> udfInputProjection;
 
 	public BaseRowPythonScalarFunctionOperator(
+		Configuration config,
 		PythonFunctionInfo[] scalarFunctions,
 		RowType inputType,
 		RowType outputType,
 		int[] udfInputOffsets,
 		int[] forwardedFields) {
-		super(scalarFunctions, inputType, outputType, udfInputOffsets, forwardedFields);
+		super(config, scalarFunctions, inputType, outputType, udfInputOffsets, forwardedFields);
 	}
 
 	@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperator.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -58,12 +59,13 @@ public class PythonScalarFunctionOperator extends AbstractPythonScalarFunctionOp
 	private transient TypeSerializer<CRow> forwardedInputSerializer;
 
 	public PythonScalarFunctionOperator(
+		Configuration config,
 		PythonFunctionInfo[] scalarFunctions,
 		RowType inputType,
 		RowType outputType,
 		int[] udfInputOffsets,
 		int[] forwardedFields) {
-		super(scalarFunctions, inputType, outputType, udfInputOffsets, forwardedFields);
+		super(config, scalarFunctions, inputType, outputType, udfInputOffsets, forwardedFields);
 	}
 
 	@Override

--- a/flink-python/src/test/java/org/apache/flink/python/PythonConfigTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/PythonConfigTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.python;
+
+import org.apache.flink.configuration.Configuration;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link PythonConfig}.
+ */
+public class PythonConfigTest {
+
+	@Test
+	public void testDefaultConfigure() {
+		PythonConfig pythonConfig = new PythonConfig(new Configuration());
+		assertThat(pythonConfig.getMaxBundleSize(),
+			is(equalTo(PythonOptions.MAX_BUNDLE_SIZE.defaultValue())));
+		assertThat(pythonConfig.getMaxBundleTimeMills(),
+			is(equalTo(PythonOptions.MAX_BUNDLE_TIME_MILLS.defaultValue())));
+		assertThat(pythonConfig.getPythonFrameworkMemorySize(),
+			is(equalTo(PythonOptions.PYTHON_FRAMEWORK_MEMORY_SIZE.defaultValue())));
+		assertThat(pythonConfig.getPythonDataBufferMemorySize(),
+			is(equalTo(PythonOptions.PYTHON_DATA_BUFFER_MEMORY_SIZE.defaultValue())));
+		assertThat(pythonConfig.getPythonFilesInfo().isPresent(), is(false));
+		assertThat(pythonConfig.getPythonRequirementsFileInfo().isPresent(), is(false));
+		assertThat(pythonConfig.getPythonRequirementsCacheDirInfo().isPresent(), is(false));
+		assertThat(pythonConfig.getPythonArchivesInfo().isPresent(), is(false));
+		assertThat(pythonConfig.getPythonExec().isPresent(), is(false));
+	}
+
+	@Test
+	public void testMaxBundleSize() {
+		Configuration config = new Configuration();
+		config.set(PythonOptions.MAX_BUNDLE_SIZE, 10);
+		PythonConfig pythonConfig = new PythonConfig(config);
+		assertThat(pythonConfig.getMaxBundleSize(), is(equalTo(10)));
+	}
+
+	@Test
+	public void testMaxBundleTimeMills() {
+		Configuration config = new Configuration();
+		config.set(PythonOptions.MAX_BUNDLE_TIME_MILLS, 10L);
+		PythonConfig pythonConfig = new PythonConfig(config);
+		assertThat(pythonConfig.getMaxBundleTimeMills(), is(equalTo(10)));
+	}
+
+	@Test
+	public void testPythonFrameworkMemorySize() {
+		Configuration config = new Configuration();
+		config.set(PythonOptions.PYTHON_FRAMEWORK_MEMORY_SIZE, "100mb");
+		PythonConfig pythonConfig = new PythonConfig(config);
+		assertThat(pythonConfig.getMaxBundleTimeMills(), is(equalTo("100mb")));
+	}
+
+	@Test
+	public void testPythonDataBufferMemorySize() {
+		Configuration config = new Configuration();
+		config.set(PythonOptions.PYTHON_DATA_BUFFER_MEMORY_SIZE, "100mb");
+		PythonConfig pythonConfig = new PythonConfig(config);
+		assertThat(pythonConfig.getMaxBundleTimeMills(), is(equalTo("100mb")));
+	}
+
+	@Test
+	public void testPythonFilesInfo() {
+		Configuration config = new Configuration();
+		config.setString(PythonConfig.PYTHON_FILES, "{\"python_file_0\" : \"file0.py\"}");
+		PythonConfig pythonConfig = new PythonConfig(config);
+		assertThat(pythonConfig.getPythonFilesInfo().get(), is(equalTo("{\"python_file_0\" : \"file0.py\"}")));
+	}
+
+	@Test
+	public void testPythonRequirementsFileInfo() {
+		Configuration config = new Configuration();
+		config.setString(PythonConfig.PYTHON_REQUIREMENTS_FILE, "python_requirements_file_0");
+		PythonConfig pythonConfig = new PythonConfig(config);
+		assertThat(pythonConfig.getPythonRequirementsFileInfo().get(), is(equalTo("python_requirements_file_0")));
+	}
+
+	@Test
+	public void testPythonRequirementsCacheDirInfo() {
+		Configuration config = new Configuration();
+		config.setString(PythonConfig.PYTHON_REQUIREMENTS_CACHE, "python_requirements_cache_1");
+		PythonConfig pythonConfig = new PythonConfig(config);
+		assertThat(pythonConfig.getPythonRequirementsCacheDirInfo().get(), is(equalTo("python_requirements_cache_1")));
+	}
+
+	@Test
+	public void testPythonArchivesInfo() {
+		Configuration config = new Configuration();
+		config.setString(PythonConfig.PYTHON_ARCHIVES, "{\"python_archive_0\" : \"file0.zip\"}");
+		PythonConfig pythonConfig = new PythonConfig(config);
+		assertThat(pythonConfig.getPythonArchivesInfo().get(), is(equalTo("{\"python_archive_0\" : \"file0.zip\"}")));
+	}
+
+	@Test
+	public void testPythonExec() {
+		Configuration config = new Configuration();
+		config.setString(PythonConfig.PYTHON_EXEC, "/usr/local/bin/python3");
+		PythonConfig pythonConfig = new PythonConfig(config);
+		assertThat(pythonConfig.getPythonExec().get(), is(equalTo("/usr/local/bin/python3")));
+	}
+
+}

--- a/flink-python/src/test/java/org/apache/flink/python/env/PythonDependencyInfoTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/env/PythonDependencyInfoTest.java
@@ -19,7 +19,9 @@
 package org.apache.flink.python.env;
 
 import org.apache.flink.api.common.cache.DistributedCache;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.python.PythonConfig;
 
 import org.junit.Test;
 
@@ -64,11 +66,11 @@ public class PythonDependencyInfoTest {
 
 	@Test
 	public void testParsePythonFiles() throws IOException {
-		Map<String, String> pythonFileMetaData = new HashMap<>();
-		pythonFileMetaData.put(PythonDependencyInfo.PYTHON_FILES,
+		Configuration config = new Configuration();
+		config.setString(
+			PythonConfig.PYTHON_FILES,
 			"{\"python_file_0_{uuid}\": \"test_file1.py\", \"python_file_1_{uuid}\": \"test_file2.py\"}");
-		PythonDependencyInfo dependencyInfo =
-			PythonDependencyInfo.create(pythonFileMetaData, distributedCache);
+		PythonDependencyInfo dependencyInfo = PythonDependencyInfo.create(new PythonConfig(config), distributedCache);
 
 		Map<String, String> expected = new HashMap<>();
 		expected.put("/distributed_cache/file0", "test_file1.py");
@@ -78,18 +80,15 @@ public class PythonDependencyInfoTest {
 
 	@Test
 	public void testParsePythonRequirements() throws IOException {
-		Map<String, String> pythonRequirementsMetaData = new HashMap<>();
-		pythonRequirementsMetaData.put(
-			PythonDependencyInfo.PYTHON_REQUIREMENTS_FILE, "python_requirements_file_2_{uuid}");
-		PythonDependencyInfo dependencyInfo =
-			PythonDependencyInfo.create(pythonRequirementsMetaData, distributedCache);
+		Configuration config = new Configuration();
+		config.setString(PythonConfig.PYTHON_REQUIREMENTS_FILE, "python_requirements_file_2_{uuid}");
+		PythonDependencyInfo dependencyInfo = PythonDependencyInfo.create(new PythonConfig(config), distributedCache);
 
 		assertEquals("/distributed_cache/file2", dependencyInfo.getRequirementsFilePath().get());
 		assertFalse(dependencyInfo.getRequirementsCacheDir().isPresent());
 
-		pythonRequirementsMetaData.put(
-			PythonDependencyInfo.PYTHON_REQUIREMENTS_CACHE, "python_requirements_cache_3_{uuid}");
-		dependencyInfo = PythonDependencyInfo.create(pythonRequirementsMetaData, distributedCache);
+		config.setString(PythonConfig.PYTHON_REQUIREMENTS_CACHE, "python_requirements_cache_3_{uuid}");
+		dependencyInfo = PythonDependencyInfo.create(new PythonConfig(config), distributedCache);
 
 		assertEquals("/distributed_cache/file2", dependencyInfo.getRequirementsFilePath().get());
 		assertEquals("/distributed_cache/file3", dependencyInfo.getRequirementsCacheDir().get());
@@ -97,12 +96,12 @@ public class PythonDependencyInfoTest {
 
 	@Test
 	public void testParsePythonArchives() throws IOException {
-		Map<String, String> pythonArchiveMetaData = new HashMap<>();
-		pythonArchiveMetaData.put(
-			PythonDependencyInfo.PYTHON_ARCHIVES,
+		Configuration config = new Configuration();
+		config.setString(
+			PythonConfig.PYTHON_ARCHIVES,
 			"{\"python_archive_4_{uuid}\": \"py27.zip\", \"python_archive_5_{uuid}\": \"py37\"}");
 		PythonDependencyInfo dependencyInfo =
-			PythonDependencyInfo.create(pythonArchiveMetaData, distributedCache);
+			PythonDependencyInfo.create(new PythonConfig(config), distributedCache);
 
 		Map<String, String> expected = new HashMap<>();
 		expected.put("/distributed_cache/file4", "py27.zip");
@@ -112,10 +111,10 @@ public class PythonDependencyInfoTest {
 
 	@Test
 	public void testParsePythonExec() throws IOException {
-		Map<String, String> pythonFileMetaData = new HashMap<>();
-		pythonFileMetaData.put(PythonDependencyInfo.PYTHON_EXEC, "/usr/bin/python3");
+		Configuration config = new Configuration();
+		config.setString(PythonConfig.PYTHON_EXEC, "/usr/bin/python3");
 		PythonDependencyInfo dependencyInfo =
-			PythonDependencyInfo.create(pythonFileMetaData, distributedCache);
+			PythonDependencyInfo.create(new PythonConfig(config), distributedCache);
 
 		assertEquals("/usr/bin/python3", dependencyInfo.getPythonExec().get());
 	}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonScalarFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonScalarFunctionOperatorTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.runtime.operators.python;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -52,12 +53,14 @@ public class BaseRowPythonScalarFunctionOperatorTest
 
 	@Override
 	public AbstractPythonScalarFunctionOperator<BaseRow, BaseRow, BaseRow, BaseRow> getTestOperator(
+		Configuration config,
 		PythonFunctionInfo[] scalarFunctions,
 		RowType inputType,
 		RowType outputType,
 		int[] udfInputOffsets,
 		int[] forwardedFields) {
 		return new PassThroughPythonScalarFunctionOperator(
+			config,
 			scalarFunctions,
 			inputType,
 			outputType,
@@ -90,12 +93,13 @@ public class BaseRowPythonScalarFunctionOperatorTest
 	private static class PassThroughPythonScalarFunctionOperator extends BaseRowPythonScalarFunctionOperator {
 
 		PassThroughPythonScalarFunctionOperator(
+			Configuration config,
 			PythonFunctionInfo[] scalarFunctions,
 			RowType inputType,
 			RowType outputType,
 			int[] udfInputOffsets,
 			int[] forwardedFields) {
-			super(scalarFunctions, inputType, outputType, udfInputOffsets, forwardedFields);
+			super(config, scalarFunctions, inputType, outputType, udfInputOffsets, forwardedFields);
 		}
 
 		@Override

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperatorTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators.python;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -40,13 +41,14 @@ public class PythonScalarFunctionOperatorTest extends PythonScalarFunctionOperat
 
 	@Override
 	public AbstractPythonScalarFunctionOperator<CRow, CRow, Row, Row> getTestOperator(
+		Configuration config,
 		PythonFunctionInfo[] scalarFunctions,
 		RowType inputType,
 		RowType outputType,
 		int[] udfInputOffsets,
 		int[] forwardedFields) {
 		return new PassThroughPythonScalarFunctionOperator(
-			scalarFunctions, inputType, outputType, udfInputOffsets, forwardedFields);
+			config, scalarFunctions, inputType, outputType, udfInputOffsets, forwardedFields);
 	}
 
 	@Override
@@ -67,12 +69,13 @@ public class PythonScalarFunctionOperatorTest extends PythonScalarFunctionOperat
 	private static class PassThroughPythonScalarFunctionOperator extends PythonScalarFunctionOperator {
 
 		PassThroughPythonScalarFunctionOperator(
+			Configuration config,
 			PythonFunctionInfo[] scalarFunctions,
 			RowType inputType,
 			RowType outputType,
 			int[] udfInputOffsets,
 			int[] forwardedFields) {
-			super(scalarFunctions, inputType, outputType, udfInputOffsets, forwardedFields);
+			super(config, scalarFunctions, inputType, outputType, udfInputOffsets, forwardedFields);
 		}
 
 		@Override

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperatorTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperatorTestBase.java
@@ -64,8 +64,7 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN, UDFOU
 
 	@Test
 	public void testRetractionFieldKept() throws Exception {
-		OneInputStreamOperatorTestHarness<IN, OUT> testHarness = getTestHarness();
-
+		OneInputStreamOperatorTestHarness<IN, OUT> testHarness = getTestHarness(new Configuration());
 		long initialTime = 0L;
 		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
 
@@ -85,11 +84,9 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN, UDFOU
 
 	@Test
 	public void testFinishBundleTriggeredOnCheckpoint() throws Exception {
-		OneInputStreamOperatorTestHarness<IN, OUT> testHarness = getTestHarness();
-
 		Configuration conf = new Configuration();
 		conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
-		testHarness.getExecutionConfig().setGlobalJobParameters(conf);
+		OneInputStreamOperatorTestHarness<IN, OUT> testHarness = getTestHarness(conf);
 
 		long initialTime = 0L;
 		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
@@ -110,10 +107,9 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN, UDFOU
 
 	@Test
 	public void testFinishBundleTriggeredByCount() throws Exception {
-		OneInputStreamOperatorTestHarness<IN, OUT> testHarness = getTestHarness();
 		Configuration conf = new Configuration();
 		conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 2);
-		testHarness.getExecutionConfig().setGlobalJobParameters(conf);
+		OneInputStreamOperatorTestHarness<IN, OUT> testHarness = getTestHarness(conf);
 
 		long initialTime = 0L;
 		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
@@ -134,11 +130,10 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN, UDFOU
 
 	@Test
 	public void testFinishBundleTriggeredByTime() throws Exception {
-		OneInputStreamOperatorTestHarness<IN, OUT> testHarness = getTestHarness();
 		Configuration conf = new Configuration();
 		conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
 		conf.setLong(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);
-		testHarness.getExecutionConfig().setGlobalJobParameters(conf);
+		OneInputStreamOperatorTestHarness<IN, OUT> testHarness = getTestHarness(conf);
 
 		long initialTime = 0L;
 		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
@@ -157,10 +152,9 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN, UDFOU
 
 	@Test
 	public void testFinishBundleTriggeredByClose() throws Exception {
-		OneInputStreamOperatorTestHarness<IN, OUT> testHarness = getTestHarness();
 		Configuration conf = new Configuration();
 		conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
-		testHarness.getExecutionConfig().setGlobalJobParameters(conf);
+		OneInputStreamOperatorTestHarness<IN, OUT> testHarness = getTestHarness(conf);
 
 		long initialTime = 0L;
 		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
@@ -177,10 +171,9 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN, UDFOU
 
 	@Test
 	public void testWatermarkProcessedOnFinishBundle() throws Exception {
-		OneInputStreamOperatorTestHarness<IN, OUT> testHarness = getTestHarness();
 		Configuration conf = new Configuration();
 		conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
-		testHarness.getExecutionConfig().setGlobalJobParameters(conf);
+		OneInputStreamOperatorTestHarness<IN, OUT> testHarness = getTestHarness(conf);
 		long initialTime = 0L;
 		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
 
@@ -216,12 +209,13 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN, UDFOU
 		Assert.assertEquals(1, vertices.size());
 	}
 
-	private OneInputStreamOperatorTestHarness<IN, OUT> getTestHarness() throws Exception {
+	private OneInputStreamOperatorTestHarness<IN, OUT> getTestHarness(Configuration config) throws Exception {
 		RowType dataType = new RowType(Arrays.asList(
 			new RowType.RowField("f1", new VarCharType()),
 			new RowType.RowField("f2", new VarCharType()),
 			new RowType.RowField("f3", new BigIntType())));
 		AbstractPythonScalarFunctionOperator<IN, OUT, UDFIN, UDFOUT> operator = getTestOperator(
+			config,
 			new PythonFunctionInfo[] {
 				new PythonFunctionInfo(
 					AbstractPythonScalarFunctionRunnerTest.DummyPythonFunction.INSTANCE,
@@ -240,6 +234,7 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN, UDFOU
 	}
 
 	public abstract AbstractPythonScalarFunctionOperator<IN, OUT, UDFIN, UDFOUT> getTestOperator(
+		Configuration config,
 		PythonFunctionInfo[] scalarFunctions,
 		RowType inputType,
 		RowType outputType,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCalc.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.plan.nodes.common
 import org.apache.calcite.rex._
 import org.apache.calcite.sql.`type`.SqlTypeName
 import org.apache.flink.api.dag.Transformation
+import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.streaming.api.transformations.OneInputTransformation
 import org.apache.flink.table.api.TableException
@@ -100,6 +101,7 @@ trait CommonPythonCalc {
   }
 
   private def getPythonScalarFunctionOperator(
+      config: Configuration,
       inputRowTypeInfo: BaseRowTypeInfo,
       outputRowTypeInfo: BaseRowTypeInfo,
       udfInputOffsets: Array[Int],
@@ -107,12 +109,14 @@ trait CommonPythonCalc {
       forwardedFields: Array[Int])= {
     val clazz = loadClass(PYTHON_SCALAR_FUNCTION_OPERATOR_NAME)
     val ctor = clazz.getConstructor(
+      classOf[Configuration],
       classOf[Array[PythonFunctionInfo]],
       classOf[RowType],
       classOf[RowType],
       classOf[Array[Int]],
       classOf[Array[Int]])
     ctor.newInstance(
+      config,
       pythonFunctionInfos,
       inputRowTypeInfo.toRowType,
       outputRowTypeInfo.toRowType,
@@ -124,7 +128,8 @@ trait CommonPythonCalc {
   def createPythonOneInputTransformation(
       inputTransform: Transformation[BaseRow],
       calcProgram: RexProgram,
-      name: String): OneInputTransformation[BaseRow, BaseRow] = {
+      name: String,
+      config: Configuration): OneInputTransformation[BaseRow, BaseRow] = {
     val pythonRexCalls = calcProgram.getProjectList
       .map(calcProgram.expandLocalRef)
       .collect { case call: RexCall => call }
@@ -146,6 +151,7 @@ trait CommonPythonCalc {
         pythonRexCalls.map(node => FlinkTypeFactory.toLogicalType(node.getType)): _*)
 
     val pythonOperator = getPythonScalarFunctionOperator(
+      config,
       pythonOperatorInputTypeInfo,
       pythonOperatorResultTyeInfo,
       pythonUdfInputOffsets,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCalc.scala
@@ -57,7 +57,8 @@ class BatchExecPythonCalc(
     val ret = createPythonOneInputTransformation(
       inputTransform,
       calcProgram,
-      "BatchExecPythonCalc")
+      "BatchExecPythonCalc",
+      planner.getTableConfig.getConfiguration)
     val resource = NodeResourceUtil.fromManagedMem(
       getPythonWorkerMemory(planner.getTableConfig.getConfiguration))
     ret.setResources(resource, resource)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCalc.scala
@@ -56,7 +56,8 @@ class StreamExecPythonCalc(
     val ret = createPythonOneInputTransformation(
       inputTransform,
       calcProgram,
-      "StreamExecPythonCalc")
+      "StreamExecPythonCalc",
+      planner.getTableConfig.getConfiguration)
 
     if (inputsContainSingleton()) {
       ret.setParallelism(1)


### PR DESCRIPTION
## What is the purpose of the change

*This pull request passes python configuration to the python operators instead of global job parameters.*


## Brief change log

  - *Add class `PythonConfig` to store all python configurations.*
  - *Read python configuration from table config when instantiating the python operators.*
  - *Adjust relevant classes.*


## Verifying this change

This change is already covered by existing tests, such as *PythonConfigTest.java*, *test_dependency.py*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
