### PR TITLE
[FLINK-15058][runtime] Log required config options if TaskManager memory configuration is invalid

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
@@ -142,8 +142,12 @@ public class TaskExecutorResourceUtils {
 			// derive from total process memory
 			return deriveResourceSpecWithTotalProcessMemory(config);
 		} else {
-			throw new IllegalConfigurationException("Either Task Heap Memory size and Managed Memory size, or Total Flink"
-				+ " Memory size, or Total Process Memory size need to be configured explicitly.");
+			throw new IllegalConfigurationException(String.format("Either Task Heap Memory size (%s) and Managed Memory size (%s), or Total Flink"
+				+ " Memory size (%s), or Total Process Memory size (%s) need to be configured explicitly.",
+				TaskManagerOptions.TASK_HEAP_MEMORY.key(),
+				TaskManagerOptions.MANAGED_MEMORY_SIZE.key(),
+				TaskManagerOptions.TOTAL_FLINK_MEMORY.key(),
+				TaskManagerOptions.TOTAL_PROCESS_MEMORY.key()));
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtilsTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
@@ -38,6 +39,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -526,6 +528,18 @@ public class TaskExecutorResourceUtilsTest extends TestLogger {
 		assertThat(
 			TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(TM_RESOURCE_SPEC, NUMBER_OF_SLOTS),
 			is(DEFAULT_RESOURCE_PROFILE));
+	}
+
+	@Test
+	public void testExceptionShouldContainRequiredConfigOptions() {
+		try {
+			TaskExecutorResourceUtils.resourceSpecFromConfig(new Configuration());
+		} catch (final IllegalConfigurationException e) {
+			assertThat(e.getMessage(), containsString(TaskManagerOptions.TASK_HEAP_MEMORY.key()));
+			assertThat(e.getMessage(), containsString(TaskManagerOptions.MANAGED_MEMORY_SIZE.key()));
+			assertThat(e.getMessage(), containsString(TaskManagerOptions.TOTAL_FLINK_MEMORY.key()));
+			assertThat(e.getMessage(), containsString(TaskManagerOptions.TOTAL_PROCESS_MEMORY.key()));
+		}
 	}
 
 	private void validateInAllConfigurations(final Configuration customConfig, Consumer<TaskExecutorResourceSpec> validateFunc) {


### PR DESCRIPTION
## What is the purpose of the change

*Log required config options if TaskManager memory configuration is invalid.*


## Brief change log

  - *Include required config options in exception message.*
  - *Add unit test*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit test to TaskExecutorResourceUtilsTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
