### PR TITLE
[FLINK-15197][kubernetes] Add resource related config options to dynamical properties for Kubernetes

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -163,16 +163,21 @@ public class KubernetesUtils {
 			String mainClass,
 			@Nullable String mainArgs) {
 		final TaskExecutorResourceSpec taskExecutorResourceSpec = tmParams.getTaskExecutorResourceSpec();
+		final String jvmMemOpts = TaskExecutorResourceUtils.generateJvmParametersStr(taskExecutorResourceSpec);
+		String args = TaskExecutorResourceUtils.generateDynamicConfigsStr(taskExecutorResourceSpec);
+		if (mainArgs != null) {
+			args += " " + mainArgs;
+		}
 		return getCommonStartCommand(
 			flinkConfig,
 			ClusterComponent.TASK_MANAGER,
-			TaskExecutorResourceUtils.generateJvmParametersStr(taskExecutorResourceSpec),
+			jvmMemOpts,
 			configDirectory,
 			logDirectory,
 			hasLogback,
 			hasLog4j,
 			mainClass,
-			mainArgs
+			args
 		);
 	}
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesUtilsTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesUtilsTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
 import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.TestLogger;
 
@@ -65,7 +66,21 @@ public class KubernetesUtilsTest extends TestLogger {
 	// Memory variables
 	private static final int jobManagerMem = 768;
 	private static final String jmJvmMem = String.format("-Xms%dm -Xmx%dm", jobManagerMem, jobManagerMem);
+
+	private static final TaskExecutorResourceSpec taskExecutorResourceSpec = new TaskExecutorResourceSpec(
+		new CPUResource(1.0),
+		new MemorySize(0), // frameworkHeapSize
+		new MemorySize(0), // frameworkOffHeapSize
+		new MemorySize(111), // taskHeapSize
+		new MemorySize(0), // taskOffHeapSize
+		new MemorySize(222), // shuffleMemSize
+		new MemorySize(0), // managedMemorySize
+		new MemorySize(333), // jvmMetaspaceSize
+		new MemorySize(0)); // jvmOverheadSize
+
 	private static final String tmJvmMem = "-Xmx111 -Xms111 -XX:MaxDirectMemorySize=222 -XX:MaxMetaspaceSize=333";
+	private static final String tmMemDynamicProperties =
+		TaskExecutorResourceUtils.generateDynamicConfigsStr(taskExecutorResourceSpec).trim();
 
 	@Test
 	public void testGetJobManagerStartCommand() {
@@ -181,7 +196,7 @@ public class KubernetesUtilsTest extends TestLogger {
 			java + " 1 " + classpath + " 2 " + tmJvmMem +
 				" " + jvmOpts + " " + tmJvmOpts + // jvmOpts
 				" " + tmLogfile + " " + logback + " " + log4j +
-				" " + mainClass + " " + mainClassArgs + " " + tmLogRedirects,
+				" " + mainClass + " " + tmMemDynamicProperties + " " + mainClassArgs + " " + tmLogRedirects,
 			getTaskManagerStartCommand(cfg, true, true, mainClassArgs));
 
 		cfg.setString(KubernetesConfigOptions.CONTAINER_START_COMMAND_TEMPLATE,
@@ -234,7 +249,7 @@ public class KubernetesUtilsTest extends TestLogger {
 		return java + " " + classpath + " " + tmJvmMem +
 			(jvmAllOpts.isEmpty() ? "" : " " + jvmAllOpts) +
 			(logging.isEmpty() ? "" : " " + tmLogfile + " " + logging) +
-			" " + mainClass + (mainClassArgs.isEmpty() ? "" : " " + mainClassArgs) + " " + tmLogRedirects;
+			" " + mainClass + " " + tmMemDynamicProperties + (mainClassArgs.isEmpty() ? "" : " " + mainClassArgs) + " " + tmLogRedirects;
 	}
 
 	private String getJobManagerStartCommand(
@@ -260,16 +275,6 @@ public class KubernetesUtilsTest extends TestLogger {
 			boolean hasLog4j,
 			String mainClassArgs) {
 
-		final TaskExecutorResourceSpec taskExecutorResourceSpec = new TaskExecutorResourceSpec(
-			new CPUResource(1.0),
-			new MemorySize(0), // frameworkHeapSize
-			new MemorySize(0), // frameworkOffHeapSize
-			new MemorySize(111), // taskHeapSize
-			new MemorySize(0), // taskOffHeapSize
-			new MemorySize(222), // shuffleMemSize
-			new MemorySize(0), // managedMemorySize
-			new MemorySize(333), // jvmMetaspaceSize
-			new MemorySize(0)); // jvmOverheadSize
 		final ContaineredTaskManagerParameters containeredParams =
 			new ContaineredTaskManagerParameters(taskExecutorResourceSpec, 4, new HashMap<>());
 


### PR DESCRIPTION
## What is the purpose of the change

FLIP-49 requires passing pre-calculated memory sizes into task executors as dynamic properties. This PR is to add those parameters for the newly introduced active kubernetes integration.

## Brief change log

- Add resource dynamic properties when generating shell command for starting task executors on kubernetes.
- Update corresponding test cases.

## Verifying this change

This change is already covered by existing `KubernetesUtilsTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
