### PR TITLE
[FLINK-14992][client] Add job listener to execution environments

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -70,7 +70,7 @@ public class ContextEnvironment extends ExecutionEnvironment {
 	public JobExecutionResult execute(String jobName) throws Exception {
 		verifyExecuteIsCalledOnceWhenInDetachedMode();
 
-		JobClient jobClient = executeAsync(jobName).get();
+		JobClient jobClient = executeAsync(jobName);
 
 		JobExecutionResult jobExecutionResult;
 		if (getConfiguration().getBoolean(DeploymentOptions.ATTACHED)) {

--- a/flink-core/src/main/java/org/apache/flink/core/execution/JobListener.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/JobListener.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.execution;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
+
+import javax.annotation.Nullable;
+
+/**
+ * A listener that is notified on specific job status changed, which should be firstly
+ * registered by {@code #registerJobListener} of execution environments.
+ *
+ * <p>It is highly recommended NOT to perform any blocking operation inside
+ * the callbacks. If you block the thread the invoker of environment execute methods
+ * is possibly blocked.
+ */
+@PublicEvolving
+public interface JobListener {
+
+	/**
+	 * Callback on job submission succeeded or failed.
+	 *
+	 * <p>Exactly one of the passed parameters is null, respectively for failure or success.
+ 	 *
+	 * @param jobClient {@link JobClient} to interactive with the submitted flink job.
+	 * @param throwable the cause if submission failed
+	 */
+	void onJobSubmitted(@Nullable JobClient jobClient, @Nullable Throwable throwable);
+
+	/**
+	 * Callback on job execution finished, successfully or unsuccessfully. It is only called
+	 * back when you call {@code #execute} instead of {@code executeAsync} methods of execution
+	 * environments.
+	 *
+	 * <p>Exactly one of the passed parameters is null, respectively for failure or success.
+	 */
+	void onJobExecuted(@Nullable JobExecutionResult jobExecutionResult, @Nullable Throwable throwable);
+
+}

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -58,6 +58,7 @@ import org.apache.flink.core.execution.DetachedJobExecutionResult;
 import org.apache.flink.core.execution.ExecutorFactory;
 import org.apache.flink.core.execution.ExecutorServiceLoader;
 import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.core.execution.JobListener;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.types.StringValue;
 import org.apache.flink.util.NumberSequenceIterator;
@@ -135,6 +136,8 @@ public class ExecutionEnvironment {
 	private final Configuration configuration;
 
 	private final ClassLoader userClassloader;
+
+	protected final List<JobListener> jobListeners = new ArrayList<>();
 
 	/**
 	 * Creates a new Execution Environment.
@@ -804,7 +807,7 @@ public class ExecutionEnvironment {
 	 * @throws Exception Thrown, if the program executions fails.
 	 */
 	public JobExecutionResult execute(String jobName) throws Exception {
-		final JobClient jobClient = executeAsync(jobName).get();
+		final JobClient jobClient = executeAsync(jobName);
 
 		if (configuration.getBoolean(DeploymentOptions.ATTACHED)) {
 			lastJobExecutionResult = jobClient.getJobExecutionResult(userClassloader).get();
@@ -813,6 +816,24 @@ public class ExecutionEnvironment {
 		}
 
 		return lastJobExecutionResult;
+	}
+
+	/**
+	 * Register a {@link JobListener} in this environment. The {@link JobListener} will be
+	 * notified on specific job status changed.
+	 */
+	@PublicEvolving
+	public void registerJobListener(JobListener jobListener) {
+		checkNotNull(jobListener, "JobListener cannot be null");
+		jobListeners.add(jobListener);
+	}
+
+	/**
+	 * Clear all registered {@link JobListener}s.
+	 */
+	@PublicEvolving
+	public void clearJobListeners() {
+		this.jobListeners.clear();
 	}
 
 	/**
@@ -828,7 +849,7 @@ public class ExecutionEnvironment {
 	 * @throws Exception Thrown, if the program submission fails.
 	 */
 	@PublicEvolving
-	public final CompletableFuture<JobClient> executeAsync() throws Exception {
+	public final JobClient executeAsync() throws Exception {
 		return executeAsync(getDefaultName());
 	}
 
@@ -845,7 +866,7 @@ public class ExecutionEnvironment {
 	 * @throws Exception Thrown, if the program submission fails.
 	 */
 	@PublicEvolving
-	public CompletableFuture<JobClient> executeAsync(String jobName) throws Exception {
+	public JobClient executeAsync(String jobName) throws Exception {
 		checkNotNull(configuration.get(DeploymentOptions.TARGET), "No execution.target specified in your configuration file.");
 
 		consolidateParallelismDefinitionsInConfiguration();
@@ -859,9 +880,21 @@ public class ExecutionEnvironment {
 			"Cannot find compatible factory for specified execution.target (=%s)",
 			configuration.get(DeploymentOptions.TARGET));
 
-		return executorFactory
+		CompletableFuture<JobClient> jobClientFuture = executorFactory
 			.getExecutor(configuration)
 			.execute(plan, configuration);
+
+		// Need to call the JobListener in the job submission main thread, this is just for
+		// downstream project (e.g. Zeppelin needs to call InterpreterContext.get() which use ThreadLocal
+		// for more job submission context info)
+		try {
+			JobClient jobClient = jobClientFuture.get();
+			jobListeners.forEach(jobListener -> jobListener.onJobSubmitted(jobClient, null));
+			return jobClient;
+		} catch (Exception e) {
+			jobListeners.forEach(jobListener -> jobListener.onJobSubmitted(null, e));
+			return null;
+		}
 	}
 
 	private void consolidateParallelismDefinitionsInConfiguration() {

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -132,7 +132,7 @@ object FlinkShell {
     }
   }
 
-  private def ensureYarnConfig(config: Config) = config.yarnConfig match {
+  def ensureYarnConfig(config: Config) = config.yarnConfig match {
     case Some(yarnConfig) => yarnConfig
     case None => YarnConfig()
   }
@@ -196,7 +196,7 @@ object FlinkShell {
     println(" good bye ..")
   }
 
-  private def fetchConnectionInfo(
+  def fetchConnectionInfo(
       config: Config,
       flinkConfig: Configuration): (Configuration, Option[ClusterClient[_]]) = {
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -32,7 +32,7 @@ import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.api.java.typeutils.{PojoTypeInfo, TupleTypeInfoBase, ValueTypeInfo}
 import org.apache.flink.api.java.{CollectionEnvironment, ExecutionEnvironment => JavaEnv}
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.core.execution.JobClient
+import org.apache.flink.core.execution.{JobClient, JobListener}
 import org.apache.flink.core.fs.Path
 import org.apache.flink.types.StringValue
 import org.apache.flink.util.{NumberSequenceIterator, Preconditions, SplittableIterator}
@@ -495,6 +495,22 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
   }
 
   /**
+   * Register a [[JobListener]] in this environment. The [[JobListener]] will be
+   * notified on specific job status changed.
+   */
+  @PublicEvolving
+  def registerJobListener(jobListener: JobListener): Unit = {
+    javaEnv.registerJobListener(jobListener)
+  }
+
+  /**
+   * Clear all registered [[JobListener]]s.
+   */
+  @PublicEvolving def clearJobListeners(): Unit = {
+    javaEnv.clearJobListeners()
+  }
+
+  /**
    * Triggers the program execution asynchronously.
    * The environment will execute all parts of the program that have
    * resulted in a "sink" operation. Sink operations are for example printing results
@@ -508,11 +524,11 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
    * its usage. In other case, there may be resource leaks depending on the JobClient
    * implementation.
    *
-   * @return A future of [[JobClient]] that can be used to communicate with the submitted job,
+   * @return [[JobClient]] that can be used to communicate with the submitted job,
    *         completed on submission succeeded.
    */
   @PublicEvolving
-  def executeAsync(): CompletableFuture[JobClient] = javaEnv.executeAsync()
+  def executeAsync(): JobClient = javaEnv.executeAsync()
 
   /**
    * Triggers the program execution asynchronously.
@@ -528,11 +544,11 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
    * its usage. In other case, there may be resource leaks depending on the JobClient
    * implementation.
    *
-   * @return A future of [[JobClient]] that can be used to communicate with the submitted job,
+   * @return [[JobClient]] that can be used to communicate with the submitted job,
    *         completed on submission succeeded.
    */
   @PublicEvolving
-  def executeAsync(jobName: String): CompletableFuture[JobClient] = javaEnv.executeAsync(jobName)
+  def executeAsync(jobName: String): JobClient = javaEnv.executeAsync(jobName)
 
   /**
    * Creates the plan with which the system will execute the program, and returns it as  a String

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamContextEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamContextEnvironment.java
@@ -62,7 +62,7 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
 	public JobExecutionResult execute(StreamGraph streamGraph) throws Exception {
 		transformations.clear();
 
-		JobClient jobClient = executeAsync(streamGraph).get();
+		JobClient jobClient = executeAsync(streamGraph);
 
 		JobExecutionResult jobExecutionResult;
 		if (getConfiguration().getBoolean(DeploymentOptions.ATTACHED)) {

--- a/flink-tests/src/test/java/org/apache/flink/test/execution/JobListenerTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/execution/JobListenerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.execution;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.core.execution.JobListener;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Unit tests for {@link JobListener}.
+ */
+public class JobListenerTest extends TestLogger {
+
+	@Test
+	public void testJobListenerOnBatchEnvironment() throws Exception {
+		OneShotLatch submissionLatch = new OneShotLatch();
+		OneShotLatch executionLatch = new OneShotLatch();
+
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		env.registerJobListener(new JobListener() {
+			@Override
+			public void onJobSubmitted(JobClient jobClient, Throwable throwable) {
+				submissionLatch.trigger();
+			}
+
+			@Override
+			public void onJobExecuted(JobExecutionResult jobExecutionResult, Throwable throwable) {
+				executionLatch.trigger();
+			}
+		});
+
+		env.fromElements(1, 2, 3, 4, 5).output(new DiscardingOutputFormat<>());
+		env.execute();
+
+		submissionLatch.await(2000L, TimeUnit.MILLISECONDS);
+		executionLatch.await(2000L, TimeUnit.MILLISECONDS);
+	}
+
+	@Test
+	public void testJobListenerOnStreamingEnvironment() throws Exception {
+		OneShotLatch submissionLatch = new OneShotLatch();
+		OneShotLatch executionLatch = new OneShotLatch();
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		env.registerJobListener(new JobListener() {
+			@Override
+			public void onJobSubmitted(JobClient jobClient, Throwable throwable) {
+				submissionLatch.trigger();
+			}
+
+			@Override
+			public void onJobExecuted(JobExecutionResult jobExecutionResult, Throwable throwable) {
+				executionLatch.trigger();
+			}
+		});
+
+		env.fromElements(1, 2, 3, 4, 5).addSink(new DiscardingSink<>());
+		env.execute();
+
+		submissionLatch.await(2000L, TimeUnit.MILLISECONDS);
+		executionLatch.await(2000L, TimeUnit.MILLISECONDS);
+	}
+
+}


### PR DESCRIPTION
 [FLINK-14992][client] Add job listener to execution environments

## What is the purpose of the change

This PR is to add job listener to execution environments so that other project using flink can have hooks in the lifecycle of flink.  

## Brief change log

Add registerJobListener in `ExecutionEnvironment` & `StreamExecutionEnvironment`. Call `JobListener.onJobSubmitted` when after job is submitted, and call `JobListener.onJobExecuted` when job is finished. 


## Verifying this change


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
