### PR TITLE
[FLINK-13589][1.9] Fixing DelimitedInputFormat for whole file input splits.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
@@ -671,7 +671,7 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 				return false;
 			} else {
 				this.readPos = offset;
-				this.limit = read;
+				this.limit = read + offset;
 				return true;
 			}
 		}


### PR DESCRIPTION
Unchanged backport from https://github.com/apache/flink/pull/10573.