### PR TITLE
[FLINK-15065][docs] Correct default value of RocksDB options in documentation

### DIFF
--- a/docs/_includes/generated/rocks_db_configurable_configuration.html
+++ b/docs/_includes/generated/rocks_db_configurable_configuration.html
@@ -24,13 +24,13 @@
             <td><h5>state.backend.rocksdb.compaction.level.max-size-level-base</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>MemorySize</td>
-            <td>The upper-bound of the total size of level base files in bytes. RocksDB has default configuration as '10MB'.</td>
+            <td>The upper-bound of the total size of level base files in bytes. RocksDB has default configuration as '256MB'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.compaction.level.target-file-size-base</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>MemorySize</td>
-            <td>The target file size for compaction, which determines a level-1 file size. RocksDB has default configuration as '2MB'.</td>
+            <td>The target file size for compaction, which determines a level-1 file size. RocksDB has default configuration as '64MB'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.compaction.level.use-dynamic-size</h5></td>
@@ -48,7 +48,7 @@
             <td><h5>state.backend.rocksdb.files.open</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
-            <td>The maximum number of open files (per TaskManager) that can be used by the DB, '-1' means no limit. RocksDB has default configuration as '5000'.</td>
+            <td>The maximum number of open files (per TaskManager) that can be used by the DB, '-1' means no limit. RocksDB has default configuration as '-1'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.thread.num</h5></td>

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -58,7 +58,7 @@ public class RocksDBConfigurableOptions implements Serializable {
 			.intType()
 			.noDefaultValue()
 			.withDescription("The maximum number of open files (per TaskManager) that can be used by the DB, '-1' means no limit. " +
-				"RocksDB has default configuration as '5000'.");
+				"RocksDB has default configuration as '-1'.");
 
 	//--------------------------------------------------------------------------
 	// Provided configurable ColumnFamilyOptions within Flink
@@ -90,14 +90,14 @@ public class RocksDBConfigurableOptions implements Serializable {
 			.memoryType()
 			.noDefaultValue()
 			.withDescription("The target file size for compaction, which determines a level-1 file size. " +
-				"RocksDB has default configuration as '2MB'.");
+				"RocksDB has default configuration as '64MB'.");
 
 	public static final ConfigOption<MemorySize> MAX_SIZE_LEVEL_BASE =
 		key("state.backend.rocksdb.compaction.level.max-size-level-base")
 			.memoryType()
 			.noDefaultValue()
 			.withDescription("The upper-bound of the total size of level base files in bytes. " +
-				"RocksDB has default configuration as '10MB'.");
+				"RocksDB has default configuration as '256MB'.");
 
 	public static final ConfigOption<MemorySize> WRITE_BUFFER_SIZE =
 		key("state.backend.rocksdb.writebuffer.size")


### PR DESCRIPTION

## What is the purpose of the change

This PR refer to https://github.com/facebook/rocksdb/pull/6123 which correctis RocksDB javadoc. 

Please note that we did not include facebook/rocksdb#6123 in FRocksDB but the actual default value already changes as facebook/rocksdb#6123 said.


## Brief change log

Change `RocksDBConfigurableOptions.java` to correct actual default values.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
