### PR TITLE
[FLINK-15163][1.10][build] [FLINK-15163][build] Set japicmp.referenceVersion to 1.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@ under the License.
 			For Hadoop 2.7, the minor Hadoop version supported for flink-shaded-hadoop-2-uber is 2.7.5
 		-->
 		<hivemetastore.hadoop.version>2.7.5</hivemetastore.hadoop.version>
-		<japicmp.referenceVersion>1.8.0</japicmp.referenceVersion>
+		<japicmp.referenceVersion>1.9.1</japicmp.referenceVersion>
 		<japicmp.outputDir>tools/japicmp-output</japicmp.outputDir>
 		<test.scheduler.type></test.scheduler.type>
 		<test.groups></test.groups>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@ under the License.
 			For Hadoop 2.7, the minor Hadoop version supported for flink-shaded-hadoop-2-uber is 2.7.5
 		-->
 		<hivemetastore.hadoop.version>2.7.5</hivemetastore.hadoop.version>
-		<jamicmp.referenceVersion>1.8.0</jamicmp.referenceVersion>
+		<japicmp.referenceVersion>1.8.0</japicmp.referenceVersion>
 		<japicmp.outputDir>tools/japicmp-output</japicmp.outputDir>
 		<test.scheduler.type></test.scheduler.type>
 		<test.groups></test.groups>
@@ -1857,7 +1857,7 @@ under the License.
 							<dependency>
 								<groupId>org.apache.flink</groupId>
 								<artifactId>${project.artifactId}</artifactId>
-								<version>${jamicmp.referenceVersion}</version>
+								<version>${japicmp.referenceVersion}</version>
 								<type>${project.packaging}</type>
 							</dependency>
 						</oldVersion>


### PR DESCRIPTION
## What is the purpose of the change

*This sets japicmp.referenceVersion to 1.9.1*


## Brief change log

  - *See commits*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
