### PR TITLE
[FLINK-15131][connector/source] Add the APIs for Source (FLIP-27).

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/eventtime/Watermark.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/eventtime/Watermark.java
@@ -1,0 +1,106 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package org.apache.flink.api.common.eventtime;
+
+import org.apache.flink.annotation.Public;
+
+import java.io.Serializable;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * Watermarks are the progress indicators in the data streams. A watermark signifies
+ * that no events with a timestamp smaller or equal to the watermark's time will occur after the
+ * water. A watermark with timestamp <i>T</i> indicates that the stream's event time has progressed
+ * to time <i>T</i>.
+ *
+ * <p>Watermarks are created at the sources and propagate through the streams and operators.
+ *
+ * <p>In some cases a watermark is only a heuristic, meaning some events with a lower timestamp
+ * may still follow. In that case, it is up to the logic of the operators to decide what to do
+ * with the "late events". Operators can for example ignore these late events, route them to a
+ * different stream, or send update to their previously emitted results.
+ *
+ * <p>When a source reaches the end of the input, it emits a final watermark with timestamp
+ * {@code Long.MAX_VALUE}, indicating the "end of time".
+ *
+ * <p>Note: A stream's time starts with a watermark of {@code Long.MIN_VALUE}. That means that all records
+ * in the stream with a timestamp of {@code Long.MIN_VALUE} are immediately late.
+ */
+@Public
+public final class Watermark implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	/** Thread local formatter for stringifying the timestamps. */
+	private static final ThreadLocal<SimpleDateFormat> TS_FORMATTER = ThreadLocal.withInitial(
+		() -> new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS"));
+
+	// ------------------------------------------------------------------------
+
+	/** The watermark that signifies end-of-event-time. */
+	public static final Watermark MAX_WATERMARK = new Watermark(Long.MAX_VALUE);
+
+	// ------------------------------------------------------------------------
+
+	/** The timestamp of the watermark in milliseconds. */
+	private final long timestamp;
+
+	/**
+	 * Creates a new watermark with the given timestamp in milliseconds.
+	 */
+	public Watermark(long timestamp) {
+		this.timestamp = timestamp;
+	}
+
+	/**
+	 * Returns the timestamp associated with this Watermark.
+	 */
+	public long getTimestamp() {
+		return timestamp;
+	}
+
+	/**
+	 * Formats the timestamp of this watermark, assuming it is a millisecond timestamp.
+	 * The returned format is "yyyy-MM-dd HH:mm:ss.SSS".
+	 */
+	public String getFormattedTimestamp() {
+		return TS_FORMATTER.get().format(new Date(timestamp));
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Override
+	public boolean equals(Object o) {
+		return this == o ||
+				o != null &&
+				o.getClass() == Watermark.class &&
+				((Watermark) o).timestamp == this.timestamp;
+	}
+
+	@Override
+	public int hashCode() {
+		return Long.hashCode(timestamp);
+	}
+
+	@Override
+	public String toString() {
+		return "Watermark @ " + timestamp + " (" + getFormattedTimestamp() + ')';
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkOutput.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkOutput.java
@@ -16,30 +16,29 @@
  limitations under the License.
  */
 
-package org.apache.flink.api.connector.source;
+package org.apache.flink.api.common.eventtime;
 
 import org.apache.flink.annotation.Public;
-import org.apache.flink.api.common.eventtime.WatermarkOutput;
 
 /**
- * The interface provided by Flink task to the {@link SourceReader} to emit records
- * to downstream operators for message processing.
+ * An output for watermarks. The output accepts watermarks and idleness (inactivity) status.
  */
 @Public
-public interface SourceOutput<T> extends WatermarkOutput {
+public interface WatermarkOutput {
 
 	/**
-	 * Emit a record without a timestamp. Equivalent to {@link #collect(Object, Long) collect(timestamp, null)};
+	 * Emits the given watermark.
 	 *
-	 * @param record the record to emit.
+	 * <p>Emitting a watermark also implicitly marks the stream as <i>active</i>, ending
+	 * previously marked idleness.
 	 */
-	void collect(T record) throws Exception;
+	void emitWatermark(Watermark watermark);
 
 	/**
-	 * Emit a record with timestamp.
+	 * Marks this output as idle, meaning that downstream operations do not
+	 * wait for watermarks from this output.
 	 *
-	 * @param record the record to emit.
-	 * @param timestamp the timestamp of the record.
+	 * <p>An output becomes active again as soon as the next watermark is emitted.
 	 */
-	void collect(T record, Long timestamp) throws Exception;
+	void markIdle();
 }

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/Boundedness.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/Boundedness.java
@@ -1,0 +1,55 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source;
+
+import org.apache.flink.annotation.Public;
+
+/**
+ * The boundedness of a stream. A stream could either be "bounded" (a stream with finite records) or
+ * "unbounded" (a stream with infinite records).
+ */
+@Public
+public enum Boundedness {
+	/**
+	 * A BOUNDED stream is a stream with finite records.
+	 *
+	 * <p>In the context of sources, a BOUNDED stream expects the source to put a boundary of the
+	 * records it emits. Such boundaries could be number of records, number of bytes, elapsed time,
+	 * and so on. Such indication of how to bound a stream is typically passed to the sources via
+	 * configurations. When the sources emit a BOUNDED stream, Flink may leverage this property to
+	 * do specific optimizations in the execution.
+	 *
+	 * <p>Unlike unbounded streams, the bounded streams are usually order insensitive. That means
+	 * the source implementations may not have to keep track of the event times or watermarks.
+	 * Instead, a higher throughput would be preferred.
+	 */
+	BOUNDED,
+
+	/**
+	 * An UNBOUNDED stream is a stream with infinite records.
+	 *
+	 * <p>In the context of sources, an infinite stream expects the source implementation to run
+	 * without an upfront indication to Flink that they will eventually stop. The sources may
+	 * eventually be terminated when users cancel the jobs or some source-specific condition is met.
+	 *
+	 * <p>An UNBOUNDED stream may also eventually stop at some point. But before that happens, Flink
+	 * always assumes the sources are going to run forever.
+	 */
+	UNBOUNDED
+}

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/Boundedness.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/Boundedness.java
@@ -42,14 +42,14 @@ public enum Boundedness {
 	BOUNDED,
 
 	/**
-	 * An UNBOUNDED stream is a stream with infinite records.
+	 * A CONTINUOUS_UNBOUNDED stream is a stream with infinite records.
 	 *
 	 * <p>In the context of sources, an infinite stream expects the source implementation to run
 	 * without an upfront indication to Flink that they will eventually stop. The sources may
 	 * eventually be terminated when users cancel the jobs or some source-specific condition is met.
 	 *
-	 * <p>An UNBOUNDED stream may also eventually stop at some point. But before that happens, Flink
-	 * always assumes the sources are going to run forever.
+	 * <p>A CONTINUOUS_UNBOUNDED stream may also eventually stop at some point. But before that
+	 * happens, Flink always assumes the sources are going to run forever.
 	 */
-	UNBOUNDED
+	CONTINUOUS_UNBOUNDED
 }

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/ReaderInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/ReaderInfo.java
@@ -1,0 +1,51 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source;
+
+import org.apache.flink.annotation.Public;
+
+import java.io.Serializable;
+
+/**
+ * A container class hosting the information of a {@link SourceReader}.
+ */
+@Public
+public final class ReaderInfo implements Serializable {
+	private final int subtaskId;
+	private final String location;
+
+	public ReaderInfo(int subtaskId, String location) {
+		this.subtaskId = subtaskId;
+		this.location = location;
+	}
+
+	/**
+	 * @return the ID of the subtask that runs the source reader.
+	 */
+	public int getSubtaskId() {
+		return subtaskId;
+	}
+
+	/**
+	 * @return the location of the subtask that runs this source reader.
+	 */
+	public String getLocation() {
+		return location;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/Source.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/Source.java
@@ -37,15 +37,11 @@ import java.io.Serializable;
 public interface Source<T, SplitT extends SourceSplit, EnumChkT> extends Serializable {
 
 	/**
-	 * Checks whether the source supports the given boundedness.
+	 * Get the boundedness of this source.
 	 *
-	 * <p>Some sources might only support either continuous unbounded streams, or
-	 * bounded streams.
-	 *
-	 * @param boundedness The boundedness to check.
-	 * @return <code>true</code> if the given boundedness is supported, <code>false</code> otherwise.
+	 * @return the boundedness of this source.
 	 */
-	boolean supportsBoundedness(Boundedness boundedness);
+	Boundedness getBoundedness();
 
 	/**
 	 * Creates a new reader to read data from the spits it gets assigned.
@@ -59,13 +55,10 @@ public interface Source<T, SplitT extends SourceSplit, EnumChkT> extends Seriali
 	/**
 	 * Creates a new SplitEnumerator for this source, starting a new input.
 	 *
-	 * @param boundedness The boundedness of this source.
 	 * @param enumContext The {@link SplitEnumeratorContext context} for the split enumerator.
 	 * @return A new SplitEnumerator.
 	 */
-	SplitEnumerator<SplitT, EnumChkT> createEnumerator(
-			Boundedness boundedness,
-			SplitEnumeratorContext<SplitT> enumContext);
+	SplitEnumerator<SplitT, EnumChkT> createEnumerator(SplitEnumeratorContext<SplitT> enumContext);
 
 	/**
 	 * Restores an enumerator from a checkpoint.

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/Source.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/Source.java
@@ -1,0 +1,98 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source;
+
+import org.apache.flink.annotation.Public;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * The interface for Source. It acts like a factory class that helps construct
+ * the {@link SplitEnumerator} and {@link SourceReader} and corresponding
+ * serializers.
+ *
+ * @param <T>        The type of records produced by the source.
+ * @param <SplitT>   The type of splits handled by the source.
+ * @param <EnumChkT> The type of the enumerator checkpoints.
+ */
+@Public
+public interface Source<T, SplitT extends SourceSplit, EnumChkT> extends Serializable {
+
+	/**
+	 * Checks whether the source supports the given boundedness.
+	 *
+	 * <p>Some sources might only support either continuous unbounded streams, or
+	 * bounded streams.
+	 *
+	 * @param boundedness The boundedness to check.
+	 * @return <code>true</code> if the given boundedness is supported, <code>false</code> otherwise.
+	 */
+	boolean supportsBoundedness(Boundedness boundedness);
+
+	/**
+	 * Creates a new reader to read data from the spits it gets assigned.
+	 * The reader starts fresh and does not have any state to resume.
+	 *
+	 * @param readerContext The {@link SourceReaderContext context} for the source reader.
+	 * @return A new SourceReader.
+	 */
+	SourceReader<T, SplitT> createReader(SourceReaderContext readerContext);
+
+	/**
+	 * Creates a new SplitEnumerator for this source, starting a new input.
+	 *
+	 * @param enumContext The {@link SplitEnumeratorContext context} for the split enumerator.
+	 * @return A new SplitEnumerator.
+	 */
+	SplitEnumerator<SplitT, EnumChkT> createEnumerator(SplitEnumeratorContext<SplitT> enumContext);
+
+	/**
+	 * Restores an enumerator from a checkpoint.
+	 *
+	 * @param enumContext The {@link SplitEnumeratorContext context} for the restored split enumerator.
+	 * @param checkpoint The checkpoint to restore the SplitEnumerator from.
+	 * @return A SplitEnumerator restored from the given checkpoint.
+	 */
+	SplitEnumerator<SplitT, EnumChkT> restoreEnumerator(
+			SplitEnumeratorContext<SplitT> enumContext,
+			EnumChkT checkpoint) throws IOException;
+
+	// ------------------------------------------------------------------------
+	//  serializers for the metadata
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Creates a serializer for the source splits. Splits are serialized when sending them
+	 * from enumerator to reader, and when checkpointing the reader's current state.
+	 *
+	 * @return The serializer for the split type.
+	 */
+	SimpleVersionedSerializer<SplitT> getSplitSerializer();
+
+	/**
+	 * Creates the serializer for the {@link SplitEnumerator} checkpoint.
+	 * The serializer is used for the result of the {@link SplitEnumerator#snapshotState()}
+	 * method.
+	 *
+	 * @return The serializer for the SplitEnumerator checkpoint.
+	 */
+	SimpleVersionedSerializer<EnumChkT> getEnumeratorCheckpointSerializer();
+}

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/Source.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/Source.java
@@ -59,10 +59,13 @@ public interface Source<T, SplitT extends SourceSplit, EnumChkT> extends Seriali
 	/**
 	 * Creates a new SplitEnumerator for this source, starting a new input.
 	 *
+	 * @param boundedness The boundedness of this source.
 	 * @param enumContext The {@link SplitEnumeratorContext context} for the split enumerator.
 	 * @return A new SplitEnumerator.
 	 */
-	SplitEnumerator<SplitT, EnumChkT> createEnumerator(SplitEnumeratorContext<SplitT> enumContext);
+	SplitEnumerator<SplitT, EnumChkT> createEnumerator(
+			Boundedness boundedness,
+			SplitEnumeratorContext<SplitT> enumContext);
 
 	/**
 	 * Restores an enumerator from a checkpoint.

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceEvent.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceEvent.java
@@ -1,0 +1,31 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source;
+
+import org.apache.flink.annotation.Public;
+
+import java.io.Serializable;
+
+/**
+ * An base class for the events passed between the SourceReaders and Enumerators.
+ */
+@Public
+public interface SourceEvent extends Serializable {
+
+}

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceOutput.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceOutput.java
@@ -1,0 +1,44 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source;
+
+import org.apache.flink.annotation.Public;
+
+/**
+ * The interface provided by Flink task to the {@link SourceReader} to emit records
+ * to downstream operators for message processing.
+ */
+@Public
+public interface SourceOutput<T> {
+
+	/**
+	 * Emit a record without a timestamp. Equivalent to {@link #collect(Object, Long) collect(timestamp, null)};
+	 *
+	 * @param record the record to emit.
+	 */
+	void collect(T record) throws Exception;
+
+	/**
+	 * Emit a record with timestamp.
+	 *
+	 * @param record the record to emit.
+	 * @param timestamp the timestamp of the record.
+	 */
+	void collect(T record, Long timestamp) throws Exception;
+}

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceOutput.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceOutput.java
@@ -29,7 +29,7 @@ import org.apache.flink.api.common.eventtime.WatermarkOutput;
 public interface SourceOutput<T> extends WatermarkOutput {
 
 	/**
-	 * Emit a record without a timestamp. Equivalent to {@link #collect(Object, Long) collect(timestamp, null)};
+	 * Emit a record without a timestamp. Equivalent to {@link #collect(Object, long) collect(timestamp, null)};
 	 *
 	 * @param record the record to emit.
 	 */
@@ -41,5 +41,5 @@ public interface SourceOutput<T> extends WatermarkOutput {
 	 * @param record the record to emit.
 	 * @param timestamp the timestamp of the record.
 	 */
-	void collect(T record, Long timestamp) throws Exception;
+	void collect(T record, long timestamp) throws Exception;
 }

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceReader.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceReader.java
@@ -1,0 +1,93 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source;
+
+import org.apache.flink.annotation.Public;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * The interface for a source reader which is responsible for reading the records from
+ * the source splits assigned by {@link SplitEnumerator}.
+ *
+ * @param <T> The type of the record emitted by this source reader.
+ * @param <SplitT> The type of the the source splits.
+ */
+@Public
+public interface SourceReader<T, SplitT extends SourceSplit> extends Serializable, AutoCloseable {
+
+	/**
+	 * Start the reader.
+	 */
+	void start();
+
+	/**
+	 * Poll the next available record into the {@link SourceOutput}.
+	 *
+	 * <p>The implementation must make sure this method is non-blocking.
+	 *
+	 * <p>Although the implementation can emit multiple records into the given SourceOutput,
+	 * it is recommended not doing so. Instead, emit one record into the SourceOutput
+	 * and return a {@link Status#AVAILABLE_NOW} to let the caller thread
+	 * know there are more records available.
+	 *
+	 * @return The {@link Status} of the SourceReader after the method invocation.
+	 */
+	Status pollNext(SourceOutput<T> sourceOutput) throws Exception;
+
+	/**
+	 * Checkpoint on the state of the source.
+	 *
+	 * @return the state of the source.
+	 */
+	List<SplitT> snapshotState();
+
+	/**
+	 * @return a future that will be completed once there is a record available to poll.
+	 */
+	CompletableFuture<Void> isAvailable();
+
+	/**
+	 * Adds a list of splits for this reader to read.
+	 *
+	 * @param splits The splits assigned by the split enumerator.
+	 */
+	void addSplits(List<SplitT> splits);
+
+	/**
+	 * Handle a source event sent by the {@link SplitEnumerator}.
+	 *
+	 * @param sourceEvent the event sent by the {@link SplitEnumerator}.
+	 */
+	void handleSourceEvents(SourceEvent sourceEvent);
+
+	/**
+	 * The status of this reader.
+	 */
+	enum Status {
+		/** The next record is available right now. */
+		AVAILABLE_NOW,
+		/** The next record will be available later. */
+		AVAILABLE_LATER,
+		/** The source reader has completed all the reading work. */
+		FINISHED
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceReaderContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceReaderContext.java
@@ -1,0 +1,45 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source;
+
+import org.apache.flink.annotation.Public;
+import org.apache.flink.metrics.MetricGroup;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * The class that expose some context from runtime to the {@link SourceReader}.
+ */
+@Public
+public interface SourceReaderContext {
+
+	/**
+	 * @return The metric group this source belongs to.
+	 */
+	MetricGroup metricGroup();
+
+	/**
+	 * Send a source event to the source coordinator.
+	 *
+	 * @param sourceEvent the source event to coordinator.
+	 * @return a completable future which will be completed either the event has been successfully sent
+	 * or failed.
+	 */
+	CompletableFuture<Boolean> sendSourceEventToCoordinator(SourceEvent sourceEvent);
+}

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceSplit.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceSplit.java
@@ -1,0 +1,34 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source;
+
+import org.apache.flink.annotation.Public;
+
+/**
+ * An interface for all the Split types to extend.
+ */
+@Public
+public interface SourceSplit {
+
+	/**
+	 * Get the split id of this source split.
+	 * @return id of this source split.
+	 */
+	String splitId();
+}

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumerator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumerator.java
@@ -1,0 +1,78 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source;
+
+import org.apache.flink.annotation.Public;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * A interface of a split enumerator responsible for the followings:
+ * 1. discover the splits for the {@link SourceReader} to read.
+ * 2. assign the splits to the source reader.
+ */
+@Public
+public interface SplitEnumerator<SplitT extends SourceSplit, CheckpointT> extends AutoCloseable {
+
+	/**
+	 * Start the split enumerator.
+	 *
+	 * <p>The default behavior does nothing.
+	 */
+	void start();
+
+	/**
+	 * Handles the source event from the source reader.
+	 *
+	 * @param subtaskId the subtask id of the source reader who sent the source event.
+	 * @param sourceEvent the source event from the source reader.
+	 */
+	void handleSourceEvent(int subtaskId, SourceEvent sourceEvent);
+
+	/**
+	 * Add a split back to the split enumerator. It will only happen when a {@link SourceReader} fails
+	 * and there are splits assigned to it after the last successful checkpoint.
+	 *
+	 * @param splits The split to add back to the enumerator for reassignment.
+	 * @param subtaskId The id of the subtask to which the returned splits belong.
+	 */
+	void addSplitsBack(List<SplitT> splits, int subtaskId);
+
+	/**
+	 * Add a new source reader with the given subtask ID.
+	 *
+	 * @param subtaskId the subtask ID of the new source reader.
+	 */
+	void addReader(int subtaskId);
+
+	/**
+	 * Checkpoints the state of this split enumerator.
+	 *
+	 * @return an object containing the state of the split enumerator.
+	 */
+	CheckpointT snapshotState();
+
+	/**
+	 * Called to close the enumerator, in case it holds on to any resources, like threads or
+	 * network connections.
+	 */
+	@Override
+	void close() throws IOException;
+}

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
@@ -52,7 +52,7 @@ public interface SplitEnumeratorContext<SplitT extends SourceSplit> {
 	 *
 	 * @return the number of subtasks.
 	 */
-	int getNumSubtasks();
+	int numSubtasks();
 
 	/**
 	 * Get the currently registered readers. The mapping is from subtask id to the reader info.

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
@@ -1,0 +1,96 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source;
+
+import org.apache.flink.annotation.Public;
+import org.apache.flink.metrics.MetricGroup;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.function.BiConsumer;
+
+/**
+ * A context class for the {@link SplitEnumerator}. This class serves the following purposes:
+ * 1. Host information necessary for the SplitEnumerator to make split assignment decisions.
+ * 2. Accept and track the split assignment from the enumerator.
+ * 3. Provide a managed threading model so the split enumerators do not need to create their
+ *    own internal threads.
+ *
+ * @param <SplitT> the type of the splits.
+ */
+@Public
+public interface SplitEnumeratorContext<SplitT extends SourceSplit> {
+
+	MetricGroup metricGroup();
+
+	/**
+	 * Send a source event to a source reader. The source reader is identified by its subtask id.
+	 *
+	 * @param subtaskId the subtask id of the source reader to send this event to.
+	 * @param event the source event to send.
+	 */
+	void sendEventToSourceReader(int subtaskId, SourceEvent event);
+
+	/**
+	 * Get the number of subtasks.
+	 *
+	 * @return the number of subtasks.
+	 */
+	int getNumSubtasks();
+
+	/**
+	 * Get the currently registered readers. The mapping is from subtask id to the reader info.
+	 *
+	 * @return the currently registered readers.
+	 */
+	Map<Integer, ReaderInfo> registeredReaders();
+
+	/**
+	 * Assign the splits.
+	 *
+	 * @param newSplitAssignments the new split assignments to add.
+	 */
+	void assignSplits(SplitsAssignment<SplitT> newSplitAssignments);
+
+	/**
+	 * Invoke the callable and handover the return value to the handler which will be executed
+	 * by the source coordinator.
+	 *
+	 * <p>It is important to make sure that the callable should not modify
+	 * any shared state. Otherwise the there might be unexpected behavior.
+	 *
+	 * @param callable a callable to call.
+	 * @param handler a handler that handles the return value of or the exception thrown from the callable.
+	 */
+	<T> void callAsync(Callable<T> callable, BiConsumer<T, Throwable> handler);
+
+	/**
+	 * Invoke the callable and handover the return value to the handler which will be executed
+	 * by the source coordinator.
+	 *
+	 * <p>It is important to make sure that the callable should not modify
+	 * any shared state. Otherwise the there might be unexpected behavior.
+	 *
+	 * @param callable the callable to call.
+	 * @param handler a handler that handles the return value of or the exception thrown from the callable.
+	 * @param initialDelay the initial delay of calling the callable.
+	 * @param period the period between two invocations of the callable.
+	 */
+	<T> void callAsync(Callable<T> callable, BiConsumer<T, Throwable> handler, long initialDelay, long period);
+}

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitsAssignment.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitsAssignment.java
@@ -1,0 +1,51 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source;
+
+import org.apache.flink.annotation.Public;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A class containing the splits assignment to the source readers.
+ *
+ * <p>The assignment is always incremental. In another word, splits in the assignment are simply
+ * added to the existing assignment.
+ */
+@Public
+public final class SplitsAssignment<SplitT extends SourceSplit> {
+	private final Map<Integer, List<SplitT>> assignment;
+
+	public SplitsAssignment(Map<Integer, List<SplitT>> assignment) {
+		this.assignment = assignment;
+	}
+
+	/**
+	 * @return A mapping from subtask ID to their split assignment.
+	 */
+	public Map<Integer, List<SplitT>> assignment() {
+		return assignment;
+	}
+
+	@Override
+	public String toString() {
+		return assignment.toString();
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change
Add the top tier interfaces for FLIP-27. These classes are prerequisite for the rest of the PRs of FLIP-27. See the [FLIP wiki](https://cwiki.apache.org/confluence/display/FLINK/FLIP-27%3A+Refactor+Source+Interface#FLIP-27:RefactorSourceInterface-Toplevelpublicinterfaces) for more details.

## Brief change log
The classes introduced include: 
- Boundedness - A enum indicating whether the input stream is Bounded or Unbounded
- Source - A factory style class that helps create SplitEnumerator and SourceReader at runtime.
- SourceSplit - An interface for all the split types.
- SplitEnumerator - Discover the splits and assign them to the SourceReaders
- SplitEnumeratorContext - Provide necessary information to the SplitEnumerator to assign splits and send custom events to the the SourceReaders.
- SplitAssignment - A container class holding the source split assignment for each subtask.
- SourceReader - Read the records from the splits assigned by the SplitEnumerator.
- ReaderInfo - A container class about reader information.
- SourceReaderContext - Provide necessary function to the SourceReader to communicate with SplitEnumerator.
- SourceOutput - A collector style interface to take the records and timestamps emit by the SourceReader.

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change only introduces the interfaces, so there is no tests needed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs, FLIP)
