### PR TITLE
[FLINK-15196][Mesos] Using the mesos.resourcemanager.tasks.cpus to determine the cpus of Mesos worker

### DIFF
--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -424,7 +424,7 @@ public class MesosTaskManagerParameters {
 	}
 
 	private static double getCpuCores(final Configuration configuration) {
-		double fallback = configuration.getInteger(MESOS_RM_TASKS_SLOTS);
+		double fallback = configuration.getDouble(MESOS_RM_TASKS_CPUS);
 		return TaskExecutorResourceUtils.getCpuCoresWithFallback(configuration, fallback).getValue().doubleValue();
 	}
 

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
@@ -238,6 +238,14 @@ public class MesosTaskManagerParametersTest extends TestLogger {
 	}
 
 	@Test
+	public void testLegacyConfigCpuCores() {
+		Configuration config = getConfiguration();
+		config.setDouble(MesosTaskManagerParameters.MESOS_RM_TASKS_CPUS, 1.5);
+		MesosTaskManagerParameters mesosTaskManagerParameters = MesosTaskManagerParameters.create(config);
+		assertThat(mesosTaskManagerParameters.cpus(), is(1.5));
+	}
+
+	@Test
 	public void testUnifiedTotalProcessMemoryConfiguration() {
 		assertTotalProcessMemory(MesosTaskManagerParameters.create(getConfiguration()));
 	}


### PR DESCRIPTION
##  What is the purpose of the change

Using the correct option "mesos.resourcemanager.tasks.cpus" to determine the cpu cores of Mesos worker.

## Brief change log

- Using the mesos.resourcemanager.tasks.cpus to determine the cpus of Mesos worker
- Adding relevant test case.

## Verifying this change

This change added tests and can be verified as follows:
- Extends MesosTaskManagerParametersTest#testLegacyConfigCpuCores

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

cc @xintongsong @azagrebin 
