### PR TITLE
[FLINK-15076][task] Fix SourceStreamTask cancellation (backport to 1.9)

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -153,8 +153,13 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 
 	@Override
 	protected void cancelTask() {
-		if (headOperator != null) {
-			headOperator.cancel();
+		try {
+			if (headOperator != null) {
+				headOperator.cancel();
+			}
+		}
+		finally {
+			sourceThread.interrupt();
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -281,6 +281,26 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		}
 	}
 
+	private void runAndHandleCancel() throws Exception {
+		try {
+			run();
+		}
+		catch (InterruptedException e) {
+			if (!canceled) {
+				Thread.currentThread().interrupt();
+				throw e;
+			}
+		}
+		catch (Exception e) {
+			if (canceled) {
+				LOG.warn("Error while canceling task.", e);
+			}
+			else {
+				throw e;
+			}
+		}
+	}
+
 	/**
 	 * Runs the stream-tasks main processing loop.
 	 */
@@ -403,7 +423,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
 			// let the task do its work
 			isRunning = true;
-			run();
+			runAndHandleCancel();
 
 			// if this left the run() method cleanly despite the fact that this was canceled,
 			// make sure the "clean shutdown" is not attempted


### PR DESCRIPTION
Source thread should be interrupted more or less the same way how task thread is
being interrupted. This is important for example as in the scenario presented in the
SourceStreamTaskTest#testCancellationWithSourceBlockedOnLock(). SourceFunction is
blocked while holding checkpointLock, which might prevent task thread from
cancelling properly if the SourceFunction is not interrupted.

## Verifying this change

This PR is adding a couple of tests and modifies some of the existing ones.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
