### PR TITLE
[FLINK-15093][streaming-java] StreamExecutionEnvironment does not cle…

### DIFF
--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCAppendTableSinkTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCAppendTableSinkTest.java
@@ -61,11 +61,16 @@ public class JDBCAppendTableSinkTest {
 		DataStream<Row> ds = env.fromCollection(Collections.singleton(Row.of("foo")), ROW_TYPE);
 		sink.emitDataStream(ds);
 
-		Collection<Integer> sinkIds = env.getStreamGraph().getSinkIDs();
+		Collection<Integer> sinkIds = env
+				.getStreamGraph(StreamExecutionEnvironment.DEFAULT_JOB_NAME, false)
+				.getSinkIDs();
 		assertEquals(1, sinkIds.size());
 		int sinkId = sinkIds.iterator().next();
 
-		StreamSink planSink = (StreamSink) env.getStreamGraph().getStreamNode(sinkId).getOperator();
+		StreamSink planSink = (StreamSink) env
+				.getStreamGraph(StreamExecutionEnvironment.DEFAULT_JOB_NAME, false)
+				.getStreamNode(sinkId)
+				.getOperator();
 		assertTrue(planSink.getUserFunction() instanceof JDBCSinkFunction);
 
 		JDBCSinkFunction sinkFunction = (JDBCSinkFunction) planSink.getUserFunction();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
@@ -19,11 +19,9 @@ package org.apache.flink.streaming.api.environment;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.common.InvalidProgramException;
-import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
-import org.apache.flink.streaming.api.graph.StreamGraph;
 
 import javax.annotation.Nonnull;
 
@@ -67,20 +65,5 @@ public class LocalStreamEnvironment extends StreamExecutionEnvironment {
 		effectiveConfiguration.set(DeploymentOptions.TARGET, "local-executor");
 		effectiveConfiguration.set(DeploymentOptions.ATTACHED, true);
 		return effectiveConfiguration;
-	}
-
-	/**
-	 * Executes the JobGraph of the on a mini cluster of ClusterUtil with a user
-	 * specified name.
-	 *
-	 * @return The result of the job execution, containing elapsed time and accumulators.
-	 */
-	@Override
-	public JobExecutionResult execute(StreamGraph streamGraph) throws Exception {
-		try {
-			return super.execute(streamGraph);
-		} finally {
-			transformations.clear();
-		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -215,7 +215,6 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 
 	@Override
 	public JobExecutionResult execute(StreamGraph streamGraph) throws Exception {
-		transformations.clear();
 		try {
 			return super.execute(streamGraph);
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamContextEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamContextEnvironment.java
@@ -60,8 +60,6 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
 
 	@Override
 	public JobExecutionResult execute(StreamGraph streamGraph) throws Exception {
-		transformations.clear();
-
 		JobClient jobClient = executeAsync(streamGraph).get();
 
 		JobExecutionResult jobExecutionResult;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -1702,7 +1702,7 @@ public class StreamExecutionEnvironment {
 	 */
 	@Internal
 	public StreamGraph getStreamGraph() {
-		return getStreamGraphGenerator().generate();
+		return getStreamGraph(DEFAULT_JOB_NAME);
 	}
 
 	/**
@@ -1713,7 +1713,23 @@ public class StreamExecutionEnvironment {
 	 */
 	@Internal
 	public StreamGraph getStreamGraph(String jobName) {
-		return getStreamGraphGenerator().setJobName(jobName).generate();
+		return getStreamGraph(jobName, true);
+	}
+
+	/**
+	 * Getter of the {@link org.apache.flink.streaming.api.graph.StreamGraph} of the streaming job.
+	 *
+	 * @param jobName Desired name of the job
+	 * @param clearTransformations Whether or not to start a new stage of execution
+	 * @return The streamgraph representing the transformations
+	 */
+	@Internal
+	public StreamGraph getStreamGraph(String jobName, boolean clearTransformations) {
+		StreamGraph streamGraph = getStreamGraphGenerator().setJobName(jobName).generate();
+		if (clearTransformations) {
+			this.transformations.clear();
+		}
+		return streamGraph;
 	}
 
 	private StreamGraphGenerator getStreamGraphGenerator() {
@@ -1737,7 +1753,7 @@ public class StreamExecutionEnvironment {
 	 * @return The execution plan of the program, as a JSON String.
 	 */
 	public String getExecutionPlan() {
-		return getStreamGraph().getStreamingPlanAsJSON();
+		return getStreamGraph(DEFAULT_JOB_NAME, false).getStreamingPlanAsJSON();
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamPlanEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamPlanEnvironment.java
@@ -49,8 +49,6 @@ public class StreamPlanEnvironment extends StreamExecutionEnvironment {
 
 	@Override
 	public JobExecutionResult execute(StreamGraph streamGraph) throws Exception {
-		transformations.clear();
-
 		if (env instanceof OptimizerPlanEnvironment) {
 			((OptimizerPlanEnvironment) env).setPipeline(streamGraph);
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
@@ -195,7 +195,7 @@ public class DataStreamTest extends TestLogger {
 			}
 		}).setParallelism(4);
 
-		StreamGraph streamGraph = env.getStreamGraph();
+		StreamGraph streamGraph = getStreamGraph(env);
 
 		// verify self union
 		assertTrue(streamGraph.getStreamNode(selfUnion.getId()).getInEdges().size() == 2);
@@ -326,10 +326,10 @@ public class DataStreamTest extends TestLogger {
 		int id3 = createDownStreamId(group3);
 		int id4 = createDownStreamId(group4);
 
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src1.getId(), id1)));
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src1.getId(), id2)));
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src1.getId(), id3)));
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src1.getId(), id4)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), id1)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), id2)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), id3)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), id4)));
 
 		assertTrue(isKeyed(group1));
 		assertTrue(isKeyed(group2));
@@ -347,10 +347,10 @@ public class DataStreamTest extends TestLogger {
 		int pid3 = createDownStreamId(partition3);
 		int pid4 = createDownStreamId(partition4);
 
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src1.getId(), pid1)));
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src1.getId(), pid2)));
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src1.getId(), pid3)));
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src1.getId(), pid4)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), pid1)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), pid2)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), pid3)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), pid4)));
 
 		assertTrue(isKeyed(partition1));
 		assertTrue(isKeyed(partition3));
@@ -373,9 +373,9 @@ public class DataStreamTest extends TestLogger {
 		int cid2 = createDownStreamId(customPartition3);
 		int cid3 = createDownStreamId(customPartition4);
 
-		assertTrue(isCustomPartitioned(env.getStreamGraph().getStreamEdges(src1.getId(), cid1)));
-		assertTrue(isCustomPartitioned(env.getStreamGraph().getStreamEdges(src1.getId(), cid2)));
-		assertTrue(isCustomPartitioned(env.getStreamGraph().getStreamEdges(src1.getId(), cid3)));
+		assertTrue(isCustomPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), cid1)));
+		assertTrue(isCustomPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), cid2)));
+		assertTrue(isCustomPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), cid3)));
 
 		assertFalse(isKeyed(customPartition1));
 		assertFalse(isKeyed(customPartition3));
@@ -397,20 +397,20 @@ public class DataStreamTest extends TestLogger {
 		ConnectedStreams<Tuple2<Long, Long>, Tuple2<Long, Long>> connectedGroup5 = connected.keyBy(new FirstSelector(), new FirstSelector());
 		Integer downStreamId5 = createDownStreamId(connectedGroup5);
 
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src1.getId(), downStreamId1)));
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src2.getId(), downStreamId1)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), downStreamId1)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId(), downStreamId1)));
 
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src1.getId(), downStreamId2)));
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src2.getId(), downStreamId2)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), downStreamId2)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId(), downStreamId2)));
 
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src1.getId(), downStreamId3)));
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src2.getId(), downStreamId3)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), downStreamId3)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId(), downStreamId3)));
 
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src1.getId(), downStreamId4)));
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src2.getId(), downStreamId4)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), downStreamId4)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId(), downStreamId4)));
 
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src1.getId(), downStreamId5)));
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src2.getId(), downStreamId5)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), downStreamId5)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId(), downStreamId5)));
 
 		assertTrue(isKeyed(connectedGroup1));
 		assertTrue(isKeyed(connectedGroup2));
@@ -434,29 +434,29 @@ public class DataStreamTest extends TestLogger {
 		ConnectedStreams<Tuple2<Long, Long>, Tuple2<Long, Long>> connectedPartition5 = connected.keyBy(new FirstSelector(), new FirstSelector());
 		Integer connectDownStreamId5 = createDownStreamId(connectedPartition5);
 
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src1.getId(),
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(),
 				connectDownStreamId1)));
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src2.getId(),
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId(),
 				connectDownStreamId1)));
 
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src1.getId(),
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(),
 				connectDownStreamId2)));
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src2.getId(),
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId(),
 				connectDownStreamId2)));
 
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src1.getId(),
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(),
 				connectDownStreamId3)));
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src2.getId(),
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId(),
 				connectDownStreamId3)));
 
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src1.getId(),
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(),
 				connectDownStreamId4)));
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src2.getId(),
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId(),
 				connectDownStreamId4)));
 
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src1.getId(),
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(),
 				connectDownStreamId5)));
-		assertTrue(isPartitioned(env.getStreamGraph().getStreamEdges(src2.getId(),
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId(),
 				connectDownStreamId5)));
 
 		assertTrue(isKeyed(connectedPartition1));
@@ -503,21 +503,21 @@ public class DataStreamTest extends TestLogger {
 			}
 		});
 
-		assertEquals(1, env.getStreamGraph().getStreamNode(src.getId()).getParallelism());
-		assertEquals(10, env.getStreamGraph().getStreamNode(map.getId()).getParallelism());
-		assertEquals(1, env.getStreamGraph().getStreamNode(windowed.getId()).getParallelism());
+		assertEquals(1, getStreamGraph(env).getStreamNode(src.getId()).getParallelism());
+		assertEquals(10, getStreamGraph(env).getStreamNode(map.getId()).getParallelism());
+		assertEquals(1, getStreamGraph(env).getStreamNode(windowed.getId()).getParallelism());
 		assertEquals(10,
-				env.getStreamGraph().getStreamNode(sink.getTransformation().getId()).getParallelism());
+				getStreamGraph(env).getStreamNode(sink.getTransformation().getId()).getParallelism());
 
 		env.setParallelism(7);
 
 		// Some parts, such as windowing rely on the fact that previous operators have a parallelism
 		// set when instantiating the Discretizer. This would break if we dynamically changed
 		// the parallelism of operations when changing the setting on the Execution Environment.
-		assertEquals(1, env.getStreamGraph().getStreamNode(src.getId()).getParallelism());
-		assertEquals(10, env.getStreamGraph().getStreamNode(map.getId()).getParallelism());
-		assertEquals(1, env.getStreamGraph().getStreamNode(windowed.getId()).getParallelism());
-		assertEquals(10, env.getStreamGraph().getStreamNode(sink.getTransformation().getId()).getParallelism());
+		assertEquals(1, getStreamGraph(env).getStreamNode(src.getId()).getParallelism());
+		assertEquals(10, getStreamGraph(env).getStreamNode(map.getId()).getParallelism());
+		assertEquals(1, getStreamGraph(env).getStreamNode(windowed.getId()).getParallelism());
+		assertEquals(10, getStreamGraph(env).getStreamNode(sink.getTransformation().getId()).getParallelism());
 
 		try {
 			src.setParallelism(3);
@@ -528,16 +528,16 @@ public class DataStreamTest extends TestLogger {
 
 		DataStreamSource<Long> parallelSource = env.generateSequence(0, 0);
 		parallelSource.addSink(new DiscardingSink<Long>());
-		assertEquals(7, env.getStreamGraph().getStreamNode(parallelSource.getId()).getParallelism());
+		assertEquals(7, getStreamGraph(env).getStreamNode(parallelSource.getId()).getParallelism());
 
 		parallelSource.setParallelism(3);
-		assertEquals(3, env.getStreamGraph().getStreamNode(parallelSource.getId()).getParallelism());
+		assertEquals(3, getStreamGraph(env).getStreamNode(parallelSource.getId()).getParallelism());
 
 		map.setParallelism(2);
-		assertEquals(2, env.getStreamGraph().getStreamNode(map.getId()).getParallelism());
+		assertEquals(2, getStreamGraph(env).getStreamNode(map.getId()).getParallelism());
 
 		sink.setParallelism(4);
-		assertEquals(4, env.getStreamGraph().getStreamNode(sink.getTransformation().getId()).getParallelism());
+		assertEquals(4, getStreamGraph(env).getStreamNode(sink.getTransformation().getId()).getParallelism());
 	}
 
 	/**
@@ -624,26 +624,26 @@ public class DataStreamTest extends TestLogger {
 		DataStreamSink<Long> sink = windowed.print();
 		sinkMethod.invoke(sink, minResource7, preferredResource7);
 
-		assertEquals(minResource1, env.getStreamGraph().getStreamNode(source1.getId()).getMinResources());
-		assertEquals(preferredResource1, env.getStreamGraph().getStreamNode(source1.getId()).getPreferredResources());
+		assertEquals(minResource1, getStreamGraph(env).getStreamNode(source1.getId()).getMinResources());
+		assertEquals(preferredResource1, getStreamGraph(env).getStreamNode(source1.getId()).getPreferredResources());
 
-		assertEquals(minResource2, env.getStreamGraph().getStreamNode(map1.getId()).getMinResources());
-		assertEquals(preferredResource2, env.getStreamGraph().getStreamNode(map1.getId()).getPreferredResources());
+		assertEquals(minResource2, getStreamGraph(env).getStreamNode(map1.getId()).getMinResources());
+		assertEquals(preferredResource2, getStreamGraph(env).getStreamNode(map1.getId()).getPreferredResources());
 
-		assertEquals(minResource3, env.getStreamGraph().getStreamNode(source2.getId()).getMinResources());
-		assertEquals(preferredResource3, env.getStreamGraph().getStreamNode(source2.getId()).getPreferredResources());
+		assertEquals(minResource3, getStreamGraph(env).getStreamNode(source2.getId()).getMinResources());
+		assertEquals(preferredResource3, getStreamGraph(env).getStreamNode(source2.getId()).getPreferredResources());
 
-		assertEquals(minResource4, env.getStreamGraph().getStreamNode(map2.getId()).getMinResources());
-		assertEquals(preferredResource4, env.getStreamGraph().getStreamNode(map2.getId()).getPreferredResources());
+		assertEquals(minResource4, getStreamGraph(env).getStreamNode(map2.getId()).getMinResources());
+		assertEquals(preferredResource4, getStreamGraph(env).getStreamNode(map2.getId()).getPreferredResources());
 
-		assertEquals(minResource5, env.getStreamGraph().getStreamNode(connected.getId()).getMinResources());
-		assertEquals(preferredResource5, env.getStreamGraph().getStreamNode(connected.getId()).getPreferredResources());
+		assertEquals(minResource5, getStreamGraph(env).getStreamNode(connected.getId()).getMinResources());
+		assertEquals(preferredResource5, getStreamGraph(env).getStreamNode(connected.getId()).getPreferredResources());
 
-		assertEquals(minResource6, env.getStreamGraph().getStreamNode(windowed.getId()).getMinResources());
-		assertEquals(preferredResource6, env.getStreamGraph().getStreamNode(windowed.getId()).getPreferredResources());
+		assertEquals(minResource6, getStreamGraph(env).getStreamNode(windowed.getId()).getMinResources());
+		assertEquals(preferredResource6, getStreamGraph(env).getStreamNode(windowed.getId()).getPreferredResources());
 
-		assertEquals(minResource7, env.getStreamGraph().getStreamNode(sink.getTransformation().getId()).getMinResources());
-		assertEquals(preferredResource7, env.getStreamGraph().getStreamNode(sink.getTransformation().getId()).getPreferredResources());
+		assertEquals(minResource7, getStreamGraph(env).getStreamNode(sink.getTransformation().getId()).getMinResources());
+		assertEquals(preferredResource7, getStreamGraph(env).getStreamNode(sink.getTransformation().getId()).getPreferredResources());
 	}
 
 	@Test
@@ -942,13 +942,13 @@ public class DataStreamTest extends TestLogger {
 		assertEquals(filterFunction, getFunctionForDataStream(unionFilter));
 
 		try {
-			env.getStreamGraph().getStreamEdges(map.getId(), unionFilter.getId());
+			getStreamGraph(env).getStreamEdges(map.getId(), unionFilter.getId());
 		} catch (RuntimeException e) {
 			fail(e.getMessage());
 		}
 
 		try {
-			env.getStreamGraph().getStreamEdges(flatMap.getId(), unionFilter.getId());
+			getStreamGraph(env).getStreamEdges(flatMap.getId(), unionFilter.getId());
 		} catch (RuntimeException e) {
 			fail(e.getMessage());
 		}
@@ -957,18 +957,18 @@ public class DataStreamTest extends TestLogger {
 
 		SplitStream<Integer> split = unionFilter.split(outputSelector);
 		split.select("dummy").addSink(new DiscardingSink<Integer>());
-		List<OutputSelector<?>> outputSelectors = env.getStreamGraph().getStreamNode(unionFilter.getId()).getOutputSelectors();
+		List<OutputSelector<?>> outputSelectors = getStreamGraph(env).getStreamNode(unionFilter.getId()).getOutputSelectors();
 		assertEquals(1, outputSelectors.size());
 		assertEquals(outputSelector, outputSelectors.get(0));
 
 		DataStream<Integer> select = split.select("a");
 		DataStreamSink<Integer> sink = select.print();
 
-		StreamEdge splitEdge = env.getStreamGraph().getStreamEdges(unionFilter.getId(), sink.getTransformation().getId()).get(0);
+		StreamEdge splitEdge = getStreamGraph(env).getStreamEdges(unionFilter.getId(), sink.getTransformation().getId()).get(0);
 		assertEquals("a", splitEdge.getSelectedNames().get(0));
 
 		DataStreamSink<Integer> sinkWithIdentifier = select.print("identifier");
-		StreamEdge newSplitEdge = env.getStreamGraph().getStreamEdges(unionFilter.getId(), sinkWithIdentifier.getTransformation().getId()).get(0);
+		StreamEdge newSplitEdge = getStreamGraph(env).getStreamEdges(unionFilter.getId(), sinkWithIdentifier.getTransformation().getId()).get(0);
 		assertEquals("a", newSplitEdge.getSelectedNames().get(0));
 
 		ConnectedStreams<Integer, Integer> connect = map.connect(flatMap);
@@ -990,13 +990,13 @@ public class DataStreamTest extends TestLogger {
 		assertEquals(coMapper, getFunctionForDataStream(coMap));
 
 		try {
-			env.getStreamGraph().getStreamEdges(map.getId(), coMap.getId());
+			getStreamGraph(env).getStreamEdges(map.getId(), coMap.getId());
 		} catch (RuntimeException e) {
 			fail(e.getMessage());
 		}
 
 		try {
-			env.getStreamGraph().getStreamEdges(flatMap.getId(), coMap.getId());
+			getStreamGraph(env).getStreamEdges(flatMap.getId(), coMap.getId());
 		} catch (RuntimeException e) {
 			fail(e.getMessage());
 		}
@@ -1007,8 +1007,8 @@ public class DataStreamTest extends TestLogger {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
 		DataStreamSink<Long> sink = env.generateSequence(1, 100).print();
-		assertTrue(env.getStreamGraph().getStreamNode(sink.getTransformation().getId()).getStatePartitioner1() == null);
-		assertTrue(env.getStreamGraph().getStreamNode(sink.getTransformation().getId()).getInEdges().get(0).getPartitioner() instanceof ForwardPartitioner);
+		assertTrue(getStreamGraph(env).getStreamNode(sink.getTransformation().getId()).getStatePartitioner1() == null);
+		assertTrue(getStreamGraph(env).getStreamNode(sink.getTransformation().getId()).getInEdges().get(0).getPartitioner() instanceof ForwardPartitioner);
 
 		KeySelector<Long, Long> key1 = new KeySelector<Long, Long>() {
 
@@ -1022,11 +1022,11 @@ public class DataStreamTest extends TestLogger {
 
 		DataStreamSink<Long> sink2 = env.generateSequence(1, 100).keyBy(key1).print();
 
-		assertNotNull(env.getStreamGraph().getStreamNode(sink2.getTransformation().getId()).getStatePartitioner1());
-		assertNotNull(env.getStreamGraph().getStreamNode(sink2.getTransformation().getId()).getStateKeySerializer());
-		assertNotNull(env.getStreamGraph().getStreamNode(sink2.getTransformation().getId()).getStateKeySerializer());
-		assertEquals(key1, env.getStreamGraph().getStreamNode(sink2.getTransformation().getId()).getStatePartitioner1());
-		assertTrue(env.getStreamGraph().getStreamNode(sink2.getTransformation().getId()).getInEdges().get(0).getPartitioner() instanceof KeyGroupStreamPartitioner);
+		assertNotNull(getStreamGraph(env).getStreamNode(sink2.getTransformation().getId()).getStatePartitioner1());
+		assertNotNull(getStreamGraph(env).getStreamNode(sink2.getTransformation().getId()).getStateKeySerializer());
+		assertNotNull(getStreamGraph(env).getStreamNode(sink2.getTransformation().getId()).getStateKeySerializer());
+		assertEquals(key1, getStreamGraph(env).getStreamNode(sink2.getTransformation().getId()).getStatePartitioner1());
+		assertTrue(getStreamGraph(env).getStreamNode(sink2.getTransformation().getId()).getInEdges().get(0).getPartitioner() instanceof KeyGroupStreamPartitioner);
 
 		KeySelector<Long, Long> key2 = new KeySelector<Long, Long>() {
 
@@ -1040,9 +1040,9 @@ public class DataStreamTest extends TestLogger {
 
 		DataStreamSink<Long> sink3 = env.generateSequence(1, 100).keyBy(key2).print();
 
-		assertTrue(env.getStreamGraph().getStreamNode(sink3.getTransformation().getId()).getStatePartitioner1() != null);
-		assertEquals(key2, env.getStreamGraph().getStreamNode(sink3.getTransformation().getId()).getStatePartitioner1());
-		assertTrue(env.getStreamGraph().getStreamNode(sink3.getTransformation().getId()).getInEdges().get(0).getPartitioner() instanceof KeyGroupStreamPartitioner);
+		assertTrue(getStreamGraph(env).getStreamNode(sink3.getTransformation().getId()).getStatePartitioner1() != null);
+		assertEquals(key2, getStreamGraph(env).getStreamNode(sink3.getTransformation().getId()).getStatePartitioner1());
+		assertTrue(getStreamGraph(env).getStreamNode(sink3.getTransformation().getId()).getInEdges().get(0).getPartitioner() instanceof KeyGroupStreamPartitioner);
 	}
 
 	@Test
@@ -1054,35 +1054,35 @@ public class DataStreamTest extends TestLogger {
 		DataStream<Long> broadcast = src.broadcast();
 		DataStreamSink<Long> broadcastSink = broadcast.print();
 		StreamPartitioner<?> broadcastPartitioner =
-				env.getStreamGraph().getStreamEdges(src.getId(),
+				getStreamGraph(env).getStreamEdges(src.getId(),
 						broadcastSink.getTransformation().getId()).get(0).getPartitioner();
 		assertTrue(broadcastPartitioner instanceof BroadcastPartitioner);
 
 		DataStream<Long> shuffle = src.shuffle();
 		DataStreamSink<Long> shuffleSink = shuffle.print();
 		StreamPartitioner<?> shufflePartitioner =
-				env.getStreamGraph().getStreamEdges(src.getId(),
+				getStreamGraph(env).getStreamEdges(src.getId(),
 						shuffleSink.getTransformation().getId()).get(0).getPartitioner();
 		assertTrue(shufflePartitioner instanceof ShufflePartitioner);
 
 		DataStream<Long> forward = src.forward();
 		DataStreamSink<Long> forwardSink = forward.print();
 		StreamPartitioner<?> forwardPartitioner =
-				env.getStreamGraph().getStreamEdges(src.getId(),
+				getStreamGraph(env).getStreamEdges(src.getId(),
 						forwardSink.getTransformation().getId()).get(0).getPartitioner();
 		assertTrue(forwardPartitioner instanceof ForwardPartitioner);
 
 		DataStream<Long> rebalance = src.rebalance();
 		DataStreamSink<Long> rebalanceSink = rebalance.print();
 		StreamPartitioner<?> rebalancePartitioner =
-				env.getStreamGraph().getStreamEdges(src.getId(),
+				getStreamGraph(env).getStreamEdges(src.getId(),
 						rebalanceSink.getTransformation().getId()).get(0).getPartitioner();
 		assertTrue(rebalancePartitioner instanceof RebalancePartitioner);
 
 		DataStream<Long> global = src.global();
 		DataStreamSink<Long> globalSink = global.print();
 		StreamPartitioner<?> globalPartitioner =
-				env.getStreamGraph().getStreamEdges(src.getId(),
+				getStreamGraph(env).getStreamEdges(src.getId(),
 						globalSink.getTransformation().getId()).get(0).getPartitioner();
 		assertTrue(globalPartitioner instanceof GlobalPartitioner);
 	}
@@ -1104,7 +1104,7 @@ public class DataStreamTest extends TestLogger {
 		expectedException.expect(IllegalStateException.class);
 		expectedException.expectMessage("Consecutive multiple splits are not supported. Splits are deprecated. Please use side-outputs.");
 
-		env.getStreamGraph();
+		getStreamGraph(env);
 	}
 
 	@Test
@@ -1121,7 +1121,7 @@ public class DataStreamTest extends TestLogger {
 		expectedException.expect(IllegalStateException.class);
 		expectedException.expectMessage("Split after side-outputs are not supported. Splits are deprecated. Please use side-outputs.");
 
-		env.getStreamGraph();
+		getStreamGraph(env);
 	}
 
 	@Test
@@ -1137,7 +1137,7 @@ public class DataStreamTest extends TestLogger {
 		expectedException.expect(IllegalStateException.class);
 		expectedException.expectMessage("Consecutive multiple splits are not supported. Splits are deprecated. Please use side-outputs.");
 
-		env.getStreamGraph();
+		getStreamGraph(env);
 	}
 
 	@Test
@@ -1153,7 +1153,7 @@ public class DataStreamTest extends TestLogger {
 		expectedException.expect(IllegalStateException.class);
 		expectedException.expectMessage("Consecutive multiple splits are not supported. Splits are deprecated. Please use side-outputs.");
 
-		env.getStreamGraph();
+		getStreamGraph(env);
 	}
 
 	@Test
@@ -1169,7 +1169,7 @@ public class DataStreamTest extends TestLogger {
 		expectedException.expect(IllegalStateException.class);
 		expectedException.expectMessage("Consecutive multiple splits are not supported. Splits are deprecated. Please use side-outputs.");
 
-		env.getStreamGraph();
+		getStreamGraph(env);
 	}
 
 	/////////////////////////////////////////////////////////////
@@ -1406,7 +1406,7 @@ public class DataStreamTest extends TestLogger {
 
 	private static StreamOperator<?> getOperatorForDataStream(DataStream<?> dataStream) {
 		StreamExecutionEnvironment env = dataStream.getExecutionEnvironment();
-		StreamGraph streamGraph = env.getStreamGraph();
+		StreamGraph streamGraph = getStreamGraph(env);
 		return streamGraph.getStreamNode(dataStream.getId()).getOperator();
 	}
 
@@ -1414,6 +1414,11 @@ public class DataStreamTest extends TestLogger {
 		AbstractUdfStreamOperator<?, ?> operator =
 				(AbstractUdfStreamOperator<?, ?>) getOperatorForDataStream(dataStream);
 		return operator.getUserFunction();
+	}
+
+	/** Returns the StreamGraph without clearing the transformations. */
+	private static StreamGraph getStreamGraph(StreamExecutionEnvironment sEnv) {
+		return sEnv.getStreamGraph(StreamExecutionEnvironment.DEFAULT_JOB_NAME, false);
 	}
 
 	private static Integer createDownStreamId(DataStream<?> dataStream) {

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -733,6 +733,26 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
   def getStreamGraph = javaEnv.getStreamGraph
 
   /**
+   * Getter of the [[org.apache.flink.streaming.api.graph.StreamGraph]] of the streaming job.
+   *
+   * @param jobName Desired name of the job
+   * @return The StreamGraph representing the transformations
+   */
+  @Internal
+  def getStreamGraph(jobName: String) = javaEnv.getStreamGraph(jobName)
+
+  /**
+   * Getter of the [[org.apache.flink.streaming.api.graph.StreamGraph]] of the streaming job.
+   *
+   * @param jobName Desired name of the job
+   * @param clearTransformations Whether or not to start a new stage of execution
+   * @return The StreamGraph representing the transformations
+   */
+  @Internal
+  def getStreamGraph(jobName: String, clearTransformations: Boolean) =
+    javaEnv.getStreamGraph(jobName, clearTransformations)
+
+  /**
    * Getter of the wrapped [[org.apache.flink.streaming.api.environment.StreamExecutionEnvironment]]
  *
    * @return The encased ExecutionEnvironment

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
@@ -19,11 +19,11 @@
 package org.apache.flink.streaming.api.scala
 
 import java.lang
-
 import org.apache.flink.api.common.functions._
 import org.apache.flink.api.java.io.ParallelIteratorInputFormat
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.streaming.api.collector.selector.OutputSelector
+import org.apache.flink.streaming.api.environment.{StreamExecutionEnvironment => JStreamExecutionEnvironment}
 import org.apache.flink.streaming.api.functions.{KeyedProcessFunction, ProcessFunction}
 import org.apache.flink.streaming.api.functions.co.CoMapFunction
 import org.apache.flink.streaming.api.graph.{StreamEdge, StreamGraph}
@@ -34,6 +34,7 @@ import org.apache.flink.streaming.api.windowing.windows.GlobalWindow
 import org.apache.flink.streaming.runtime.partitioner._
 import org.apache.flink.test.util.AbstractTestBase
 import org.apache.flink.util.Collector
+
 import org.junit.Assert._
 import org.junit.rules.ExpectedException
 import org.junit.{Rule, Test}
@@ -116,10 +117,10 @@ class DataStreamTest extends AbstractTestBase {
     val gid2 = createDownStreamId(group2)
     val gid3 = createDownStreamId(group3)
     val gid4 = createDownStreamId(group4)
-    assert(isPartitioned(env.getStreamGraph.getStreamEdges(src1.getId, gid1)))
-    assert(isPartitioned(env.getStreamGraph.getStreamEdges(src1.getId, gid2)))
-    assert(isPartitioned(env.getStreamGraph.getStreamEdges(src1.getId, gid3)))
-    assert(isPartitioned(env.getStreamGraph.getStreamEdges(src1.getId, gid4)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, gid1)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, gid2)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, gid3)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, gid4)))
 
     //Testing DataStream partitioning
     val partition1: DataStream[_] = src1.keyBy(0)
@@ -132,10 +133,10 @@ class DataStreamTest extends AbstractTestBase {
     val pid3 = createDownStreamId(partition3)
     val pid4 = createDownStreamId(partition4)
 
-    assert(isPartitioned(env.getStreamGraph.getStreamEdges(src1.getId, pid1)))
-    assert(isPartitioned(env.getStreamGraph.getStreamEdges(src1.getId, pid2)))
-    assert(isPartitioned(env.getStreamGraph.getStreamEdges(src1.getId, pid3)))
-    assert(isPartitioned(env.getStreamGraph.getStreamEdges(src1.getId, pid4)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, pid1)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, pid2)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, pid3)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, pid4)))
 
     // Testing DataStream custom partitioning
     val longPartitioner: Partitioner[Long] = new Partitioner[Long] {
@@ -152,9 +153,9 @@ class DataStreamTest extends AbstractTestBase {
     val cpid1 = createDownStreamId(customPartition1)
     val cpid2 = createDownStreamId(customPartition3)
     val cpid3 = createDownStreamId(customPartition4)
-    assert(isCustomPartitioned(env.getStreamGraph.getStreamEdges(src1.getId, cpid1)))
-    assert(isCustomPartitioned(env.getStreamGraph.getStreamEdges(src1.getId, cpid2)))
-    assert(isCustomPartitioned(env.getStreamGraph.getStreamEdges(src1.getId, cpid3)))
+    assert(isCustomPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, cpid1)))
+    assert(isCustomPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, cpid2)))
+    assert(isCustomPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, cpid3)))
 
     //Testing ConnectedStreams grouping
     val connectedGroup1: ConnectedStreams[_, _] = connected.keyBy(0, 0)
@@ -173,20 +174,20 @@ class DataStreamTest extends AbstractTestBase {
     val connectedGroup5: ConnectedStreams[_, _] = connected.keyBy(x => x._1, x => x._1)
     val downStreamId5: Integer = createDownStreamId(connectedGroup5)
 
-    assert(isPartitioned(env.getStreamGraph.getStreamEdges(src1.getId, downStreamId1)))
-    assert(isPartitioned(env.getStreamGraph.getStreamEdges(src2.getId, downStreamId1)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, downStreamId1)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId, downStreamId1)))
 
-    assert(isPartitioned(env.getStreamGraph.getStreamEdges(src1.getId, downStreamId2)))
-    assert(isPartitioned(env.getStreamGraph.getStreamEdges(src2.getId, downStreamId2)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, downStreamId2)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId, downStreamId2)))
 
-    assert(isPartitioned(env.getStreamGraph.getStreamEdges(src1.getId, downStreamId3)))
-    assert(isPartitioned(env.getStreamGraph.getStreamEdges(src2.getId, downStreamId3)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, downStreamId3)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId, downStreamId3)))
 
-    assert(isPartitioned(env.getStreamGraph.getStreamEdges(src1.getId, downStreamId4)))
-    assert(isPartitioned(env.getStreamGraph.getStreamEdges(src2.getId, downStreamId4)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, downStreamId4)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId, downStreamId4)))
 
-    assert(isPartitioned(env.getStreamGraph.getStreamEdges(src1.getId, downStreamId5)))
-    assert(isPartitioned(env.getStreamGraph.getStreamEdges(src2.getId, downStreamId5)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, downStreamId5)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId, downStreamId5)))
 
     //Testing ConnectedStreams partitioning
     val connectedPartition1: ConnectedStreams[_, _] = connected.keyBy(0, 0)
@@ -208,38 +209,38 @@ class DataStreamTest extends AbstractTestBase {
     val connectDownStreamId5: Integer = createDownStreamId(connectedPartition5)
 
     assert(
-      isPartitioned(env.getStreamGraph.getStreamEdges(src1.getId, connectDownStreamId1))
+      isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, connectDownStreamId1))
     )
     assert(
-      isPartitioned(env.getStreamGraph.getStreamEdges(src2.getId, connectDownStreamId1))
-    )
-
-    assert(
-      isPartitioned(env.getStreamGraph.getStreamEdges(src1.getId, connectDownStreamId2))
-    )
-    assert(
-      isPartitioned(env.getStreamGraph.getStreamEdges(src2.getId, connectDownStreamId2))
+      isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId, connectDownStreamId1))
     )
 
     assert(
-      isPartitioned(env.getStreamGraph.getStreamEdges(src1.getId, connectDownStreamId3))
+      isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, connectDownStreamId2))
     )
     assert(
-      isPartitioned(env.getStreamGraph.getStreamEdges(src2.getId, connectDownStreamId3))
-    )
-
-    assert(
-      isPartitioned(env.getStreamGraph.getStreamEdges(src1.getId, connectDownStreamId4))
-    )
-    assert(
-      isPartitioned(env.getStreamGraph.getStreamEdges(src2.getId, connectDownStreamId4))
+      isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId, connectDownStreamId2))
     )
 
     assert(
-      isPartitioned(env.getStreamGraph.getStreamEdges(src1.getId, connectDownStreamId5))
+      isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, connectDownStreamId3))
     )
     assert(
-      isPartitioned(env.getStreamGraph.getStreamEdges(src2.getId, connectDownStreamId5))
+      isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId, connectDownStreamId3))
+    )
+
+    assert(
+      isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, connectDownStreamId4))
+    )
+    assert(
+      isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId, connectDownStreamId4))
+    )
+
+    assert(
+      isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, connectDownStreamId5))
+    )
+    assert(
+      isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId, connectDownStreamId5))
     )
   }
 
@@ -261,11 +262,10 @@ class DataStreamTest extends AbstractTestBase {
     windowed.print()
     val sink = map.addSink(x => {})
 
-    assert(1 == env.getStreamGraph.getStreamNode(src.getId).getParallelism)
-    assert(parallelism == env.getStreamGraph.getStreamNode(map.getId).getParallelism)
-    assert(1 == env.getStreamGraph.getStreamNode(windowed.getId).getParallelism)
-    assert(parallelism == env
-      .getStreamGraph
+    assert(1 == getStreamGraph(env).getStreamNode(src.getId).getParallelism)
+    assert(parallelism == getStreamGraph(env).getStreamNode(map.getId).getParallelism)
+    assert(1 == getStreamGraph(env).getStreamNode(windowed.getId).getParallelism)
+    assert(parallelism == getStreamGraph(env)
       .getStreamNode(sink.getTransformation.getId)
       .getParallelism)
 
@@ -283,27 +283,26 @@ class DataStreamTest extends AbstractTestBase {
     env.setParallelism(newParallelism)
     // the parallelism does not change since some windowing code takes the parallelism from
     // input operations and that cannot change dynamically
-    assert(1 == env.getStreamGraph.getStreamNode(src.getId).getParallelism)
-    assert(parallelism == env.getStreamGraph.getStreamNode(map.getId).getParallelism)
-    assert(1 == env.getStreamGraph.getStreamNode(windowed.getId).getParallelism)
-    assert(parallelism == env
-      .getStreamGraph
+    assert(1 == getStreamGraph(env).getStreamNode(src.getId).getParallelism)
+    assert(parallelism == getStreamGraph(env).getStreamNode(map.getId).getParallelism)
+    assert(1 == getStreamGraph(env).getStreamNode(windowed.getId).getParallelism)
+    assert(parallelism == getStreamGraph(env)
       .getStreamNode(sink.getTransformation.getId)
       .getParallelism)
 
     val parallelSource = env.generateSequence(0, 0)
     parallelSource.print()
 
-    assert(newParallelism == env.getStreamGraph.getStreamNode(parallelSource.getId).getParallelism)
+    assert(newParallelism == getStreamGraph(env).getStreamNode(parallelSource.getId).getParallelism)
 
     parallelSource.setParallelism(3)
-    assert(3 == env.getStreamGraph.getStreamNode(parallelSource.getId).getParallelism)
+    assert(3 == getStreamGraph(env).getStreamNode(parallelSource.getId).getParallelism)
 
     map.setParallelism(2)
-    assert(2 == env.getStreamGraph.getStreamNode(map.getId).getParallelism)
+    assert(2 == getStreamGraph(env).getStreamNode(map.getId).getParallelism)
 
     sink.setParallelism(4)
-    assert(4 == env.getStreamGraph.getStreamNode(sink.getTransformation.getId).getParallelism)
+    assert(4 == getStreamGraph(env).getStreamNode(sink.getTransformation.getId).getParallelism)
   }
 
 
@@ -372,33 +371,33 @@ class DataStreamTest extends AbstractTestBase {
 
     val plan = env.getExecutionPlan
 
-    assertEquals(minResource1, env.getStreamGraph.getStreamNode(source1.getId).
+    assertEquals(minResource1, getStreamGraph(env).getStreamNode(source1.getId).
       getMinResource)
-    assertEquals(preferredResource1, env.getStreamGraph.getStreamNode(source1.getId).
+    assertEquals(preferredResource1, getStreamGraph(env).getStreamNode(source1.getId).
       getPreferredResource)
-    assertEquals(minResource2, env.getStreamGraph.getStreamNode(map1.getId).
+    assertEquals(minResource2, getStreamGraph(env).getStreamNode(map1.getId).
       getMinResource)
-    assertEquals(preferredResource2, env.getStreamGraph.getStreamNode(map1.getId).
+    assertEquals(preferredResource2, getStreamGraph(env).getStreamNode(map1.getId).
       getPreferredResource)
-    assertEquals(minResource3, env.getStreamGraph.getStreamNode(source2.getId).
+    assertEquals(minResource3, getStreamGraph(env).getStreamNode(source2.getId).
       getMinResource)
-    assertEquals(preferredResource3, env.getStreamGraph.getStreamNode(source2.getId).
+    assertEquals(preferredResource3, getStreamGraph(env).getStreamNode(source2.getId).
       getPreferredResource)
-    assertEquals(minResource4, env.getStreamGraph.getStreamNode(map2.getId).
+    assertEquals(minResource4, getStreamGraph(env).getStreamNode(map2.getId).
       getMinResource)
-    assertEquals(preferredResource4, env.getStreamGraph.getStreamNode(map2.getId).
+    assertEquals(preferredResource4, getStreamGraph(env).getStreamNode(map2.getId).
       getPreferredResource)
-    assertEquals(minResource5, env.getStreamGraph.getStreamNode(connected.getId).
+    assertEquals(minResource5, getStreamGraph(env).getStreamNode(connected.getId).
       getMinResource)
-    assertEquals(preferredResource5, env.getStreamGraph.getStreamNode(connected.getId).
+    assertEquals(preferredResource5, getStreamGraph(env).getStreamNode(connected.getId).
       getPreferredResource)
-    assertEquals(minResource6, env.getStreamGraph.getStreamNode(windowed.getId).
+    assertEquals(minResource6, getStreamGraph(env).getStreamNode(windowed.getId).
       getMinResource)
-    assertEquals(preferredResource6, env.getStreamGraph.getStreamNode(windowed.getId).
+    assertEquals(preferredResource6, getStreamGraph(env).getStreamNode(windowed.getId).
       getPreferredResource)
-    assertEquals(minResource7, env.getStreamGraph.getStreamNode(
+    assertEquals(minResource7, getStreamGraph(env).getStreamNode(
       sink.getPreferredResource.getId).getMinResource)
-    assertEquals(preferredResource7, env.getStreamGraph.getStreamNode(
+    assertEquals(preferredResource7, getStreamGraph(env).getStreamNode(
       sink.getPreferredResource.getId).getPreferredResource)
   }*/
 
@@ -542,7 +541,7 @@ class DataStreamTest extends AbstractTestBase {
         (in, state: Option[Long]) => (false, None))
    
     try {
-      env.getStreamGraph.getStreamEdges(map.getId, unionFilter.getId)
+      getStreamGraph(env).getStreamEdges(map.getId, unionFilter.getId)
     }
     catch {
       case e: Throwable => {
@@ -551,7 +550,7 @@ class DataStreamTest extends AbstractTestBase {
     }
 
     try {
-      env.getStreamGraph.getStreamEdges(flatMap.getId, unionFilter.getId)
+      getStreamGraph(env).getStreamEdges(flatMap.getId, unionFilter.getId)
     }
     catch {
       case e: Throwable => {
@@ -565,22 +564,24 @@ class DataStreamTest extends AbstractTestBase {
 
     val split = unionFilter.split(outputSelector)
     split.print()
-    val outputSelectors = env.getStreamGraph.getStreamNode(unionFilter.getId).getOutputSelectors
+    val outputSelectors = getStreamGraph(env).getStreamNode(unionFilter.getId).getOutputSelectors
     assert(1 == outputSelectors.size)
     assert(outputSelector == outputSelectors.get(0))
 
     unionFilter.split(x => List("a")).print()
-    val moreOutputSelectors = env.getStreamGraph.getStreamNode(unionFilter.getId).getOutputSelectors
+    val moreOutputSelectors = getStreamGraph(env)
+      .getStreamNode(unionFilter.getId)
+      .getOutputSelectors
     assert(2 == moreOutputSelectors.size)
 
     val select = split.select("a")
     val sink = select.print()
     val splitEdge =
-      env.getStreamGraph.getStreamEdges(unionFilter.getId, sink.getTransformation.getId)
+      getStreamGraph(env).getStreamEdges(unionFilter.getId, sink.getTransformation.getId)
     assert("a" == splitEdge.get(0).getSelectedNames.get(0))
 
     val sinkWithIdentifier = select.print("identifier")
-    val newSplitEdge = env.getStreamGraph.getStreamEdges(
+    val newSplitEdge = getStreamGraph(env).getStreamEdges(
       unionFilter.getId,
       sinkWithIdentifier.getTransformation.getId)
     assert("a" == newSplitEdge.get(0).getSelectedNames.get(0))
@@ -607,7 +608,7 @@ class DataStreamTest extends AbstractTestBase {
     assert(coMapFunction == getFunctionForDataStream(coMap))
 
     try {
-      env.getStreamGraph.getStreamEdges(fold.getId, coMap.getId)
+      getStreamGraph(env).getStreamEdges(fold.getId, coMap.getId)
     }
     catch {
       case e: Throwable => {
@@ -615,7 +616,7 @@ class DataStreamTest extends AbstractTestBase {
       }
     }
     try {
-      env.getStreamGraph.getStreamEdges(flatMap.getId, coMap.getId)
+      getStreamGraph(env).getStreamEdges(flatMap.getId, coMap.getId)
     }
     catch {
       case e: Throwable => {
@@ -632,31 +633,31 @@ class DataStreamTest extends AbstractTestBase {
 
     val broadcast = src.broadcast
     val broadcastSink = broadcast.print()
-    val broadcastPartitioner = env.getStreamGraph
+    val broadcastPartitioner = getStreamGraph(env)
       .getStreamEdges(src.getId, broadcastSink.getTransformation.getId).get(0).getPartitioner
     assert(broadcastPartitioner.isInstanceOf[BroadcastPartitioner[_]])
 
     val shuffle: DataStream[Long] = src.shuffle
     val shuffleSink = shuffle.print()
-    val shufflePartitioner = env.getStreamGraph
+    val shufflePartitioner = getStreamGraph(env)
       .getStreamEdges(src.getId, shuffleSink.getTransformation.getId).get(0).getPartitioner
     assert(shufflePartitioner.isInstanceOf[ShufflePartitioner[_]])
 
     val forward: DataStream[Long] = src.forward
     val forwardSink = forward.print()
-    val forwardPartitioner = env.getStreamGraph
+    val forwardPartitioner = getStreamGraph(env)
       .getStreamEdges(src.getId, forwardSink.getTransformation.getId).get(0).getPartitioner
     assert(forwardPartitioner.isInstanceOf[ForwardPartitioner[_]])
 
     val rebalance: DataStream[Long] = src.rebalance
     val rebalanceSink = rebalance.print()
-    val rebalancePartitioner = env.getStreamGraph
+    val rebalancePartitioner = getStreamGraph(env)
       .getStreamEdges(src.getId, rebalanceSink.getTransformation.getId).get(0).getPartitioner
     assert(rebalancePartitioner.isInstanceOf[RebalancePartitioner[_]])
 
     val global: DataStream[Long] = src.global
     val globalSink = global.print()
-    val globalPartitioner = env.getStreamGraph
+    val globalPartitioner = getStreamGraph(env)
       .getStreamEdges(src.getId, globalSink.getTransformation.getId).get(0).getPartitioner
     assert(globalPartitioner.isInstanceOf[GlobalPartitioner[_]])
   }
@@ -675,7 +676,7 @@ class DataStreamTest extends AbstractTestBase {
     val iterated2 = source.iterate((input: DataStream[Int]) => 
       (input.map(_ + 1), input.map(_.toString)), 2000)
 
-    val sg = env.getStreamGraph
+    val sg = getStreamGraph(env)
 
     assert(sg.getIterationSourceSinkPairs.size() == 2)
   }
@@ -700,11 +701,17 @@ class DataStreamTest extends AbstractTestBase {
   private def getOperatorForDataStream(dataStream: DataStream[_]): StreamOperator[_] = {
     dataStream.print()
     val env = dataStream.javaStream.getExecutionEnvironment
-    val streamGraph: StreamGraph = env.getStreamGraph
+    val streamGraph: StreamGraph =
+      env.getStreamGraph(JStreamExecutionEnvironment.DEFAULT_JOB_NAME, false)
     streamGraph.getStreamNode(dataStream.getId).getOperator
   }
 
-  private def isPartitioned(edges: java.util.List[StreamEdge]): Boolean = {
+  /** Returns the StreamGraph without clearing the transformations. */
+  private def getStreamGraph(sEnv: StreamExecutionEnvironment): StreamGraph = {
+    sEnv.getStreamGraph(JStreamExecutionEnvironment.DEFAULT_JOB_NAME, clearTransformations = false)
+  }
+
+  private def isPartitioned(edges: java.util.List[StreamEdge]) = {
     import scala.collection.JavaConverters._
     edges.asScala.forall( _.getPartitioner.isInstanceOf[KeyGroupStreamPartitioner[_, _]])
   }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -640,7 +640,7 @@ public class LocalExecutorITCase extends TestLogger {
 		return throwableWithMessage;
 	}
 
-	@Test(timeout = 30_000L)
+	@Test(timeout = 90_000L)
 	public void testStreamQueryExecutionSink() throws Exception {
 		final String csvOutputPath = new File(tempFolder.newFolder().getAbsolutePath(), "test-out.csv").toURI().toString();
 		final URL url = getClass().getClassLoader().getResource("test-data.csv");
@@ -660,27 +660,16 @@ public class LocalExecutorITCase extends TestLogger {
 
 		try {
 			// Case 1: Registered sink
-			final ProgramTargetDescriptor targetDescriptor = executor.executeUpdate(
-				sessionId,
-				"INSERT INTO TableSourceSink SELECT IntegerField1 = 42, StringField1 FROM TableNumber1");
-
-			// wait for job completion and verify result
-			boolean isRunning = true;
-			while (isRunning) {
-				Thread.sleep(50); // slow the processing down
-				final JobStatus jobStatus = clusterClient.getJobStatus(JobID.fromHexString(targetDescriptor.getJobId())).get();
-				switch (jobStatus) {
-					case CREATED:
-					case RUNNING:
-						continue;
-					case FINISHED:
-						isRunning = false;
-						verifySinkResult(csvOutputPath);
-						break;
-					default:
-						fail("Unexpected job status.");
-				}
-			}
+			// Case 1.1: Registered sink with uppercase insert into keyword.
+			final String statement1 = "INSERT INTO TableSourceSink SELECT IntegerField1 = 42, StringField1 FROM TableNumber1";
+			executeAndVerifySinkResult(executor, sessionId, statement1, csvOutputPath);
+			// Case 1.2: Registered sink with lowercase insert into keyword.
+			final String statement2 = "insert Into TableSourceSink \n "
+					+ "SELECT IntegerField1 = 42, StringField1 "
+					+ "FROM TableNumber1";
+			executeAndVerifySinkResult(executor, sessionId, statement2, csvOutputPath);
+			// Case 1.3: Execute the same statement again, the results should expect to be the same.
+			executeAndVerifySinkResult(executor, sessionId, statement2, csvOutputPath);
 
 			// Case 2: Temporary sink
 			executor.useCatalog(sessionId, "simple-catalog");
@@ -697,53 +686,6 @@ public class LocalExecutorITCase extends TestLogger {
 				SimpleCatalogFactory.TABLE_CONTENTS.stream().map(Row::toString).collect(Collectors.toList()),
 				otherCatalogResults,
 				Comparator.naturalOrder());
-		} finally {
-			executor.closeSession(sessionId);
-		}
-	}
-
-	@Test(timeout = 30_000L)
-	public void testExecuteInsertInto() throws Exception {
-		final String csvOutputPath = new File(tempFolder.newFolder().getAbsolutePath(), "test-out.csv").toURI().toString();
-		final URL url = getClass().getClassLoader().getResource("test-data.csv");
-		Objects.requireNonNull(url);
-		final Map<String, String> replaceVars = new HashMap<>();
-		replaceVars.put("$VAR_PLANNER", planner);
-		replaceVars.put("$VAR_SOURCE_PATH1", url.getPath());
-		replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
-		replaceVars.put("$VAR_SOURCE_SINK_PATH", csvOutputPath);
-		replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
-		replaceVars.put("$VAR_MAX_ROWS", "100");
-
-		final Executor executor = createModifiedExecutor(clusterClient, replaceVars);
-		final SessionContext session = new SessionContext("test-session", new Environment());
-		String sessionId = executor.openSession(session);
-		assertEquals("test-session", sessionId);
-
-		try {
-			final ProgramTargetDescriptor targetDescriptor = executor.executeUpdate(
-					sessionId,
-					"insert Into TableSourceSink \n " +
-					"SELECT IntegerField1 = 42, StringField1 " +
-					"FROM TableNumber1");
-
-			// wait for job completion and verify result
-			boolean isRunning = true;
-			while (isRunning) {
-				Thread.sleep(50); // slow the processing down
-				final JobStatus jobStatus = clusterClient.getJobStatus(JobID.fromHexString(targetDescriptor.getJobId())).get();
-				switch (jobStatus) {
-					case CREATED:
-					case RUNNING:
-						continue;
-					case FINISHED:
-						isRunning = false;
-						verifySinkResult(csvOutputPath);
-						break;
-					default:
-						fail("Unexpected job status.");
-				}
-			}
 		} finally {
 			executor.closeSession(sessionId);
 		}
@@ -955,7 +897,7 @@ public class LocalExecutorITCase extends TestLogger {
 	}
 
 	@Test
-	public void testCreateTableWithMultiSession() throws Exception {
+	public void testCreateTableWithPropertiesChanged() throws Exception {
 		final Executor executor = createDefaultExecutor(clusterClient);
 		final SessionContext session = new SessionContext("test-session", new Environment());
 		String sessionId = executor.openSession(session);
@@ -1097,6 +1039,34 @@ public class LocalExecutorITCase extends TestLogger {
 		expectedResults.add("true,Hello World");
 		expectedResults.add("false,Hello World!!!!");
 		TestBaseUtils.compareResultCollections(expectedResults, actualResults, Comparator.naturalOrder());
+	}
+
+	private void executeAndVerifySinkResult(
+			Executor executor,
+			String sessionId,
+			String statement,
+			String resultPath) throws Exception {
+		final ProgramTargetDescriptor targetDescriptor = executor.executeUpdate(
+				sessionId,
+				statement);
+
+		// wait for job completion and verify result
+		boolean isRunning = true;
+		while (isRunning) {
+			Thread.sleep(50); // slow the processing down
+			final JobStatus jobStatus = clusterClient.getJobStatus(JobID.fromHexString(targetDescriptor.getJobId())).get();
+			switch (jobStatus) {
+			case CREATED:
+			case RUNNING:
+				continue;
+			case FINISHED:
+				isRunning = false;
+				verifySinkResult(resultPath);
+				break;
+			default:
+				fail("Unexpected job status.");
+			}
+		}
 	}
 
 	private <T> LocalExecutor createDefaultExecutor(ClusterClient<T> clusterClient) throws Exception {

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
@@ -67,7 +67,6 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
 	@Override
 	public JobExecutionResult execute(StreamGraph streamGraph) throws Exception {
 		final JobGraph jobGraph = streamGraph.getJobGraph();
-		transformations.clear();
 
 		for (Path jarFile : jarFiles) {
 			jobGraph.addJar(jarFile);


### PR DESCRIPTION
…ar transformations when executing

## What is the purpose of the change

Add internal interface `StreamExecutionEnvironment#getStreamGraph(String, boolean)` with the
ability to clean existing transformations


## Brief change log

* Add internal interface
StreamExecutionEnvironment#getStreamGraph(String, boolean) with the
ability to clean existing transformations;
* Add tests for this new interface;
* Add ITCase in SQL-CLI LocalExecutorITCase because FLINK-15052 can also
be fixed by this patch.


## Verifying this change

See tests in `StreamExecutionEnvironmentTest` and `LocalExecutorITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
