### PR TITLE
[FLINK-15256][hive] HiveModuleFactory should take hive-version as property

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModule.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModule.java
@@ -23,11 +23,14 @@ import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
 import org.apache.flink.table.catalog.hive.factories.HiveFunctionDefinitionFactory;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.module.Module;
+import org.apache.flink.util.StringUtils;
 
 import org.apache.hadoop.hive.ql.exec.FunctionInfo;
 
 import java.util.Optional;
 import java.util.Set;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * Module to provide Hive built-in metadata.
@@ -35,9 +38,13 @@ import java.util.Set;
 public class HiveModule implements Module {
 
 	private final HiveFunctionDefinitionFactory factory;
+	private final String hiveVersion;
 	private final HiveShim hiveShim;
 
 	public HiveModule(String hiveVersion) {
+		checkArgument(!StringUtils.isNullOrWhitespaceOnly(hiveVersion), "hiveVersion cannot be null");
+
+		this.hiveVersion = hiveVersion;
 		this.hiveShim = HiveShimLoader.loadHiveShim(hiveVersion);
 		this.factory = new HiveFunctionDefinitionFactory(hiveShim);
 	}
@@ -54,5 +61,9 @@ public class HiveModule implements Module {
 		return info.isPresent() ?
 			Optional.of(factory.createFunctionDefinitionFromHiveFunction(name, info.get().getFunctionClass().getName()))
 			: Optional.empty();
+	}
+
+	public String getHiveVersion() {
+		return hiveVersion;
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModuleDescriptor.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModuleDescriptor.java
@@ -34,14 +34,11 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 public class HiveModuleDescriptor extends ModuleDescriptor {
 	private String hiveVersion;
 
-	public HiveModuleDescriptor() {
+	public HiveModuleDescriptor(String hiveVersion) {
 		super(MODULE_TYPE_HIVE);
-	}
 
-	public HiveModuleDescriptor hiveVersion(String hiveVersion) {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(hiveVersion));
 		this.hiveVersion = hiveVersion;
-		return this;
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModuleDescriptorValidator.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModuleDescriptorValidator.java
@@ -32,6 +32,6 @@ public class HiveModuleDescriptorValidator extends ModuleDescriptorValidator {
 	public void validate(DescriptorProperties properties) {
 		super.validate(properties);
 		properties.validateValue(MODULE_TYPE, MODULE_TYPE_HIVE, false);
-		properties.validateString(MODULE_HIVE_VERSION, false, 1);
+		properties.validateString(MODULE_HIVE_VERSION, true, 1);
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModuleDescriptorValidator.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModuleDescriptorValidator.java
@@ -32,6 +32,6 @@ public class HiveModuleDescriptorValidator extends ModuleDescriptorValidator {
 	public void validate(DescriptorProperties properties) {
 		super.validate(properties);
 		properties.validateValue(MODULE_TYPE, MODULE_TYPE_HIVE, false);
-		properties.validateString(MODULE_HIVE_VERSION, true, 1);
+		properties.validateString(MODULE_HIVE_VERSION, false, 1);
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModuleFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModuleFactory.java
@@ -23,7 +23,7 @@ import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.factories.ModuleFactory;
 import org.apache.flink.table.module.Module;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +66,6 @@ public class HiveModuleFactory implements ModuleFactory {
 
 	@Override
 	public List<String> supportedProperties() {
-		return new ArrayList<>();
+		return Arrays.asList(MODULE_HIVE_VERSION);
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/module/hive/HiveModuleDescriptorTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/module/hive/HiveModuleDescriptorTest.java
@@ -32,9 +32,11 @@ import java.util.Map;
  */
 public class HiveModuleDescriptorTest extends DescriptorTestBase {
 
+	private final String hiveVersion = "2.3.4";
+
 	@Override
 	protected List<Descriptor> descriptors() {
-		final Descriptor descriptor = new HiveModuleDescriptor();
+		final Descriptor descriptor = new HiveModuleDescriptor(hiveVersion);
 
 		return Arrays.asList(descriptor);
 	}
@@ -43,6 +45,7 @@ public class HiveModuleDescriptorTest extends DescriptorTestBase {
 	protected List<Map<String, String>> properties() {
 		final Map<String, String> props1 = new HashMap<>();
 		props1.put("type", "hive");
+		props1.put("hive-version", hiveVersion);
 
 		return Arrays.asList(props1);
 	}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/module/hive/HiveModuleFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/module/hive/HiveModuleFactoryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.module.hive;
+
+import org.apache.flink.table.descriptors.ModuleDescriptor;
+import org.apache.flink.table.factories.ModuleFactory;
+import org.apache.flink.table.factories.TableFactoryService;
+import org.apache.flink.table.module.Module;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+
+/**
+ * Test for {@link HiveModuleFactory}.
+ */
+public class HiveModuleFactoryTest {
+	@Test
+	public void test() {
+		final String hiveVersion = "2.3.4";
+
+		final HiveModule expected = new HiveModule(hiveVersion);
+
+		final ModuleDescriptor moduleDescriptor = new HiveModuleDescriptor(hiveVersion);
+
+		final Map<String, String> properties = moduleDescriptor.toProperties();
+
+		final Module actualModule = TableFactoryService.find(ModuleFactory.class, properties)
+			.createModule(properties);
+
+		checkEquals(expected, (HiveModule) actualModule);
+	}
+
+	private static void checkEquals(HiveModule m1, HiveModule m2) {
+		assertEquals(m1.getHiveVersion(), m2.getHiveVersion());
+	}
+}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
@@ -90,12 +90,14 @@ public class ExecutionContextTest {
 		final TableEnvironment tableEnv = context.getTableEnvironment();
 
 		Set<String> allModules = new HashSet<>(Arrays.asList(tableEnv.listModules()));
-		assertEquals(2, allModules.size());
+		assertEquals(4, allModules.size());
 		assertEquals(
 			new HashSet<>(
 				Arrays.asList(
 					"core",
-					"mymodule")
+					"mymodule",
+					"myhive",
+					"myhive2")
 			),
 			allModules
 		);

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-modules.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-modules.yaml
@@ -49,4 +49,9 @@ modules:
   - name: mymodule
     type: ModuleDependencyTest
     test: test
+  - name: myhive
+    type: hive
+  - name: myhive2
+    type: hive
+    hive-version: 2.3.4
 


### PR DESCRIPTION
## What is the purpose of the change

HiveModuleFactory should have hive-version as property. Currently it cannot pick up hive-version from service discovery

## Brief change log

- added 'hive-version' as supported property
- added UT

## Verifying this change

This change added tests and can be verified as `HiveModuleFactoryTest`

## Does this pull request potentially affect one of the following parts:

n/a

## Documentation

n/a