### PR TITLE
add space to exception info

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/shipping/OutputCollector.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/shipping/OutputCollector.java
@@ -73,7 +73,7 @@ public class OutputCollector<T> implements Collector<T> {
 			}
 		}
 		else {
-			throw new NullPointerException("The system does not support records that are null."
+			throw new NullPointerException("The system does not support records that are null. "
 								+ "Null values are only supported as fields inside other objects.");
 		}
 	}


### PR DESCRIPTION
minor spelling change. The original null.Null without space make it a little confusing