### PR TITLE
[FLINK-15053][runtime] Escape all dynamical property values for taskmanager

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
@@ -304,7 +304,7 @@ public class KubernetesResourceManager extends ActiveResourceManager<KubernetesW
 
 		final String mainClassArgs = "--" + CommandLineOptions.CONFIG_DIR_OPTION.getLongOpt() + " " +
 			flinkConfig.getString(KubernetesConfigOptions.FLINK_CONF_DIR) + " " +
-			BootstrapTools.getDynamicProperties(flinkClientConfig, flinkConfig);
+			BootstrapTools.getDynamicPropertiesAsString(flinkClientConfig, flinkConfig);
 
 		final String command = KubernetesUtils.getTaskManagerStartCommand(
 			flinkConfig,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -28,7 +28,10 @@ import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.entrypoint.parser.CommandLineOptions;
 import org.apache.flink.util.NetUtils;
+import org.apache.flink.util.OperatingSystem;
 
+import org.apache.flink.shaded.guava18.com.google.common.escape.Escaper;
+import org.apache.flink.shaded.guava18.com.google.common.escape.Escapers;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelException;
 
 import akka.actor.ActorSystem;
@@ -68,6 +71,15 @@ public class BootstrapTools {
 		.defaultValue(false);
 
 	private static final Logger LOG = LoggerFactory.getLogger(BootstrapTools.class);
+
+	private static final Escaper UNIX_SINGLE_QUOTE_ESCAPER = Escapers.builder()
+		.addEscape('\'', "'\\''")
+		.build();
+
+	private static final Escaper WINDOWS_DOUBLE_QUOTE_ESCAPER = Escapers.builder()
+		.addEscape('"', "\\\"")
+		.addEscape('^', "\"^^\"")
+		.build();
 
 	/**
 	 * Starts an ActorSystem with the given configuration listening at the address/ports.
@@ -624,7 +636,7 @@ public class BootstrapTools {
 	 * @param targetConfig The target configuration.
 	 * @return Dynamic properties as string, separated by whitespace.
 	 */
-	public static String getDynamicProperties(Configuration baseConfig, Configuration targetConfig) {
+	public static String getDynamicPropertiesAsString(Configuration baseConfig, Configuration targetConfig) {
 
 		String[] newAddedConfigs = targetConfig.keySet().stream().flatMap(
 			(String key) -> {
@@ -633,13 +645,45 @@ public class BootstrapTools {
 
 				if (!baseConfig.keySet().contains(key) || !baseValue.equals(targetValue)) {
 					return Stream.of("-" + CommandLineOptions.DYNAMIC_PROPERTY_OPTION.getOpt() + key +
-						CommandLineOptions.DYNAMIC_PROPERTY_OPTION.getValueSeparator() + targetValue);
+						CommandLineOptions.DYNAMIC_PROPERTY_OPTION.getValueSeparator() + escapeForDifferentOS(targetValue));
 				} else {
 					return Stream.empty();
 				}
 			})
 			.toArray(String[]::new);
 		return String.join(" ", newAddedConfigs);
+	}
+
+	/**
+	 * Escape all the dynamic property values.
+	 * For Unix-like OS(Linux, MacOS, FREE_BSD, etc.), each value will be surrounded with single quotes. This works for
+	 * all chars except single quote itself. To escape the single quote, close the quoting before it, insert the escaped
+	 * single quote, and then re-open the quoting. For example, the value is foo'bar and the escaped value is
+	 * 'foo'\''bar'. See <a href="https://stackoverflow.com/questions/15783701/which-characters-need-to-be-escaped-when-using-bash">https://stackoverflow.com/questions/15783701/which-characters-need-to-be-escaped-when-using-bash</a>
+	 * for more information about Unix escaping.
+	 *
+	 * <p>For Windows OS, each value will be surrounded with double quotes. The double quote itself needs to be escaped with
+	 * back slash. Also the caret symbol need to be escaped with double carets since Windows uses it to escape characters.
+	 * See <a href="https://en.wikibooks.org/wiki/Windows_Batch_Scripting">https://en.wikibooks.org/wiki/Windows_Batch_Scripting</a>
+	 * for more information about Windows escaping.
+	 *
+	 * @param value value to be escaped
+	 * @return escaped value
+	 */
+	public static String escapeForDifferentOS(String value) {
+		if (OperatingSystem.isWindows()) {
+			return escapeWithDoubleQuote(value);
+		} else {
+			return escapeWithSingleQuote(value);
+		}
+	}
+
+	public static String escapeWithSingleQuote(String value) {
+		return "'" + UNIX_SINGLE_QUOTE_ESCAPER.escape(value) + "'";
+	}
+
+	public static String escapeWithDoubleQuote(String value) {
+		return "\"" + WINDOWS_DOUBLE_QUOTE_ESCAPER.escape(value) + "\"";
 	}
 
 	/**

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/ShellScript.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/ShellScript.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.util;
+
+import org.apache.flink.util.OperatingSystem;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.List;
+
+/**
+ * ShellScript for creating shell script on linux and windows.
+ */
+public class ShellScript {
+
+	public static ShellScriptBuilder createShellScriptBuilder() {
+		if (OperatingSystem.isWindows()) {
+			return new WindowsShellScriptBuilder();
+		}
+		return new UnixShellScriptBuilder();
+	}
+
+	public static String getScriptExtension() {
+		return OperatingSystem.isWindows() ? ".cmd" : ".sh";
+	}
+
+	/**
+	 * Builder to create shell script.
+	 */
+	public abstract static class ShellScriptBuilder {
+		private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+		private final StringBuilder sb = new StringBuilder();
+
+		void line(String... command) {
+			for (String s : command) {
+				sb.append(s);
+			}
+			sb.append(LINE_SEPARATOR);
+		}
+
+		public void write(File file) throws IOException {
+			try (FileWriter fwrt = new FileWriter(file); PrintWriter out = new PrintWriter(fwrt)) {
+				out.append(sb);
+			}
+			file.setExecutable(true, false);
+		}
+
+		public abstract void command(List<String> command);
+
+		public abstract void env(String key, String value);
+	}
+
+	private static final class UnixShellScriptBuilder extends ShellScriptBuilder {
+
+		UnixShellScriptBuilder(){
+			line("#!/usr/bin/env bash");
+			line();
+		}
+
+		public void command(List<String> command) {
+			line("exec ", String.join(" ", command));
+		}
+
+		public void env(String key, String value) {
+			line("export ", key, "=\"", value, "\"");
+		}
+	}
+
+	private static final class WindowsShellScriptBuilder extends ShellScriptBuilder {
+
+		WindowsShellScriptBuilder() {
+			line("@setlocal");
+			line();
+		}
+
+		public void command(List<String> command) {
+			line("@call ", String.join(" ", command));
+		}
+
+		public void env(String key, String value) {
+			line("@set ", key, "=", value);
+		}
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/TaskManagerLoadingDynamicPropertiesITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/TaskManagerLoadingDynamicPropertiesITCase.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.runtime;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.clusterframework.BootstrapTools;
+import org.apache.flink.runtime.entrypoint.FlinkParseException;
+import org.apache.flink.runtime.taskexecutor.TaskManagerRunner;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.test.util.ShellScript;
+import org.apache.flink.util.OperatingSystem;
+import org.apache.flink.util.TestLogger;
+
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.configuration.GlobalConfiguration.FLINK_CONF_FILENAME;
+import static org.apache.flink.runtime.testutils.CommonTestUtils.getCurrentClasspath;
+import static org.apache.flink.runtime.testutils.CommonTestUtils.getJavaCommandPath;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for passing and loading dynamical properties of task manager.
+ * Usually(in Yarn, Kubernetes), the taskmanager java start commands are wrapped within bash. This test will generate a
+ * launch_container.sh script to validate the dynamical properties passing and loading.
+ */
+public class TaskManagerLoadingDynamicPropertiesITCase extends TestLogger {
+
+	private static final String KEY_A = "key.a";
+	private static final String VALUE_A = "#a,b&c^d*e@f(g!h";
+	private static final String KEY_B = "key.b";
+	private static final String VALUE_B = "'foobar";
+	private static final String KEY_C = "key.c";
+	private static final String VALUE_C = "foo''bar";
+	private static final String KEY_D = "key.d";
+	private static final String VALUE_D = "'foo' 'bar'";
+	private static final String KEY_E = "key.e";
+	private static final String VALUE_E = "foo\"bar'";
+	private static final String KEY_F = "key.f";
+	private static final String VALUE_F = "\"foo\" \"bar\"";
+
+	@Rule
+	public TemporaryFolder folder = new TemporaryFolder();
+
+	@Test
+	public void testLoadingDynamicPropertiesInBash() throws Exception {
+		final Configuration clientConfiguration = new Configuration();
+		final File root = folder.getRoot();
+		final File homeDir = new File(root, "home");
+		assertTrue(homeDir.mkdir());
+		BootstrapTools.writeConfiguration(clientConfiguration, new File(homeDir, FLINK_CONF_FILENAME));
+
+		final Configuration jmUpdatedConfiguration = getJobManagerUpdatedConfiguration();
+
+		final File shellScriptFile = generateLaunchContainerScript(
+			homeDir,
+			BootstrapTools.getDynamicPropertiesAsString(clientConfiguration, jmUpdatedConfiguration));
+
+		Process process = new ProcessBuilder(shellScriptFile.getAbsolutePath()).start();
+		try {
+			final StringWriter processOutput = new StringWriter();
+			new CommonTestUtils.PipeForwarder(process.getErrorStream(), processOutput);
+
+			if (!process.waitFor(10, TimeUnit.SECONDS)) {
+				throw new Exception("TestingTaskManagerRunner did not shutdown in time.");
+			}
+			assertEquals(processOutput.toString(), 0, process.exitValue());
+		} finally {
+			process.destroy();
+		}
+	}
+
+	private Configuration getJobManagerUpdatedConfiguration() {
+		final Configuration updatedConfig = new Configuration();
+		updatedConfig.setString(KEY_A, VALUE_A);
+		updatedConfig.setString(KEY_B, VALUE_B);
+		updatedConfig.setString(KEY_C, VALUE_C);
+		updatedConfig.setString(KEY_D, VALUE_D);
+		updatedConfig.setString(KEY_E, VALUE_E);
+		updatedConfig.setString(KEY_F, VALUE_F);
+		return updatedConfig;
+	}
+
+	private File generateLaunchContainerScript(File homeDir, String dynamicProperties) throws IOException {
+		final ShellScript.ShellScriptBuilder shellScriptBuilder = ShellScript.createShellScriptBuilder();
+		final List<String> commands = new ArrayList<>();
+		commands.add(getJavaCommandWithOS());
+		commands.add(getInternalClassNameWithOS(TestingTaskManagerRunner.class.getName()));
+		commands.add("--configDir");
+		commands.add(homeDir.getAbsolutePath());
+		commands.add(dynamicProperties);
+		shellScriptBuilder.env("CLASSPATH", getCurrentClasspath());
+		shellScriptBuilder.command(commands);
+		final File shellScriptFile = new File(homeDir, "launch_container" + ShellScript.getScriptExtension());
+		shellScriptBuilder.write(shellScriptFile);
+		return shellScriptFile;
+	}
+
+	private String getJavaCommandWithOS() {
+		if (OperatingSystem.isWindows()) {
+			return "\"" + getJavaCommandPath() + "\"";
+		}
+		return getJavaCommandPath();
+	}
+
+	private String getInternalClassNameWithOS(String className) {
+		if (!OperatingSystem.isWindows()) {
+			return className.replace("$", "'$'");
+		}
+		return className;
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * The testing taskmanager runner. The exit code will be 0 if configuration values check passed.
+	 */
+	public static class TestingTaskManagerRunner {
+
+		public static void main(String[] args) throws FlinkParseException {
+			final Configuration flinkConfig = TaskManagerRunner.loadConfiguration(args);
+			assertThat(
+				flinkConfig.toMap().values(),
+				Matchers.containsInAnyOrder(VALUE_A, VALUE_B, VALUE_C, VALUE_D, VALUE_E, VALUE_F));
+		}
+	}
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -571,9 +571,10 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 			containerId,
 			taskExecutorResourceSpec);
 
-		Configuration taskManagerConfig = BootstrapTools.cloneConfiguration(flinkConfig);
+		final Configuration taskManagerConfig = BootstrapTools.cloneConfiguration(flinkConfig);
 
-		String taskManagerDynamicProperties = BootstrapTools.getDynamicProperties(flinkClientConfig, taskManagerConfig);
+		final String taskManagerDynamicProperties =
+			BootstrapTools.getDynamicPropertiesAsString(flinkClientConfig, taskManagerConfig);
 
 		log.debug("TaskManager configuration: {}", taskManagerConfig);
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Currently on Yarn setups, we are passing task executor specific configurations through dynamic properties in the starting command (see FLINK-13184).

If the jobmanager updated value of configuration contains space, the dynamic properties may not be correctly parsed, which could cause task executor failures. On occurrence can be found in FLINK-15047.

It would be good to allow spaces when passing dynamic properties. E.g., surrounding the values with single quotes. 


## Brief change log

* Each value will put in single quotes. This works for all chars except single quote itself. To escape the single quote, close the quoting before it, insert the escaped single quote, and then re-open the quoting. For example, the value is `my'value` and the escaped value is `'my'\''value'`.


## Verifying this change

* Update the existing unit test to cover space values case
* Add a new ITCase to verify passing and loading dynamic properties for TaskManager
* Manually run flink job on Yarn and Kubernetes

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
