### PR TITLE
[FLINK-12484][runtime] move checkpoint lock to source task

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AbstractDataOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AbstractDataOutput.java
@@ -35,17 +35,12 @@ public abstract class AbstractDataOutput<T> implements PushingAsyncDataInput.Dat
 	/** The maintainer toggles the current stream status. */
 	protected final StreamStatusMaintainer streamStatusMaintainer;
 
-	protected final Object lock;
-
-	public AbstractDataOutput(StreamStatusMaintainer streamStatusMaintainer, Object lock) {
+	public AbstractDataOutput(StreamStatusMaintainer streamStatusMaintainer) {
 		this.streamStatusMaintainer = checkNotNull(streamStatusMaintainer);
-		this.lock = checkNotNull(lock);
 	}
 
 	@Override
 	public void emitStreamStatus(StreamStatus streamStatus) {
-		synchronized (lock) {
-			streamStatusMaintainer.toggleStreamStatus(streamStatus);
-		}
+		streamStatusMaintainer.toggleStreamStatus(streamStatus);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
@@ -43,19 +43,15 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
 	private final StreamTaskInput<IN> input;
 	private final DataOutput<IN> output;
 
-	private final Object lock;
-
 	private final OperatorChain<?, ?> operatorChain;
 
 	public StreamOneInputProcessor(
 			StreamTaskInput<IN> input,
 			DataOutput<IN> output,
-			Object lock,
 			OperatorChain<?, ?> operatorChain) {
 
 		this.input = checkNotNull(input);
 		this.output = checkNotNull(output);
-		this.lock = checkNotNull(lock);
 		this.operatorChain = checkNotNull(operatorChain);
 	}
 
@@ -69,9 +65,7 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
 		InputStatus status = input.emitNext(output);
 
 		if (status == InputStatus.END_OF_INPUT) {
-			synchronized (lock) {
-				operatorChain.endHeadOperatorInput(1);
-			}
+			operatorChain.endHeadOperatorInput(1);
 		}
 
 		return status;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -97,7 +97,6 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 			inputProcessor = new StreamOneInputProcessor<>(
 				input,
 				output,
-				getCheckpointLock(),
 				operatorChain);
 		}
 		headOperator.getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_WATERMARK, this.inputWatermarkGauge);
@@ -121,7 +120,6 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 		return new StreamTaskNetworkOutput<>(
 			headOperator,
 			getStreamStatusMaintainer(),
-			getCheckpointLock(),
 			inputWatermarkGauge,
 			setupNumRecordsInCounter(headOperator));
 	}
@@ -153,10 +151,9 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 		private StreamTaskNetworkOutput(
 				OneInputStreamOperator<IN, ?> operator,
 				StreamStatusMaintainer streamStatusMaintainer,
-				Object lock,
 				WatermarkGauge watermarkGauge,
 				Counter numRecordsIn) {
-			super(streamStatusMaintainer, lock);
+			super(streamStatusMaintainer);
 
 			this.operator = checkNotNull(operator);
 			this.watermarkGauge = checkNotNull(watermarkGauge);
@@ -165,26 +162,20 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 
 		@Override
 		public void emitRecord(StreamRecord<IN> record) throws Exception {
-			synchronized (lock) {
-				numRecordsIn.inc();
-				operator.setKeyContextElement1(record);
-				operator.processElement(record);
-			}
+			numRecordsIn.inc();
+			operator.setKeyContextElement1(record);
+			operator.processElement(record);
 		}
 
 		@Override
 		public void emitWatermark(Watermark watermark) throws Exception {
-			synchronized (lock) {
-				watermarkGauge.setCurrentWatermark(watermark.getTimestamp());
-				operator.processWatermark(watermark);
-			}
+			watermarkGauge.setCurrentWatermark(watermark.getTimestamp());
+			operator.processWatermark(watermark);
 		}
 
 		@Override
 		public void emitLatencyMarker(LatencyMarker latencyMarker) throws Exception {
-			synchronized (lock) {
-				operator.processLatencyMarker(latencyMarker);
-			}
+			operator.processLatencyMarker(latencyMarker);
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceReaderStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceReaderStreamTask.java
@@ -49,13 +49,11 @@ public class SourceReaderStreamTask<T> extends StreamTask<T, SourceReaderOperato
 		StreamTaskInput<T> input = new StreamTaskSourceInput<>(headOperator);
 		DataOutput<T> output = new StreamTaskSourceOutput<>(
 			operatorChain.getChainEntryPoint(),
-			getStreamStatusMaintainer(),
-			getCheckpointLock());
+			getStreamStatusMaintainer());
 
 		inputProcessor = new StreamOneInputProcessor<>(
 			input,
 			output,
-			getCheckpointLock(),
 			operatorChain);
 	}
 
@@ -69,32 +67,25 @@ public class SourceReaderStreamTask<T> extends StreamTask<T, SourceReaderOperato
 
 		StreamTaskSourceOutput(
 				Output<StreamRecord<T>> output,
-				StreamStatusMaintainer streamStatusMaintainer,
-				Object lock) {
-			super(streamStatusMaintainer, lock);
+				StreamStatusMaintainer streamStatusMaintainer) {
+			super(streamStatusMaintainer);
 
 			this.output = checkNotNull(output);
 		}
 
 		@Override
 		public void emitRecord(StreamRecord<T> streamRecord) {
-			synchronized (lock) {
-				output.collect(streamRecord);
-			}
+			output.collect(streamRecord);
 		}
 
 		@Override
 		public void emitLatencyMarker(LatencyMarker latencyMarker) {
-			synchronized (lock) {
-				output.emitLatencyMarker(latencyMarker);
-			}
+			output.emitLatencyMarker(latencyMarker);
 		}
 
 		@Override
 		public void emitWatermark(Watermark watermark) {
-			synchronized (lock) {
-				output.emitWatermark(watermark);
-			}
+			output.emitWatermark(watermark);
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationHead.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationHead.java
@@ -73,10 +73,8 @@ public class StreamIterationHead<OUT> extends OneInputStreamTask<OUT, OUT> {
 			dataChannel.take();
 
 		if (nextRecord != null) {
-			synchronized (getCheckpointLock()) {
-				for (RecordWriterOutput<OUT> output : streamOutputs) {
-					output.collect(nextRecord);
-				}
+			for (RecordWriterOutput<OUT> output : streamOutputs) {
+				output.collect(nextRecord);
 			}
 		} else {
 			controller.allActionsCompleted();
@@ -96,10 +94,8 @@ public class StreamIterationHead<OUT> extends OneInputStreamTask<OUT, OUT> {
 
 		// If timestamps are enabled we make sure to remove cyclic watermark dependencies
 		if (isSerializingTimestamps()) {
-			synchronized (getCheckpointLock()) {
-				for (RecordWriterOutput<OUT> output : streamOutputs) {
-					output.emitWatermark(new Watermark(Long.MAX_VALUE));
-				}
+			for (RecordWriterOutput<OUT> output : streamOutputs) {
+				output.emitWatermark(new Watermark(Long.MAX_VALUE));
 			}
 		}
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -153,11 +153,9 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	 * to ensure that we don't have concurrent method calls that void consistent checkpoints.
 	 * <p>CheckpointLock is superseded by {@link MailboxExecutor}, with
 	 * {@link StreamTaskActionExecutor.SynchronizedStreamTaskActionExecutor SynchronizedStreamTaskActionExecutor}
-	 * to provide lock to {@link SourceStreamTask} (will be pushed down later). </p>
-	 * {@link StreamTaskActionExecutor.SynchronizedStreamTaskActionExecutor SynchronizedStreamTaskActionExecutor}
-	 * will be replaced <b>here</b> with {@link StreamTaskActionExecutor} once {@link #getCheckpointLock()} pushed down to {@link SourceStreamTask}.
+	 * to provide lock to {@link SourceStreamTask}. </p>
 	 */
-	private final StreamTaskActionExecutor.SynchronizedStreamTaskActionExecutor actionExecutor;
+	private final StreamTaskActionExecutor actionExecutor;
 
 	/**
 	 * The input processor. Initialized in {@link #init()} method.
@@ -242,7 +240,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			Environment environment,
 			@Nullable TimerService timerService,
 			Thread.UncaughtExceptionHandler uncaughtExceptionHandler) {
-		this(environment, timerService, uncaughtExceptionHandler, StreamTaskActionExecutor.synchronizedExecutor());
+		this(environment, timerService, uncaughtExceptionHandler, StreamTaskActionExecutor.IMMEDIATE);
 	}
 
 	/**
@@ -261,7 +259,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			Environment environment,
 			@Nullable TimerService timerService,
 			Thread.UncaughtExceptionHandler uncaughtExceptionHandler,
-			StreamTaskActionExecutor.SynchronizedStreamTaskActionExecutor actionExecutor) {
+			StreamTaskActionExecutor actionExecutor) {
 		this(environment, timerService, uncaughtExceptionHandler, actionExecutor, new TaskMailboxImpl(Thread.currentThread()));
 	}
 
@@ -269,7 +267,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			Environment environment,
 			@Nullable TimerService timerService,
 			Thread.UncaughtExceptionHandler uncaughtExceptionHandler,
-			StreamTaskActionExecutor.SynchronizedStreamTaskActionExecutor actionExecutor,
+			StreamTaskActionExecutor actionExecutor,
 			TaskMailbox mailbox) {
 
 		super(environment);
@@ -704,26 +702,6 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	String getTaskNameWithSubtaskAndId() {
 		return getEnvironment().getTaskInfo().getTaskNameWithSubtasks() +
 			" (" + getEnvironment().getExecutionId() + ')';
-	}
-
-	/**
-	 * Gets the lock object on which all operations that involve data and state mutation have to lock.
-	 * @return The checkpoint lock object.
-	 * @deprecated This method will be removed in future releases. Use {@linkplain MailboxExecutor mailbox executor}
-	 * to run {@link StreamTask} actions that require synchronization (e.g. checkpointing, collecting output).
-	 * <p>
-	 * For other (non-{@link StreamTask}) actions other synchronization means can be used.
-	 * </p>
-	 * MailboxExecutor {@link MailboxExecutor#yield() yield} or {@link MailboxExecutor#tryYield() tryYield} methods can
-	 * be used for actions that should give control to other actions temporarily.
-	 * <p>
-	 * MailboxExecutor can be accessed by using {@link org.apache.flink.streaming.api.operators.YieldingOperatorFactory YieldingOperatorFactory}.
-	 * Example usage can be found in {@link org.apache.flink.streaming.api.operators.async.AsyncWaitOperator AsyncWaitOperator}.
-	 * </p>
-	 */
-	@Deprecated
-	public Object getCheckpointLock() {
-		return actionExecutor.getMutex();
 	}
 
 	public CheckpointStorageWorkerView getCheckpointStorage() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTaskActionExecutor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTaskActionExecutor.java
@@ -70,8 +70,6 @@ public interface StreamTaskActionExecutor {
 	/**
 	 * A {@link StreamTaskActionExecutor} that synchronizes every operation on the provided mutex.
 	 * @deprecated this class should only be used in {@link SourceStreamTask} which exposes the checkpoint lock as part of Public API.
-	 * During transitional period it is used in {@link StreamTask} (until {@link StreamTask#getCheckpointLock()}
-	 * is pushed down to {@link SourceStreamTask}).
 	 */
 	@Deprecated
 	class SynchronizedStreamTaskActionExecutor implements StreamTaskActionExecutor {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -71,7 +71,6 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
 			checkpointedInputGates,
 			inputDeserializer1,
 			inputDeserializer2,
-			getCheckpointLock(),
 			getEnvironment().getIOManager(),
 			getStreamStatusMaintainer(),
 			headOperator,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorWatermarksTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorWatermarksTest.java
@@ -144,14 +144,14 @@ public class StreamSourceOperatorWatermarksTest {
 		TestProcessingTimeService processingTimeService = new TestProcessingTimeService();
 		processingTimeService.setCurrentTime(0);
 
-		setupSourceOperator(operator, TimeCharacteristic.IngestionTime, watermarkInterval, processingTimeService);
+		MockStreamTask<?, ?> task = setupSourceOperator(operator, TimeCharacteristic.IngestionTime, watermarkInterval, processingTimeService);
 
 		final List<StreamElement> output = new ArrayList<>();
 
 		StreamSourceContexts.getSourceContext(
 			TimeCharacteristic.IngestionTime,
 			processingTimeService,
-			operator.getContainingTask().getCheckpointLock(),
+			task.getCheckpointLock(),
 			operator.getContainingTask().getStreamStatusMaintainer(),
 			new CollectorOutput<String>(output),
 			operator.getExecutionConfig().getAutoWatermarkInterval(),
@@ -178,7 +178,7 @@ public class StreamSourceOperatorWatermarksTest {
 	// ------------------------------------------------------------------------
 
 	@SuppressWarnings("unchecked")
-	private static <T> void setupSourceOperator(
+	private static <T> MockStreamTask setupSourceOperator(
 			StreamSource<T, ?> operator,
 			TimeCharacteristic timeChar,
 			long watermarkInterval,
@@ -206,6 +206,7 @@ public class StreamSourceOperatorWatermarksTest {
 			.build();
 
 		operator.setup(mockTask, cfg, (Output<StreamRecord<T>>) mock(Output.class));
+		return mockTask;
 	}
 
 	private static <T> StreamTaskTestHarness<T> setupSourceStreamTask(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamTaskTimerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamTaskTimerTest.java
@@ -42,7 +42,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -75,31 +74,6 @@ public class StreamTaskTimerTest extends TestLogger {
 		});
 
 		assertEquals(1, StreamTask.TRIGGER_THREAD_GROUP.activeCount());
-	}
-
-	@Test
-	public void timeTriggerIsCalledWithAcquiredCheckpointLock() throws Exception {
-		AtomicReference<Throwable> errorRef = new AtomicReference<>();
-		OneShotLatch latch = new OneShotLatch();
-		Object checkpointLock = testHarness.getTask().getCheckpointLock();
-		ProcessingTimeCallback callback = timestamp -> {
-			try {
-				assertTrue(Thread.holdsLock(checkpointLock));
-				latch.trigger();
-			}
-			catch (Throwable t) {
-				errorRef.compareAndSet(null, t);
-				latch.trigger();
-			}
-		};
-
-		timeService.registerTimer(System.currentTimeMillis(), callback);
-		latch.await();
-		verifyNoException(errorRef.get());
-
-		timeService.scheduleAtFixedRate(callback, 0, 100);
-		latch.await();
-		verifyNoException(errorRef.get());
 	}
 
 	@Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -285,6 +285,10 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 		}
 	}
 
+	/**
+	 * @deprecated Checkpoint lock in {@link StreamTask} is replaced by {@link org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor StreamTaskActionExecutor}.
+	 */
+	@Deprecated
 	public Object getCheckpointLock() {
 		return mockTask.getCheckpointLock();
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
@@ -104,7 +104,11 @@ public class MockStreamTask<OUT, OP extends StreamOperator<OUT>> extends StreamT
 		return name;
 	}
 
-	@Override
+	/**
+	 * Checkpoint lock in {@link StreamTask} is replaced by {@link StreamTaskActionExecutor}.
+	 * <code>getCheckpointLock</code> method was moved from to the {@link org.apache.flink.streaming.runtime.tasks.SourceStreamTask SourceStreamTask}.
+	 */
+	@Deprecated
 	public Object getCheckpointLock() {
 		return checkpointLock;
 	}


### PR DESCRIPTION
## What is the purpose of the change

**This PR depends on #10435**

This PR removes usages of the `StreamTask#getCheckpointLock()` method and moves the field to `SourceStreamTask`.
Checkpoint lock acquisition in "network" tasks (not source/sink) is unnecessary after moving them to the mailbox execution model.


This PR depends on the removal of the checkpoint lock usage from `ContinuousFileReaderOperator` (#10435).

## Brief change log

  - *remove usages of the `StreamTask#getCheckpointLock()` method*
  - *use `IMMEDIATE` (no-op) `StreamTaskActionExecutor` (decorator) in `StreamTask` by default*
  - *move the actual checkpoint lock object (field) to `SourceStreamTask` and use `SynchronizedStreamTaskActionExecutor` in it*
     - also push lock down to `MockStreamTask`
- *remove testing of checkpoint lock acquisition*

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes (removes lock acquisition for mails in network tasks which may be per record)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
