### PR TITLE
[FLINK-14992][client] Add job listener to execution environments

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/execution/JobListener.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/JobListener.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.JobExecutionResult;
 
 import javax.annotation.Nullable;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * A listener that is notified on specific job status changed, which should be firstly
  * registered by {@code #registerJobListener} of execution environments.
@@ -35,18 +37,16 @@ import javax.annotation.Nullable;
 public interface JobListener {
 
 	/**
-	 * Callback on job submission succeeded or failed.
+	 * Callback on job submission. This is called when {@code execute()} or {@code executeAsync()}
+	 * is called.
 	 *
-	 * <p>Exactly one of the passed parameters is null, respectively for failure or success.
- 	 *
 	 * @param jobClient a {@link JobClient} for the submitted job
-	 * @param throwable the cause if submission failed
 	 */
-	void onJobSubmitted(@Nullable JobClient jobClient, @Nullable Throwable throwable);
+	void onJobSubmitted(CompletableFuture<JobClient> jobClient);
 
 	/**
 	 * Callback on job execution finished, successfully or unsuccessfully. It is only called
-	 * back when you call {@code #execute} instead of {@code executeAsync} methods of execution
+	 * back when you call {@code execute()} instead of {@code executeAsync()} methods of execution
 	 * environments.
 	 *
 	 * <p>Exactly one of the passed parameters is null, respectively for failure or success.

--- a/flink-core/src/main/java/org/apache/flink/core/execution/JobListener.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/JobListener.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.execution;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.JobExecutionResult;
+
+import javax.annotation.Nullable;
+
+/**
+ * A listener that is notified on specific job status changed, which should be firstly
+ * registered by {@code #registerJobListener} of execution environments.
+ *
+ * <p>It is highly recommended NOT to perform any blocking operation inside
+ * the callbacks. If you block the thread the invoker of environment execute methods
+ * is possibly blocked.
+ */
+@PublicEvolving
+public interface JobListener {
+
+	/**
+	 * Callback on job submission succeeded or failed.
+	 *
+	 * <p>Exactly one of the passed parameters is null, respectively for failure or success.
+ 	 *
+	 * @param jobClient a {@link JobClient} for the submitted job
+	 * @param throwable the cause if submission failed
+	 */
+	void onJobSubmitted(@Nullable JobClient jobClient, @Nullable Throwable throwable);
+
+	/**
+	 * Callback on job execution finished, successfully or unsuccessfully. It is only called
+	 * back when you call {@code #execute} instead of {@code executeAsync} methods of execution
+	 * environments.
+	 *
+	 * <p>Exactly one of the passed parameters is null, respectively for failure or success.
+	 */
+	void onJobExecuted(@Nullable JobExecutionResult jobExecutionResult, @Nullable Throwable throwable);
+
+}

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -58,8 +58,10 @@ import org.apache.flink.core.execution.DetachedJobExecutionResult;
 import org.apache.flink.core.execution.ExecutorFactory;
 import org.apache.flink.core.execution.ExecutorServiceLoader;
 import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.core.execution.JobListener;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.types.StringValue;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.NumberSequenceIterator;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SplittableIterator;
@@ -135,6 +137,8 @@ public class ExecutionEnvironment {
 	private final Configuration configuration;
 
 	private final ClassLoader userClassloader;
+
+	private final List<JobListener> jobListeners = new ArrayList<>();
 
 	/**
 	 * Creates a new {@link ExecutionEnvironment} that will use the given {@link Configuration} to
@@ -819,13 +823,42 @@ public class ExecutionEnvironment {
 	public JobExecutionResult execute(String jobName) throws Exception {
 		final JobClient jobClient = executeAsync(jobName).get();
 
-		if (configuration.getBoolean(DeploymentOptions.ATTACHED)) {
-			lastJobExecutionResult = jobClient.getJobExecutionResult(userClassloader).get();
-		} else {
-			lastJobExecutionResult = new DetachedJobExecutionResult(jobClient.getJobID());
+		try {
+			if (configuration.getBoolean(DeploymentOptions.ATTACHED)) {
+				lastJobExecutionResult = jobClient.getJobExecutionResult(userClassloader).get();
+			} else {
+				lastJobExecutionResult = new DetachedJobExecutionResult(jobClient.getJobID());
+			}
+
+			jobListeners.forEach(
+					jobListener -> jobListener.onJobExecuted(lastJobExecutionResult, null));
+
+		} catch (Throwable t) {
+			jobListeners.forEach(jobListener -> {
+				jobListener.onJobExecuted(null, ExceptionUtils.stripExecutionException(t));
+			});
+			ExceptionUtils.rethrowException(t);
 		}
 
 		return lastJobExecutionResult;
+	}
+
+	/**
+	 * Register a {@link JobListener} in this environment. The {@link JobListener} will be
+	 * notified on specific job status changed.
+	 */
+	@PublicEvolving
+	public void registerJobListener(JobListener jobListener) {
+		checkNotNull(jobListener, "JobListener cannot be null");
+		jobListeners.add(jobListener);
+	}
+
+	/**
+	 * Clear all registered {@link JobListener}s.
+	 */
+	@PublicEvolving
+	public void clearJobListeners() {
+		this.jobListeners.clear();
 	}
 
 	/**
@@ -872,9 +905,17 @@ public class ExecutionEnvironment {
 			"Cannot find compatible factory for specified execution.target (=%s)",
 			configuration.get(DeploymentOptions.TARGET));
 
-		return executorFactory
+		CompletableFuture<JobClient> jobClientFuture = executorFactory
 			.getExecutor(configuration)
 			.execute(plan, configuration);
+
+		return jobClientFuture.whenComplete((jobClient, throwable) -> {
+			if (throwable != null) {
+				jobListeners.forEach(jobListener -> jobListener.onJobSubmitted(null, throwable));
+			} else {
+				jobListeners.forEach(jobListener -> jobListener.onJobSubmitted(jobClient, null));
+			}
+		});
 	}
 
 	private void consolidateParallelismDefinitionsInConfiguration() {

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -909,13 +909,9 @@ public class ExecutionEnvironment {
 			.getExecutor(configuration)
 			.execute(plan, configuration);
 
-		return jobClientFuture.whenComplete((jobClient, throwable) -> {
-			if (throwable != null) {
-				jobListeners.forEach(jobListener -> jobListener.onJobSubmitted(null, throwable));
-			} else {
-				jobListeners.forEach(jobListener -> jobListener.onJobSubmitted(jobClient, null));
-			}
-		});
+		jobListeners.forEach(jobListener -> jobListener.onJobSubmitted(jobClientFuture));
+
+		return jobClientFuture;
 	}
 
 	private void consolidateParallelismDefinitionsInConfiguration() {

--- a/flink-python/pyflink/dataset/tests/test_execution_environment_completeness.py
+++ b/flink-python/pyflink/dataset/tests/test_execution_environment_completeness.py
@@ -51,7 +51,7 @@ class ExecutionEnvironmentCompletenessTests(PythonAPICompletenessTestCase,
                 'createCollectionsEnvironment', 'readFile', 'readFileOfPrimitives',
                 'generateSequence', 'areExplicitEnvironmentsAllowed', 'createInput',
                 'getUserCodeClassLoader', 'getExecutorServiceLoader', 'getConfiguration',
-                'executeAsync'}
+                'executeAsync', 'registerJobListener', 'clearJobListeners'}
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
@@ -48,7 +48,8 @@ class StreamExecutionEnvironmentCompletenessTests(PythonAPICompletenessTestCase,
                 'readFileStream', 'isForceCheckpointing', 'readFile', 'clean',
                 'createInput', 'createLocalEnvironmentWithWebUI', 'fromCollection',
                 'socketTextStream', 'initializeContextEnvironment', 'readTextFile', 'addSource',
-                'setNumberOfExecutionRetries', 'configure', 'executeAsync'}
+                'setNumberOfExecutionRetries', 'configure', 'executeAsync', 'registerJobListener',
+                'clearJobListeners'}
 
 
 if __name__ == '__main__':

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -20,6 +20,7 @@ package org.apache.flink.api.scala
 
 import java.io._
 
+import org.apache.flink.annotation.Internal
 import org.apache.flink.client.cli.{CliFrontend, CliFrontendParser}
 import org.apache.flink.client.deployment.executors.RemoteExecutor
 import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader
@@ -132,7 +133,8 @@ object FlinkShell {
     }
   }
 
-  private def ensureYarnConfig(config: Config) = config.yarnConfig match {
+
+  @Internal def ensureYarnConfig(config: Config) = config.yarnConfig match {
     case Some(yarnConfig) => yarnConfig
     case None => YarnConfig()
   }
@@ -196,7 +198,7 @@ object FlinkShell {
     println(" good bye ..")
   }
 
-  private def fetchConnectionInfo(
+  @Internal def fetchConnectionInfo(
       config: Config,
       flinkConfig: Configuration): (Configuration, Option[ClusterClient[_]]) = {
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -519,11 +519,6 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
    *
    * The program execution will be logged and displayed with a generated default name.
    *
-   * <b>ATTENTION:</b> The caller of this method is responsible for managing the lifecycle
-   * of the returned [[JobClient]]. This means calling [[JobClient#close()]] at the end of
-   * its usage. In other case, there may be resource leaks depending on the JobClient
-   * implementation.
-   *
    * @return A future of [[JobClient]] that can be used to communicate with the submitted job,
    *         completed on submission succeeded.
    */
@@ -538,11 +533,6 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
    * generic data sinks created with [[DataSet.output]].
    *
    * The program execution will be logged and displayed with the given name.
-   *
-   * <b>ATTENTION:</b> The caller of this method is responsible for managing the lifecycle
-   * of the returned [[JobClient]]. This means calling [[JobClient#close()]] at the end of
-   * its usage. In other case, there may be resource leaks depending on the JobClient
-   * implementation.
    *
    * @return A future of [[JobClient]] that can be used to communicate with the submitted job,
    *         completed on submission succeeded.

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -32,7 +32,7 @@ import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.api.java.typeutils.{PojoTypeInfo, TupleTypeInfoBase, ValueTypeInfo}
 import org.apache.flink.api.java.{CollectionEnvironment, ExecutionEnvironment => JavaEnv}
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.core.execution.JobClient
+import org.apache.flink.core.execution.{JobClient, JobListener}
 import org.apache.flink.core.fs.Path
 import org.apache.flink.types.StringValue
 import org.apache.flink.util.{NumberSequenceIterator, Preconditions, SplittableIterator}
@@ -492,6 +492,22 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
    */
   def execute(jobName: String): JobExecutionResult = {
     javaEnv.execute(jobName)
+  }
+
+  /**
+   * Register a [[JobListener]] in this environment. The [[JobListener]] will be
+   * notified on specific job status changed.
+   */
+  @PublicEvolving
+  def registerJobListener(jobListener: JobListener): Unit = {
+    javaEnv.registerJobListener(jobListener)
+  }
+
+  /**
+   * Clear all registered [[JobListener]]s.
+   */
+  @PublicEvolving def clearJobListeners(): Unit = {
+    javaEnv.clearJobListeners()
   }
 
   /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -1740,13 +1740,9 @@ public class StreamExecutionEnvironment {
 			.getExecutor(configuration)
 			.execute(streamGraph, configuration);
 
-		return jobClientFuture.whenComplete((jobClient, throwable) -> {
-			if (throwable != null) {
-				jobListeners.forEach(jobListener -> jobListener.onJobSubmitted(null, throwable));
-			} else {
-				jobListeners.forEach(jobListener -> jobListener.onJobSubmitted(jobClient, null));
-			}
-		});
+		jobListeners.forEach(jobListener -> jobListener.onJobSubmitted(jobClientFuture));
+
+		return jobClientFuture;
 	}
 
 	private void consolidateParallelismDefinitionsInConfiguration() {

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -704,11 +704,6 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * The program execution will be logged and displayed with a generated
    * default name.
    *
-   * <b>ATTENTION:</b> The caller of this method is responsible for managing the lifecycle
-   * of the returned [[JobClient]]. This means calling [[JobClient#close()]] at the end of
-   * its usage. In other case, there may be resource leaks depending on the JobClient
-   * implementation.
-   *
    * @return A future of [[JobClient]] that can be used to communicate with the submitted job,
    *         completed on submission succeeded.
    */
@@ -721,11 +716,6 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * for example printing results or forwarding them to a message queue.
    *
    * The program execution will be logged and displayed with the provided name.
-   *
-   * <b>ATTENTION:</b> The caller of this method is responsible for managing the lifecycle
-   * of the returned [[JobClient]]. This means calling [[JobClient#close()]] at the end of
-   * its usage. In other case, there may be resource leaks depending on the JobClient
-   * implementation.
    *
    * @return A future of [[JobClient]] that can be used to communicate with the submitted job,
    *         completed on submission succeeded.

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -29,13 +29,14 @@ import org.apache.flink.api.java.typeutils.ResultTypeQueryable
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.api.scala.ClosureCleaner
 import org.apache.flink.configuration.{Configuration, ReadableConfig}
-import org.apache.flink.core.execution.JobClient
+import org.apache.flink.core.execution.{JobClient, JobListener}
 import org.apache.flink.runtime.state.AbstractStateBackend
 import org.apache.flink.runtime.state.StateBackend
 import org.apache.flink.streaming.api.environment.{StreamExecutionEnvironment => JavaEnv}
 import org.apache.flink.streaming.api.functions.source._
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
 import org.apache.flink.streaming.api.{CheckpointingMode, TimeCharacteristic}
+import org.apache.flink.util.Preconditions.checkNotNull
 import org.apache.flink.util.SplittableIterator
 
 import scala.collection.JavaConverters._
@@ -678,6 +679,22 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * @return The result of the job execution, containing elapsed time and accumulators.
    */
   def execute(jobName: String) = javaEnv.execute(jobName)
+
+  /**
+   * Register a [[JobListener]] in this environment. The [[JobListener]] will be
+   * notified on specific job status changed.
+   */
+  @PublicEvolving
+  def registerJobListener(jobListener: JobListener): Unit = {
+    javaEnv.registerJobListener(jobListener)
+  }
+
+  /**
+   * Clear all registered [[JobListener]]s.
+   */
+  @PublicEvolving def clearJobListeners(): Unit = {
+    javaEnv.clearJobListeners()
+  }
 
   /**
    * Triggers the program execution asynchronously. The environment will execute all parts of

--- a/flink-tests/src/test/java/org/apache/flink/test/execution/JobListenerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/execution/JobListenerITCase.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.execution;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.core.execution.JobListener;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Unit tests for {@link JobListener}.
+ */
+public class JobListenerITCase extends TestLogger {
+
+	@Test
+	public void testJobListenerOnBatchEnvironment() throws Exception {
+		OneShotLatch submissionLatch = new OneShotLatch();
+		OneShotLatch executionLatch = new OneShotLatch();
+
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		env.registerJobListener(new JobListener() {
+			@Override
+			public void onJobSubmitted(JobClient jobClient, Throwable throwable) {
+				submissionLatch.trigger();
+			}
+
+			@Override
+			public void onJobExecuted(JobExecutionResult jobExecutionResult, Throwable throwable) {
+				executionLatch.trigger();
+			}
+		});
+
+		env.fromElements(1, 2, 3, 4, 5).output(new DiscardingOutputFormat<>());
+		env.execute();
+
+		submissionLatch.await(2000L, TimeUnit.MILLISECONDS);
+		executionLatch.await(2000L, TimeUnit.MILLISECONDS);
+	}
+
+	@Test
+	public void testJobListenerOnStreamingEnvironment() throws Exception {
+		OneShotLatch submissionLatch = new OneShotLatch();
+		OneShotLatch executionLatch = new OneShotLatch();
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		env.registerJobListener(new JobListener() {
+			@Override
+			public void onJobSubmitted(JobClient jobClient, Throwable throwable) {
+				submissionLatch.trigger();
+			}
+
+			@Override
+			public void onJobExecuted(JobExecutionResult jobExecutionResult, Throwable throwable) {
+				executionLatch.trigger();
+			}
+		});
+
+		env.fromElements(1, 2, 3, 4, 5).addSink(new DiscardingSink<>());
+		env.execute();
+
+		submissionLatch.await(2000L, TimeUnit.MILLISECONDS);
+		executionLatch.await(2000L, TimeUnit.MILLISECONDS);
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/execution/JobListenerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/execution/JobListenerITCase.java
@@ -19,35 +19,63 @@
 package org.apache.flink.test.execution;
 
 import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
+import org.apache.flink.client.deployment.executors.RemoteExecutor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.core.execution.JobListener;
 import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Unit tests for {@link JobListener}.
  */
 public class JobListenerITCase extends TestLogger {
 
+	@ClassRule
+	public static MiniClusterWithClientResource miniClusterResource = new MiniClusterWithClientResource(
+			new MiniClusterResourceConfiguration.Builder()
+					.build());
+
+	private static Configuration getClientConfiguration() {
+		Configuration result = new Configuration(miniClusterResource.getClientConfiguration());
+		result.set(DeploymentOptions.TARGET, RemoteExecutor.NAME);
+		return result;
+	}
+
 	@Test
 	public void testExecuteCallsJobListenerOnBatchEnvironment() throws Exception {
+		AtomicReference<JobID> jobIdReference = new AtomicReference<>();
 		OneShotLatch submissionLatch = new OneShotLatch();
 		OneShotLatch executionLatch = new OneShotLatch();
 
-		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		ExecutionEnvironment env = new ExecutionEnvironment(getClientConfiguration());
 
 		env.registerJobListener(new JobListener() {
 			@Override
-			public void onJobSubmitted(JobClient jobClient, Throwable throwable) {
-				submissionLatch.trigger();
+			public void onJobSubmitted(CompletableFuture<JobClient> jobClientFuture) {
+				jobClientFuture
+						.thenAccept((jobClient -> {
+							jobIdReference.set(jobClient.getJobID());
+							submissionLatch.trigger();
+						}));
 			}
 
 			@Override
@@ -57,87 +85,198 @@ public class JobListenerITCase extends TestLogger {
 		});
 
 		env.fromElements(1, 2, 3, 4, 5).output(new DiscardingOutputFormat<>());
-		env.execute();
+		JobExecutionResult jobExecutionResult = env.execute();
 
 		submissionLatch.await(2000L, TimeUnit.MILLISECONDS);
 		executionLatch.await(2000L, TimeUnit.MILLISECONDS);
+
+		assertThat(jobExecutionResult.getJobID(), is(jobIdReference.get()));
 	}
 
 	@Test
 	public void testExecuteAsyncCallsJobListenerOnBatchEnvironment() throws Exception {
+		AtomicReference<JobID> jobIdReference = new AtomicReference<>();
 		OneShotLatch submissionLatch = new OneShotLatch();
-		OneShotLatch executionLatch = new OneShotLatch();
 
-		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		ExecutionEnvironment env = new ExecutionEnvironment(getClientConfiguration());
 
 		env.registerJobListener(new JobListener() {
 			@Override
-			public void onJobSubmitted(JobClient jobClient, Throwable throwable) {
-				submissionLatch.trigger();
+			public void onJobSubmitted(CompletableFuture<JobClient> jobClientFuture) {
+				jobClientFuture
+						.thenAccept((jobClient -> {
+							jobIdReference.set(jobClient.getJobID());
+							submissionLatch.trigger();
+						}));
 			}
 
 			@Override
 			public void onJobExecuted(JobExecutionResult jobExecutionResult, Throwable throwable) {
-				executionLatch.trigger();
+			}
+		});
+
+		env.fromElements(1, 2, 3, 4, 5).output(new DiscardingOutputFormat<>());
+		CompletableFuture<JobClient> jobClientFuture = env.executeAsync();
+
+		submissionLatch.await(2000L, TimeUnit.MILLISECONDS);
+		// when executing asynchronously we don't get an "executed" callback
+
+		assertThat(jobClientFuture.get().getJobID(), is(jobIdReference.get()));
+	}
+
+	@Test
+	public void testExecuteCallsJobListenerOnMainThreadOnBatchEnvironment() throws Exception {
+		AtomicReference<Thread> threadReference = new AtomicReference<>();
+
+		ExecutionEnvironment env = new ExecutionEnvironment(getClientConfiguration());
+
+		env.registerJobListener(new JobListener() {
+			@Override
+			public void onJobSubmitted(CompletableFuture<JobClient> jobClientFuture) {
+				threadReference.set(Thread.currentThread());
+			}
+
+			@Override
+			public void onJobExecuted(JobExecutionResult jobExecutionResult, Throwable throwable) {
+			}
+		});
+
+		env.fromElements(1, 2, 3, 4, 5).output(new DiscardingOutputFormat<>());
+		env.execute();
+
+		assertThat(Thread.currentThread(), is(threadReference.get()));
+	}
+
+	@Test
+	public void testExecuteAsyncCallsJobListenerOnMainThreadOnBatchEnvironment() throws Exception {
+		AtomicReference<Thread> threadReference = new AtomicReference<>();
+
+		ExecutionEnvironment env = new ExecutionEnvironment(getClientConfiguration());
+
+		env.registerJobListener(new JobListener() {
+			@Override
+			public void onJobSubmitted(CompletableFuture<JobClient> jobClientFuture) {
+				threadReference.set(Thread.currentThread());
+			}
+
+			@Override
+			public void onJobExecuted(JobExecutionResult jobExecutionResult, Throwable throwable) {
 			}
 		});
 
 		env.fromElements(1, 2, 3, 4, 5).output(new DiscardingOutputFormat<>());
 		env.executeAsync();
 
-		submissionLatch.await(2000L, TimeUnit.MILLISECONDS);
-		// when executing asynchronously we don't get an "executed" callback
+		assertThat(Thread.currentThread(), is(threadReference.get()));
 	}
 
 	@Test
 	public void testExecuteCallsJobListenerOnStreamingEnvironment() throws Exception {
+		AtomicReference<JobID> jobIdReference = new AtomicReference<>();
 		OneShotLatch submissionLatch = new OneShotLatch();
 		OneShotLatch executionLatch = new OneShotLatch();
 
-		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		StreamExecutionEnvironment env = new StreamExecutionEnvironment(getClientConfiguration());
 
 		env.registerJobListener(new JobListener() {
 			@Override
-			public void onJobSubmitted(JobClient jobClient, Throwable throwable) {
-				submissionLatch.trigger();
+			public void onJobSubmitted(CompletableFuture<JobClient> jobClientFuture) {
+				jobClientFuture
+						.thenAccept((jobClient -> {
+							jobIdReference.set(jobClient.getJobID());
+							submissionLatch.trigger();
+						}));
 			}
 
 			@Override
 			public void onJobExecuted(JobExecutionResult jobExecutionResult, Throwable throwable) {
 				executionLatch.trigger();
+			}
+		});
+
+		env.fromElements(1, 2, 3, 4, 5).addSink(new DiscardingSink<>());
+		JobExecutionResult jobExecutionResult = env.execute();
+
+		submissionLatch.await(2000L, TimeUnit.MILLISECONDS);
+		executionLatch.await(2000L, TimeUnit.MILLISECONDS);
+
+		assertThat(jobExecutionResult.getJobID(), is(jobIdReference.get()));
+	}
+
+	@Test
+	public void testExecuteAsyncCallsJobListenerOnStreamingEnvironment() throws Exception {
+		AtomicReference<JobID> jobIdReference = new AtomicReference<>();
+		OneShotLatch submissionLatch = new OneShotLatch();
+
+		StreamExecutionEnvironment env = new StreamExecutionEnvironment(getClientConfiguration());
+
+		env.registerJobListener(new JobListener() {
+			@Override
+			public void onJobSubmitted(CompletableFuture<JobClient> jobClientFuture) {
+				jobClientFuture
+						.thenAccept((jobClient -> {
+							jobIdReference.set(jobClient.getJobID());
+							submissionLatch.trigger();
+						}));
+			}
+
+			@Override
+			public void onJobExecuted(JobExecutionResult jobExecutionResult, Throwable throwable) {
+			}
+		});
+
+		env.fromElements(1, 2, 3, 4, 5).addSink(new DiscardingSink<>());
+		CompletableFuture<JobClient> jobClientFuture = env.executeAsync();
+
+		submissionLatch.await(2000L, TimeUnit.MILLISECONDS);
+		// when executing asynchronously we don't get an "executed" callback
+
+		assertThat(jobClientFuture.get().getJobID(), is(jobIdReference.get()));
+	}
+
+	@Test
+	public void testExecuteCallsJobListenerOnMainThreadOnStreamEnvironment() throws Exception {
+		AtomicReference<Thread> threadReference = new AtomicReference<>();
+
+		StreamExecutionEnvironment env = new StreamExecutionEnvironment(getClientConfiguration());
+
+		env.registerJobListener(new JobListener() {
+			@Override
+			public void onJobSubmitted(CompletableFuture<JobClient> jobClientFuture) {
+				threadReference.set(Thread.currentThread());
+			}
+
+			@Override
+			public void onJobExecuted(JobExecutionResult jobExecutionResult, Throwable throwable) {
 			}
 		});
 
 		env.fromElements(1, 2, 3, 4, 5).addSink(new DiscardingSink<>());
 		env.execute();
 
-		submissionLatch.await(2000L, TimeUnit.MILLISECONDS);
-		executionLatch.await(2000L, TimeUnit.MILLISECONDS);
+		assertThat(Thread.currentThread(), is(threadReference.get()));
 	}
 
 	@Test
-	public void testExecuteAsyncCallsJobListenerOnStreamingEnvironment() throws Exception {
-		OneShotLatch submissionLatch = new OneShotLatch();
-		OneShotLatch executionLatch = new OneShotLatch();
+	public void testExecuteAsyncCallsJobListenerOnMainThreadOnStreamEnvironment() throws Exception {
+		AtomicReference<Thread> threadReference = new AtomicReference<>();
 
-		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		StreamExecutionEnvironment env = new StreamExecutionEnvironment(getClientConfiguration());
 
 		env.registerJobListener(new JobListener() {
 			@Override
-			public void onJobSubmitted(JobClient jobClient, Throwable throwable) {
-				submissionLatch.trigger();
+			public void onJobSubmitted(CompletableFuture<JobClient> jobClientFuture) {
+				threadReference.set(Thread.currentThread());
 			}
 
 			@Override
 			public void onJobExecuted(JobExecutionResult jobExecutionResult, Throwable throwable) {
-				executionLatch.trigger();
 			}
 		});
 
 		env.fromElements(1, 2, 3, 4, 5).addSink(new DiscardingSink<>());
 		env.executeAsync();
 
-		submissionLatch.await(2000L, TimeUnit.MILLISECONDS);
-		// when executing asynchronously we don't get an "executed" callback
+		assertThat(Thread.currentThread(), is(threadReference.get()));
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This adds the `JobListener` for frameworks to hook into the job submission process.

## Brief change log

- this adds the listener interface, hooks it into the environments and adds tests

## Verifying this change

- newly added `JobListenerITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes, this adds `JobListener`
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
