### PR TITLE
[FLINK-15245][hive] Flink running in one cluster cannot write data to…

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOutputFormatFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOutputFormatFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.connectors.hive;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.fs.hdfs.HadoopFileSystem;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.hive.client.HiveShim;
 import org.apache.flink.table.filesystem.OutputFormatFactory;
@@ -167,7 +168,7 @@ public class HiveOutputFormatFactory implements OutputFormatFactory<Row> {
 					recordSerDe.getSerializedClass(),
 					isCompressed,
 					tableProperties,
-					new org.apache.hadoop.fs.Path(outPath.toUri()));
+					HadoopFileSystem.toHadoopPath(outPath));
 			return new HiveOutputFormat(recordWriter);
 		} catch (Exception e) {
 			throw new FlinkHiveException(e);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOutputFormatFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOutputFormatFactory.java
@@ -167,7 +167,7 @@ public class HiveOutputFormatFactory implements OutputFormatFactory<Row> {
 					recordSerDe.getSerializedClass(),
 					isCompressed,
 					tableProperties,
-					new org.apache.hadoop.fs.Path(outPath.getPath()));
+					new org.apache.hadoop.fs.Path(outPath.toUri()));
 			return new HiveOutputFormat(recordWriter);
 		} catch (Exception e) {
 			throw new FlinkHiveException(e);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveOutputFormatFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveOutputFormatFactoryTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.api.SerDeInfo;
+import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
+import org.apache.hadoop.hive.ql.io.HiveOutputFormat;
+import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordWriter;
+import org.apache.hadoop.util.Progressable;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for HiveOutputFormatFactory.
+ */
+public class HiveOutputFormatFactoryTest {
+
+	private static final String TEST_URI_SCHEME = "testscheme";
+	private static final String TEST_URI_AUTHORITY = "test-uri-auth:8888";
+
+	@Test
+	public void testCreateOutputFormat() {
+		TableSchema schema = TableSchema.builder().field("x", DataTypes.INT()).build();
+		SerDeInfo serDeInfo = new SerDeInfo("name", LazySimpleSerDe.class.getName(), Collections.emptyMap());
+		HiveOutputFormatFactory factory = new HiveOutputFormatFactory(
+				new JobConf(),
+				VerifyURIOutputFormat.class.getName(),
+				serDeInfo, schema,
+				new String[0],
+				new Properties(),
+				HiveShimLoader.loadHiveShim(HiveShimLoader.getHiveVersion()));
+		org.apache.flink.core.fs.Path path = new org.apache.flink.core.fs.Path(TEST_URI_SCHEME, TEST_URI_AUTHORITY, "/foo/path");
+		factory.createOutputFormat(path);
+	}
+
+	/**
+	 * A HiveOutputFormat that verifies scheme and authority of the output path uri.
+	 */
+	public static class VerifyURIOutputFormat implements HiveOutputFormat {
+
+		@Override
+		public FileSinkOperator.RecordWriter getHiveRecordWriter(JobConf jc, Path finalOutPath, Class valueClass,
+				boolean isCompressed, Properties tableProperties, Progressable progress) throws IOException {
+			URI uri = finalOutPath.toUri();
+			assertEquals(TEST_URI_SCHEME, uri.getScheme());
+			assertEquals(TEST_URI_AUTHORITY, uri.getAuthority());
+			return null;
+		}
+
+		@Override
+		public RecordWriter getRecordWriter(FileSystem fileSystem, JobConf jobConf, String s, Progressable progressable)
+				throws IOException {
+			return null;
+		}
+
+		@Override
+		public void checkOutputSpecs(FileSystem fileSystem, JobConf jobConf) throws IOException {
+		}
+	}
+}


### PR DESCRIPTION
… Hive tables in another cluster

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix the issue that we can't run flink in one cluster and write to Hive tables in another cluster.


## Brief change log

  - When creating Hive record writer, use the passed out path URI instead of just its path.
  - Add new test case.


## Verifying this change

New test case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? NA
