### PR TITLE
[FLINK-15176][container] Add '--job-classname' to flink-container 'jo…

### DIFF
--- a/flink-container/kubernetes/README.md
+++ b/flink-container/kubernetes/README.md
@@ -29,7 +29,7 @@ In non HA mode, you should first start the job cluster service:
 
 In order to deploy the job cluster entrypoint run:
 
-`FLINK_IMAGE_NAME=<IMAGE_NAME> FLINK_JOB_PARALLELISM=<PARALLELISM> envsubst < job-cluster-job.yaml.template | kubectl create -f -`
+`FLINK_IMAGE_NAME=<IMAGE_NAME> FLINK_JOB_PARALLELISM=<PARALLELISM> JOB_CLASSNAME=<JOBCLASSNAME> envsubst < job-cluster-job.yaml.template | kubectl create -f -`
 
 Now you should see the `flink-job-cluster` job being started by calling `kubectl get job`.
 

--- a/flink-container/kubernetes/job-cluster-job.yaml.template
+++ b/flink-container/kubernetes/job-cluster-job.yaml.template
@@ -31,7 +31,7 @@ spec:
       containers:
       - name: flink-job-cluster
         image: ${FLINK_IMAGE_NAME}
-        args: ["job-cluster", "-Djobmanager.rpc.address=flink-job-cluster",
+        args: ["job-cluster", "--job-classname=${JOB_CLASSNAME}", "-Djobmanager.rpc.address=flink-job-cluster",
                "-Dparallelism.default=${FLINK_JOB_PARALLELISM}", "-Dblob.server.port=6124", "-Dqueryable-state.server.ports=6125"]
         ports:
         - containerPort: 6123


### PR DESCRIPTION
…b-cluster-job.yaml.template'

## What is the purpose of the change

* When use 'job-cluster-job.yaml.template' deploy a job, the template don't have a good sense about how to use  '--job-classname', add '--job-classname' to 'job-cluster-job.yaml.template'*


## Brief change log
  - *add '--job-classname' to 'job-cluster-job.yaml.template'**

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs )
