### PR TITLE
[FLINK-15251] In Fabric8FlinkKubeClient use ingress hostname if IP is not present

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
@@ -197,6 +197,9 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
 			service.getStatus().getLoadBalancer().getIngress() != null)) {
 			if (service.getStatus().getLoadBalancer().getIngress().size() > 0) {
 				address = service.getStatus().getLoadBalancer().getIngress().get(0).getIp();
+				if (address == null) {
+					address = service.getStatus().getLoadBalancer().getIngress().get(0).getHostname();
+				}
 			} else {
 				address = this.internalClient.getMasterUrl().getHost();
 				restPort = getServiceNodePort(service, RestOptions.PORT);


### PR DESCRIPTION
## What is the purpose of the change

In the Kubernetes client, also use the hostname if the service load balancer doesn't have an IP.

## Verifying this change

I still have to add a test for this, if we agree that it's a good fix.