### PR TITLE
[FLINK-15254][sql cli][module] modules in SQL CLI yaml should preserve order

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Environment.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Environment.java
@@ -69,7 +69,7 @@ public class Environment {
 	private DeploymentEntry deployment;
 
 	public Environment() {
-		this.modules = Collections.emptyMap();
+		this.modules = new LinkedHashMap<>();
 		this.catalogs = Collections.emptyMap();
 		this.tables = Collections.emptyMap();
 		this.functions = Collections.emptyMap();
@@ -83,7 +83,7 @@ public class Environment {
 	}
 
 	public void setModules(List<Map<String, Object>> modules) {
-		this.modules = new HashMap<>(modules.size());
+		this.modules = new LinkedHashMap<>(modules.size());
 
 		modules.forEach(config -> {
 			final ModuleEntry entry = ModuleEntry.create(config);
@@ -235,7 +235,7 @@ public class Environment {
 		final Environment mergedEnv = new Environment();
 
 		// merge modules
-		final Map<String, ModuleEntry> modules = new HashMap<>(env1.getModules());
+		final Map<String, ModuleEntry> modules = new LinkedHashMap<>(env1.getModules());
 		modules.putAll(env2.getModules());
 		mergedEnv.modules = modules;
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/EnvironmentTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/EnvironmentTest.java
@@ -26,6 +26,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -108,6 +109,33 @@ public class EnvironmentTest {
 			createModule("module1", "test"),
 			createModule("module2", "test"),
 			createModule("module2", "test")));
+	}
+
+	@Test
+	public void testModuleOrder() {
+		Environment env1 = new Environment();
+		Environment env2 = new Environment();
+		env1.setModules(Arrays.asList(
+			createModule("b", "test"),
+			createModule("d", "test")));
+
+		env2.setModules(Arrays.asList(
+			createModule("c", "test"),
+			createModule("a", "test")));
+
+		assertEquals(
+			Arrays.asList("b", "d"), new ArrayList<>(env1.getModules().keySet())
+		);
+
+		assertEquals(
+			Arrays.asList("c", "a"), new ArrayList<>(env2.getModules().keySet())
+		);
+
+		Environment env = Environment.merge(env1, env2);
+
+		assertEquals(
+			Arrays.asList("b", "d", "c", "a"), new ArrayList<>(env.getModules().keySet())
+		);
 	}
 
 	private static Map<String, Object> createCatalog(String name, String type) {


### PR DESCRIPTION
## What is the purpose of the change

currently the module map is a hash map in sql cli, which doesn't preserve module loading order from yaml.
fix it by always using a linked hash map

## Brief change log

- always using a linked hash map in sql cli to handle module order
- added UT

## Verifying this change

This change added tests and can be verified as follows: `EnvironmentTest.testModuleOrder`

## Does this pull request potentially affect one of the following parts:

n/a

## Documentation

n/a