### PR TITLE
[FLINK-15234][hive] hive table created from flink catalog table cannot have null properties in parameters

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
 import org.apache.flink.table.sources.InputFormatTableSource;
@@ -87,7 +88,7 @@ public class HiveTableSinkTest {
 	public void testInsertIntoNonPartitionTable() throws Exception {
 		String dbName = "default";
 		String tblName = "dest";
-		RowTypeInfo rowTypeInfo = createDestTable(dbName, tblName, 0);
+		RowTypeInfo rowTypeInfo = createHiveDestTable(dbName, tblName, 0);
 		ObjectPath tablePath = new ObjectPath(dbName, tblName);
 
 		TableEnvironment tableEnv = HiveTestUtils.createTableEnv();
@@ -116,7 +117,7 @@ public class HiveTableSinkTest {
 				DataTypes.MAP(DataTypes.INT(), DataTypes.STRING()),
 				DataTypes.ROW(DataTypes.FIELD("f1", DataTypes.INT()), DataTypes.FIELD("f2", DataTypes.STRING()))});
 
-		RowTypeInfo rowTypeInfo = createDestTable(dbName, tblName, builder.build(), 0);
+		RowTypeInfo rowTypeInfo = createHiveDestTable(dbName, tblName, builder.build(), 0);
 		List<Row> toWrite = new ArrayList<>();
 		Row row = new Row(rowTypeInfo.getArity());
 		Object[] array = new Object[]{1, 2, 3};
@@ -159,7 +160,7 @@ public class HiveTableSinkTest {
 		// array of rows
 		builder.fields(new String[]{"a"}, new DataType[]{DataTypes.ARRAY(
 				DataTypes.ROW(DataTypes.FIELD("f1", DataTypes.INT()), DataTypes.FIELD("f2", DataTypes.STRING())))});
-		RowTypeInfo rowTypeInfo = createDestTable(dbName, tblName, builder.build(), 0);
+		RowTypeInfo rowTypeInfo = createHiveDestTable(dbName, tblName, builder.build(), 0);
 		Row row = new Row(rowTypeInfo.getArity());
 		Object[] array = new Object[3];
 		row.setField(0, array);
@@ -186,13 +187,13 @@ public class HiveTableSinkTest {
 		hiveCatalog.dropTable(tablePath, false);
 	}
 
-	private RowTypeInfo createDestTable(String dbName, String tblName, TableSchema tableSchema, int numPartCols) throws Exception {
-		CatalogTable catalogTable = createCatalogTable(tableSchema, numPartCols);
+	private RowTypeInfo createHiveDestTable(String dbName, String tblName, TableSchema tableSchema, int numPartCols) throws Exception {
+		CatalogTable catalogTable = createHiveCatalogTable(tableSchema, numPartCols);
 		hiveCatalog.createTable(new ObjectPath(dbName, tblName), catalogTable, false);
 		return new RowTypeInfo(tableSchema.getFieldTypes(), tableSchema.getFieldNames());
 	}
 
-	private RowTypeInfo createDestTable(String dbName, String tblName, int numPartCols) throws Exception {
+	private RowTypeInfo createHiveDestTable(String dbName, String tblName, int numPartCols) throws Exception {
 		TableSchema.Builder builder = new TableSchema.Builder();
 		builder.fields(new String[]{"i", "l", "d", "s"},
 				new DataType[]{
@@ -200,16 +201,29 @@ public class HiveTableSinkTest {
 						DataTypes.BIGINT(),
 						DataTypes.DOUBLE(),
 						DataTypes.STRING()});
-		return createDestTable(dbName, tblName, builder.build(), numPartCols);
+		return createHiveDestTable(dbName, tblName, builder.build(), numPartCols);
 	}
 
-	private CatalogTable createCatalogTable(TableSchema tableSchema, int numPartCols) {
+	private CatalogTable createHiveCatalogTable(TableSchema tableSchema, int numPartCols) {
 		if (numPartCols == 0) {
-			return new CatalogTableImpl(tableSchema, new HashMap<>(), "");
+			return new CatalogTableImpl(
+				tableSchema,
+				new HashMap<String, String>() {{
+					// creating a hive table needs explicit is_generic=false flag
+					put(CatalogConfig.IS_GENERIC, String.valueOf(false));
+				}},
+				"");
 		}
 		String[] partCols = new String[numPartCols];
 		System.arraycopy(tableSchema.getFieldNames(), tableSchema.getFieldNames().length - numPartCols, partCols, 0, numPartCols);
-		return new CatalogTableImpl(tableSchema, Arrays.asList(partCols), new HashMap<>(), "");
+		return new CatalogTableImpl(
+			tableSchema,
+			Arrays.asList(partCols),
+			new HashMap<String, String>() {{
+				// creating a hive table needs explicit is_generic=false flag
+				put(CatalogConfig.IS_GENERIC, String.valueOf(false));
+			}},
+			"");
 	}
 
 	private void verifyWrittenData(List<Row> expected, List<String> results) throws Exception {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogGenericMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogGenericMetadataTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 /**
  * Test for HiveCatalog on generic metadata.
  */
-public class HiveCatalogGenericMetadataTest extends HiveCatalogTestBase {
+public class HiveCatalogGenericMetadataTest extends HiveCatalogMetadataTestBase {
 
 	@BeforeClass
 	public static void init() {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertFalse;
 /**
  * Test for HiveCatalog on Hive metadata.
  */
-public class HiveCatalogHiveMetadataTest extends HiveCatalogTestBase {
+public class HiveCatalogHiveMetadataTest extends HiveCatalogMetadataTestBase {
 
 	@BeforeClass
 	public static void init() {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
@@ -21,8 +21,11 @@ package org.apache.flink.table.catalog.hive;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.connectors.hive.FlinkStandaloneHiveRunner;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.TableUtils;
 import org.apache.flink.table.api.Types;
 import org.apache.flink.table.api.java.BatchTableEnvironment;
 import org.apache.flink.table.catalog.CatalogTable;
@@ -49,6 +52,7 @@ import java.io.FileReader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -88,7 +92,37 @@ public class HiveCatalogITCase {
 	}
 
 	@Test
-	public void testGenericTable() throws Exception {
+	public void testCsvTableViaSQL() throws Exception {
+		EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build();
+		TableEnvironment tableEnv = TableEnvironment.create(settings);
+
+		tableEnv.registerCatalog("myhive", hiveCatalog);
+		tableEnv.useCatalog("myhive");
+
+		String path = this.getClass().getResource("/csv/test.csv").getPath();
+
+		tableEnv.sqlUpdate("create table test2 (name String, age Int) with (\n" +
+			"   'connector.type' = 'filesystem',\n" +
+			"   'connector.path' = 'file://" + path + "',\n" +
+			"   'format.type' = 'csv'\n" +
+			")");
+
+		Table t = tableEnv.sqlQuery("SELECT * FROM myhive.`default`.test2");
+
+		List<Row> result = TableUtils.collectToList(t);
+
+		// assert query result
+		assertEquals(
+			new HashSet<>(Arrays.asList(
+				Row.of("1", 1),
+				Row.of("2", 2),
+				Row.of("3", 3))),
+			new HashSet<>(result)
+		);
+	}
+
+	@Test
+	public void testCsvTableViaAPI() throws Exception {
 		ExecutionEnvironment execEnv = ExecutionEnvironment.createLocalEnvironment(1);
 		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(execEnv);
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
@@ -119,6 +119,8 @@ public class HiveCatalogITCase {
 				Row.of("3", 3))),
 			new HashSet<>(result)
 		);
+
+		tableEnv.sqlUpdate("drop table tests2");
 	}
 
 	@Test
@@ -200,5 +202,9 @@ public class HiveCatalogITCase {
 
 		// No more line
 		assertNull(reader.readLine());
+
+		tableEnv.sqlUpdate(String.format("drop table myhive.`default`.%s", sourceTableName));
+
+		tableEnv.sqlUpdate(String.format("drop table myhive.`default`.%s", sinkTableName));
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogMetadataTestBase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogMetadataTestBase.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 /**
  * Base class for testing HiveCatalog.
  */
-public abstract class HiveCatalogTestBase extends CatalogTestBase {
+public abstract class HiveCatalogMetadataTestBase extends CatalogTestBase {
 
 	// ------ table and column stats ------
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.hive;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.config.CatalogConfig;
+import org.apache.flink.table.descriptors.FileSystem;
+
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for HiveCatalog.
+ */
+public class HiveCatalogTest {
+
+	TableSchema schema = TableSchema.builder()
+		.field("name", DataTypes.STRING())
+		.field("age", DataTypes.INT())
+		.build();
+
+	@Test
+	public void testCreateGenericTable() {
+		Table hiveTable = HiveCatalog.instantiateHiveTable(
+			new ObjectPath("test", "test"),
+			new CatalogTableImpl(
+				schema,
+				new FileSystem().path("/test_path").toProperties(),
+				null
+			));
+
+		Map<String, String> prop = hiveTable.getParameters();
+		assertEquals(prop.remove(CatalogConfig.IS_GENERIC), String.valueOf("true"));
+		assertTrue(prop.keySet().stream().allMatch(k -> k.startsWith(CatalogConfig.FLINK_PROPERTY_PREFIX)));
+	}
+
+	@Test
+	public void testCreateHiveTable() {
+		Map<String, String> map = new HashMap<>(new FileSystem().path("/test_path").toProperties());
+
+		map.put(CatalogConfig.IS_GENERIC, String.valueOf(false));
+
+		Table hiveTable = HiveCatalog.instantiateHiveTable(
+			new ObjectPath("test", "test"),
+			new CatalogTableImpl(
+				schema,
+				map,
+				null
+			));
+
+		Map<String, String> prop = hiveTable.getParameters();
+		assertEquals(prop.remove(CatalogConfig.IS_GENERIC), String.valueOf(false));
+		assertTrue(prop.keySet().stream().noneMatch(k -> k.startsWith(CatalogConfig.FLINK_PROPERTY_PREFIX)));
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

discovered a couple bugs in HiveCatalog

FLINK-15234 - hive table created from flink catalog table cannot have null properties in parameters
FLINK-15240 - is_generic key is missing for Flink table stored in HiveCatalog

## Brief change log



## Verifying this change

*(Please pick either of the following options)*

Added new UT and IT 

## Does this pull request potentially affect one of the following parts:

N/A

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
