### PR TITLE
[FLINK-15121] Add public constructors for execution environments that take Configuration

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -137,23 +137,36 @@ public class ExecutionEnvironment {
 	private final ClassLoader userClassloader;
 
 	/**
-	 * Creates a new Execution Environment.
+	 * Creates a new {@link ExecutionEnvironment} that will use the given {@link Configuration} to
+	 * configure the {@link org.apache.flink.core.execution.Executor}.
 	 */
-	protected ExecutionEnvironment() {
-		this(new Configuration());
-	}
-
-	protected ExecutionEnvironment(final Configuration configuration) {
+	@PublicEvolving
+	public ExecutionEnvironment(final Configuration configuration) {
 		this(DefaultExecutorServiceLoader.INSTANCE, configuration, null);
 	}
 
-	protected ExecutionEnvironment(
+	/**
+	 * Creates a new {@link ExecutionEnvironment} that will use the given {@link
+	 * Configuration} to configure the {@link org.apache.flink.core.execution.Executor}.
+	 *
+	 * <p>In addition, this constructor allows specifying the {@link ExecutorServiceLoader} and
+	 * user code {@link ClassLoader}.
+	 */
+	@PublicEvolving
+	public ExecutionEnvironment(
 			final ExecutorServiceLoader executorServiceLoader,
 			final Configuration configuration,
 			final ClassLoader userClassloader) {
 		this.executorServiceLoader = checkNotNull(executorServiceLoader);
 		this.configuration = checkNotNull(configuration);
 		this.userClassloader = userClassloader == null ? getClass().getClassLoader() : userClassloader;
+	}
+
+	/**
+	 * Creates a new Execution Environment.
+	 */
+	protected ExecutionEnvironment() {
+		this(new Configuration());
 	}
 
 	@Internal

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -173,12 +173,28 @@ public class StreamExecutionEnvironment {
 
 	public StreamExecutionEnvironment() {
 		this(new Configuration());
+		// unfortunately, StreamExecutionEnvironment always (implicitly) had a public constructor.
+		// This constructor is not useful because the execution environment cannot be used for
+		// execution. We're keeping this to appease the binary compatibiliy checks.
 	}
 
+	/**
+	 * Creates a new {@link StreamExecutionEnvironment} that will use the given {@link
+	 * Configuration} to configure the {@link org.apache.flink.core.execution.Executor}.
+	 */
+	@PublicEvolving
 	public StreamExecutionEnvironment(final Configuration configuration) {
 		this(DefaultExecutorServiceLoader.INSTANCE, configuration, null);
 	}
 
+	/**
+	 * Creates a new {@link StreamExecutionEnvironment} that will use the given {@link
+	 * Configuration} to configure the {@link org.apache.flink.core.execution.Executor}.
+	 *
+	 * <p>In addition, this constructor allows specifying the {@link ExecutorServiceLoader} and
+	 * user code {@link ClassLoader}.
+	 */
+	@PublicEvolving
 	public StreamExecutionEnvironment(
 			final ExecutorServiceLoader executorServiceLoader,
 			final Configuration configuration,


### PR DESCRIPTION
## Brief change log

This makes useful constructors on ExecutionEnvironment public and adds
Javadoc.

This makes the useless zero-argument constructor of
StreamExecutionEnvironment protected and adds Javadoc to
StreamExecutionEnvironment constructors.

This allows creating execution environments with arbitrary executor configurations, i.e. one can now create an execution environment that uses a YARN executor.

## Verifying this change

No new tests, this only changes the constructors.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes, we add `@PublicEvolving` to constructors that should have it.
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

