### PR TITLE
[FLINK-15135][e2e][Mesos] Adding e2e tests for Flink's Mesos integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -351,7 +351,7 @@ jobs:
       name: e2e - checkpoints
     - if: type = cron
       env: PROFILE="-DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup5"
-      script: ./tools/travis/nightly.sh split_container.sh
+      script: ./tools/travis/nightly.sh split_container.sh without
       name: e2e - container
     - if: type = cron
       env: PROFILE="-DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup6"

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -114,6 +114,12 @@ run_test "Running HA per-job cluster (rocks, incremental) end-to-end test" "$END
 run_test "Run Kubernetes test" "$END_TO_END_DIR/test-scripts/test_kubernetes_embedded_job.sh"
 
 ################################################################################
+# Mesos
+################################################################################
+
+run_test "Run Mesos WordCount test" "$END_TO_END_DIR/test-scripts/test_mesos_wordcount.sh"
+
+################################################################################
 # Miscellaneous
 ################################################################################
 

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -536,7 +536,7 @@ function tm_watchdog {
 
 # Kills all job manager.
 function jm_kill_all {
-  kill_all 'StandaloneSessionClusterEntrypoint'
+  kill_all 'ClusterEntrypoint'
 }
 
 # Kills all task manager.

--- a/flink-end-to-end-tests/test-scripts/common_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_docker.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+set -o pipefail
+
+source "$(dirname "$0")"/common.sh
+
+docker --version
+docker-compose --version
+
+function containers_health_check() {
+  local container_names=${@:1}
+  for container in ${container_names}; do
+    if ! [ $(docker inspect -f '{{.State.Running}}' ${container} 2>&1) = 'true' ];
+    then
+      return 1;
+    fi
+  done
+}

--- a/flink-end-to-end-tests/test-scripts/common_mesos_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_mesos_docker.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+set -o pipefail
+
+source "$(dirname "$0")"/common.sh
+source "$(dirname "$0")"/common_docker.sh
+
+MAX_RETRY_SECONDS=120
+IMAGE_BUILD_RETRIES=5
+NODENAME=${NODENAME:-`hostname -f`}
+
+export INPUT_VOLUME=${END_TO_END_DIR}/test-scripts/test-data
+
+echo "End-to-end directory $END_TO_END_DIR"
+
+start_time=$(date +%s)
+
+# make sure we stop our cluster at the end
+function cluster_shutdown {
+  docker-compose -f $END_TO_END_DIR/test-scripts/docker-mesos-cluster/docker-compose.yml down
+  rm -rf ${INPUT_VOLUME}/log
+  rm -rf ${INPUT_VOLUME}/tmp
+}
+on_exit cluster_shutdown
+
+function start_flink_cluster_with_mesos() {
+    echo "Starting Flink on Mesos cluster"
+    build_image
+
+    docker-compose -f $END_TO_END_DIR/test-scripts/docker-mesos-cluster/docker-compose.yml up -d
+
+    # wait for the Mesos master and slave set up
+    start_time=$(date +%s)
+    wait_rest_endpoint_up "http://${NODENAME}:5050/slaves" "Mesos" "\{\"slaves\":\[.+\].*\}"
+
+    # perform health checks
+    containers_health_check "mesos-master" "mesos-slave"
+
+    set_config_key "jobmanager.rpc.address" "mesos-master"
+    set_config_key "rest.address" "mesos-master"
+
+    docker exec -it mesos-master nohup bash -c "${FLINK_DIR}/bin/mesos-appmaster.sh -Dmesos.master=mesos-master:5050 &"
+    wait_rest_endpoint_up "http://${NODENAME}:8081/taskmanagers" "Dispatcher" "\{\"taskmanagers\":\[.*\]\}"
+    return 0
+}
+
+function build_image() {
+    echo "Building Mesos Docker container"
+    if ! retry_times $IMAGE_BUILD_RETRIES 0 docker build -f $END_TO_END_DIR/test-scripts/docker-mesos-cluster/Dockerfile \
+        -t flink/docker-mesos-cluster:latest \
+        $END_TO_END_DIR/test-scripts/docker-mesos-cluster/; then
+        echo "ERROR: Could not build mesos image. Aborting..."
+        exit 1
+    fi
+}

--- a/flink-end-to-end-tests/test-scripts/common_yarn_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_yarn_docker.sh
@@ -19,6 +19,7 @@
 set -o pipefail
 
 source "$(dirname "$0")"/common.sh
+source "$(dirname "$0")"/common_docker.sh
 
 FLINK_TARBALL_DIR=$TEST_DATA_DIR
 FLINK_TARBALL=flink.tar.gz
@@ -31,8 +32,6 @@ echo "Flink Tarball directory $FLINK_TARBALL_DIR"
 echo "Flink tarball filename $FLINK_TARBALL"
 echo "Flink distribution directory name $FLINK_DIRNAME"
 echo "End-to-end directory $END_TO_END_DIR"
-docker --version
-docker-compose --version
 
 start_time=$(date +%s)
 
@@ -62,13 +61,7 @@ function start_hadoop_cluster() {
     done
 
     # perform health checks
-    if ! { [ $(docker inspect -f '{{.State.Running}}' master 2>&1) = 'true' ] &&
-           [ $(docker inspect -f '{{.State.Running}}' slave1 2>&1) = 'true' ] &&
-           [ $(docker inspect -f '{{.State.Running}}' slave2 2>&1) = 'true' ] &&
-           [ $(docker inspect -f '{{.State.Running}}' kdc 2>&1) = 'true' ]; };
-    then
-        return 1
-    fi
+    containers_health_check "master" "slave1" "slave2" "kdc"
 
     # try and see if NodeManagers are up, otherwise the Flink job will not have enough resources
     # to run

--- a/flink-end-to-end-tests/test-scripts/common_yarn_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_yarn_docker.sh
@@ -27,6 +27,7 @@ FLINK_DIRNAME=$(basename $FLINK_DIR)
 
 MAX_RETRY_SECONDS=120
 CLUSTER_SETUP_RETRIES=3
+IMAGE_BUILD_RETRIES=5
 
 echo "Flink Tarball directory $FLINK_TARBALL_DIR"
 echo "Flink tarball filename $FLINK_TARBALL"
@@ -90,16 +91,13 @@ function start_hadoop_cluster() {
 
 function build_image() {
     echo "Building Hadoop Docker container"
-    until docker build --build-arg HADOOP_VERSION=2.8.4 \
+    if ! retry_times $IMAGE_BUILD_RETRIES 2 docker build --build-arg HADOOP_VERSION=2.8.4 \
         -f $END_TO_END_DIR/test-scripts/docker-hadoop-secure-cluster/Dockerfile \
         -t flink/docker-hadoop-secure-cluster:latest \
-        $END_TO_END_DIR/test-scripts/docker-hadoop-secure-cluster/;
-    do
-        # with all the downloading and ubuntu updating a lot of flakiness can happen, make sure
-        # we don't immediately fail
-        echo "Something went wrong while building the Docker image, retrying ..."
-        sleep 2
-    done
+        $END_TO_END_DIR/test-scripts/docker-hadoop-secure-cluster/; then
+        echo "ERROR: Could not build hadoop image. Aborting..."
+        exit 1
+    fi
 }
 
 function start_hadoop_cluster_and_prepare_flink() {

--- a/flink-end-to-end-tests/test-scripts/docker-mesos-cluster/Dockerfile
+++ b/flink-end-to-end-tests/test-scripts/docker-mesos-cluster/Dockerfile
@@ -1,0 +1,36 @@
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Creates Mesos cluster on Docker
+
+FROM ubuntu:xenial
+
+RUN apt-get update && \
+  apt-get -y install apt-transport-https ca-certificates && \
+  apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
+  echo deb https://apt.dockerproject.org/repo ubuntu-xenial main > /etc/apt/sources.list.d/docker.list && \
+  apt-get update && \
+  apt-get -y install curl docker-engine
+
+RUN echo "deb http://repos.mesosphere.io/ubuntu/ xenial main" > /etc/apt/sources.list.d/mesosphere.list && \
+  apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
+  apt-get -y update && \
+  apt-get -y install openjdk-8-jdk && \
+  apt-get -y install mesos=1.7.1-2.0.1 openjdk-9-jre-headless- && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*

--- a/flink-end-to-end-tests/test-scripts/docker-mesos-cluster/docker-compose.yml
+++ b/flink-end-to-end-tests/test-scripts/docker-mesos-cluster/docker-compose.yml
@@ -1,0 +1,69 @@
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+version: '3.5'
+
+networks:
+  docker-mesos-cluster-network:
+    name: docker-mesos-cluster-network
+
+services:
+  master:
+    image: flink/docker-mesos-cluster:latest
+    entrypoint: mesos-master
+    container_name: "mesos-master"
+    networks:
+      docker-mesos-cluster-network:
+        aliases:
+          - mesos-master
+    ports:
+      - "8081:8081"
+      - "5050:5050"
+    volumes:
+      - ${INPUT_VOLUME}/log/mesos:/var/log/mesos
+      - ${INPUT_VOLUME}/tmp/mesos:/var/tmp/mesos
+      - ${END_TO_END_DIR}:${END_TO_END_DIR}
+      - ${FLINK_DIR}:${FLINK_DIR}
+    environment:
+      MESOS_PORT: 5050
+      MESOS_QUORUM: 1
+      MESOS_REGISTRY: in_memory
+      MESOS_LOG_DIR: /var/log/mesos
+      MESOS_WORK_DIR: /var/tmp/mesos
+
+  slave:
+    image: flink/docker-mesos-cluster:latest
+    entrypoint: mesos-slave
+    privileged: true
+    depends_on:
+      - master
+    container_name: "mesos-slave"
+    networks:
+      - docker-mesos-cluster-network
+    volumes:
+      - ${INPUT_VOLUME}/log/mesos-sl:/var/log/mesos
+      - ${INPUT_VOLUME}/tmp/mesos-sl:/var/tmp/mesos
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${END_TO_END_DIR}:${END_TO_END_DIR}
+    environment:
+      MESOS_PORT: 5051
+      MESOS_MASTER: mesos-master:5050
+      MESOS_SWITCH_USER: 0
+      MESOS_CONTAINERIZERS: mesos
+      MESOS_LOG_DIR: /var/log/mesos
+      MESOS_WORK_DIR: /var/tmp/mesos
+      MESOS_SYSTEMD_ENABLE_SUPPORT: 'false'

--- a/flink-end-to-end-tests/test-scripts/test-runner-common.sh
+++ b/flink-end-to-end-tests/test-scripts/test-runner-common.sh
@@ -101,7 +101,7 @@ function cleanup_proc {
 
 # Cleans up all temporary folders and files
 function cleanup_tmp_files {
-    rm ${FLINK_DIR}/log/*
+    rm -f ${FLINK_DIR}/log/*
     echo "Deleted all files under ${FLINK_DIR}/log/"
 
     rm -rf ${TEST_DATA_DIR} 2> /dev/null

--- a/flink-end-to-end-tests/test-scripts/test_mesos_wordcount.sh
+++ b/flink-end-to-end-tests/test-scripts/test_mesos_wordcount.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+set -o pipefail
+
+source "$(dirname "$0")"/common.sh
+source "$(dirname "$0")"/common_mesos_docker.sh
+
+RESULT_HASH="72a690412be8928ba239c2da967328a5"
+INPUT_ARGS="--input ${TEST_INFRA_DIR}/test-data/words"
+OUTPUT_LOCATION="${TEST_DATA_DIR}/out/wc_out_mesos"
+TEST_PROGRAM_JAR=${FLINK_DIR}/examples/batch/WordCount.jar
+
+mkdir -p "${TEST_DATA_DIR}"
+
+start_flink_cluster_with_mesos
+
+docker exec -it mesos-master nohup bash -c "${FLINK_DIR}/bin/flink run -p 1 ${TEST_PROGRAM_JAR} ${INPUT_ARGS} --output ${OUTPUT_LOCATION}"
+
+check_result_hash "Mesos WordCount test" "${OUTPUT_LOCATION}" "${RESULT_HASH}"

--- a/tools/travis/nightly.sh
+++ b/tools/travis/nightly.sh
@@ -26,6 +26,7 @@ if [ -z "${HERE}" ] ; then
 fi
 
 SCRIPT=$1
+CMD=${@:2}
 
 source ${HERE}/setup_docker.sh
 source ${HERE}/setup_kubernetes.sh
@@ -71,7 +72,7 @@ if [ $EXIT_CODE == 0 ]; then
 	printf "Running end-to-end tests\n"
 	printf "==============================================================================\n"
 
-	FLINK_DIR=build-target flink-end-to-end-tests/${SCRIPT}
+	FLINK_DIR=build-target flink-end-to-end-tests/${SCRIPT} ${CMD}
 
 	EXIT_CODE=$?
 else

--- a/tools/travis/splits/split_container.sh
+++ b/tools/travis/splits/split_container.sh
@@ -24,6 +24,7 @@ if [ -z "$END_TO_END_DIR" ] ; then
     # to the script (e.g. permissions re-evaled after suid)
     exit 1  # fail
 fi
+HADOOP_INTEGRATION=${1-with}
 
 export END_TO_END_DIR
 
@@ -47,6 +48,10 @@ run_test "Wordcount on Docker test (custom fs plugin)" "$END_TO_END_DIR/test-scr
 run_test "Running Kerberized YARN on Docker test (default input)" "$END_TO_END_DIR/test-scripts/test_yarn_kerberos_docker.sh"
 run_test "Running Kerberized YARN on Docker test (custom fs plugin)" "$END_TO_END_DIR/test-scripts/test_yarn_kerberos_docker.sh dummy-fs"
 run_test "Run kubernetes test" "$END_TO_END_DIR/test-scripts/test_kubernetes_embedded_job.sh"
+if [[ "${HADOOP_INTEGRATION}" = "with" ]]; then
+    run_test "Run Mesos WordCount test" "$END_TO_END_DIR/test-scripts/test_mesos_wordcount.sh"
+fi
+
 
 printf "\n[PASS] All tests passed\n"
 exit 0


### PR DESCRIPTION
## What is the purpose of the change

This PR adds e2e tests for Flink's Mesos integration.

## Brief change log

- [56588e1](https://github.com/apache/flink/commit/56588e199a463564b92039ce590821ddab1e3c9d)..[fa10c39](https://github.com/apache/flink/commit/fa10c393215803621e198ff64939c969b3108c93): Hotfixes, refactors and code clean-ups.
- [6e4fb08](https://github.com/apache/flink/commit/6e4fb08ea363c442395053f85fd5b6a114ebcfb5): Adding the Dockerfile and Compose file for building docker images and deploying Mesos cluster using docker-compose.
- [dc64604](https://github.com/apache/flink/commit/dc646045124dd6b5af2fcd3f8b11039a6265ac26): Facilities for maintaining Mesos cluster and running Flink on it.
- [06887f6](https://github.com/apache/flink/pull/10538/commits/06887f61e9d550330f947e61de64e05ac5e88383): WordCount e2e tests for Flink's Mesos integration
- [c796e73](https://github.com/apache/flink/pull/10538/commits/c796e73285d2551783a5dd5f44e778115219b5a2): Enable the Mesos e2e test in Travis.
- [0bf31f2](https://github.com/apache/flink/pull/10538/commits/0bf31f2295910838b8feb3d09c1e26fb355156d5): Adding the Mesos e2e test to run-nightly-test script

## Verifying this change

This change is independent with Flink core code and belong to end to end test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

