### PR TITLE
FLINK-15174 added certificate pinning for SSL mutual auth to further protect cluster

### DIFF
--- a/docs/_includes/generated/security_configuration.html
+++ b/docs/_includes/generated/security_configuration.html
@@ -13,6 +13,11 @@
             <td>The comma separated list of standard SSL algorithms to be supported. Read more <a href="http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#ciphersuites">here</a></td>
         </tr>
         <tr>
+            <td><h5>security.ssl.internal.cert.fingerprint</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>The sha1 fingerprint of the internal certificate. This further protects the internal communication to present the exact certificate used by Flink.This is necessary where one cannot use private CA(self signed) or there is internal firm wide CA is required</td>
+        </tr>
+        <tr>
             <td><h5>security.ssl.internal.close-notify-flush-timeout</h5></td>
             <td style="word-wrap: break-word;">-1</td>
             <td>The timeout (in ms) for flushing the `close_notify` that was triggered by closing a channel. If the `close_notify` was not flushed in the given timeout the channel will be closed forcibly. (-1 = use system default)</td>
@@ -91,6 +96,11 @@
             <td><h5>security.ssl.rest.authentication-enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Turns on mutual SSL authentication for external communication via the REST endpoints.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.rest.cert.fingerprint</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>The sha1 fingerprint of the rest certificate. This further protects the rest REST endpoints to present certificate which is only used by proxy serverThis is necessary where once uses public CA or internal firm wide CA</td>
         </tr>
         <tr>
             <td><h5>security.ssl.rest.enabled</h5></td>

--- a/docs/ops/security-ssl.md
+++ b/docs/ops/security-ssl.md
@@ -50,12 +50,16 @@ Internal connectivity includes:
 
 All internal connections are SSL authenticated and encrypted. The connections use **mutual authentication**, meaning both server
 and client side of each connection need to present the certificate to each other. The certificate acts effectively as a shared
-secret.
+secret when a dedicated CA is used to exclusively sign an internal cert.
 
-A common setup is to generate a dedicated certificate (may be self-signed) for a Flink deployment. The certificate for internal communication
+It is highly recommended to generate a dedicated certificate (self-signed) for a Flink deployment. The certificate for internal communication
 is not needed by any other party to interact with Flink, and can be simply added to the container images, or attached to the YARN deployment.
 
+An environment where operators are constrained to use firm wide Internal CA and can not generate self-signed certificate, specify the SHA1 certificate fingerprint to protect the cluster allowing only specific certificate to trusted by the cluster.
+
 *Note: Because internal connections are mutually authenticated with shared certificates, Flink can skip hostname verification. This makes container-based setups easier.*
+
+*IMPORTANT: Do not use certificate issued by public CA without pinning the fingerprint of the certificate.*
 
 ### External / REST Connectivity
 
@@ -113,6 +117,12 @@ security.ssl.internal.keystore-password: keystore_password
 security.ssl.internal.key-password: key_password
 security.ssl.internal.truststore: /path/to/file.truststore
 security.ssl.internal.truststore-password: truststore_password
+{% endhighlight %}
+
+When using certificate from public CA, Use certificate pinning to allow only specific internal certificate to establish the connectivity.
+
+{% highlight yaml %}
+security.ssl.internal.cert.fingerprint: 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
 {% endhighlight %}
 
 #### REST Endpoints (external connectivity)

--- a/docs/ops/security-ssl.zh.md
+++ b/docs/ops/security-ssl.zh.md
@@ -50,12 +50,16 @@ Internal connectivity includes:
 
 All internal connections are SSL authenticated and encrypted. The connections use **mutual authentication**, meaning both server
 and client side of each connection need to present the certificate to each other. The certificate acts effectively as a shared
-secret.
+secret when a dedicated CA is used to exclusively sign an internal cert.
 
-A common setup is to generate a dedicated certificate (may be self-signed) for a Flink deployment. The certificate for internal communication
+It is highly recommended to generate a dedicated certificate (self-signed) for a Flink deployment. The certificate for internal communication
 is not needed by any other party to interact with Flink, and can be simply added to the container images, or attached to the YARN deployment.
 
+An environment where operators are constrained to use firm wide Internal CA and can not generate self-signed certificate, specify the SHA1 certificate fingerprint to protect the cluster allowing only specific certificate to trusted by the cluster.
+
 *Note: Because internal connections are mutually authenticated with shared certificates, Flink can skip hostname verification. This makes container-based setups easier.*
+
+*IMPORTANT: Do not use certificate issued by public CA without pinning the fingerprint of the certificate.*
 
 ### External / REST Connectivity
 
@@ -113,6 +117,12 @@ security.ssl.internal.keystore-password: keystore_password
 security.ssl.internal.key-password: key_password
 security.ssl.internal.truststore: /path/to/file.truststore
 security.ssl.internal.truststore-password: truststore_password
+{% endhighlight %}
+
+When using certificate from public CA, Use certificate pinning to allow only specific internal certificate to establish the connectivity.
+
+{% highlight yaml %}
+security.ssl.internal.cert.fingerprint: 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
 {% endhighlight %}
 
 #### REST Endpoints (external connectivity)

--- a/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
@@ -221,6 +221,16 @@ public class SecurityOptions {
 					.withDescription("The password to decrypt the truststore " +
 							"for Flink's internal endpoints (rpc, data transport, blob server).");
 
+	/**
+	 * For internal SSL, the sha1 fingerprint of the internal certificate to verify the client.
+	 */
+	public static final ConfigOption<String> SSL_INTERNAL_CERT_FINGERPRINT =
+		key("security.ssl.internal.cert.fingerprint")
+			.noDefaultValue()
+			.withDescription("The sha1 fingerprint of the internal certificate. " +
+				"This further protects the internal communication to present the exact certificate used by Flink." +
+				"This is necessary where one cannot use private CA(self signed) or there is internal firm wide CA is required");
+
 	// ----------------------- certificates (external) ------------------------
 
 	/**
@@ -267,6 +277,16 @@ public class SecurityOptions {
 					.noDefaultValue()
 					.withDescription("The password to decrypt the truststore " +
 							"for Flink's external REST endpoints.");
+
+	/**
+	 * For external (REST) SSL, the sha1 fingerprint of the rest client certificate to verify.
+	 */
+	public static final ConfigOption<String> SSL_REST_CERT_FINGERPRINT =
+		key("security.ssl.rest.cert.fingerprint")
+			.noDefaultValue()
+			.withDescription("The sha1 fingerprint of the rest certificate. " +
+				"This further protects the rest REST endpoints to present certificate which is only used by proxy server" +
+				"This is necessary where once uses public CA or internal firm wide CA");
 
 	// ------------------------ ssl parameters --------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.io.network.netty.SSLHandlerFactory;
+import org.apache.flink.util.StringUtils;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.ssl.ClientAuth;
 import org.apache.flink.shaded.netty4.io.netty.handler.ssl.JdkSslContext;
@@ -32,6 +33,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.ssl.OpenSslX509KeyManager
 import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslContext;
 import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslContextBuilder;
 import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslProvider;
+import org.apache.flink.shaded.netty4.io.netty.handler.ssl.util.FingerprintTrustManagerFactory;
 
 import javax.annotation.Nullable;
 import javax.net.ServerSocketFactory;
@@ -234,8 +236,16 @@ public class SSLUtils {
 			trustStore.load(trustStoreFile, trustStorePassword.toCharArray());
 		}
 
-		TrustManagerFactory tmf =
-			TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+		String certFingerprint = config.getString(
+			internal ? SecurityOptions.SSL_INTERNAL_CERT_FINGERPRINT : SecurityOptions.SSL_REST_CERT_FINGERPRINT);
+
+		TrustManagerFactory tmf;
+		if (StringUtils.isNullOrWhitespaceOnly(certFingerprint)) {
+			tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+		} else {
+			tmf = new FingerprintTrustManagerFactory(certFingerprint.split(","));
+		}
+
 		tmf.init(trustStore);
 
 		return tmf;

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -465,6 +465,13 @@ object AkkaUtils {
                               SecurityOptions.SSL_INTERNAL_TRUSTSTORE_PASSWORD,
                               configuration.getString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD))
 
+    val akkaSSLCertFingerprintString = configuration.getString(
+                              SecurityOptions.SSL_INTERNAL_CERT_FINGERPRINT)
+
+    val akkaSSLCertFingerprints = if ( akkaSSLCertFingerprintString != null ) {
+      akkaSSLCertFingerprintString.split(",").toList.mkString("[\"", "\",\"", "\"]")
+    } else  "[]"
+
     val akkaSSLProtocol = configuration.getString(SecurityOptions.SSL_PROTOCOL)
 
     val akkaSSLAlgorithmsString = configuration.getString(SecurityOptions.SSL_ALGORITHMS)
@@ -578,6 +585,7 @@ object AkkaUtils {
          |      ssl {
          |
          |        enable-ssl = $akkaEnableSSL
+         |        ssl-engine-provider = org.apache.flink.runtime.akka.CustomSSLEngineProvider
          |        security {
          |          key-store = "$akkaSSLKeyStore"
          |          key-store-password = "$akkaSSLKeyStorePassword"
@@ -588,6 +596,7 @@ object AkkaUtils {
          |          enabled-algorithms = $akkaSSLAlgorithms
          |          random-number-generator = ""
          |          require-mutual-authentication = on
+         |          cert-fingerprints = $akkaSSLCertFingerprints
          |        }
          |      }
          |    }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/CustomSSLEngineProvider.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/CustomSSLEngineProvider.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.akka
+
+
+import akka.remote.transport.netty.ConfigSSLEngineProvider
+import javax.net.ssl.{TrustManager, TrustManagerFactory}
+import org.apache.flink.shaded.netty4.io.netty.handler.ssl.util.FingerprintTrustManagerFactory
+
+class CustomSSLEngineProvider(system : akka.actor.ActorSystem)
+                              extends ConfigSSLEngineProvider(system) {
+
+  private val securityConfig = system.settings.config.getConfig("akka.remote.netty.ssl.security")
+  private val SSLTrustStore = securityConfig.getString("trust-store")
+  private val SSLTrustStorePassword = securityConfig.getString("trust-store-password")
+  private val SSLCertFingerprints = securityConfig.getStringList("cert-fingerprints")
+
+  override protected def trustManagers: Array[TrustManager] = {
+
+    val trustManagerFactory = if (SSLCertFingerprints.isEmpty) {
+      TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+    } else new FingerprintTrustManagerFactory(SSLCertFingerprints)
+
+    trustManagerFactory.init(loadKeystore(SSLTrustStore, SSLTrustStorePassword))
+    trustManagerFactory.getTrustManagers
+  }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyClientServerSslTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyClientServerSslTest.java
@@ -229,6 +229,48 @@ public class NettyClientServerSslTest extends TestLogger {
 		NettyTestUtil.shutdown(serverAndClient);
 	}
 
+	@Test
+	public void testSslPinningForValidFingerprint() throws Exception {
+		NettyProtocol protocol = new NoOpProtocol();
+
+		Configuration config = createSslConfig();
+
+		// pin the certificate based on internal cert
+		config.setString(SecurityOptions.SSL_INTERNAL_CERT_FINGERPRINT, SSLUtilsTest.getCertificateFingerprint(config, "flink.test"));
+
+		NettyConfig nettyConfig = createNettyConfig(config);
+
+		NettyTestUtil.NettyServerAndClient serverAndClient = NettyTestUtil.initServerAndClient(protocol, nettyConfig);
+
+		Channel ch = NettyTestUtil.connect(serverAndClient);
+		ch.pipeline().addLast(new StringDecoder()).addLast(new StringEncoder());
+
+		assertTrue(ch.writeAndFlush("test").await().isSuccess());
+
+		NettyTestUtil.shutdown(serverAndClient);
+	}
+
+	@Test
+	public void testSslPinningForInvalidFingerprint() throws Exception {
+		NettyProtocol protocol = new NoOpProtocol();
+
+		Configuration config = createSslConfig();
+
+		// pin the certificate based on internal cert
+		config.setString(SecurityOptions.SSL_INTERNAL_CERT_FINGERPRINT, SSLUtilsTest.getCertificateFingerprint(config, "flink.test").replaceAll("[0-9A-Z]", "0"));
+
+		NettyConfig nettyConfig = createNettyConfig(config);
+
+		NettyTestUtil.NettyServerAndClient serverAndClient = NettyTestUtil.initServerAndClient(protocol, nettyConfig);
+
+		Channel ch = NettyTestUtil.connect(serverAndClient);
+		ch.pipeline().addLast(new StringDecoder()).addLast(new StringEncoder());
+
+		assertFalse(ch.writeAndFlush("test").await().isSuccess());
+
+		NettyTestUtil.shutdown(serverAndClient);
+	}
+
 	private Configuration createSslConfig() {
 		return SSLUtilsTest.createInternalSslConfigWithKeyAndTrustStores(sslProvider);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
@@ -34,10 +34,19 @@ import org.junit.runners.Parameterized;
 
 import javax.net.ssl.SSLServerSocket;
 
+import java.io.File;
+import java.io.InputStream;
 import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.security.KeyStore;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.junit.Assert.assertEquals;
@@ -281,6 +290,15 @@ public class SSLUtilsTest extends TestLogger {
 	}
 
 	@Test
+	public void testInternalSSLWithSSLPinning() throws Exception {
+		final Configuration config = createInternalSslConfigWithKeyAndTrustStores();
+		config.setString(SecurityOptions.SSL_INTERNAL_CERT_FINGERPRINT, getCertificateFingerprint(config, "flink.test"));
+
+		assertNotNull(SSLUtils.createInternalServerSSLEngineFactory(config));
+		assertNotNull(SSLUtils.createInternalClientSSLEngineFactory(config));
+	}
+
+	@Test
 	public void testInternalSSLDisables() throws Exception {
 		final Configuration config = createInternalSslConfigWithKeyAndTrustStores();
 		config.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, false);
@@ -493,6 +511,22 @@ public class SSLUtilsTest extends TestLogger {
 		return config;
 	}
 
+	public static String getCertificateFingerprint(Configuration config, String certificateAlias) throws Exception {
+		KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+		try (InputStream keyStoreFile = Files.newInputStream(new File(config.getString(SecurityOptions.SSL_INTERNAL_KEYSTORE)).toPath())) {
+			keyStore.load(keyStoreFile, config.getString(SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD).toCharArray());
+		}
+		return getSha1Fingerprint(keyStore.getCertificate(certificateAlias));
+	}
+
+	public static String getRestCertificateFingerprint(Configuration config, String certificateAlias) throws Exception {
+		KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+		try (InputStream keyStoreFile = Files.newInputStream(new File(config.getString(SecurityOptions.SSL_REST_KEYSTORE)).toPath())) {
+			keyStore.load(keyStoreFile, config.getString(SecurityOptions.SSL_REST_KEYSTORE_PASSWORD).toCharArray());
+		}
+		return getSha1Fingerprint(keyStore.getCertificate(certificateAlias));
+	}
+
 	private static void addSslProviderConfig(Configuration config, String sslProvider) {
 		if (sslProvider.equalsIgnoreCase("OPENSSL")) {
 			assertTrue("openSSL not available", OpenSsl.isAvailable());
@@ -523,5 +557,34 @@ public class SSLUtilsTest extends TestLogger {
 	private static void addInternalTrustStoreConfig(Configuration config) {
 		config.setString(SecurityOptions.SSL_INTERNAL_TRUSTSTORE, TRUST_STORE_PATH);
 		config.setString(SecurityOptions.SSL_INTERNAL_TRUSTSTORE_PASSWORD, TRUST_STORE_PASSWORD);
+	}
+
+	private static String getSha1Fingerprint(Certificate cert) {
+		if (cert == null) {
+			return null;
+		}
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA1");
+			return toHexadecimalString(digest.digest(cert.getEncoded()));
+		} catch (NoSuchAlgorithmException | CertificateEncodingException e) {
+			// ignore
+		}
+		return null;
+	}
+
+	private static String toHexadecimalString(byte[] value) {
+		StringBuilder sb = new StringBuilder();
+		int len = value.length;
+		for (int i = 0; i < len; i++) {
+			int num = ((int) value[i]) & 0xff;
+			if (num < 0x10) {
+				sb.append('0');
+			}
+			sb.append(Integer.toHexString(num));
+			if (i < len - 1) {
+				sb.append(':');
+			}
+		}
+		return sb.toString().toUpperCase(Locale.US);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.runtime.net.SSLUtils;
+import org.apache.flink.runtime.net.SSLUtilsTest;
 import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.RestHandlerException;
@@ -144,7 +145,7 @@ public class RestServerEndpointITCase extends TestLogger {
 	}
 
 	@Parameterized.Parameters
-	public static Collection<Object[]> data() {
+	public static Collection<Object[]> data() throws Exception {
 		final Configuration config = getBaseConfig();
 
 		final String truststorePath = getTestResource("local127.truststore").getAbsolutePath();
@@ -161,8 +162,12 @@ public class RestServerEndpointITCase extends TestLogger {
 		final Configuration sslRestAuthConfig = new Configuration(sslConfig);
 		sslRestAuthConfig.setBoolean(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
 
+		final Configuration sslPinningRestAuthConfig = new Configuration(sslRestAuthConfig);
+		sslPinningRestAuthConfig.setString(SecurityOptions.SSL_REST_CERT_FINGERPRINT,
+			SSLUtilsTest.getRestCertificateFingerprint(sslPinningRestAuthConfig, "flink.test"));
+
 		return Arrays.asList(new Object[][]{
-			{config}, {sslConfig}, {sslRestAuthConfig}
+			{config}, {sslConfig}, {sslRestAuthConfig}, {sslPinningRestAuthConfig}
 		});
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerSSLAuthITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerSSLAuthITCase.java
@@ -38,7 +38,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLHandshakeException;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -47,7 +46,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import static java.util.Objects.requireNonNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerSSLAuthITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerSSLAuthITCase.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.SecurityOptions;
+import org.apache.flink.runtime.net.SSLUtilsTest;
 import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
@@ -33,22 +34,28 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.Objects.requireNonNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
  * This test validates that connections are failing when mutual auth is enabled but untrusted
- * keys are used.
+ * keys or fingerprints are used.
  */
+@RunWith(Parameterized.class)
 public class RestServerSSLAuthITCase extends TestLogger {
 
 	private static final String KEY_STORE_FILE = RestServerSSLAuthITCase.class.getResource("/local127.keystore").getFile();
@@ -57,7 +64,37 @@ public class RestServerSSLAuthITCase extends TestLogger {
 
 	private static final Time timeout = Time.seconds(10L);
 
-	private RestfulGateway restfulGateway;
+	private final Configuration clientConfig;
+	private final Configuration serverConfig;
+
+	public RestServerSSLAuthITCase(final Tuple2<Configuration, Configuration> clinetServerConfig) {
+		this.clientConfig = clinetServerConfig.f0;
+		this.serverConfig = clinetServerConfig.f1;
+	}
+
+	@Parameterized.Parameters
+	public static Collection<Object[]> data() throws Exception {
+		//client and server trust store does not match
+		Tuple2<Configuration, Configuration> untrusted = getClientServerConfiguration();
+
+		Configuration serverConfig = new Configuration(untrusted.f1);
+		serverConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE, TRUST_STORE_FILE);
+		//expect fingerprint which client does not have
+		serverConfig.setString(SecurityOptions.SSL_REST_CERT_FINGERPRINT,
+			SSLUtilsTest.getRestCertificateFingerprint(serverConfig, "flink.test")
+				.replaceAll("[0-9A-Z]", "0"));
+
+		Configuration clientConfig = new Configuration(untrusted.f0);
+		clientConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE, TRUST_STORE_FILE);
+
+		//client and server uses same trust store, however server configured with mismatching fingerprint
+		Tuple2<Configuration, Configuration> withFingerprint = Tuple2.of(clientConfig, serverConfig);
+
+		return Arrays.asList(new Object[][]{
+			{untrusted},
+			{withFingerprint}
+		});
+	}
 
 	@Test
 	public void testConnectFailure() throws Exception {
@@ -65,27 +102,6 @@ public class RestServerSSLAuthITCase extends TestLogger {
 		RestServerEndpoint serverEndpoint = null;
 
 		try {
-			final Configuration baseConfig = new Configuration();
-			baseConfig.setString(RestOptions.BIND_PORT, "0");
-			baseConfig.setString(RestOptions.ADDRESS, "localhost");
-			baseConfig.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
-			baseConfig.setBoolean(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
-			baseConfig.setString(SecurityOptions.SSL_ALGORITHMS, "TLS_RSA_WITH_AES_128_CBC_SHA");
-
-			Configuration serverConfig = new Configuration(baseConfig);
-			serverConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE, TRUST_STORE_FILE);
-			serverConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, "password");
-			serverConfig.setString(SecurityOptions.SSL_REST_KEYSTORE, KEY_STORE_FILE);
-			serverConfig.setString(SecurityOptions.SSL_REST_KEYSTORE_PASSWORD, "password");
-			serverConfig.setString(SecurityOptions.SSL_REST_KEY_PASSWORD, "password");
-
-			Configuration clientConfig = new Configuration(baseConfig);
-			clientConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE, UNTRUSTED_KEY_STORE_FILE);
-			clientConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, "password");
-			clientConfig.setString(SecurityOptions.SSL_REST_KEYSTORE, KEY_STORE_FILE);
-			clientConfig.setString(SecurityOptions.SSL_REST_KEYSTORE_PASSWORD, "password");
-			clientConfig.setString(SecurityOptions.SSL_REST_KEY_PASSWORD, "password");
-
 			RestServerEndpointConfiguration restServerConfig = RestServerEndpointConfiguration.fromConfiguration(serverConfig);
 			RestClientConfiguration restClientConfig = RestClientConfiguration.fromConfiguration(clientConfig);
 
@@ -113,7 +129,7 @@ public class RestServerSSLAuthITCase extends TestLogger {
 			fail("should never complete normally");
 		} catch (ExecutionException exception) {
 			// that is what we want
-			assertTrue(ExceptionUtils.findThrowable(exception, SSLHandshakeException.class).isPresent());
+			assertTrue(ExceptionUtils.findThrowable(exception, SSLException.class).isPresent());
 		} finally {
 			if (restClient != null) {
 				restClient.shutdown(timeout);
@@ -123,5 +139,29 @@ public class RestServerSSLAuthITCase extends TestLogger {
 				serverEndpoint.close();
 			}
 		}
+	}
+
+	private static  Tuple2<Configuration, Configuration> getClientServerConfiguration() {
+		final Configuration baseConfig = new Configuration();
+		baseConfig.setString(RestOptions.BIND_PORT, "0");
+		baseConfig.setString(RestOptions.ADDRESS, "localhost");
+		baseConfig.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
+		baseConfig.setBoolean(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
+		baseConfig.setString(SecurityOptions.SSL_ALGORITHMS, "TLS_RSA_WITH_AES_128_CBC_SHA");
+
+		Configuration serverConfig = new Configuration(baseConfig);
+		serverConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE, TRUST_STORE_FILE);
+		serverConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, "password");
+		serverConfig.setString(SecurityOptions.SSL_REST_KEYSTORE, KEY_STORE_FILE);
+		serverConfig.setString(SecurityOptions.SSL_REST_KEYSTORE_PASSWORD, "password");
+		serverConfig.setString(SecurityOptions.SSL_REST_KEY_PASSWORD, "password");
+
+		Configuration clientConfig = new Configuration(baseConfig);
+		clientConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE, UNTRUSTED_KEY_STORE_FILE);
+		clientConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, "password");
+		clientConfig.setString(SecurityOptions.SSL_REST_KEYSTORE, KEY_STORE_FILE);
+		clientConfig.setString(SecurityOptions.SSL_REST_KEYSTORE_PASSWORD, "password");
+		clientConfig.setString(SecurityOptions.SSL_REST_KEY_PASSWORD, "password");
+		return Tuple2.of(clientConfig, serverConfig);
 	}
 }

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/AkkaUtilsTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/AkkaUtilsTest.scala
@@ -19,19 +19,17 @@
 package org.apache.flink.runtime.akka
 
 import java.net.{InetAddress, InetSocketAddress}
+import java.util.Collections
 
-import org.apache.flink.configuration.{AkkaOptions, Configuration, IllegalConfigurationException, MetricOptions}
+import org.apache.flink.configuration.{AkkaOptions, Configuration, IllegalConfigurationException, MetricOptions, SecurityOptions}
 import org.apache.flink.runtime.clusterframework.BootstrapTools.FixedThreadPoolExecutorConfiguration
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils.AddressResolution
-import org.apache.flink.runtime.metrics.util.MetricUtils
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils.AkkaProtocol
 import org.apache.flink.util.NetUtils
-import org.junit.Assert.assertEquals
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
-import org.slf4j.LoggerFactory
 
 @RunWith(classOf[JUnitRunner])
 class AkkaUtilsTest
@@ -219,5 +217,37 @@ class AkkaUtilsTest
 
     akkaConfig.getString("akka.remote.netty.tcp.hostname") should
       equal(NetUtils.unresolvedHostToNormalizedString(ipv6AddressString))
+  }
+
+  test("getAkkaConfig for ssl engine provider without cert fingerprint") {
+    val configuration = new Configuration()
+    configuration.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true)
+
+    val akkaConfig = AkkaUtils.getAkkaConfig(configuration, Some(("localhost", 31337)))
+
+    val sslConfig = akkaConfig.getConfig("akka.remote.netty.ssl")
+
+    sslConfig.getString("ssl-engine-provider") should
+      equal("org.apache.flink.runtime.akka.CustomSSLEngineProvider")
+
+    sslConfig.getStringList("security.cert-fingerprints") shouldBe empty
+  }
+
+  test("getAkkaConfig for ssl engine provider with cert fingerprint") {
+    val configuration = new Configuration()
+    configuration.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true)
+
+    val fingerprint = "A8:98:5D:3A:65:E5:E5:C4:B2:D7:D6:6D:40:C6:DD:2F:B1:9C:54:36"
+    configuration.setString(SecurityOptions.SSL_INTERNAL_CERT_FINGERPRINT, fingerprint)
+
+    val akkaConfig = AkkaUtils.getAkkaConfig(configuration, Some(("localhost", 31337)))
+
+    val sslConfig = akkaConfig.getConfig("akka.remote.netty.ssl")
+
+    sslConfig.getString("ssl-engine-provider") should
+      equal("org.apache.flink.runtime.akka.CustomSSLEngineProvider")
+
+    sslConfig.getStringList("security.cert-fingerprints") should
+      equal(Collections.singletonList(fingerprint))
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

* Pull request implements changes discussed in https://issues.apache.org/jira/browse/FLINK-15174

*Allow the operator to specify the certificate fingerprint to further protect the cluster allowing only specific certificate*

## Brief change log

  - *Conditionally replace default TrustMangerFactory with FingerprintTrustManagerFactory*
  - *For Akka use custom ssl-engine-provider to plug FingerprintTrustManagerFactory*
  - *Added tests to cover the changes*


## Verifying this change
This change added tests and can be verified as follows:

  - *Added unit test for SSLUtils*
  - *Added unit test for AkkaUtils*
  - *Extended NettyClientServerSslTest for SSL pinning*
  - *Extended RestServerEndpointITCase for SSL pinning*
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper:  don't know
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? documented
