### PR TITLE
[FLINK-15234] hive table created from flink catalog table shouldn't have null properties in parameters

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -567,7 +567,9 @@ public class HiveCatalog extends AbstractCatalog {
 
 		Map<String, String> properties = new HashMap<>(table.getProperties());
 		// Table comment
-		properties.put(HiveCatalogConfig.COMMENT, table.getComment());
+		if (table.getComment() != null) {
+			properties.put(HiveCatalogConfig.COMMENT, table.getComment());
+		}
 
 		boolean isGeneric = Boolean.valueOf(properties.get(CatalogConfig.IS_GENERIC));
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogGenericMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogGenericMetadataTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 /**
  * Test for HiveCatalog on generic metadata.
  */
-public class HiveCatalogGenericMetadataTest extends HiveCatalogTestBase {
+public class HiveCatalogGenericMetadataTest extends HiveCatalogMetadataTestBase {
 
 	@BeforeClass
 	public static void init() {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertFalse;
 /**
  * Test for HiveCatalog on Hive metadata.
  */
-public class HiveCatalogHiveMetadataTest extends HiveCatalogTestBase {
+public class HiveCatalogHiveMetadataTest extends HiveCatalogMetadataTestBase {
 
 	@BeforeClass
 	public static void init() {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
@@ -21,8 +21,11 @@ package org.apache.flink.table.catalog.hive;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.connectors.hive.FlinkStandaloneHiveRunner;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.TableUtils;
 import org.apache.flink.table.api.Types;
 import org.apache.flink.table.api.java.BatchTableEnvironment;
 import org.apache.flink.table.catalog.CatalogTable;
@@ -49,6 +52,7 @@ import java.io.FileReader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -88,7 +92,37 @@ public class HiveCatalogITCase {
 	}
 
 	@Test
-	public void testGenericTable() throws Exception {
+	public void testCsvTableViaSQL() throws Exception {
+		EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build();
+		TableEnvironment tableEnv = TableEnvironment.create(settings);
+
+		tableEnv.registerCatalog("myhive", hiveCatalog);
+		tableEnv.useCatalog("myhive");
+
+		String path = this.getClass().getResource("/csv/test.csv").getPath();
+
+		tableEnv.sqlUpdate("create table test2 (name String, age Int) with (\n" +
+			"   'connector.type' = 'filesystem',\n" +
+			"   'connector.path' = 'file://" + path + "',\n" +
+			"   'format.type' = 'csv'\n" +
+			")");
+
+		Table t = tableEnv.sqlQuery("SELECT * FROM myhive.`default`.test2");
+
+		List<Row> result = TableUtils.collectToList(t);
+
+		// assert query result
+		assertEquals(
+			new HashSet<>(Arrays.asList(
+				Row.of("1", 1),
+				Row.of("2", 2),
+				Row.of("3", 3))),
+			new HashSet<>(result)
+		);
+	}
+
+	@Test
+	public void testCsvTableViaAPI() throws Exception {
 		ExecutionEnvironment execEnv = ExecutionEnvironment.createLocalEnvironment(1);
 		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(execEnv);
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogMetadataTestBase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogMetadataTestBase.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 /**
  * Base class for testing HiveCatalog.
  */
-public abstract class HiveCatalogTestBase extends CatalogTestBase {
+public abstract class HiveCatalogMetadataTestBase extends CatalogTestBase {
 
 	// ------ table and column stats ------
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.hive;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.config.CatalogConfig;
+import org.apache.flink.table.descriptors.FileSystem;
+
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for HiveCatalog.
+ */
+public class HiveCatalogTest {
+
+	TableSchema schema = TableSchema.builder()
+		.field("name", DataTypes.STRING())
+		.field("age", DataTypes.INT())
+		.build();
+
+	@Test
+	public void testCreateGenericTable() {
+		Table hiveTable = HiveCatalog.instantiateHiveTable(
+			new ObjectPath("test", "test"),
+			new CatalogTableImpl(
+				schema,
+				new FileSystem().path("/test_path").toProperties(),
+				null
+			));
+
+		Map<String, String> prop = hiveTable.getParameters();
+		assertEquals(prop.remove(CatalogConfig.IS_GENERIC), String.valueOf("true"));
+		assertTrue(prop.keySet().stream().allMatch(k -> k.startsWith(CatalogConfig.FLINK_PROPERTY_PREFIX)));
+	}
+
+	@Test
+	public void testCreateHiveTable() {
+		Map<String, String> map = new HashMap<>(new FileSystem().path("/test_path").toProperties());
+
+		map.put(CatalogConfig.IS_GENERIC, String.valueOf(false));
+
+		Table hiveTable = HiveCatalog.instantiateHiveTable(
+			new ObjectPath("test", "test"),
+			new CatalogTableImpl(
+				schema,
+				map,
+				null
+			));
+
+		Map<String, String> prop = hiveTable.getParameters();
+		assertEquals(prop.remove(CatalogConfig.IS_GENERIC), String.valueOf(false));
+		assertTrue(prop.keySet().stream().noneMatch(k -> k.startsWith(CatalogConfig.FLINK_PROPERTY_PREFIX)));
+	}
+}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
@@ -213,7 +213,7 @@ public class DependencyTest {
 	public static class TestHiveCatalogFactory extends HiveCatalogFactory {
 		public static final String ADDITIONAL_TEST_DATABASE = "additional_test_database";
 		public static final String TEST_TABLE = "test_table";
-		static final String TABLE_WITH_PARAMETERIZED_TYPES = "para_types_table";
+		static final String TABLE_WITH_PARAMETERIZED_TYPES = "param_types_table";
 
 		@Override
 		public Map<String, String> requiredContext() {
@@ -222,6 +222,14 @@ public class DependencyTest {
 			// For factory discovery service to distinguish TestHiveCatalogFactory from HiveCatalogFactory
 			context.put("test", "test");
 			return context;
+		}
+
+		@Override
+		public List<String> supportedProperties() {
+			List<String> list = super.supportedProperties();
+			list.add(CatalogConfig.IS_GENERIC);
+
+			return list;
 		}
 
 		@Override
@@ -249,7 +257,7 @@ public class DependencyTest {
 							.field("testcol", DataTypes.INT())
 							.build(),
 						new HashMap<String, String>() {{
-							put(CatalogConfig.IS_GENERIC, String.valueOf(true));
+							put(CatalogConfig.IS_GENERIC, String.valueOf(false));
 						}},
 						""
 					),
@@ -269,7 +277,12 @@ public class DependencyTest {
 		private CatalogTable tableWithParameterizedTypes() {
 			TableSchema tableSchema = TableSchema.builder().fields(new String[]{"dec", "ch", "vch"},
 					new DataType[]{DataTypes.DECIMAL(10, 10), DataTypes.CHAR(5), DataTypes.VARCHAR(15)}).build();
-			return new CatalogTableImpl(tableSchema, Collections.emptyMap(), "");
+			return new CatalogTableImpl(
+				tableSchema,
+				new HashMap<String, String>() {{
+					put(CatalogConfig.IS_GENERIC, String.valueOf(false));
+				}},
+				"");
 		}
 	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/AbstractCatalogTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/AbstractCatalogTable.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -54,6 +55,11 @@ public abstract class AbstractCatalogTable implements CatalogTable {
 		this.tableSchema = checkNotNull(tableSchema, "tableSchema cannot be null");
 		this.partitionKeys = checkNotNull(partitionKeys, "partitionKeys cannot be null");
 		this.properties = checkNotNull(properties, "properties cannot be null");
+
+		checkArgument(
+			properties.entrySet().stream().allMatch(e -> e.getKey() != null && e.getValue() != null),
+			"properties cannot have null keys or values");
+
 		this.comment = comment;
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

discovered a couple bugs in HiveCatalog, related code seem to have been manipulated and introduced bugs but we didn't catch them due to lack of test coverage. Fix them now and add more UT and IT.

[FLINK-15234] hive table created from flink catalog table cannot have null properties in parameters - this one is when user created table doesn't have comment (null), we still put it into a hive table's params and HMS reports error. Solution: don't put 'comment' into hive table param if its value is null

[FLINK-15240] is_generic key is missing for Flink table stored in HiveCatalog - the is_generic key is missing for generic tables stored in HiveCatalog. the expected behavior is: 

- When creating a table, A hive table needs explicitly have a key is_generic = false; otherwise, this is a generic table if 1) the key is missing 2) is_generic = true
- When retrieving a table, a generic table needs explicitly have a key is_generic = true; otherwise, this is a Hive table if 1) the key is missing 2) is_generic = false

I'm also testing release 1.9 and will fix it there if there's a problem

## Brief change log

fix bugs mentioned above, added more UT and IT

## Verifying this change

This change added tests and can be verified as `HiveCatalogTest` and `HiveCatalogITCase`

## Does this pull request potentially affect one of the following parts:

n/a

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs / JavaDocs)

docs will be updated later
