### PR TITLE
[FLINK-14007][python][docs] Add documentation for how to use Java user-defined source/sink in Python API

### DIFF
--- a/docs/dev/table/sourceSinks.md
+++ b/docs/dev/table/sourceSinks.md
@@ -714,10 +714,11 @@ connector.debug=true
 
 For a type-safe, programmatic approach with explanatory Scaladoc/Javadoc, the Table & SQL API offers descriptors in `org.apache.flink.table.descriptors` that translate into string-based properties. See the [built-in descriptors](connect.html) for sources, sinks, and formats as a reference.
 
-A connector for `MySystem` in our example can extend `ConnectorDescriptor` as shown below:
-
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
+
+A connector for `MySystem` in our example can extend `ConnectorDescriptor` as shown below:
+
 {% highlight java %}
 import org.apache.flink.table.descriptors.ConnectorDescriptor;
 import java.util.HashMap;
@@ -743,9 +744,25 @@ public class MySystemConnector extends ConnectorDescriptor {
   }
 }
 {% endhighlight %}
+
+The descriptor can then be used in the API as follows:
+
+{% highlight java %}
+StreamTableEnvironment tableEnv = // ...
+
+tableEnv
+  .connect(new MySystemConnector(true))
+  .withSchema(...)
+  .inAppendMode()
+  .createTemporaryTable("MySystemTable");
+{% endhighlight %}
+
 </div>
 
 <div data-lang="scala" markdown="1">
+
+A connector for `MySystem` in our example can extend `ConnectorDescriptor` as shown below:
+
 {% highlight scala %}
 import org.apache.flink.table.descriptors.ConnectorDescriptor
 import java.util.HashMap
@@ -763,25 +780,9 @@ class MySystemConnector(isDebug: Boolean) extends ConnectorDescriptor("my-system
   }
 }
 {% endhighlight %}
-</div>
-</div>
 
 The descriptor can then be used in the API as follows:
 
-<div class="codetabs" markdown="1">
-<div data-lang="java" markdown="1">
-{% highlight java %}
-StreamTableEnvironment tableEnv = // ...
-
-tableEnv
-  .connect(new MySystemConnector(true))
-  .withSchema(...)
-  .inAppendMode()
-  .createTemporaryTable("MySystemTable");
-{% endhighlight %}
-</div>
-
-<div data-lang="scala" markdown="1">
 {% highlight scala %}
 val tableEnv: StreamTableEnvironment = // ...
 
@@ -791,7 +792,26 @@ tableEnv
   .inAppendMode()
   .createTemporaryTable("MySystemTable")
 {% endhighlight %}
+
 </div>
+
+<div data-lang="python" markdown="1">
+
+You can also use the Java TableFactory in Python. A default `CustomConnectorDescriptor` python class has been provided and you can use it in the API as follows:
+
+{% highlight python %}
+s_env = StreamExecutionEnvironment.get_execution_environment()
+st_env = StreamTableEnvironment.create(s_env)
+
+custom_connector = CustomConnectorDescriptor('my-system', 1, False)
+st_env\
+    .connect(custom_connector.property("connector.debug", "true")) \
+    .with_schema(...) \
+    .in_append_mode()\
+    .create_temporary_table("MySystemTable")
+{% endhighlight %}
+</div>
+
 </div>
 
 {% top %}

--- a/docs/dev/table/sourceSinks.zh.md
+++ b/docs/dev/table/sourceSinks.zh.md
@@ -714,10 +714,11 @@ connector.debug=true
 
 For a type-safe, programmatic approach with explanatory Scaladoc/Javadoc, the Table & SQL API offers descriptors in `org.apache.flink.table.descriptors` that translate into string-based properties. See the [built-in descriptors](connect.html) for sources, sinks, and formats as a reference.
 
-A connector for `MySystem` in our example can extend `ConnectorDescriptor` as shown below:
-
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
+
+A connector for `MySystem` in our example can extend `ConnectorDescriptor` as shown below:
+
 {% highlight java %}
 import org.apache.flink.table.descriptors.ConnectorDescriptor;
 import java.util.HashMap;
@@ -743,9 +744,24 @@ public class MySystemConnector extends ConnectorDescriptor {
   }
 }
 {% endhighlight %}
+
+The descriptor can then be used in the API as follows:
+
+{% highlight java %}
+StreamTableEnvironment tableEnv = // ...
+
+tableEnv
+  .connect(new MySystemConnector(true))
+  .withSchema(...)
+  .inAppendMode()
+  .createTemporaryTable("MySystemTable");
+{% endhighlight %}
 </div>
 
 <div data-lang="scala" markdown="1">
+
+A connector for `MySystem` in our example can extend `ConnectorDescriptor` as shown below:
+
 {% highlight scala %}
 import org.apache.flink.table.descriptors.ConnectorDescriptor
 import java.util.HashMap
@@ -763,25 +779,9 @@ class MySystemConnector(isDebug: Boolean) extends ConnectorDescriptor("my-system
   }
 }
 {% endhighlight %}
-</div>
-</div>
 
 The descriptor can then be used in the API as follows:
 
-<div class="codetabs" markdown="1">
-<div data-lang="java" markdown="1">
-{% highlight java %}
-StreamTableEnvironment tableEnv = // ...
-
-tableEnv
-  .connect(new MySystemConnector(true))
-  .withSchema(...)
-  .inAppendMode()
-  .createTemporaryTable("MySystemTable");
-{% endhighlight %}
-</div>
-
-<div data-lang="scala" markdown="1">
 {% highlight scala %}
 val tableEnv: StreamTableEnvironment = // ...
 
@@ -791,7 +791,25 @@ tableEnv
   .inAppendMode()
   .createTemporaryTable("MySystemTable")
 {% endhighlight %}
+
+</div>
+<div data-lang="python" markdown="1">
+
+You can also use the Java TableFactory in Python. A default `CustomConnectorDescriptor` python class has been provided and you can use it in the API as follows:
+
+{% highlight python %}
+s_env = StreamExecutionEnvironment.get_execution_environment()
+st_env = StreamTableEnvironment.create(s_env)
+
+custom_connector = CustomConnectorDescriptor('my-system', 1, False)
+st_env\
+    .connect(custom_connector.property("connector.debug", "true")) \
+    .with_schema(...) \
+    .in_append_mode()\
+    .create_temporary_table("MySystemTable")
+{% endhighlight %}
 </div>
 </div>
+
 
 {% top %}


### PR DESCRIPTION


## What is the purpose of the change

This pull request adds documentation for how to use Java user-defined source/sink in Python API.


## Brief change log

  - Add document on how to use the Java TableFactory in Python.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
