### PR TITLE
[FLINK-15272][table-planner-blink] Better error message when insert partition with values

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/PreValidateReWriter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/PreValidateReWriter.scala
@@ -51,7 +51,8 @@ class PreValidateReWriter(
           appendPartitionProjects(r, catalogReader, typeFactory, select, r.getStaticPartitions)
         case source =>
           throw new ValidationException(
-            s"INSERT INTO <table> PARTITION statement only support SELECT clause for now, '$source' is not supported yet.")
+            s"INSERT INTO <table> PARTITION statement only support SELECT clause for now," +
+                s" '$source' is not supported yet.")
       }
       case _ =>
     }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/PreValidateReWriter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/PreValidateReWriter.scala
@@ -51,7 +51,7 @@ class PreValidateReWriter(
           appendPartitionProjects(r, catalogReader, typeFactory, select, r.getStaticPartitions)
         case source =>
           throw new ValidationException(
-            s"Only support static partitions with select, current is: $source")
+            s"INSERT INTO <table> PARTITION statement only support SELECT clause for now, '$source' is not supported yet.")
       }
       case _ =>
     }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/PreValidateReWriter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/PreValidateReWriter.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.calcite
 
 import org.apache.flink.sql.parser.SqlProperty
 import org.apache.flink.sql.parser.dml.RichSqlInsert
+import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.planner.calcite.PreValidateReWriter.appendPartitionProjects
 
 import org.apache.calcite.plan.RelOptTable
@@ -45,10 +46,13 @@ class PreValidateReWriter(
     val typeFactory: RelDataTypeFactory) extends SqlBasicVisitor[Unit] {
   override def visit(call: SqlCall): Unit = {
     call match {
-      case r: RichSqlInsert if r.getStaticPartitions.nonEmpty
-        && r.getSource.isInstanceOf[SqlSelect] =>
-        appendPartitionProjects(r, catalogReader, typeFactory,
-          r.getSource.asInstanceOf[SqlSelect], r.getStaticPartitions)
+      case r: RichSqlInsert if r.getStaticPartitions.nonEmpty => r.getSource match {
+        case select: SqlSelect =>
+          appendPartitionProjects(r, catalogReader, typeFactory, select, r.getStaticPartitions)
+        case source =>
+          throw new ValidationException(
+            s"Only support static partitions with select, current is: $source")
+      }
       case _ =>
     }
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.scala
@@ -71,7 +71,9 @@ class PartitionableSinkTest extends TableTestBase {
   @Test
   def testStaticWithValues(): Unit = {
     thrown.expect(classOf[ValidationException])
-    thrown.expectMessage("Only support static partitions with select, current is: VALUES ROW(5)")
+    thrown.expectMessage(
+      "INSERT INTO <table> PARTITION statement only support SELECT clause for now," +
+          " 'VALUES ROW(5)' is not supported yet")
     util.verifySqlUpdate("INSERT INTO sink PARTITION (b=1, c=1) VALUES (5)")
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.scala
@@ -67,4 +67,11 @@ class PartitionableSinkTest extends TableTestBase {
   def testWrongFields(): Unit = {
     util.verifySqlUpdate("INSERT INTO sink PARTITION (b=1) SELECT a, b, c FROM MyTable")
   }
+
+  @Test
+  def testStaticWithValues(): Unit = {
+    thrown.expect(classOf[ValidationException])
+    thrown.expectMessage("Only support static partitions with select, current is: VALUES ROW(5)")
+    util.verifySqlUpdate("INSERT INTO sink PARTITION (b=1, c=1) VALUES (5)")
+  }
 }


### PR DESCRIPTION

## What is the purpose of the change

Now, we not support insert partition with values like:
```
Insert into mytable partition (date='2019-08-08') values ('jason', 25)
```
Will throw a exception:
schema not match.

We should improve error message to tell user we not support this pattern.

## Brief change log

Check insert partition with select, others will throw validate exception.

## Verifying this change

PartitionableSinkTest.testStaticWithValues

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no