### PR TITLE
[FLINK-15069][benchmark] Supplement the pipelined shuffle compression case for benchmark

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkCompressionThroughputBenchmark.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkCompressionThroughputBenchmark.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io.benchmark;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
+
+/**
+ * Network compression throughput benchmarks executed by the external
+ * <a href="https://github.com/dataArtisans/flink-benchmarks">flink-benchmarks</a> project.
+ */
+public class StreamNetworkCompressionThroughputBenchmark extends StreamNetworkThroughputBenchmark {
+
+	/**
+	 * Same as {@link StreamNetworkThroughputBenchmark#setUp(int, int, int, boolean, int, int)}
+	 * but also enables compression for pipelined mode.
+	 */
+	@Override
+	public void setUp(
+			int recordWriters,
+			int channels,
+			int flushTimeout,
+			boolean localMode,
+			int senderBufferPoolSize,
+			int receiverBufferPoolSize) throws Exception {
+
+		final Configuration configuration = new Configuration();
+		configuration.setBoolean(NettyShuffleEnvironmentOptions.PIPELINED_SHUFFLE_COMPRESSION_ENABLED, true);
+
+		setUp(
+			recordWriters,
+			channels,
+			flushTimeout,
+			false,
+			localMode,
+			senderBufferPoolSize,
+			receiverBufferPoolSize,
+			configuration
+		);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkCompressionThroughputBenchmarkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkCompressionThroughputBenchmarkTest.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io.benchmark;
+
+/**
+ * Tests for various network benchmarks based on {@link StreamNetworkCompressionThroughputBenchmark}.
+ */
+public class StreamNetworkCompressionThroughputBenchmarkTest extends StreamNetworkThroughputBenchmarkTest {
+	@Override
+	protected StreamNetworkThroughputBenchmark createBenchmark() {
+		return new StreamNetworkCompressionThroughputBenchmark();
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

*While reviewing the PR of introducing data compression for persistent storage and network shuffle, we think it is better to also cover this scenario in the benchmark for tracing the performance issues future.*
    
*This PR would supplement the compression case for pipelined partition shuffle, and the compression cases for blocking partition would be added in FLINK-15070.*

## Brief change log

  - *Introduce `StreamNetworkCompressionThroughputBenchmark` for enabling the pipelined partition shuffle for streaming job.*

## Verifying this change

The change is covered by `StreamNetworkCompressionThroughputBenchmarkTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
