### PR TITLE
[FLINK-15127][table] rename function operations to catalog function o…

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterCatalogFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterCatalogFunctionOperation.java
@@ -28,14 +28,14 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Operation to describe a ALTER FUNCTION statement for temporary catalog function.
+ * Operation to describe a ALTER FUNCTION statement for catalog functions.
  */
-public class AlterFunctionOperation implements AlterOperation  {
+public class AlterCatalogFunctionOperation implements AlterOperation  {
 	private final ObjectIdentifier functionIdentifier;
 	private CatalogFunction catalogFunction;
 	private boolean ifExists;
 
-	public AlterFunctionOperation(
+	public AlterCatalogFunctionOperation(
 			ObjectIdentifier functionIdentifier,
 			CatalogFunction catalogFunction,
 			boolean ifExists) {
@@ -64,7 +64,7 @@ public class AlterFunctionOperation implements AlterOperation  {
 		params.put("ifExists", ifExists);
 
 		return OperationUtils.formatWithChildren(
-			"ALTER FUNCTION",
+			"ALTER CATALOG FUNCTION",
 			params,
 			Collections.emptyList(),
 			Operation::asSummaryString);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateCatalogFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateCatalogFunctionOperation.java
@@ -28,14 +28,14 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Operation to describe a CREATE FUNCTION statement for catalog function.
+ * Operation to describe a CREATE FUNCTION statement for catalog functions.
  */
-public class CreateFunctionOperation implements CreateOperation {
+public class CreateCatalogFunctionOperation implements CreateOperation {
 	private final ObjectIdentifier functionIdentifier;
 	private CatalogFunction catalogFunction;
 	private boolean ignoreIfExists;
 
-	public CreateFunctionOperation(
+	public CreateCatalogFunctionOperation(
 		ObjectIdentifier functionIdentifier,
 		CatalogFunction catalogFunction,
 		boolean ignoreIfExists) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropCatalogFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropCatalogFunctionOperation.java
@@ -27,15 +27,15 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- *  Operation to describe a DROP FUNCTION statement for catalog function.
+ *  Operation to describe a DROP FUNCTION statement for catalog functions.
  */
-public class DropFunctionOperation implements DropOperation {
+public class DropCatalogFunctionOperation implements DropOperation {
 	private final ObjectIdentifier functionIdentifier;
 	private final boolean ifExists;
 	private final boolean isTemporary;
 	private final boolean isSystemFunction;
 
-	public DropFunctionOperation(
+	public DropCatalogFunctionOperation(
 			ObjectIdentifier functionIdentifier,
 			boolean isTemporary,
 			boolean isSystemFunction,
@@ -63,7 +63,7 @@ public class DropFunctionOperation implements DropOperation {
 		params.put("isTemporary", isTemporary);
 
 		return OperationUtils.formatWithChildren(
-			"DROP FUNCTION",
+			"DROP CATALOG FUNCTION",
 			params,
 			Collections.emptyList(),
 			Operation::asSummaryString);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -53,16 +53,16 @@ import org.apache.flink.table.operations.CatalogSinkModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
+import org.apache.flink.table.operations.ddl.AlterCatalogFunctionOperation;
 import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
-import org.apache.flink.table.operations.ddl.AlterFunctionOperation;
 import org.apache.flink.table.operations.ddl.AlterTablePropertiesOperation;
 import org.apache.flink.table.operations.ddl.AlterTableRenameOperation;
+import org.apache.flink.table.operations.ddl.CreateCatalogFunctionOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
-import org.apache.flink.table.operations.ddl.CreateFunctionOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.CreateTempSystemFunctionOperation;
+import org.apache.flink.table.operations.ddl.DropCatalogFunctionOperation;
 import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
-import org.apache.flink.table.operations.ddl.DropFunctionOperation;
 import org.apache.flink.table.operations.ddl.DropTableOperation;
 import org.apache.flink.table.operations.ddl.DropTempSystemFunctionOperation;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
@@ -258,7 +258,7 @@ public class SqlToOperationConverter {
 				sqlCreateFunction.isTemporary());
 			ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
-			return new CreateFunctionOperation(
+			return new CreateCatalogFunctionOperation(
 				identifier,
 				catalogFunction,
 				sqlCreateFunction.isIfNotExists()
@@ -280,7 +280,7 @@ public class SqlToOperationConverter {
 
 		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlAlterFunction.getFunctionIdentifier());
 		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
-		return new AlterFunctionOperation(
+		return new AlterCatalogFunctionOperation(
 			identifier,
 			catalogFunction,
 			sqlAlterFunction.isIfExists()
@@ -298,7 +298,7 @@ public class SqlToOperationConverter {
 		} else {
 			ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
-			return new DropFunctionOperation(
+			return new DropCatalogFunctionOperation(
 				identifier,
 				sqlDropFunction.isTemporary(),
 				sqlDropFunction.isSystemFunction(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -56,16 +56,16 @@ import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.PlannerQueryOperation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
+import org.apache.flink.table.operations.ddl.AlterCatalogFunctionOperation;
 import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
-import org.apache.flink.table.operations.ddl.AlterFunctionOperation;
 import org.apache.flink.table.operations.ddl.AlterTablePropertiesOperation;
 import org.apache.flink.table.operations.ddl.AlterTableRenameOperation;
+import org.apache.flink.table.operations.ddl.CreateCatalogFunctionOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
-import org.apache.flink.table.operations.ddl.CreateFunctionOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.CreateTempSystemFunctionOperation;
+import org.apache.flink.table.operations.ddl.DropCatalogFunctionOperation;
 import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
-import org.apache.flink.table.operations.ddl.DropFunctionOperation;
 import org.apache.flink.table.operations.ddl.DropTableOperation;
 import org.apache.flink.table.operations.ddl.DropTempSystemFunctionOperation;
 import org.apache.flink.table.types.utils.TypeConversions;
@@ -264,7 +264,7 @@ public class SqlToOperationConverter {
 
 			ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
-			return new CreateFunctionOperation(
+			return new CreateCatalogFunctionOperation(
 				identifier,
 				catalogFunction,
 				sqlCreateFunction.isIfNotExists()
@@ -286,7 +286,7 @@ public class SqlToOperationConverter {
 
 		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlAlterFunction.getFunctionIdentifier());
 		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
-		return new AlterFunctionOperation(
+		return new AlterCatalogFunctionOperation(
 			identifier,
 			catalogFunction,
 			sqlAlterFunction.isIfExists()
@@ -304,7 +304,7 @@ public class SqlToOperationConverter {
 		} else {
 			ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
-			return new DropFunctionOperation(
+			return new DropCatalogFunctionOperation(
 				identifier,
 				sqlDropFunction.isTemporary(),
 				sqlDropFunction.isSystemFunction(),

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -546,13 +546,13 @@ abstract class TableEnvImpl(
           case ex: DatabaseNotExistException => throw new ValidationException(exMsg, ex)
           case ex: Exception => throw new TableException(exMsg, ex)
         }
-      case createFunctionOperation: CreateFunctionOperation =>
+      case createFunctionOperation: CreateCatalogFunctionOperation =>
           createCatalogFunction(createFunctionOperation)
       case createTempSystemFunctionOperation: CreateTempSystemFunctionOperation =>
           createSystemFunction(createTempSystemFunctionOperation)
-      case alterFunctionOperation: AlterFunctionOperation =>
+      case alterFunctionOperation: AlterCatalogFunctionOperation =>
           alterCatalogFunction(alterFunctionOperation)
-      case dropFunctionOperation: DropFunctionOperation =>
+      case dropFunctionOperation: DropCatalogFunctionOperation =>
           dropCatalogFunction(dropFunctionOperation)
       case dropTempSystemFunctionOperation: DropTempSystemFunctionOperation =>
           dropSystemFunction(dropTempSystemFunctionOperation)
@@ -699,7 +699,7 @@ abstract class TableEnvImpl(
       .map(_.getTable)
   }
 
-  private def createCatalogFunction(createFunctionOperation: CreateFunctionOperation)= {
+  private def createCatalogFunction(createFunctionOperation: CreateCatalogFunctionOperation)= {
     val exMsg = getDDLOpExecuteErrorMsg(createFunctionOperation.asSummaryString)
     try {
       val function = createFunctionOperation.getCatalogFunction
@@ -732,7 +732,7 @@ abstract class TableEnvImpl(
     }
   }
 
-  private def alterCatalogFunction(alterFunctionOperation: AlterFunctionOperation) = {
+  private def alterCatalogFunction(alterFunctionOperation: AlterCatalogFunctionOperation) = {
     val exMsg = getDDLOpExecuteErrorMsg(alterFunctionOperation.asSummaryString)
     try {
       val function = alterFunctionOperation.getCatalogFunction
@@ -753,7 +753,7 @@ abstract class TableEnvImpl(
     }
   }
 
-  private def dropCatalogFunction(dropFunctionOperation: DropFunctionOperation) = {
+  private def dropCatalogFunction(dropFunctionOperation: DropCatalogFunctionOperation) = {
     val exMsg = getDDLOpExecuteErrorMsg(dropFunctionOperation.asSummaryString)
     try {
       if (dropFunctionOperation.isTemporary)  {


### PR DESCRIPTION
## What is the purpose of the change
Function DDL supports operations for both catalog and system functions. To better distinguish two
different types of operations, this PR rename original FunctionOperations to CatalogFunctionOperations.

## Brief change log

  - Rename {Alter/Create/Drop}FunctionOperations to {Alter/Create/Drop}CatalogFunctionOperations.

## Verifying this change
It is verified by existing function integration tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (o)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not documented)
