### PR TITLE
[FLINK-14495][docs] Add documentation for memory control of RocksDB state backend

### DIFF
--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -209,7 +209,7 @@ The configuration keys in this section are independent of the used resource mana
 {% include generated/rocks_db_configuration.html %}
 
 ### RocksDB Configurable Options
-Specific RocksDB configurable options, provided by Flink, to create a corresponding `ConfigurableOptionsFactory`.
+Specific RocksDB configurable options, provided by Flink, to create a corresponding `ConfigurableRocksDBOptionsFactory`.
 And the created one would be used as default `OptionsFactory` in `RocksDBStateBackend`
 unless user define a `OptionsFactory` and set via `RocksDBStateBackend.setOptions(optionsFactory)`
 

--- a/docs/ops/config.zh.md
+++ b/docs/ops/config.zh.md
@@ -209,7 +209,7 @@ The configuration keys in this section are independent of the used resource mana
 {% include generated/rocks_db_configuration.html %}
 
 ### RocksDB Configurable Options
-Specific RocksDB configurable options, provided by Flink, to create a corresponding `ConfigurableOptionsFactory`.
+Specific RocksDB configurable options, provided by Flink, to create a corresponding `ConfigurableRocksDBOptionsFactory`.
 And the created one would be used as default `OptionsFactory` in `RocksDBStateBackend`
 unless user define a `OptionsFactory` and set via `RocksDBStateBackend.setOptions(optionsFactory)`
 

--- a/docs/ops/state/large_state_tuning.md
+++ b/docs/ops/state/large_state_tuning.md
@@ -172,19 +172,20 @@ There existed two ways to pass options factory to RocksDB in Flink:
 
     {% highlight java %}
 
-    public class MyOptionsFactory implements ConfigurableOptionsFactory {
+    public class MyOptionsFactory implements ConfigurableRocksDBOptionsFactory {
 
         private static final long DEFAULT_SIZE = 256 * 1024 * 1024;  // 256 MB
         private long blockCacheSize = DEFAULT_SIZE;
 
         @Override
-        public DBOptions createDBOptions(DBOptions currentOptions) {
+        public DBOptions createDBOptions(DBOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
             return currentOptions.setIncreaseParallelism(4)
                    .setUseFsync(false);
         }
 
         @Override
-        public ColumnFamilyOptions createColumnOptions(ColumnFamilyOptions currentOptions) {
+        public ColumnFamilyOptions createColumnOptions(
+            ColumnFamilyOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
             return currentOptions.setTableFormatConfig(
                 new BlockBasedTableConfig()
                     .setBlockCacheSize(blockCacheSize)
@@ -214,15 +215,16 @@ allocating more memory than configured.
 
 RocksDB allocates native memory outside of the JVM, which could lead the process to exceed the total memory budget.
 This can be especially problematic in containerized environments such as Kubernetes that kill processes who exceed their memory budgets.
-Flink can limit total memory usage of RocksDB instance(s) per slot by leveraging shareable [cache](https://github.com/facebook/rocksdb/wiki/Block-Cache)
-and [write buffer manager](https://github.com/facebook/rocksdb/wiki/Write-Buffer-Manager) among all instances in a single slot.
+Flink limit total memory usage of RocksDB instance(s) per slot by leveraging shareable [cache](https://github.com/facebook/rocksdb/wiki/Block-Cache)
+and [write buffer manager](https://github.com/facebook/rocksdb/wiki/Write-Buffer-Manager) among all instances in a single slot by default.
 The shared cache will place an upper limit on the [three components](https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB) that use the majority of memory
 when RocksDB is deployed as a state backend: block cache, index and bloom filters, and MemTables.
-There exist two ways to enable this feature:
-  -  Turn `state.backend.rocksdb.memory.managed` as true. If so, RocksDB state backend will use the managed memory budget of the task slot to set the capacity of that shared cache object.
-  This operation is recommend to take with the configuration to managed memory per task manager.
-  -  Configure the memory size of `state.backend.rocksdb.memory.fixed-per-slot` to set the fixed total amount of memory per slot.
+This feature is enabled by default and could be controlled by two ways:
+  -  Integrate with managed memory of task manager: turn `state.backend.rocksdb.memory.managed` as true. If so, RocksDB state backend will use the managed memory budget of the task slot to set the capacity of that shared cache object.
+  This operation is enabled by default, which means Flink would always choose to integrate RocksDB memory usage with the managed memory first.
+  -  Not integrated with managed memory: configure the memory size of `state.backend.rocksdb.memory.fixed-per-slot` to set the fixed total amount of memory per slot.
   This option will override `state.backend.rocksdb.memory.managed` option when configured and ignore calculated managed memory per slot from task manager.
+  User could also configure `taskmanager.memory.task.off-heap.size` to set additional quota in off-heap memory, which should be equal to `taskmanager.numberOfTaskSlots` * ``state.backend.rocksdb.memory.fixed-per-slot``, to fit in Flink's memory model.
 
 Flink also provides two parameters to tune the memory fraction of MemTable and index & filters:
   - `state.backend.rocksdb.memory.write-buffer-ratio`, by default `0.5`. If RocksDB memory bounded feature is turned on, 50% of memory size would be used by write buffer manager by default.
@@ -233,6 +235,46 @@ Flink also provides two parameters to tune the memory fraction of MemTable and i
   more details could refer to the [RocksDB-documentation](https://github.com/facebook/rocksdb/wiki/Block-Cache#caching-index-filter-and-compression-dictionary-blocks).
 
 <span class="label label-info">Note</span> The shared `cahe` and `write buffer manager` will override customized settings of block cache and write buffer via `PredefinedOptions` and `OptionsFactory`.
+
+#### Tune performance when bounding RocksDB memory usage.
+
+There might existed performance regression compared with previous no-memory-limit case if you have too many states per slot.
+If you observed this behavior and not running jobs in containerized environment or does not care about the over-limit memory usage.
+The easiest way to wipe out the performance regression is to disable memory bound for RocksDB, e.g. turn `state.backend.rocksdb.memory.managed` as false.
+Otherwise you need to increase the upper memory for RocksDB:
+  - Increase the managed memory size of `taskmanager.memory.managed.size` or the fraction via `taskmanager.memory.managed.fraction`.
+  - Increase the memory size of `state.backend.rocksdb.memory.fixed-per-slot`, which is not integrated with managed memory of task manager, as well as increasing `taskmanager.memory.task.off-heap.size` accordingly.
+
+Apart from increasing total memory, you could also tune some options:
+  - Decrease the arena block size, which is 1/8 of write-buffer size by default. This targets to decrease the possibility of turning mutable mem-table as immutable when write buffer manager reserve memory at the granularity of arena block.
+  Increase the max background flush threads for each DB instance. This targets to flush immutable mem-tables as fast as possible to not block or stall writes.
+  User could use options factory below to tune:
+
+      {% highlight java %}
+  
+      public class MyOptionsFactory implements ConfigurableRocksDBOptionsFactory {
+  
+          @Override
+          public DBOptions createDBOptions(DBOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
+              // increase the max background flush threads when we have many states in one operator,
+              // which means we would have many column families in one DB instance.
+              return currentOptions.setMaxBackgroundFlushes(4);
+          }
+  
+          @Override
+          public ColumnFamilyOptions createColumnOptions(
+              ColumnFamilyOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
+              // decrease the arena block size, which is 1/8 of write-buffer size.
+              // if we did not change the write-buffer size, this default value is 8MB, decrease it to 1MB. 
+              return currentOptions.setArenaBlockSize(1024 * 1024);
+          }
+  
+          @Override
+          public OptionsFactory configure(Configuration configuration) {
+              return this;
+          }
+      }
+      {% endhighlight %}
 
 ## Capacity Planning
 

--- a/docs/ops/state/large_state_tuning.md
+++ b/docs/ops/state/large_state_tuning.md
@@ -122,7 +122,7 @@ Unfortunately, RocksDB's performance can vary with configuration, and there is l
 RocksDB properly. For example, the default configuration is tailored towards SSDs and performs suboptimal
 on spinning disks.
 
-**Incremental Checkpoints**
+#### Incremental Checkpoints
 
 Incremental checkpoints can dramatically reduce the checkpointing time in comparison to full checkpoints, at the cost of a (potentially) longer
 recovery time. The core idea is that incremental checkpoints only record all changes to the previous completed checkpoint, instead of
@@ -138,7 +138,7 @@ by default. To enable this feature, users can instantiate a `RocksDBStateBackend
         new RocksDBStateBackend(filebackend, true);
 {% endhighlight %}
 
-**RocksDB Timers**
+#### RocksDB Timers
 
 For RocksDB, a user can chose whether timers are stored on the heap or inside RocksDB (default). Heap-based timers can have a better performance for smaller numbers of
 timers, while storing timers inside RocksDB offers higher scalability as the number of timers in RocksDB can exceed the available main memory (spilling to disk).
@@ -149,7 +149,7 @@ Possible choices are `heap` (to store timers on the heap, default) and `rocksdb`
 <span class="label label-info">Note</span> *The combination RocksDB state backend with heap-based timers currently does NOT support asynchronous snapshots for the timers state.
 Other state like keyed state is still snapshotted asynchronously. Please note that this is not a regression from previous versions and will be resolved with `FLINK-10026`.*
 
-**Predefined Options**
+#### Predefined Options
 
 Flink provides some predefined collections of option for RocksDB for different settings, and there existed two ways
 to pass these predefined options to RocksDB:
@@ -162,7 +162,7 @@ found a set of options that work well and seem representative for certain worklo
 
 <span class="label label-info">Note</span> Predefined options which set programmatically would override the one configured via `flink-conf.yaml`.
 
-**Passing Options Factory to RocksDB**
+#### Passing Options Factory to RocksDB
 
 There existed two ways to pass options factory to RocksDB in Flink:
 
@@ -209,6 +209,28 @@ and options factory has a higher priority over the predefined options if ever co
 and not from the JVM. Any memory you assign to RocksDB will have to be accounted for, typically by decreasing the JVM heap size
 of the TaskManagers by the same amount. Not doing that may result in YARN/Mesos/etc terminating the JVM processes for
 allocating more memory than configured.
+
+#### Bound total memory usage of RocksDB instance(s) per slot
+
+RocksDB allocates native memory without control of JVM, and might lead the process to exceed total memory budget of the container to get killed in container environment (e.g. Kubernetes).
+From Flink-1.10, we provide a solution to limit total memory usage for RocksDb instance(s) per slot by leveraging RocksDB's mechanism to 
+share [cache](https://github.com/facebook/rocksdb/wiki/Block-Cache) and [write buffer manager](https://github.com/facebook/rocksdb/wiki/Write-Buffer-Manager) among instance(s).
+Generally speaking, we mainly have three parts of memory usage for RocksDB in Flink scenario: block cache, index & bloom filters and memtables 
+(refer to [memory-usage-in-rocksdb](https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB)).
+The basic idea is to share a `Cache` object with desired capacity among all RocksDB instances, 
+and [cost memory used in memtable to that cache](https://github.com/facebook/rocksdb/wiki/Write-Buffer-Manager#cost-memory-used-in-memtable-to-block-cache) via write buffer manager.
+Besides, we also cache index & filters into that cache, then the major use of memory would be well capped.
+There exist two ways to enable this feature:
+  -  Turn `state.backend.rocksdb.memory.managed` as true. If so, RocksDB state backend will use the managed memory budget of the task slot to set the capacity of that shared cache object.
+  -  Configure the memory size of `state.backend.rocksdb.memory.fixed-per-slot` to set the fixed total amount of memory per slot. 
+  This option will override `state.backend.rocksdb.memory.managed` option when configured.
+
+We also provide two parameters to tune the memory fraction of memtable and index & filters:
+  - `state.backend.rocksdb.memory.write-buffer-ratio`, by default `0.5`. If RocksDB memory bounded feature is turned on, 50% of memory size would be used by write buffer manager by default.
+  - `state.backend.rocksdb.memory.high-prio-pool-ratio`, by default `0.1`.
+  If RocksDB memory bounded feature is turned on, 10% 0f memory size would be set as high priority for index and filters in shared block cache by default. 
+  By enabling this, index and filters would not need to compete against data blocks for staying in cache to minimize performance problem if those index and filters are evicted by data blocks frequently.
+  Moreover, we also pin L0 level filter and index into cache by default to mitigate performance problem, more details could refer to [RocksDB-doc](https://github.com/facebook/rocksdb/wiki/Block-Cache#caching-index-filter-and-compression-dictionary-blocks).
 
 ## Capacity Planning
 

--- a/docs/ops/state/large_state_tuning.md
+++ b/docs/ops/state/large_state_tuning.md
@@ -243,7 +243,6 @@ and increase `taskmanager.memory.task.off-heap.size` by "`taskmanager.numberOfTa
 There might existed performance regression compared with previous no-memory-limit case if you have too many states per slot.
 - If you observed this behavior and not running jobs in containerized environment or don't care about the over-limit memory usage.
 The easiest way to wipe out the performance regression is to disable memory bound for RocksDB, e.g. turn `state.backend.rocksdb.memory.managed` as `false`.
-Moreover, please refer to [memory configuration migration guide](WIP) to know how to keep backward compatibility to previous memory configuration.
 - Otherwise you need to increase the upper memory for RocksDB by tuning up `taskmanager.memory.managed.size` or `taskmanager.memory.managed.fraction`, or increasing the total memory for task manager.
 
 *Experts only*: Apart from increasing total memory, user could also tune RocksDB options (e.g. arena block size, max background flush threads, etc.) via `RocksDBOptionsFactory`:

--- a/docs/ops/state/large_state_tuning.md
+++ b/docs/ops/state/large_state_tuning.md
@@ -222,59 +222,57 @@ when RocksDB is deployed as a state backend: block cache, index and bloom filter
 This feature is enabled by default and could be controlled by two ways:
   -  Integrate with managed memory of task manager: turn `state.backend.rocksdb.memory.managed` as true. If so, RocksDB state backend will use the managed memory budget of the task slot to set the capacity of that shared cache object.
   This operation is enabled by default, which means Flink would always choose to integrate RocksDB memory usage with the managed memory first.
-  -  Not integrated with managed memory: configure the memory size of `state.backend.rocksdb.memory.fixed-per-slot` to set the fixed total amount of memory per slot.
+  -  Not integrated with managed memory (which is for experts only): configure the memory size of `state.backend.rocksdb.memory.fixed-per-slot` to set the fixed total amount of memory per slot.
+  Please tune down `taskmanager.memory.managed.size` or `taskmanager.memory.managed.fraction` to zero and increase `taskmanager.memory.task.off-heap.size` by "`taskmanager.numberOfTaskSlots` * `state.backend.rocksdb.memory.fixed-per-slot`" accordingly.
   This option will override `state.backend.rocksdb.memory.managed` option when configured and ignore calculated managed memory per slot from task manager.
-  User could also configure `taskmanager.memory.task.off-heap.size` to set additional quota in off-heap memory, which should be equal to `taskmanager.numberOfTaskSlots` * ``state.backend.rocksdb.memory.fixed-per-slot``, to fit in Flink's memory model.
 
-Flink also provides two parameters to tune the memory fraction of MemTable and index & filters:
-  - `state.backend.rocksdb.memory.write-buffer-ratio`, by default `0.5`. If RocksDB memory bounded feature is turned on, 50% of memory size would be used by write buffer manager by default.
-  - `state.backend.rocksdb.memory.high-prio-pool-ratio`, by default `0.1`.
-  If RocksDB memory bounded feature is turned on, 10% 0f memory size would be set as high priority for index and filters in shared block cache by default.
-  By enabling this, index and filters would not need to compete against data blocks for staying in cache to minimize performance problem if those index and filters are evicted by data blocks frequently.
+Flink also provides two parameters to tune the memory fraction of MemTable and index & filters along with the bounding RocksDB memory usage feature:
+  - `state.backend.rocksdb.memory.write-buffer-ratio`, by default `0.5`, which means 50% of the given memory would be used by write buffer manager.
+  - `state.backend.rocksdb.memory.high-prio-pool-ratio`, by default `0.1`, which means 10% of the given memory would be set as high priority for index and filters in shared block cache.
+  We strongly suggest not to set this to zero, to prevent index and filters from competing against data blocks for staying in cache and causing performance issues.
   Moreover, the L0 level filter and index are pinned into the cache by default to mitigate performance problems,
-  more details could refer to the [RocksDB-documentation](https://github.com/facebook/rocksdb/wiki/Block-Cache#caching-index-filter-and-compression-dictionary-blocks).
+  more details please refer to the [RocksDB-documentation](https://github.com/facebook/rocksdb/wiki/Block-Cache#caching-index-filter-and-compression-dictionary-blocks).
 
-<span class="label label-info">Note</span> The shared `cahe` and `write buffer manager` will override customized settings of block cache and write buffer via `PredefinedOptions` and `OptionsFactory`.
+<span class="label label-info">Note</span> When bounded RocksDB memory usage is enabled by default,
+the shared `cache` and `write buffer manager` will override customized settings of block cache and write buffer via `PredefinedOptions` and `OptionsFactory`.
 
 #### Tune performance when bounding RocksDB memory usage.
 
 There might existed performance regression compared with previous no-memory-limit case if you have too many states per slot.
-If you observed this behavior and not running jobs in containerized environment or does not care about the over-limit memory usage.
-The easiest way to wipe out the performance regression is to disable memory bound for RocksDB, e.g. turn `state.backend.rocksdb.memory.managed` as false.
-Otherwise you need to increase the upper memory for RocksDB:
-  - Increase the managed memory size of `taskmanager.memory.managed.size` or the fraction via `taskmanager.memory.managed.fraction`.
-  - Increase the memory size of `state.backend.rocksdb.memory.fixed-per-slot`, which is not integrated with managed memory of task manager, as well as increasing `taskmanager.memory.task.off-heap.size` accordingly.
+If you observed this behavior and not running jobs in containerized environment or don't care about the over-limit memory usage.
+- The easiest way to wipe out the performance regression is to disable memory bound for RocksDB, e.g. turn `state.backend.rocksdb.memory.managed` as false.
+- Otherwise you need to increase the upper memory for RocksDB by tuning up `taskmanager.memory.managed.size` or `taskmanager.memory.managed.fraction`, or increasing the total memory for task manager.
 
 Apart from increasing total memory, you could also tune some options:
-  - Decrease the arena block size, which is 1/8 of write-buffer size by default. This targets to decrease the possibility of turning mutable mem-table as immutable when write buffer manager reserve memory at the granularity of arena block.
-  Increase the max background flush threads for each DB instance. This targets to flush immutable mem-tables as fast as possible to not block or stall writes.
-  User could use options factory below to tune:
+- Decrease the arena block size, which is 1/8 of write-buffer size by default. This targets to decrease the possibility of turning mutable mem-table as immutable when write buffer manager reserve memory at the granularity of arena block.
+- Increase the max background flush threads for each DB instance. This targets to flush immutable mem-tables as fast as possible to not block or stall writes.
+ 
+User could use options factory below to tune:
 
-      {% highlight java %}
-  
-      public class MyOptionsFactory implements ConfigurableRocksDBOptionsFactory {
-  
-          @Override
-          public DBOptions createDBOptions(DBOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
-              // increase the max background flush threads when we have many states in one operator,
-              // which means we would have many column families in one DB instance.
-              return currentOptions.setMaxBackgroundFlushes(4);
-          }
-  
-          @Override
-          public ColumnFamilyOptions createColumnOptions(
-              ColumnFamilyOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
-              // decrease the arena block size, which is 1/8 of write-buffer size.
-              // if we did not change the write-buffer size, this default value is 8MB, decrease it to 1MB. 
-              return currentOptions.setArenaBlockSize(1024 * 1024);
-          }
-  
-          @Override
-          public OptionsFactory configure(Configuration configuration) {
-              return this;
-          }
-      }
-      {% endhighlight %}
+{% highlight java %}
+public class MyOptionsFactory implements ConfigurableRocksDBOptionsFactory {
+
+    @Override
+    public DBOptions createDBOptions(DBOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
+        // increase the max background flush threads when we have many states in one operator,
+        // which means we would have many column families in one DB instance.
+        return currentOptions.setMaxBackgroundFlushes(4);
+    }
+
+    @Override
+    public ColumnFamilyOptions createColumnOptions(
+        ColumnFamilyOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
+        // decrease the arena block size, which is 1/8 of write-buffer size.
+        // if we did not change the write-buffer size, this default value is 8MB, decrease it to 1MB. 
+        return currentOptions.setArenaBlockSize(1024 * 1024);
+    }
+
+    @Override
+    public OptionsFactory configure(Configuration configuration) {
+        return this;
+    }
+}
+{% endhighlight %}
 
 ## Capacity Planning
 

--- a/docs/ops/state/large_state_tuning.md
+++ b/docs/ops/state/large_state_tuning.md
@@ -122,7 +122,7 @@ Unfortunately, RocksDB's performance can vary with configuration, and there is l
 RocksDB properly. For example, the default configuration is tailored towards SSDs and performs suboptimal
 on spinning disks.
 
-#### Incremental Checkpoints
+### Incremental Checkpoints
 
 Incremental checkpoints can dramatically reduce the checkpointing time in comparison to full checkpoints, at the cost of a (potentially) longer
 recovery time. The core idea is that incremental checkpoints only record all changes to the previous completed checkpoint, instead of
@@ -138,7 +138,7 @@ by default. To enable this feature, users can instantiate a `RocksDBStateBackend
         new RocksDBStateBackend(filebackend, true);
 {% endhighlight %}
 
-#### RocksDB Timers
+### RocksDB Timers
 
 For RocksDB, a user can chose whether timers are stored on the heap or inside RocksDB (default). Heap-based timers can have a better performance for smaller numbers of
 timers, while storing timers inside RocksDB offers higher scalability as the number of timers in RocksDB can exceed the available main memory (spilling to disk).
@@ -149,7 +149,7 @@ Possible choices are `heap` (to store timers on the heap, default) and `rocksdb`
 <span class="label label-info">Note</span> *The combination RocksDB state backend with heap-based timers currently does NOT support asynchronous snapshots for the timers state.
 Other state like keyed state is still snapshotted asynchronously. Please note that this is not a regression from previous versions and will be resolved with `FLINK-10026`.*
 
-#### Predefined Options
+### Predefined Options
 
 Flink provides some predefined collections of option for RocksDB for different settings, and there existed two ways
 to pass these predefined options to RocksDB:
@@ -162,7 +162,7 @@ found a set of options that work well and seem representative for certain worklo
 
 <span class="label label-info">Note</span> Predefined options which set programmatically would override the one configured via `flink-conf.yaml`.
 
-#### Passing Options Factory to RocksDB
+### Passing Options Factory to RocksDB
 
 There existed two ways to pass options factory to RocksDB in Flink:
 
@@ -210,27 +210,29 @@ and not from the JVM. Any memory you assign to RocksDB will have to be accounted
 of the TaskManagers by the same amount. Not doing that may result in YARN/Mesos/etc terminating the JVM processes for
 allocating more memory than configured.
 
-#### Bound total memory usage of RocksDB instance(s) per slot
+### Bounding RocksDB Memory Usage
 
-RocksDB allocates native memory without control of JVM, and might lead the process to exceed total memory budget of the container to get killed in container environment (e.g. Kubernetes).
-From Flink-1.10, we provide a solution to limit total memory usage for RocksDb instance(s) per slot by leveraging RocksDB's mechanism to 
-share [cache](https://github.com/facebook/rocksdb/wiki/Block-Cache) and [write buffer manager](https://github.com/facebook/rocksdb/wiki/Write-Buffer-Manager) among instance(s).
-Generally speaking, we mainly have three parts of memory usage for RocksDB in Flink scenario: block cache, index & bloom filters and memtables 
-(refer to [memory-usage-in-rocksdb](https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB)).
-The basic idea is to share a `Cache` object with desired capacity among all RocksDB instances, 
-and [cost memory used in memtable to that cache](https://github.com/facebook/rocksdb/wiki/Write-Buffer-Manager#cost-memory-used-in-memtable-to-block-cache) via write buffer manager.
-Besides, we also cache index & filters into that cache, then the major use of memory would be well capped.
+RocksDB allocates native memory outside of the JVM, which could lead the process to exceed the total memory budget.
+This can be especially problematic in containerized environments such as Kubernetes that kill processes who exceed their memory budgets.
+Flink can limit total memory usage of RocksDB instance(s) per slot by leveraging shareable [cache](https://github.com/facebook/rocksdb/wiki/Block-Cache)
+and [write buffer manager](https://github.com/facebook/rocksdb/wiki/Write-Buffer-Manager) among all instances in a single slot.
+The shared cache will place an upper limit on the [three components](https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB) that use the majority of memory
+when RocksDB is deployed as a state backend: block cache, index and bloom filters, and MemTables.
 There exist two ways to enable this feature:
   -  Turn `state.backend.rocksdb.memory.managed` as true. If so, RocksDB state backend will use the managed memory budget of the task slot to set the capacity of that shared cache object.
-  -  Configure the memory size of `state.backend.rocksdb.memory.fixed-per-slot` to set the fixed total amount of memory per slot. 
-  This option will override `state.backend.rocksdb.memory.managed` option when configured.
+  This operation is recommend to take with the configuration to managed memory per task manager.
+  -  Configure the memory size of `state.backend.rocksdb.memory.fixed-per-slot` to set the fixed total amount of memory per slot.
+  This option will override `state.backend.rocksdb.memory.managed` option when configured and ignore calculated managed memory per slot from task manager.
 
-We also provide two parameters to tune the memory fraction of memtable and index & filters:
+Flink also provides two parameters to tune the memory fraction of MemTable and index & filters:
   - `state.backend.rocksdb.memory.write-buffer-ratio`, by default `0.5`. If RocksDB memory bounded feature is turned on, 50% of memory size would be used by write buffer manager by default.
   - `state.backend.rocksdb.memory.high-prio-pool-ratio`, by default `0.1`.
-  If RocksDB memory bounded feature is turned on, 10% 0f memory size would be set as high priority for index and filters in shared block cache by default. 
+  If RocksDB memory bounded feature is turned on, 10% 0f memory size would be set as high priority for index and filters in shared block cache by default.
   By enabling this, index and filters would not need to compete against data blocks for staying in cache to minimize performance problem if those index and filters are evicted by data blocks frequently.
-  Moreover, we also pin L0 level filter and index into cache by default to mitigate performance problem, more details could refer to [RocksDB-doc](https://github.com/facebook/rocksdb/wiki/Block-Cache#caching-index-filter-and-compression-dictionary-blocks).
+  Moreover, the L0 level filter and index are pinned into the cache by default to mitigate performance problems,
+  more details could refer to the [RocksDB-documentation](https://github.com/facebook/rocksdb/wiki/Block-Cache#caching-index-filter-and-compression-dictionary-blocks).
+
+<span class="label label-info">Note</span> The shared `cahe` and `write buffer manager` will override customized settings of block cache and write buffer via `PredefinedOptions` and `OptionsFactory`.
 
 ## Capacity Planning
 

--- a/docs/ops/state/large_state_tuning.zh.md
+++ b/docs/ops/state/large_state_tuning.zh.md
@@ -122,7 +122,7 @@ Unfortunately, RocksDB's performance can vary with configuration, and there is l
 RocksDB properly. For example, the default configuration is tailored towards SSDs and performs suboptimal
 on spinning disks.
 
-#### Incremental Checkpoints
+### Incremental Checkpoints
 
 Incremental checkpoints can dramatically reduce the checkpointing time in comparison to full checkpoints, at the cost of a (potentially) longer
 recovery time. The core idea is that incremental checkpoints only record all changes to the previous completed checkpoint, instead of
@@ -138,7 +138,7 @@ by default. To enable this feature, users can instantiate a `RocksDBStateBackend
         new RocksDBStateBackend(filebackend, true);
 {% endhighlight %}
 
-#### RocksDB Timers
+### RocksDB Timers
 
 For RocksDB, a user can chose whether timers are stored on the heap or inside RocksDB (default). Heap-based timers can have a better performance for smaller numbers of
 timers, while storing timers inside RocksDB offers higher scalability as the number of timers in RocksDB can exceed the available main memory (spilling to disk).
@@ -149,7 +149,7 @@ Possible choices are `heap` (to store timers on the heap, default) and `rocksdb`
 <span class="label label-info">Note</span> *The combination RocksDB state backend with heap-based timers currently does NOT support asynchronous snapshots for the timers state.
 Other state like keyed state is still snapshotted asynchronously. Please note that this is not a regression from previous versions and will be resolved with `FLINK-10026`.*
 
-#### Predefined Options
+### Predefined Options
 
 Flink provides some predefined collections of option for RocksDB for different settings, and there existed two ways
 to pass these predefined options to RocksDB:
@@ -162,7 +162,7 @@ found a set of options that work well and seem representative for certain worklo
 
 <span class="label label-info">Note</span> Predefined options which set programmatically would override the one configured via `flink-conf.yaml`.
 
-#### Passing Options Factory to RocksDB
+### Passing Options Factory to RocksDB
 
 There existed two ways to pass options factory to RocksDB in Flink:
 
@@ -210,27 +210,29 @@ and not from the JVM. Any memory you assign to RocksDB will have to be accounted
 of the TaskManagers by the same amount. Not doing that may result in YARN/Mesos/etc terminating the JVM processes for
 allocating more memory than configured.
 
-#### Bound total memory usage of RocksDB instance(s) per slot
+### Bounding RocksDB Memory Usage
 
-RocksDB allocates native memory without control of JVM, and might lead the process to exceed total memory budget of the container to get killed in container environment (e.g. Kubernetes).
-From Flink-1.10, we provide a solution to limit total memory usage for RocksDb instance(s) per slot by leveraging RocksDB's mechanism to 
-share [cache](https://github.com/facebook/rocksdb/wiki/Block-Cache) and [write buffer manager](https://github.com/facebook/rocksdb/wiki/Write-Buffer-Manager) among instance(s).
-Generally speaking, we mainly have three parts of memory usage for RocksDB in Flink scenario: block cache, index & bloom filters and memtables 
-(refer to [memory-usage-in-rocksdb](https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB)).
-The basic idea is to share a `Cache` object with desired capacity among all RocksDB instances, 
-and [cost memory used in memtable to that cache](https://github.com/facebook/rocksdb/wiki/Write-Buffer-Manager#cost-memory-used-in-memtable-to-block-cache) via write buffer manager.
-Besides, we also cache index & filters into that cache, then the major use of memory would be well capped.
+RocksDB allocates native memory outside of the JVM, which could lead the process to exceed the total memory budget.
+This can be especially problematic in containerized environments such as Kubernetes that kill processes who exceed their memory budgets.
+Flink can limit total memory usage of RocksDB instance(s) per slot by leveraging shareable [cache](https://github.com/facebook/rocksdb/wiki/Block-Cache)
+and [write buffer manager](https://github.com/facebook/rocksdb/wiki/Write-Buffer-Manager) among all instances in a single slot.
+The shared cache will place an upper limit on the [three components](https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB) that use the majority of memory
+when RocksDB is deployed as a state backend: block cache, index and bloom filters, and MemTables.
 There exist two ways to enable this feature:
   -  Turn `state.backend.rocksdb.memory.managed` as true. If so, RocksDB state backend will use the managed memory budget of the task slot to set the capacity of that shared cache object.
-  -  Configure the memory size of `state.backend.rocksdb.memory.fixed-per-slot` to set the fixed total amount of memory per slot. 
-  This option will override `state.backend.rocksdb.memory.managed` option when configured.
+  This operation is recommend to take with the configuration to managed memory per task manager.
+  -  Configure the memory size of `state.backend.rocksdb.memory.fixed-per-slot` to set the fixed total amount of memory per slot.
+  This option will override `state.backend.rocksdb.memory.managed` option when configured and ignore calculated managed memory per slot from task manager.
 
-We also provide two parameters to tune the memory fraction of memtable and index & filters:
+Flink also provides two parameters to tune the memory fraction of MemTable and index & filters:
   - `state.backend.rocksdb.memory.write-buffer-ratio`, by default `0.5`. If RocksDB memory bounded feature is turned on, 50% of memory size would be used by write buffer manager by default.
-  - `state.backend.rocksdb.memory.high-prio-pool-ratio`, by default `0.1`. 
-  If RocksDB memory bounded feature is turned on, 10% 0f memory size would be set as high priority for index and filters in shared block cache by default. 
+  - `state.backend.rocksdb.memory.high-prio-pool-ratio`, by default `0.1`.
+  If RocksDB memory bounded feature is turned on, 10% 0f memory size would be set as high priority for index and filters in shared block cache by default.
   By enabling this, index and filters would not need to compete against data blocks for staying in cache to minimize performance problem if those index and filters are evicted by data blocks frequently.
-  Moreover, we also pin L0 level filter and index into cache by default to mitigate performance problem, more details could refer to [RocksDB-doc](https://github.com/facebook/rocksdb/wiki/Block-Cache#caching-index-filter-and-compression-dictionary-blocks).
+  Moreover, the L0 level filter and index are pinned into the cache by default to mitigate performance problems,
+  more details could refer to the [RocksDB-documentation](https://github.com/facebook/rocksdb/wiki/Block-Cache#caching-index-filter-and-compression-dictionary-blocks).
+
+<span class="label label-info">Note</span> The shared `cahe` and `write buffer manager` will override customized settings of block cache and write buffer via `PredefinedOptions` and `OptionsFactory`.
 
 ## Capacity Planning
 

--- a/docs/ops/state/large_state_tuning.zh.md
+++ b/docs/ops/state/large_state_tuning.zh.md
@@ -222,59 +222,57 @@ when RocksDB is deployed as a state backend: block cache, index and bloom filter
 This feature is enabled by default and could be controlled by two ways:
   -  Integrate with managed memory of task manager: turn `state.backend.rocksdb.memory.managed` as true. If so, RocksDB state backend will use the managed memory budget of the task slot to set the capacity of that shared cache object.
   This operation is enabled by default, which means Flink would always choose to integrate RocksDB memory usage with the managed memory first.
-  -  Not integrated with managed memory: configure the memory size of `state.backend.rocksdb.memory.fixed-per-slot` to set the fixed total amount of memory per slot.
+  -  Not integrated with managed memory (which is for experts only): configure the memory size of `state.backend.rocksdb.memory.fixed-per-slot` to set the fixed total amount of memory per slot.
+  Please tune down `taskmanager.memory.managed.size` or `taskmanager.memory.managed.fraction` to zero and increase `taskmanager.memory.task.off-heap.size` by "`taskmanager.numberOfTaskSlots` * `state.backend.rocksdb.memory.fixed-per-slot`" accordingly.
   This option will override `state.backend.rocksdb.memory.managed` option when configured and ignore calculated managed memory per slot from task manager.
-  User could also configure `taskmanager.memory.task.off-heap.size` to set additional quota in off-heap memory, which should be equal to `taskmanager.numberOfTaskSlots` * ``state.backend.rocksdb.memory.fixed-per-slot``, to fit in Flink's memory framework.
 
-Flink also provides two parameters to tune the memory fraction of MemTable and index & filters:
-  - `state.backend.rocksdb.memory.write-buffer-ratio`, by default `0.5`. If RocksDB memory bounded feature is turned on, 50% of memory size would be used by write buffer manager by default.
-  - `state.backend.rocksdb.memory.high-prio-pool-ratio`, by default `0.1`.
-  If RocksDB memory bounded feature is turned on, 10% 0f memory size would be set as high priority for index and filters in shared block cache by default.
-  By enabling this, index and filters would not need to compete against data blocks for staying in cache to minimize performance problem if those index and filters are evicted by data blocks frequently.
+Flink also provides two parameters to tune the memory fraction of MemTable and index & filters along with the bounding RocksDB memory usage feature:
+  - `state.backend.rocksdb.memory.write-buffer-ratio`, by default `0.5`, which means 50% of the given memory would be used by write buffer manager.
+  - `state.backend.rocksdb.memory.high-prio-pool-ratio`, by default `0.1`, which means 10% of the given memory would be set as high priority for index and filters in shared block cache.
+  We strongly suggest not to set this to zero, to prevent index and filters from competing against data blocks for staying in cache and causing performance issues.
   Moreover, the L0 level filter and index are pinned into the cache by default to mitigate performance problems,
-  more details could refer to the [RocksDB-documentation](https://github.com/facebook/rocksdb/wiki/Block-Cache#caching-index-filter-and-compression-dictionary-blocks).
+  more details please refer to the [RocksDB-documentation](https://github.com/facebook/rocksdb/wiki/Block-Cache#caching-index-filter-and-compression-dictionary-blocks).
 
-<span class="label label-info">Note</span> The shared `cahe` and `write buffer manager` will override customized settings of block cache and write buffer via `PredefinedOptions` and `OptionsFactory`.
+<span class="label label-info">Note</span> When bounded RocksDB memory usage is enabled by default,
+the shared `cache` and `write buffer manager` will override customized settings of block cache and write buffer via `PredefinedOptions` and `OptionsFactory`.
 
 #### Tune performance when bounding RocksDB memory usage.
 
 There might existed performance regression compared with previous no-memory-limit case if you have too many states per slot.
-If you observed this behavior and not running jobs in containerized environment or does not care about the over-limit memory usage.
-The easiest way to wipe out the performance regression is to disable memory bound for RocksDB, e.g. turn `state.backend.rocksdb.memory.managed` as false.
-Otherwise you need to increase the upper memory for RocksDB:
-  - Increase the managed memory size of `taskmanager.memory.managed.size` or the fraction via `taskmanager.memory.managed.fraction`.
-  - Increase the memory size of `state.backend.rocksdb.memory.fixed-per-slot`, which is not integrated with managed memory of task manager, as well as increasing `taskmanager.memory.task.off-heap.size` accordingly.
+If you observed this behavior and not running jobs in containerized environment or don't care about the over-limit memory usage.
+- The easiest way to wipe out the performance regression is to disable memory bound for RocksDB, e.g. turn `state.backend.rocksdb.memory.managed` as false.
+- Otherwise you need to increase the upper memory for RocksDB by tuning up `taskmanager.memory.managed.size` or `taskmanager.memory.managed.fraction`, or increasing the total memory for task manager.
 
 Apart from increasing total memory, you could also tune some options:
-  - Decrease the arena block size, which is 1/8 of write-buffer size by default. This targets to decrease the possibility of turning mutable mem-table as immutable when write buffer manager reserve memory at the granularity of arena block.
-  Increase the max background flush threads for each DB instance. This targets to flush immutable mem-tables as fast as possible to not block or stall writes.
-  User could use options factory below to tune:
+- Decrease the arena block size, which is 1/8 of write-buffer size by default. This targets to decrease the possibility of turning mutable mem-table as immutable when write buffer manager reserve memory at the granularity of arena block.
+- Increase the max background flush threads for each DB instance. This targets to flush immutable mem-tables as fast as possible to not block or stall writes.
+ 
+User could use options factory below to tune:
 
-      {% highlight java %}
-  
-      public class MyOptionsFactory implements ConfigurableRocksDBOptionsFactory {
-  
-          @Override
-          public DBOptions createDBOptions(DBOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
-              // increase the max background flush threads when we have many states in one operator,
-              // which means we would have many column families in one DB instance.
-              return currentOptions.setMaxBackgroundFlushes(4);
-          }
-  
-          @Override
-          public ColumnFamilyOptions createColumnOptions(
-              ColumnFamilyOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
-              // decrease the arena block size, which is 1/8 of write-buffer size.
-              // if we did not change the write-buffer size, this default value is 8MB, decrease it to 1MB. 
-              return currentOptions.setArenaBlockSize(1024 * 1024);
-          }
-  
-          @Override
-          public OptionsFactory configure(Configuration configuration) {
-              return this;
-          }
-      }
-      {% endhighlight %}
+{% highlight java %}
+public class MyOptionsFactory implements ConfigurableRocksDBOptionsFactory {
+
+    @Override
+    public DBOptions createDBOptions(DBOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
+        // increase the max background flush threads when we have many states in one operator,
+        // which means we would have many column families in one DB instance.
+        return currentOptions.setMaxBackgroundFlushes(4);
+    }
+
+    @Override
+    public ColumnFamilyOptions createColumnOptions(
+        ColumnFamilyOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
+        // decrease the arena block size, which is 1/8 of write-buffer size.
+        // if we did not change the write-buffer size, this default value is 8MB, decrease it to 1MB. 
+        return currentOptions.setArenaBlockSize(1024 * 1024);
+    }
+
+    @Override
+    public OptionsFactory configure(Configuration configuration) {
+        return this;
+    }
+}
+{% endhighlight %}
 
 ## Capacity Planning
 

--- a/docs/ops/state/large_state_tuning.zh.md
+++ b/docs/ops/state/large_state_tuning.zh.md
@@ -243,7 +243,6 @@ and increase `taskmanager.memory.task.off-heap.size` by "`taskmanager.numberOfTa
 There might existed performance regression compared with previous no-memory-limit case if you have too many states per slot.
 - If you observed this behavior and not running jobs in containerized environment or don't care about the over-limit memory usage.
 The easiest way to wipe out the performance regression is to disable memory bound for RocksDB, e.g. turn `state.backend.rocksdb.memory.managed` as `false`.
-Moreover, please refer to [memory configuration migration guide](WIP) to know how to keep backward compatibility to previous memory configuration.
 - Otherwise you need to increase the upper memory for RocksDB by tuning up `taskmanager.memory.managed.size` or `taskmanager.memory.managed.fraction`, or increasing the total memory for task manager.
 
 *Experts only*: Apart from increasing total memory, user could also tune RocksDB options (e.g. arena block size, max background flush threads, etc.) via `RocksDBOptionsFactory`:

--- a/docs/ops/state/large_state_tuning.zh.md
+++ b/docs/ops/state/large_state_tuning.zh.md
@@ -172,19 +172,20 @@ There existed two ways to pass options factory to RocksDB in Flink:
 
     {% highlight java %}
 
-    public class MyOptionsFactory implements ConfigurableOptionsFactory {
+    public class MyOptionsFactory implements ConfigurableRocksDBOptionsFactory {
 
         private static final long DEFAULT_SIZE = 256 * 1024 * 1024;  // 256 MB
         private long blockCacheSize = DEFAULT_SIZE;
 
         @Override
-        public DBOptions createDBOptions(DBOptions currentOptions) {
+        public DBOptions createDBOptions(DBOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
             return currentOptions.setIncreaseParallelism(4)
                    .setUseFsync(false);
         }
 
         @Override
-        public ColumnFamilyOptions createColumnOptions(ColumnFamilyOptions currentOptions) {
+        public ColumnFamilyOptions createColumnOptions(
+            ColumnFamilyOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
             return currentOptions.setTableFormatConfig(
                 new BlockBasedTableConfig()
                     .setBlockCacheSize(blockCacheSize)
@@ -214,15 +215,16 @@ allocating more memory than configured.
 
 RocksDB allocates native memory outside of the JVM, which could lead the process to exceed the total memory budget.
 This can be especially problematic in containerized environments such as Kubernetes that kill processes who exceed their memory budgets.
-Flink can limit total memory usage of RocksDB instance(s) per slot by leveraging shareable [cache](https://github.com/facebook/rocksdb/wiki/Block-Cache)
-and [write buffer manager](https://github.com/facebook/rocksdb/wiki/Write-Buffer-Manager) among all instances in a single slot.
+Flink limit total memory usage of RocksDB instance(s) per slot by leveraging shareable [cache](https://github.com/facebook/rocksdb/wiki/Block-Cache)
+and [write buffer manager](https://github.com/facebook/rocksdb/wiki/Write-Buffer-Manager) among all instances in a single slot by default.
 The shared cache will place an upper limit on the [three components](https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB) that use the majority of memory
 when RocksDB is deployed as a state backend: block cache, index and bloom filters, and MemTables.
-There exist two ways to enable this feature:
-  -  Turn `state.backend.rocksdb.memory.managed` as true. If so, RocksDB state backend will use the managed memory budget of the task slot to set the capacity of that shared cache object.
-  This operation is recommend to take with the configuration to managed memory per task manager.
-  -  Configure the memory size of `state.backend.rocksdb.memory.fixed-per-slot` to set the fixed total amount of memory per slot.
+This feature is enabled by default and could be controlled by two ways:
+  -  Integrate with managed memory of task manager: turn `state.backend.rocksdb.memory.managed` as true. If so, RocksDB state backend will use the managed memory budget of the task slot to set the capacity of that shared cache object.
+  This operation is enabled by default, which means Flink would always choose to integrate RocksDB memory usage with the managed memory first.
+  -  Not integrated with managed memory: configure the memory size of `state.backend.rocksdb.memory.fixed-per-slot` to set the fixed total amount of memory per slot.
   This option will override `state.backend.rocksdb.memory.managed` option when configured and ignore calculated managed memory per slot from task manager.
+  User could also configure `taskmanager.memory.task.off-heap.size` to set additional quota in off-heap memory, which should be equal to `taskmanager.numberOfTaskSlots` * ``state.backend.rocksdb.memory.fixed-per-slot``, to fit in Flink's memory framework.
 
 Flink also provides two parameters to tune the memory fraction of MemTable and index & filters:
   - `state.backend.rocksdb.memory.write-buffer-ratio`, by default `0.5`. If RocksDB memory bounded feature is turned on, 50% of memory size would be used by write buffer manager by default.
@@ -233,6 +235,46 @@ Flink also provides two parameters to tune the memory fraction of MemTable and i
   more details could refer to the [RocksDB-documentation](https://github.com/facebook/rocksdb/wiki/Block-Cache#caching-index-filter-and-compression-dictionary-blocks).
 
 <span class="label label-info">Note</span> The shared `cahe` and `write buffer manager` will override customized settings of block cache and write buffer via `PredefinedOptions` and `OptionsFactory`.
+
+#### Tune performance when bounding RocksDB memory usage.
+
+There might existed performance regression compared with previous no-memory-limit case if you have too many states per slot.
+If you observed this behavior and not running jobs in containerized environment or does not care about the over-limit memory usage.
+The easiest way to wipe out the performance regression is to disable memory bound for RocksDB, e.g. turn `state.backend.rocksdb.memory.managed` as false.
+Otherwise you need to increase the upper memory for RocksDB:
+  - Increase the managed memory size of `taskmanager.memory.managed.size` or the fraction via `taskmanager.memory.managed.fraction`.
+  - Increase the memory size of `state.backend.rocksdb.memory.fixed-per-slot`, which is not integrated with managed memory of task manager, as well as increasing `taskmanager.memory.task.off-heap.size` accordingly.
+
+Apart from increasing total memory, you could also tune some options:
+  - Decrease the arena block size, which is 1/8 of write-buffer size by default. This targets to decrease the possibility of turning mutable mem-table as immutable when write buffer manager reserve memory at the granularity of arena block.
+  Increase the max background flush threads for each DB instance. This targets to flush immutable mem-tables as fast as possible to not block or stall writes.
+  User could use options factory below to tune:
+
+      {% highlight java %}
+  
+      public class MyOptionsFactory implements ConfigurableRocksDBOptionsFactory {
+  
+          @Override
+          public DBOptions createDBOptions(DBOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
+              // increase the max background flush threads when we have many states in one operator,
+              // which means we would have many column families in one DB instance.
+              return currentOptions.setMaxBackgroundFlushes(4);
+          }
+  
+          @Override
+          public ColumnFamilyOptions createColumnOptions(
+              ColumnFamilyOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
+              // decrease the arena block size, which is 1/8 of write-buffer size.
+              // if we did not change the write-buffer size, this default value is 8MB, decrease it to 1MB. 
+              return currentOptions.setArenaBlockSize(1024 * 1024);
+          }
+  
+          @Override
+          public OptionsFactory configure(Configuration configuration) {
+              return this;
+          }
+      }
+      {% endhighlight %}
 
 ## Capacity Planning
 

--- a/docs/ops/state/state_backends.md
+++ b/docs/ops/state/state_backends.md
@@ -123,6 +123,8 @@ RocksDBStateBackend is currently the only backend that offers incremental checkp
 
 Certain RocksDB native metrics are available but disabled by default, you can find full documentation [here]({{ site.baseurl }}/ops/config.html#rocksdb-native-metrics)
 
+The total memory amount of RocksDB instance(s) per slot could also be bounded, please refer to documentation [here](large_state_tuning.html#bound-total-memory-usage-of-rocksdb-instances-per-slot) for details.
+
 ## Configuring a State Backend
 
 The default state backend, if you specify nothing, is the jobmanager. If you wish to establish a different default for all jobs on your cluster, you can do so by defining a new default state backend in **flink-conf.yaml**. The default state backend can be overridden on a per-job basis, as shown below.

--- a/docs/ops/state/state_backends.md
+++ b/docs/ops/state/state_backends.md
@@ -123,7 +123,7 @@ RocksDBStateBackend is currently the only backend that offers incremental checkp
 
 Certain RocksDB native metrics are available but disabled by default, you can find full documentation [here]({{ site.baseurl }}/ops/config.html#rocksdb-native-metrics)
 
-The total memory amount of RocksDB instance(s) per slot could also be bounded, please refer to documentation [here](large_state_tuning.html#bound-total-memory-usage-of-rocksdb-instances-per-slot) for details.
+The total memory amount of RocksDB instance(s) per slot can also be bounded, please refer to documentation [here](large_state_tuning.html#bounding-rocksdb-memory-usage) for details.
 
 ## Configuring a State Backend
 

--- a/docs/ops/state/state_backends.zh.md
+++ b/docs/ops/state/state_backends.zh.md
@@ -119,6 +119,8 @@ RocksDBStateBackend 是目前唯一支持增量 CheckPoint 的 State Backend (�
 
 可以使用一些 RocksDB 的本地指标(metrics)，但默认是关闭的。你能在 [这里]({{ site.baseurl }}/zh/ops/config.html#rocksdb-native-metrics) 找到关于 RocksDB 本地指标的文档。
 
+The total memory amount of RocksDB instance(s) per slot could also be bounded, please refer to documentation [here](large_state_tuning.html#bound-total-memory-usage-of-rocksdb-instances-per-slot) for details.
+
 ## 设置 State Backend
 
 如果没有明确指定，将使用 jobmanager 做为默认的 state backend。你能在 **flink-conf.yaml** 中为所有 Job 设置其他默认的 State Backend。

--- a/docs/ops/state/state_backends.zh.md
+++ b/docs/ops/state/state_backends.zh.md
@@ -119,7 +119,7 @@ RocksDBStateBackend 是目前唯一支持增量 CheckPoint 的 State Backend (�
 
 可以使用一些 RocksDB 的本地指标(metrics)，但默认是关闭的。你能在 [这里]({{ site.baseurl }}/zh/ops/config.html#rocksdb-native-metrics) 找到关于 RocksDB 本地指标的文档。
 
-The total memory amount of RocksDB instance(s) per slot could also be bounded, please refer to documentation [here](large_state_tuning.html#bound-total-memory-usage-of-rocksdb-instances-per-slot) for details.
+The total memory amount of RocksDB instance(s) per slot can also be bounded, please refer to documentation [here](large_state_tuning.html#bounding-rocksdb-memory-usage) for details.
 
 ## 设置 State Backend
 


### PR DESCRIPTION
## What is the purpose of the change

Add user documentation of how to bound total memory for RocksDB instance(s) per slot.


## Brief change log

Add description in `large_state_tuning.md` and `large_state_tuning.zh.md`, also modify `state_backends.md` and `state_backends.zh.md` to give url.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no 
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
