### PR TITLE
[FLINK-15140][runtime] Fix shuffle data compression doesn't work with BroadcastRecordWriter.

### DIFF
--- a/docs/_includes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/_includes/generated/netty_shuffle_environment_configuration.html
@@ -24,7 +24,7 @@
             <td><h5>taskmanager.network.blocking-shuffle.compression.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Boolean flag indicating whether the shuffle data will be compressed for blocking shuffle mode. Note that data is compressed per buffer and compression can incur extra CPU overhead, so it is more effective for IO bounded scenario when data compression ratio is high.</td>
+            <td>Boolean flag indicating whether the shuffle data will be compressed for blocking shuffle mode. Note that data is compressed per buffer and compression can incur extra CPU overhead, so it is more effective for IO bounded scenario when data compression ratio is high. Currently, shuffle data compression is an experimental feature and the config option can be changed in the future.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.blocking-shuffle.type</h5></td>
@@ -54,7 +54,7 @@
             <td><h5>taskmanager.network.pipelined-shuffle.compression.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Boolean flag indicating whether the shuffle data will be compressed for pipelined shuffle mode. Note that data is compressed per sliced buffer and compression can incur extra CPU overhead, so it is not recommended to enable compression if network is not the bottleneck or compression ratio is low.</td>
+            <td>Boolean flag indicating whether the shuffle data will be compressed for pipelined shuffle mode. Note that data is compressed per sliced buffer and compression is disabled for operators using broadcast partitioner. Because of the extra CPU overhead, it is not recommended to enable compression if network is not the bottleneck or compression ratio is low. Currently, shuffle data compression is an experimental feature and the config option can be changed in the future.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.request-backoff.initial</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -70,15 +70,17 @@ public class NettyShuffleEnvironmentOptions {
 	/**
 	 * Boolean flag indicating whether the shuffle data will be compressed for pipelined shuffle mode.
 	 *
-	 * <p>Note: Data is compressed per sliced buffer and compression can incur extra CPU overhead, so it is not recommended
-	 * to enable compression if network is not the bottleneck or compression ratio is low.
+	 * <p>Note: Data is compressed per sliced buffer and compression is disabled for operators using broadcast partitioner.
+	 * Because of the extra CPU overhead, it is not recommended to enable compression if network is not the bottleneck or
+	 * compression ratio is low.
 	 */
 	public static final ConfigOption<Boolean> PIPELINED_SHUFFLE_COMPRESSION_ENABLED =
 		key("taskmanager.network.pipelined-shuffle.compression.enabled")
 			.defaultValue(false)
 			.withDescription("Boolean flag indicating whether the shuffle data will be compressed for pipelined shuffle" +
-				" mode. Note that data is compressed per sliced buffer and compression can incur extra CPU overhead, so" +
-				" it is not recommended to enable compression if network is not the bottleneck or compression ratio is low.");
+				" mode. Note that data is compressed per sliced buffer and compression is disabled for operators using " +
+				"broadcast partitioner. Because of the extra CPU overhead, it is not recommended to enable compression " +
+				"if network is not the bottleneck or compression ratio is low.");
 
 	/**
 	 * The codec to be used when compressing shuffle data.

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -57,22 +57,25 @@ public class NettyShuffleEnvironmentOptions {
 	/**
 	 * Boolean flag indicating whether the shuffle data will be compressed for blocking shuffle mode.
 	 *
-	 * <p>Note: Data is compressed per buffer and compression can incur extra CPU overhead so it is more effective for IO
-	 * bounded scenario when data compression ratio is high.
+	 * <p>Note: Data is compressed per buffer and compression can incur extra CPU overhead so it is more effective for
+	 * IO bounded scenario when data compression ratio is high. Currently, shuffle data compression is an experimental
+	 * feature and the config option can be changed in the future.
 	 */
 	public static final ConfigOption<Boolean> BLOCKING_SHUFFLE_COMPRESSION_ENABLED =
 		key("taskmanager.network.blocking-shuffle.compression.enabled")
 			.defaultValue(false)
 			.withDescription("Boolean flag indicating whether the shuffle data will be compressed for blocking shuffle" +
 				" mode. Note that data is compressed per buffer and compression can incur extra CPU overhead, so it is" +
-				" more effective for IO bounded scenario when data compression ratio is high.");
+				" more effective for IO bounded scenario when data compression ratio is high. Currently, shuffle data " +
+				"compression is an experimental feature and the config option can be changed in the future.");
 
 	/**
 	 * Boolean flag indicating whether the shuffle data will be compressed for pipelined shuffle mode.
 	 *
 	 * <p>Note: Data is compressed per sliced buffer and compression is disabled for operators using broadcast partitioner.
 	 * Because of the extra CPU overhead, it is not recommended to enable compression if network is not the bottleneck or
-	 * compression ratio is low.
+	 * compression ratio is low. Currently, shuffle data compression is an experimental feature and the config option can
+	 * be changed in the future.
 	 */
 	public static final ConfigOption<Boolean> PIPELINED_SHUFFLE_COMPRESSION_ENABLED =
 		key("taskmanager.network.pipelined-shuffle.compression.enabled")
@@ -80,7 +83,8 @@ public class NettyShuffleEnvironmentOptions {
 			.withDescription("Boolean flag indicating whether the shuffle data will be compressed for pipelined shuffle" +
 				" mode. Note that data is compressed per sliced buffer and compression is disabled for operators using " +
 				"broadcast partitioner. Because of the extra CPU overhead, it is not recommended to enable compression " +
-				"if network is not the bottleneck or compression ratio is low.");
+				"if network is not the bottleneck or compression ratio is low. Currently, shuffle data compression is " +
+				"an experimental feature and the config option can be changed in the future.");
 
 	/**
 	 * The codec to be used when compressing shuffle data.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
@@ -284,12 +284,12 @@ public class EventSerializer {
 		return buffer;
 	}
 
-	public static BufferConsumer toBufferConsumer(AbstractEvent event) throws IOException {
+	public static BufferConsumer toBufferConsumer(AbstractEvent event, boolean isShareable) throws IOException {
 		final ByteBuffer serializedEvent = EventSerializer.toSerializedEvent(event);
 
 		MemorySegment data = MemorySegmentFactory.wrap(serializedEvent.array());
 
-		return new BufferConsumer(data, FreeingBufferRecycler.INSTANCE, false);
+		return new BufferConsumer(data, FreeingBufferRecycler.INSTANCE, false, isShareable);
 	}
 
 	public static AbstractEvent fromBuffer(Buffer buffer, ClassLoader classLoader) throws IOException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/BroadcastRecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/BroadcastRecordWriter.java
@@ -84,7 +84,7 @@ public final class BroadcastRecordWriter<T extends IOReadableWritable> extends R
 		if (bufferBuilder != null) {
 			for (int index = 0; index < numberOfChannels; index++) {
 				if (index != targetChannelIndex) {
-					targetPartition.addBufferConsumer(bufferBuilder.createBufferConsumer(), index);
+					targetPartition.addBufferConsumer(bufferBuilder.createBufferConsumer(true), index);
 				}
 			}
 		}
@@ -130,9 +130,9 @@ public final class BroadcastRecordWriter<T extends IOReadableWritable> extends R
 
 		BufferBuilder builder = targetPartition.getBufferBuilder();
 		if (randomTriggered) {
-			targetPartition.addBufferConsumer(builder.createBufferConsumer(), targetChannel);
+			targetPartition.addBufferConsumer(builder.createBufferConsumer(true), targetChannel);
 		} else {
-			try (BufferConsumer bufferConsumer = builder.createBufferConsumer()) {
+			try (BufferConsumer bufferConsumer = builder.createBufferConsumer(true)) {
 				for (int channel = 0; channel < numberOfChannels; channel++) {
 					targetPartition.addBufferConsumer(bufferConsumer.copy(), channel);
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ChannelSelectorRecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ChannelSelectorRecordWriter.java
@@ -101,7 +101,7 @@ public final class ChannelSelectorRecordWriter<T extends IOReadableWritable> ext
 		checkState(bufferBuilders[targetChannel] == null || bufferBuilders[targetChannel].isFinished());
 
 		BufferBuilder bufferBuilder = targetPartition.getBufferBuilder();
-		targetPartition.addBufferConsumer(bufferBuilder.createBufferConsumer(), targetChannel);
+		targetPartition.addBufferConsumer(bufferBuilder.createBufferConsumer(false), targetChannel);
 		bufferBuilders[targetChannel] = bufferBuilder;
 		return bufferBuilder;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
@@ -154,7 +154,7 @@ public abstract class RecordWriter<T extends IOReadableWritable> implements Avai
 	}
 
 	public void broadcastEvent(AbstractEvent event) throws IOException {
-		try (BufferConsumer eventBufferConsumer = EventSerializer.toBufferConsumer(event)) {
+		try (BufferConsumer eventBufferConsumer = EventSerializer.toBufferConsumer(event, true)) {
 			for (int targetChannel = 0; targetChannel < numberOfChannels; targetChannel++) {
 				tryFinishCurrentBufferBuilder(targetChannel);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferBuilder.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.buffer;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.memory.MemorySegment;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -49,14 +50,21 @@ public class BufferBuilder {
 	 * This method always creates a {@link BufferConsumer} starting from the current writer offset. Data written to
 	 * {@link BufferBuilder} before creation of {@link BufferConsumer} won't be visible for that {@link BufferConsumer}.
 	 *
+	 * @param isShareable whether the created {@link BufferConsumer} is shareable.
 	 * @return created matching instance of {@link BufferConsumer} to this {@link BufferBuilder}.
 	 */
-	public BufferConsumer createBufferConsumer() {
+	public BufferConsumer createBufferConsumer(boolean isShareable) {
 		return new BufferConsumer(
 			memorySegment,
 			recycler,
 			positionMarker,
-			positionMarker.cachedPosition);
+			positionMarker.cachedPosition,
+			isShareable);
+	}
+
+	@VisibleForTesting
+	public BufferConsumer createBufferConsumer() {
+		return createBufferConsumer(false);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
@@ -180,7 +180,7 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
 
 		isFinished = true;
 		flushCurrentBuffer();
-		writeAndCloseBufferConsumer(EventSerializer.toBufferConsumer(EndOfPartitionEvent.INSTANCE));
+		writeAndCloseBufferConsumer(EventSerializer.toBufferConsumer(EndOfPartitionEvent.INSTANCE, false));
 		data.finishWrite();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -96,7 +96,7 @@ class PipelinedSubpartition extends ResultSubpartition {
 
 	@Override
 	public void finish() throws IOException {
-		add(EventSerializer.toBufferConsumer(EndOfPartitionEvent.INSTANCE), true);
+		add(EventSerializer.toBufferConsumer(EndOfPartitionEvent.INSTANCE, false), true);
 		LOG.debug("{}: Finished {}.", parent.getOwningTaskName(), this);
 	}
 
@@ -169,7 +169,7 @@ class PipelinedSubpartition extends ResultSubpartition {
 				BufferConsumer bufferConsumer = buffers.peek();
 
 				buffer = bufferConsumer.build();
-				if (!isLocalChannel && canBeCompressed(buffer)) {
+				if (!isLocalChannel && !bufferConsumer.isShareable() && canBeCompressed(buffer)) {
 					buffer = parent.bufferCompressor.compressToOriginalBuffer(buffer);
 				}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderAndConsumerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderAndConsumerTest.java
@@ -137,7 +137,7 @@ public class BufferBuilderAndConsumerTest {
 	@Test
 	public void copy() {
 		BufferBuilder bufferBuilder = createBufferBuilder();
-		BufferConsumer bufferConsumer1 = bufferBuilder.createBufferConsumer();
+		BufferConsumer bufferConsumer1 = bufferBuilder.createBufferConsumer(true);
 
 		bufferBuilder.appendAndCommit(toByteBuffer(0, 1));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderTestUtils.java
@@ -67,18 +67,22 @@ public class BufferBuilderTestUtils {
 	}
 
 	public static BufferConsumer createFilledFinishedBufferConsumer(int dataSize) {
-		return createFilledBufferConsumer(dataSize, dataSize, true);
+		return createFilledBufferConsumer(dataSize, dataSize, true, false);
+	}
+
+	public static BufferConsumer createFilledFinishedBufferConsumer(int dataSize, boolean isShareable) {
+		return createFilledBufferConsumer(dataSize, dataSize, true, isShareable);
 	}
 
 	public static BufferConsumer createFilledUnfinishedBufferConsumer(int dataSize) {
-		return createFilledBufferConsumer(dataSize, dataSize, false);
+		return createFilledBufferConsumer(dataSize, dataSize, false, false);
 	}
 
-	public static BufferConsumer createFilledBufferConsumer(int size, int dataSize, boolean isFinished) {
+	public static BufferConsumer createFilledBufferConsumer(int size, int dataSize, boolean isFinished, boolean isShareable) {
 		checkArgument(size >= dataSize);
 
 		BufferBuilder bufferBuilder = createBufferBuilder(size);
-		BufferConsumer bufferConsumer = bufferBuilder.createBufferConsumer();
+		BufferConsumer bufferConsumer = bufferBuilder.createBufferConsumer(isShareable);
 		fillBufferBuilder(bufferBuilder, dataSize);
 
 		if (isFinished) {
@@ -92,6 +96,7 @@ public class BufferBuilderTestUtils {
 		return new BufferConsumer(
 			MemorySegmentFactory.allocateUnpooledSegment(size),
 			FreeingBufferRecycler.INSTANCE,
+			false,
 			false);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionWriteReadTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionWriteReadTest.java
@@ -210,7 +210,7 @@ public class BoundedBlockingSubpartitionWriteReadTest {
 				nums--;
 			}
 
-			partition.add(new BufferConsumer(memory, (ignored) -> {}, pos, true));
+			partition.add(new BufferConsumer(memory, (ignored) -> {}, pos, true, false));
 
 			// we need to flush after every buffer as long as the add() contract is that
 			// buffer are immediately added and can be filled further after that (for low latency

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
@@ -68,7 +68,7 @@ public class InputGateFairnessTest {
 		final int buffersPerChannel = 27;
 
 		final ResultPartition resultPartition = mock(ResultPartition.class);
-		final BufferConsumer bufferConsumer = createFilledFinishedBufferConsumer(42);
+		final BufferConsumer bufferConsumer = createFilledFinishedBufferConsumer(42, true);
 
 		// ----- create some source channels and fill them with buffers -----
 
@@ -122,7 +122,7 @@ public class InputGateFairnessTest {
 		final int buffersPerChannel = 27;
 
 		final ResultPartition resultPartition = mock(ResultPartition.class);
-		try (BufferConsumer bufferConsumer = createFilledFinishedBufferConsumer(42)) {
+		try (BufferConsumer bufferConsumer = createFilledFinishedBufferConsumer(42, true)) {
 
 			// ----- create some source channels and fill them with one buffer each -----
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
@@ -318,11 +318,13 @@ public class PipelinedSubpartitionWithReadViewTest {
 
 	@Test
 	public void testBufferCompression() {
-		subpartition.add(createFilledFinishedBufferConsumer(BUFFER_SIZE));
-		subpartition.add(createFilledFinishedBufferConsumer(BUFFER_SIZE));
+		subpartition.add(createFilledFinishedBufferConsumer(BUFFER_SIZE, false));
+		subpartition.add(createFilledFinishedBufferConsumer(BUFFER_SIZE, false));
+		subpartition.add(createFilledFinishedBufferConsumer(BUFFER_SIZE, true));
 
 		assertFalse(checkNotNull(readView.getNextBuffer(true)).buffer().isCompressed());
 		assertThat(checkNotNull(readView.getNextBuffer(false)).buffer().isCompressed(), is(compressionEnabled));
+		assertFalse(checkNotNull(readView.getNextBuffer(false)).buffer().isCompressed());
 	}
 
 	private void testBacklogConsistentWithNumberOfConsumableBuffers(boolean isFlushRequested, boolean isFinished) throws Exception {

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/ShuffleCompressionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/ShuffleCompressionITCase.java
@@ -45,6 +45,8 @@ import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
 import org.apache.flink.types.LongValue;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
@@ -55,6 +57,7 @@ import static org.junit.Assert.assertFalse;
 /**
  * Tests pipeline/blocking shuffle when data compression is enabled.
  */
+@RunWith(Parameterized.class)
 public class ShuffleCompressionITCase {
 
 	private static final int NUM_BUFFERS_TO_SEND = 1000;
@@ -70,7 +73,13 @@ public class ShuffleCompressionITCase {
 
 	private static final LongValue RECORD_TO_SEND = new LongValue(4387942071694473832L);
 
-	private static boolean useBroadcastPartitioner = false;
+	@Parameterized.Parameter
+	public static boolean useBroadcastPartitioner = false;
+
+	@Parameterized.Parameters(name = "useBroadcastPartitioner = {0}")
+	public static Boolean[] params() {
+		return new Boolean[] { true, false };
+	}
 
 	@Test
 	public void testDataCompressionForPipelineShuffle() throws Exception {
@@ -79,12 +88,6 @@ public class ShuffleCompressionITCase {
 
 	@Test
 	public void testDataCompressionForBlockingShuffle() throws Exception {
-		executeTest(createJobGraph(ScheduleMode.LAZY_FROM_SOURCES, ResultPartitionType.BLOCKING, ExecutionMode.BATCH));
-	}
-
-	@Test
-	public void testDataCompressionForBlockingShuffleWithBroadcastPartitioner() throws Exception {
-		useBroadcastPartitioner = true;
 		executeTest(createJobGraph(ScheduleMode.LAZY_FROM_SOURCES, ResultPartitionType.BLOCKING, ExecutionMode.BATCH));
 	}
 


### PR DESCRIPTION
## What is the purpose of the change
We implemented shuffle data compression in FLINK-14845 to reduce disk and network IO, but unfortunately, a bug was introduced, which makes the compression doesn't work when broadcast partitioner is used.
For pipelined mode, because the compressor copies the data back to the input buffer, however, the underlying buffer is shared when BroadcastRecordWriter is used. So we can not copy the compressed buffer back to the input buffer if the underlying buffer is shared. For blocking mode, we wrongly recycle the buffer when buffer is not compressed, and the problem is also triggered when BroadcastRecordWriter is used.
This PR tries to fix the problem.


## Brief change log

  - Disable data compression for operators which use broadcast partitioner in pipelined mode.
  - Not recycle buffer if it not compressed in blocking mode.=


## Verifying this change

```ShuffleCompressionITCase``` is modified to cover the scenario.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
