### PR TITLE
[FLINK-11524][tests] Throw descriptive error if job terminates prematurely

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobResultUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobResultUtils.java
@@ -19,8 +19,6 @@ package org.apache.flink.runtime.jobmaster.utils;
 
 import org.apache.flink.runtime.jobmaster.JobResult;
 
-import org.apache.hadoop.mapreduce.Job;
-
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobResultUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobResultUtils.java
@@ -19,6 +19,11 @@ package org.apache.flink.runtime.jobmaster.utils;
 
 import org.apache.flink.runtime.jobmaster.JobResult;
 
+import org.apache.hadoop.mapreduce.Job;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
 /**
  * Testing utils surrounding the {@link JobResult}.
  */
@@ -29,6 +34,25 @@ public final class JobResultUtils {
 				throw new AssertionError("Job failed.", result.getSerializedThrowable().get().deserializeError(JobResultUtils.class.getClassLoader()));
 			} else {
 				throw new AssertionError("Job was not successful but did not fail with an error.");
+			}
+		}
+	}
+
+	public static void assertIncomplete(final CompletableFuture<JobResult> result) {
+		if (result.isDone()) {
+			final JobResult jobResult;
+			try {
+				jobResult = result.get();
+			} catch (InterruptedException | ExecutionException e) {
+				// we already know it is done so this doesn't happen
+				throw new AssertionError("Unexpected exception when processing finished future.", e);
+			}
+
+			if (jobResult.isSuccess()) {
+				throw new AssertionError("Job finished successfully.");
+			} else {
+				// this is guarantee to fail with an error
+				assertSuccess(jobResult);
 			}
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderChangeClusterComponentsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderChangeClusterComponentsTest.java
@@ -142,7 +142,7 @@ public class LeaderChangeClusterComponentsTest extends TestLogger {
 
 		highAvailabilityServices.revokeJobMasterLeadership(jobId).get();
 
-		assertThat(jobResultFuture.isDone(), is(false));
+		JobResultUtils.assertIncomplete(jobResultFuture);
 		BlockingOperator.isBlocking = false;
 
 		highAvailabilityServices.grantJobMasterLeadership(jobId);


### PR DESCRIPTION
Enhances the `LeaderChangeClusterComponentsTest` to fail with an descriptive error if the job terminated prematurely.