### PR TITLE
[FLINK-15153]Service selector needs to contain jobmanager component label

### DIFF
--- a/docs/_includes/generated/kubernetes_config_configuration.html
+++ b/docs/_includes/generated/kubernetes_config_configuration.html
@@ -12,7 +12,7 @@
             <td><h5>kubernetes.cluster-id</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>The cluster id that will be used for flink cluster. If it's not set, the client will generate a random UUID name.</td>
+            <td>The cluster id used for identifying the unique flink cluster. If it's not set, the client will generate a random UUID name.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.config.file</h5></td>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/FlinkKubernetesCustomCli.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/FlinkKubernetesCustomCli.java
@@ -33,7 +33,6 @@ import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
-import org.apache.flink.kubernetes.configuration.KubernetesConfigOptionsInternal;
 import org.apache.flink.kubernetes.executors.KubernetesSessionClusterExecutor;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.KubeClientFactory;
@@ -57,8 +56,6 @@ import static org.apache.flink.kubernetes.cli.KubernetesCliOptions.CLUSTER_ID_OP
 import static org.apache.flink.kubernetes.cli.KubernetesCliOptions.DYNAMIC_PROPERTY_OPTION;
 import static org.apache.flink.kubernetes.cli.KubernetesCliOptions.HELP_OPTION;
 import static org.apache.flink.kubernetes.cli.KubernetesCliOptions.IMAGE_OPTION;
-import static org.apache.flink.kubernetes.cli.KubernetesCliOptions.JOB_CLASS_NAME_OPTION;
-import static org.apache.flink.kubernetes.cli.KubernetesCliOptions.JOB_ID_OPTION;
 
 /**
  * Kubernetes customized commandline.
@@ -84,9 +81,6 @@ public class FlinkKubernetesCustomCli extends AbstractCustomCommandLine {
 	private final Option taskManagerSlotsOption;
 	private final Option dynamicPropertiesOption;
 	private final Option helpOption;
-
-	private final Option jobClassOption;
-	private final Option jobIdOption;
 
 	private final ClusterClientServiceLoader clusterClientServiceLoader;
 
@@ -114,9 +108,6 @@ public class FlinkKubernetesCustomCli extends AbstractCustomCommandLine {
 			KubernetesCliOptions.TASK_MANAGER_MEMORY_OPTION, shortPrefix, longPrefix);
 		this.taskManagerSlotsOption = KubernetesCliOptions.getOptionWithPrefix(
 			KubernetesCliOptions.TASK_MANAGER_SLOTS_OPTION, shortPrefix, longPrefix);
-
-		this.jobClassOption = KubernetesCliOptions.getOptionWithPrefix(JOB_CLASS_NAME_OPTION, shortPrefix, longPrefix);
-		this.jobIdOption = KubernetesCliOptions.getOptionWithPrefix(JOB_ID_OPTION, shortPrefix, longPrefix);
 
 		this.helpOption = KubernetesCliOptions.getOptionWithPrefix(HELP_OPTION, shortPrefix, longPrefix);
 	}
@@ -195,25 +186,6 @@ public class FlinkKubernetesCustomCli extends AbstractCustomCommandLine {
 		final Properties dynamicProperties = commandLine.getOptionProperties(dynamicPropertiesOption.getOpt());
 		for (String key : dynamicProperties.stringPropertyNames()) {
 			effectiveConfiguration.setString(key, dynamicProperties.getProperty(key));
-		}
-
-		final StringBuilder entryPointClassArgs = new StringBuilder();
-		if (commandLine.hasOption(jobClassOption.getOpt())) {
-			entryPointClassArgs.append(" --")
-				.append(jobClassOption.getLongOpt())
-				.append(" ")
-				.append(commandLine.getOptionValue(jobClassOption.getOpt()));
-		}
-
-		if (commandLine.hasOption(jobIdOption.getOpt())) {
-			entryPointClassArgs.append(" --")
-				.append(jobIdOption.getLongOpt())
-				.append(" ")
-				.append(commandLine.getOptionValue(jobIdOption.getOpt()));
-		}
-		if (!entryPointClassArgs.toString().isEmpty()) {
-			effectiveConfiguration.setString(KubernetesConfigOptionsInternal.ENTRY_POINT_CLASS_ARGS,
-				entryPointClassArgs.toString());
 		}
 
 		return effectiveConfiguration;

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesCliOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesCliOptions.java
@@ -91,22 +91,6 @@ public class KubernetesCliOptions {
 		.desc("Help for Kubernetes session CLI.")
 		.build();
 
-	public static final Option JOB_CLASS_NAME_OPTION = Option.builder("jc")
-		.longOpt("job-classname")
-		.required(false)
-		.hasArg(true)
-		.argName("job class name")
-		.desc("Class name of the job to run.")
-		.build();
-
-	public static final Option JOB_ID_OPTION = Option.builder("jid")
-		.longOpt("job-id")
-		.required(false)
-		.hasArg(true)
-		.argName("job id")
-		.desc("Job ID of the job to run.")
-		.build();
-
 	/** This class is not meant to be instantiated. */
 	private KubernetesCliOptions() {}
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesCliOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesCliOptions.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.kubernetes.cli;
 
-import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
-
 import org.apache.commons.cli.Option;
 
 /**
@@ -46,7 +44,8 @@ public class KubernetesCliOptions {
 		.longOpt("clusterId")
 		.required(false)
 		.hasArg(true)
-		.desc(KubernetesConfigOptions.CLUSTER_ID.description().toString())
+		.desc("The cluster id used for identifying the unique flink cluster. If it's not set, the client will generate " +
+			"a random UUID name.")
 		.build();
 
 	public static final Option IMAGE_OPTION = Option.builder("i")
@@ -54,7 +53,7 @@ public class KubernetesCliOptions {
 		.required(false)
 		.hasArg(true)
 		.argName("image-name")
-		.desc(KubernetesConfigOptions.CONTAINER_IMAGE.description().toString())
+		.desc("Image to use for Flink containers")
 		.build();
 
 	public static final Option JOB_MANAGER_MEMORY_OPTION = Option.builder("jm")

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -97,7 +97,7 @@ public class KubernetesConfigOptions {
 		key("kubernetes.cluster-id")
 		.stringType()
 		.noDefaultValue()
-		.withDescription("The cluster id that will be used for flink cluster. If it's not set, " +
+		.withDescription("The cluster id used for identifying the unique flink cluster. If it's not set, " +
 			"the client will generate a random UUID name.");
 
 	public static final ConfigOption<String> CONTAINER_IMAGE =

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/ServiceDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/ServiceDecorator.java
@@ -33,6 +33,7 @@ import io.fabric8.kubernetes.api.model.ServiceSpec;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Setup services port.
@@ -89,7 +90,13 @@ public class ServiceDecorator extends Decorator<Service, KubernetesService> {
 		}
 
 		spec.setPorts(servicePorts);
-		spec.setSelector(resource.getMetadata().getLabels());
+
+		final Map<String, String> labels = new LabelBuilder()
+			.withExist(resource.getMetadata().getLabels())
+			.withJobManagerComponent()
+			.toLabels();
+
+		spec.setSelector(labels);
 
 		resource.setSpec(spec);
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8ClientTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8ClientTest.java
@@ -106,6 +106,8 @@ public class Fabric8ClientTest extends KubernetesTestBase {
 
 		assertEquals(KubernetesConfigOptions.ServiceExposedType.ClusterIP.toString(), service.getSpec().getType());
 
+		// The selector labels should contain jobmanager component
+		labels.put(Constants.LABEL_COMPONENT_KEY, Constants.LABEL_COMPONENT_JOB_MANAGER);
 		assertEquals(labels, service.getSpec().getSelector());
 
 		assertThat(service.getSpec().getPorts().stream().map(ServicePort::getPort).collect(Collectors.toList()),
@@ -133,6 +135,7 @@ public class Fabric8ClientTest extends KubernetesTestBase {
 
 		assertEquals(KubernetesConfigOptions.ServiceExposedType.LoadBalancer.toString(), service.getSpec().getType());
 
+		labels.put(Constants.LABEL_COMPONENT_KEY, Constants.LABEL_COMPONENT_JOB_MANAGER);
 		assertEquals(labels, service.getSpec().getSelector());
 
 		assertThat(service.getSpec().getPorts().stream().map(ServicePort::getPort).collect(Collectors.toList()),


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The jobmanager label needs to be added to service selector. Otherwise, it may select the wrong backend pods(taskmanager).

The internal service is used for taskmanager talking to jobmanager. If it does not have correct backend pods, the taskmanager may fail to register.


## Brief change log

* hotfix, Since we will not support per-job mode for native kubernetes, the per-job related config options is better to removed
* hotfix, Move logs out of `createClusterClientProvider`. Otherwise, when we call `clusterClientProvider.getClusterClient()` the logs will show.
* Add jobmanager component label to service selector


## Verifying this change

* The changes is covered by Unit test
* Manually running a native flink on k8s cluster, using the command `kubectl describe svc {cluster-id}` to check the selector

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
