### PR TITLE
[FLINK-15249] Improve PipelinedRegions calculation performance

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/DisjointSet.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/DisjointSet.java
@@ -18,9 +18,11 @@
 package org.apache.flink.runtime.executiongraph.failover.flip1;
 
 import com.esotericsoftware.kryo.util.IdentityObjectIntMap;
-import com.google.common.collect.Iterables;
+import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
 
 
 public class DisjointSet<V> {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/DisjointSet.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/DisjointSet.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.executiongraph.failover.flip1;
+
+import com.esotericsoftware.kryo.util.IdentityObjectIntMap;
+import com.google.common.collect.Iterables;
+
+import java.util.*;
+
+
+public class DisjointSet<V> {
+	private Object[] elements;
+	private int[] toSet;
+	private int[] stack;
+	private int[] ranks;
+	private IdentityObjectIntMap<Object> indices;
+	public DisjointSet(Iterable<V> elements) {
+		this.elements = Iterables.toArray(elements, Object.class);
+		this.toSet = new int[this.elements.length];
+		this.stack = new int[this.elements.length];
+		this.ranks = new int[this.elements.length];
+		this.indices = new IdentityObjectIntMap<>(this.elements.length);
+		for (int i = 0; i < this.elements.length; i++) {
+			this.indices.put(this.elements[i], i);
+			this.toSet[i] = i;
+			this.ranks[i] = 1;
+		}
+	}
+
+	public int mergeSet(int from, int to) {
+		if (from == to) {
+			return to;
+		}
+		if (ranks[from] > ranks[to]) {
+			// switch from, to if from's rank is bigger than to
+			int tmp;
+			tmp = from;
+			from = to;
+			to = tmp;
+		}
+		toSet[from] = to;
+		ranks[to] += ranks[from];
+		return to;
+	}
+
+	public int getSetByIndex(int e) {
+		int set = toSet[e];
+		if (set == e) {
+			return e;
+		}
+		int stackIndex = 0;
+		do {
+			stack[stackIndex] = e;
+			e = set;
+			stackIndex += 1;
+			set = toSet[set];
+		} while (e != set);
+		for (int i = 0; i < stackIndex; i++) {
+			toSet[stack[i]] = set;
+		}
+		return set;
+	}
+
+	public int getSet(V e) {
+		int index = indices.get(e, -1);
+		return getSetByIndex(index);
+	}
+
+	public Set<Set<V>> toSets() {
+		Set[] sets = new Set[this.elements.length];
+		Set<Set<V>> ret = Collections.newSetFromMap(new IdentityHashMap<>());
+		for (int i = 0; i < this.elements.length; i++) {
+			int set = getSetByIndex(i);
+			if (sets[set] == null) {
+				sets[set] = Collections.newSetFromMap(new IdentityHashMap<>(ranks[set]));
+				ret.add(sets[set]);
+			}
+			sets[set].add(this.elements[i]);
+		}
+		return ret;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/PipelinedRegionComputeUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/PipelinedRegionComputeUtil.java
@@ -112,7 +112,6 @@ public final class PipelinedRegionComputeUtil {
 				set = new HashSet<>(1);
 				vertexToRegion.put(region, set);
 			}
-			vertexToRegion.put(vertex, set);
 			set.add(vertex);
 		}
 		return uniqueRegions(vertexToRegion);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/PipelinedRegionComputeUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/PipelinedRegionComputeUtil.java
@@ -29,11 +29,9 @@ import org.apache.flink.runtime.topology.Vertex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RegionFailoverPerfTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RegionFailoverPerfTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.flip1;
+
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+
+/**
+ * Perf test for region building.
+ */
+public class RegionFailoverPerfTest extends TestLogger {
+
+	@Test
+	public void complexPerfTest() {
+		final int parallelism = 2000;
+
+		final FailoverTopology topology = buildComplexTopology(parallelism);
+
+		final long start = System.nanoTime();
+		final RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology);
+		final long end = System.nanoTime();
+		System.out.println("build regions: " + (end - start) / 1000000);
+	}
+
+	public FailoverTopology buildComplexTopology(int parallelism) {
+		TestFailoverTopology.Builder topologyBuilder = new TestFailoverTopology.Builder();
+
+		int pa = parallelism;
+		HashSet<TestFailoverTopology.TestFailoverVertex> aSet = new HashSet<>();
+		for (int i = 0; i < pa; i++) {
+			TestFailoverTopology.TestFailoverVertex v = topologyBuilder.newVertex();
+			aSet.add(v);
+		}
+
+		int pb = pa;
+		HashSet<TestFailoverTopology.TestFailoverVertex> bSet = new HashSet<>();
+		for (int i = 0; i < pb; i++) {
+			TestFailoverTopology.TestFailoverVertex v = topologyBuilder.newVertex();
+			bSet.add(v);
+		}
+
+		int pc = pa;
+		HashSet<TestFailoverTopology.TestFailoverVertex> cSet = new HashSet<>();
+		for (int i = 0; i < pc; i++) {
+			TestFailoverTopology.TestFailoverVertex v = topologyBuilder.newVertex();
+			cSet.add(v);
+		}
+
+		int pd = pa;
+		HashSet<TestFailoverTopology.TestFailoverVertex> dSet = new HashSet<>();
+		for (int i = 0; i < pd; i++) {
+			TestFailoverTopology.TestFailoverVertex v = topologyBuilder.newVertex();
+			dSet.add(v);
+		}
+
+		int pe = pa;
+		HashSet<TestFailoverTopology.TestFailoverVertex> eSet = new HashSet<>();
+		for (int i = 0; i < pe; i++) {
+			TestFailoverTopology.TestFailoverVertex v = topologyBuilder.newVertex();
+			eSet.add(v);
+		}
+
+		for (TestFailoverTopology.TestFailoverVertex source : aSet) {
+			IntermediateResultPartitionID partitionID = new IntermediateResultPartitionID();
+			for (TestFailoverTopology.TestFailoverVertex target : bSet) {
+				topologyBuilder.connect(source, target, ResultPartitionType.BLOCKING, partitionID);
+			}
+		}
+
+		for (TestFailoverTopology.TestFailoverVertex source : bSet) {
+			IntermediateResultPartitionID partitionID = new IntermediateResultPartitionID();
+			for (TestFailoverTopology.TestFailoverVertex target : cSet) {
+				topologyBuilder.connect(source, target, ResultPartitionType.BLOCKING, partitionID);
+			}
+		}
+
+		for (TestFailoverTopology.TestFailoverVertex source : cSet) {
+			IntermediateResultPartitionID partitionID = new IntermediateResultPartitionID();
+			for (TestFailoverTopology.TestFailoverVertex target : dSet) {
+				topologyBuilder.connect(source, target, ResultPartitionType.PIPELINED, partitionID);
+			}
+		}
+
+		for (TestFailoverTopology.TestFailoverVertex source : dSet) {
+			IntermediateResultPartitionID partitionID = new IntermediateResultPartitionID();
+			for (TestFailoverTopology.TestFailoverVertex target : eSet) {
+				topologyBuilder.connect(source, target, ResultPartitionType.BLOCKING, partitionID);
+			}
+		}
+
+		return topologyBuilder.build();
+	}
+
+	@Test
+	public void testRegionFailoverPerformance() throws Exception {
+		TestFailoverTopology.Builder topologyBuilder = new TestFailoverTopology.Builder();
+		ArrayList<ArrayList<TestFailoverTopology.TestFailoverVertex>> graph = new ArrayList<>();
+		int level = 16;
+		int curLevel = 0;
+		for (int i = level; i >= 0; i--, curLevel++) {
+			ArrayList<TestFailoverTopology.TestFailoverVertex> jv = new ArrayList<>();
+			int currentNum = 1 << i;
+			for (int j = 0; j < currentNum; j++) {
+				TestFailoverTopology.TestFailoverVertex nv = topologyBuilder.newVertex();
+				jv.add(nv);
+				if (curLevel != 0) {
+					topologyBuilder.connect(graph.get(curLevel - 1).get(j << 1), nv, ResultPartitionType.PIPELINED);
+					topologyBuilder.connect(graph.get(curLevel - 1).get((j << 1) + 1), nv, ResultPartitionType.PIPELINED);
+				}
+			}
+			graph.add(jv);
+		}
+		TestFailoverTopology topology = topologyBuilder.build();
+
+		long time = System.currentTimeMillis();
+		for (int i = 0; i < 10; i++) {
+			RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology);
+		}
+		System.out.println("cost:" + (System.currentTimeMillis() - time));
+
+	}
+}


### PR DESCRIPTION
# What is the purpose of the change
This pull request improves the performance of PipelinedRegions calculation.

# Brief change log
The cost of union set merging is O(1). But current implement copies all vertices in one set to another set, its cost is O(n).

# Verifying this change
This change is already covered by existing tests.

# Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): (no)
The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
The serializers: (no)
The runtime per-record code paths (performance sensitive): (no)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
The S3 file system connector: (no)
# Documentation
Does this pull request introduce a new feature? (no)
If yes, how is the feature documented? (not applicable)