### PR TITLE
[FLINK-15266] Fix NPE for case operator code gen in blink planner

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1279,11 +1279,12 @@ object ScalarOperatorGens {
 
       val Seq(resultTerm, nullTerm) = newNames("result", "isNull")
       val resultTypeTerm = primitiveTypeTermForType(resultType)
+      val defaultValue = primitiveDefaultValue(resultType)
 
       val operatorCode = if (ctx.nullCheck) {
         s"""
            |${condition.code}
-           |$resultTypeTerm $resultTerm;
+           |$resultTypeTerm $resultTerm = $defaultValue;
            |boolean $nullTerm;
            |if (${condition.resultTerm}) {
            |  ${trueAction.code}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1287,17 +1287,17 @@ object ScalarOperatorGens {
            |boolean $nullTerm;
            |if (${condition.resultTerm}) {
            |  ${trueAction.code}
-           |  if (!${trueAction.nullTerm}) {
+           |  $nullTerm = ${trueAction.nullTerm};
+           |  if (!$nullTerm) {
            |    $resultTerm = ${trueAction.resultTerm};
            |  }
-           |  $nullTerm = ${trueAction.nullTerm};
            |}
            |else {
            |  ${falseAction.code}
-           |  if (!${falseAction.nullTerm}) {
+           |  $nullTerm = ${falseAction.nullTerm};
+           |  if (!$nullTerm) {
            |    $resultTerm = ${falseAction.resultTerm};
            |  }
-           |  $nullTerm = ${falseAction.nullTerm};
            |}
            |""".stripMargin.trim
       }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1278,11 +1278,7 @@ object ScalarOperatorGens {
       val falseAction = generateIfElse(ctx, operands, resultType, i + 2)
 
       val Seq(resultTerm, nullTerm) = newNames("result", "isNull")
-      val resultTypeTerm = if (trueAction.resultType.isNullable || falseAction.resultType.isNullable) {
-        boxedTypeTermForType(resultType)
-      } else {
-        primitiveTypeTermForType(resultType)
-      }
+      val resultTypeTerm = primitiveTypeTermForType(resultType)
 
       val operatorCode = if (ctx.nullCheck) {
         s"""
@@ -1291,12 +1287,16 @@ object ScalarOperatorGens {
            |boolean $nullTerm;
            |if (${condition.resultTerm}) {
            |  ${trueAction.code}
-           |  $resultTerm = ${trueAction.resultTerm};
+           |  if (!${trueAction.nullTerm}) {
+           |    $resultTerm = ${trueAction.resultTerm};
+           |  }
            |  $nullTerm = ${trueAction.nullTerm};
            |}
            |else {
            |  ${falseAction.code}
-           |  $resultTerm = ${falseAction.resultTerm};
+           |  if (!${falseAction.nullTerm}) {
+           |    $resultTerm = ${falseAction.resultTerm};
+           |  }
            |  $nullTerm = ${falseAction.nullTerm};
            |}
            |""".stripMargin.trim

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1278,7 +1278,11 @@ object ScalarOperatorGens {
       val falseAction = generateIfElse(ctx, operands, resultType, i + 2)
 
       val Seq(resultTerm, nullTerm) = newNames("result", "isNull")
-      val resultTypeTerm = primitiveTypeTermForType(resultType)
+      val resultTypeTerm = if (trueAction.resultType.isNullable || falseAction.resultType.isNullable) {
+        boxedTypeTermForType(resultType)
+      } else {
+        primitiveTypeTermForType(resultType)
+      }
 
       val operatorCode = if (ctx.nullCheck) {
         s"""

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarOperatorsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarOperatorsTest.scala
@@ -122,5 +122,7 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testSqlApi("CASE f7 WHEN 1 THEN 11 WHEN 2 THEN 4 ELSE NULL END", "null")
     testSqlApi("CASE 42 WHEN 1 THEN 'a' WHEN 2 THEN 'bcd' END", "null")
     testSqlApi("CASE 1 WHEN 1 THEN true WHEN 2 THEN false ELSE NULL END", "true")
+
+    testSqlApi("CASE WHEN f2 = 1 THEN CAST('' as INT) ELSE 0 END", "null")
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pr fixes the NPE bug in blink case operator code gen as described in FLINK-15266. 

## Brief change log

For case operator result type, generate primitive type only when trueAction and falseAction both return non-null types.

## Verifying this change


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
