### PR TITLE
[FLINK-14952][network] Solve the issue of exceeding memory limits when using mmap blocking partition

### DIFF
--- a/docs/_includes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/_includes/generated/netty_shuffle_environment_configuration.html
@@ -27,6 +27,12 @@
             <td>Boolean flag indicating whether the shuffle data will be compressed for blocking shuffle mode. Note that data is compressed per buffer and compression can incur extra CPU overhead, so it is more effective for IO bounded scenario when data compression ratio is high.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.network.blocking-shuffle.type</h5></td>
+            <td style="word-wrap: break-word;">"file"</td>
+            <td>String</td>
+            <td>The blocking shuffle type, either "mmap" or "file". The "auto" means selecting the property type automatically based on system memory architecture (64 bit for mmap and 32 bit for file). Note that the memory usage of mmap is not accounted by configured memory limits, but some resource frameworks like yarn would track this memory usage and kill the container once memory exceeding some threshold. Also note that this option is experimental and might be changed future.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.network.detailed-metrics</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/_includes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/_includes/generated/netty_shuffle_environment_configuration.html
@@ -27,12 +27,6 @@
             <td>Boolean flag indicating whether the shuffle data will be compressed for blocking shuffle mode. Note that data is compressed per buffer and compression can incur extra CPU overhead, so it is more effective for IO bounded scenario when data compression ratio is high.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.network.pipelined-shuffle.compression.enabled</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>Boolean flag indicating whether the shuffle data will be compressed for pipelined shuffle mode. Note that data is compressed per sliced buffer and compression can incur extra CPU overhead, so it is not recommended to enable compression if network is not the bottleneck or compression ratio is low.</td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.network.detailed-metrics</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
@@ -49,6 +43,12 @@
             <td style="word-wrap: break-word;">8</td>
             <td>Integer</td>
             <td>Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate). In credit-based flow control mode, this indicates how many floating credits are shared among all the input channels. The floating buffers are distributed based on backlog (real-time output buffers in the subpartition) feedback, and can help relieve back-pressure caused by unbalanced data distribution among the subpartitions. This value should be increased in case of higher round trip times between nodes and/or larger number of machines in the cluster.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.pipelined-shuffle.compression.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Boolean flag indicating whether the shuffle data will be compressed for pipelined shuffle mode. Note that data is compressed per sliced buffer and compression can incur extra CPU overhead, so it is not recommended to enable compression if network is not the bottleneck or compression ratio is low.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.request-backoff.initial</h5></td>

--- a/docs/_includes/generated/rocks_db_configurable_configuration.html
+++ b/docs/_includes/generated/rocks_db_configurable_configuration.html
@@ -11,67 +11,67 @@
         <tr>
             <td><h5>state.backend.rocksdb.block.blocksize</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
+            <td>MemorySize</td>
             <td>The approximate size (in bytes) of user data packed per block. RocksDB has default blocksize as '4KB'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.block.cache-size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
+            <td>MemorySize</td>
             <td>The amount of the cache for data blocks in RocksDB. RocksDB has default block-cache size as '8MB'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.compaction.level.max-size-level-base</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
+            <td>MemorySize</td>
             <td>The upper-bound of the total size of level base files in bytes. RocksDB has default configuration as '10MB'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.compaction.level.target-file-size-base</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
+            <td>MemorySize</td>
             <td>The target file size for compaction, which determines a level-1 file size. RocksDB has default configuration as '2MB'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.compaction.level.use-dynamic-size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
+            <td>Boolean</td>
             <td>If true, RocksDB will pick target size of each level dynamically. From an empty DB, RocksDB would make last level the base level, which means merging L0 data into the last level, until it exceeds max_bytes_for_level_base. And then repeat this process for second last level and so on. RocksDB has default configuration as 'false'. For more information, please refer to <a href="https://github.com/facebook/rocksdb/wiki/Leveled-Compaction#level_compaction_dynamic_level_bytes-is-true">RocksDB's doc.</a></td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.compaction.style</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
+            <td><p>Enum</p>Possible values: [LEVEL, UNIVERSAL, FIFO]</td>
             <td>The specified compaction style for DB. Candidate compaction style is LEVEL, FIFO or UNIVERSAL, and RocksDB choose 'LEVEL' as default style.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.files.open</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
+            <td>Integer</td>
             <td>The maximum number of open files (per TaskManager) that can be used by the DB, '-1' means no limit. RocksDB has default configuration as '5000'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.thread.num</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
+            <td>Integer</td>
             <td>The maximum number of concurrent background flush and compaction jobs (per TaskManager). RocksDB has default configuration as '1'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.writebuffer.count</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
+            <td>Integer</td>
             <td>Tne maximum number of write buffers that are built up in memory. RocksDB has default configuration as '2'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.writebuffer.number-to-merge</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
+            <td>Integer</td>
             <td>The minimum number of write buffers that will be merged together before writing to storage. RocksDB has default configuration as '1'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.writebuffer.size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
+            <td>MemorySize</td>
             <td>The amount of data built up in memory (backed by an unsorted log on disk) before converting to a sorted on-disk files. RocksDB has default writebuffer size as '64MB'.</td>
         </tr>
     </tbody>

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -184,12 +184,13 @@ public class NettyShuffleEnvironmentOptions {
 					"tasks have occupied all the buffers and the downstream tasks are waiting for the exclusive buffers. The timeout breaks" +
 					"the tie by failing the request of exclusive buffers and ask users to increase the number of total buffers.");
 
-	@Documentation.ExcludeFromDocumentation("This option is only used for testing at the moment.")
-	public static final ConfigOption<String> NETWORK_BOUNDED_BLOCKING_SUBPARTITION_TYPE =
-		key("taskmanager.network.bounded-blocking-subpartition-type")
-			.defaultValue("auto")
-			.withDescription("The bounded blocking subpartition type, either \"mmap\" or \"file\". The default \"auto\" means selecting the" +
-					"property type automatically based on system memory architecture.");
+	public static final ConfigOption<String> NETWORK_BLOCKING_SHUFFLE_TYPE =
+		key("taskmanager.network.blocking-shuffle.type")
+			.defaultValue("file")
+			.withDescription("The blocking shuffle type, either \"mmap\" or \"file\". The \"auto\" means selecting the property type automatically" +
+					" based on system memory architecture (64 bit for mmap and 32 bit for file). Note that the memory usage of mmap is not accounted" +
+					" by configured memory limits, but some resource frameworks like yarn would track this memory usage and kill the container once" +
+					" memory exceeding some threshold. Also note that this option is experimental and might be changed future.");
 
 	// ------------------------------------------------------------------------
 	//  Netty Options

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -324,7 +324,7 @@ public class NettyShuffleEnvironmentConfiguration {
 	}
 
 	private static BoundedBlockingSubpartitionType getBlockingSubpartitionType(Configuration config) {
-		String transport = config.getString(NettyShuffleEnvironmentOptions.NETWORK_BOUNDED_BLOCKING_SUBPARTITION_TYPE);
+		String transport = config.getString(NettyShuffleEnvironmentOptions.NETWORK_BLOCKING_SHUFFLE_TYPE);
 
 		switch (transport) {
 			case "mmap":

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/FileBufferReaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/FileBufferReaderITCase.java
@@ -87,7 +87,7 @@ public class FileBufferReaderITCase extends TestLogger {
 		// setup
 		final Configuration configuration = new Configuration();
 		configuration.setString(RestOptions.BIND_PORT, "0");
-		configuration.setString(NettyShuffleEnvironmentOptions.NETWORK_BOUNDED_BLOCKING_SUBPARTITION_TYPE, "file");
+		configuration.setString(NettyShuffleEnvironmentOptions.NETWORK_BLOCKING_SHUFFLE_TYPE, "file");
 		configuration.setString(TaskManagerOptions.TOTAL_FLINK_MEMORY, "1g");
 
 		final MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder()


### PR DESCRIPTION
## What is the purpose of the change

*As reported by users in mail list, the container would be killed by yarn because of exceeding physical memory limits. It is mainly because the memory usage of mmap in `BoundedBlockingSubpartition` is not capped and not accounted by configured memory limits, but yarn would track this memory usage and kill the container once exceeding some threshold.*
    
*To solve this issue, we adjust the default option of `taskmanager.network.bounded-blocking-subpartition-type` from `auto` to `file` for safety usage. And users can still enable mmap way via configuration if they make a proper adjustment in yarn configuration to avoid container killing.*

## Brief change log

  - *Generates the respective html files for previous changed configurations*
  - *Adjusts the default option of blocking subpartition type from `auto` to `file`*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
