### PR TITLE
[FLINK-15169][runtime] Set failures happen in DefaultScheduler to ExecutionGraph/Execution to make them visible to REST

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -1260,7 +1260,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 		numberOfRestartsCounter.inc();
 	}
 
-	private void initFailureCause(Throwable t) {
+	public void initFailureCause(Throwable t) {
 		this.failureCause = t;
 		this.failureInfo = new ErrorInfo(t, System.currentTimeMillis());
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -739,6 +739,16 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 	}
 
 	/**
+	 * This method marks the task as failed, but will make no attempt to remove task execution from the task manager.
+	 * It is intended for cases where the task is known not to be deployed yet.
+	 *
+	 * @param t The exception that caused the task to fail.
+	 */
+	public void markFailed(Throwable t) {
+		currentExecution.markFailed(t);
+	}
+
+	/**
 	 * Schedules or updates the consumer tasks of the result partition with the given ID.
 	 */
 	void scheduleOrUpdateConsumers(ResultPartitionID partitionId) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionVertexOperations.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionVertexOperations.java
@@ -35,4 +35,9 @@ class DefaultExecutionVertexOperations implements ExecutionVertexOperations {
 	public CompletableFuture<?> cancel(final ExecutionVertex executionVertex) {
 		return executionVertex.cancel();
 	}
+
+	@Override
+	public void markFailed(final ExecutionVertex executionVertex, final Throwable cause) {
+		executionVertex.markFailed(cause);
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -191,6 +191,8 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 
 	@Override
 	public void handleGlobalFailure(final Throwable error) {
+		setGlobalFailureCause(error);
+
 		log.info("Trying to recover from a global failure.", error);
 		final FailureHandlingResult failureHandlingResult = executionFailureHandler.getGlobalFailureHandlingResult(error);
 		maybeRestartTasks(failureHandlingResult);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -423,8 +423,7 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 	}
 
 	private void handleTaskDeploymentFailure(final ExecutionVertexID executionVertexId, final Throwable error) {
-		log.info("Error while scheduling or deploying task {}.", executionVertexId, error);
-		handleTaskFailure(executionVertexId, error);
+		executionVertexOperations.markFailed(getExecutionVertex(executionVertexId), error);
 	}
 
 	private static Throwable maybeWrapWithNoResourceAvailableException(final Throwable failure) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexOperations.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexOperations.java
@@ -32,4 +32,6 @@ interface ExecutionVertexOperations {
 	void deploy(ExecutionVertex executionVertex) throws JobException;
 
 	CompletableFuture<?> cancel(ExecutionVertex executionVertex);
+
+	void markFailed(ExecutionVertex executionVertex, Throwable cause);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -340,6 +340,10 @@ public abstract class SchedulerBase implements SchedulerNG {
 			.transitionState(ExecutionState.SCHEDULED));
 	}
 
+	protected void setGlobalFailureCause(final Throwable cause) {
+		getExecutionGraph().initFailureCause(cause);
+	}
+
 	protected ComponentMainThreadExecutor getMainThreadExecutor() {
 		return mainThreadExecutor;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestExecutionVertexOperationsDecorator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestExecutionVertexOperationsDecorator.java
@@ -62,6 +62,11 @@ public class TestExecutionVertexOperationsDecorator implements ExecutionVertexOp
 		return delegate.cancel(executionVertex);
 	}
 
+	@Override
+	public void markFailed(ExecutionVertex executionVertex, Throwable cause) {
+		delegate.markFailed(executionVertex, cause);
+	}
+
 	public void enableFailDeploy() {
 		failDeploy = true;
 	}


### PR DESCRIPTION
## What is the purpose of the change

WebUI relies on ExecutionGraph#failureInfo and Execution#failureCause to generate error info (via JobExceptionsHandler#createJobExceptionsInfo).
Errors happen in the scheduling of DefaultScheduler are not recorded into those fields, thus cannot be shown to users in WebUI (nor via REST queries).

## Brief change log

  - *set global failures to ExecutionGraph*
  - *set task deployment failures in DefaultScheduler to Execution via invoking Execution#markFailed*

## Verifying this change

This change is verified by manually triggering glboal/task failures and checking the WebUI and REST.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
