### PR TITLE
[FLINK-15231][table-planner-blink] Do not support TIMESTAMP/DECIMAL t…

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/AbstractHeapVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/AbstractHeapVector.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.table.dataformat.vector.heap;
 
-import org.apache.flink.table.dataformat.Decimal;
 import org.apache.flink.table.dataformat.vector.AbstractColumnVector;
-import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
 
 import java.util.Arrays;
@@ -109,18 +107,7 @@ public abstract class AbstractHeapVector extends AbstractColumnVector {
 			case TIME_WITHOUT_TIME_ZONE:
 				return new HeapIntVector(maxRows);
 			case BIGINT:
-			case TIMESTAMP_WITHOUT_TIME_ZONE:
-			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
 				return new HeapLongVector(maxRows);
-			case DECIMAL:
-				DecimalType decimalType = (DecimalType) fieldType;
-				if (Decimal.is32BitDecimal(decimalType.getPrecision())) {
-					return new HeapIntVector(maxRows);
-				} else if (Decimal.is64BitDecimal(decimalType.getPrecision())) {
-					return new HeapLongVector(maxRows);
-				} else {
-					return new HeapBytesVector(maxRows);
-				}
 			case SMALLINT:
 				return new HeapShortVector(maxRows);
 			case CHAR:

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/AbstractHeapVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/AbstractHeapVector.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.dataformat.vector.heap;
 
 import org.apache.flink.table.dataformat.vector.AbstractColumnVector;
-import org.apache.flink.table.types.logical.LogicalType;
 
 import java.util.Arrays;
 
@@ -82,41 +81,5 @@ public abstract class AbstractHeapVector extends AbstractColumnVector {
 	 */
 	public HeapIntVector getDictionaryIds() {
 		return dictionaryIds;
-	}
-
-	public static AbstractHeapVector[] allocateHeapVectors(LogicalType[] fieldTypes, int maxRows) {
-		AbstractHeapVector[] columns = new AbstractHeapVector[fieldTypes.length];
-		for (int i = 0; i < fieldTypes.length; i++) {
-			columns[i] = createHeapColumn(fieldTypes[i], maxRows);
-		}
-		return columns;
-	}
-
-	public static AbstractHeapVector createHeapColumn(LogicalType fieldType, int maxRows) {
-		switch (fieldType.getTypeRoot()) {
-			case BOOLEAN:
-				return new HeapBooleanVector(maxRows);
-			case TINYINT:
-				return new HeapByteVector(maxRows);
-			case DOUBLE:
-				return new HeapDoubleVector(maxRows);
-			case FLOAT:
-				return new HeapFloatVector(maxRows);
-			case INTEGER:
-			case DATE:
-			case TIME_WITHOUT_TIME_ZONE:
-				return new HeapIntVector(maxRows);
-			case BIGINT:
-				return new HeapLongVector(maxRows);
-			case SMALLINT:
-				return new HeapShortVector(maxRows);
-			case CHAR:
-			case VARCHAR:
-			case BINARY:
-			case VARBINARY:
-				return new HeapBytesVector(maxRows);
-			default:
-				throw new UnsupportedOperationException(fieldType  + " is not supported now.");
-		}
 	}
 }


### PR DESCRIPTION
…ypes for HeapVector

## What is the purpose of the change

For TIMESTAMP WITHOUT TIME ZONE/TIMESTAMP WITH LOCAL TIME ZONE/DECIMAL types, AbstractHeapVector.createHeapColumn generates wrong HeapVectors. This PR removes TIMESTAMP/TIMESTAMP WITH LOCAL TIME ZONE/DECIMAL support since the HeapVectors is used for testing.

## Brief change log

- dc4897 do not support TIMESTAMP/DECIMAL types for HeapVector

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
