### PR TITLE
[FLINK-13567][e2e] Harden schema registry test

### DIFF
--- a/flink-end-to-end-tests/run-pre-commit-tests.sh
+++ b/flink-end-to-end-tests/run-pre-commit-tests.sh
@@ -48,6 +48,8 @@ echo "Flink distribution directory: $FLINK_DIR"
 # those checks are disabled, one should take care that a proper checks are performed in the tests itself that ensure that the test finished
 # in an expected state.
 
+run_test "Avro Confluent Schema Registry nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_confluent_schema_registry.sh"
+
 run_test "State Migration end-to-end test from 1.6" "$END_TO_END_DIR/test-scripts/test_state_migration.sh"
 run_test "State Evolution end-to-end test" "$END_TO_END_DIR/test-scripts/test_state_evolution.sh"
 run_test "Wordcount end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_wordcount.sh file"

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -729,14 +729,21 @@ function find_latest_completed_checkpoint {
 }
 
 function retry_times() {
+    retry_times_with_backoff_and_cleanup $1 $2 "${@:3}" "true"
+}
+
+function retry_times_with_backoff_and_cleanup() {
     local retriesNumber=$1
     local backoff=$2
-    local command=${@:3}
+    local command="$3"
+    local cleanup_command="$4"
 
     for (( i = 0; i < ${retriesNumber}; i++ ))
     do
         if ${command}; then
             return 0
+        else
+            ${cleanup_command}
         fi
 
         echo "Command: ${command} failed. Retrying..."
@@ -744,6 +751,7 @@ function retry_times() {
     done
 
     echo "Command: ${command} failed ${retriesNumber} times."
+    ${cleanup_command}
     return 1
 }
 

--- a/flink-end-to-end-tests/test-scripts/kafka-common.sh
+++ b/flink-end-to-end-tests/test-scripts/kafka-common.sh
@@ -75,7 +75,10 @@ function start_kafka_cluster {
 }
 
 function stop_kafka_cluster {
-  $KAFKA_DIR/bin/kafka-server-stop.sh
+ if ! [[ -z $(./bin/kafka-server-stop) ]]; then
+   echo "Kafka server was already shut down; dumping logs:"
+   cat ${KAFKA_DIR}/logs/server.out
+ fi
   $KAFKA_DIR/bin/zookeeper-server-stop.sh
 
   # Terminate Kafka process if it still exists

--- a/flink-end-to-end-tests/test-scripts/kafka-common.sh
+++ b/flink-end-to-end-tests/test-scripts/kafka-common.sh
@@ -146,7 +146,7 @@ function start_confluent_schema_registry {
 
   if ! get_and_verify_schema_subjects_exist; then
       echo "Could not start confluent schema registry"
-      exit 1
+      return 1
   fi
 }
 

--- a/flink-end-to-end-tests/test-scripts/test_confluent_schema_registry.sh
+++ b/flink-end-to-end-tests/test-scripts/test_confluent_schema_registry.sh
@@ -34,6 +34,11 @@ function verify_output {
   fi
 }
 
+function test_setup {
+  start_kafka_cluster
+  start_confluent_schema_registry
+}
+
 function test_cleanup {
   stop_confluent_schema_registry
   stop_kafka_cluster
@@ -44,8 +49,7 @@ on_exit test_cleanup
 setup_kafka_dist
 setup_confluent_dist
 
-start_kafka_cluster
-start_confluent_schema_registry
+retry_times_with_backoff_and_cleanup 3 5 test_setup test_cleanup
 
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-confluent-schema-registry/target/TestAvroConsumerConfluent.jar
 

--- a/tools/travis/splits/split_misc.sh
+++ b/tools/travis/splits/split_misc.sh
@@ -66,8 +66,7 @@ run_test "Elasticsearch (v6.3.1) sink end-to-end test" "$END_TO_END_DIR/test-scr
 run_test "Quickstarts Java nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_quickstarts.sh java"
 run_test "Quickstarts Scala nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_quickstarts.sh scala"
 
-# Disabled until FLINK-13567 has been fixed
-#run_test "Avro Confluent Schema Registry nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_confluent_schema_registry.sh"
+run_test "Avro Confluent Schema Registry nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_confluent_schema_registry.sh"
 
 run_test "State TTL Heap backend end-to-end test" "$END_TO_END_DIR/test-scripts/test_stream_state_ttl.sh file"
 run_test "State TTL RocksDb backend end-to-end test" "$END_TO_END_DIR/test-scripts/test_stream_state_ttl.sh rocks"

--- a/tools/travis/splits/split_misc_hadoopfree.sh
+++ b/tools/travis/splits/split_misc_hadoopfree.sh
@@ -63,8 +63,7 @@ run_test "Elasticsearch (v6.3.1) sink end-to-end test" "$END_TO_END_DIR/test-scr
 run_test "Quickstarts Java nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_quickstarts.sh java"
 run_test "Quickstarts Scala nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_quickstarts.sh scala"
 
-# Disabled until FLINK-13567 has been fixed
-#run_test "Avro Confluent Schema Registry nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_confluent_schema_registry.sh"
+run_test "Avro Confluent Schema Registry nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_confluent_schema_registry.sh"
 
 run_test "State TTL Heap backend end-to-end test" "$END_TO_END_DIR/test-scripts/test_stream_state_ttl.sh file"
 run_test "State TTL RocksDb backend end-to-end test" "$END_TO_END_DIR/test-scripts/test_stream_state_ttl.sh rocks"


### PR DESCRIPTION
Hardens the schema registry test by retrying the setup of kafka/ZK/registry . For this the existing `retry_times` function was extended to optionally include a cleanup command; in this case for shutting down previously started processes.
Additionally, if kafka isn't running when shutting it down we now dump the kafka logs to ease debugging.

The last commit in this PR flags the schema test as a pre-commit tests for demonstration purposes.

The exact failure cause of the test is still unknown; what we do know however is that kafka broke down after being successfully started.