### PR TITLE
[FLINK-14906][table] create and drop temp system functions from DDL t…

### DIFF
--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterFunction.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterFunction.java
@@ -118,6 +118,10 @@ public class SqlAlterFunction extends SqlCall {
 		return isTemporary;
 	}
 
+	public boolean isSystemFunction() {
+		return isSystemFunction;
+	}
+
 	public boolean isIfExists() {
 		return this.ifExists;
 	}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropFunction.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropFunction.java
@@ -96,6 +96,10 @@ public class SqlDropFunction extends SqlDrop implements ExtendedSqlNode {
 		return isTemporary;
 	}
 
+	public boolean isSystemFunction() {
+		return isSystemFunction;
+	}
+
 	public boolean getIfExists() {
 		return this.ifExists;
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogFunctionImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogFunctionImpl.java
@@ -38,7 +38,10 @@ public class CatalogFunctionImpl implements CatalogFunction {
 		this(className, FunctionLanguage.JAVA, false);
 	}
 
-	public CatalogFunctionImpl(String className, FunctionLanguage functionLanguage, boolean isTemporary) {
+	public CatalogFunctionImpl(
+			String className,
+			FunctionLanguage functionLanguage,
+			boolean isTemporary) {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(className), "className cannot be null or empty");
 		this.className = className;
 		this.functionLanguage = checkNotNull(functionLanguage, "functionLanguage cannot be null");
@@ -92,8 +95,8 @@ public class CatalogFunctionImpl implements CatalogFunction {
 	public String toString() {
 		return "CatalogFunctionImpl{" +
 			"className='" + getClassName() + "', " +
-			"functionLanguage='" + getFunctionLanguage() +
-			"isGeneric='" + isGeneric() +
+			"functionLanguage='" + getFunctionLanguage() + "', " +
+			"isGeneric='" + isGeneric() + "', " +
 			"isTemporary='" + isTemporary() +
 			"'}";
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -205,6 +205,15 @@ public class FunctionCatalog implements FunctionLookup {
 	}
 
 	/**
+	 * Check whether a temporary system function is already registered.
+	 * @param functionName the name of the function
+	 * @return whether the temporary system function exists in the function catalog
+	 */
+	public boolean hasTemporarySystemFunction(String functionName) {
+		return tempSystemFunctions.containsKey(functionName);
+	}
+
+	/**
 	 * Drop a temporary system function.
 	 *
 	 * @param funcName name of the function
@@ -328,7 +337,8 @@ public class FunctionCatalog implements FunctionLookup {
 					fd = catalog.getFunctionDefinitionFactory().get()
 						.createFunctionDefinition(oi.getObjectName(), catalogFunction);
 				} else {
-					fd = FunctionDefinitionUtil.createFunctionDefinition(oi.getObjectName(), catalogFunction);
+					fd = FunctionDefinitionUtil.createFunctionDefinition(
+						oi.getObjectName(), catalogFunction.getClassName());
 				}
 
 				return Optional.of(

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/functions/FunctionDefinitionUtil.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/functions/FunctionDefinitionUtil.java
@@ -18,21 +18,19 @@
 
 package org.apache.flink.table.functions;
 
-import org.apache.flink.table.catalog.CatalogFunction;
-
 /**
  * A util to instantiate {@link FunctionDefinition} in the default way.
  */
 public class FunctionDefinitionUtil {
 
-	public static FunctionDefinition createFunctionDefinition(String name, CatalogFunction catalogFunction) {
+	public static FunctionDefinition createFunctionDefinition(String name, String className) {
 		// Currently only handles Java class-based functions
 		Object func;
 		try {
-			func = Thread.currentThread().getContextClassLoader().loadClass(catalogFunction.getClassName()).newInstance();
+			func = Thread.currentThread().getContextClassLoader().loadClass(className).newInstance();
 		} catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
 			throw new IllegalStateException(
-				String.format("Failed instantiating '%s'", catalogFunction.getClassName()), e);
+				String.format("Failed instantiating '%s'", className), e);
 		}
 
 		UserDefinedFunction udf = (UserDefinedFunction) func;
@@ -69,7 +67,7 @@ public class FunctionDefinitionUtil {
 			);
 		} else {
 			throw new UnsupportedOperationException(
-				String.format("Function %s should be of ScalarFunction, TableFunction, AggregateFunction, or TableAggregateFunction", catalogFunction.getClassName())
+				String.format("Function %s should be of ScalarFunction, TableFunction, AggregateFunction, or TableAggregateFunction", className)
 			);
 		}
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterFunctionOperation.java
@@ -28,7 +28,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Operation to describe a ALTER FUNCTION statement.
+ * Operation to describe a ALTER FUNCTION statement for temporary catalog function.
  */
 public class AlterFunctionOperation implements AlterOperation  {
 	private final ObjectIdentifier functionIdentifier;

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateTempSystemFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateTempSystemFunctionOperation.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.table.operations.ddl;
 
-import org.apache.flink.table.catalog.CatalogFunction;
-import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.OperationUtils;
 
@@ -28,28 +26,28 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Operation to describe a CREATE FUNCTION statement for catalog function.
+ * Operation to describe a CREATE FUNCTION statement for temporary system function.
  */
-public class CreateFunctionOperation implements CreateOperation {
-	private final ObjectIdentifier functionIdentifier;
-	private CatalogFunction catalogFunction;
+public class CreateTempSystemFunctionOperation implements CreateOperation {
+	private final String functionName;
+	private String functionClass;
 	private boolean ignoreIfExists;
 
-	public CreateFunctionOperation(
-		ObjectIdentifier functionIdentifier,
-		CatalogFunction catalogFunction,
+	public CreateTempSystemFunctionOperation(
+		String functionName,
+		String functionClass,
 		boolean ignoreIfExists) {
-		this.functionIdentifier = functionIdentifier;
-		this.catalogFunction = catalogFunction;
+		this.functionName = functionName;
+		this.functionClass = functionClass;
 		this.ignoreIfExists = ignoreIfExists;
 	}
 
-	public CatalogFunction getCatalogFunction() {
-		return this.catalogFunction;
+	public String getFunctionName() {
+		return this.functionName;
 	}
 
-	public ObjectIdentifier getFunctionIdentifier() {
-		return this.functionIdentifier;
+	public String getFunctionClass() {
+		return this.functionClass;
 	}
 
 	public boolean isIgnoreIfExists() {
@@ -59,18 +57,14 @@ public class CreateFunctionOperation implements CreateOperation {
 	@Override
 	public String asSummaryString() {
 		Map<String, Object> params = new LinkedHashMap<>();
-		params.put("catalogFunction", catalogFunction.getDetailedDescription());
-		params.put("identifier", functionIdentifier);
+		params.put("functionName", functionName);
+		params.put("functionClass", functionClass);
 		params.put("ignoreIfExists", ignoreIfExists);
 
 		return OperationUtils.formatWithChildren(
-			"CREATE CATALOG FUNCTION",
+			"CREATE TEMPORARY SYSTEM FUNCTION",
 			params,
 			Collections.emptyList(),
 			Operation::asSummaryString);
-	}
-
-	public String getFunctionName() {
-		return this.functionIdentifier.getObjectName();
 	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropFunctionOperation.java
@@ -27,20 +27,23 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- *  Operation to describe a DROP FUNCTION statement.
+ *  Operation to describe a DROP FUNCTION statement for catalog function.
  */
 public class DropFunctionOperation implements DropOperation {
 	private final ObjectIdentifier functionIdentifier;
 	private final boolean ifExists;
 	private final boolean isTemporary;
+	private final boolean isSystemFunction;
 
 	public DropFunctionOperation(
 			ObjectIdentifier functionIdentifier,
 			boolean isTemporary,
+			boolean isSystemFunction,
 			boolean ifExists) {
 		this.functionIdentifier = functionIdentifier;
 		this.ifExists = ifExists;
 		this.isTemporary = isTemporary;
+		this.isSystemFunction = isSystemFunction;
 	}
 
 	public ObjectIdentifier getFunctionIdentifier() {
@@ -56,6 +59,7 @@ public class DropFunctionOperation implements DropOperation {
 		Map<String, Object> params = new LinkedHashMap<>();
 		params.put("identifier", functionIdentifier);
 		params.put("ifExists", ifExists);
+		params.put("isSystemFunction", isSystemFunction);
 		params.put("isTemporary", isTemporary);
 
 		return OperationUtils.formatWithChildren(
@@ -67,6 +71,10 @@ public class DropFunctionOperation implements DropOperation {
 
 	public boolean isTemporary() {
 		return isTemporary;
+	}
+
+	public boolean isSystemFunction() {
+		return isSystemFunction;
 	}
 
 	public String getFunctionName() {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropTempSystemFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropTempSystemFunctionOperation.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.table.operations.ddl;
 
-import org.apache.flink.table.catalog.CatalogFunction;
-import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.OperationUtils;
 
@@ -28,49 +26,38 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Operation to describe a CREATE FUNCTION statement for catalog function.
+ *  Operation to describe a DROP FUNCTION statement for temporary
+ *  system function.
  */
-public class CreateFunctionOperation implements CreateOperation {
-	private final ObjectIdentifier functionIdentifier;
-	private CatalogFunction catalogFunction;
-	private boolean ignoreIfExists;
+public class DropTempSystemFunctionOperation implements DropOperation {
+	private final String functionName;
+	private final boolean ifExists;
 
-	public CreateFunctionOperation(
-		ObjectIdentifier functionIdentifier,
-		CatalogFunction catalogFunction,
-		boolean ignoreIfExists) {
-		this.functionIdentifier = functionIdentifier;
-		this.catalogFunction = catalogFunction;
-		this.ignoreIfExists = ignoreIfExists;
+	public DropTempSystemFunctionOperation(
+		String functionName,
+		boolean ifExists) {
+		this.functionName = functionName;
+		this.ifExists = ifExists;
 	}
 
-	public CatalogFunction getCatalogFunction() {
-		return this.catalogFunction;
+	public String getFunctionName() {
+		return functionName;
 	}
 
-	public ObjectIdentifier getFunctionIdentifier() {
-		return this.functionIdentifier;
-	}
-
-	public boolean isIgnoreIfExists() {
-		return this.ignoreIfExists;
+	public boolean isIfExists() {
+		return ifExists;
 	}
 
 	@Override
 	public String asSummaryString() {
 		Map<String, Object> params = new LinkedHashMap<>();
-		params.put("catalogFunction", catalogFunction.getDetailedDescription());
-		params.put("identifier", functionIdentifier);
-		params.put("ignoreIfExists", ignoreIfExists);
+		params.put("functionName", functionName);
+		params.put("ifExists", ifExists);
 
 		return OperationUtils.formatWithChildren(
-			"CREATE CATALOG FUNCTION",
+			"DROP TEMPORARY SYSTEM FUNCTION",
 			params,
 			Collections.emptyList(),
 			Operation::asSummaryString);
-	}
-
-	public String getFunctionName() {
-		return this.functionIdentifier.getObjectName();
 	}
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/functions/FunctionDefinitionUtilTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/functions/FunctionDefinitionUtilTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.functions;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.table.catalog.CatalogFunctionImpl;
 
 import org.junit.Test;
 
@@ -33,7 +32,7 @@ public class FunctionDefinitionUtilTest {
 	public void testScalarFunction() {
 		FunctionDefinition fd = FunctionDefinitionUtil.createFunctionDefinition(
 			"test",
-				new CatalogFunctionImpl(TestScalarFunction.class.getName())
+				TestScalarFunction.class.getName()
 		);
 
 		assertTrue(((ScalarFunctionDefinition) fd).getScalarFunction() instanceof TestScalarFunction);
@@ -43,7 +42,7 @@ public class FunctionDefinitionUtilTest {
 	public void testTableFunction() {
 		FunctionDefinition fd = FunctionDefinitionUtil.createFunctionDefinition(
 			"test",
-			new CatalogFunctionImpl(TestTableFunction.class.getName())
+			TestTableFunction.class.getName()
 		);
 
 		assertTrue(((TableFunctionDefinition) fd).getTableFunction() instanceof TestTableFunction);
@@ -53,7 +52,7 @@ public class FunctionDefinitionUtilTest {
 	public void testAggregateFunction() {
 		FunctionDefinition fd = FunctionDefinitionUtil.createFunctionDefinition(
 			"test",
-			new CatalogFunctionImpl(TestAggFunction.class.getName())
+			TestAggFunction.class.getName()
 		);
 
 		assertTrue(((AggregateFunctionDefinition) fd).getAggregateFunction() instanceof TestAggFunction);
@@ -63,7 +62,7 @@ public class FunctionDefinitionUtilTest {
 	public void testTableAggregateFunction() {
 		FunctionDefinition fd = FunctionDefinitionUtil.createFunctionDefinition(
 			"test",
-			new CatalogFunctionImpl(TestTableAggFunction.class.getName())
+			TestTableAggFunction.class.getName()
 		);
 
 		assertTrue(((TableAggregateFunctionDefinition) fd).getTableAggregateFunction() instanceof TestTableAggFunction);

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/FunctionITCase.java
@@ -16,29 +16,24 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.runtime.batch.sql;
+package org.apache.flink.table.planner.runtime.batch.sql;
 
-import org.apache.flink.api.java.ExecutionEnvironment;
-import org.apache.flink.table.api.java.BatchTableEnvironment;
-import org.apache.flink.table.catalog.CatalogFunction;
-import org.apache.flink.table.catalog.CatalogFunctionTestBase;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.planner.functions.FunctionTestBase;
+import org.apache.flink.table.planner.utils.TestingTableEnvironment;
 
 import org.junit.BeforeClass;
 
 /**
- * Tests for {@link CatalogFunction} in batch table environment.
+ * Tests for catalog and system functions in batch table environment.
  */
-public class CatalogFunctionITCase extends CatalogFunctionTestBase {
-	private static ExecutionEnvironment executionEnvironment = ExecutionEnvironment.getExecutionEnvironment();
+public class
+FunctionITCase extends FunctionTestBase {
 
 	@BeforeClass
 	public static void setup() {
-		BatchTableEnvironment batchTableEnvironment = BatchTableEnvironment.create(executionEnvironment);
-		setTableEnv(batchTableEnvironment);
-	}
-
-	@Override
-	public void execute() throws Exception {
-		executionEnvironment.execute();
+		EnvironmentSettings environmentSettings =
+			EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build();
+		tableEnv = TestingTableEnvironment.create(environmentSettings);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
@@ -20,9 +20,8 @@ package org.apache.flink.table.planner.runtime.stream.sql;
 
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Table;
-import org.apache.flink.table.catalog.CatalogFunction;
-import org.apache.flink.table.planner.catalog.CatalogFunctionTestBase;
 import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory;
+import org.apache.flink.table.planner.functions.FunctionTestBase;
 import org.apache.flink.table.planner.utils.TestingTableEnvironment;
 import org.apache.flink.types.Row;
 
@@ -36,9 +35,9 @@ import java.util.List;
 import static org.junit.Assert.assertArrayEquals;
 
 /**
- * Tests for {@link CatalogFunction} in stream table environment.
+ * Tests for catalog and system in stream table environment.
  */
-public class CatalogFunctionITCase extends CatalogFunctionTestBase {
+public class FunctionITCase extends FunctionTestBase {
 
 	@BeforeClass
 	public static void setup() {
@@ -50,7 +49,7 @@ public class CatalogFunctionITCase extends CatalogFunctionTestBase {
 	@Test
 	public void testUseDefinedRegularCatalogFunction() throws Exception {
 		String functionDDL = "create function addOne as " +
-			"'org.apache.flink.table.planner.catalog.CatalogFunctionTestBase$TestUDF'";
+			"'org.apache.flink.table.planner.functions.FunctionTestBase$TestUDF'";
 
 		String dropFunctionDDL = "drop function addOne";
 		testUseDefinedCatalogFunction(functionDDL);
@@ -61,9 +60,20 @@ public class CatalogFunctionITCase extends CatalogFunctionTestBase {
 	@Test
 	public void testUseDefinedTemporaryCatalogFunction() throws Exception {
 		String functionDDL = "create temporary function addOne as " +
-			"'org.apache.flink.table.planner.catalog.CatalogFunctionTestBase$TestUDF'";
+			"'org.apache.flink.table.planner.functions.FunctionTestBase$TestUDF'";
 
 		String dropFunctionDDL = "drop temporary function addOne";
+		testUseDefinedCatalogFunction(functionDDL);
+		// delete the function
+		tableEnv.sqlUpdate(dropFunctionDDL);
+	}
+
+	@Test
+	public void testUseDefinedTemporarySystemFunction() throws Exception {
+		String functionDDL = "create temporary system function addOne as " +
+			"'org.apache.flink.table.planner.functions.FunctionTestBase$TestUDF'";
+
+		String dropFunctionDDL = "drop temporary system function addOne";
 		testUseDefinedCatalogFunction(functionDDL);
 		// delete the function
 		tableEnv.sqlUpdate(dropFunctionDDL);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -63,9 +63,11 @@ import org.apache.flink.table.operations.ddl.AlterTableRenameOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateFunctionOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
+import org.apache.flink.table.operations.ddl.CreateTempSystemFunctionOperation;
 import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
 import org.apache.flink.table.operations.ddl.DropFunctionOperation;
 import org.apache.flink.table.operations.ddl.DropTableOperation;
+import org.apache.flink.table.operations.ddl.DropTempSystemFunctionOperation;
 import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.util.StringUtils;
 
@@ -245,24 +247,37 @@ public class SqlToOperationConverter {
 
 	/** Convert CREATE FUNCTION statement. */
 	private Operation convertCreateFunction(SqlCreateFunction sqlCreateFunction) {
-		FunctionLanguage language = parseLanguage(sqlCreateFunction.getFunctionLanguage());
-		CatalogFunction catalogFunction = new CatalogFunctionImpl(
-			sqlCreateFunction.getFunctionClassName().getValueAs(String.class),
-			language,
-			sqlCreateFunction.isTemporary());
-
 		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlCreateFunction.getFunctionIdentifier());
-		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
-		return new CreateFunctionOperation(
-			identifier,
-			catalogFunction,
-			sqlCreateFunction.isIfNotExists()
-		);
+		if (sqlCreateFunction.isSystemFunction()) {
+			return new CreateTempSystemFunctionOperation(
+				unresolvedIdentifier.getObjectName(),
+				sqlCreateFunction.getFunctionClassName().getValueAs(String.class),
+				sqlCreateFunction.isIfNotExists()
+			);
+		} else {
+			FunctionLanguage language = parseLanguage(sqlCreateFunction.getFunctionLanguage());
+			CatalogFunction catalogFunction = new CatalogFunctionImpl(
+				sqlCreateFunction.getFunctionClassName().getValueAs(String.class),
+				language,
+				sqlCreateFunction.isTemporary());
+
+			ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
+
+			return new CreateFunctionOperation(
+				identifier,
+				catalogFunction,
+				sqlCreateFunction.isIfNotExists()
+			);
+		}
 	}
 
 	/** Convert ALTER FUNCTION statement. */
 	private Operation convertAlterFunction(SqlAlterFunction sqlAlterFunction) {
+		if (sqlAlterFunction.isSystemFunction()) {
+			throw new ValidationException("Alter temporary system function is not supported");
+		}
+
 		FunctionLanguage language = parseLanguage(sqlAlterFunction.getFunctionLanguage());
 		CatalogFunction catalogFunction = new CatalogFunctionImpl(
 			sqlAlterFunction.getFunctionClassName().getValueAs(String.class),
@@ -281,12 +296,21 @@ public class SqlToOperationConverter {
 	/** Convert DROP FUNCTION statement. */
 	private Operation convertDropFunction(SqlDropFunction sqlDropFunction) {
 		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlDropFunction.getFunctionIdentifier());
-		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
+		if (sqlDropFunction.isSystemFunction()) {
+			return new DropTempSystemFunctionOperation(
+				unresolvedIdentifier.getObjectName(),
+				sqlDropFunction.getIfExists()
+			);
+		} else {
+			ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
-		return new DropFunctionOperation(
-			identifier,
-			sqlDropFunction.isTemporary(),
-			sqlDropFunction.getIfExists());
+			return new DropFunctionOperation(
+				identifier,
+				sqlDropFunction.isTemporary(),
+				sqlDropFunction.isSystemFunction(),
+				sqlDropFunction.getIfExists()
+			);
+		}
 	}
 
 	/** Fallback method for sql query. */

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/sql/FunctionITCase.java
@@ -16,25 +16,28 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.planner.runtime.batch.sql;
+package org.apache.flink.table.runtime.batch.sql;
 
-import org.apache.flink.table.api.EnvironmentSettings;
-import org.apache.flink.table.catalog.CatalogFunction;
-import org.apache.flink.table.planner.catalog.CatalogFunctionTestBase;
-import org.apache.flink.table.planner.utils.TestingTableEnvironment;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.table.api.java.BatchTableEnvironment;
+import org.apache.flink.table.functions.FunctionTestBase;
 
 import org.junit.BeforeClass;
 
 /**
- * Tests for {@link CatalogFunction} in batch table environment.
+ * Tests for catalog and system function in batch table environment.
  */
-public class
-CatalogFunctionITCase extends CatalogFunctionTestBase {
+public class FunctionITCase extends FunctionTestBase {
+	private static ExecutionEnvironment executionEnvironment = ExecutionEnvironment.getExecutionEnvironment();
 
 	@BeforeClass
 	public static void setup() {
-		EnvironmentSettings environmentSettings =
-			EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build();
-		tableEnv = TestingTableEnvironment.create(environmentSettings);
+		BatchTableEnvironment batchTableEnvironment = BatchTableEnvironment.create(executionEnvironment);
+		setTableEnv(batchTableEnvironment);
+	}
+
+	@Override
+	public void execute() throws Exception {
+		executionEnvironment.execute();
 	}
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/stream/sql/FunctionITCase.java
@@ -20,15 +20,14 @@ package org.apache.flink.table.runtime.stream.sql;
 
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
-import org.apache.flink.table.catalog.CatalogFunction;
-import org.apache.flink.table.catalog.CatalogFunctionTestBase;
+import org.apache.flink.table.functions.FunctionTestBase;
 
 import org.junit.BeforeClass;
 
 /**
- * Tests for {@link CatalogFunction} in stream table environment.
+ * Tests for catalog and system function in stream table environment.
  */
-public class CatalogFunctionITCase extends CatalogFunctionTestBase {
+public class FunctionITCase extends FunctionTestBase {
 	private static StreamExecutionEnvironment streamExecEnvironment;
 
 	@BeforeClass


### PR DESCRIPTION
## What is the purpose of the change

Support create and drop temp system functions from DDL to FunctionCatalog with function ddl.

## Brief change log

- Create and Drop temporary system functions for both stream and batch
- Add test cases in CatalogFunctionITCase for both planner and blink planner

## Verifying this change

The features is covered in CatalogFunctionITCases

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (o)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
