### PR TITLE
[FLINK-15265] Remove "-executor" suffix from executor names

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutorCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutorCLI.java
@@ -47,7 +47,7 @@ public class ExecutorCLI implements CustomCommandLine {
 	private static final String ID = "Executor-CLI";
 
 	private final Option executorOption = new Option("e", "executor", true,
-			"The name of the executor to be used for executing the given job, e.g. \"local-executor\"." +
+			"The name of the executor to be used for executing the given job, e.g. \"local\"." +
 					" This is equivalent to the \"" + DeploymentOptions.TARGET.key() + "\" config option.");
 
 	/**

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/LocalExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/LocalExecutor.java
@@ -49,7 +49,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 @Internal
 public class LocalExecutor implements Executor {
 
-	public static final String NAME = "local-executor";
+	public static final String NAME = "local";
 
 	@Override
 	public CompletableFuture<JobClient> execute(Pipeline pipeline, Configuration configuration) throws Exception {

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/RemoteExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/RemoteExecutor.java
@@ -30,7 +30,7 @@ import org.apache.flink.core.execution.Executor;
 @Internal
 public class RemoteExecutor extends AbstractSessionClusterExecutor<StandaloneClusterId, StandaloneClientFactory> {
 
-	public static final String NAME = "remote-executor";
+	public static final String NAME = "remote";
 
 	public RemoteExecutor() {
 		super(new StandaloneClientFactory());

--- a/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
@@ -64,7 +64,7 @@ public class LocalEnvironment extends ExecutionEnvironment {
 		}
 
 		final Configuration effectiveConfiguration = new Configuration(checkNotNull(configuration));
-		effectiveConfiguration.set(DeploymentOptions.TARGET, "local-executor");
+		effectiveConfiguration.set(DeploymentOptions.TARGET, "local");
 		effectiveConfiguration.set(DeploymentOptions.ATTACHED, true);
 		return effectiveConfiguration;
 	}

--- a/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
@@ -134,7 +134,7 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 		ConfigUtils.encodeCollectionToConfig(effectiveConfiguration, PipelineOptions.CLASSPATHS, classpaths, URL::toString);
 
 		// these should be set in the end to overwrite any values from the client config provided in the constructor.
-		effectiveConfiguration.setString(DeploymentOptions.TARGET, "remote-executor");
+		effectiveConfiguration.setString(DeploymentOptions.TARGET, "remote");
 		effectiveConfiguration.setBoolean(DeploymentOptions.ATTACHED, true);
 
 		return effectiveConfiguration;

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/executors/KubernetesSessionClusterExecutor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/executors/KubernetesSessionClusterExecutor.java
@@ -29,7 +29,7 @@ import org.apache.flink.kubernetes.KubernetesClusterClientFactory;
 @Internal
 public class KubernetesSessionClusterExecutor extends AbstractSessionClusterExecutor<String, KubernetesClusterClientFactory> {
 
-	public static final String NAME = "kubernetes-session-executor";
+	public static final String NAME = "kubernetes-session";
 
 	public KubernetesSessionClusterExecutor() {
 		super(new KubernetesClusterClientFactory());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
@@ -64,7 +64,7 @@ public class LocalStreamEnvironment extends StreamExecutionEnvironment {
 							"or running in a TestEnvironment context.");
 		}
 		final Configuration effectiveConfiguration = new Configuration(checkNotNull(configuration));
-		effectiveConfiguration.set(DeploymentOptions.TARGET, "local-executor");
+		effectiveConfiguration.set(DeploymentOptions.TARGET, "local");
 		effectiveConfiguration.set(DeploymentOptions.ATTACHED, true);
 		return effectiveConfiguration;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -207,7 +207,7 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 		}
 
 		// these should be set in the end to overwrite any values from the client config provided in the constructor.
-		effectiveConfiguration.setString(DeploymentOptions.TARGET, "remote-executor");
+		effectiveConfiguration.setString(DeploymentOptions.TARGET, "remote");
 		effectiveConfiguration.setBoolean(DeploymentOptions.ATTACHED, true);
 
 		return effectiveConfiguration;

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnJobClusterExecutor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnJobClusterExecutor.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 @Internal
 public class YarnJobClusterExecutor extends AbstractJobClusterExecutor<ApplicationId, YarnClusterClientFactory> {
 
-	public static final String NAME = "yarn-per-job-executor";
+	public static final String NAME = "yarn-per-job";
 
 	public YarnJobClusterExecutor() {
 		super(new YarnClusterClientFactory());

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnSessionClusterExecutor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnSessionClusterExecutor.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 @Internal
 public class YarnSessionClusterExecutor extends AbstractSessionClusterExecutor<ApplicationId, YarnClusterClientFactory> {
 
-	public static final String NAME = "yarn-session-executor";
+	public static final String NAME = "yarn-session";
 
 	public YarnSessionClusterExecutor() {
 		super(new YarnClusterClientFactory());


### PR DESCRIPTION
The executor names always have "-executor" as a suffix, this is
reduntant. Currently, the executor name is also used to retrieve a
ClusterClient, where it is unfortunate that the name has executor as a
suffix. In the future we might provide something like a FlinkClient that
offers a programmatic API for the functionality of bin/flink, here we
would also use the same names.

In reality, the "executor names" are not names of executors but
deployment targets. That's why the current naming seems a bit unnatural.

This is a simple search-and-replace job, no new functionality. So no tests are needed.