### PR TITLE
[FLINK-15168][table-planner] Fix physical indices computing.

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ConnectorCatalogTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ConnectorCatalogTable.java
@@ -55,16 +55,16 @@ public class ConnectorCatalogTable<T1, T2> extends AbstractCatalogTable {
 	// NOTES: this should be false in BLINK planner, because BLINK planner always uses StreamTableSource.
 	private final boolean isBatch;
 
-	public static <T1> ConnectorCatalogTable source(TableSource<T1> source, boolean isBatch) {
+	public static <T1> ConnectorCatalogTable<T1, ?> source(TableSource<T1> source, boolean isBatch) {
 		final TableSchema tableSchema = calculateSourceSchema(source, isBatch);
 		return new ConnectorCatalogTable<>(source, null, tableSchema, isBatch);
 	}
 
-	public static <T2> ConnectorCatalogTable sink(TableSink<T2> sink, boolean isBatch) {
+	public static <T2> ConnectorCatalogTable<?, T2> sink(TableSink<T2> sink, boolean isBatch) {
 		return new ConnectorCatalogTable<>(null, sink, sink.getTableSchema(), isBatch);
 	}
 
-	public static <T1, T2> ConnectorCatalogTable sourceAndSink(
+	public static <T1, T2> ConnectorCatalogTable<T1, T2> sourceAndSink(
 			TableSource<T1> source,
 			TableSink<T2> sink,
 			boolean isBatch) {
@@ -119,10 +119,6 @@ public class ConnectorCatalogTable<T1, T2> extends AbstractCatalogTable {
 
 	private static <T1> TableSchema calculateSourceSchema(TableSource<T1> source, boolean isBatch) {
 		TableSchema tableSchema = source.getTableSchema();
-		if (isBatch) {
-			return tableSchema;
-		}
-
 		DataType[] types = Arrays.copyOf(tableSchema.getFieldDataTypes(), tableSchema.getFieldCount());
 		String[] fieldNames = tableSchema.getFieldNames();
 		if (source instanceof DefinedRowtimeAttributes) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/sources/tsextractors/TimestampExtractorUtils.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/sources/tsextractors/TimestampExtractorUtils.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sources.tsextractors;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.expressions.ResolvedFieldReference;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.utils.DataTypeUtils;
+import org.apache.flink.table.types.utils.TypeConversions;
+
+import java.util.Arrays;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+
+/**
+ * Utility methods for dealing with {@link TimestampExtractor}.
+ */
+@Internal
+public final class TimestampExtractorUtils {
+	/**
+	 * Retrieves all field accesses needed for the given {@link TimestampExtractor}.
+	 *
+	 * @param timestampExtractor Extractor for which to construct array of field accesses.
+	 * @param physicalInputType Physical input type that the timestamp extractor accesses.
+	 * @param nameRemapping Additional remapping of a logical to a physical field name.
+	 *                      TimestampExtractor works with logical names, but accesses physical
+	 *                      fields
+	 * @return Array of physical field references.
+	 */
+	public static ResolvedFieldReference[] getAccessedFields(
+			TimestampExtractor timestampExtractor,
+			DataType physicalInputType,
+			Function<String, String> nameRemapping) {
+
+		final Function<String, ResolvedFieldReference> fieldMapping;
+		if (DataTypeUtils.isCompositeType(physicalInputType)) {
+			TableSchema schema = TypeConversions.expandCompositeTypeToSchema(physicalInputType);
+			fieldMapping = (arg) -> mapToResolvedField(nameRemapping, schema, arg);
+		} else {
+			fieldMapping = (arg) -> new ResolvedFieldReference(
+				arg,
+				TypeConversions.fromDataTypeToLegacyInfo(physicalInputType),
+				0);
+		}
+		return getAccessedFields(timestampExtractor, fieldMapping);
+	}
+
+	private static ResolvedFieldReference[] getAccessedFields(
+			TimestampExtractor timestampExtractor,
+			Function<String, ResolvedFieldReference> fieldMapping) {
+		return Arrays.stream(timestampExtractor.getArgumentFields())
+			.map(fieldMapping)
+			.toArray(ResolvedFieldReference[]::new);
+	}
+
+	private static ResolvedFieldReference mapToResolvedField(
+			Function<String, String> nameRemapping,
+			TableSchema schema,
+			String arg) {
+		String remappedName = nameRemapping.apply(arg);
+
+		int idx = IntStream.range(0, schema.getFieldCount())
+			.filter(i -> schema.getFieldName(i).get().equals(remappedName))
+			.findFirst()
+			.orElseThrow(() -> new TableException(String.format("Field %s does not exist", remappedName)));
+
+		TypeInformation<?> dataType = TypeConversions.fromDataTypeToLegacyInfo(schema.getTableColumn(idx)
+			.get()
+			.getType());
+		return new ResolvedFieldReference(remappedName, dataType, idx);
+	}
+
+	private TimestampExtractorUtils() {
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/TableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/TableSource.java
@@ -73,7 +73,10 @@ public interface TableSource<T> {
 	 * Returns the schema of the produced table.
 	 *
 	 * @return The {@link TableSchema} of the produced table.
+	 * @deprecated Table schema is a logical description of a table and should not be part of the physical TableSource.
+	 *             Define schema when registering a Table either in DDL or in {@code TableEnvironment#connect(...)}.
 	 */
+	@Deprecated
 	TableSchema getTableSchema();
 
 	/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/DataTypeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/DataTypeUtils.java
@@ -27,7 +27,9 @@ import org.apache.flink.table.types.FieldsDataType;
 import org.apache.flink.table.types.KeyValueDataType;
 import org.apache.flink.table.types.inference.TypeTransformation;
 import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.LegacyTypeInformationType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.RowType;
@@ -69,10 +71,21 @@ public final class DataTypeUtils {
 		return newType;
 	}
 
+	/**
+	 * Checks if the given type is a composite type.
+	 *
+	 * @param dataType Data type to check
+	 * @return True if the type is composite type. True also for legacy composite type.
+	 */
+	public static boolean isCompositeType(DataType dataType) {
+		return dataType instanceof FieldsDataType ||
+			(dataType.getLogicalType() instanceof LegacyTypeInformationType &&
+				dataType.getLogicalType().getTypeRoot() == LogicalTypeRoot.STRUCTURED_TYPE);
+	}
+
 	private DataTypeUtils() {
 		// no instantiation
 	}
-
 
 	// ------------------------------------------------------------------------------------------
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/TypeConversions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/TypeConversions.java
@@ -20,9 +20,19 @@ package org.apache.flink.table.types.utils;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.CompositeType;
+import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.FieldsDataType;
+import org.apache.flink.table.types.logical.LegacyTypeInformationType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.StructuredType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeDefaultVisitor;
 
+import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -77,6 +87,89 @@ public final class TypeConversions {
 		return Stream.of(dataTypes)
 			.map(TypeConversions::fromDataToLogicalType)
 			.toArray(LogicalType[]::new);
+	}
+
+	/**
+	 * Expands a composite {@link DataType} to a corresponding {@link TableSchema}. Useful for
+	 * flattening a column or mapping a physical to logical type of a table source
+	 *
+	 * <p>Throws an exception for a non composite type. You can use
+	 * {@link DataTypeUtils#isCompositeType(DataType)} to check that.
+	 *
+	 * @param dataType Data type to expand. Must be a composite type.
+	 * @return A corresponding table schema.
+	 */
+	public static TableSchema expandCompositeTypeToSchema(DataType dataType) {
+		if (dataType instanceof FieldsDataType) {
+			return expandCompositeType((FieldsDataType) dataType);
+		} else if (dataType.getLogicalType() instanceof LegacyTypeInformationType &&
+			dataType.getLogicalType().getTypeRoot() == LogicalTypeRoot.STRUCTURED_TYPE) {
+			return expandLegacyCompositeType(dataType);
+		}
+
+		throw new IllegalArgumentException("Expected a composite type");
+	}
+
+	private static TableSchema expandCompositeType(FieldsDataType dataType) {
+		Map<String, DataType> fieldDataTypes = dataType.getFieldDataTypes();
+		return dataType.getLogicalType().accept(new LogicalTypeDefaultVisitor<TableSchema>() {
+			@Override
+			public TableSchema visit(RowType rowType) {
+				return expandRowType(rowType, fieldDataTypes);
+			}
+
+			@Override
+			public TableSchema visit(StructuredType structuredType) {
+				return expandStructuredType(structuredType, fieldDataTypes);
+			}
+
+			@Override
+			protected TableSchema defaultMethod(LogicalType logicalType) {
+				throw new IllegalArgumentException("Expected a composite type");
+			}
+		});
+	}
+
+	private static TableSchema expandLegacyCompositeType(DataType dataType) {
+		// legacy composite type
+		CompositeType<?> compositeType = (CompositeType<?>) ((LegacyTypeInformationType<?>) dataType.getLogicalType())
+			.getTypeInformation();
+
+		String[] fieldNames = compositeType.getFieldNames();
+		TypeInformation<?>[] fieldTypes = Arrays.stream(fieldNames)
+			.map(compositeType::getTypeAt)
+			.toArray(TypeInformation[]::new);
+
+		return new TableSchema(fieldNames, fieldTypes);
+	}
+
+	private static TableSchema expandStructuredType(
+			StructuredType structuredType,
+			Map<String, DataType> fieldDataTypes) {
+		String[] fieldNames = structuredType.getAttributes()
+			.stream()
+			.map(StructuredType.StructuredAttribute::getName)
+			.toArray(String[]::new);
+		DataType[] dataTypes = structuredType.getAttributes()
+			.stream()
+			.map(attr -> fieldDataTypes.get(attr.getName()))
+			.toArray(DataType[]::new);
+		return TableSchema.builder()
+			.fields(fieldNames, dataTypes)
+			.build();
+	}
+
+	private static TableSchema expandRowType(
+			RowType rowType,
+			Map<String, DataType> fieldDataTypes) {
+		String[] fieldNames = rowType.getFieldNames().toArray(new String[0]);
+		DataType[] dataTypes = rowType.getFields()
+			.stream()
+			.map(field -> fieldDataTypes.get(field.getName()))
+			.toArray(DataType[]::new);
+		return TableSchema.builder()
+			.fields(fieldNames, dataTypes)
+			.build();
 	}
 
 	private TypeConversions() {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TableSourceUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TableSourceUtils.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.TableColumn;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
+import org.apache.flink.table.types.utils.DataTypeUtils;
+import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Utility methods for dealing with {@link org.apache.flink.table.sources.TableSource}.
+ */
+@Internal
+public final class TableSourceUtils {
+	/**
+	 * Computes indices of physical fields corresponding to the fields of a {@link TableSchema}.
+	 *
+	 * <p>It puts markers (idx < 0) for time attributes.
+	 *
+	 * @param logicalSchema          Logical schema that describes the physical type.
+	 * @param physicalType           Physical type to retrieve indices from.
+	 * @param streamMarkers          Flag to tell, what kind of time attribute markers should be used.
+	 * @param nameRemappingFunction  Additional remapping of a logical to a physical field name.
+	 *                               TimestampExtractor works with logical names, but accesses physical
+	 *                               fields
+	 * @return Physical indices of logical fields of given {@code TableSchema}.
+	 */
+	public static int[] computePhysicalIndices(
+			TableSchema logicalSchema,
+			DataType physicalType,
+			boolean streamMarkers,
+			Function<String, String> nameRemappingFunction) {
+		return computePhysicalIndices(
+			logicalSchema,
+			IntStream.range(0, logicalSchema.getFieldCount()).toArray(),
+			physicalType,
+			streamMarkers,
+			nameRemappingFunction);
+	}
+
+	/**
+	 * Computes indices of physical fields corresponding to the selected logical fields of a {@link TableSchema}.
+	 *
+	 * <p>It puts markers (idx < 0) for time attributes.
+	 *
+	 * @param logicalSchema          Logical schema that describes the physical type.
+	 * @param projectedLogicalFields Selected logical fields. The returned array will
+	 *                               describe physical indices of logical fields selected with this mask.
+	 * @param physicalType           Physical type to retrieve indices from.
+	 * @param streamMarkers          Flag to tell, what kind of time attribute markers should be used.
+	 * @param nameRemappingFunction  Additional remapping of a logical to a physical field name.
+	 *                               TimestampExtractor works with logical names, but accesses physical
+	 *                               fields
+	 * @return Physical indices of logical fields selected with {@code projectedLogicalFields} mask.
+	 */
+	public static int[] computePhysicalIndices(
+			TableSchema logicalSchema,
+			int[] projectedLogicalFields,
+			DataType physicalType,
+			boolean streamMarkers,
+			Function<String, String> nameRemappingFunction) {
+
+		Stream<TableColumn> columns = Arrays.stream(projectedLogicalFields)
+			.mapToObj(logicalSchema::getTableColumn)
+			.filter(Optional::isPresent)
+			.map(Optional::get);
+
+		return computePhysicalIndices(columns, physicalType, streamMarkers, nameRemappingFunction);
+	}
+
+	private static int[] computePhysicalIndices(
+			Stream<TableColumn> columns,
+			DataType physicalType,
+			boolean isStreamTable,
+			Function<String, String> nameRemappingFunction) {
+		if (DataTypeUtils.isCompositeType(physicalType)) {
+			TableSchema physicalSchema = TypeConversions.expandCompositeTypeToSchema(physicalType);
+			return computeInCompositeType(columns, physicalSchema, isStreamTable, nameRemappingFunction);
+		} else {
+			return computeInSimpleType(columns, physicalType, isStreamTable);
+		}
+	}
+
+	private static int[] computeInCompositeType(
+			Stream<TableColumn> columns,
+			TableSchema physicalSchema,
+			boolean isStreamTable,
+			Function<String, String> nameRemappingFunction) {
+
+		return mapToIndex(
+			columns,
+			isStreamTable,
+			column -> {
+				String remappedName = nameRemappingFunction.apply(column.getName());
+
+				int idx = IntStream.range(0, physicalSchema.getFieldCount())
+					.filter(i -> physicalSchema.getFieldName(i).get().equals(remappedName))
+					.findFirst()
+					.orElseThrow(() -> new TableException(String.format(
+						"Could not map %s column to the underlying physical type %s. No such field.",
+						column.getName(),
+						physicalSchema
+					)));
+
+				LogicalType physicalFieldType = physicalSchema.getFieldDataType(idx).get().getLogicalType();
+				LogicalType logicalFieldType = column.getType().getLogicalType();
+
+				if (!physicalFieldType.equals(logicalFieldType)) {
+					throw new ValidationException(String.format(
+						"Type %s of table field '%s' does not match with type %s of the field of the " +
+							"TableSource return type.",
+						physicalFieldType,
+						column.getName(),
+						logicalFieldType));
+				}
+
+				return idx;
+			});
+	}
+
+	private static int[] computeInSimpleType(
+			Stream<TableColumn> columns,
+			DataType physicalType,
+			boolean isStreamTable) {
+		int[] indices = mapToIndex(
+			columns,
+			isStreamTable,
+			column -> 0);
+
+		if (Arrays.stream(indices).filter(i -> i == 0).count() > 1) {
+			throw new ValidationException(String.format(
+				"More than one table field matched to atomic input type %s.)",
+				physicalType));
+		}
+
+		return indices;
+	}
+
+	private static int[] mapToIndex(
+			Stream<TableColumn> columns,
+			boolean isStreamTable,
+			Function<TableColumn, Integer> nonTimeAttributeMapper) {
+		return columns.mapToInt(tableColumn -> {
+				LogicalType logicalType = tableColumn.getType().getLogicalType();
+				if (isTimeAttribute(logicalType)) {
+					return timeAttributeToIdxMarker(isStreamTable, logicalType);
+				} else {
+					return nonTimeAttributeMapper.apply(tableColumn);
+				}
+			}
+		).toArray();
+	}
+
+	private static boolean isTimeAttribute(LogicalType logicalType) {
+		return LogicalTypeChecks.hasFamily(logicalType, LogicalTypeFamily.TIMESTAMP) &&
+			LogicalTypeChecks.isTimeAttribute(logicalType);
+	}
+
+	private static int timeAttributeToIdxMarker(boolean isStreamTable, LogicalType logicalType) {
+		if (LogicalTypeChecks.isRowtimeAttribute(logicalType)) {
+			if (isStreamTable) {
+				return TimeIndicatorTypeInfo.ROWTIME_STREAM_MARKER;
+			} else {
+				return TimeIndicatorTypeInfo.ROWTIME_BATCH_MARKER;
+			}
+		} else {
+			if (isStreamTable) {
+				return TimeIndicatorTypeInfo.PROCTIME_STREAM_MARKER;
+			} else {
+				return TimeIndicatorTypeInfo.PROCTIME_BATCH_MARKER;
+			}
+		}
+	}
+
+	private TableSourceUtils() {
+	}
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/utils/DataTypeUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/utils/DataTypeUtilsTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.utils;
+
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.FieldsDataType;
+import org.apache.flink.table.types.logical.StructuredType;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.table.api.DataTypes.FIELD;
+import static org.apache.flink.table.api.DataTypes.INT;
+import static org.apache.flink.table.api.DataTypes.ROW;
+import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link DataTypeUtils}.
+ */
+public class DataTypeUtilsTest {
+	@Test
+	public void testIsCompositeTypeRowType() {
+		DataType dataType = ROW(FIELD("f0", INT()), FIELD("f1", STRING()));
+		boolean isCompositeType = DataTypeUtils.isCompositeType(dataType);
+
+		assertThat(isCompositeType, is(true));
+	}
+
+	@Test
+	public void testIsCompositeTypeLegacyCompositeType() {
+		DataType dataType = TypeConversions.fromLegacyInfoToDataType(new RowTypeInfo(Types.STRING, Types.INT));
+		boolean isCompositeType = DataTypeUtils.isCompositeType(dataType);
+
+		assertThat(isCompositeType, is(true));
+	}
+
+	@Test
+	public void testIsCompositeTypeStructuredType() {
+		StructuredType logicalType = StructuredType.newBuilder(ObjectIdentifier.of("catalog", "database", "type"))
+			.attributes(Arrays.asList(
+				new StructuredType.StructuredAttribute("f0", DataTypes.INT().getLogicalType()),
+				new StructuredType.StructuredAttribute("f1", DataTypes.STRING().getLogicalType())
+			))
+			.build();
+
+		Map<String, DataType> dataTypes = new HashMap<>();
+		dataTypes.put("f0", DataTypes.INT());
+		dataTypes.put("f1", DataTypes.STRING());
+		FieldsDataType dataType = new FieldsDataType(logicalType, dataTypes);
+		boolean isCompositeType = DataTypeUtils.isCompositeType(dataType);
+
+		assertThat(isCompositeType, is(true));
+	}
+
+	@Test
+	public void testIsCompositeTypeLegacySimpleType() {
+		DataType dataType = TypeConversions.fromLegacyInfoToDataType(Types.STRING);
+		boolean isCompositeType = DataTypeUtils.isCompositeType(dataType);
+
+		assertThat(isCompositeType, is(false));
+	}
+
+	@Test
+	public void testIsCompositeTypeSimpleType() {
+		DataType dataType = DataTypes.TIMESTAMP();
+		boolean isCompositeType = DataTypeUtils.isCompositeType(dataType);
+
+		assertThat(isCompositeType, is(false));
+	}
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/utils/TypeConversionsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/utils/TypeConversionsTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.utils;
+
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.FieldsDataType;
+import org.apache.flink.table.types.logical.StructuredType;
+
+import org.junit.Test;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.table.api.DataTypes.FIELD;
+import static org.apache.flink.table.api.DataTypes.INT;
+import static org.apache.flink.table.api.DataTypes.ROW;
+import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.apache.flink.table.api.DataTypes.TIMESTAMP;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link TypeConversions}.
+ */
+public class TypeConversionsTest {
+	@Test
+	public void testExpandRowType() {
+		DataType dataType = ROW(
+			FIELD("f0", INT()),
+			FIELD("f1", STRING()),
+			FIELD("f2", TIMESTAMP(5).bridgedTo(Timestamp.class)),
+			FIELD("f3", TIMESTAMP(3)));
+		TableSchema schema = TypeConversions.expandCompositeTypeToSchema(dataType);
+
+		assertThat(
+			schema,
+			equalTo(
+				TableSchema.builder()
+					.field("f0", INT())
+					.field("f1", STRING())
+					.field("f2", TIMESTAMP(5).bridgedTo(Timestamp.class))
+					.field("f3", TIMESTAMP(3).bridgedTo(LocalDateTime.class))
+					.build()));
+	}
+
+	@Test
+	public void testExpandLegacyCompositeType() {
+		DataType dataType = TypeConversions.fromLegacyInfoToDataType(new TupleTypeInfo<>(
+			Types.STRING,
+			Types.INT,
+			Types.SQL_TIMESTAMP));
+		TableSchema schema = TypeConversions.expandCompositeTypeToSchema(dataType);
+
+		assertThat(
+			schema,
+			equalTo(
+				TableSchema.builder()
+					.field("f0", STRING())
+					.field("f1", INT())
+					.field("f2", TIMESTAMP(3).bridgedTo(Timestamp.class))
+					.build()));
+	}
+
+	@Test
+	public void testExpandStructuredType() {
+		StructuredType logicalType = StructuredType.newBuilder(ObjectIdentifier.of("catalog", "database", "type"))
+			.attributes(Arrays.asList(
+				new StructuredType.StructuredAttribute("f0", DataTypes.INT().getLogicalType()),
+				new StructuredType.StructuredAttribute("f1", DataTypes.STRING().getLogicalType()),
+				new StructuredType.StructuredAttribute("f2", DataTypes.TIMESTAMP(5).getLogicalType()),
+				new StructuredType.StructuredAttribute("f3", DataTypes.TIMESTAMP(3).getLogicalType())
+			))
+			.build();
+
+		Map<String, DataType> dataTypes = new HashMap<>();
+		dataTypes.put("f0", DataTypes.INT());
+		dataTypes.put("f1", DataTypes.STRING());
+		dataTypes.put("f2", DataTypes.TIMESTAMP(5).bridgedTo(Timestamp.class));
+		dataTypes.put("f3", DataTypes.TIMESTAMP(3));
+		FieldsDataType dataType = new FieldsDataType(logicalType, dataTypes);
+
+		TableSchema schema = TypeConversions.expandCompositeTypeToSchema(dataType);
+
+		assertThat(
+			schema,
+			equalTo(
+				TableSchema.builder()
+					.field("f0", INT())
+					.field("f1", STRING())
+					.field("f2", TIMESTAMP(5).bridgedTo(Timestamp.class))
+					.field("f3", TIMESTAMP(3).bridgedTo(LocalDateTime.class))
+					.build()));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testExpandThrowExceptionOnAtomicType() {
+		TypeConversions.expandCompositeTypeToSchema(DataTypes.TIMESTAMP());
+	}
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/TableSourceUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/TableSourceUtilsTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.utils;
+
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.types.AtomicDataType;
+import org.apache.flink.table.types.logical.TimestampKind;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.function.Function;
+
+import static org.apache.flink.table.api.DataTypes.FIELD;
+import static org.apache.flink.table.api.DataTypes.ROW;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link TableSourceUtils}.
+ */
+public class TableSourceUtilsTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testFieldMappingReordered() {
+		int[] indices = TableSourceUtils.computePhysicalIndices(
+			TableSchema.builder()
+				.field("f1", DataTypes.BIGINT())
+				.field("f0", DataTypes.STRING())
+				.build(),
+			ROW(FIELD("f0", DataTypes.STRING()), FIELD("f1", DataTypes.BIGINT())),
+			true,
+			Function.identity()
+		);
+
+		assertThat(indices, equalTo(new int[] {1, 0}));
+	}
+
+	@Test
+	public void testFieldMappingNonMatchingTypes() {
+		thrown.expect(ValidationException.class);
+		thrown.expectMessage("Type STRING of table field 'f0' does not match with type " +
+			"TIMESTAMP(3) of the field of the TableSource return type.");
+		TableSourceUtils.computePhysicalIndices(
+			TableSchema.builder()
+				.field("f1", DataTypes.BIGINT())
+				.field("f0", DataTypes.TIMESTAMP(3))
+				.build(),
+			ROW(FIELD("f0", DataTypes.STRING()), FIELD("f1", DataTypes.BIGINT())),
+			true,
+			Function.identity()
+		);
+	}
+
+	@Test
+	public void testFieldMappingTimeAtributes() {
+		int[] indices = TableSourceUtils.computePhysicalIndices(
+			TableSchema.builder()
+				.field("f1", DataTypes.BIGINT())
+				.field("f0", new AtomicDataType(new TimestampType(true, TimestampKind.ROWTIME, 3)))
+				.field("f2", new AtomicDataType(new TimestampType(true, TimestampKind.PROCTIME, 3)))
+				.build(),
+			ROW(FIELD("f0", DataTypes.STRING()), FIELD("f1", DataTypes.BIGINT())),
+			true,
+			Function.identity()
+		);
+
+		assertThat(indices,
+			equalTo(new int[]{
+				1, TimeIndicatorTypeInfo.ROWTIME_STREAM_MARKER, TimeIndicatorTypeInfo.PROCTIME_STREAM_MARKER}));
+	}
+
+	@Test
+	public void testFieldMappingProjected() {
+		int[] indices = TableSourceUtils.computePhysicalIndices(
+			TableSchema.builder()
+				.field("f1", DataTypes.BIGINT())
+				.field("f0", DataTypes.STRING())
+				.field("f2", DataTypes.TIMESTAMP(3))
+				.build(),
+			new int[] {1, 0},
+			ROW(FIELD("f0", DataTypes.STRING()), FIELD("f1", DataTypes.BIGINT())),
+			true,
+			Function.identity()
+		);
+
+		assertThat(indices, equalTo(new int[] {0, 1}));
+	}
+
+	@Test
+	public void testFieldMappingLegacyCompositeType() {
+		int[] indices = TableSourceUtils.computePhysicalIndices(
+			TableSchema.builder()
+				.field("f1", DataTypes.BIGINT())
+				.field("f0", DataTypes.STRING())
+				.build(),
+			TypeConversions.fromLegacyInfoToDataType(new TupleTypeInfo<>(Types.STRING, Types.LONG)),
+			true,
+			Function.identity()
+		);
+
+		assertThat(indices, equalTo(new int[] {1, 0}));
+	}
+
+	@Test
+	public void testFieldMappingLegacyCompositeTypeWithRenaming() {
+		int[] indices = TableSourceUtils.computePhysicalIndices(
+			TableSchema.builder()
+				.field("a", DataTypes.BIGINT())
+				.field("b", DataTypes.STRING())
+				.build(),
+			TypeConversions.fromLegacyInfoToDataType(new TupleTypeInfo<>(Types.STRING, Types.LONG)),
+			true,
+			str -> {
+				switch (str) {
+					case "a":
+						return "f1";
+					case "b":
+						return "f0";
+					default:
+						throw new AssertionError();
+				}
+			}
+		);
+
+		assertThat(indices, equalTo(new int[]{1, 0}));
+	}
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/catalog/DatabaseCalciteSchema.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/catalog/DatabaseCalciteSchema.java
@@ -105,6 +105,7 @@ class DatabaseCalciteSchema implements Schema {
 	private Table convertConnectorTable(ConnectorCatalogTable<?, ?> table) {
 		Optional<TableSourceTable> tableSourceTable = table.getTableSource()
 			.map(tableSource -> new TableSourceTable<>(
+				table.getSchema(),
 				tableSource,
 				!table.isBatch(),
 				FlinkStatistic.UNKNOWN()));
@@ -142,6 +143,7 @@ class DatabaseCalciteSchema implements Schema {
 		}
 
 		return new TableSourceTable<>(
+			table.getSchema(),
 			tableSource,
 			// this means the TableSource extends from StreamTableSource, this is needed for the
 			// legacy Planner. Blink Planner should use the information that comes from the TableSource

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/QueryOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/QueryOperationConverter.java
@@ -299,6 +299,7 @@ public class QueryOperationConverter extends QueryOperationDefaultVisitor<RelNod
 		@Override
 		public <U> RelNode visit(TableSourceQueryOperation<U> tableSourceTable) {
 			final Table relTable = new TableSourceTable<>(
+				tableSourceTable.getTableSchema(),
 				tableSourceTable.getTableSource(),
 				!tableSourceTable.isBatch(),
 				FlinkStatistic.UNKNOWN());
@@ -316,6 +317,7 @@ public class QueryOperationConverter extends QueryOperationDefaultVisitor<RelNod
 					relTable.getRowType(relBuilder.getTypeFactory()),
 					relTable,
 					Schemas.path(catalogReader.getRootSchema(), Collections.singletonList(refId))),
+				tableSourceTable.getTableSchema(),
 				tableSourceTable.getTableSource(),
 				Option.empty()
 			);

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/PhysicalTableSourceScan.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/PhysicalTableSourceScan.scala
@@ -18,12 +18,12 @@
 
 package org.apache.flink.table.plan.nodes
 
+import org.apache.flink.table.api.TableSchema
+import org.apache.flink.table.sources.TableSource
+
 import org.apache.calcite.plan.{RelOptCluster, RelOptTable, RelTraitSet}
 import org.apache.calcite.rel.RelWriter
-import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.TableScan
-import org.apache.flink.table.calcite.FlinkTypeFactory
-import org.apache.flink.table.sources.{StreamTableSource, TableSource, TableSourceUtil}
 
 import scala.collection.JavaConverters._
 
@@ -31,17 +31,10 @@ abstract class PhysicalTableSourceScan(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
     table: RelOptTable,
+    tableSchema: TableSchema,
     tableSource: TableSource[_],
     val selectedFields: Option[Array[Int]])
   extends TableScan(cluster, traitSet, table) {
-
-  override def deriveRowType(): RelDataType = {
-    val flinkTypeFactory = cluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
-    val streamingTable = tableSource.isInstanceOf[StreamTableSource[_]]
-
-    TableSourceUtil
-      .getRelDataType(tableSource, selectedFields, streamingTable, flinkTypeFactory)
-  }
 
   override def explainTerms(pw: RelWriter): RelWriter = {
     val terms = super.explainTerms(pw)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/BatchTableSourceScan.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/BatchTableSourceScan.scala
@@ -18,41 +18,52 @@
 
 package org.apache.flink.table.plan.nodes.dataset
 
-import org.apache.calcite.plan._
-import org.apache.calcite.rel.RelNode
-import org.apache.calcite.rel.`type`.RelDataType
-import org.apache.calcite.rel.metadata.RelMetadataQuery
-import org.apache.calcite.rex.RexNode
 import org.apache.flink.api.common.io.InputFormat
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.DataSet
 import org.apache.flink.core.io.InputSplit
 import org.apache.flink.table.api.internal.BatchTableEnvImpl
-import org.apache.flink.table.api.{BatchQueryConfig, TableException, Types}
-import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.api.{BatchQueryConfig, TableException, TableSchema, Types}
 import org.apache.flink.table.plan.nodes.PhysicalTableSourceScan
 import org.apache.flink.table.plan.schema.RowSchema
 import org.apache.flink.table.sources._
+import org.apache.flink.table.types.utils.TypeConversions
 import org.apache.flink.table.types.utils.TypeConversions.{fromDataTypeToLegacyInfo, fromLegacyInfoToDataType}
+import org.apache.flink.table.utils.TableSourceUtils
 import org.apache.flink.types.Row
+
+import org.apache.calcite.plan._
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.metadata.RelMetadataQuery
+
+import java.util.function.{Function => JFunction}
 
 /** Flink RelNode to read data from an external source defined by a [[BatchTableSource]]. */
 class BatchTableSourceScan(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
     table: RelOptTable,
+    tableSchema: TableSchema,
     tableSource: TableSource[_],
     selectedFields: Option[Array[Int]])
-  extends PhysicalTableSourceScan(cluster, traitSet, table, tableSource, selectedFields)
+  extends PhysicalTableSourceScan(
+    cluster,
+    traitSet,
+    table,
+    tableSchema,
+    tableSource,
+    selectedFields)
   with BatchScan {
 
   override def deriveRowType(): RelDataType = {
-    val flinkTypeFactory = cluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
-    TableSourceUtil.getRelDataType(
-      tableSource,
-      selectedFields,
-      streaming = false,
-      flinkTypeFactory)
+    val baseRowType = table.getRowType
+    selectedFields.map(idxs => {
+      val fields = baseRowType.getFieldList
+      val builder = cluster.getTypeFactory.builder()
+      idxs.map(fields.get).foreach(builder.add)
+      builder.build()
+    }).getOrElse(baseRowType)
   }
 
   override def computeSelfCost (planner: RelOptPlanner, metadata: RelMetadataQuery): RelOptCost = {
@@ -65,6 +76,7 @@ class BatchTableSourceScan(
       cluster,
       traitSet,
       getTable,
+      tableSchema,
       tableSource,
       selectedFields
     )
@@ -78,6 +90,7 @@ class BatchTableSourceScan(
       cluster,
       traitSet,
       getTable,
+      tableSchema,
       tableSource,
       selectedFields
     )
@@ -86,11 +99,6 @@ class BatchTableSourceScan(
   override def translateToPlan(
       tableEnv: BatchTableEnvImpl,
       queryConfig: BatchQueryConfig): DataSet[Row] = {
-
-    val fieldIndexes = TableSourceUtil.computeIndexMapping(
-      tableSource,
-      isStreamTable = false,
-      selectedFields)
 
     val config = tableEnv.getConfig
     val inputDataSet = tableSource match {
@@ -108,8 +116,6 @@ class BatchTableSourceScan(
       case _ => throw new TableException("Only BatchTableSource and InputFormatTableSource are " +
         "supported in BatchTableEnvironment.")
     }
-    val outputSchema = new RowSchema(this.getRowType)
-
     val inputDataType = fromLegacyInfoToDataType(inputDataSet.getType)
     val producedDataType = tableSource.getProducedDataType
 
@@ -121,18 +127,36 @@ class BatchTableSourceScan(
         s"Please validate the implementation of the TableSource.")
     }
 
-    // get expression to extract rowtime attribute
-    val rowtimeExpression: Option[RexNode] = TableSourceUtil.getRowtimeExtractionExpression(
-      tableSource,
-      selectedFields,
-      cluster,
-      tableEnv.getRelBuilder,
-      Types.SQL_TIMESTAMP
+    val nameMapping: JFunction[String, String] = tableSource match {
+      case mapping: DefinedFieldMapping if mapping.getFieldMapping != null =>
+          new JFunction[String, String] {
+            override def apply(t: String): String = mapping.getFieldMapping.get(t)
+          }
+      case _ => JFunction.identity()
+    }
+
+    val fieldIndexes = TableSourceUtils.computePhysicalIndices(
+      tableSchema,
+      selectedFields.getOrElse((0 until tableSchema.getFieldCount).toArray),
+      producedDataType,
+      false,
+      nameMapping
     )
+
+    val rowtimeExpression = TableSourceUtil.getRowtimeAttributeDescriptor(
+        tableSource,
+        selectedFields)
+      .map(desc => TableSourceUtil.getRowtimeExtractionExpression(
+        desc.getTimestampExtractor,
+        producedDataType,
+        TypeConversions.fromLegacyInfoToDataType(Types.SQL_TIMESTAMP()),
+        tableEnv.getRelBuilder,
+        nameMapping
+      ))
 
     // ingest table and convert and extract time attributes if necessary
     convertToInternalRow(
-      outputSchema,
+      new RowSchema(getRowType),
       inputDataSet,
       fieldIndexes,
       config,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/StreamTableSourceScan.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/StreamTableSourceScan.scala
@@ -18,15 +18,10 @@
 
 package org.apache.flink.table.plan.nodes.datastream
 
-import org.apache.calcite.plan._
-import org.apache.calcite.rel.RelNode
-import org.apache.calcite.rel.`type`.RelDataType
-import org.apache.calcite.rel.metadata.RelMetadataQuery
-import org.apache.calcite.rex.RexNode
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.functions.{AssignerWithPeriodicWatermarks, AssignerWithPunctuatedWatermarks}
 import org.apache.flink.streaming.api.watermark.Watermark
-import org.apache.flink.table.api.{StreamQueryConfig, TableException}
+import org.apache.flink.table.api.{StreamQueryConfig, TableException, TableSchema}
 import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.plan.nodes.PhysicalTableSourceScan
 import org.apache.flink.table.plan.schema.RowSchema
@@ -34,26 +29,43 @@ import org.apache.flink.table.planner.StreamPlanner
 import org.apache.flink.table.runtime.types.CRow
 import org.apache.flink.table.sources._
 import org.apache.flink.table.sources.wmstrategies.{PeriodicWatermarkAssigner, PreserveWatermarks, PunctuatedWatermarkAssigner}
+import org.apache.flink.table.types.utils.TypeConversions
 import org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType
 import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
+import org.apache.flink.table.utils.TableSourceUtils
+
+import org.apache.calcite.plan._
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.metadata.RelMetadataQuery
+
+import java.util.function.{Function => JFunction}
 
 /** Flink RelNode to read data from an external source defined by a [[StreamTableSource]]. */
 class StreamTableSourceScan(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
     table: RelOptTable,
+    tableSchema: TableSchema,
     tableSource: StreamTableSource[_],
     selectedFields: Option[Array[Int]])
-  extends PhysicalTableSourceScan(cluster, traitSet, table, tableSource, selectedFields)
+  extends PhysicalTableSourceScan(
+    cluster,
+    traitSet,
+    table,
+    tableSchema,
+    tableSource,
+    selectedFields)
   with StreamScan {
 
   override def deriveRowType(): RelDataType = {
-    val flinkTypeFactory = cluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
-    TableSourceUtil.getRelDataType(
-      tableSource,
-      selectedFields,
-      streaming = true,
-      flinkTypeFactory)
+    val baseRowType = table.getRowType
+    selectedFields.map(idxs => {
+      val fields = baseRowType.getFieldList
+      val builder = cluster.getTypeFactory.builder()
+      idxs.map(fields.get).foreach(builder.add)
+      builder.build()
+    }).getOrElse(baseRowType)
   }
 
   override def computeSelfCost (planner: RelOptPlanner, metadata: RelMetadataQuery): RelOptCost = {
@@ -66,6 +78,7 @@ class StreamTableSourceScan(
       cluster,
       traitSet,
       getTable,
+      tableSchema,
       tableSource,
       selectedFields
     )
@@ -79,6 +92,7 @@ class StreamTableSourceScan(
       cluster,
       traitSet,
       getTable,
+      tableSchema,
       newTableSource.asInstanceOf[StreamTableSource[_]],
       selectedFields
     )
@@ -87,11 +101,6 @@ class StreamTableSourceScan(
   override def translateToPlan(
       planner: StreamPlanner,
       queryConfig: StreamQueryConfig): DataStream[CRow] = {
-
-    val fieldIndexes = TableSourceUtil.computeIndexMapping(
-      tableSource,
-      isStreamTable = true,
-      selectedFields)
 
     val config = planner.getConfig
     val inputDataStream = tableSource.getDataStream(planner.getExecutionEnvironment)
@@ -109,13 +118,32 @@ class StreamTableSourceScan(
         s"Please validate the implementation of the TableSource.")
     }
 
+    val nameMapping: JFunction[String, String] = tableSource match {
+      case mapping: DefinedFieldMapping if mapping.getFieldMapping != null =>
+        new JFunction[String, String] {
+          override def apply(t: String): String = mapping.getFieldMapping.get(t)
+        }
+      case _ => JFunction.identity()
+    }
+
     // get expression to extract rowtime attribute
-    val rowtimeExpression: Option[RexNode] = TableSourceUtil.getRowtimeExtractionExpression(
+    val rowtimeExpression = TableSourceUtil.getRowtimeAttributeDescriptor(
       tableSource,
-      selectedFields,
-      cluster,
-      planner.getRelBuilder,
-      TimeIndicatorTypeInfo.ROWTIME_INDICATOR
+      selectedFields)
+      .map(desc => TableSourceUtil.getRowtimeExtractionExpression(
+        desc.getTimestampExtractor,
+        producedDataType,
+        TypeConversions.fromLegacyInfoToDataType(TimeIndicatorTypeInfo.ROWTIME_INDICATOR),
+        planner.getRelBuilder,
+        nameMapping
+      ))
+
+    val fieldIndexes = TableSourceUtils.computePhysicalIndices(
+      tableSchema,
+      selectedFields.getOrElse((0 until tableSchema.getFieldCount).toArray),
+      producedDataType,
+      true,
+      nameMapping
     )
 
     // ingest table and convert and extract time attributes if necessary

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalTableSourceScan.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalTableSourceScan.scala
@@ -18,6 +18,13 @@
 
 package org.apache.flink.table.plan.nodes.logical
 
+import org.apache.flink.table.api.TableSchema
+import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.schema.TableSourceTable
+import org.apache.flink.table.sources.{FilterableTableSource, TableSource}
+import org.apache.flink.table.types.utils.{DataTypeUtils, TypeConversions}
+
 import org.apache.calcite.plan._
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.convert.ConverterRule
@@ -25,10 +32,6 @@ import org.apache.calcite.rel.core.TableScan
 import org.apache.calcite.rel.logical.LogicalTableScan
 import org.apache.calcite.rel.metadata.RelMetadataQuery
 import org.apache.calcite.rel.{RelNode, RelWriter}
-import org.apache.flink.table.calcite.FlinkTypeFactory
-import org.apache.flink.table.plan.nodes.FlinkConventions
-import org.apache.flink.table.plan.schema.TableSourceTable
-import org.apache.flink.table.sources.{FilterableTableSource, TableSource, TableSourceUtil}
 
 import scala.collection.JavaConverters._
 
@@ -36,6 +39,7 @@ class FlinkLogicalTableSourceScan(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
     table: RelOptTable,
+    val tableSchema: TableSchema,
     val tableSource: TableSource[_],
     val selectedFields: Option[Array[Int]])
   extends TableScan(cluster, traitSet, table)
@@ -43,16 +47,26 @@ class FlinkLogicalTableSourceScan(
 
   def copy(
       traitSet: RelTraitSet,
+      tableSchema: TableSchema,
       tableSource: TableSource[_],
       selectedFields: Option[Array[Int]]): FlinkLogicalTableSourceScan = {
-    new FlinkLogicalTableSourceScan(cluster, traitSet, getTable, tableSource, selectedFields)
+    new FlinkLogicalTableSourceScan(
+      cluster,
+      traitSet,
+      getTable,
+      tableSchema,
+      tableSource,
+      selectedFields)
   }
 
   override def deriveRowType(): RelDataType = {
-    val flinkTypeFactory = cluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
-    val streamingTable = table.unwrap(classOf[TableSourceTable[_]]).isStreamingMode
-
-    TableSourceUtil.getRelDataType(tableSource, selectedFields, streamingTable, flinkTypeFactory)
+    val baseRowType = table.getRowType
+    selectedFields.map(idxs => {
+      val fields = baseRowType.getFieldList
+      val builder = cluster.getTypeFactory.builder()
+      idxs.map(fields.get).foreach(builder.add)
+      builder.build()
+    }).getOrElse(baseRowType)
   }
 
   override def computeSelfCost(planner: RelOptPlanner, metadata: RelMetadataQuery): RelOptCost = {
@@ -113,11 +127,13 @@ class FlinkLogicalTableSourceScanConverter
     val scan = rel.asInstanceOf[TableScan]
     val traitSet = rel.getTraitSet.replace(FlinkConventions.LOGICAL)
 
+    val tableSourceTable = scan.getTable.unwrap(classOf[TableSourceTable[_]])
     new FlinkLogicalTableSourceScan(
       rel.getCluster,
       traitSet,
       scan.getTable,
-      scan.getTable.unwrap(classOf[TableSourceTable[_]]).tableSource,
+      tableSourceTable.tableSchema,
+      tableSourceTable.tableSource,
       None
     )
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/dataSet/BatchTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/dataSet/BatchTableSourceScanRule.scala
@@ -50,6 +50,7 @@ class BatchTableSourceScanRule
       rel.getCluster,
       traitSet,
       scan.getTable,
+      scan.tableSchema,
       scan.tableSource,
       scan.selectedFields
     )

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/datastream/StreamTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/datastream/StreamTableSourceScanRule.scala
@@ -52,6 +52,7 @@ class StreamTableSourceScanRule
       rel.getCluster,
       traitSet,
       scan.getTable,
+      scan.tableSchema,
       scan.tableSource.asInstanceOf[StreamTableSource[_]],
       scan.selectedFields
     )

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/PushFilterIntoTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/PushFilterIntoTableSourceScanRule.scala
@@ -113,7 +113,7 @@ class PushFilterIntoTableSourceScanRule extends RelOptRule(
 
     // check whether we still need a RexProgram. An RexProgram is needed when either
     // projection or filter exists.
-    val newScan = scan.copy(scan.getTraitSet, newTableSource, scan.selectedFields)
+    val newScan = scan.copy(scan.getTraitSet, scan.tableSchema, newTableSource, scan.selectedFields)
     val newRexProgram = {
       if (remainingCondition != null || !program.projectsOnlyIdentity) {
         val expandedProjectList = program.getProjectList.asScala

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/PushProjectIntoTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/PushProjectIntoTableSourceScanRule.scala
@@ -18,12 +18,19 @@
 
 package org.apache.flink.table.plan.rules.logical
 
+import org.apache.flink.table.api.{TableException, TableSchema}
+import org.apache.flink.table.plan.nodes.logical.{FlinkLogicalCalc, FlinkLogicalTableSourceScan}
+import org.apache.flink.table.plan.util.{RexProgramExtractor, RexProgramRewriter}
+import org.apache.flink.table.sources.TableSourceUtil.getRowtimeAttributeDescriptor
+import org.apache.flink.table.sources._
+import org.apache.flink.table.types.utils.{DataTypeUtils, TypeConversions}
+import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
+import org.apache.flink.table.utils.TableSourceUtils
+
 import org.apache.calcite.plan.RelOptRule.{none, operand}
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
-import org.apache.flink.table.api.TableException
-import org.apache.flink.table.plan.util.{RexProgramExtractor, RexProgramRewriter}
-import org.apache.flink.table.plan.nodes.logical.{FlinkLogicalCalc, FlinkLogicalTableSourceScan}
-import org.apache.flink.table.sources._
+
+import java.util.function.{Function => JFunction}
 
 class PushProjectIntoTableSourceScanRule extends RelOptRule(
   operand(classOf[FlinkLogicalCalc],
@@ -43,7 +50,30 @@ class PushProjectIntoTableSourceScanRule extends RelOptRule(
     val source = scan.tableSource
 
     val accessedLogicalFields = RexProgramExtractor.extractRefInputFields(calc.getProgram)
-    val accessedPhysicalFields = TableSourceUtil.getPhysicalIndexes(source, accessedLogicalFields)
+
+    val nameMapping: JFunction[String, String] = source match {
+      case mapping: DefinedFieldMapping if mapping.getFieldMapping != null =>
+        new JFunction[String, String] {
+          override def apply(t: String): String = mapping.getFieldMapping.get(t)
+        }
+      case _ => JFunction.identity()
+    }
+
+    val accessedIndices = TableSourceUtils.computePhysicalIndices(
+      scan.tableSchema,
+      accessedLogicalFields,
+      source.getProducedDataType,
+      source.isInstanceOf[StreamTableSource[_]],
+      nameMapping
+    )
+    val physicalFields = expandTimeAttributes(
+      source,
+      if (DataTypeUtils.isCompositeType(source.getProducedDataType)) {
+        TypeConversions.expandCompositeTypeToSchema(source.getProducedDataType)
+      } else {
+        null
+      },
+      accessedIndices)
 
     // only continue if fields are projected or reordered.
     // eager reordering can remove a calc operator.
@@ -53,10 +83,10 @@ class PushProjectIntoTableSourceScanRule extends RelOptRule(
       val (newTableSource, isProjectSuccess) = source match {
         case nested: NestedFieldsProjectableTableSource[_] =>
           val nestedFields = RexProgramExtractor
-            .extractRefNestedInputFields(calc.getProgram, accessedPhysicalFields)
-          (nested.projectNestedFields(accessedPhysicalFields, nestedFields), true)
+            .extractRefNestedInputFields(calc.getProgram, physicalFields)
+          (nested.projectNestedFields(physicalFields, nestedFields), true)
         case projecting: ProjectableTableSource[_] =>
-          (projecting.projectFields(accessedPhysicalFields), true)
+          (projecting.projectFields(physicalFields), true)
         case nonProjecting: TableSource[_] =>
           // projection cannot be pushed to TableSource
           (nonProjecting, false)
@@ -77,7 +107,11 @@ class PushProjectIntoTableSourceScanRule extends RelOptRule(
       }
 
       // Apply the projection during the input conversion of the scan.
-      val newScan = scan.copy(scan.getTraitSet, newTableSource, Some(accessedLogicalFields))
+      val newScan = scan.copy(
+        scan.getTraitSet,
+        scan.tableSchema,
+        newTableSource,
+        Some(accessedLogicalFields))
       val newCalcProgram = RexProgramRewriter.rewriteWithFieldProjection(
         calc.getProgram,
         newScan.getRowType,
@@ -92,6 +126,55 @@ class PushProjectIntoTableSourceScanRule extends RelOptRule(
         call.transformTo(newCalc)
       }
     }
+  }
+
+  private def expandTimeAttributes(
+      tableSource: TableSource[_],
+      physicalSchema: TableSchema,
+      physicalIndices: Array[Int]): Array[Int] = {
+
+      physicalIndices
+      // resolve time indicator markers to physical indexes
+      .flatMap {
+        case TimeIndicatorTypeInfo.PROCTIME_STREAM_MARKER =>
+          // proctime field do not access a physical field
+          Seq()
+        case TimeIndicatorTypeInfo.ROWTIME_STREAM_MARKER =>
+          // rowtime field is computed.
+          // get names of fields which are accessed by the expression to compute the rowtime field.
+          val rowtimeAttributeDescriptor = getRowtimeAttributeDescriptor(tableSource, None)
+          val accessedFields = if (rowtimeAttributeDescriptor.isDefined) {
+            rowtimeAttributeDescriptor.get.getTimestampExtractor.getArgumentFields
+          } else {
+            throw new TableException("Computed field mapping includes a rowtime marker but the " +
+              "TableSource does not provide a RowtimeAttributeDescriptor. " +
+              "This is a bug and should be reported.")
+          }
+          // resolve field names to physical fields
+          accessedFields.map(name => {
+            if (physicalSchema != null) {
+              mapToCompositeType(tableSource, physicalSchema, name)
+            } else {
+              0
+            }
+          })
+        case idx =>
+          Seq(idx)
+      }
+  }
+
+  private def mapToCompositeType(
+      tableSource: TableSource[_],
+      physicalSchema: TableSchema,
+      name: String)
+    : Int = {
+    val fieldName = tableSource match {
+      case mapping: DefinedFieldMapping if mapping.getFieldMapping != null =>
+        mapping.getFieldMapping.get(name)
+      case _ =>
+        name
+    }
+    physicalSchema.getFieldNames.indexWhere(_.equals(fieldName)) // logical accessed field
   }
 }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/schema/TableSourceTable.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/schema/TableSourceTable.scala
@@ -18,12 +18,20 @@
 
 package org.apache.flink.table.plan.schema
 
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.table.api.{TableSchema, Types}
+import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.plan.stats.FlinkStatistic
+import org.apache.flink.table.sources.{DefinedFieldMapping, TableSource, TableSourceValidation}
+import org.apache.flink.table.types.utils.{DataTypeUtils, TypeConversions}
+import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
+import org.apache.flink.table.utils.TableSourceUtils
+
 import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeFactory}
 import org.apache.calcite.schema.Statistic
 import org.apache.calcite.schema.impl.AbstractTable
-import org.apache.flink.table.calcite.FlinkTypeFactory
-import org.apache.flink.table.plan.stats.FlinkStatistic
-import org.apache.flink.table.sources.{TableSource, TableSourceUtil, TableSourceValidation}
+
+import java.util.function.{Function => JFunction}
 
 /**
   * Abstract class which define the interfaces required to convert a [[TableSource]] to
@@ -34,6 +42,7 @@ import org.apache.flink.table.sources.{TableSource, TableSourceUtil, TableSource
   * @param statistic The table statistics.
   */
 class TableSourceTable[T](
+    val tableSchema: TableSchema,
     val tableSource: TableSource[T],
     val isStreamingMode: Boolean,
     val statistic: FlinkStatistic)
@@ -48,11 +57,53 @@ class TableSourceTable[T](
     */
   override def getStatistic: Statistic = statistic
 
+  // We must enrich logical schema from catalog table with physical type coming from table source.
+  // Schema coming from catalog table might not have proper conversion classes. Those must be
+  // extracted from produced type, before converting to RelDataType
   def getRowType(typeFactory: RelDataTypeFactory): RelDataType = {
-    TableSourceUtil.getRelDataType(
-      tableSource,
-      None,
+
+    val flinkTypeFactory = typeFactory.asInstanceOf[FlinkTypeFactory]
+
+    val fieldNames = tableSchema.getFieldNames
+
+    val nameMapping: JFunction[String, String] = tableSource match {
+      case mapping: DefinedFieldMapping if mapping.getFieldMapping != null =>
+        new JFunction[String, String] {
+          override def apply(t: String): String = mapping.getFieldMapping.get(t)
+        }
+      case _ => JFunction.identity()
+    }
+
+    val producedDataType = tableSource.getProducedDataType
+    val fieldIndexes = TableSourceUtils.computePhysicalIndices(
+      tableSchema,
+      producedDataType,
       isStreamingMode,
-      typeFactory.asInstanceOf[FlinkTypeFactory])
+      nameMapping
+    )
+
+    val dataTypes = if (DataTypeUtils.isCompositeType(producedDataType)) {
+      val physicalSchema = TypeConversions.expandCompositeTypeToSchema(producedDataType)
+      fieldIndexes.map(mapIndex(_,
+        idx =>
+          TypeConversions.fromDataTypeToLegacyInfo(physicalSchema.getFieldDataType(idx).get()))
+      )
+    } else {
+      fieldIndexes.map(mapIndex(_, _ => TypeConversions.fromDataTypeToLegacyInfo(producedDataType)))
+    }
+
+    flinkTypeFactory.buildLogicalRowType(fieldNames, dataTypes)
+  }
+
+  def mapIndex(idx: Int, mapNonMarker: Int => TypeInformation[_]): TypeInformation[_] = {
+    idx match {
+      case TimeIndicatorTypeInfo.ROWTIME_BATCH_MARKER => Types.SQL_TIMESTAMP()
+      case TimeIndicatorTypeInfo.PROCTIME_BATCH_MARKER => Types.SQL_TIMESTAMP()
+      case TimeIndicatorTypeInfo.PROCTIME_STREAM_MARKER =>
+        TimeIndicatorTypeInfo.PROCTIME_INDICATOR
+      case TimeIndicatorTypeInfo.ROWTIME_STREAM_MARKER => TimeIndicatorTypeInfo.ROWTIME_INDICATOR
+      case _ =>
+       mapNonMarker(idx)
+    }
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/sources/TableSourceUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/sources/TableSourceUtil.scala
@@ -18,164 +18,25 @@
 
 package org.apache.flink.table.sources
 
-import java.sql.Timestamp
-import com.google.common.collect.ImmutableList
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.table.api.{DataTypes, Types, ValidationException}
+import org.apache.flink.table.calcite.{FlinkRelBuilder, FlinkTypeFactory}
+import org.apache.flink.table.expressions.utils.ApiExpressionUtils.{typeLiteral, unresolvedCall}
+import org.apache.flink.table.expressions.{Expression, PlannerExpressionConverter, ResolvedFieldReference}
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions.CAST
+import org.apache.flink.table.sources.tsextractors.{TimestampExtractor, TimestampExtractorUtils}
+import org.apache.flink.table.types.DataType
+
 import org.apache.calcite.plan.RelOptCluster
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.logical.LogicalValues
-import org.apache.calcite.rex.{RexLiteral, RexNode}
-import org.apache.calcite.tools.RelBuilder
-import org.apache.flink.api.common.typeinfo.{SqlTimeTypeInfo, TypeInformation}
-import org.apache.flink.api.common.typeutils.CompositeType
-import org.apache.flink.table.api.{DataTypes, TableException, Types, ValidationException}
-import org.apache.flink.table.calcite.FlinkTypeFactory
-import org.apache.flink.table.expressions.utils.ApiExpressionUtils.{typeLiteral, unresolvedCall}
-import org.apache.flink.table.expressions.{PlannerExpressionConverter, ResolvedFieldReference}
-import org.apache.flink.table.functions.BuiltInFunctionDefinitions.CAST
-import org.apache.flink.table.types.utils.TypeConversions.{fromDataTypeToLegacyInfo, fromLegacyInfoToDataType}
-import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
+import org.apache.calcite.rex.RexNode
 
-import scala.collection.JavaConverters._
+import java.util.function.{Function => JFunction}
 
 /** Util class for [[TableSource]]. */
 object TableSourceUtil {
-
-  /** Returns true if the [[TableSource]] has a rowtime attribute. */
-  def hasRowtimeAttribute(tableSource: TableSource[_]): Boolean =
-    getRowtimeAttributes(tableSource).nonEmpty
-
-  /** Returns true if the [[TableSource]] has a proctime attribute. */
-  def hasProctimeAttribute(tableSource: TableSource[_]): Boolean =
-    getProctimeAttribute(tableSource).nonEmpty
-
-  /**
-    * Computes the indices that map the input type of the DataStream to the schema of the table.
-    *
-    * The mapping is based on the field names and fails if a table field cannot be
-    * mapped to a field of the input type.
-    *
-    * @param tableSource The table source for which the table schema is mapped to the input type.
-    * @param isStreamTable True if the mapping is computed for a streaming table, false otherwise.
-    * @param selectedFields The indexes of the table schema fields for which a mapping is
-    *                       computed. If None, a mapping for all fields is computed.
-    * @return An index mapping from input type to table schema.
-    */
-  def computeIndexMapping(
-      tableSource: TableSource[_],
-      isStreamTable: Boolean,
-      selectedFields: Option[Array[Int]]): Array[Int] = {
-    val inputType = fromDataTypeToLegacyInfo(tableSource.getProducedDataType)
-    val tableSchema = tableSource.getTableSchema
-
-    // get names of selected fields
-    val tableFieldNames = if (selectedFields.isDefined) {
-      val names = tableSchema.getFieldNames
-      selectedFields.get.map(names(_))
-    } else {
-      tableSchema.getFieldNames
-    }
-
-    // get types of selected fields
-    val tableFieldTypes = if (selectedFields.isDefined) {
-      val types = tableSchema.getFieldTypes
-      selectedFields.get.map(types(_))
-    } else {
-      tableSchema.getFieldTypes
-    }
-
-    // get rowtime and proctime attributes
-    val rowtimeAttributes = getRowtimeAttributes(tableSource)
-    val proctimeAttributes = getProctimeAttribute(tableSource)
-
-    // compute mapping of selected fields and time attributes
-    val mapping: Array[Int] = tableFieldTypes.zip(tableFieldNames).map {
-      case (t: SqlTimeTypeInfo[_], name: String)
-        if t.getTypeClass == classOf[Timestamp] && proctimeAttributes.contains(name) =>
-        if (isStreamTable) {
-          TimeIndicatorTypeInfo.PROCTIME_STREAM_MARKER
-        } else {
-          TimeIndicatorTypeInfo.PROCTIME_BATCH_MARKER
-        }
-      case (t: SqlTimeTypeInfo[_], name: String)
-        if t.getTypeClass == classOf[Timestamp] && rowtimeAttributes.contains(name) =>
-        if (isStreamTable) {
-          TimeIndicatorTypeInfo.ROWTIME_STREAM_MARKER
-        } else {
-          TimeIndicatorTypeInfo.ROWTIME_BATCH_MARKER
-        }
-      case (t: TypeInformation[_], name) =>
-        // check if field is registered as time indicator
-        if (getProctimeAttribute(tableSource).contains(name)) {
-          throw new ValidationException(s"Processing time field '$name' has invalid type $t. " +
-            s"Processing time attributes must be of type ${Types.SQL_TIMESTAMP}.")
-        }
-        if (getRowtimeAttributes(tableSource).contains(name)) {
-          throw new ValidationException(s"Rowtime field '$name' has invalid type $t. " +
-            s"Rowtime attributes must be of type ${Types.SQL_TIMESTAMP}.")
-        }
-
-        val (physicalName, idx, tpe) = resolveInputField(name, tableSource)
-        // validate that mapped fields are are same type
-        if (tpe != t) {
-          throw new ValidationException(s"Type $t of table field '$name' does not " +
-            s"match with type $tpe of the field '$physicalName' of the TableSource return type.")
-        }
-        idx
-    }
-
-    // ensure that only one field is mapped to an atomic type
-    if (!inputType.isInstanceOf[CompositeType[_]] && mapping.count(_ >= 0) > 1) {
-      throw new ValidationException(
-        s"More than one table field matched to atomic input type $inputType.")
-    }
-
-    mapping
-  }
-
-  /**
-    * Returns the Calcite schema of a [[TableSource]].
-    *
-    * @param tableSource The [[TableSource]] for which the Calcite schema is generated.
-    * @param selectedFields The indices of all selected fields. None, if all fields are selected.
-    * @param streaming Flag to determine whether the schema of a stream or batch table is created.
-    * @param typeFactory The type factory to create the schema.
-    * @return The Calcite schema for the selected fields of the given [[TableSource]].
-    */
-  def getRelDataType(
-      tableSource: TableSource[_],
-      selectedFields: Option[Array[Int]],
-      streaming: Boolean,
-      typeFactory: FlinkTypeFactory): RelDataType = {
-
-    val fieldNames = tableSource.getTableSchema.getFieldNames
-    var fieldTypes = tableSource.getTableSchema.getFieldTypes
-
-    if (streaming) {
-      // adjust the type of time attributes for streaming tables
-      val rowtimeAttributes = getRowtimeAttributes(tableSource)
-      val proctimeAttributes = getProctimeAttribute(tableSource)
-
-      // patch rowtime fields with time indicator type
-      rowtimeAttributes.foreach { rowtimeField =>
-        val idx = fieldNames.indexOf(rowtimeField)
-        fieldTypes = fieldTypes.patch(idx, Seq(TimeIndicatorTypeInfo.ROWTIME_INDICATOR), 1)
-      }
-      // patch proctime field with time indicator type
-      proctimeAttributes.foreach { proctimeField =>
-        val idx = fieldNames.indexOf(proctimeField)
-        fieldTypes = fieldTypes.patch(idx, Seq(TimeIndicatorTypeInfo.PROCTIME_INDICATOR), 1)
-      }
-    }
-
-    val (selectedFieldNames, selectedFieldTypes) = if (selectedFields.isDefined) {
-      // filter field names and types by selected fields
-      (selectedFields.get.map(fieldNames(_)), selectedFields.get.map(fieldTypes(_)))
-    } else {
-      (fieldNames, fieldTypes)
-    }
-    typeFactory.buildLogicalRowType(selectedFieldNames, selectedFieldTypes)
-  }
 
   /**
     * Returns the [[RowtimeAttributeDescriptor]] of a [[TableSource]].
@@ -220,207 +81,71 @@ object TableSourceUtil {
   }
 
   /**
-    * Obtains the [[RexNode]] expression to extract the rowtime timestamp for a [[TableSource]].
-    *
-    * @param tableSource The [[TableSource]] for which the expression is extracted.
-    * @param selectedFields The selected fields of the [[TableSource]].
-    *                       If None, all fields are selected.
-    * @param cluster The [[RelOptCluster]] of the current optimization process.
-    * @param relBuilder The [[RelBuilder]] to build the [[RexNode]].
-    * @param resultType The result type of the timestamp expression.
-    * @return The [[RexNode]] expression to extract the timestamp of the table source.
-    */
+   * Retrieves an expression to compute a rowtime attribute.
+   *
+   * @param extractor Timestamp extractor to construct an expression for.
+   * @param physicalInputType Physical input type that the timestamp extractor accesses.
+   * @param expectedDataType Expected type of the expression. Different in case of batch and
+   *                         streaming.
+   * @param relBuilder  Builder needed to construct the resulting RexNode.
+   * @param nameMapping Additional remapping of a logical to a physical field name.
+   *                    TimestampExtractor works with logical names, but accesses physical
+   *                    fields
+   * @return The [[RexNode]] expression to extract the timestamp.
+   */
   def getRowtimeExtractionExpression(
-      tableSource: TableSource[_],
-      selectedFields: Option[Array[Int]],
-      cluster: RelOptCluster,
-      relBuilder: RelBuilder,
-      resultType: TypeInformation[_]): Option[RexNode] = {
+      extractor: TimestampExtractor,
+      physicalInputType: DataType,
+      expectedDataType: DataType,
+      relBuilder: FlinkRelBuilder,
+      nameMapping: JFunction[String, String])
+    : RexNode = {
+    val accessedFields = TimestampExtractorUtils.getAccessedFields(
+      extractor,
+      physicalInputType,
+      nameMapping)
 
-    val typeFactory = cluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
+    relBuilder.push(createSchemaRelNode(accessedFields, relBuilder.getCluster))
+    val expr = constructExpression(
+      expectedDataType,
+      extractor,
+      accessedFields
+    ).accept(PlannerExpressionConverter.INSTANCE)
+      .toRexNode(relBuilder)
+    relBuilder.clear()
+    expr
+  }
 
-    /**
-      * Creates a RelNode with a schema that corresponds on the given fields
-      * Fields for which no information is available, will have default values.
-      */
-    def createSchemaRelNode(fields: Array[(String, Int, TypeInformation[_])]): RelNode = {
-      val maxIdx = fields.map(_._2).max
-      val idxMap: Map[Int, (String, TypeInformation[_])] = Map(
-        fields.map(f => f._2 -> (f._1, f._3)): _*)
-      val (physicalFields, physicalTypes) = (0 to maxIdx)
-        .map(i => idxMap.getOrElse(i, ("", Types.BYTE))).unzip
-      val physicalSchema: RelDataType = typeFactory.buildLogicalRowType(
+  private def createSchemaRelNode(
+      fields: Array[ResolvedFieldReference],
+      cluster: RelOptCluster)
+    : RelNode = {
+    val maxIdx = fields.map(_.fieldIndex()).max
+    val idxMap: Map[Int, (String, TypeInformation[_])] = Map(
+      fields.map(f => f.fieldIndex() -> (f.name(), f.resultType())): _*)
+    val (physicalFields, physicalTypes) = (0 to maxIdx)
+      .map(i => idxMap.getOrElse(i, ("", Types.BYTE))).unzip
+    val physicalSchema: RelDataType = cluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
+      .buildLogicalRowType(
         physicalFields,
         physicalTypes)
-      LogicalValues.create(
-        cluster,
-        physicalSchema,
-        ImmutableList.of().asInstanceOf[ImmutableList[ImmutableList[RexLiteral]]])
-    }
-
-    val rowtimeDesc = getRowtimeAttributeDescriptor(tableSource, selectedFields)
-    rowtimeDesc.map { r =>
-      val tsExtractor = r.getTimestampExtractor
-
-      val fieldAccesses = if (tsExtractor.getArgumentFields.nonEmpty) {
-        val resolvedFields = resolveInputFields(tsExtractor.getArgumentFields, tableSource)
-        // push an empty values node with the physical schema on the relbuilder
-        relBuilder.push(createSchemaRelNode(resolvedFields))
-        // get extraction expression
-        resolvedFields.map(f => new ResolvedFieldReference(f._1, f._3, f._2))
-      } else {
-        new Array[ResolvedFieldReference](0)
-      }
-
-      val expression = tsExtractor.getExpression(fieldAccesses)
-      // add cast to requested type and convert expression to RexNode
-      // If resultType is TimeIndicatorTypeInfo, its internal format is long, but cast
-      // from Timestamp is java.sql.Timestamp. So we need cast to long first.
-      val castExpression = unresolvedCall(CAST,
-        unresolvedCall(CAST, expression, typeLiteral(DataTypes.BIGINT())),
-        typeLiteral(fromLegacyInfoToDataType(resultType)))
-
-      // TODO we convert to planner expressions as a temporary solution
-      val rexExpression = castExpression
-          .accept(PlannerExpressionConverter.INSTANCE)
-          .toRexNode(relBuilder)
-      relBuilder.clear()
-      rexExpression
-    }
+    LogicalValues.createEmpty(
+      cluster,
+      physicalSchema)
   }
 
-  /**
-    * Returns the indexes of the physical fields that required to compute the given logical fields.
-    *
-    * @param tableSource The [[TableSource]] for which the physical indexes are computed.
-    * @param logicalFieldIndexes The indexes of the accessed logical fields for which the physical
-    *                            indexes are computed.
-    * @return The indexes of the physical fields are accessed to forward and compute the logical
-    *         fields.
-    */
-  def getPhysicalIndexes(
-      tableSource: TableSource[_],
-      logicalFieldIndexes: Array[Int]): Array[Int] = {
-
-    // get the mapping from logical to physical positions.
-    // stream / batch distinction not important here
-    val fieldMapping = computeIndexMapping(tableSource, isStreamTable = true, None)
-
-    logicalFieldIndexes
-      // resolve logical indexes to physical indexes
-      .map(fieldMapping(_))
-      // resolve time indicator markers to physical indexes
-      .flatMap {
-      case TimeIndicatorTypeInfo.PROCTIME_STREAM_MARKER =>
-        // proctime field do not access a physical field
-        Seq()
-      case TimeIndicatorTypeInfo.ROWTIME_STREAM_MARKER =>
-        // rowtime field is computed.
-        // get names of fields which are accessed by the expression to compute the rowtime field.
-        val rowtimeAttributeDescriptor = getRowtimeAttributeDescriptor(tableSource, None)
-        val accessedFields = if (rowtimeAttributeDescriptor.isDefined) {
-          rowtimeAttributeDescriptor.get.getTimestampExtractor.getArgumentFields
-        } else {
-          throw new TableException("Computed field mapping includes a rowtime marker but the " +
-            "TableSource does not provide a RowtimeAttributeDescriptor. " +
-            "This is a bug and should be reported.")
-        }
-        // resolve field names to physical fields
-        resolveInputFields(accessedFields, tableSource).map(_._2)
-      case idx =>
-        Seq(idx)
-    }
+  private def constructExpression(
+      expectedType: DataType,
+      timestampExtractor: TimestampExtractor,
+      fieldAccesses: Array[ResolvedFieldReference])
+    : Expression = {
+    val expression = timestampExtractor.getExpression(fieldAccesses)
+    // add cast to requested type and convert expression to RexNode
+    // If resultType is TimeIndicatorTypeInfo, its internal format is long, but cast
+    // from Timestamp is java.sql.Timestamp. So we need cast to long first.
+    unresolvedCall(
+      CAST,
+      unresolvedCall(CAST, expression, typeLiteral(DataTypes.BIGINT)),
+      typeLiteral(expectedType))
   }
-
-  /** Returns a list with all rowtime attribute names of the [[TableSource]]. */
-  private def getRowtimeAttributes(tableSource: TableSource[_]): Array[String] = {
-    tableSource match {
-      case r: DefinedRowtimeAttributes =>
-        r.getRowtimeAttributeDescriptors.asScala.map(_.getAttributeName).toArray
-      case _ =>
-        Array()
-    }
-  }
-
-  /** Returns the proctime attribute of the [[TableSource]] if it is defined. */
-  private def getProctimeAttribute(tableSource: TableSource[_]): Option[String] = {
-    tableSource match {
-      case p: DefinedProctimeAttribute if p.getProctimeAttribute != null =>
-        Some(p.getProctimeAttribute)
-      case _ =>
-        None
-    }
-  }
-
-  /**
-    * Identifies for a field name of the logical schema, the corresponding physical field in the
-    * return type of a [[TableSource]].
-    *
-    * @param fieldName The logical field to look up.
-    * @param tableSource The table source in which to look for the field.
-    * @return The name, index, and type information of the physical field.
-    */
-  private def resolveInputField(
-      fieldName: String,
-      tableSource: TableSource[_]): (String, Int, TypeInformation[_]) = {
-
-    val returnType = fromDataTypeToLegacyInfo(tableSource.getProducedDataType)
-
-    /** Look up a field by name in a type information */
-    def lookupField(fieldName: String, failMsg: String): (String, Int, TypeInformation[_]) = {
-      returnType match {
-
-        case c: CompositeType[_] =>
-          // get and check field index
-          val idx = c.getFieldIndex(fieldName)
-          if (idx < 0) {
-            throw new ValidationException(failMsg)
-          }
-          // return field name, index, and field type
-          (fieldName, idx, c.getTypeAt(idx))
-
-        case t: TypeInformation[_] =>
-          // no composite type, we return the full atomic type as field
-          (fieldName, 0, t)
-      }
-    }
-
-    tableSource match {
-      case d: DefinedFieldMapping if d.getFieldMapping != null =>
-        // resolve field name in field mapping
-        val resolvedFieldName = d.getFieldMapping.get(fieldName)
-        if (resolvedFieldName == null) {
-          throw new ValidationException(
-            s"Field '$fieldName' could not be resolved by the field mapping.")
-        }
-        // look up resolved field in return type
-        lookupField(
-          resolvedFieldName,
-          s"Table field '$fieldName' was resolved to TableSource return type field " +
-            s"'$resolvedFieldName', but field '$resolvedFieldName' was not found in the return " +
-            s"type $returnType of the TableSource. " +
-            s"Please verify the field mapping of the TableSource.")
-      case _ =>
-        // look up field in return type
-        lookupField(
-          fieldName,
-          s"Table field '$fieldName' was not found in the return type $returnType of the " +
-            s"TableSource.")
-    }
-  }
-
-  /**
-    * Identifies the physical fields in the return type [[TypeInformation]] of a [[TableSource]]
-    * for a list of field names of the [[TableSource]]'s [[org.apache.flink.table.api.TableSchema]].
-    *
-    * @param fieldNames The field names to look up.
-    * @param tableSource The table source in which to look for the field.
-    * @return The name, index, and type information of the physical field.
-    */
-  private def resolveInputFields(
-      fieldNames: Array[String],
-      tableSource: TableSource[_]): Array[(String, Int, TypeInformation[_])] = {
-    fieldNames.map(resolveInputField(_, tableSource))
-  }
-
 }


### PR DESCRIPTION
## What is the purpose of the change
Starting from this PR we use the schema that comes from CatalogTable instead of schema that comes from TableSource.

Computing physical indices is based on the new type hierarchy instead of TypeInformation.

## Verifying this change

This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
