### PR TITLE
[FLINK-15203][doc] rephrase Hive's data types doc

### DIFF
--- a/docs/dev/table/hive/index.md
+++ b/docs/dev/table/hive/index.md
@@ -265,6 +265,10 @@ Currently `HiveCatalog` supports most Flink data types with the following mappin
         <td class="text-center">DATE</td>
     </tr>
     <tr>
+        <td class="text-center">TIMESTAMP</td>
+        <td class="text-center">TIMESTAMP</td>
+    </tr>
+    <tr>
         <td class="text-center">BYTES</td>
         <td class="text-center">BINARY</td>
     </tr>
@@ -283,15 +287,14 @@ Currently `HiveCatalog` supports most Flink data types with the following mappin
   </tbody>
 </table>
 
-### Limitations
 
-The following limitations in Hive's data types impact the mapping between Flink and Hive:
-
-* `CHAR(p)` has a maximum length of 255
-* `VARCHAR(p)` has a maximum length of 65535
+* Hive's `CHAR(p)` has a maximum length of 255
+* Hive's `VARCHAR(p)` has a maximum length of 65535
 * Hive's `MAP` only supports primitive key types while Flink's `MAP` can be any data type
-* Hive's `UNION` type is not supported
-* Flink's `INTERVAL` type cannot be mapped to Hive `INTERVAL` type
-* Flink's `TIMESTAMP_WITH_TIME_ZONE` and `TIMESTAMP_WITH_LOCAL_TIME_ZONE` are not supported by Hive
-* Flink's `TIMESTAMP_WITHOUT_TIME_ZONE` type cannot be mapped to Hive's `TIMESTAMP` type due to precision difference.
-* Flink's `MULTISET` is not supported by Hive
+
+
+Note that:
+
+* Flink doesn't support Hive's `UNION` type is not supported
+* Hive doesn't support Flink's `TIMESTAMP_WITH_TIME_ZONE`, `TIMESTAMP_WITH_LOCAL_TIME_ZONE`, and `MULTISET`
+* Flink's `INTERVAL` type cannot be mapped to Hive `INTERVAL` type yet

--- a/docs/dev/table/hive/index.zh.md
+++ b/docs/dev/table/hive/index.zh.md
@@ -283,15 +283,14 @@ Currently `HiveCatalog` supports most Flink data types with the following mappin
   </tbody>
 </table>
 
-### Limitations
 
-The following limitations in Hive's data types impact the mapping between Flink and Hive:
-
-* `CHAR(p)` has a maximum length of 255
-* `VARCHAR(p)` has a maximum length of 65535
+* Hive's `CHAR(p)` has a maximum length of 255
+* Hive's `VARCHAR(p)` has a maximum length of 65535
 * Hive's `MAP` only supports primitive key types while Flink's `MAP` can be any data type
-* Hive's `UNION` type is not supported
-* Flink's `INTERVAL` type cannot be mapped to Hive `INTERVAL` type
-* Flink's `TIMESTAMP_WITH_TIME_ZONE` and `TIMESTAMP_WITH_LOCAL_TIME_ZONE` are not supported by Hive
-* Flink's `TIMESTAMP_WITHOUT_TIME_ZONE` type cannot be mapped to Hive's `TIMESTAMP` type due to precision difference.
-* Flink's `MULTISET` is not supported by Hive
+
+
+Note that:
+
+* Flink doesn't support Hive's `UNION` type is not supported
+* Hive doesn't support Flink's `TIMESTAMP_WITH_TIME_ZONE`, `TIMESTAMP_WITH_LOCAL_TIME_ZONE`, and `MULTISET`
+* Flink's `INTERVAL` type cannot be mapped to Hive `INTERVAL` type yet


### PR DESCRIPTION
## What is the purpose of the change

rephrase the doc to 1) reflect latest changes 2) not scare users away

a more detailed doc on Flink-Hive timestamp precision conversion is tracked by https://issues.apache.org/jira/browse/FLINK-15204

## Brief change log

rephrase the doc to 1) reflect latest changes 2) not scare users away

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
