### PR TITLE
[FLINK-15269][table] Fix hive dialect limitation to overwrite and partition syntax

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -570,7 +570,12 @@ SqlCreate SqlCreateTable(Span s, boolean replace) :
     }]
     [
         <PARTITIONED> <BY>
-        partitionColumns = ParenthesizedSimpleIdentifierList()
+        partitionColumns = ParenthesizedSimpleIdentifierList() {
+            if (!((FlinkSqlConformance) this.conformance).allowCreatePartitionTable()) {
+                throw SqlUtil.newContextException(getPos(),
+                    ParserResource.RESOURCE.partitionIsOnlyAllowedForHive());
+            }
+        }
     ]
     [
         <WITH>
@@ -636,10 +641,7 @@ SqlNode RichSqlInsert() :
         <INTO>
     |
         <OVERWRITE> {
-            if (!((FlinkSqlConformance) this.conformance).allowInsertOverwrite()) {
-                throw SqlUtil.newContextException(getPos(),
-                    ParserResource.RESOURCE.overwriteIsOnlyAllowedForHive());
-            } else if (RichSqlInsert.isUpsert(keywords)) {
+            if (RichSqlInsert.isUpsert(keywords)) {
                 throw SqlUtil.newContextException(getPos(),
                     ParserResource.RESOURCE.overwriteIsOnlyUsedWithInsert());
             }
@@ -672,12 +674,7 @@ SqlNode RichSqlInsert() :
         }
     ]
     [
-        <PARTITION> PartitionSpecCommaList(partitionList) {
-            if (!((FlinkSqlConformance) this.conformance).allowInsertIntoPartition()) {
-                throw SqlUtil.newContextException(getPos(),
-                    ParserResource.RESOURCE.partitionIsOnlyAllowedForHive());
-            }
-        }
+        <PARTITION> PartitionSpecCommaList(partitionList)
     ]
     source = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY) {
         return new RichSqlInsert(s.end(source), keywordList, extendedKeywordList, table, source,

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -571,9 +571,9 @@ SqlCreate SqlCreateTable(Span s, boolean replace) :
     [
         <PARTITIONED> <BY>
         partitionColumns = ParenthesizedSimpleIdentifierList() {
-            if (!((FlinkSqlConformance) this.conformance).allowCreatePartitionTable()) {
+            if (!((FlinkSqlConformance) this.conformance).allowCreatePartitionedTable()) {
                 throw SqlUtil.newContextException(getPos(),
-                    ParserResource.RESOURCE.partitionIsOnlyAllowedForHive());
+                    ParserResource.RESOURCE.createPartitionedTableIsOnlyAllowedForHive());
             }
         }
     ]

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/utils/ParserResource.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/utils/ParserResource.java
@@ -33,9 +33,6 @@ public interface ParserResource {
 	@Resources.BaseMessage("Multiple WATERMARK statements is not supported yet.")
 	Resources.ExInst<ParseException> multipleWatermarksUnsupported();
 
-	@Resources.BaseMessage("OVERWRITE expression is only allowed for HIVE dialect.")
-	Resources.ExInst<ParseException> overwriteIsOnlyAllowedForHive();
-
 	@Resources.BaseMessage("OVERWRITE expression is only used with INSERT statement.")
 	Resources.ExInst<ParseException> overwriteIsOnlyUsedWithInsert();
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/utils/ParserResource.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/utils/ParserResource.java
@@ -36,6 +36,6 @@ public interface ParserResource {
 	@Resources.BaseMessage("OVERWRITE expression is only used with INSERT statement.")
 	Resources.ExInst<ParseException> overwriteIsOnlyUsedWithInsert();
 
-	@Resources.BaseMessage("PARTITION expression is only allowed for HIVE dialect.")
-	Resources.ExInst<ParseException> partitionIsOnlyAllowedForHive();
+	@Resources.BaseMessage("Creating partitioned table is only allowed for HIVE dialect.")
+	Resources.ExInst<ParseException> createPartitionedTableIsOnlyAllowedForHive();
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/validate/FlinkSqlConformance.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/validate/FlinkSqlConformance.java
@@ -149,11 +149,7 @@ public enum FlinkSqlConformance implements SqlConformance {
 	/**
 	 * Whether to allow "create table T(i int, j int) partitioned by (i)" grammar.
 	 */
-	public boolean allowCreatePartitionTable() {
-		switch (this) {
-			case HIVE:
-				return true;
-		}
-		return false;
+	public boolean allowCreatePartitionedTable() {
+		return this == FlinkSqlConformance.HIVE;
 	}
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/validate/FlinkSqlConformance.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/validate/FlinkSqlConformance.java
@@ -147,20 +147,9 @@ public enum FlinkSqlConformance implements SqlConformance {
 	}
 
 	/**
-	 * Whether to allow "insert into tbl1 partition(col1=val1)" grammar.
+	 * Whether to allow "create table T(i int, j int) partitioned by (i)" grammar.
 	 */
-	public boolean allowInsertIntoPartition() {
-		switch (this) {
-			case HIVE:
-				return true;
-		}
-		return false;
-	}
-
-	/**
-	 * Whether to allow "insert overwrite tbl1 partition(col1=val1)" grammar.
-	 */
-	public boolean allowInsertOverwrite() {
+	public boolean allowCreatePartitionTable() {
 		switch (this) {
 			case HIVE:
 				return true;

--- a/flink-table/flink-sql-parser/src/main/resources/org.apache.flink.sql.parser.utils/ParserResource.properties
+++ b/flink-table/flink-sql-parser/src/main/resources/org.apache.flink.sql.parser.utils/ParserResource.properties
@@ -18,4 +18,4 @@
 #
 MultipleWatermarksUnsupported=Multiple WATERMARK statements is not supported yet.
 OverwriteIsOnlyUsedWithInsert=OVERWRITE expression is only used with INSERT statement.
-PartitionIsOnlyAllowedForHive=PARTITION expression is only allowed for HIVE dialect.
+CreatePartitionedTableIsOnlyAllowedForHive=Creating partitioned table is only allowed for HIVE dialect.

--- a/flink-table/flink-sql-parser/src/main/resources/org.apache.flink.sql.parser.utils/ParserResource.properties
+++ b/flink-table/flink-sql-parser/src/main/resources/org.apache.flink.sql.parser.utils/ParserResource.properties
@@ -17,6 +17,5 @@
 # See wrapper class org.apache.calcite.runtime.CalciteResource.
 #
 MultipleWatermarksUnsupported=Multiple WATERMARK statements is not supported yet.
-OverwriteIsOnlyAllowedForHive=OVERWRITE expression is only allowed for HIVE dialect.
 OverwriteIsOnlyUsedWithInsert=OVERWRITE expression is only used with INSERT statement.
 PartitionIsOnlyAllowedForHive=PARTITION expression is only allowed for HIVE dialect.

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -556,7 +556,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 				"  a bigint,\n" +
 				"  b VARCHAR\n" +
 				") PARTITIONED BY (a^)^ with ( 'x' = 'y', 'asd' = 'dada')";
-		sql(sql).fails("PARTITION expression is only allowed for HIVE dialect.");
+		sql(sql).fails("Creating partitioned table is only allowed for HIVE dialect.");
 	}
 
 	@Test

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -203,6 +203,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 
 	@Test
 	public void testCreateTable() {
+		conformance0 = FlinkSqlConformance.HIVE;
 		check("CREATE TABLE tbl1 (\n" +
 				"  a bigint,\n" +
 				"  h varchar, \n" +
@@ -235,6 +236,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 
 	@Test
 	public void testCreateTableWithComment() {
+		conformance0 = FlinkSqlConformance.HIVE;
 		check("CREATE TABLE tbl1 (\n" +
 				"  a bigint comment 'test column comment AAA.',\n" +
 				"  h varchar, \n" +
@@ -269,6 +271,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 
 	@Test
 	public void testCreateTableWithPrimaryKeyAndUniqueKey() {
+		conformance0 = FlinkSqlConformance.HIVE;
 		check("CREATE TABLE tbl1 (\n" +
 				"  a bigint comment 'test column comment AAA.',\n" +
 				"  h varchar, \n" +
@@ -533,6 +536,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 
 	@Test
 	public void testCreateInvalidPartitionedTable() {
+		conformance0 = FlinkSqlConformance.HIVE;
 		String sql = "create table sls_stream1(\n" +
 			"  a bigint,\n" +
 			"  b VARCHAR,\n" +
@@ -543,7 +547,16 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 			") with ( 'x' = 'y', 'asd' = 'dada')";
 		sql(sql).node(new ValidationMatcher()
 			.fails("Partition column [C] not defined in columns, at line 6, column 3"));
+	}
 
+	@Test
+	public void testNotAllowedCreatePartition() {
+		conformance0 = FlinkSqlConformance.DEFAULT;
+		String sql = "create table sls_stream1(\n" +
+				"  a bigint,\n" +
+				"  b VARCHAR\n" +
+				") PARTITIONED BY (a^)^ with ( 'x' = 'y', 'asd' = 'dada')";
+		sql(sql).fails("PARTITION expression is only allowed for HIVE dialect.");
 	}
 
 	@Test
@@ -598,7 +611,6 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 
 	@Test
 	public void testInsertPartitionSpecs() {
-		conformance0 = FlinkSqlConformance.HIVE;
 		final String sql1 = "insert into emps(x,y) partition (x='ab', y='bc') select * from emps";
 		final String expected = "INSERT INTO `EMPS` (`X`, `Y`)\n"
 			+ "PARTITION (`X` = 'ab', `Y` = 'bc')\n"
@@ -620,7 +632,6 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 
 	@Test
 	public void testInsertCaseSensitivePartitionSpecs() {
-		conformance0 = FlinkSqlConformance.HIVE;
 		final String expected = "INSERT INTO `emps` (`x`, `y`)\n"
 			+ "PARTITION (`x` = 'ab', `y` = 'bc')\n"
 			+ "(SELECT *\n"
@@ -632,7 +643,6 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 
 	@Test
 	public void testInsertExtendedColumnAsStaticPartition1() {
-		conformance0 = FlinkSqlConformance.HIVE;
 		String expected = "INSERT INTO `EMPS` EXTEND (`Z` BOOLEAN) (`X`, `Y`)\n"
 			+ "PARTITION (`Z` = 'ab')\n"
 			+ "(SELECT *\n"
@@ -643,7 +653,6 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 
 	@Test(expected = SqlParseException.class)
 	public void testInsertExtendedColumnAsStaticPartition2() {
-		conformance0 = FlinkSqlConformance.HIVE;
 		sql("insert into emps(x, y, z boolean) partition (z='ab') select * from emps")
 			.node(new ValidationMatcher()
 				.fails("Extended columns not allowed under the current SQL conformance level"));
@@ -651,7 +660,6 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 
 	@Test
 	public void testInsertOverwrite() {
-		conformance0 = FlinkSqlConformance.HIVE;
 		// non-partitioned
 		check("INSERT OVERWRITE myDB.myTbl SELECT * FROM src",
 			"INSERT OVERWRITE `MYDB`.`MYTBL`\n"
@@ -668,7 +676,6 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 
 	@Test
 	public void testInvalidUpsertOverwrite() {
-		conformance0 = FlinkSqlConformance.HIVE;
 		sql("UPSERT ^OVERWRITE^ myDB.myTbl SELECT * FROM src")
 			.fails("OVERWRITE expression is only used with INSERT statement.");
 	}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -241,8 +241,8 @@ public class SqlToOperationConverterTest {
 			"    'connector' = 'kafka', \n" +
 			"    'kafka.topic' = 'log.test'\n" +
 			")\n";
-		FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
-		final CalciteParser parser = getParserBySqlDialect(SqlDialect.DEFAULT);
+		FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.HIVE);
+		final CalciteParser parser = getParserBySqlDialect(SqlDialect.HIVE);
 		Operation operation = parse(sql, planner, parser);
 		assert operation instanceof CreateTableOperation;
 		CreateTableOperation op = (CreateTableOperation) operation;
@@ -260,8 +260,8 @@ public class SqlToOperationConverterTest {
 
 	@Test(expected = SqlConversionException.class)
 	public void testCreateTableWithPkUniqueKeys() {
-		FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
-		final CalciteParser parser = getParserBySqlDialect(SqlDialect.DEFAULT);
+		FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.HIVE);
+		final CalciteParser parser = getParserBySqlDialect(SqlDialect.HIVE);
 		final String sql = "CREATE TABLE tbl1 (\n" +
 			"  a bigint,\n" +
 			"  b varchar, \n" +
@@ -348,8 +348,8 @@ public class SqlToOperationConverterTest {
 	@Test
 	public void testSqlInsertWithStaticPartition() {
 		final String sql = "insert into t1 partition(a=1) select b, c, d from t2";
-		FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.HIVE);
-		final CalciteParser parser = getParserBySqlDialect(SqlDialect.HIVE);
+		FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
+		final CalciteParser parser = getParserBySqlDialect(SqlDialect.DEFAULT);
 		Operation operation = parse(sql, planner, parser);
 		assert operation instanceof CatalogSinkModifyOperation;
 		CatalogSinkModifyOperation sinkModifyOperation = (CatalogSinkModifyOperation) operation;

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.scala
@@ -30,9 +30,7 @@ import org.junit.Test
 
 class PartitionableSinkTest extends TableTestBase {
 
-  val conf = new TableConfig
-  conf.setSqlDialect(SqlDialect.HIVE)
-  private val util = batchTestUtil(conf)
+  private val util = batchTestUtil()
   util.addTableSource[(Long, Long, Long)]("MyTable", 'a, 'b, 'c)
   PartitionableSinkITCase.registerTableSink(
     util.tableEnv,

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/PartitionableSinkTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/PartitionableSinkTest.scala
@@ -30,9 +30,7 @@ import org.junit.Test
 
 class PartitionableSinkTest extends TableTestBase {
 
-  val conf = new TableConfig
-  conf.setSqlDialect(SqlDialect.HIVE)
-  private val util = streamTestUtil(conf)
+  private val util = streamTestUtil()
   util.addTableSource[(Long, Long, Long)]("MyTable", 'a, 'b, 'c)
   PartitionableSinkITCase.registerTableSink(
     util.tableEnv,

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSinkITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSinkITCase.scala
@@ -70,7 +70,6 @@ class PartitionableSinkITCase extends BatchTestBase {
     tEnv.getConfig
       .getConfiguration
       .setInteger(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 3)
-    tEnv.getConfig.setSqlDialect(SqlDialect.HIVE)
     registerCollection("nonSortTable", testData, type3, "a, b, c", dataNullables)
     registerCollection("sortTable", testData1, type3, "a, b, c", dataNullables)
     PartitionableSinkITCase.init()

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
@@ -241,8 +241,8 @@ public class SqlToOperationConverterTest {
 			"    'connector' = 'kafka', \n" +
 			"    'kafka.topic' = 'log.test'\n" +
 			")\n";
-		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
-		SqlNode node = getParserBySqlDialect(SqlDialect.DEFAULT).parse(sql);
+		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.HIVE);
+		SqlNode node = getParserBySqlDialect(SqlDialect.HIVE).parse(sql);
 		assert node instanceof SqlCreateTable;
 		Operation operation = SqlToOperationConverter.convert(planner, catalogManager, node).get();
 		assert operation instanceof CreateTableOperation;
@@ -302,8 +302,8 @@ public class SqlToOperationConverterTest {
 			"    'connector' = 'kafka', \n" +
 			"    'kafka.topic' = 'log.test'\n" +
 			")\n";
-		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
-		SqlNode node = getParserBySqlDialect(SqlDialect.DEFAULT).parse(sql);
+		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.HIVE);
+		SqlNode node = getParserBySqlDialect(SqlDialect.HIVE).parse(sql);
 		assert node instanceof SqlCreateTable;
 		SqlToOperationConverter.convert(planner, catalogManager, node);
 	}
@@ -311,8 +311,8 @@ public class SqlToOperationConverterTest {
 	@Test
 	public void testSqlInsertWithStaticPartition() {
 		final String sql = "insert into t1 partition(a=1) select b, c, d from t2";
-		FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.HIVE);
-		SqlNode node = getParserBySqlDialect(SqlDialect.HIVE).parse(sql);
+		FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
+		SqlNode node = getParserBySqlDialect(SqlDialect.DEFAULT).parse(sql);
 		assert node instanceof RichSqlInsert;
 		Operation operation = SqlToOperationConverter.convert(planner, catalogManager, node).get();
 		assert operation instanceof CatalogSinkModifyOperation;


### PR DESCRIPTION

## What is the purpose of the change

We should support "INSERT OVERWRITE" "INSERT ... PARTITION()" without dialect limitation.
As http://apache-flink-mailing-list-archive.1008284.n3.nabble.com/DISCUSS-Overwrite-and-partition-inserting-support-in-1-10-td35829.html#a35885 discussed.

## Brief change log

We should:
- Remove hive dialect limitation for supported "INSERT OVERWRITE" and "INSERT ... PARTITION(...)".
- Limit "CREATE TABLE ... PARTITIONED BY" to hive dialect.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no