### PR TITLE
[FLINK-14006][python][docs] Add documentation for how to specify JAR file when submit python jobs

### DIFF
--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -107,6 +107,10 @@ These examples about how to submit a job in CLI.
         ./bin/flink run -py examples/python/table/batch/word_count.py \
                                 -pyfs file:///user.txt,hdfs:///$namenode_address/username.txt
 
+-   Run Python Table program with a JAR file:
+
+        ./bin/flink run -py examples/python/table/batch/word_count.py -j <jarFile>
+
 -   Run Python Table program with pyFiles and pyModule:
 
         ./bin/flink run -pym batch.word_count -pyfs examples/python/table/batch

--- a/docs/ops/cli.zh.md
+++ b/docs/ops/cli.zh.md
@@ -107,6 +107,10 @@ available.
         ./bin/flink run -py examples/python/table/batch/word_count.py \
                                 -pyfs file:///user.txt,hdfs:///$namenode_address/username.txt
 
+-   提交一个Python Table的作业，并指定依赖的jar包:
+
+        ./bin/flink run -py examples/python/table/batch/word_count.py -j <jarFile>
+
 -   提交一个有多个依赖的Python Table的作业，Python作业的主入口通过pym选项指定:
 
         ./bin/flink run -pym batch.word_count -pyfs examples/python/table/batch


### PR DESCRIPTION

## What is the purpose of the change
Currently, we only have documentation on how to using the Java UDF APIs in Python, but do not mention how to add the JARs to the classpath. This pull request adds documentation on how to specify the user Jar file through the command line when submitting python jobs.

## Brief change log

  - Add documentation for how to specify JAR file when submitting python jobs

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
