### PR TITLE
[FLINK-15095] [table-planner-blink] bridge table schema's primary key to metadata handler in blink planner

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/catalog/CatalogConstraintTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/catalog/CatalogConstraintTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.catalog;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery;
+import org.apache.flink.table.planner.utils.TableTestUtil;
+import org.apache.flink.table.types.AtomicDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.BigIntType;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test for Catalog constraints.
+ */
+public class CatalogConstraintTest {
+
+	private String databaseName = "default_database";
+
+	private TableEnvironment tEnv;
+	private Catalog catalog;
+
+	@Before
+	public void setup() {
+		EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build();
+		tEnv = TableEnvironment.create(settings);
+		catalog = tEnv.getCatalog(tEnv.getCurrentCatalog()).orElse(null);
+		assertNotNull(catalog);
+	}
+
+	@Test
+	public void testWithPrimaryKey() throws Exception {
+		TableSchema tableSchema = TableSchema.builder().fields(
+				new String[] { "a", "b", "c" },
+				new DataType[] { DataTypes.STRING(), new AtomicDataType(new BigIntType(false)), DataTypes.INT() }
+		).primaryKey("b").build();
+		Map<String, String> properties = buildCatalogTableProperties(tableSchema);
+
+		catalog.createTable(
+				new ObjectPath(databaseName, "T1"),
+				new CatalogTableImpl(tableSchema, properties, ""),
+				false);
+
+		RelNode t1 = TableTestUtil.toRelNode(tEnv.sqlQuery("select * from T1"));
+		FlinkRelMetadataQuery mq = FlinkRelMetadataQuery.reuseOrCreate(t1.getCluster().getMetadataQuery());
+		assertEquals(ImmutableSet.of(ImmutableBitSet.of(1)), mq.getUniqueKeys(t1));
+	}
+
+	@Test
+	public void testWithoutPrimaryKey() throws Exception {
+		TableSchema tableSchema = TableSchema.builder().fields(
+				new String[] { "a", "b", "c" },
+				new DataType[] { DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.INT() }
+		).build();
+		Map<String, String> properties = buildCatalogTableProperties(tableSchema);
+
+		catalog.createTable(
+				new ObjectPath(databaseName, "T1"),
+				new CatalogTableImpl(tableSchema, properties, ""),
+				false);
+
+		RelNode t1 = TableTestUtil.toRelNode(tEnv.sqlQuery("select * from T1"));
+		FlinkRelMetadataQuery mq = FlinkRelMetadataQuery.reuseOrCreate(t1.getCluster().getMetadataQuery());
+		assertEquals(ImmutableSet.of(), mq.getUniqueKeys(t1));
+	}
+
+	private Map<String, String> buildCatalogTableProperties(TableSchema tableSchema) {
+		Map<String, String> properties = new HashMap<>();
+		properties.put("connector.type", "filesystem");
+		properties.put("connector.property-version", "1");
+		properties.put("connector.path", "/path/to/csv");
+
+		properties.put("format.type", "csv");
+		properties.put("format.property-version", "1");
+		properties.put("format.field-delimiter", ";");
+
+		// schema
+		DescriptorProperties descriptorProperties = new DescriptorProperties(true);
+		descriptorProperties.putTableSchema("format.fields", tableSchema);
+		properties.putAll(descriptorProperties.asMap());
+		return properties;
+	}
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/catalog/CatalogConstraintTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/catalog/CatalogConstraintTest.java
@@ -32,7 +32,8 @@ import org.apache.flink.table.types.AtomicDataType;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.BigIntType;
 
-import com.google.common.collect.ImmutableSet;
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableSet;
+
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.junit.Before;


### PR DESCRIPTION

## What is the purpose of the change

*bridge table schema's primary key to metadata handler in blink planner. current approach is a temporary solution, [FLINK-15123](https://issues.apache.org/jira/browse/FLINK-15123) will resolve this*


## Brief change log

  - *bridge table schema's primary key to FlinkStatistic in DatabaseCalciteSchema*


## Verifying this change



This change added tests and can be verified as follows:

  - *Added CatalogConstraintTest to verify whether the primary key is used in metadata handler*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no)**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no)**
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no)**
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
