### PR TITLE
[FLINK-14926][state-backend-rocksdb] Ensure that RocksObjects are always closed on backend disposal

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/ConfigurableRocksDBOptionsFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/ConfigurableRocksDBOptionsFactory.java
@@ -21,9 +21,9 @@ package org.apache.flink.contrib.streaming.state;
 import org.apache.flink.configuration.Configuration;
 
 /**
- * @deprecated Replaced by {@link ConfigurableRocksDBOptionsFactory}.
+ * An interface for options factory that pick up additional parameters from a configuration.
  */
-public interface ConfigurableOptionsFactory extends OptionsFactory {
+public interface ConfigurableRocksDBOptionsFactory extends RocksDBOptionsFactory {
 
 	/**
 	 * Creates a variant of the options factory that applies additional configuration parameters.
@@ -35,5 +35,5 @@ public interface ConfigurableOptionsFactory extends OptionsFactory {
 	 * @param configuration The configuration to pick the values from.
 	 * @return A reconfigured options factory.
 	 */
-	OptionsFactory configure(Configuration configuration);
+	RocksDBOptionsFactory configure(Configuration configuration);
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/DefaultConfigurableOptionsFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/DefaultConfigurableOptionsFactory.java
@@ -32,12 +32,11 @@ import org.rocksdb.TableFormatConfig;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.BLOCK_CACHE_SIZE;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.BLOCK_SIZE;
@@ -56,6 +55,8 @@ import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOption
  * It acts as the default options factory within {@link RocksDBStateBackend} if the user did not define a {@link OptionsFactory}.
  */
 public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFactory {
+
+	private static final long serialVersionUID = 1L;
 
 	private final Map<String, String> configuredOptions = new HashMap<>();
 
@@ -131,7 +132,7 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFac
 		return new HashMap<>(configuredOptions);
 	}
 
-	private boolean isOptionConfigured(ConfigOption configOption) {
+	private boolean isOptionConfigured(ConfigOption<?> configOption) {
 		return configuredOptions.containsKey(configOption.key());
 	}
 
@@ -300,43 +301,36 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFac
 		return this;
 	}
 
-	private static final String[] CANDIDATE_CONFIGS = new String[]{
+	private static final ConfigOption<?>[] CANDIDATE_CONFIGS = new ConfigOption<?>[] {
 		// configurable DBOptions
-		MAX_BACKGROUND_THREADS.key(),
-		MAX_OPEN_FILES.key(),
+		MAX_BACKGROUND_THREADS,
+		MAX_OPEN_FILES,
 
 		// configurable ColumnFamilyOptions
-		COMPACTION_STYLE.key(),
-		USE_DYNAMIC_LEVEL_SIZE.key(),
-		TARGET_FILE_SIZE_BASE.key(),
-		MAX_SIZE_LEVEL_BASE.key(),
-		WRITE_BUFFER_SIZE.key(),
-		MAX_WRITE_BUFFER_NUMBER.key(),
-		MIN_WRITE_BUFFER_NUMBER_TO_MERGE.key(),
-		BLOCK_SIZE.key(),
-		BLOCK_CACHE_SIZE.key()
+		COMPACTION_STYLE,
+		USE_DYNAMIC_LEVEL_SIZE,
+		TARGET_FILE_SIZE_BASE,
+		MAX_SIZE_LEVEL_BASE,
+		WRITE_BUFFER_SIZE,
+		MAX_WRITE_BUFFER_NUMBER,
+		MIN_WRITE_BUFFER_NUMBER_TO_MERGE,
+		BLOCK_SIZE,
+		BLOCK_CACHE_SIZE
 	};
 
-	private static final Set<String> POSITIVE_INT_CONFIG_SET = new HashSet<>(Arrays.asList(
-		MAX_BACKGROUND_THREADS.key(),
-		MAX_WRITE_BUFFER_NUMBER.key(),
-		MIN_WRITE_BUFFER_NUMBER_TO_MERGE.key()
+	private static final Set<ConfigOption<?>> POSITIVE_INT_CONFIG_SET = new HashSet<>(Arrays.asList(
+		MAX_BACKGROUND_THREADS,
+		MAX_WRITE_BUFFER_NUMBER,
+		MIN_WRITE_BUFFER_NUMBER_TO_MERGE
 	));
 
-	private static final Set<String> SIZE_CONFIG_SET = new HashSet<>(Arrays.asList(
-		TARGET_FILE_SIZE_BASE.key(),
-		MAX_SIZE_LEVEL_BASE.key(),
-		WRITE_BUFFER_SIZE.key(),
-		BLOCK_SIZE.key(),
-		BLOCK_CACHE_SIZE.key()
+	private static final Set<ConfigOption<?>> SIZE_CONFIG_SET = new HashSet<>(Arrays.asList(
+		TARGET_FILE_SIZE_BASE,
+		MAX_SIZE_LEVEL_BASE,
+		WRITE_BUFFER_SIZE,
+		BLOCK_SIZE,
+		BLOCK_CACHE_SIZE
 	));
-
-	private static final Set<String> BOOLEAN_CONFIG_SET = new HashSet<>(Collections.singletonList(
-		USE_DYNAMIC_LEVEL_SIZE.key()
-	));
-
-	private static final Set<String> COMPACTION_STYLE_SET = Arrays.stream(CompactionStyle.values())
-		.map(c -> c.name().toLowerCase()).collect(Collectors.toSet());
 
 	/**
 	 * Creates a {@link DefaultConfigurableOptionsFactory} instance from a {@link Configuration}.
@@ -349,13 +343,12 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFac
 	 */
 	@Override
 	public DefaultConfigurableOptionsFactory configure(Configuration configuration) {
-		for (String key : CANDIDATE_CONFIGS) {
-			String newValue = configuration.getString(key, null);
+		for (ConfigOption<?> option : CANDIDATE_CONFIGS) {
+			Optional<?> newValue = configuration.getOptional(option);
 
-			if (newValue != null) {
-				if (checkArgumentValid(key, newValue)) {
-					this.configuredOptions.put(key, newValue);
-				}
+			if (newValue.isPresent()) {
+				checkArgumentValid(option, newValue.get());
+				this.configuredOptions.put(option.key(), newValue.get().toString());
 			}
 		}
 		return this;
@@ -371,30 +364,19 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFac
 	/**
 	 * Helper method to check whether the (key,value) is valid through given configuration and returns the formatted value.
 	 *
-	 * @param key The configuration key which is configurable in {@link RocksDBConfigurableOptions}.
+	 * @param option The configuration key which is configurable in {@link RocksDBConfigurableOptions}.
 	 * @param value The value within given configuration.
-	 *
-	 * @return whether the given key and value in string format is legal.
 	 */
-	private static boolean checkArgumentValid(String key, String value) {
-		if (POSITIVE_INT_CONFIG_SET.contains(key)) {
+	private static void checkArgumentValid(ConfigOption<?> option, Object value) {
+		final String key = option.key();
 
-			Preconditions.checkArgument(Integer.parseInt(value) > 0,
+		if (POSITIVE_INT_CONFIG_SET.contains(option)) {
+			Preconditions.checkArgument((Integer) value  > 0,
 				"Configured value for key: " + key + " must be larger than 0.");
-		} else if (SIZE_CONFIG_SET.contains(key)) {
-
-			Preconditions.checkArgument(MemorySize.parseBytes(value) > 0,
+		} else if (SIZE_CONFIG_SET.contains(option)) {
+			Preconditions.checkArgument(((MemorySize) value).getBytes() > 0,
 				"Configured size for key" + key + " must be larger than 0.");
-		} else if (BOOLEAN_CONFIG_SET.contains(key)) {
-
-			Preconditions.checkArgument("true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value),
-				"The configured boolean value: " + value + " for key: " + key + " is illegal.");
-		} else if (key.equals(COMPACTION_STYLE.key())) {
-			value = value.toLowerCase();
-			Preconditions.checkArgument(COMPACTION_STYLE_SET.contains(value),
-				"Compression type: " + value + " is not recognized with legal types: " + String.join(", ", COMPACTION_STYLE_SET));
 		}
-		return true;
 	}
 
 	/**

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/DefaultConfigurableOptionsFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/DefaultConfigurableOptionsFactory.java
@@ -51,10 +51,10 @@ import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOption
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.WRITE_BUFFER_SIZE;
 
 /**
- * An implementation of {@link ConfigurableOptionsFactory} using options provided by {@link RocksDBConfigurableOptions}.
- * It acts as the default options factory within {@link RocksDBStateBackend} if the user did not define a {@link OptionsFactory}.
+ * An implementation of {@link ConfigurableRocksDBOptionsFactory} using options provided by {@link RocksDBConfigurableOptions}.
+ * It acts as the default options factory within {@link RocksDBStateBackend} if the user did not define a {@link RocksDBOptionsFactory}.
  */
-public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFactory {
+public class DefaultConfigurableOptionsFactory implements ConfigurableRocksDBOptionsFactory {
 
 	private static final long serialVersionUID = 1L;
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/DefaultConfigurableOptionsFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/DefaultConfigurableOptionsFactory.java
@@ -31,6 +31,7 @@ import org.rocksdb.PlainTableConfig;
 import org.rocksdb.TableFormatConfig;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -59,7 +60,7 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFac
 	private final Map<String, String> configuredOptions = new HashMap<>();
 
 	@Override
-	public DBOptions createDBOptions(DBOptions currentOptions) {
+	public DBOptions createDBOptions(DBOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
 		if (isOptionConfigured(MAX_BACKGROUND_THREADS)) {
 			currentOptions.setIncreaseParallelism(getMaxBackgroundThreads());
 		}
@@ -72,7 +73,7 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableOptionsFac
 	}
 
 	@Override
-	public ColumnFamilyOptions createColumnOptions(ColumnFamilyOptions currentOptions) {
+	public ColumnFamilyOptions createColumnOptions(ColumnFamilyOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
 		if (isOptionConfigured(COMPACTION_STYLE)) {
 			currentOptions.setCompactionStyle(getCompactionStyle());
 		}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/OptionsFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/OptionsFactory.java
@@ -21,6 +21,8 @@ package org.apache.flink.contrib.streaming.state;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
 
+import java.util.Collection;
+
 /**
  * A factory for {@link DBOptions} and {@link ColumnFamilyOptions} to be passed to the {@link RocksDBStateBackend}.
  * Options have to be created lazily by this factory, because the {@code Options}
@@ -52,9 +54,21 @@ public interface OptionsFactory extends java.io.Serializable {
 	 * the setter methods, otherwise the pre-defined options may get lost.
 	 *
 	 * @param currentOptions The options object with the pre-defined options.
+	 * @param handlesToClose The collection to register newly created {@link org.rocksdb.RocksObject}s.
 	 * @return The options object on which the additional options are set.
 	 */
-	DBOptions createDBOptions(DBOptions currentOptions);
+	DBOptions createDBOptions(DBOptions currentOptions, Collection<AutoCloseable> handlesToClose);
+
+	/**
+	 * Set the additional options on top of the current options object.
+	 *
+	 * @param currentOptions The options object with the pre-defined options.
+	 * @return The options object on which the additional options are set.
+	 * @deprecated use {@link #createDBOptions(DBOptions, Collection)} instead.
+	 */
+	default DBOptions createDBOptions(DBOptions currentOptions) {
+		return createDBOptions(currentOptions, null);
+	}
 
 	/**
 	 * This method should set the additional options on top of the current options object.
@@ -65,9 +79,21 @@ public interface OptionsFactory extends java.io.Serializable {
 	 * the setter methods, otherwise the pre-defined options may get lost.
 	 *
 	 * @param currentOptions The options object with the pre-defined options.
+	 * @param handlesToClose The collection to register newly created {@link org.rocksdb.RocksObject}s.
 	 * @return The options object on which the additional options are set.
 	 */
-	ColumnFamilyOptions createColumnOptions(ColumnFamilyOptions currentOptions);
+	ColumnFamilyOptions createColumnOptions(ColumnFamilyOptions currentOptions, Collection<AutoCloseable> handlesToClose);
+
+	/**
+	 * Set the additional options on top of the current options object.
+	 *
+	 * @param currentOptions The options object with the pre-defined options.
+	 * @return The options object on which the additional options are set.
+	 * @deprecated use {@link #createColumnOptions(ColumnFamilyOptions, Collection)} instead.
+	 */
+	default ColumnFamilyOptions createColumnOptions(ColumnFamilyOptions currentOptions) {
+		return createColumnOptions(currentOptions, null);
+	}
 
 	/**
 	 * This method should enable certain RocksDB metrics to be forwarded to

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
@@ -25,6 +25,7 @@ import org.rocksdb.CompactionStyle;
 import org.rocksdb.DBOptions;
 import org.rocksdb.InfoLogLevel;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 /**
@@ -58,24 +59,15 @@ public enum PredefinedOptions {
 
 		@Override
 		public DBOptions createDBOptions(Collection<AutoCloseable> handlesToClose) {
-			DBOptions dbOptions =
-				new DBOptions()
+			return new DBOptions()
 					.setUseFsync(false)
 					.setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)
 					.setStatsDumpPeriodSec(0);
-			if (handlesToClose != null) {
-				handlesToClose.add(dbOptions);
-			}
-			return dbOptions;
 		}
 
 		@Override
 		public ColumnFamilyOptions createColumnOptions(Collection<AutoCloseable> handlesToClose) {
-			ColumnFamilyOptions columnFamilyOptions = new ColumnFamilyOptions();
-			if (handlesToClose != null) {
-				handlesToClose.add(columnFamilyOptions);
-			}
-			return columnFamilyOptions;
+			return new ColumnFamilyOptions();
 		}
 
 	},
@@ -106,29 +98,19 @@ public enum PredefinedOptions {
 
 		@Override
 		public DBOptions createDBOptions(Collection<AutoCloseable> handlesToClose) {
-			DBOptions dbOptions =
-				new DBOptions()
+			return new DBOptions()
 					.setIncreaseParallelism(4)
 					.setUseFsync(false)
 					.setMaxOpenFiles(-1)
 					.setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)
 					.setStatsDumpPeriodSec(0);
-			if (handlesToClose != null) {
-				handlesToClose.add(dbOptions);
-			}
-			return dbOptions;
 		}
 
 		@Override
 		public ColumnFamilyOptions createColumnOptions(Collection<AutoCloseable> handlesToClose) {
-			ColumnFamilyOptions columnFamilyOptions =
-				new ColumnFamilyOptions()
+			return new ColumnFamilyOptions()
 					.setCompactionStyle(CompactionStyle.LEVEL)
 					.setLevelCompactionDynamicLevelBytes(true);
-			if (handlesToClose != null) {
-				handlesToClose.add(columnFamilyOptions);
-			}
-			return columnFamilyOptions;
 		}
 	},
 
@@ -164,18 +146,12 @@ public enum PredefinedOptions {
 
 		@Override
 		public DBOptions createDBOptions(Collection<AutoCloseable> handlesToClose) {
-
-			DBOptions dbOptions =
-				new DBOptions()
+			return new DBOptions()
 					.setIncreaseParallelism(4)
 					.setUseFsync(false)
 					.setMaxOpenFiles(-1)
 					.setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)
 					.setStatsDumpPeriodSec(0);
-			if (handlesToClose != null) {
-				handlesToClose.add(dbOptions);
-			}
-			return dbOptions;
 		}
 
 		@Override
@@ -187,8 +163,9 @@ public enum PredefinedOptions {
 			final long writeBufferSize = 64 * 1024 * 1024;
 
 			BloomFilter bloomFilter = new BloomFilter();
-			ColumnFamilyOptions columnFamilyOptions =
-				new ColumnFamilyOptions()
+			handlesToClose.add(bloomFilter);
+
+			return new ColumnFamilyOptions()
 					.setCompactionStyle(CompactionStyle.LEVEL)
 					.setLevelCompactionDynamicLevelBytes(true)
 					.setTargetFileSizeBase(targetFileSize)
@@ -202,11 +179,6 @@ public enum PredefinedOptions {
 									.setBlockSize(blockSize)
 									.setFilter(bloomFilter)
 					);
-			if (handlesToClose != null) {
-				handlesToClose.add(bloomFilter);
-				handlesToClose.add(columnFamilyOptions);
-			}
-			return columnFamilyOptions;
 		}
 	},
 
@@ -233,26 +205,17 @@ public enum PredefinedOptions {
 
 		@Override
 		public DBOptions createDBOptions(Collection<AutoCloseable> handlesToClose) {
-			DBOptions dbOptions =
-				new DBOptions()
+			return new DBOptions()
 					.setIncreaseParallelism(4)
 					.setUseFsync(false)
 					.setMaxOpenFiles(-1)
 					.setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)
 					.setStatsDumpPeriodSec(0);
-			if (handlesToClose != null) {
-				handlesToClose.add(dbOptions);
-			}
-			return dbOptions;
 		}
 
 		@Override
 		public ColumnFamilyOptions createColumnOptions(Collection<AutoCloseable> handlesToClose) {
-			ColumnFamilyOptions columnFamilyOptions = new ColumnFamilyOptions();
-			if (handlesToClose != null) {
-				handlesToClose.add(columnFamilyOptions);
-			}
-			return columnFamilyOptions;
+			return new ColumnFamilyOptions();
 		}
 	};
 
@@ -271,7 +234,7 @@ public enum PredefinedOptions {
 	 * @deprecated use {@link #createColumnOptions(Collection)} instead.
 	 */
 	public DBOptions createDBOptions() {
-		return createDBOptions(null);
+		return createDBOptions(new ArrayList<>());
 	}
 
 	/**
@@ -287,7 +250,7 @@ public enum PredefinedOptions {
 	 * @deprecated use {@link #createColumnOptions(Collection)} instead.
 	 */
 	public ColumnFamilyOptions createColumnOptions() {
-		return createColumnOptions(null);
+		return createColumnOptions(new ArrayList<>());
 	}
 
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
@@ -25,6 +25,8 @@ import org.rocksdb.CompactionStyle;
 import org.rocksdb.DBOptions;
 import org.rocksdb.InfoLogLevel;
 
+import java.util.Collection;
+
 /**
  * The {@code PredefinedOptions} are configuration settings for the {@link RocksDBStateBackend}.
  * The various pre-defined choices are configurations that have been empirically
@@ -55,16 +57,25 @@ public enum PredefinedOptions {
 	DEFAULT {
 
 		@Override
-		public DBOptions createDBOptions() {
-			return new DBOptions()
+		public DBOptions createDBOptions(Collection<AutoCloseable> handlesToClose) {
+			DBOptions dbOptions =
+				new DBOptions()
 					.setUseFsync(false)
 					.setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)
 					.setStatsDumpPeriodSec(0);
+			if (handlesToClose != null) {
+				handlesToClose.add(dbOptions);
+			}
+			return dbOptions;
 		}
 
 		@Override
-		public ColumnFamilyOptions createColumnOptions() {
-			return new ColumnFamilyOptions();
+		public ColumnFamilyOptions createColumnOptions(Collection<AutoCloseable> handlesToClose) {
+			ColumnFamilyOptions columnFamilyOptions = new ColumnFamilyOptions();
+			if (handlesToClose != null) {
+				handlesToClose.add(columnFamilyOptions);
+			}
+			return columnFamilyOptions;
 		}
 
 	},
@@ -94,21 +105,30 @@ public enum PredefinedOptions {
 	SPINNING_DISK_OPTIMIZED {
 
 		@Override
-		public DBOptions createDBOptions() {
-
-			return new DBOptions()
+		public DBOptions createDBOptions(Collection<AutoCloseable> handlesToClose) {
+			DBOptions dbOptions =
+				new DBOptions()
 					.setIncreaseParallelism(4)
 					.setUseFsync(false)
 					.setMaxOpenFiles(-1)
 					.setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)
 					.setStatsDumpPeriodSec(0);
+			if (handlesToClose != null) {
+				handlesToClose.add(dbOptions);
+			}
+			return dbOptions;
 		}
 
 		@Override
-		public ColumnFamilyOptions createColumnOptions() {
-			return new ColumnFamilyOptions()
+		public ColumnFamilyOptions createColumnOptions(Collection<AutoCloseable> handlesToClose) {
+			ColumnFamilyOptions columnFamilyOptions =
+				new ColumnFamilyOptions()
 					.setCompactionStyle(CompactionStyle.LEVEL)
 					.setLevelCompactionDynamicLevelBytes(true);
+			if (handlesToClose != null) {
+				handlesToClose.add(columnFamilyOptions);
+			}
+			return columnFamilyOptions;
 		}
 	},
 
@@ -143,25 +163,32 @@ public enum PredefinedOptions {
 	SPINNING_DISK_OPTIMIZED_HIGH_MEM {
 
 		@Override
-		public DBOptions createDBOptions() {
+		public DBOptions createDBOptions(Collection<AutoCloseable> handlesToClose) {
 
-			return new DBOptions()
+			DBOptions dbOptions =
+				new DBOptions()
 					.setIncreaseParallelism(4)
 					.setUseFsync(false)
 					.setMaxOpenFiles(-1)
 					.setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)
 					.setStatsDumpPeriodSec(0);
+			if (handlesToClose != null) {
+				handlesToClose.add(dbOptions);
+			}
+			return dbOptions;
 		}
 
 		@Override
-		public ColumnFamilyOptions createColumnOptions() {
+		public ColumnFamilyOptions createColumnOptions(Collection<AutoCloseable> handlesToClose) {
 
 			final long blockCacheSize = 256 * 1024 * 1024;
 			final long blockSize = 128 * 1024;
 			final long targetFileSize = 256 * 1024 * 1024;
 			final long writeBufferSize = 64 * 1024 * 1024;
 
-			return new ColumnFamilyOptions()
+			BloomFilter bloomFilter = new BloomFilter();
+			ColumnFamilyOptions columnFamilyOptions =
+				new ColumnFamilyOptions()
 					.setCompactionStyle(CompactionStyle.LEVEL)
 					.setLevelCompactionDynamicLevelBytes(true)
 					.setTargetFileSizeBase(targetFileSize)
@@ -173,8 +200,13 @@ public enum PredefinedOptions {
 							new BlockBasedTableConfig()
 									.setBlockCacheSize(blockCacheSize)
 									.setBlockSize(blockSize)
-									.setFilter(new BloomFilter())
+									.setFilter(bloomFilter)
 					);
+			if (handlesToClose != null) {
+				handlesToClose.add(bloomFilter);
+				handlesToClose.add(columnFamilyOptions);
+			}
+			return columnFamilyOptions;
 		}
 	},
 
@@ -200,18 +232,27 @@ public enum PredefinedOptions {
 	FLASH_SSD_OPTIMIZED {
 
 		@Override
-		public DBOptions createDBOptions() {
-			return new DBOptions()
+		public DBOptions createDBOptions(Collection<AutoCloseable> handlesToClose) {
+			DBOptions dbOptions =
+				new DBOptions()
 					.setIncreaseParallelism(4)
 					.setUseFsync(false)
 					.setMaxOpenFiles(-1)
 					.setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)
 					.setStatsDumpPeriodSec(0);
+			if (handlesToClose != null) {
+				handlesToClose.add(dbOptions);
+			}
+			return dbOptions;
 		}
 
 		@Override
-		public ColumnFamilyOptions createColumnOptions() {
-			return new ColumnFamilyOptions();
+		public ColumnFamilyOptions createColumnOptions(Collection<AutoCloseable> handlesToClose) {
+			ColumnFamilyOptions columnFamilyOptions = new ColumnFamilyOptions();
+			if (handlesToClose != null) {
+				handlesToClose.add(columnFamilyOptions);
+			}
+			return columnFamilyOptions;
 		}
 	};
 
@@ -220,15 +261,33 @@ public enum PredefinedOptions {
 	/**
 	 * Creates the {@link DBOptions}for this pre-defined setting.
 	 *
+	 * @param handlesToClose The collection to register newly created {@link org.rocksdb.RocksObject}s.
 	 * @return The pre-defined options object.
 	 */
-	public abstract DBOptions createDBOptions();
+	public abstract DBOptions createDBOptions(Collection<AutoCloseable> handlesToClose);
+
+	/**
+	 * @return The pre-defined options object.
+	 * @deprecated use {@link #createColumnOptions(Collection)} instead.
+	 */
+	public DBOptions createDBOptions() {
+		return createDBOptions(null);
+	}
 
 	/**
 	 * Creates the {@link org.rocksdb.ColumnFamilyOptions}for this pre-defined setting.
 	 *
+	 * @param handlesToClose The collection to register newly created {@link org.rocksdb.RocksObject}s.
 	 * @return The pre-defined options object.
 	 */
-	public abstract ColumnFamilyOptions createColumnOptions();
+	public abstract ColumnFamilyOptions createColumnOptions(Collection<AutoCloseable> handlesToClose);
+
+	/**
+	 * @return The pre-defined options object.
+	 * @deprecated use {@link #createColumnOptions(Collection)} instead.
+	 */
+	public ColumnFamilyOptions createColumnOptions() {
+		return createColumnOptions(null);
+	}
 
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -35,10 +35,10 @@ import static org.rocksdb.CompactionStyle.UNIVERSAL;
 /**
  * This class contains the configuration options for the {@link DefaultConfigurableOptionsFactory}.
  *
- * <p>If nothing specified, RocksDB's options would be configured by {@link PredefinedOptions} and user-defined {@link OptionsFactory}.
+ * <p>If nothing specified, RocksDB's options would be configured by {@link PredefinedOptions} and user-defined {@link RocksDBOptionsFactory}.
  *
  * <p>If some options has been specifically configured, a corresponding {@link DefaultConfigurableOptionsFactory} would be created
- * and applied on top of {@link PredefinedOptions} except if a user-defined {@link OptionsFactory} overrides it.
+ * and applied on top of {@link PredefinedOptions} except if a user-defined {@link RocksDBOptionsFactory} overrides it.
  */
 public class RocksDBConfigurableOptions implements Serializable {
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -19,7 +19,10 @@
 package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.description.Description;
+
+import org.rocksdb.CompactionStyle;
 
 import java.io.Serializable;
 
@@ -43,14 +46,16 @@ public class RocksDBConfigurableOptions implements Serializable {
 	// Provided configurable DBOptions within Flink
 	//--------------------------------------------------------------------------
 
-	public static final ConfigOption<String> MAX_BACKGROUND_THREADS =
+	public static final ConfigOption<Integer> MAX_BACKGROUND_THREADS =
 		key("state.backend.rocksdb.thread.num")
+			.intType()
 			.noDefaultValue()
 			.withDescription("The maximum number of concurrent background flush and compaction jobs (per TaskManager). " +
 				"RocksDB has default configuration as '1'.");
 
-	public static final ConfigOption<String> MAX_OPEN_FILES =
+	public static final ConfigOption<Integer> MAX_OPEN_FILES =
 		key("state.backend.rocksdb.files.open")
+			.intType()
 			.noDefaultValue()
 			.withDescription("The maximum number of open files (per TaskManager) that can be used by the DB, '-1' means no limit. " +
 				"RocksDB has default configuration as '5000'.");
@@ -59,15 +64,17 @@ public class RocksDBConfigurableOptions implements Serializable {
 	// Provided configurable ColumnFamilyOptions within Flink
 	//--------------------------------------------------------------------------
 
-	public static final ConfigOption<String> COMPACTION_STYLE =
+	public static final ConfigOption<CompactionStyle> COMPACTION_STYLE =
 		key("state.backend.rocksdb.compaction.style")
+			.enumType(CompactionStyle.class)
 			.noDefaultValue()
 			.withDescription(String.format("The specified compaction style for DB. Candidate compaction style is %s, %s or %s, " +
 					"and RocksDB choose '%s' as default style.", LEVEL.name(), FIFO.name(), UNIVERSAL.name(),
 				LEVEL.name()));
 
-	public static final ConfigOption<String> USE_DYNAMIC_LEVEL_SIZE =
+	public static final ConfigOption<Boolean> USE_DYNAMIC_LEVEL_SIZE =
 		key("state.backend.rocksdb.compaction.level.use-dynamic-size")
+			.booleanType()
 			.noDefaultValue()
 			.withDescription(Description.builder().text("If true, RocksDB will pick target size of each level dynamically. From an empty DB, ")
 				.text("RocksDB would make last level the base level, which means merging L0 data into the last level, ")
@@ -78,44 +85,51 @@ public class RocksDBConfigurableOptions implements Serializable {
 						"RocksDB's doc."))
 				.build());
 
-	public static final ConfigOption<String> TARGET_FILE_SIZE_BASE =
+	public static final ConfigOption<MemorySize> TARGET_FILE_SIZE_BASE =
 		key("state.backend.rocksdb.compaction.level.target-file-size-base")
+			.memoryType()
 			.noDefaultValue()
 			.withDescription("The target file size for compaction, which determines a level-1 file size. " +
 				"RocksDB has default configuration as '2MB'.");
 
-	public static final ConfigOption<String> MAX_SIZE_LEVEL_BASE =
+	public static final ConfigOption<MemorySize> MAX_SIZE_LEVEL_BASE =
 		key("state.backend.rocksdb.compaction.level.max-size-level-base")
+			.memoryType()
 			.noDefaultValue()
 			.withDescription("The upper-bound of the total size of level base files in bytes. " +
 				"RocksDB has default configuration as '10MB'.");
 
-	public static final ConfigOption<String> WRITE_BUFFER_SIZE =
+	public static final ConfigOption<MemorySize> WRITE_BUFFER_SIZE =
 		key("state.backend.rocksdb.writebuffer.size")
+			.memoryType()
 			.noDefaultValue()
 			.withDescription("The amount of data built up in memory (backed by an unsorted log on disk) " +
 				"before converting to a sorted on-disk files. RocksDB has default writebuffer size as '64MB'.");
 
-	public static final ConfigOption<String> MAX_WRITE_BUFFER_NUMBER =
+	public static final ConfigOption<Integer> MAX_WRITE_BUFFER_NUMBER =
 		key("state.backend.rocksdb.writebuffer.count")
+			.intType()
 			.noDefaultValue()
 			.withDescription("Tne maximum number of write buffers that are built up in memory. " +
 				"RocksDB has default configuration as '2'.");
 
-	public static final ConfigOption<String> MIN_WRITE_BUFFER_NUMBER_TO_MERGE =
+	public static final ConfigOption<Integer> MIN_WRITE_BUFFER_NUMBER_TO_MERGE =
 		key("state.backend.rocksdb.writebuffer.number-to-merge")
+			.intType()
 			.noDefaultValue()
 			.withDescription("The minimum number of write buffers that will be merged together before writing to storage. " +
 				"RocksDB has default configuration as '1'.");
 
-	public static final ConfigOption<String> BLOCK_SIZE =
+	public static final ConfigOption<MemorySize> BLOCK_SIZE =
 		key("state.backend.rocksdb.block.blocksize")
+			.memoryType()
 			.noDefaultValue()
 			.withDescription("The approximate size (in bytes) of user data packed per block. " +
 				"RocksDB has default blocksize as '4KB'.");
 
-	public static final ConfigOption<String> BLOCK_CACHE_SIZE =
+	public static final ConfigOption<MemorySize> BLOCK_CACHE_SIZE =
 		key("state.backend.rocksdb.block.cache-size")
+			.memoryType()
 			.noDefaultValue()
 			.withDescription("The amount of the cache for data blocks in RocksDB. " +
 				"RocksDB has default block-cache size as '8MB'.");

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptionsFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptionsFactory.java
@@ -21,12 +21,36 @@ package org.apache.flink.contrib.streaming.state;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 /**
- * @deprecated Use {@link RocksDBOptionsFactory} instead. This factory has no mechanism to register
- *             native handles to be closed and is thus deprecated in favor or a new variant.
+ * A factory for {@link DBOptions} and {@link ColumnFamilyOptions} to be passed to the {@link RocksDBStateBackend}.
+ * Options have to be created lazily by this factory, because the {@code Options}
+ * class is not serializable and holds pointers to native code.
+ *
+ * <p>A typical pattern to use this OptionsFactory is as follows:
+ *
+ * <pre>{@code
+ * rocksDbBackend.setOptions(new RocksDBOptionsFactory() {
+ *
+ *		public DBOptions createDBOptions(DBOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
+ *			return currentOptions.setMaxOpenFiles(1024);
+ *		}
+ *
+ *		public ColumnFamilyOptions createColumnOptions(ColumnFamilyOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
+ *			BloomFilter bloomFilter = new BloomFilter();
+ * 			handlesToClose.add(bloomFilter);
+ *
+ * 			return currentOptions
+ * 					.setTableFormatConfig(
+ * 							new BlockBasedTableConfig().setFilter(bloomFilter));
+ *		}
+ * });
+ * }</pre>
  */
-@Deprecated
-public interface OptionsFactory extends java.io.Serializable {
+@SuppressWarnings("deprecation")
+public interface RocksDBOptionsFactory extends OptionsFactory, java.io.Serializable {
 
 	/**
 	 * This method should set the additional options on top of the current options object.
@@ -37,9 +61,10 @@ public interface OptionsFactory extends java.io.Serializable {
 	 * the setter methods, otherwise the pre-defined options may get lost.
 	 *
 	 * @param currentOptions The options object with the pre-defined options.
+	 * @param handlesToClose The collection to register newly created {@link org.rocksdb.RocksObject}s.
 	 * @return The options object on which the additional options are set.
 	 */
-	DBOptions createDBOptions(DBOptions currentOptions);
+	DBOptions createDBOptions(DBOptions currentOptions, Collection<AutoCloseable> handlesToClose);
 
 	/**
 	 * This method should set the additional options on top of the current options object.
@@ -50,9 +75,10 @@ public interface OptionsFactory extends java.io.Serializable {
 	 * the setter methods, otherwise the pre-defined options may get lost.
 	 *
 	 * @param currentOptions The options object with the pre-defined options.
+	 * @param handlesToClose The collection to register newly created {@link org.rocksdb.RocksObject}s.
 	 * @return The options object on which the additional options are set.
 	 */
-	ColumnFamilyOptions createColumnOptions(ColumnFamilyOptions currentOptions);
+	ColumnFamilyOptions createColumnOptions(ColumnFamilyOptions currentOptions, Collection<AutoCloseable> handlesToClose);
 
 	/**
 	 * This method should enable certain RocksDB metrics to be forwarded to
@@ -65,5 +91,27 @@ public interface OptionsFactory extends java.io.Serializable {
 	 */
 	default RocksDBNativeMetricOptions createNativeMetricsOptions(RocksDBNativeMetricOptions nativeMetricOptions) {
 		return nativeMetricOptions;
+	}
+
+	// ------------------------------------------------------------------------
+	//  for compatibility
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Do not override these methods, they are only to maintain interface compatibility with
+	 * prior versions. They will be removed in one of the next versions.
+	 */
+	@Override
+	default DBOptions createDBOptions(DBOptions currentOptions) {
+		return createDBOptions(currentOptions, new ArrayList<>());
+	}
+
+	/**
+	 * Do not override these methods, they are only to maintain interface compatibility with
+	 * prior versions. They will be removed in one of the next versions.
+	 */
+	@Override
+	default ColumnFamilyOptions createColumnOptions(ColumnFamilyOptions currentOptions) {
+		return createColumnOptions(currentOptions, new ArrayList<>());
 	}
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptionsFactoryAdapter.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptionsFactoryAdapter.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.configuration.Configuration;
+
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.DBOptions;
+
+import javax.annotation.Nullable;
+
+import java.util.Collection;
+
+/**
+ * A conversion from {@link OptionsFactory} to {@link RocksDBOptionsFactory}.
+ */
+@SuppressWarnings("deprecation")
+final class RocksDBOptionsFactoryAdapter implements ConfigurableRocksDBOptionsFactory {
+
+	private static final long serialVersionUID = 1L;
+
+	private final OptionsFactory optionsFactory;
+
+	RocksDBOptionsFactoryAdapter(OptionsFactory optionsFactory) {
+		this.optionsFactory = optionsFactory;
+	}
+
+	@Override
+	public DBOptions createDBOptions(DBOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
+		return optionsFactory.createDBOptions(currentOptions);
+	}
+
+	@Override
+	public ColumnFamilyOptions createColumnOptions(ColumnFamilyOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
+		return optionsFactory.createColumnOptions(currentOptions);
+	}
+
+	@Override
+	public RocksDBNativeMetricOptions createNativeMetricsOptions(RocksDBNativeMetricOptions nativeMetricOptions) {
+		return optionsFactory.createNativeMetricsOptions(nativeMetricOptions);
+	}
+
+	@Override
+	public RocksDBOptionsFactory configure(Configuration configuration) {
+		if (optionsFactory instanceof ConfigurableOptionsFactory) {
+			final OptionsFactory reconfigured = ((ConfigurableOptionsFactory) optionsFactory).configure(configuration);
+			return reconfigured == optionsFactory ? this : new RocksDBOptionsFactoryAdapter(reconfigured);
+		}
+
+		return this;
+	}
+
+	@Nullable
+	public static OptionsFactory unwrapIfAdapter(RocksDBOptionsFactory factory) {
+		return factory instanceof RocksDBOptionsFactoryAdapter
+				? ((RocksDBOptionsFactoryAdapter) factory).optionsFactory
+				: factory;
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.runtime.memory.OpaqueMemoryResource;
+import org.apache.flink.util.IOUtils;
+
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.DBOptions;
+
+import javax.annotation.Nonnull;
+
+import java.util.ArrayList;
+
+/**
+ * The container for RocksDB resources, including predefined options, option factory and
+ * shared resource among instances.
+ * <p/>
+ * This should be the only entrance for {@link RocksDBStateBackend} to get RocksDB options,
+ * and should be properly (and necessarily) closed to prevent resource leak.
+ */
+public class RocksDBResourceContainer implements AutoCloseable {
+
+	/** The pre-configured option settings. */
+	private PredefinedOptions predefinedOptions;
+	/** The options factory to create the RocksDB options. */
+	private OptionsFactory optionsFactory;
+	/** The shared resource among RocksDB instances. */
+	private OpaqueMemoryResource<RocksDBSharedResources> sharedResources;
+
+	private final ArrayList<AutoCloseable> handlesToClose;
+
+	public RocksDBResourceContainer() {
+		handlesToClose = new ArrayList<>();
+	}
+
+	/**
+	 * Gets the RocksDB {@link DBOptions} to be used for RocksDB instances.
+	 */
+	DBOptions getDbOptions() {
+		// initial options from pre-defined profile
+		DBOptions opt = checkAndGetPredefinedOptions().createDBOptions(handlesToClose);
+
+		// add user-defined options factory, if specified
+		if (optionsFactory != null) {
+			opt = optionsFactory.createDBOptions(opt, handlesToClose);
+		}
+
+		// add necessary default options
+		opt = opt.setCreateIfMissing(true);
+
+		return opt;
+	}
+
+	/**
+	 * Gets the RocksDB {@link ColumnFamilyOptions} to be used for all RocksDB instances.
+	 */
+	public ColumnFamilyOptions getColumnOptions() {
+		// initial options from pre-defined profile
+		ColumnFamilyOptions opt = checkAndGetPredefinedOptions().createColumnOptions(handlesToClose);
+
+		// add user-defined options, if specified
+		if (optionsFactory != null) {
+			opt = optionsFactory.createColumnOptions(opt, handlesToClose);
+		}
+
+		return opt;
+	}
+
+	PredefinedOptions getPredefinedOptions() {
+		return predefinedOptions;
+	}
+
+	PredefinedOptions checkAndGetPredefinedOptions() {
+		if (predefinedOptions == null) {
+			predefinedOptions = PredefinedOptions.DEFAULT;
+		}
+		return predefinedOptions;
+	}
+
+	OptionsFactory getOptionsFactory() {
+		return optionsFactory;
+	}
+
+	void setPredefinedOptions(@Nonnull PredefinedOptions predefinedOptions) {
+		this.predefinedOptions = predefinedOptions;
+	}
+
+	void setOptionsFactory(@Nonnull OptionsFactory optionsFactory) {
+		this.optionsFactory = optionsFactory;
+	}
+
+	void setSharedResources(OpaqueMemoryResource<RocksDBSharedResources> sharedResources) {
+		this.sharedResources = sharedResources;
+	}
+
+	@Override
+	public void close() throws Exception {
+		handlesToClose.forEach(IOUtils::closeQuietly);
+		handlesToClose.clear();
+
+		if (sharedResources != null) {
+			sharedResources.close();
+		}
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
@@ -44,7 +44,7 @@ final class RocksDBResourceContainer implements AutoCloseable {
 
 	/** The options factory to create the RocksDB options. */
 	@Nullable
-	private final OptionsFactory optionsFactory;
+	private final RocksDBOptionsFactory optionsFactory;
 
 	/** The shared resource among RocksDB instances. This resource is not part of the 'handlesToClose',
 	 * because the handles to close are closed quietly, whereas for this one, we want exceptions to be reported. */
@@ -58,13 +58,13 @@ final class RocksDBResourceContainer implements AutoCloseable {
 		this(PredefinedOptions.DEFAULT, null, null);
 	}
 
-	public RocksDBResourceContainer(PredefinedOptions predefinedOptions, @Nullable OptionsFactory optionsFactory) {
+	public RocksDBResourceContainer(PredefinedOptions predefinedOptions, @Nullable RocksDBOptionsFactory optionsFactory) {
 		this(predefinedOptions, optionsFactory, null);
 	}
 
 	public RocksDBResourceContainer(
 		PredefinedOptions predefinedOptions,
-		@Nullable OptionsFactory optionsFactory,
+		@Nullable RocksDBOptionsFactory optionsFactory,
 		@Nullable OpaqueMemoryResource<RocksDBSharedResources> sharedResources) {
 
 		this.predefinedOptions = checkNotNull(predefinedOptions);
@@ -119,7 +119,7 @@ final class RocksDBResourceContainer implements AutoCloseable {
 	}
 
 	@Nullable
-	OptionsFactory getOptionsFactory() {
+	RocksDBOptionsFactory getOptionsFactory() {
 		return optionsFactory;
 	}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
@@ -112,6 +112,10 @@ final class RocksDBResourceContainer implements AutoCloseable {
 				: optionsFactory.createNativeMetricsOptions(defaultMetricOptions);
 	}
 
+	PredefinedOptions getPredefinedOptions() {
+		return predefinedOptions;
+	}
+
 	@Nullable
 	OptionsFactory getOptionsFactory() {
 		return optionsFactory;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
@@ -79,6 +79,7 @@ final class RocksDBResourceContainer implements AutoCloseable {
 	DBOptions getDbOptions() {
 		// initial options from pre-defined profile
 		DBOptions opt = predefinedOptions.createDBOptions(handlesToClose);
+		handlesToClose.add(opt);
 
 		// add user-defined options factory, if specified
 		if (optionsFactory != null) {
@@ -97,6 +98,7 @@ final class RocksDBResourceContainer implements AutoCloseable {
 	ColumnFamilyOptions getColumnOptions() {
 		// initial options from pre-defined profile
 		ColumnFamilyOptions opt = predefinedOptions.createColumnOptions(handlesToClose);
+		handlesToClose.add(opt);
 
 		// add user-defined options, if specified
 		if (optionsFactory != null) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
@@ -106,6 +106,12 @@ final class RocksDBResourceContainer implements AutoCloseable {
 		return opt;
 	}
 
+	RocksDBNativeMetricOptions getMemoryWatcherOptions(RocksDBNativeMetricOptions defaultMetricOptions) {
+		return optionsFactory == null
+				? defaultMetricOptions
+				: optionsFactory.createNativeMetricsOptions(defaultMetricOptions);
+	}
+
 	@Nullable
 	OptionsFactory getOptionsFactory() {
 		return optionsFactory;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -560,7 +560,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 			.setEnableIncrementalCheckpointing(isIncrementalCheckpointsEnabled())
 			.setEnableTtlCompactionFilter(isTtlCompactionFilterEnabled())
 			.setNumberOfTransferingThreads(getNumberOfTransferThreads())
-			.setNativeMetricOptions(getMemoryWatcherOptions(resourceContainer));
+			.setNativeMetricOptions(resourceContainer.getMemoryWatcherOptions(defaultMetricOptions));
 		return builder.build();
 	}
 
@@ -851,16 +851,6 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 			getConfiguredPredefinedOptionsOrDefault(),
 			optionsFactory);
 		return resourceContainer.getColumnOptions();
-	}
-
-	public RocksDBNativeMetricOptions getMemoryWatcherOptions(RocksDBResourceContainer resourceContainer) {
-		RocksDBNativeMetricOptions options = this.defaultMetricOptions;
-		OptionsFactory optionsFactory = resourceContainer.getOptionsFactory();
-		if (optionsFactory != null) {
-			options = optionsFactory.createNativeMetricsOptions(options);
-		}
-
-		return options;
 	}
 
 	/**

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -93,7 +93,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *
  * <p>The behavior of the RocksDB instances can be parametrized by setting RocksDB Options
  * using the methods {@link #setPredefinedOptions(PredefinedOptions)} and
- * {@link #setOptions(OptionsFactory)}.
+ * {@link #setRocksDBOptions(RocksDBOptionsFactory)}.
  */
 public class RocksDBStateBackend extends AbstractStateBackend implements ConfigurableStateBackend {
 
@@ -136,7 +136,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 
 	/** The options factory to create the RocksDB options in the cluster. */
 	@Nullable
-	private OptionsFactory optionsFactory;
+	private RocksDBOptionsFactory rocksDbOptionsFactory;
 
 	/** This determines if incremental checkpointing is enabled. */
 	private final TernaryBoolean enableIncrementalCheckpointing;
@@ -359,8 +359,8 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 
 		// configure RocksDB options factory
 		try {
-			optionsFactory = configureOptionsFactory(
-				original.optionsFactory,
+			rocksDbOptionsFactory = configureOptionsFactory(
+				original.rocksDbOptionsFactory,
 				config.getString(RocksDBOptions.OPTIONS_FACTORY),
 				config,
 				classLoader);
@@ -582,15 +582,15 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 			cancelStreamRegistry).build();
 	}
 
-	private OptionsFactory configureOptionsFactory(
-			@Nullable OptionsFactory originalOptionsFactory,
+	private RocksDBOptionsFactory configureOptionsFactory(
+			@Nullable RocksDBOptionsFactory originalOptionsFactory,
 			String factoryClassName,
 			Configuration config,
 			ClassLoader classLoader) throws DynamicCodeLoadingException {
 
 		if (originalOptionsFactory != null) {
-			if (originalOptionsFactory instanceof ConfigurableOptionsFactory) {
-				originalOptionsFactory = ((ConfigurableOptionsFactory) originalOptionsFactory).configure(config);
+			if (originalOptionsFactory instanceof ConfigurableRocksDBOptionsFactory) {
+				originalOptionsFactory = ((ConfigurableRocksDBOptionsFactory) originalOptionsFactory).configure(config);
 			}
 			LOG.info("Using application-defined options factory: {}.", originalOptionsFactory);
 
@@ -607,13 +607,13 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 		} else {
 			try {
 				@SuppressWarnings("rawtypes")
-				Class<? extends OptionsFactory> clazz =
+				Class<? extends RocksDBOptionsFactory> clazz =
 					Class.forName(factoryClassName, false, classLoader)
-						.asSubclass(OptionsFactory.class);
+						.asSubclass(RocksDBOptionsFactory.class);
 
-				OptionsFactory optionsFactory = clazz.newInstance();
-				if (optionsFactory instanceof ConfigurableOptionsFactory) {
-					optionsFactory = ((ConfigurableOptionsFactory) optionsFactory).configure(config);
+				RocksDBOptionsFactory optionsFactory = clazz.newInstance();
+				if (optionsFactory instanceof ConfigurableRocksDBOptionsFactory) {
+					optionsFactory = ((ConfigurableRocksDBOptionsFactory) optionsFactory).configure(config);
 				}
 				LOG.info("Using configured options factory: {}.", optionsFactory);
 
@@ -776,7 +776,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	 * Sets the predefined options for RocksDB.
 	 *
 	 * <p>If user-configured options within {@link RocksDBConfigurableOptions} is set (through flink-conf.yaml)
-	 * or a user-defined options factory is set (via {@link #setOptions(OptionsFactory)}),
+	 * or a user-defined options factory is set (via {@link #setRocksDBOptions(RocksDBOptionsFactory)}),
 	 * then the options from the factory are applied on top of the here specified
 	 * predefined options and customized options.
 	 *
@@ -792,7 +792,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	 * are {@link PredefinedOptions#DEFAULT}.
 	 *
 	 * <p>If user-configured options within {@link RocksDBConfigurableOptions} is set (through flink-conf.yaml)
-	 * of a user-defined options factory is set (via {@link #setOptions(OptionsFactory)}),
+	 * of a user-defined options factory is set (via {@link #setRocksDBOptions(RocksDBOptionsFactory)}),
 	 * then the options from the factory are applied on top of the predefined and customized options.
 	 *
 	 * @return The currently set predefined options for RocksDB.
@@ -818,18 +818,45 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	 *
 	 * @param optionsFactory The options factory that lazily creates the RocksDB options.
 	 */
-	public void setOptions(OptionsFactory optionsFactory) {
-		this.optionsFactory = optionsFactory;
+	public void setRocksDBOptions(RocksDBOptionsFactory optionsFactory) {
+		this.rocksDbOptionsFactory = optionsFactory;
 	}
 
 	/**
-	 * Gets the options factory that lazily creates the RocksDB options.
+	 * Gets {@link org.rocksdb.Options} for the RocksDB instances.
 	 *
-	 * @return The options factory.
+	 * <p>The options created by the factory here are applied on top of the pre-defined
+	 * options profile selected via {@link #setPredefinedOptions(PredefinedOptions)}.
+	 * If the pre-defined options profile is the default
+	 * ({@link PredefinedOptions#DEFAULT}), then the factory fully controls the RocksDB options.
 	 */
 	@Nullable
+	public RocksDBOptionsFactory getRocksDBOptions() {
+		return rocksDbOptionsFactory;
+	}
+
+	/**
+	 * The options factory supplied here was prone to resource leaks, because it did not have a way
+	 * to register native handles / objects that need to be disposed when the state backend is closed.
+	 *
+	 * @deprecated Use {@link #setRocksDBOptions(RocksDBOptionsFactory)} instead.
+	 */
+	@Deprecated
+	public void setOptions(OptionsFactory optionsFactory) {
+		this.rocksDbOptionsFactory = optionsFactory instanceof RocksDBOptionsFactory
+				? (RocksDBOptionsFactory) optionsFactory
+				: new RocksDBOptionsFactoryAdapter(optionsFactory);
+	}
+
+	/**
+	 * The options factory supplied here was prone to resource leaks, because it did not have a way
+	 * to register native handles / objects that need to be disposed when the state backend is closed.
+	 *
+	 * @deprecated Use {@link #setRocksDBOptions(RocksDBOptionsFactory)} and {@link #getRocksDBOptions()} instead.
+	 */
+	@Deprecated
 	public OptionsFactory getOptions() {
-		return optionsFactory;
+		return RocksDBOptionsFactoryAdapter.unwrapIfAdapter(rocksDbOptionsFactory);
 	}
 
 	/**
@@ -882,7 +909,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 
 		return new RocksDBResourceContainer(
 			predefinedOptions != null ? predefinedOptions : PredefinedOptions.DEFAULT,
-			optionsFactory,
+			rocksDbOptionsFactory,
 			sharedResources);
 	}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBOptionsFactoryCompatibilityTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBOptionsFactoryCompatibilityTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.configuration.Configuration;
+
+import org.junit.Test;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.DBOptions;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests that the changes introducing the {@link RocksDBOptionsFactory} are backwards compatible.
+ */
+public class RocksDBOptionsFactoryCompatibilityTest {
+
+	@Test
+	public void testInheritance() {
+		assertThat(new DefaultConfigurableOptionsFactory(), instanceOf(RocksDBOptionsFactory.class));
+	}
+
+	@Test
+	public void testSetAndGet() throws Exception {
+		final RocksDBStateBackend backend = new RocksDBStateBackend("file:///a/b/c");
+		final OptionsFactory testFactory = new TestOptionsFactory();
+
+		backend.setOptions(testFactory);
+
+		assertSame(testFactory, backend.getOptions());
+	}
+
+	@Test
+	public void testConfiguration() throws Exception {
+		final RocksDBStateBackend backend = new RocksDBStateBackend("file:///a/b/c");
+		final OptionsFactory testFactory = new TestOptionsFactory();
+
+		backend.setOptions(testFactory);
+
+		final TestOptionsFactory reconfigured = (TestOptionsFactory) backend
+				.configure(new Configuration(), getClass().getClassLoader())
+				.getOptions();
+
+		assertTrue(reconfigured.wasConfigured);
+	}
+
+	// ------------------------------------------------------------------------
+
+	private static class TestOptionsFactory implements ConfigurableOptionsFactory {
+
+		boolean wasConfigured;
+
+		@Override
+		public OptionsFactory configure(Configuration configuration) {
+			wasConfigured = true;
+			return this;
+		}
+
+		@Override
+		public DBOptions createDBOptions(DBOptions currentOptions) {
+			return currentOptions;
+		}
+
+		@Override
+		public ColumnFamilyOptions createColumnOptions(ColumnFamilyOptions currentOptions) {
+			return currentOptions;
+		}
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResource.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResource.java
@@ -49,7 +49,7 @@ public class RocksDBResource extends ExternalResource {
 	private static final Logger LOG = LoggerFactory.getLogger(RocksDBResource.class);
 
 	/** Factory for {@link DBOptions} and {@link ColumnFamilyOptions}. */
-	private final OptionsFactory optionsFactory;
+	private final RocksDBOptionsFactory optionsFactory;
 
 	/** Temporary folder that provides the working directory for the RocksDB instance. */
 	private TemporaryFolder temporaryFolder;
@@ -79,7 +79,7 @@ public class RocksDBResource extends ExternalResource {
 	private ArrayList<AutoCloseable> handlesToClose = new ArrayList<>();
 
 	public RocksDBResource() {
-		this(new OptionsFactory() {
+		this(new RocksDBOptionsFactory() {
 			@Override
 			public DBOptions createDBOptions(DBOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
 				//close it before reuse the reference.
@@ -106,7 +106,7 @@ public class RocksDBResource extends ExternalResource {
 		});
 	}
 
-	public RocksDBResource(@Nonnull OptionsFactory optionsFactory) {
+	public RocksDBResource(@Nonnull RocksDBOptionsFactory optionsFactory) {
 		this.optionsFactory = optionsFactory;
 	}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainerTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.runtime.memory.OpaqueMemoryResource;
+import org.apache.flink.util.function.ThrowingRunnable;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.DBOptions;
+import org.rocksdb.LRUCache;
+import org.rocksdb.NativeLibraryLoader;
+import org.rocksdb.WriteBufferManager;
+
+import java.util.ArrayList;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests to guard {@link RocksDBResourceContainer}.
+ */
+public class RocksDBResourceContainerTest {
+
+	@Rule
+	public final TemporaryFolder tmp = new TemporaryFolder();
+
+	@Test
+	public void testFreeDBOptionsAfterClose() throws Exception {
+		RocksDBResourceContainer container = new RocksDBResourceContainer();
+		DBOptions dbOptions = container.getDbOptions();
+		assertThat(dbOptions.isOwningHandle(), is(true));
+		container.close();
+		assertThat(dbOptions.isOwningHandle(), is(false));
+	}
+
+	@Test
+	public void testFreeMultipleDBOptionsAfterClose() throws Exception {
+		RocksDBResourceContainer container = new RocksDBResourceContainer();
+		final int optionNumber = 20;
+		ArrayList<DBOptions> dbOptions = new ArrayList<>(optionNumber);
+		for (int i = 0; i < optionNumber; i++) {
+			dbOptions.add(container.getDbOptions());
+		}
+		container.close();
+		for (DBOptions dbOption: dbOptions) {
+			assertThat(dbOption.isOwningHandle(), is(false));
+		}
+	}
+
+	@Test
+	public void testFreeColumnOptionsAfterClose() throws Exception {
+		RocksDBResourceContainer container = new RocksDBResourceContainer();
+		ColumnFamilyOptions columnFamilyOptions = container.getColumnOptions();
+		assertThat(columnFamilyOptions.isOwningHandle(), is(true));
+		container.close();
+		assertThat(columnFamilyOptions.isOwningHandle(), is(false));
+	}
+
+	@Test
+	public void testFreeMultipleColumnOptionsAfterClose() throws Exception {
+		RocksDBResourceContainer container = new RocksDBResourceContainer();
+		final int optionNumber = 20;
+		ArrayList<ColumnFamilyOptions> columnFamilyOptions = new ArrayList<>(optionNumber);
+		for (int i = 0; i < optionNumber; i++) {
+			columnFamilyOptions.add(container.getColumnOptions());
+		}
+		container.close();
+		for (ColumnFamilyOptions columnFamilyOption: columnFamilyOptions) {
+			assertThat(columnFamilyOption.isOwningHandle(), is(false));
+		}
+	}
+
+	@Test
+	public void testFreeMultipleColumnOptionsWithPredefinedOptions() throws Exception {
+		RocksDBResourceContainer container = new RocksDBResourceContainer();
+		for (PredefinedOptions predefinedOptions: PredefinedOptions.values()) {
+			container.setPredefinedOptions(predefinedOptions);
+			final int optionNumber = 20;
+			ArrayList<ColumnFamilyOptions> columnFamilyOptions = new ArrayList<>(optionNumber);
+			for (int i = 0; i < optionNumber; i++) {
+				columnFamilyOptions.add(container.getColumnOptions());
+			}
+			container.close();
+			for (ColumnFamilyOptions columnFamilyOption: columnFamilyOptions) {
+				assertThat(columnFamilyOption.isOwningHandle(), is(false));
+			}
+		}
+	}
+
+	@Test
+	public void testFreeSharedResourcesAfterClose() throws Exception {
+		NativeLibraryLoader.getInstance().loadLibrary(tmp.newFolder().getAbsolutePath());
+		RocksDBResourceContainer container = new RocksDBResourceContainer();
+		LRUCache cache = new LRUCache(1024L);
+		WriteBufferManager wbm = new WriteBufferManager(1024L, cache);
+		RocksDBSharedResources sharedResources = new RocksDBSharedResources(cache, wbm);
+		final ThrowingRunnable<Exception> disposer = sharedResources::close;
+		OpaqueMemoryResource<RocksDBSharedResources> opaqueResource =
+			new OpaqueMemoryResource<>(sharedResources, 1024L, disposer);
+		container.setSharedResources(opaqueResource);
+
+		container.close();
+		assertThat(cache.isOwningHandle(), is(false));
+		assertThat(wbm.isOwningHandle(), is(false));
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainerTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainerTest.java
@@ -100,9 +100,8 @@ public class RocksDBResourceContainerTest {
 
 	@Test
 	public void testFreeMultipleColumnOptionsWithPredefinedOptions() throws Exception {
-		RocksDBResourceContainer container = new RocksDBResourceContainer();
 		for (PredefinedOptions predefinedOptions: PredefinedOptions.values()) {
-			container.setPredefinedOptions(predefinedOptions);
+			RocksDBResourceContainer container = new RocksDBResourceContainer(predefinedOptions, null);
 			final int optionNumber = 20;
 			ArrayList<ColumnFamilyOptions> columnFamilyOptions = new ArrayList<>(optionNumber);
 			for (int i = 0; i < optionNumber; i++) {
@@ -117,14 +116,14 @@ public class RocksDBResourceContainerTest {
 
 	@Test
 	public void testFreeSharedResourcesAfterClose() throws Exception {
-		RocksDBResourceContainer container = new RocksDBResourceContainer();
 		LRUCache cache = new LRUCache(1024L);
 		WriteBufferManager wbm = new WriteBufferManager(1024L, cache);
 		RocksDBSharedResources sharedResources = new RocksDBSharedResources(cache, wbm);
 		final ThrowingRunnable<Exception> disposer = sharedResources::close;
 		OpaqueMemoryResource<RocksDBSharedResources> opaqueResource =
 			new OpaqueMemoryResource<>(sharedResources, 1024L, disposer);
-		container.setSharedResources(opaqueResource);
+
+		RocksDBResourceContainer container = new RocksDBResourceContainer(PredefinedOptions.DEFAULT, null, opaqueResource);
 
 		container.close();
 		assertThat(cache.isOwningHandle(), is(false));

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainerTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainerTest.java
@@ -21,7 +21,8 @@ package org.apache.flink.contrib.streaming.state;
 import org.apache.flink.runtime.memory.OpaqueMemoryResource;
 import org.apache.flink.util.function.ThrowingRunnable;
 
-import org.junit.Rule;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.rocksdb.ColumnFamilyOptions;
@@ -30,6 +31,7 @@ import org.rocksdb.LRUCache;
 import org.rocksdb.NativeLibraryLoader;
 import org.rocksdb.WriteBufferManager;
 
+import java.io.IOException;
 import java.util.ArrayList;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -40,8 +42,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 public class RocksDBResourceContainerTest {
 
-	@Rule
-	public final TemporaryFolder tmp = new TemporaryFolder();
+	@ClassRule
+	public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+	@BeforeClass
+	public static void ensureRocksDbNativeLibraryLoaded() throws IOException {
+		NativeLibraryLoader.getInstance().loadLibrary(TMP_FOLDER.newFolder().getAbsolutePath());
+	}
+
+	// ------------------------------------------------------------------------
 
 	@Test
 	public void testFreeDBOptionsAfterClose() throws Exception {
@@ -108,7 +117,6 @@ public class RocksDBResourceContainerTest {
 
 	@Test
 	public void testFreeSharedResourcesAfterClose() throws Exception {
-		NativeLibraryLoader.getInstance().loadLibrary(tmp.newFolder().getAbsolutePath());
 		RocksDBResourceContainer container = new RocksDBResourceContainer();
 		LRUCache cache = new LRUCache(1024L);
 		WriteBufferManager wbm = new WriteBufferManager(1024L, cache);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -483,16 +483,16 @@ public class RocksDBStateBackendConfigTest {
 
 		// verify legal configuration
 		{
-			configuration.setString(RocksDBConfigurableOptions.COMPACTION_STYLE, "level");
-			configuration.setString(RocksDBConfigurableOptions.USE_DYNAMIC_LEVEL_SIZE, "TRUE");
-			configuration.setString(RocksDBConfigurableOptions.TARGET_FILE_SIZE_BASE, "8 mb");
-			configuration.setString(RocksDBConfigurableOptions.MAX_SIZE_LEVEL_BASE, "128MB");
-			configuration.setString(RocksDBConfigurableOptions.MAX_BACKGROUND_THREADS, "4");
-			configuration.setString(RocksDBConfigurableOptions.MAX_WRITE_BUFFER_NUMBER, "4");
-			configuration.setString(RocksDBConfigurableOptions.MIN_WRITE_BUFFER_NUMBER_TO_MERGE, "2");
-			configuration.setString(RocksDBConfigurableOptions.WRITE_BUFFER_SIZE, "64 MB");
-			configuration.setString(RocksDBConfigurableOptions.BLOCK_SIZE, "4 kb");
-			configuration.setString(RocksDBConfigurableOptions.BLOCK_CACHE_SIZE, "512 mb");
+			configuration.setString(RocksDBConfigurableOptions.COMPACTION_STYLE.key(), "level");
+			configuration.setString(RocksDBConfigurableOptions.USE_DYNAMIC_LEVEL_SIZE.key(), "TRUE");
+			configuration.setString(RocksDBConfigurableOptions.TARGET_FILE_SIZE_BASE.key(), "8 mb");
+			configuration.setString(RocksDBConfigurableOptions.MAX_SIZE_LEVEL_BASE.key(), "128MB");
+			configuration.setString(RocksDBConfigurableOptions.MAX_BACKGROUND_THREADS.key(), "4");
+			configuration.setString(RocksDBConfigurableOptions.MAX_WRITE_BUFFER_NUMBER.key(), "4");
+			configuration.setString(RocksDBConfigurableOptions.MIN_WRITE_BUFFER_NUMBER_TO_MERGE.key(), "2");
+			configuration.setString(RocksDBConfigurableOptions.WRITE_BUFFER_SIZE.key(), "64 MB");
+			configuration.setString(RocksDBConfigurableOptions.BLOCK_SIZE.key(), "4 kb");
+			configuration.setString(RocksDBConfigurableOptions.BLOCK_CACHE_SIZE.key(), "512 mb");
 
 			DefaultConfigurableOptionsFactory optionsFactory = new DefaultConfigurableOptionsFactory();
 			optionsFactory.configure(configuration);
@@ -740,10 +740,10 @@ public class RocksDBStateBackendConfigTest {
 	}
 
 	private void verifyIllegalArgument(
-			ConfigOption<String> configOption,
+			ConfigOption<?> configOption,
 			String configValue) {
 		Configuration configuration = new Configuration();
-		configuration.setString(configOption, configValue);
+		configuration.setString(configOption.key(), configValue);
 
 		DefaultConfigurableOptionsFactory optionsFactory = new DefaultConfigurableOptionsFactory();
 		try {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -521,6 +521,7 @@ public class RocksDBStateBackendConfigTest {
 
 		rocksDbBackend = rocksDbBackend.configure(config, getClass().getClassLoader());
 
+		assertTrue(rocksDbBackend.getRocksDBOptions() instanceof TestOptionsFactory);
 		assertTrue(rocksDbBackend.getOptions() instanceof TestOptionsFactory);
 
 		try (RocksDBResourceContainer optionsContainer = rocksDbBackend.createOptionsAndResourceContainer()) {
@@ -529,7 +530,7 @@ public class RocksDBStateBackendConfigTest {
 		}
 
 		// verify that user-defined options factory could be set programmatically and override pre-configured one.
-		rocksDbBackend.setOptions(new OptionsFactory() {
+		rocksDbBackend.setRocksDBOptions(new RocksDBOptionsFactory() {
 			@Override
 			public DBOptions createDBOptions(DBOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
 				return currentOptions;
@@ -549,7 +550,7 @@ public class RocksDBStateBackendConfigTest {
 
 	@Test
 	public void testPredefinedAndOptionsFactory() throws Exception {
-		final OptionsFactory optionsFactory = new OptionsFactory() {
+		final RocksDBOptionsFactory optionsFactory = new RocksDBOptionsFactory() {
 			@Override
 			public DBOptions createDBOptions(DBOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
 				return currentOptions;
@@ -598,8 +599,8 @@ public class RocksDBStateBackendConfigTest {
 		assertNotEquals(predOptions, original.getPredefinedOptions());
 		original.setPredefinedOptions(predOptions);
 
-		final OptionsFactory optionsFactory = mock(OptionsFactory.class);
-		original.setOptions(optionsFactory);
+		final RocksDBOptionsFactory optionsFactory = mock(RocksDBOptionsFactory.class);
+		original.setRocksDBOptions(optionsFactory);
 
 		final String[] localDirs = new String[] {
 				tempFolder.newFolder().getAbsolutePath(), tempFolder.newFolder().getAbsolutePath() };
@@ -744,7 +745,7 @@ public class RocksDBStateBackendConfigTest {
 	/**
 	 * An implementation of options factory for testing.
 	 */
-	public static class TestOptionsFactory implements ConfigurableOptionsFactory {
+	public static class TestOptionsFactory implements ConfigurableRocksDBOptionsFactory {
 		public static final String BACKGROUND_JOBS_OPTION = "my.custom.rocksdb.backgroundJobs";
 
 		private static final int DEFAULT_BACKGROUND_JOBS = 2;
@@ -761,7 +762,7 @@ public class RocksDBStateBackendConfigTest {
 		}
 
 		@Override
-		public OptionsFactory configure(Configuration configuration) {
+		public RocksDBOptionsFactory configure(Configuration configuration) {
 			this.backgroundJobs = configuration.getInteger(BACKGROUND_JOBS_OPTION, DEFAULT_BACKGROUND_JOBS);
 			return this;
 		}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -46,6 +46,7 @@ import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.util.IOUtils;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -311,16 +312,13 @@ public class RocksDBStateBackendConfigTest {
 
 	@Test
 	public void testFailWhenNoLocalStorageDir() throws Exception {
+		final File targetDir = tempFolder.newFolder();
+		Assume.assumeTrue("Cannot mark directory non-writable", targetDir.setWritable(false, false));
+
 		String checkpointPath = tempFolder.newFolder().toURI().toString();
 		RocksDBStateBackend rocksDbBackend = new RocksDBStateBackend(checkpointPath);
-		File targetDir = tempFolder.newFolder();
 
 		try {
-			if (!targetDir.setWritable(false, false)) {
-				System.err.println("Cannot execute 'testFailWhenNoLocalStorageDir' because cannot mark directory non-writable");
-				return;
-			}
-
 			rocksDbBackend.setDbStoragePath(targetDir.getAbsolutePath());
 
 			boolean hasFailure = false;
@@ -354,19 +352,14 @@ public class RocksDBStateBackendConfigTest {
 
 	@Test
 	public void testContinueOnSomeDbDirectoriesMissing() throws Exception {
-		File targetDir1 = tempFolder.newFolder();
-		File targetDir2 = tempFolder.newFolder();
+		final File targetDir1 = tempFolder.newFolder();
+		final File targetDir2 = tempFolder.newFolder();
+		Assume.assumeTrue("Cannot mark directory non-writable", targetDir1.setWritable(false, false));
 
 		String checkpointPath = tempFolder.newFolder().toURI().toString();
 		RocksDBStateBackend rocksDbBackend = new RocksDBStateBackend(checkpointPath);
 
 		try {
-
-			if (!targetDir1.setWritable(false, false)) {
-				System.err.println("Cannot execute 'testContinueOnSomeDbDirectoriesMissing' because cannot mark directory non-writable");
-				return;
-			}
-
 			rocksDbBackend.setDbStoragePaths(targetDir1.getAbsolutePath(), targetDir2.getAbsolutePath());
 
 			try {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
@@ -115,14 +115,12 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 	private String dbPath;
 	private RocksDB db = null;
 	private ColumnFamilyHandle defaultCFHandle = null;
-	private ColumnFamilyOptions columnOptions = null;
-	private RocksDBResourceContainer optionsContainer = null;
-	private ArrayList<AutoCloseable> handlesToClose = new ArrayList<>();
+	private final RocksDBResourceContainer optionsContainer = new RocksDBResourceContainer();
 
 	public void prepareRocksDB() throws Exception {
 		String dbPath = new File(tempFolder.newFolder(), DB_INSTANCE_DIR_STRING).getAbsolutePath();
-		columnOptions = PredefinedOptions.DEFAULT.createColumnOptions(handlesToClose);
-		optionsContainer = new RocksDBResourceContainer();
+		ColumnFamilyOptions columnOptions = optionsContainer.getColumnOptions();
+
 		ArrayList<ColumnFamilyHandle> columnFamilyHandles = new ArrayList<>(1);
 		db = RocksDBOperationUtils.openDB(dbPath, Collections.emptyList(),
 			columnFamilyHandles, columnOptions, optionsContainer.getDbOptions());
@@ -157,9 +155,7 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 		}
 		IOUtils.closeQuietly(defaultCFHandle);
 		IOUtils.closeQuietly(db);
-		IOUtils.closeQuietly(columnOptions);
 		IOUtils.closeQuietly(optionsContainer);
-		handlesToClose.forEach(IOUtils::closeQuietly);
 
 		if (allCreatedCloseables != null) {
 			for (RocksObject rocksCloseable : allCreatedCloseables) {
@@ -185,7 +181,7 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 				IntSerializer.INSTANCE,
 				spy(db),
 				defaultCFHandle,
-				PredefinedOptions.DEFAULT.createColumnOptions(handlesToClose))
+				optionsContainer.getColumnOptions())
 			.setEnableIncrementalCheckpointing(enableIncrementalCheckpointing)
 			.build();
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
@@ -114,16 +114,13 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 	// Store it because we need it for the cleanup test.
 	private String dbPath;
 	private RocksDB db = null;
-	private File instanceBasePath = null;
 	private ColumnFamilyHandle defaultCFHandle = null;
 	private ColumnFamilyOptions columnOptions = null;
 	private RocksDBResourceContainer optionsContainer = null;
 	private ArrayList<AutoCloseable> handlesToClose = new ArrayList<>();
 
 	public void prepareRocksDB() throws Exception {
-		instanceBasePath = tempFolder.newFolder();
-		instanceBasePath.mkdirs();
-		String dbPath = new File(instanceBasePath, DB_INSTANCE_DIR_STRING).getAbsolutePath();
+		String dbPath = new File(tempFolder.newFolder(), DB_INSTANCE_DIR_STRING).getAbsolutePath();
 		columnOptions = PredefinedOptions.DEFAULT.createColumnOptions(handlesToClose);
 		optionsContainer = new RocksDBResourceContainer();
 		ArrayList<ColumnFamilyHandle> columnFamilyHandles = new ArrayList<>(1);
@@ -170,11 +167,6 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 			}
 			allCreatedCloseables = null;
 		}
-		try {
-			org.apache.flink.util.FileUtils.deleteDirectory(instanceBasePath);
-		} catch (Exception ex) {
-			// ignored
-		}
 	}
 
 	public void setupRocksKeyedStateBackend() throws Exception {
@@ -189,7 +181,7 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 		prepareRocksDB();
 
 		keyedStateBackend = RocksDBTestUtils.builderForTestDB(
-				instanceBasePath,
+				tempFolder.newFolder(), // this is not used anyways because the DB is injected
 				IntSerializer.INSTANCE,
 				spy(db),
 				defaultCFHandle,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBTestUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBTestUtils.java
@@ -32,7 +32,6 @@ import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
-import org.rocksdb.DBOptions;
 import org.rocksdb.RocksDB;
 
 import java.io.File;
@@ -47,15 +46,14 @@ public final class RocksDBTestUtils {
 			File instanceBasePath,
 			TypeSerializer<K> keySerializer) {
 
-		final DBOptions dbOptions = PredefinedOptions.DEFAULT.createDBOptions();
-		dbOptions.setCreateIfMissing(true);
+		final RocksDBResourceContainer optionsContainer = new RocksDBResourceContainer();
 
 		return new RocksDBKeyedStateBackendBuilder<>(
 			"no-op",
 			ClassLoader.getSystemClassLoader(),
 			instanceBasePath,
-			dbOptions,
-			stateName -> PredefinedOptions.DEFAULT.createColumnOptions(),
+			optionsContainer,
+			stateName -> optionsContainer.getColumnOptions(),
 			new KvStateRegistry().createTaskRegistry(new JobID(), new JobVertexID()),
 			keySerializer,
 			2,
@@ -77,14 +75,13 @@ public final class RocksDBTestUtils {
 			ColumnFamilyHandle defaultCFHandle,
 			ColumnFamilyOptions columnFamilyOptions) {
 
-		final DBOptions dbOptions = PredefinedOptions.DEFAULT.createDBOptions();
-		dbOptions.setCreateIfMissing(true);
+		final RocksDBResourceContainer optionsContainer = new RocksDBResourceContainer();
 
 		return new RocksDBKeyedStateBackendBuilder<>(
 				"no-op",
 				ClassLoader.getSystemClassLoader(),
 				instanceBasePath,
-				dbOptions,
+				optionsContainer,
 				stateName -> columnFamilyOptions,
 				new KvStateRegistry().createTaskRegistry(new JobID(), new JobVertexID()),
 				keySerializer,


### PR DESCRIPTION
## This PR is based PR #10300

## What is the purpose of the change

This PR ensures that the RocksDB objects are always deallocated when the keyed state backend is closed. These objects consist of

  - The RocksDB options objects, with the native handles.
  - Objects with native handles to options that users configure (like bloom filters)
  - Shared RocksDB data structures, Caches


## Brief change log

  - The PR introduces one component to hold an collect all these objects: 
  - This `RocksDBResourceContainer`is given to the keyed state backend object upon creation, and disposed when the state backend is disposed.
  - The factories for options are changed to that they can put created objects with native handles into a collection (owned by the resource container) so they will get closed in disposal.

## Verifying this change

  - The effect is better release of native memory, which can be verified by monitoring a TaskManager process with RocksDB state backend that undergoes several restarts.
  - The individual components are unit tested.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
