### PR TITLE
[FLINK-15061][table]create/alter and table/databases properties should be case sensitive stored in catalog

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -172,8 +172,7 @@ public class SqlToOperationConverter {
 		// set with properties
 		Map<String, String> properties = new HashMap<>();
 		sqlCreateTable.getPropertyList().getList().forEach(p ->
-			properties.put(((SqlTableOption) p).getKeyString().toLowerCase(),
-				((SqlTableOption) p).getValueString()));
+			properties.put(((SqlTableOption) p).getKeyString(), ((SqlTableOption) p).getValueString()));
 
 		TableSchema tableSchema = createTableSchema(sqlCreateTable);
 		String tableComment = sqlCreateTable.getComment().map(comment ->
@@ -223,8 +222,7 @@ public class SqlToOperationConverter {
 				Map<String, String> properties = new HashMap<>();
 				properties.putAll(originalCatalogTable.getProperties());
 				((SqlAlterTableProperties) sqlAlterTable).getPropertyList().getList().forEach(p ->
-					properties.put(((SqlTableOption) p).getKeyString().toLowerCase(),
-						((SqlTableOption) p).getValueString()));
+					properties.put(((SqlTableOption) p).getKeyString(), ((SqlTableOption) p).getValueString()));
 				CatalogTable catalogTable = new CatalogTableImpl(
 					originalCatalogTable.getSchema(),
 					originalCatalogTable.getPartitionKeys(),
@@ -386,8 +384,7 @@ public class SqlToOperationConverter {
 		// set with properties
 		Map<String, String> properties = new HashMap<>();
 		sqlCreateDatabase.getPropertyList().getList().forEach(p ->
-			properties.put(((SqlTableOption) p).getKeyString().toLowerCase(),
-				((SqlTableOption) p).getValueString()));
+			properties.put(((SqlTableOption) p).getKeyString(), ((SqlTableOption) p).getValueString()));
 		CatalogDatabase catalogDatabase = new CatalogDatabaseImpl(properties, databaseComment);
 		return new CreateDatabaseOperation(catalogName, databaseName, catalogDatabase, ignoreIfExists);
 	}
@@ -430,7 +427,7 @@ public class SqlToOperationConverter {
 		}
 		// set with properties
 		sqlAlterDatabase.getPropertyList().getList().forEach(p ->
-			properties.put(((SqlTableOption) p).getKeyString().toLowerCase(), ((SqlTableOption) p).getValueString()));
+			properties.put(((SqlTableOption) p).getKeyString(), ((SqlTableOption) p).getValueString()));
 		CatalogDatabase catalogDatabase = new CatalogDatabaseImpl(properties, originCatalogDatabase.getComment());
 		return new AlterDatabaseOperation(catalogName, databaseName, catalogDatabase);
 	}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -157,13 +157,20 @@ public class SqlToOperationConverterTest {
 				"create database db1",
 				"create database if not exists cat1.db1",
 				"create database cat1.db1 comment 'db1_comment'",
-				"create database cat1.db1 comment 'db1_comment' with ('k1' = 'v1', 'k2' = 'v2')"
+				"create database cat1.db1 comment 'db1_comment' with ('k1' = 'v1', 'K2' = 'V2')"
 		};
 		final String[] expectedCatalogs = new String[] {"builtin", "cat1", "cat1", "cat1"};
 		final String expectedDatabase = "db1";
 		final String[] expectedComments = new String[] {null, null, "db1_comment", "db1_comment"};
 		final boolean[] expectedIgnoreIfExists = new boolean[] {false, true, false, false};
-		final int[] expectedPropertySize = new int[] {0, 0, 0, 2};
+		Map<String, String> properties = new HashMap<>();
+		properties.put("k1", "v1");
+		properties.put("K2", "V2");
+		final Map[] expectedProperties = new Map[] {
+				new HashMap<String, String>(),
+				new HashMap<String, String>(),
+				new HashMap<String, String>(),
+				new HashMap(properties)};
 
 		for (int i = 0; i < createDatabaseSqls.length; i++) {
 			Operation operation = parse(createDatabaseSqls[i], SqlDialect.DEFAULT);
@@ -173,7 +180,7 @@ public class SqlToOperationConverterTest {
 			assertEquals(expectedDatabase, createDatabaseOperation.getDatabaseName());
 			assertEquals(expectedComments[i], createDatabaseOperation.getCatalogDatabase().getComment());
 			assertEquals(expectedIgnoreIfExists[i], createDatabaseOperation.isIgnoreIfExists());
-			assertEquals(expectedPropertySize[i], createDatabaseOperation.getCatalogDatabase().getProperties().size());
+			assertEquals(expectedProperties[i], createDatabaseOperation.getCatalogDatabase().getProperties());
 		}
 	}
 
@@ -209,12 +216,16 @@ public class SqlToOperationConverterTest {
 						.createDatabase("db1",
 										new CatalogDatabaseImpl(new HashMap<>(), "db1_comment"),
 										true);
-		final String sql = "alter database cat1.db1 set ('k1'='a')";
+		final String sql = "alter database cat1.db1 set ('k1'='v1', 'K2'='V2')";
 		Operation operation = parse(sql, SqlDialect.DEFAULT);
 		assert operation instanceof AlterDatabaseOperation;
+		Map<String, String> properties = new HashMap<>();
+		properties.put("k1", "v1");
+		properties.put("K2", "V2");
 		assertEquals("db1", ((AlterDatabaseOperation) operation).getDatabaseName());
 		assertEquals("cat1", ((AlterDatabaseOperation) operation).getCatalogName());
 		assertEquals("db1_comment", ((AlterDatabaseOperation) operation).getCatalogDatabase().getComment());
+		assertEquals(properties, ((AlterDatabaseOperation) operation).getCatalogDatabase().getProperties());
 	}
 
 	@Test
@@ -274,7 +285,7 @@ public class SqlToOperationConverterTest {
 			"  b bigint,\n" +
 			"  c varchar\n" +
 			") with (\n" +
-			"  'a-b-c-d124' = 'ab',\n" +
+			"  'a-B-c-d124' = 'Ab',\n" +
 			"  'a.b-c-d.e-f.g' = 'ada',\n" +
 			"  'a.b-c-d.e-f1231.g' = 'ada',\n" +
 			"  'a.b-c-d.*' = 'adad')\n";
@@ -286,12 +297,10 @@ public class SqlToOperationConverterTest {
 		assert operation instanceof CreateTableOperation;
 		CreateTableOperation op = (CreateTableOperation) operation;
 		CatalogTable catalogTable = op.getCatalogTable();
-		Map<String, String> properties = catalogTable.toProperties()
-			.entrySet().stream()
-			.filter(e -> !e.getKey().contains("schema"))
-			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+		Map<String, String> properties = catalogTable.getProperties()
+			.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 		Map<String, String> sortedProperties = new TreeMap<>(properties);
-		final String expected = "{a-b-c-d124=ab, "
+		final String expected = "{a-B-c-d124=Ab, "
 			+ "a.b-c-d.*=adad, "
 			+ "a.b-c-d.e-f.g=ada, "
 			+ "a.b-c-d.e-f1231.g=ada}";
@@ -575,11 +584,15 @@ public class SqlToOperationConverterTest {
 			assertEquals(expectedNewIdentifier, alterTableRenameOperation.getNewTableIdentifier());
 		}
 		// test alter table properties
-		Operation operation = parse("alter table cat1.db1.tb1 set ('k1' = 'v1', 'k2' = 'v2')", SqlDialect.DEFAULT);
+		Operation operation = parse("alter table cat1.db1.tb1 set ('k1' = 'v1', 'K2' = 'V2')", SqlDialect.DEFAULT);
 		assert operation instanceof AlterTablePropertiesOperation;
 		final AlterTablePropertiesOperation alterTablePropertiesOperation = (AlterTablePropertiesOperation) operation;
 		assertEquals(expectedIdentifier, alterTablePropertiesOperation.getTableIdentifier());
 		assertEquals(2, alterTablePropertiesOperation.getCatalogTable().getProperties().size());
+		Map<String, String> properties = new HashMap<>();
+		properties.put("k1", "v1");
+		properties.put("K2", "V2");
+		assertEquals(properties, alterTablePropertiesOperation.getCatalogTable().getProperties());
 	}
 
 	//~ Tool Methods ----------------------------------------------------------

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -178,8 +178,7 @@ public class SqlToOperationConverter {
 		// set with properties
 		Map<String, String> properties = new HashMap<>();
 		sqlCreateTable.getPropertyList().getList().forEach(p ->
-			properties.put(((SqlTableOption) p).getKeyString().toLowerCase(),
-				((SqlTableOption) p).getValueString()));
+			properties.put(((SqlTableOption) p).getKeyString(), ((SqlTableOption) p).getValueString()));
 
 		TableSchema tableSchema = createTableSchema(sqlCreateTable);
 		String tableComment = sqlCreateTable.getComment().map(comment ->
@@ -229,8 +228,7 @@ public class SqlToOperationConverter {
 				Map<String, String> properties = new HashMap<>();
 				properties.putAll(originalCatalogTable.getProperties());
 				((SqlAlterTableProperties) sqlAlterTable).getPropertyList().getList().forEach(p ->
-					properties.put(((SqlTableOption) p).getKeyString().toLowerCase(),
-						((SqlTableOption) p).getValueString()));
+					properties.put(((SqlTableOption) p).getKeyString(), ((SqlTableOption) p).getValueString()));
 				CatalogTable catalogTable = new CatalogTableImpl(
 					originalCatalogTable.getSchema(),
 					originalCatalogTable.getPartitionKeys(),
@@ -370,8 +368,7 @@ public class SqlToOperationConverter {
 		// set with properties
 		Map<String, String> properties = new HashMap<>();
 		sqlCreateDatabase.getPropertyList().getList().forEach(p ->
-			properties.put(((SqlTableOption) p).getKeyString().toLowerCase(),
-				((SqlTableOption) p).getValueString()));
+			properties.put(((SqlTableOption) p).getKeyString(), ((SqlTableOption) p).getValueString()));
 		CatalogDatabase catalogDatabase = new CatalogDatabaseImpl(properties, databaseComment);
 		return new CreateDatabaseOperation(catalogName, databaseName, catalogDatabase, ignoreIfExists);
 	}
@@ -414,8 +411,7 @@ public class SqlToOperationConverter {
 		}
 		// set with properties
 		sqlAlterDatabase.getPropertyList().getList().forEach(p ->
-			properties.put(((SqlTableOption) p).getKeyString().toLowerCase(),
-				((SqlTableOption) p).getValueString()));
+			properties.put(((SqlTableOption) p).getKeyString(), ((SqlTableOption) p).getValueString()));
 		CatalogDatabase catalogDatabase = new CatalogDatabaseImpl(properties, originCatalogDatabase.getComment());
 		return new AlterDatabaseOperation(catalogName, databaseName, catalogDatabase);
 	}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
@@ -157,13 +157,20 @@ public class SqlToOperationConverterTest {
 				"create database db1",
 				"create database if not exists cat1.db1",
 				"create database cat1.db1 comment 'db1_comment'",
-				"create database cat1.db1 comment 'db1_comment' with ('k1' = 'v1', 'k2' = 'v2')"
+				"create database cat1.db1 comment 'db1_comment' with ('k1' = 'v1', 'K2' = 'V2')"
 		};
 		final String[] expectedCatalogs = new String[] {"builtin", "cat1", "cat1", "cat1"};
 		final String expectedDatabase = "db1";
 		final String[] expectedComments = new String[] {null, null, "db1_comment", "db1_comment"};
 		final boolean[] expectedIgnoreIfExists = new boolean[] {false, true, false, false};
-		final int[] expectedPropertySize = new int[] {0, 0, 0, 2};
+		Map<String, String> properties = new HashMap<>();
+		properties.put("k1", "v1");
+		properties.put("K2", "V2");
+		final Map[] expectedProperties = new Map[] {
+				new HashMap<String, String>(),
+				new HashMap<String, String>(),
+				new HashMap<String, String>(),
+				new HashMap(properties)};
 
 		for (int i = 0; i < createDatabaseSqls.length; i++) {
 			Operation operation = parse(createDatabaseSqls[i], SqlDialect.DEFAULT);
@@ -173,7 +180,7 @@ public class SqlToOperationConverterTest {
 			assertEquals(expectedDatabase, createDatabaseOperation.getDatabaseName());
 			assertEquals(expectedComments[i], createDatabaseOperation.getCatalogDatabase().getComment());
 			assertEquals(expectedIgnoreIfExists[i], createDatabaseOperation.isIgnoreIfExists());
-			assertEquals(expectedPropertySize[i], createDatabaseOperation.getCatalogDatabase().getProperties().size());
+			assertEquals(expectedProperties[i], createDatabaseOperation.getCatalogDatabase().getProperties());
 		}
 	}
 
@@ -185,12 +192,16 @@ public class SqlToOperationConverterTest {
 						.createDatabase("db1",
 								new CatalogDatabaseImpl(new HashMap<>(), "db1_comment"),
 								true);
-		final String sql = "alter database cat1.db1 set ('k1'='a')";
+		final String sql = "alter database cat1.db1 set ('k1'='v1', 'K2'='V2')";
 		Operation operation = parse(sql, SqlDialect.DEFAULT);
 		assert operation instanceof AlterDatabaseOperation;
+		Map<String, String> properties = new HashMap<>();
+		properties.put("k1", "v1");
+		properties.put("K2", "V2");
 		assertEquals("db1", ((AlterDatabaseOperation) operation).getDatabaseName());
 		assertEquals("cat1", ((AlterDatabaseOperation) operation).getCatalogName());
 		assertEquals("db1_comment", ((AlterDatabaseOperation) operation).getCatalogDatabase().getComment());
+		assertEquals(properties, ((AlterDatabaseOperation) operation).getCatalogDatabase().getProperties());
 	}
 
 	@Test
@@ -255,7 +266,7 @@ public class SqlToOperationConverterTest {
 			"  b bigint,\n" +
 			"  c varchar\n" +
 			") with (\n" +
-			"  'a-b-c-d124' = 'ab',\n" +
+			"  'a-B-c-d124' = 'Ab',\n" +
 			"  'a.b-c-d.e-f.g' = 'ada',\n" +
 			"  'a.b-c-d.e-f1231.g' = 'ada',\n" +
 			"  'a.b-c-d.*' = 'adad')\n";
@@ -266,12 +277,10 @@ public class SqlToOperationConverterTest {
 		assert operation instanceof CreateTableOperation;
 		CreateTableOperation op = (CreateTableOperation) operation;
 		CatalogTable catalogTable = op.getCatalogTable();
-		Map<String, String> properties = catalogTable.toProperties()
-			.entrySet().stream()
-			.filter(e -> !e.getKey().contains("schema"))
-			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+		Map<String, String> properties = catalogTable.getProperties()
+			.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 		Map<String, String> sortedProperties = new TreeMap<>(properties);
-		final String expected = "{a-b-c-d124=ab, "
+		final String expected = "{a-B-c-d124=Ab, "
 			+ "a.b-c-d.*=adad, "
 			+ "a.b-c-d.e-f.g=ada, "
 			+ "a.b-c-d.e-f1231.g=ada}";
@@ -540,11 +549,15 @@ public class SqlToOperationConverterTest {
 			assertEquals(expectedNewIdentifier, alterTableRenameOperation.getNewTableIdentifier());
 		}
 		// test alter table properties
-		Operation operation = parse("alter table cat1.db1.tb1 set ('k1' = 'v1', 'k2' = 'v2')", SqlDialect.DEFAULT);
+		Operation operation = parse("alter table cat1.db1.tb1 set ('k1' = 'v1', 'K2' = 'V2')", SqlDialect.DEFAULT);
 		assert operation instanceof AlterTablePropertiesOperation;
 		final AlterTablePropertiesOperation alterTablePropertiesOperation = (AlterTablePropertiesOperation) operation;
 		assertEquals(expectedIdentifier, alterTablePropertiesOperation.getTableIdentifier());
 		assertEquals(2, alterTablePropertiesOperation.getCatalogTable().getProperties().size());
+		Map<String, String> properties = new HashMap<>();
+		properties.put("k1", "v1");
+		properties.put("K2", "V2");
+		assertEquals(properties, alterTablePropertiesOperation.getCatalogTable().getProperties());
 	}
 
 	//~ Tool Methods ----------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

*Now in the class `SqlToOperationConverter`, when creating a table the logic will convert all properties key to lower format, which will cause the properties stored in catalog to lose the case style and not intuitively be observed to user.*


## Brief change log

  - [a79225d](https://github.com/apache/flink/commit/a79225d75a53240951a4378380ff2aac457c1278) create/alter and table/databases properties should be case sensitive stored in catalog


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
