### PR TITLE
[FLINK-15195] Remove unused KubernetesConfigOptionsInternal.ENTRY_POINT_CLASS_ARGS

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptionsInternal.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptionsInternal.java
@@ -40,12 +40,6 @@ public class KubernetesConfigOptionsInternal {
 		.noDefaultValue()
 		.withDescription("The entrypoint class for jobmanager. It will be set in kubernetesClusterDescriptor.");
 
-	public static final ConfigOption<String> ENTRY_POINT_CLASS_ARGS = ConfigOptions
-		.key("kubernetes.internal.jobmanager.entrypoint.class.args")
-		.stringType()
-		.noDefaultValue()
-		.withDescription("The args of entrypoint class for jobmanager. It will be set in FlinkKubernetesCustomCli.");
-
 	/** This class is not meant to be instantiated. */
 	private KubernetesConfigOptionsInternal() {}
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkMasterDeploymentDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkMasterDeploymentDecorator.java
@@ -109,7 +109,6 @@ public class FlinkMasterDeploymentDecorator extends Decorator<Deployment, Kubern
 			int blobServerPort) {
 		final String flinkConfDirInPod = flinkConfig.getString(KubernetesConfigOptions.FLINK_CONF_DIR);
 		final String logDirInPod = flinkConfig.getString(KubernetesConfigOptions.FLINK_LOG_DIR);
-		final String mainClassArgs = flinkConfig.getString(KubernetesConfigOptionsInternal.ENTRY_POINT_CLASS_ARGS);
 		final String startCommand = KubernetesUtils.getJobManagerStartCommand(
 			flinkConfig,
 			clusterSpecification.getMasterMemoryMB(),
@@ -118,7 +117,7 @@ public class FlinkMasterDeploymentDecorator extends Decorator<Deployment, Kubern
 			hasLogback,
 			hasLog4j,
 			mainClass,
-			mainClassArgs);
+			null);
 
 		final ResourceRequirements requirements = KubernetesUtils.getResourceRequirements(
 			clusterSpecification.getMasterMemoryMB(),


### PR DESCRIPTION
## What is the purpose of the change

As the title suggests, this simply removes an unused, internal config option.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
