### PR TITLE
[FLINK-15082] Respect new FLIP-49 taskmanager.memory.total-process.size in Mesos RM

### DIFF
--- a/docs/_includes/generated/mesos_task_manager_configuration.html
+++ b/docs/_includes/generated/mesos_task_manager_configuration.html
@@ -75,12 +75,6 @@
             <td>Optional value to define the TaskManager’s hostname. The pattern _TASK_ is replaced by the actual id of the Mesos task. This can be used to configure the TaskManager to use Mesos DNS (e.g. _TASK_.flink-service.mesos) for name lookups.</td>
         </tr>
         <tr>
-            <td><h5>mesos.resourcemanager.tasks.mem</h5></td>
-            <td style="word-wrap: break-word;">1024</td>
-            <td>Integer</td>
-            <td>Memory to assign to the Mesos workers in MB.</td>
-        </tr>
-        <tr>
             <td><h5>mesos.resourcemanager.tasks.taskmanager-cmd</h5></td>
             <td style="word-wrap: break-word;">"$FLINK_HOME/bin/mesos-taskmanager.sh"</td>
             <td>String</td>

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -57,6 +57,12 @@ public class MesosTaskManagerParameters {
 	public static final ConfigOption<Integer> MESOS_RM_TASKS_SLOTS =
 		TaskManagerOptions.NUM_TASK_SLOTS;
 
+	/**
+	 * Total task executor container memory in megabytes to allocate.
+	 *
+	 * @deprecated set explicitly {@link TaskManagerOptions#TOTAL_PROCESS_MEMORY} instead
+	 */
+	@Deprecated
 	public static final ConfigOption<Integer> MESOS_RM_TASKS_MEMORY_MB =
 		key("mesos.resourcemanager.tasks.mem")
 		.defaultValue(1024)

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.mesos.runtime.clusterframework;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.util.TestLogger;
 
@@ -42,6 +43,9 @@ import static org.junit.Assert.assertThat;
  * Tests for the {@link MesosTaskManagerParameters}.
  */
 public class MesosTaskManagerParametersTest extends TestLogger {
+	private static final int TOTAL_PROCESS_MEMORY_MB = 1280;
+	private static final String TOTAL_PROCESS_MEMORY_MB_STRING = TOTAL_PROCESS_MEMORY_MB + "m";
+	private static final MemorySize TOTAL_PROCESS_MEMORY_SIZE = MemorySize.parse(TOTAL_PROCESS_MEMORY_MB_STRING);
 
 	@Test
 	public void testBuildVolumes() throws Exception {
@@ -233,9 +237,41 @@ public class MesosTaskManagerParametersTest extends TestLogger {
 		assertThat(mesosTaskManagerParameters.cpus(), is(1.5));
 	}
 
+	@Test
+	public void testUnifiedTotalProcessMemoryConfiguration() {
+		assertTotalProcessMemory(MesosTaskManagerParameters.create(getConfiguration()));
+	}
+
+	@Test
+	public void testLegacyMesosSpecificTotalProcessMemoryConfiguration() {
+		Configuration config = new Configuration();
+		config.setInteger(MESOS_RM_TASKS_MEMORY_MB, TOTAL_PROCESS_MEMORY_MB);
+		assertTotalProcessMemory(MesosTaskManagerParameters.create(config));
+	}
+
+	@Test
+	public void testUnifiedAndLegacyMesosSpecificTotalProcessMemoryConfigMatchIsOk() {
+		Configuration config = getConfiguration();
+		config.setInteger(MESOS_RM_TASKS_MEMORY_MB, TOTAL_PROCESS_MEMORY_MB);
+		assertTotalProcessMemory(MesosTaskManagerParameters.create(config));
+	}
+
+	@Test(expected = IllegalConfigurationException.class)
+	public void testUnifiedAndLegacyMesosSpecificTotalProcessMemoryConfigDifferFails() {
+		Configuration config = getConfiguration();
+		config.setInteger(MESOS_RM_TASKS_MEMORY_MB, TOTAL_PROCESS_MEMORY_MB / 2);
+		assertTotalProcessMemory(MesosTaskManagerParameters.create(config));
+	}
+
+	private void assertTotalProcessMemory(MesosTaskManagerParameters mesosTaskManagerParameters) {
+		assertThat(
+			mesosTaskManagerParameters.containeredParameters().getTaskExecutorResourceSpec().getTotalProcessMemorySize(),
+			is(TOTAL_PROCESS_MEMORY_SIZE));
+	}
+
 	private static Configuration getConfiguration() {
 		Configuration config = new Configuration();
-		config.setInteger(MESOS_RM_TASKS_MEMORY_MB, 1280);
+		config.setString(TaskManagerOptions.TOTAL_PROCESS_MEMORY, TOTAL_PROCESS_MEMORY_MB_STRING);
 		return config;
 	}
 


### PR DESCRIPTION
## What is the purpose of the change


- If `taskmanager.memory.total-process.size` and `mesos.resourcemanager.tasks.mem` are both set and differ in their values, an exception should be thrown
- If only `taskmanager.memory.total-process.size` is set and `mesos.resourcemanager.tasks.mem` is not set, then the value configured by the former should be respected
- If only `mesos.resourcemanager.tasks.mem` is set and` taskmanager.memory.total-process.size` is not set, then the value configured by the former should be respected

## Brief change log

  - Add the described configuration change to `MesosTaskManagerParameters#createContaineredTaskManagerParameters`
  - Add unit tests for that


## Verifying this change

Unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (the options are already documented)
