### PR TITLE
[FLINK-15013] Fix non local slot selection and root slot resolution

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/LocationPreferenceSlotSelectionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/LocationPreferenceSlotSelectionStrategy.java
@@ -74,7 +74,7 @@ public abstract class LocationPreferenceSlotSelectionStrategy implements SlotSel
 
 		SlotInfoAndResources bestCandidate = null;
 		Locality bestCandidateLocality = Locality.UNKNOWN;
-		double bestCandidateScore = Double.MIN_VALUE;
+		double bestCandidateScore = -1;
 
 		for (SlotInfoAndResources candidate : availableSlots) {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.jobmaster.slotpool;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobmanager.scheduler.Locality;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
@@ -143,41 +144,44 @@ public class SlotSharingManager {
 			SlotRequestId slotRequestId,
 			CompletableFuture<? extends SlotContext> slotContextFuture,
 			SlotRequestId allocatedSlotRequestId) {
+		final CompletableFuture<SlotContext> slotContextFutureAfterRootSlotResolution = new CompletableFuture<>();
 		final MultiTaskSlot rootMultiTaskSlot = new MultiTaskSlot(
 			slotRequestId,
-			slotContextFuture,
+			slotContextFutureAfterRootSlotResolution,
 			allocatedSlotRequestId);
 
 		LOG.debug("Create multi task slot [{}] in slot [{}].", slotRequestId, allocatedSlotRequestId);
 
 		allTaskSlots.put(slotRequestId, rootMultiTaskSlot);
-
 		unresolvedRootSlots.put(slotRequestId, rootMultiTaskSlot);
 
-		// add the root node to the set of resolved root nodes once the SlotContext future has
-		// been completed and we know the slot's TaskManagerLocation
-		slotContextFuture.whenComplete(
-			(SlotContext slotContext, Throwable throwable) -> {
-				if (slotContext != null) {
-					final MultiTaskSlot resolvedRootNode = unresolvedRootSlots.remove(slotRequestId);
-
-					if (resolvedRootNode != null) {
-						final AllocationID allocationId = slotContext.getAllocationId();
-						LOG.trace("Fulfill multi task slot [{}] with slot [{}].", slotRequestId, allocationId);
-
-						final Map<AllocationID, MultiTaskSlot> innerMap = resolvedRootSlots.computeIfAbsent(
-							slotContext.getTaskManagerLocation(),
-							taskManagerLocation -> new HashMap<>(4));
-
-						MultiTaskSlot previousValue = innerMap.put(allocationId, resolvedRootNode);
-						Preconditions.checkState(previousValue == null);
-					}
-				} else {
-					rootMultiTaskSlot.release(throwable);
-				}
-			});
+		FutureUtils.forward(
+			slotContextFuture.thenApply(
+				(SlotContext slotContext) -> {
+					// add the root node to the set of resolved root nodes once the SlotContext future has
+					// been completed and we know the slot's TaskManagerLocation
+					tryMarkSlotAsResolved(slotRequestId, slotContext);
+					return slotContext;
+				}),
+			slotContextFutureAfterRootSlotResolution);
 
 		return rootMultiTaskSlot;
+	}
+
+	private void tryMarkSlotAsResolved(SlotRequestId slotRequestId, SlotInfo slotInfo) {
+		final MultiTaskSlot resolvedRootNode = unresolvedRootSlots.remove(slotRequestId);
+
+		if (resolvedRootNode != null) {
+			final AllocationID allocationId = slotInfo.getAllocationId();
+			LOG.trace("Fulfill multi task slot [{}] with slot [{}].", slotRequestId, allocationId);
+
+			final Map<AllocationID, MultiTaskSlot> innerMap = resolvedRootSlots.computeIfAbsent(
+				slotInfo.getTaskManagerLocation(),
+				taskManagerLocation -> new HashMap<>(4));
+
+			MultiTaskSlot previousValue = innerMap.put(allocationId, resolvedRootNode);
+			Preconditions.checkState(previousValue == null);
+		}
 	}
 
 	@Nonnull

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
@@ -144,16 +144,13 @@ public class SlotSharingManager {
 			SlotRequestId slotRequestId,
 			CompletableFuture<? extends SlotContext> slotContextFuture,
 			SlotRequestId allocatedSlotRequestId) {
-		final CompletableFuture<SlotContext> slotContextFutureAfterRootSlotResolution = new CompletableFuture<>();
-		final MultiTaskSlot rootMultiTaskSlot = new MultiTaskSlot(
-			slotRequestId,
-			slotContextFutureAfterRootSlotResolution,
-			allocatedSlotRequestId);
-
 		LOG.debug("Create multi task slot [{}] in slot [{}].", slotRequestId, allocatedSlotRequestId);
 
-		allTaskSlots.put(slotRequestId, rootMultiTaskSlot);
-		unresolvedRootSlots.put(slotRequestId, rootMultiTaskSlot);
+		final CompletableFuture<SlotContext> slotContextFutureAfterRootSlotResolution = new CompletableFuture<>();
+		final MultiTaskSlot rootMultiTaskSlot = createAndRegisterRootSlot(
+			slotRequestId,
+			allocatedSlotRequestId,
+			slotContextFutureAfterRootSlotResolution);
 
 		FutureUtils.forward(
 			slotContextFuture.thenApply(
@@ -165,6 +162,20 @@ public class SlotSharingManager {
 				}),
 			slotContextFutureAfterRootSlotResolution);
 
+		return rootMultiTaskSlot;
+	}
+
+	private SlotSharingManager.MultiTaskSlot createAndRegisterRootSlot(
+			SlotRequestId slotRequestId,
+			SlotRequestId allocatedSlotRequestId,
+			CompletableFuture<? extends SlotContext> slotContextFuture) {
+		final MultiTaskSlot rootMultiTaskSlot = new MultiTaskSlot(
+			slotRequestId,
+			slotContextFuture,
+			allocatedSlotRequestId);
+
+		allTaskSlots.put(slotRequestId, rootMultiTaskSlot);
+		unresolvedRootSlots.put(slotRequestId, rootMultiTaskSlot);
 		return rootMultiTaskSlot;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
@@ -188,7 +188,7 @@ public class SlotSharingManager {
 
 			final Map<AllocationID, MultiTaskSlot> innerMap = resolvedRootSlots.computeIfAbsent(
 				slotInfo.getTaskManagerLocation(),
-				taskManagerLocation -> new HashMap<>(4));
+				taskManagerLocation -> new HashMap<>());
 
 			MultiTaskSlot previousValue = innerMap.put(allocationId, resolvedRootNode);
 			Preconditions.checkState(previousValue == null);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/LocationPreferenceSlotSelectionStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/LocationPreferenceSlotSelectionStrategyTest.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.runtime.clusterframework.types;
 
+import org.apache.flink.runtime.jobmanager.scheduler.Locality;
 import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.jobmaster.slotpool.LocationPreferenceSlotSelectionStrategy;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotSelectionStrategy;
 
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 import org.junit.Assert;
@@ -34,6 +34,7 @@ import java.util.HashSet;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -85,6 +86,7 @@ public class LocationPreferenceSlotSelectionStrategyTest extends SlotSelectionSt
 		Assert.assertTrue(match.isPresent());
 		final SlotSelectionStrategy.SlotInfoAndLocality slotInfoAndLocality = match.get();
 		assertThat(candidates, hasItem(withSlotInfo(slotInfoAndLocality.getSlotInfo())));
+		assertThat(slotInfoAndLocality, hasLocality(Locality.UNCONSTRAINED));
 	}
 
 	@Test
@@ -97,6 +99,11 @@ public class LocationPreferenceSlotSelectionStrategyTest extends SlotSelectionSt
 		final SlotSelectionStrategy.SlotInfoAndLocality slotInfoAndLocality = match.get();
 		final SlotInfo slotInfo = slotInfoAndLocality.getSlotInfo();
 		assertThat(candidates, hasItem(withSlotInfo(slotInfo)));
+		assertThat(slotInfoAndLocality, hasLocality(Locality.HOST_LOCAL));
+	}
+
+	private Matcher<SlotSelectionStrategy.SlotInfoAndLocality> hasLocality(Locality locality) {
+		return new LocalityFeatureMatcher(locality);
 	}
 
 	private Matcher<SlotSelectionStrategy.SlotInfoAndResources> withSlotInfo(SlotInfo slotInfo) {
@@ -142,13 +149,24 @@ public class LocationPreferenceSlotSelectionStrategyTest extends SlotSelectionSt
 	}
 
 	private static class SlotInfoFeatureMatcher extends FeatureMatcher<SlotSelectionStrategy.SlotInfoAndResources, SlotInfo> {
-		public SlotInfoFeatureMatcher(SlotInfo slotInfo) {
-			super(CoreMatchers.is(slotInfo), "Slot info of a SlotInfoAndResources instance", "slotInfo");
+		SlotInfoFeatureMatcher(SlotInfo slotInfo) {
+			super(is(slotInfo), "Slot info of a SlotInfoAndResources instance", "slotInfo");
 		}
 
 		@Override
 		protected SlotInfo featureValueOf(SlotSelectionStrategy.SlotInfoAndResources actual) {
 			return actual.getSlotInfo();
+		}
+	}
+
+	private static class LocalityFeatureMatcher extends FeatureMatcher<SlotSelectionStrategy.SlotInfoAndLocality, Locality> {
+		LocalityFeatureMatcher(Locality locality) {
+			super(is(locality), "Locality of SlotInfoAndLocality instance", "locality");
+		}
+
+		@Override
+		protected Locality featureValueOf(SlotSelectionStrategy.SlotInfoAndLocality actual) {
+			return actual.getLocality();
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/LocationPreferenceSlotSelectionStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/LocationPreferenceSlotSelectionStrategyTest.java
@@ -18,9 +18,13 @@
 
 package org.apache.flink.runtime.clusterframework.types;
 
+import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.jobmaster.slotpool.LocationPreferenceSlotSelectionStrategy;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotSelectionStrategy;
 
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -28,7 +32,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
-import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.junit.Assert.assertThat;
 
 /**
  * Tests for {@link LocationPreferenceSlotSelectionStrategy}.
@@ -76,24 +82,25 @@ public class LocationPreferenceSlotSelectionStrategyTest extends SlotSelectionSt
 		SlotProfile slotProfile = SlotProfile.noRequirements();
 		Optional<SlotSelectionStrategy.SlotInfoAndLocality> match = runMatching(slotProfile);
 
-		Assert.assertTrue(
-				candidates.stream()
-						.map(SlotSelectionStrategy.SlotInfoAndResources::getSlotInfo)
-						.collect(Collectors.toList())
-						.contains(match.get().getSlotInfo()));
+		Assert.assertTrue(match.isPresent());
+		final SlotSelectionStrategy.SlotInfoAndLocality slotInfoAndLocality = match.get();
+		assertThat(candidates, hasItem(withSlotInfo(slotInfoAndLocality.getSlotInfo())));
 	}
 
 	@Test
-	public void matchPreferredLocationNotAvailable() {
+	public void returnsHostLocalMatchingIfExactTMLocationCannotBeFulfilled() {
 
 		SlotProfile slotProfile = SlotProfile.preferredLocality(resourceProfile, Collections.singletonList(tmlX));
 		Optional<SlotSelectionStrategy.SlotInfoAndLocality> match = runMatching(slotProfile);
 
-		Assert.assertTrue(
-				candidates.stream()
-						.map(SlotSelectionStrategy.SlotInfoAndResources::getSlotInfo)
-						.collect(Collectors.toList())
-						.contains(match.get().getSlotInfo()));
+		Assert.assertTrue(match.isPresent());
+		final SlotSelectionStrategy.SlotInfoAndLocality slotInfoAndLocality = match.get();
+		final SlotInfo slotInfo = slotInfoAndLocality.getSlotInfo();
+		assertThat(candidates, hasItem(withSlotInfo(slotInfo)));
+	}
+
+	private Matcher<SlotSelectionStrategy.SlotInfoAndResources> withSlotInfo(SlotInfo slotInfo) {
+		return new SlotInfoFeatureMatcher(slotInfo);
 	}
 
 	@Test
@@ -132,5 +139,16 @@ public class LocationPreferenceSlotSelectionStrategyTest extends SlotSelectionSt
 
 		// available previous allocation should override blacklisting
 		Assert.assertEquals(slotInfo3, match.get().getSlotInfo());
+	}
+
+	private static class SlotInfoFeatureMatcher extends FeatureMatcher<SlotSelectionStrategy.SlotInfoAndResources, SlotInfo> {
+		public SlotInfoFeatureMatcher(SlotInfo slotInfo) {
+			super(CoreMatchers.is(slotInfo), "Slot info of a SlotInfoAndResources instance", "slotInfo");
+		}
+
+		@Override
+		protected SlotInfo featureValueOf(SlotSelectionStrategy.SlotInfoAndResources actual) {
+			return actual.getSlotInfo();
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManagerTest.java
@@ -80,12 +80,7 @@ public class SlotSharingManagerTest extends TestLogger {
 
 	@Test
 	public void testRootSlotCreation() {
-		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
-
-		final SlotSharingManager slotSharingManager = new SlotSharingManager(
-			SLOT_SHARING_GROUP_ID,
-			allocatedSlotActions,
-			SLOT_OWNER);
+		final SlotSharingManager slotSharingManager = createTestingSlotSharingManager();
 
 		SlotRequestId slotRequestId = new SlotRequestId();
 		SlotRequestId allocatedSlotRequestId = new SlotRequestId();
@@ -137,12 +132,7 @@ public class SlotSharingManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testNestedSlotCreation() {
-		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
-
-		final SlotSharingManager slotSharingManager = new SlotSharingManager(
-			SLOT_SHARING_GROUP_ID,
-			allocatedSlotActions,
-			SLOT_OWNER);
+		final SlotSharingManager slotSharingManager = createTestingSlotSharingManager();
 
 		SlotSharingManager.MultiTaskSlot rootSlot = slotSharingManager.createRootSlot(
 			new SlotRequestId(),
@@ -239,12 +229,7 @@ public class SlotSharingManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testInnerSlotRelease() {
-		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
-
-		final SlotSharingManager slotSharingManager = new SlotSharingManager(
-			SLOT_SHARING_GROUP_ID,
-			allocatedSlotActions,
-			SLOT_OWNER);
+		final SlotSharingManager slotSharingManager = createTestingSlotSharingManager();
 
 		SlotSharingManager.MultiTaskSlot rootSlot = slotSharingManager.createRootSlot(
 			new SlotRequestId(),
@@ -283,12 +268,7 @@ public class SlotSharingManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testSlotContextFutureCompletion() throws Exception {
-		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
-
-		final SlotSharingManager slotSharingManager = new SlotSharingManager(
-			SLOT_SHARING_GROUP_ID,
-			allocatedSlotActions,
-			SLOT_OWNER);
+		final SlotSharingManager slotSharingManager = createTestingSlotSharingManager();
 
 		final SlotContext slotContext = new SimpleSlotContext(
 			new AllocationID(),
@@ -355,12 +335,7 @@ public class SlotSharingManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testSlotContextFutureFailure() {
-		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
-
-		SlotSharingManager slotSharingManager = new SlotSharingManager(
-			SLOT_SHARING_GROUP_ID,
-			allocatedSlotActions,
-			SLOT_OWNER);
+		SlotSharingManager slotSharingManager = createTestingSlotSharingManager();
 
 		CompletableFuture<SlotContext> slotContextFuture = new CompletableFuture<>();
 
@@ -391,12 +366,7 @@ public class SlotSharingManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testRootSlotTransition() {
-		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
-
-		SlotSharingManager slotSharingManager = new SlotSharingManager(
-			SLOT_SHARING_GROUP_ID,
-			allocatedSlotActions,
-			SLOT_OWNER);
+		SlotSharingManager slotSharingManager = createTestingSlotSharingManager();
 
 		CompletableFuture<SlotContext> slotContextFuture = new CompletableFuture<>();
 		SlotSharingManager.MultiTaskSlot rootSlot = slotSharingManager.createRootSlot(
@@ -424,12 +394,7 @@ public class SlotSharingManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testGetResolvedSlot() {
-		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
-
-		SlotSharingManager slotSharingManager = new SlotSharingManager(
-			SLOT_SHARING_GROUP_ID,
-			allocatedSlotActions,
-			SLOT_OWNER);
+		SlotSharingManager slotSharingManager = createTestingSlotSharingManager();
 
 		SlotSharingManager.MultiTaskSlot rootSlot = createRootSlot(new LocalTaskManagerLocation(), slotSharingManager);
 
@@ -466,12 +431,7 @@ public class SlotSharingManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testGetResolvedSlotWithLocationPreferences() {
-		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
-
-		SlotSharingManager slotSharingManager = new SlotSharingManager(
-			SLOT_SHARING_GROUP_ID,
-			allocatedSlotActions,
-			SLOT_OWNER);
+		SlotSharingManager slotSharingManager = createTestingSlotSharingManager();
 
 		SlotSharingManager.MultiTaskSlot rootSlot1 = createRootSlot(new LocalTaskManagerLocation(), slotSharingManager);
 
@@ -512,12 +472,7 @@ public class SlotSharingManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testResolvedSlotInReleasingIsNotAvailable() throws Exception {
-		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
-
-		final SlotSharingManager slotSharingManager = new SlotSharingManager(
-			SLOT_SHARING_GROUP_ID,
-			allocatedSlotActions,
-			SLOT_OWNER);
+		final SlotSharingManager slotSharingManager = createTestingSlotSharingManager();
 
 		final SlotSharingManager.MultiTaskSlot rootSlot = createRootSlot(new LocalTaskManagerLocation(), slotSharingManager);
 
@@ -556,12 +511,7 @@ public class SlotSharingManagerTest extends TestLogger {
 
 	@Test
 	public void testGetUnresolvedSlot() {
-		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
-
-		SlotSharingManager slotSharingManager = new SlotSharingManager(
-			SLOT_SHARING_GROUP_ID,
-			allocatedSlotActions,
-			SLOT_OWNER);
+		SlotSharingManager slotSharingManager = createTestingSlotSharingManager();
 
 		SlotSharingManager.MultiTaskSlot rootSlot1 = slotSharingManager.createRootSlot(
 			new SlotRequestId(),
@@ -613,12 +563,7 @@ public class SlotSharingManagerTest extends TestLogger {
 			.addExtendedResource("gpu", new GPUResource(3.0))
 			.build();
 
-		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
-
-		SlotSharingManager slotSharingManager = new SlotSharingManager(
-				SLOT_SHARING_GROUP_ID,
-				allocatedSlotActions,
-				SLOT_OWNER);
+		SlotSharingManager slotSharingManager = createTestingSlotSharingManager();
 
 		SlotSharingManager.MultiTaskSlot unresolvedRootSlot = slotSharingManager.createRootSlot(
 				new SlotRequestId(),
@@ -674,12 +619,7 @@ public class SlotSharingManagerTest extends TestLogger {
 		ResourceProfile rp2 = ResourceProfile.fromResources(2.0, 200);
 		ResourceProfile allocatedSlotRp = ResourceProfile.fromResources(5.0, 500);
 
-		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
-
-		SlotSharingManager slotSharingManager = new SlotSharingManager(
-				SLOT_SHARING_GROUP_ID,
-				allocatedSlotActions,
-				SLOT_OWNER);
+		SlotSharingManager slotSharingManager = createTestingSlotSharingManager();
 
 		SlotSharingManager.MultiTaskSlot rootSlot = slotSharingManager.createRootSlot(
 				new SlotRequestId(),
@@ -719,12 +659,7 @@ public class SlotSharingManagerTest extends TestLogger {
 		ResourceProfile rp2 = ResourceProfile.fromResources(2.0, 200);
 		ResourceProfile allocatedSlotRp = ResourceProfile.fromResources(2.0, 200);
 
-		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
-
-		SlotSharingManager slotSharingManager = new SlotSharingManager(
-				SLOT_SHARING_GROUP_ID,
-				allocatedSlotActions,
-				SLOT_OWNER);
+		SlotSharingManager slotSharingManager = createTestingSlotSharingManager();
 
 		CompletableFuture<SlotContext> slotContextFuture = new CompletableFuture<>();
 
@@ -795,12 +730,7 @@ public class SlotSharingManagerTest extends TestLogger {
 		ResourceProfile thirdChildRp = ResourceProfile.fromResources(3.0, 300);
 		ResourceProfile forthChildRp = ResourceProfile.fromResources(9.0, 900);
 
-		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
-
-		SlotSharingManager slotSharingManager = new SlotSharingManager(
-				SLOT_SHARING_GROUP_ID,
-				allocatedSlotActions,
-				SLOT_OWNER);
+		SlotSharingManager slotSharingManager = createTestingSlotSharingManager();
 
 		CompletableFuture<SlotContext> slotContextFuture = new CompletableFuture<>();
 
@@ -846,6 +776,15 @@ public class SlotSharingManagerTest extends TestLogger {
 				slotSharingManager,
 				coLocationTaskSlot,
 				Arrays.asList(firstCoLocatedChild, secondCoLocatedChild, thirdChild, forthChild));
+	}
+
+	private SlotSharingManager createTestingSlotSharingManager() {
+		final TestingAllocatedSlotActions allocatedSlotActions = new TestingAllocatedSlotActions();
+
+		return new SlotSharingManager(
+			SLOT_SHARING_GROUP_ID,
+			allocatedSlotActions,
+			SLOT_OWNER);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManagerTest.java
@@ -53,10 +53,12 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
@@ -270,11 +272,7 @@ public class SlotSharingManagerTest extends TestLogger {
 	public void testSlotContextFutureCompletion() throws Exception {
 		final SlotSharingManager slotSharingManager = createTestingSlotSharingManager();
 
-		final SlotContext slotContext = new SimpleSlotContext(
-			new AllocationID(),
-			new LocalTaskManagerLocation(),
-			0,
-			new SimpleAckingTaskManagerGateway());
+		final SlotContext slotContext = createSimpleSlotContext();
 
 		CompletableFuture<SlotContext> slotContextFuture = new CompletableFuture<>();
 		SlotSharingManager.MultiTaskSlot rootSlot = slotSharingManager.createRootSlot(
@@ -330,6 +328,14 @@ public class SlotSharingManagerTest extends TestLogger {
 		assertEquals(slotContext.getAllocationId(), logicalSlot3.getAllocationId());
 	}
 
+	private SimpleSlotContext createSimpleSlotContext() {
+		return new SimpleSlotContext(
+			new AllocationID(),
+			new LocalTaskManagerLocation(),
+			0,
+			new SimpleAckingTaskManagerGateway());
+	}
+
 	/**
 	 * Tests that slot context future failures will release the root slot.
 	 */
@@ -378,12 +384,7 @@ public class SlotSharingManagerTest extends TestLogger {
 		assertFalse(slotSharingManager.getResolvedRootSlots().contains(rootSlot));
 
 		// now complete the slotContextFuture
-		slotContextFuture.complete(
-			new SimpleSlotContext(
-				new AllocationID(),
-				new LocalTaskManagerLocation(),
-				0,
-				new SimpleAckingTaskManagerGateway()));
+		slotContextFuture.complete(createSimpleSlotContext());
 
 		assertFalse(slotSharingManager.getUnresolvedRootSlots().contains(rootSlot));
 		assertTrue(slotSharingManager.getResolvedRootSlots().contains(rootSlot));
@@ -837,6 +838,34 @@ public class SlotSharingManagerTest extends TestLogger {
 
 		assertThat(utilizationPerTaskExecutor.get(firstTaskExecutorLocation), is(closeTo(1.0 / 2, 0.1)));
 		assertThat(utilizationPerTaskExecutor.get(secondTaskExecutorLocation), is(closeTo(0, 0.1)));
+	}
+
+	@Test
+	public void shouldResolveRootSlotBeforeCompletingChildSlots() {
+		final SlotSharingManager slotSharingManager = createTestingSlotSharingManager();
+
+		final CompletableFuture<SlotContext> slotFuture = new CompletableFuture<>();
+		// important to add additional completion stage in order to reverse the execution order of callbacks
+		final CompletableFuture<SlotContext> identityFuture = slotFuture.thenApply(Function.identity());
+
+		final SlotSharingManager.MultiTaskSlot rootSlot = slotSharingManager.createRootSlot(
+			new SlotRequestId(),
+			identityFuture,
+			new SlotRequestId());
+
+		final SlotSharingManager.SingleTaskSlot singleTaskSlot = rootSlot.allocateSingleTaskSlot(
+			new SlotRequestId(),
+			ResourceProfile.UNKNOWN,
+			new AbstractID(),
+			Locality.UNCONSTRAINED);
+
+		final CompletableFuture<Void> assertionFuture = singleTaskSlot.getLogicalSlotFuture().thenRun(() -> assertThat(
+			slotSharingManager.getResolvedRootSlots(),
+			contains(rootSlot)));
+
+		slotFuture.complete(createSimpleSlotContext());
+
+		assertionFuture.join();
 	}
 
 	private SlotSharingManager.MultiTaskSlot createRootSlot(TaskManagerLocation firstTaskExecutorLocation, SlotSharingManager slotSharingManager) {


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes two problems related to Flink's scheduling:

In order to prevent a race condition where Executions are scheduled because
their inputs' locations have been assigned but the underlying root slot not
being marked as resolved and, hence, not being available for location based
scheduling, this commit enforces that we first resolve the root slot before
completing the associated MultiTaskSlot.

The LocationPreferenceSlotSelectionStrategy ignored NON_LOCAL slots due to initializing the initial
candidate score to a positive value. As NON_LOCAL candidates have a value of 0, the initial candidate score needs to be negative, otherwise NON_LOCAL candidates will be ignored.

## Verifying this change

- Added `LocationPreferenceSlotSelectionStrategyTest#returnsNonLocalMatchingIfResourceProfileCanBeFulfilledButNotTheTMLocationPreferences` and `SlotSharingManagerTest#shouldResolveRootSlotBeforeCompletingChildSlots`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
