### PR TITLE
[Flink-13197] Fix Hive view row type mismatch when expanding in planner

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/SqlCatalogViewTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/SqlCatalogViewTable.java
@@ -21,7 +21,7 @@ package org.apache.flink.table.planner.catalog;
 import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.planner.plan.schema.ExpandingPreparingTable;
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
-import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil;
+import org.apache.flink.table.planner.plan.utils.RelOptUtils;
 
 import org.apache.calcite.plan.RelOptSchema;
 import org.apache.calcite.rel.RelNode;
@@ -57,6 +57,6 @@ public class SqlCatalogViewTable extends ExpandingPreparingTable {
 		RelNode original = context
 				.expandView(rowType, view.getExpandedQuery(), viewPath, names)
 				.project();
-		return FlinkRelOptUtil.createCastRel(original, rowType);
+		return RelOptUtils.createCastRel(original, rowType);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/SqlCatalogViewTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/SqlCatalogViewTable.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.catalog;
 import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.planner.plan.schema.ExpandingPreparingTable;
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
+import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil;
 
 import org.apache.calcite.plan.RelOptSchema;
 import org.apache.calcite.rel.RelNode;
@@ -53,6 +54,9 @@ public class SqlCatalogViewTable extends ExpandingPreparingTable {
 
 	@Override
 	public RelNode convertToRel(ToRelContext context) {
-		return context.expandView(rowType, view.getExpandedQuery(), viewPath, names).project();
+		RelNode original = context
+				.expandView(rowType, view.getExpandedQuery(), viewPath, names)
+				.project();
+		return FlinkRelOptUtil.createCastRel(original, rowType);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/utils/RelOptUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/utils/RelOptUtils.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.utils;
+
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.RelFactories;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <code>RelOptUtils</code> defines static utility methods for use in optimizing
+ * {@link RelNode}s.
+ *
+ * <p>This is an extension of {@link org.apache.calcite.plan.RelOptUtil}.
+ */
+public class RelOptUtils {
+	/**
+	 * Creates a projection which casts a rel's output to a desired row type.
+	 *
+	 * <p>This method is inspired by {@link RelOptUtil#createCastRel}, different with that,
+	 * we do not generate another {@link Project} if the {@code rel} is already a {@link Project}.
+	 *
+	 * @param rel Producer of rows to be converted
+	 * @param castRowType Row type after cast
+	 * @return Conversion rel with castRowType
+	 */
+	public static RelNode createCastRel(RelNode rel, RelDataType castRowType) {
+		RelFactories.ProjectFactory projectFactory = RelFactories.DEFAULT_PROJECT_FACTORY;
+		final RelDataType oriRowType = rel.getRowType();
+		if (RelOptUtil.areRowTypesEqual(oriRowType, castRowType, true)) {
+			// nothing to do
+			return rel;
+		}
+		final RexBuilder rexBuilder = rel.getCluster().getRexBuilder();
+
+		final List<RelDataTypeField> fieldList = oriRowType.getFieldList();
+		int n = fieldList.size();
+		assert n == castRowType.getFieldCount()
+				: "field count: lhs [" + castRowType + "] rhs [" + oriRowType +"]";
+		List<RexNode> rhsExps = null;
+		RelNode input = null;
+		if (rel instanceof Project) {
+			rhsExps = ((Project) rel).getProjects();
+			// Avoid to generate redundant project node.
+			input = rel.getInput(0);
+		} else {
+			rhsExps = new ArrayList<>();
+			for (RelDataTypeField field : fieldList) {
+				rhsExps.add(rexBuilder.makeInputRef(field.getType(), field.getIndex()));
+			}
+			input = rel;
+		}
+		final List<RexNode> castExps =
+				RexUtil.generateCastExpressions(rexBuilder, castRowType, rhsExps);
+		// Use names and types from castRowType.
+		return projectFactory.createProject(input, castExps,
+				castRowType.getFieldNames());
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/utils/RelOptUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/utils/RelOptUtils.java
@@ -60,7 +60,7 @@ public class RelOptUtils {
 		final List<RelDataTypeField> fieldList = oriRowType.getFieldList();
 		int n = fieldList.size();
 		assert n == castRowType.getFieldCount()
-				: "field count: lhs [" + castRowType + "] rhs [" + oriRowType +"]";
+				: "field count: lhs [" + castRowType + "] rhs [" + oriRowType + "]";
 		List<RexNode> rhsExps = null;
 		RelNode input = null;
 		if (rel instanceof Project) {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
@@ -30,7 +30,7 @@ import org.apache.calcite.rel.{RelFieldCollation, RelRoot}
 import org.apache.calcite.sql.advise.{SqlAdvisor, SqlAdvisorValidator}
 import org.apache.calcite.sql.{SqlKind, SqlNode, SqlOperatorTable}
 import org.apache.calcite.sql2rel.{SqlRexConvertletTable, SqlToRelConverter}
-import org.apache.calcite.tools.{FrameworkConfig, RelBuilder, RelConversionException}
+import org.apache.calcite.tools.{FrameworkConfig, RelConversionException}
 
 import java.lang.{Boolean => JBoolean}
 import java.util
@@ -185,19 +185,7 @@ class FlinkPlannerImpl(
     )
     val validator = createSqlValidator(readerWithPathAdjusted)
     val validated = validate(parsed, validator)
-    val equivRel = rel(validated, validator)
-    if (!RelOptUtil.areRowTypesEqual(
-      rowType,
-      equivRel.validatedRowType,
-      true
-    )) {
-      throw new TableException(
-        s"""Could not expand view. Types mismatch.
-           | Expected row type: $rowType
-           | Expanded view type: ${equivRel.validatedRowType}
-           |""".stripMargin)
-    }
-    equivRel
+    rel(validated, validator)
   }
 
   override def createRelBuilder(): FlinkRelBuilder = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRelOptUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRelOptUtil.scala
@@ -20,13 +20,11 @@ package org.apache.flink.table.planner.plan.utils
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkPlannerImpl, FlinkTypeFactory}
 import org.apache.flink.table.planner.plan.`trait`.{MiniBatchInterval, MiniBatchMode}
-import org.apache.flink.table.planner.{JArrayList, JBoolean, JByte, JDouble, JFloat, JList, JLong, JShort}
+import org.apache.flink.table.planner.{JBoolean, JByte, JDouble, JFloat, JLong, JShort}
 
 import org.apache.calcite.config.NullCollation
 import org.apache.calcite.plan.RelOptUtil
 import org.apache.calcite.rel.RelFieldCollation.{Direction, NullDirection}
-import org.apache.calcite.rel.`type`.RelDataType
-import org.apache.calcite.rel.core.{Project, RelFactories}
 import org.apache.calcite.rel.{RelFieldCollation, RelNode}
 import org.apache.calcite.rex.{RexBuilder, RexCall, RexInputRef, RexLiteral, RexNode, RexUtil, RexVisitorImpl}
 import org.apache.calcite.sql.SqlExplainLevel
@@ -496,49 +494,4 @@ object FlinkRelOptUtil {
         }
     }
   }
-
-  /**
-   * Creates a projection which casts a rel's output to a desired row type.
-   *
-   * <p>This method is inspired by [[RelOptUtil.createCastRel]], different with that,
-   * we do not generate another Project if the rel is already a [[Project]].
-   *
-   * @param rel Producer of rows to be converted
-   * @param castRowType Row type after cast
-   * @return Conversion rel with castRowType
-   */
-  def createCastRel(
-      rel: RelNode,
-      castRowType: RelDataType): RelNode = {
-    val projectFactory = RelFactories.DEFAULT_PROJECT_FACTORY;
-    val oriRowType = rel.getRowType;
-    if (RelOptUtil.areRowTypesEqual(oriRowType, castRowType, true)) {
-      // nothing to do
-      return rel
-    }
-    val rexBuilder = rel.getCluster.getRexBuilder
-
-    val fieldList = oriRowType.getFieldList
-    val n = fieldList.size();
-    assert(n == castRowType.getFieldCount, s"field count: lhs [$castRowType] rhs [$oriRowType]")
-    var rhsExps: JList[RexNode] = null
-    var input: RelNode = null
-    rel match {
-      case prj: Project =>
-        rhsExps = prj.getProjects
-        // Avoid to generate redundant project node.
-        input = rel.getInput(0);
-      case _ =>
-        rhsExps = new JArrayList[RexNode]
-        for (field <- fieldList) {
-          rhsExps.add(rexBuilder.makeInputRef(field.getType, field.getIndex));
-        }
-        input = rel
-    }
-    val castExps = RexUtil.generateCastExpressions(rexBuilder, castRowType, rhsExps)
-    // Use names and types from castRowType.
-    projectFactory.createProject(input, castExps,
-      castRowType.getFieldNames);
-  }
-
 }

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/common/ViewsExpandingTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/common/ViewsExpandingTest.xml
@@ -120,4 +120,56 @@ DataStreamScan(table=[[default_catalog, default_database, t1]], fields=[a, b, c]
 
     </Resource>
   </TestCase>
+  <TestCase name="testViewExpandingWithMismatchRowType[0]">
+    <Resource name="sql">
+      <![CDATA[select * from view4]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[CAST($2):INTEGER])
++- LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT($2)])
+   +- LogicalProject(a=[CAST($0):INTEGER NOT NULL], b=[$1], c=[CAST($2):INTEGER])
+      +- LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT($2)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, CAST(EXPR$2) AS c])
++- HashAggregate(isMerge=[true], groupBy=[a, b], select=[a, b, Final_COUNT(count$0) AS EXPR$2])
+   +- Exchange(distribution=[hash[a, b]])
+      +- LocalHashAggregate(groupBy=[a, b], select=[a, b, Partial_COUNT(c) AS count$0])
+         +- Calc(select=[CAST(a) AS a, b, CAST(EXPR$2) AS c])
+            +- HashAggregate(isMerge=[true], groupBy=[a, b], select=[a, b, Final_COUNT(count$0) AS EXPR$2])
+               +- Exchange(distribution=[hash[a, b]])
+                  +- LocalHashAggregate(groupBy=[a, b], select=[a, b, Partial_COUNT(c) AS count$0])
+                     +- BoundedStreamScan(table=[[default_catalog, default_database, t1]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testViewExpandingWithMismatchRowType[1]">
+    <Resource name="sql">
+      <![CDATA[select * from view4]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[CAST($2):INTEGER])
++- LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT($2)])
+   +- LogicalProject(a=[CAST($0):INTEGER NOT NULL], b=[$1], c=[CAST($2):INTEGER])
+      +- LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT($2)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, CAST(EXPR$2) AS c])
++- GroupAggregate(groupBy=[a, b], select=[a, b, COUNT_RETRACT(c) AS EXPR$2])
+   +- Exchange(distribution=[hash[a, b]])
+      +- Calc(select=[CAST(a) AS a, b, CAST(EXPR$2) AS c])
+         +- GroupAggregate(groupBy=[a, b], select=[a, b, COUNT(c) AS EXPR$2])
+            +- Exchange(distribution=[hash[a, b]])
+               +- DataStreamScan(table=[[default_catalog, default_database, t1]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/common/ViewsExpandingTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/common/ViewsExpandingTest.xml
@@ -122,53 +122,42 @@ DataStreamScan(table=[[default_catalog, default_database, t1]], fields=[a, b, c]
   </TestCase>
   <TestCase name="testViewExpandingWithMismatchRowType[0]">
     <Resource name="sql">
-      <![CDATA[select * from view4]]>
+      <![CDATA[select * from view1]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[CAST($2):INTEGER])
+LogicalProject(a=[CAST($0):INTEGER NOT NULL], b=[$1], c=[CAST($2):INTEGER])
 +- LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT($2)])
-   +- LogicalProject(a=[CAST($0):INTEGER NOT NULL], b=[$1], c=[CAST($2):INTEGER])
-      +- LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT($2)])
-         +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Calc(select=[a, b, CAST(EXPR$2) AS c])
+Calc(select=[CAST(a) AS a, b, CAST(EXPR$2) AS c])
 +- HashAggregate(isMerge=[true], groupBy=[a, b], select=[a, b, Final_COUNT(count$0) AS EXPR$2])
    +- Exchange(distribution=[hash[a, b]])
       +- LocalHashAggregate(groupBy=[a, b], select=[a, b, Partial_COUNT(c) AS count$0])
-         +- Calc(select=[CAST(a) AS a, b, CAST(EXPR$2) AS c])
-            +- HashAggregate(isMerge=[true], groupBy=[a, b], select=[a, b, Final_COUNT(count$0) AS EXPR$2])
-               +- Exchange(distribution=[hash[a, b]])
-                  +- LocalHashAggregate(groupBy=[a, b], select=[a, b, Partial_COUNT(c) AS count$0])
-                     +- BoundedStreamScan(table=[[default_catalog, default_database, t1]], fields=[a, b, c])
+         +- BoundedStreamScan(table=[[default_catalog, default_database, t1]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testViewExpandingWithMismatchRowType[1]">
     <Resource name="sql">
-      <![CDATA[select * from view4]]>
+      <![CDATA[select * from view1]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[CAST($2):INTEGER])
+LogicalProject(a=[CAST($0):INTEGER NOT NULL], b=[$1], c=[CAST($2):INTEGER])
 +- LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT($2)])
-   +- LogicalProject(a=[CAST($0):INTEGER NOT NULL], b=[$1], c=[CAST($2):INTEGER])
-      +- LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT($2)])
-         +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Calc(select=[a, b, CAST(EXPR$2) AS c])
-+- GroupAggregate(groupBy=[a, b], select=[a, b, COUNT_RETRACT(c) AS EXPR$2])
+Calc(select=[CAST(a) AS a, b, CAST(EXPR$2) AS c])
++- GroupAggregate(groupBy=[a, b], select=[a, b, COUNT(c) AS EXPR$2])
    +- Exchange(distribution=[hash[a, b]])
-      +- Calc(select=[CAST(a) AS a, b, CAST(EXPR$2) AS c])
-         +- GroupAggregate(groupBy=[a, b], select=[a, b, COUNT(c) AS EXPR$2])
-            +- Exchange(distribution=[hash[a, b]])
-               +- DataStreamScan(table=[[default_catalog, default_database, t1]], fields=[a, b, c])
+      +- DataStreamScan(table=[[default_catalog, default_database, t1]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/common/ViewsExpandingTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/common/ViewsExpandingTest.scala
@@ -114,14 +114,7 @@ class ViewsExpandingTest(tableTestUtil: TableTestBase => TableTestUtil) extends 
       new ObjectPath(tableEnv.getCurrentDatabase, "view1"),
       createAggSqlView("t1"),
       false)
-    tableEnv.createTemporaryView("view2", tableEnv.from("view1"))
-    catalog.createTable(
-      new ObjectPath(tableEnv.getCurrentDatabase, "view3"),
-      createAggSqlView("view2"),
-      false)
-    tableEnv.createTemporaryView("view4", tableEnv.from("view3"))
-
-    tableUtil.verifyPlan("select * from view4")
+    tableUtil.verifyPlan("select * from view1")
   }
 
   private def createSqlView(originTable: String): CatalogView = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/FlinkPlannerImpl.scala
@@ -177,19 +177,7 @@ class FlinkPlannerImpl(
     )
     val validator = createSqlValidator(readerWithPathAdjusted)
     val validated = validateInternal(parsed, validator)
-    val equivRel = rel(validated, validator)
-    if (!RelOptUtil.areRowTypesEqual(
-      rowType,
-      equivRel.validatedRowType,
-      true
-    )) {
-      throw new TableException(
-        s"""Could not expand view. Types mismatch.
-           | Expected row type: $rowType
-           | Expanded view type: ${equivRel.validatedRowType}
-           |""".stripMargin)
-    }
-    equivRel
+    rel(validated, validator)
   }
 
   private def createRexBuilder: RexBuilder = {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/CatalogStructureBuilder.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/CatalogStructureBuilder.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.api.Types;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.types.Row;
 
@@ -176,6 +175,8 @@ public class CatalogStructureBuilder {
 	public interface DatabaseEntryBuilder {
 		String getName();
 
+		DatabaseEntryBuilder withTableSchema(TableSchema tableSchema);
+
 		CatalogBaseTable build(String path);
 	}
 
@@ -184,6 +185,7 @@ public class CatalogStructureBuilder {
 	 */
 	public static class TableBuilder implements DatabaseEntryBuilder {
 		private final String name;
+		private TableSchema tableSchema = TableSchema.builder().build();
 
 		TableBuilder(String name) {
 			this.name = name;
@@ -193,8 +195,17 @@ public class CatalogStructureBuilder {
 			return name;
 		}
 
+		@Override
+		public TableBuilder withTableSchema(TableSchema tableSchema) {
+			this.tableSchema = Objects.requireNonNull(tableSchema);
+			return this;
+		}
+
 		public TestTable build(String path) {
-			return new TestTable(path + "." + name, false);
+			return new TestTable(
+				path + "." + name,
+				tableSchema,
+				false);
 		}
 	}
 
@@ -203,6 +214,7 @@ public class CatalogStructureBuilder {
 	 */
 	public static class ViewBuilder implements DatabaseEntryBuilder {
 		private final String name;
+		private TableSchema tableSchema = TableSchema.builder().build();
 		private String query;
 
 		ViewBuilder(String name) {
@@ -218,11 +230,17 @@ public class CatalogStructureBuilder {
 			return this;
 		}
 
+		@Override
+		public ViewBuilder withTableSchema(TableSchema tableSchema) {
+			this.tableSchema = Objects.requireNonNull(tableSchema);
+			return this;
+		}
+
 		public TestView build(String path) {
 			return new TestView(
 				query,
 				query,
-				TableSchema.builder().build(),
+				tableSchema,
 				Collections.emptyMap(),
 				"",
 				true,
@@ -241,7 +259,10 @@ public class CatalogStructureBuilder {
 			return isTemporary;
 		}
 
-		private TestTable(String fullyQualifiedPath, boolean isTemporary) {
+		private TestTable(
+				String fullyQualifiedPath,
+				TableSchema tableSchema,
+				boolean isTemporary) {
 			super(new StreamTableSource<Row>() {
 				@Override
 				public DataStream<Row> getDataStream(StreamExecutionEnvironment execEnv) {
@@ -250,12 +271,12 @@ public class CatalogStructureBuilder {
 
 				@Override
 				public TypeInformation<Row> getReturnType() {
-					return Types.ROW();
+					return tableSchema.toRowType();
 				}
 
 				@Override
 				public TableSchema getTableSchema() {
-					return TableSchema.builder().build();
+					return tableSchema;
 				}
 
 				@Override
@@ -266,6 +287,10 @@ public class CatalogStructureBuilder {
 
 			this.fullyQualifiedPath = fullyQualifiedPath;
 			this.isTemporary = isTemporary;
+		}
+
+		private TestTable(String fullyQualifiedPath, boolean isTemporary) {
+			this(fullyQualifiedPath, TableSchema.builder().build(), isTemporary);
 		}
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change

This PR fix the row type mismatch for view expanding in planner, for example: row fields name and type mismatch.


## Brief change log

  - In blink planner, add `FlinkRelOptUtil#createCastRel` to add cast rel based on specific conditions
  - Remove the type mismatch check in `FlinkPlannerImpl` for both planner
  - Add test cases for anonymous column and field type mismatch


## Verifying this change

See tests in `ViewExpansionTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no
