### PR TITLE
[FLINK-15166][runtime] Fix that buffer is wrongly recycled when data compression is enabled for blocking shuffle.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
@@ -152,7 +152,9 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
 				if (canBeCompressed(buffer)) {
 					final Buffer compressedBuffer = parent.bufferCompressor.compressToIntermediateBuffer(buffer);
 					data.writeBuffer(compressedBuffer);
-					compressedBuffer.recycleBuffer();
+					if (compressedBuffer != buffer) {
+						compressedBuffer.recycleBuffer();
+					}
 				} else {
 					data.writeBuffer(buffer);
 				}


### PR DESCRIPTION
## What is the purpose of the change

For blocking shuffle data compression, the compressed intermediate buffer is recycled each time after data is written out, however when the data can not be compressed, the return buffer is the original buffer which should not be recycled. This PR fixes the wrong recycling problem by checking the returned buffer.

## Brief change log

  - Not recycle the compressed buffer if it is the original buffer.
  - Modify the ```ShuffleCompressionITCase``` to cover the scenario.


## Verifying this change

```ShuffleCompressionITCase``` is modified to cover the scenario.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
