### PR TITLE
[FLINK-15244][FileSystems] Fix the bug that FileUtils#deleteDirectoryInternal will delete files in the symbolic link which point to a directory.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
@@ -315,7 +315,11 @@ public final class FileUtils {
 	}
 
 	private static void deleteDirectoryInternal(File directory) throws IOException {
-		if (directory.isDirectory()) {
+		if (Files.isSymbolicLink(directory.toPath())) {
+			//noinspection ResultOfMethodCallIgnored
+			Files.delete(directory.toPath());
+		}
+		else if (directory.isDirectory()) {
 			// directory exists and is a directory
 
 			// empty the directory first

--- a/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
@@ -315,11 +315,7 @@ public final class FileUtils {
 	}
 
 	private static void deleteDirectoryInternal(File directory) throws IOException {
-		if (Files.isSymbolicLink(directory.toPath())) {
-			//noinspection ResultOfMethodCallIgnored
-			Files.delete(directory.toPath());
-		}
-		else if (directory.isDirectory()) {
+		if (directory.isDirectory()) {
 			// directory exists and is a directory
 
 			// empty the directory first
@@ -346,6 +342,10 @@ public final class FileUtils {
 	}
 
 	private static void cleanDirectoryInternal(File directory) throws IOException {
+		if (Files.isSymbolicLink(directory.toPath())) {
+			// the user directories which symbolic links point to should not be cleaned.
+			return;
+		}
 		if (directory.isDirectory()) {
 			final File[] files = directory.listFiles();
 

--- a/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
@@ -202,6 +202,24 @@ public class FileUtilsTest extends TestLogger {
 		}
 	}
 
+	@Test
+	public void testDeleteSymbolicLinkDirectory() throws Exception {
+
+		// deleting a symbolic link directory should not delete the files in it.
+
+		File symbolicLinkDirectory = tmp.newFolder();
+		File symbolicLinkDirectoryChild = new File(symbolicLinkDirectory, "child");
+		//noinspection ResultOfMethodCallIgnored
+		symbolicLinkDirectoryChild.createNewFile();
+		File symbolicLink = tmp.newFile();
+		//noinspection ResultOfMethodCallIgnored
+		symbolicLink.delete();
+		Files.createSymbolicLink(symbolicLink.toPath(), symbolicLinkDirectory.toPath());
+
+		FileUtils.deleteDirectory(symbolicLink);
+		assertTrue(symbolicLinkDirectoryChild.exists());
+	}
+
 	@Ignore
 	@Test
 	public void testDeleteDirectoryConcurrently() throws Exception {

--- a/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
@@ -202,22 +202,20 @@ public class FileUtilsTest extends TestLogger {
 		}
 	}
 
+	/**
+	 * Deleting a symbolic link directory should not delete the files in it.
+	 */
 	@Test
 	public void testDeleteSymbolicLinkDirectory() throws Exception {
-
-		// deleting a symbolic link directory should not delete the files in it.
-
-		File symbolicLinkDirectory = tmp.newFolder();
-		File symbolicLinkDirectoryChild = new File(symbolicLinkDirectory, "child");
-		//noinspection ResultOfMethodCallIgnored
-		symbolicLinkDirectoryChild.createNewFile();
-		File symbolicLink = tmp.newFile();
-		//noinspection ResultOfMethodCallIgnored
-		symbolicLink.delete();
-		Files.createSymbolicLink(symbolicLink.toPath(), symbolicLinkDirectory.toPath());
+		// creating a directory to which the test creates a symbolic link
+		File linkedDirectory = tmp.newFolder();
+		File fileInLinkedDirectory = new File(linkedDirectory, "child");
+		fileInLinkedDirectory.createNewFile();
+		File symbolicLink = new File(tmp.getRoot(), "symLink");
+		Files.createSymbolicLink(symbolicLink.toPath(), linkedDirectory.toPath());
 
 		FileUtils.deleteDirectory(symbolicLink);
-		assertTrue(symbolicLinkDirectoryChild.exists());
+		assertTrue(fileInLinkedDirectory.exists());
 	}
 
 	@Ignore


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixes the bug that FileUtils#deleteDirectoryInternal will delete files in the symbolic link which point to a directory.*


## Brief change log
  
  - *Check if the directory is symbolic link before walk into it.*
  - *Add test for the change.*


## Verifying this change

This change is already covered by existing tests, such as *FileUtilsTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
