### PR TITLE
[FLINK-14929][tests] Harden ContinuousFileProcessingCheckpointITCase 

### DIFF
--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingITCase.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingITCase.java
@@ -78,35 +78,25 @@ public class ContinuousFileProcessingITCase extends AbstractTestBase {
 	//						PREPARING FOR THE TESTS
 
 	@Before
-	public void createHDFS() {
-		try {
-			baseDir = new File("./target/hdfs/hdfsTesting").getAbsoluteFile();
-			FileUtil.fullyDelete(baseDir);
+	public void createHDFS() throws IOException {
+		baseDir = new File("./target/hdfs/hdfsTesting").getAbsoluteFile();
+		FileUtil.fullyDelete(baseDir);
 
-			org.apache.hadoop.conf.Configuration hdConf = new org.apache.hadoop.conf.Configuration();
-			hdConf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath());
-			hdConf.set("dfs.block.size", String.valueOf(1048576)); // this is the minimum we can set.
+		org.apache.hadoop.conf.Configuration hdConf = new org.apache.hadoop.conf.Configuration();
+		hdConf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath());
+		hdConf.set("dfs.block.size", String.valueOf(1048576)); // this is the minimum we can set.
 
-			MiniDFSCluster.Builder builder = new MiniDFSCluster.Builder(hdConf);
-			hdfsCluster = builder.build();
+		MiniDFSCluster.Builder builder = new MiniDFSCluster.Builder(hdConf);
+		hdfsCluster = builder.build();
 
-			hdfsURI = "hdfs://" + hdfsCluster.getURI().getHost() + ":" + hdfsCluster.getNameNodePort() + "/";
-			hdfs = new org.apache.hadoop.fs.Path(hdfsURI).getFileSystem(hdConf);
-
-		} catch (Throwable e) {
-			e.printStackTrace();
-			Assert.fail("Test failed " + e.getMessage());
-		}
+		hdfsURI = "hdfs://" + hdfsCluster.getURI().getHost() + ":" + hdfsCluster.getNameNodePort() + "/";
+		hdfs = new org.apache.hadoop.fs.Path(hdfsURI).getFileSystem(hdConf);
 	}
 
 	@After
 	public void destroyHDFS() {
-		try {
-			FileUtil.fullyDelete(baseDir);
-			hdfsCluster.shutdown();
-		} catch (Throwable t) {
-			throw new RuntimeException(t);
-		}
+		FileUtil.fullyDelete(baseDir);
+		hdfsCluster.shutdown();
 	}
 
 	//						END OF PREPARATIONS

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ContinuousFileProcessingCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ContinuousFileProcessingCheckpointITCase.java
@@ -75,36 +75,26 @@ public class ContinuousFileProcessingCheckpointITCase extends StreamFaultToleran
 	private static Map<Integer, Set<String>> actualCollectedContent = new HashMap<>();
 
 	@Before
-	public void createHDFS() {
+	public void createHDFS() throws IOException {
 		if (failoverStrategy.equals(FailoverStrategy.RestartPipelinedRegionStrategy)) {
 			// TODO the 'NO_OF_RETRIES' is useless for current RestartPipelinedRegionStrategy,
 			// for this ContinuousFileProcessingCheckpointITCase, using RestartPipelinedRegionStrategy would result in endless running.
 			throw new AssumptionViolatedException("ignored ContinuousFileProcessingCheckpointITCase when using RestartPipelinedRegionStrategy");
 		}
 
-		try {
-			baseDir = new File("./target/localfs/fs_tests").getAbsoluteFile();
-			FileUtil.fullyDelete(baseDir);
+		baseDir = new File("./target/localfs/fs_tests").getAbsoluteFile();
+		FileUtil.fullyDelete(baseDir);
 
-			org.apache.hadoop.conf.Configuration hdConf = new org.apache.hadoop.conf.Configuration();
+		org.apache.hadoop.conf.Configuration hdConf = new org.apache.hadoop.conf.Configuration();
 
-			localFsURI = "file:///" + baseDir + "/";
-			localFs = new org.apache.hadoop.fs.Path(localFsURI).getFileSystem(hdConf);
-
-		} catch (Throwable e) {
-			e.printStackTrace();
-			Assert.fail("Test failed " + e.getMessage());
-		}
+		localFsURI = "file:///" + baseDir + "/";
+		localFs = new org.apache.hadoop.fs.Path(localFsURI).getFileSystem(hdConf);
 	}
 
 	@After
 	public void destroyHDFS() {
-		try {
-			if (baseDir != null) {
-				FileUtil.fullyDelete(baseDir);
-			}
-		} catch (Throwable t) {
-			throw new RuntimeException(t);
+		if (baseDir != null) {
+			FileUtil.fullyDelete(baseDir);
 		}
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ContinuousFileProcessingCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ContinuousFileProcessingCheckpointITCase.java
@@ -229,15 +229,6 @@ public class ContinuousFileProcessingCheckpointITCase extends StreamFaultToleran
 		}
 
 		@Override
-		public void close() {
-			try {
-				super.close();
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
-		}
-
-		@Override
 		public List<Tuple2<Long, Map<Integer, Set<String>>>> snapshotState(long checkpointId, long checkpointTimestamp) throws Exception {
 			Tuple2<Long, Map<Integer, Set<String>>> state = new Tuple2<>(elementCounter, actualContent);
 			return Collections.singletonList(state);


### PR DESCRIPTION
## What is the purpose of the change

*This hardens the ContinuousFileProcessingCheckpointITCase.*


## Brief change log

  - *See commits*


## Verifying this change
This change is already covered by existing tests, such as *ContinuousFileProcessingCheckpointITCase*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
