### PR TITLE
[FLINK-13662][kinesis] Relax timing requirements

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducerTest.java
@@ -325,16 +325,20 @@ public class FlinkKinesisProducerTest {
 		};
 		moreElementsThread.start();
 
-		moreElementsThread.trySync(deadline.timeLeftIfAny().toMillis());
 		assertTrue("Producer should still block, but doesn't", moreElementsThread.isAlive());
 
 		// consume msg-2 from the queue, leaving msg-3 in the queue and msg-4 blocked
+		while (producer.getPendingRecordFutures().size() < 2) {
+			Thread.sleep(50);
+		}
 		producer.getPendingRecordFutures().get(1).set(result);
 
-		moreElementsThread.trySync(deadline.timeLeftIfAny().toMillis());
 		assertTrue("Producer should still block, but doesn't", moreElementsThread.isAlive());
 
 		// consume msg-3, blocked msg-4 can be inserted into the queue and block is released
+		while (producer.getPendingRecordFutures().size() < 3) {
+			Thread.sleep(50);
+		}
 		producer.getPendingRecordFutures().get(2).set(result);
 
 		moreElementsThread.trySync(deadline.timeLeftIfAny().toMillis());

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.kinesis;
 
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.core.testutils.MultiShotLatch;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
@@ -43,6 +44,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -276,6 +278,8 @@ public class FlinkKinesisProducerTest {
 	 */
 	@Test(timeout = 10000)
 	public void testBackpressure() throws Throwable {
+		final Deadline deadline = Deadline.fromNow(Duration.ofSeconds(10));
+
 		final DummyFlinkKinesisProducer<String> producer = new DummyFlinkKinesisProducer<>(new SimpleStringSchema());
 		producer.setQueueLimit(1);
 
@@ -294,7 +298,7 @@ public class FlinkKinesisProducerTest {
 			}
 		};
 		msg1.start();
-		msg1.trySync(100);
+		msg1.trySync(deadline.timeLeftIfAny().toMillis());
 		assertFalse("Flush triggered before reaching queue limit", msg1.isAlive());
 
 		// consume msg-1 so that queue is empty again
@@ -307,7 +311,7 @@ public class FlinkKinesisProducerTest {
 			}
 		};
 		msg2.start();
-		msg2.trySync(100);
+		msg2.trySync(deadline.timeLeftIfAny().toMillis());
 		assertFalse("Flush triggered before reaching queue limit", msg2.isAlive());
 
 		CheckedThread moreElementsThread = new CheckedThread() {
@@ -321,19 +325,19 @@ public class FlinkKinesisProducerTest {
 		};
 		moreElementsThread.start();
 
-		moreElementsThread.trySync(100);
+		moreElementsThread.trySync(deadline.timeLeftIfAny().toMillis());
 		assertTrue("Producer should still block, but doesn't", moreElementsThread.isAlive());
 
 		// consume msg-2 from the queue, leaving msg-3 in the queue and msg-4 blocked
 		producer.getPendingRecordFutures().get(1).set(result);
 
-		moreElementsThread.trySync(100);
+		moreElementsThread.trySync(deadline.timeLeftIfAny().toMillis());
 		assertTrue("Producer should still block, but doesn't", moreElementsThread.isAlive());
 
 		// consume msg-3, blocked msg-4 can be inserted into the queue and block is released
 		producer.getPendingRecordFutures().get(2).set(result);
 
-		moreElementsThread.trySync(100);
+		moreElementsThread.trySync(deadline.timeLeftIfAny().toMillis());
 
 		assertFalse("Prodcuer still blocks although the queue is flushed", moreElementsThread.isAlive());
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/time/Deadline.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/time/Deadline.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.common.time;
 import org.apache.flink.annotation.Internal;
 
 import java.time.Duration;
+import java.util.concurrent.TimeoutException;
 
 /**
  * This class stores a deadline, as obtained via {@link #now()} or from {@link #plus(Duration)}.
@@ -45,6 +46,19 @@ public class Deadline {
 	 */
 	public Duration timeLeft() {
 		return Duration.ofNanos(Math.subtractExact(timeNanos, System.nanoTime()));
+	}
+
+	/**
+	 * Returns the time left between the deadline and now. If no time is left, a {@link TimeoutException} will be thrown.
+	 *
+	 * @throws TimeoutException if no time is left
+	 */
+	public Duration timeLeftIfAny() throws TimeoutException {
+		long nanos = Math.subtractExact(timeNanos, System.nanoTime());
+		if (nanos <= 0) {
+			throw new TimeoutException();
+		}
+		return Duration.ofNanos(nanos);
 	}
 
 	/**


### PR DESCRIPTION
Relaxes the timing constraints in `FlinkKinesisProducerTest#testBackpressure` by relying on a `Deadline` instead of `100ms` syncs. Some syncs (that were just used as sleeps) have been replaced with a sleep-loop.

To prevent the `Deadline` usage from obfuscating errors in case `timeLeft()` returns a negative value, a new method `timeLeftIfAny() throws TimeoutException` was introduced, which should be usable as a drop-in replacement for usage that follow this pattern:
```
if (deadline.hasTimeLeft()) {
    <do something with deadline.timeLeft()>
} else {
    <abort>
}
```

The problem in the above example is that there is no guarantee that `timeLeft()` returns a positive value, because time.