### PR TITLE
[FLINK-15241] Revert the unexpected change of the configuration for M…

### DIFF
--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
@@ -246,6 +246,14 @@ public class MesosTaskManagerParametersTest extends TestLogger {
 	}
 
 	@Test
+	public void testConfigNoCpuCores() {
+		Configuration conf = new Configuration();
+		conf.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+		MesosTaskManagerParameters mesosTaskManagerParameters = MesosTaskManagerParameters.create(conf);
+		assertThat(mesosTaskManagerParameters.cpus(), is(3.0));
+	}
+
+	@Test
 	public void testUnifiedTotalProcessMemoryConfiguration() {
 		assertTotalProcessMemory(MesosTaskManagerParameters.create(getConfiguration()));
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
@@ -568,17 +568,22 @@ public class TaskExecutorResourceUtils {
 	}
 
 	private static CPUResource getCpuCores(final Configuration config, double fallback) {
-		double cpuCores;
+		final double cpuCores;
 		if (config.contains(TaskManagerOptions.CPU_CORES)) {
 			cpuCores = config.getDouble(TaskManagerOptions.CPU_CORES);
-			if (cpuCores < 0) {
-				throw new IllegalConfigurationException("Configured cpu cores must be non-negative.");
-			}
-		} else if (fallback >= 0.0) {
+		} else if (fallback > 0.0) {
 			cpuCores = fallback;
 		} else {
 			cpuCores = config.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
 		}
+
+		if (cpuCores <= 0) {
+			throw new IllegalConfigurationException(
+				String.format(
+					"TaskExecutors need to be started with a positive number of CPU cores. Please configure %s accordingly.",
+					TaskManagerOptions.CPU_CORES.key()));
+		}
+
 		return new CPUResource(cpuCores);
 	}
 


### PR DESCRIPTION
…esos CPU cores

## What is the purpose of the change

This PR Revert the unexpected change of the configuration for Mesos CPU cores. Now, if not explicitly set "mesos.resourcemanager.tasks.cpus", the cpu cores will be setted to the "taskmanager.numberOfTaskSlots"

## Brief change log

Change the condition of using fallback cpu configuration in TaskExecutorResourceUtils#getCpuCores to "fallback > 0.0"

## Verifying this change

This change added tests and can be verified as follows:

- MesosTaskManagerParametersTest#testConfigNoCpuCores

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

cc @tillrohrmann 
