### PR TITLE
[FLINK-14958][table]ProgramTargetDescriptor#jobID possibly can be of type JobID instead of String

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/ProgramTargetDescriptor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/ProgramTargetDescriptor.java
@@ -27,13 +27,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class ProgramTargetDescriptor {
 
-	private final String jobId;
+	private final JobID jobId;
 
-	public ProgramTargetDescriptor(String jobId) {
+	public ProgramTargetDescriptor(JobID jobId) {
 		this.jobId = checkNotNull(jobId);
 	}
 
-	public String getJobId() {
+	public JobID getJobId() {
 		return jobId;
 	}
 
@@ -49,6 +49,6 @@ public class ProgramTargetDescriptor {
 	 * @return program target descriptor
 	 */
 	public static ProgramTargetDescriptor of(JobID jobId) {
-		return new ProgramTargetDescriptor(jobId.toString());
+		return new ProgramTargetDescriptor(jobId);
 	}
 }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.client.cli;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.client.cli.utils.TerminalUtils;
@@ -361,7 +362,8 @@ public class CliClientTest extends TestLogger {
 			if (failExecution) {
 				throw new SqlExecutionException("Fail execution.");
 			}
-			return new ProgramTargetDescriptor("testJobId");
+			JobID jobID = JobID.generate();
+			return new ProgramTargetDescriptor(jobID);
 		}
 	}
 }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -668,7 +668,7 @@ public class LocalExecutorITCase extends TestLogger {
 			boolean isRunning = true;
 			while (isRunning) {
 				Thread.sleep(50); // slow the processing down
-				final JobStatus jobStatus = clusterClient.getJobStatus(JobID.fromHexString(targetDescriptor.getJobId())).get();
+				final JobStatus jobStatus = clusterClient.getJobStatus(targetDescriptor.getJobId()).get();
 				switch (jobStatus) {
 					case CREATED:
 					case RUNNING:
@@ -731,7 +731,7 @@ public class LocalExecutorITCase extends TestLogger {
 			boolean isRunning = true;
 			while (isRunning) {
 				Thread.sleep(50); // slow the processing down
-				final JobStatus jobStatus = clusterClient.getJobStatus(JobID.fromHexString(targetDescriptor.getJobId())).get();
+				final JobStatus jobStatus = clusterClient.getJobStatus(targetDescriptor.getJobId()).get();
 				switch (jobStatus) {
 					case CREATED:
 					case RUNNING:

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -19,7 +19,6 @@
 
 package org.apache.flink.table.client.gateway.local;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;


### PR DESCRIPTION
## What is the purpose of the change

ProgramTargetDescriptor#jobID possibly can be of type JobID instead of String

## Brief change log

Replacing ProgramTargetDescriptor#jobID type String with type JobID.
Changing related Tests code.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (don't know)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (don't know)
  - The S3 file system connector: (don't know)

## Documentation

  - Does this pull request introduce a new feature? ( no)
