### PR TITLE
[FLINK-15270][python][docs] Add documentation about how to specify third-party dependencies via API for Python UDFs

### DIFF
--- a/docs/dev/table/functions/udfs.md
+++ b/docs/dev/table/functions/udfs.md
@@ -211,6 +211,76 @@ table_env.register_function("add", add)
 # use the function in Python Table API
 my_table.select("add(a, b)")
 {% endhighlight %}
+
+If the python scalar function depends on other dependencies, you can specify the dependencies with the following table APIs or through <a href="{{ site.baseurl }}/ops/cli.html#usage">command line</a> directly when submit the job.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 20%">Dependencies</th>
+      <th class="text-left">Description</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>files</td>
+      <td>
+        <p>Adds python file dependencies which could be python files, python packages or local directories. They will be added to the PYTHONPATH of the python UDF worker.</p>
+{% highlight python %}
+table_env.add_python_file(file_path)
+{% endhighlight %}
+      </td>
+    </tr>
+    <tr>
+      <td>requirements</td>
+      <td>
+        <p>Specifies a requirements.txt file which defines the third-party dependencies. These dependencies will be installed to a temporary directory and added to the PYTHONPATH of the python UDF worker. For the dependencies which could not be accessed in the cluster, a directory which contains the installation packages of these dependencies could be specified using the parameter "requirements_cached_dir". It will be uploaded to the cluster to support offline installation.</p>
+{% highlight python %}
+# commands executed in shell
+echo numpy==1.16.5 > requirements.txt
+pip download -d cached_dir -r requirements.txt --no-binary :all:
+
+# python code
+table_env.set_python_requirements("requirements.txt", "cached_dir")
+{% endhighlight %}
+        <p>Please make sure the installation packages matches the platform of the cluster and the python version used. These packages will be installed using pip.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>archive</td>
+      <td>
+        <p>Adds a python archive file dependency. The file will be extracted to the working directory of python UDF worker. If the parameter "target_dir" is specified, the archive file will be extracted to a directory named "target_dir". Otherwise, the archive file will be extracted to a directory with the same name of the archive file.</p>
+{% highlight python %}
+# command executed in shell
+# assert the relative path of python interpreter is py_env/bin/python
+zip -r py_env.zip py_env
+
+# python code
+table_env.add_python_archive("py_env.zip")
+table_env.get_config().set_python_executable("py_env.zip/py_env/bin/python")
+
+# or
+table_env.add_python_archive("py_env.zip", "myenv")
+table_env.get_config().set_python_executable("myenv/py_env/bin/python")
+{% endhighlight %}
+        <p>Please make sure the uploaded python environment matches the platform that the cluster is running on and that the python version must be 3.5 or higher. Currently only zip-format is supported. i.e. zip, jar, whl, egg, etc.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>python interpreter</td>
+      <td>
+        <p>Sets the path of the python interpreter which is used to execute the python udf workers, e.g., "/usr/local/bin/python3".</p>
+{% highlight python %}
+table_env.add_python_archive("py_env.zip")
+table_env.get_config().set_python_executable("py_env.zip/py_env/bin/python")
+{% endhighlight %}
+        <p>The python udf worker depends on Apache Beam (version == 2.15.0), Pip (version >= 7.1.0), SetupTools (version >= 37.0.0) and Python (version >=3.5), please ensure that the specified environment meets the above requirements.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 </div>
 </div>
 

--- a/docs/dev/table/functions/udfs.md
+++ b/docs/dev/table/functions/udfs.md
@@ -244,7 +244,7 @@ pip download -d cached_dir -r requirements.txt --no-binary :all:
 # python code
 table_env.set_python_requirements("requirements.txt", "cached_dir")
 {% endhighlight %}
-        <p>Please make sure the installation packages matches the platform of the cluster and the python version used. These packages will be installed using pip.</p>
+        <p>Please make sure the installation packages matches the platform of the cluster and the python version used. These packages will be installed using pip, so also make sure the version of Pip (version >= 7.1.0) and the version of SetupTools (version >= 37.0.0).</p>
       </td>
     </tr>
     <tr>
@@ -266,7 +266,7 @@ def my_udf():
     with open("myenv/py_env/data/data.txt") as f:
         ...
 {% endhighlight %}
-        <p>Please make sure the uploaded python environment matches the platform that the cluster is running on and that the python version must be 3.5 or higher. Currently only zip-format is supported. i.e. zip, jar, whl, egg, etc.</p>
+        <p>Please make sure the uploaded python environment matches the platform that the cluster is running on. Currently only zip-format is supported. i.e. zip, jar, whl, egg, etc.</p>
       </td>
     </tr>
     <tr>
@@ -277,7 +277,7 @@ def my_udf():
 table_env.add_python_archive("py_env.zip")
 table_env.get_config().set_python_executable("py_env.zip/py_env/bin/python")
 {% endhighlight %}
-        <p>The python udf worker depends on Apache Beam (version == 2.15.0), Pip (version >= 7.1.0), SetupTools (version >= 37.0.0) and Python (version >=3.5), please ensure that the specified environment meets the above requirements.</p>
+        <p>Please make sure that the specified environment matches the platform that the cluster is running on.</p>
       </td>
     </tr>
   </tbody>

--- a/docs/dev/table/functions/udfs.md
+++ b/docs/dev/table/functions/udfs.md
@@ -212,19 +212,19 @@ table_env.register_function("add", add)
 my_table.select("add(a, b)")
 {% endhighlight %}
 
-If the python scalar function depends on other dependencies, you can specify the dependencies with the following table APIs or through <a href="{{ site.baseurl }}/ops/cli.html#usage">command line</a> directly when submit the job.
+If the python scalar function depends on third-party dependencies, you can specify the dependencies with the following table APIs or through <a href="{{ site.baseurl }}/ops/cli.html#usage">command line</a> directly when submitting the job.
 
 <table class="table table-bordered">
   <thead>
     <tr>
-      <th class="text-left" style="width: 20%">Dependencies</th>
+      <th class="text-left" style="width: 20%">APIs</th>
       <th class="text-left">Description</th>
     </tr>
   </thead>
 
   <tbody>
     <tr>
-      <td>files</td>
+      <td><strong>add_python_file</strong></td>
       <td>
         <p>Adds python file dependencies which could be python files, python packages or local directories. They will be added to the PYTHONPATH of the python UDF worker.</p>
 {% highlight python %}
@@ -233,7 +233,7 @@ table_env.add_python_file(file_path)
       </td>
     </tr>
     <tr>
-      <td>requirements</td>
+      <td><strong>set_python_requirements</strong></td>
       <td>
         <p>Specifies a requirements.txt file which defines the third-party dependencies. These dependencies will be installed to a temporary directory and added to the PYTHONPATH of the python UDF worker. For the dependencies which could not be accessed in the cluster, a directory which contains the installation packages of these dependencies could be specified using the parameter "requirements_cached_dir". It will be uploaded to the cluster to support offline installation.</p>
 {% highlight python %}
@@ -248,7 +248,7 @@ table_env.set_python_requirements("requirements.txt", "cached_dir")
       </td>
     </tr>
     <tr>
-      <td>archive</td>
+      <td><strong>add_python_archive</strong></td>
       <td>
         <p>Adds a python archive file dependency. The file will be extracted to the working directory of python UDF worker. If the parameter "target_dir" is specified, the archive file will be extracted to a directory named "target_dir". Otherwise, the archive file will be extracted to a directory with the same name of the archive file.</p>
 {% highlight python %}
@@ -258,17 +258,19 @@ zip -r py_env.zip py_env
 
 # python code
 table_env.add_python_archive("py_env.zip")
-table_env.get_config().set_python_executable("py_env.zip/py_env/bin/python")
-
 # or
 table_env.add_python_archive("py_env.zip", "myenv")
-table_env.get_config().set_python_executable("myenv/py_env/bin/python")
+
+# the files contained in the archive file can be accessed in UDF
+def my_udf():
+    with open("myenv/py_env/data/data.txt") as f:
+        ...
 {% endhighlight %}
         <p>Please make sure the uploaded python environment matches the platform that the cluster is running on and that the python version must be 3.5 or higher. Currently only zip-format is supported. i.e. zip, jar, whl, egg, etc.</p>
       </td>
     </tr>
     <tr>
-      <td>python interpreter</td>
+      <td><strong>set_python_executable</strong></td>
       <td>
         <p>Sets the path of the python interpreter which is used to execute the python udf workers, e.g., "/usr/local/bin/python3".</p>
 {% highlight python %}

--- a/docs/dev/table/functions/udfs.zh.md
+++ b/docs/dev/table/functions/udfs.zh.md
@@ -211,6 +211,76 @@ table_env.register_function("add", add)
 # use the function in Python Table API
 my_table.select("add(a, b)")
 {% endhighlight %}
+
+If the python scalar function depends on other dependencies, you can specify the dependencies with the following table APIs or through <a href="{{ site.baseurl }}/ops/cli.html#usage">command line</a> directly when submit the job.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 20%">Dependencies</th>
+      <th class="text-left">Description</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>files</td>
+      <td>
+        <p>Adds python file dependencies which could be python files, python packages or local directories. They will be added to the PYTHONPATH of the python UDF worker.</p>
+{% highlight python %}
+table_env.add_python_file(file_path)
+{% endhighlight %}
+      </td>
+    </tr>
+    <tr>
+      <td>requirements</td>
+      <td>
+        <p>Specifies a requirements.txt file which defines the third-party dependencies. These dependencies will be installed to a temporary directory and added to the PYTHONPATH of the python UDF worker. For the dependencies which could not be accessed in the cluster, a directory which contains the installation packages of these dependencies could be specified using the parameter "requirements_cached_dir". It will be uploaded to the cluster to support offline installation.</p>
+{% highlight python %}
+# commands executed in shell
+echo numpy==1.16.5 > requirements.txt
+pip download -d cached_dir -r requirements.txt --no-binary :all:
+
+# python code
+table_env.set_python_requirements("requirements.txt", "cached_dir")
+{% endhighlight %}
+        <p>Please make sure the installation packages matches the platform of the cluster and the python version used. These packages will be installed using pip.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>archive</td>
+      <td>
+        <p>Adds a python archive file dependency. The file will be extracted to the working directory of python UDF worker. If the parameter "target_dir" is specified, the archive file will be extracted to a directory named "target_dir". Otherwise, the archive file will be extracted to a directory with the same name of the archive file.</p>
+{% highlight python %}
+# command executed in shell
+# assert the relative path of python interpreter is py_env/bin/python
+zip -r py_env.zip py_env
+
+# python code
+table_env.add_python_archive("py_env.zip")
+table_env.get_config().set_python_executable("py_env.zip/py_env/bin/python")
+
+# or
+table_env.add_python_archive("py_env.zip", "myenv")
+table_env.get_config().set_python_executable("myenv/py_env/bin/python")
+{% endhighlight %}
+        <p>Please make sure the uploaded python environment matches the platform that the cluster is running on and that the python version must be 3.5 or higher. Currently only zip-format is supported. i.e. zip, jar, whl, egg, etc.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>python interpreter</td>
+      <td>
+        <p>Sets the path of the python interpreter which is used to execute the python udf workers, e.g., "/usr/local/bin/python3".</p>
+{% highlight python %}
+table_env.add_python_archive("py_env.zip")
+table_env.get_config().set_python_executable("py_env.zip/py_env/bin/python")
+{% endhighlight %}
+        <p>The python udf worker depends on Apache Beam (version == 2.15.0), Pip (version >= 7.1.0), SetupTools (version >= 37.0.0) and Python (version >=3.5), please ensure that the specified environment meets the above requirements.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 </div>
 </div>
 

--- a/docs/dev/table/functions/udfs.zh.md
+++ b/docs/dev/table/functions/udfs.zh.md
@@ -244,7 +244,7 @@ pip download -d cached_dir -r requirements.txt --no-binary :all:
 # python code
 table_env.set_python_requirements("requirements.txt", "cached_dir")
 {% endhighlight %}
-        <p>Please make sure the installation packages matches the platform of the cluster and the python version used. These packages will be installed using pip.</p>
+        <p>Please make sure the installation packages matches the platform of the cluster and the python version used. These packages will be installed using pip, so also make sure the version of Pip (version >= 7.1.0) and the version of SetupTools (version >= 37.0.0).</p>
       </td>
     </tr>
     <tr>
@@ -266,7 +266,7 @@ def my_udf():
     with open("myenv/py_env/data/data.txt") as f:
         ...
 {% endhighlight %}
-        <p>Please make sure the uploaded python environment matches the platform that the cluster is running on and that the python version must be 3.5 or higher. Currently only zip-format is supported. i.e. zip, jar, whl, egg, etc.</p>
+        <p>Please make sure the uploaded python environment matches the platform that the cluster is running on. Currently only zip-format is supported. i.e. zip, jar, whl, egg, etc.</p>
       </td>
     </tr>
     <tr>
@@ -277,7 +277,7 @@ def my_udf():
 table_env.add_python_archive("py_env.zip")
 table_env.get_config().set_python_executable("py_env.zip/py_env/bin/python")
 {% endhighlight %}
-        <p>The python udf worker depends on Apache Beam (version == 2.15.0), Pip (version >= 7.1.0), SetupTools (version >= 37.0.0) and Python (version >=3.5), please ensure that the specified environment meets the above requirements.</p>
+        <p>Please make sure that the specified environment matches the platform that the cluster is running on.</p>
       </td>
     </tr>
   </tbody>

--- a/docs/dev/table/functions/udfs.zh.md
+++ b/docs/dev/table/functions/udfs.zh.md
@@ -212,19 +212,19 @@ table_env.register_function("add", add)
 my_table.select("add(a, b)")
 {% endhighlight %}
 
-If the python scalar function depends on other dependencies, you can specify the dependencies with the following table APIs or through <a href="{{ site.baseurl }}/ops/cli.html#usage">command line</a> directly when submit the job.
+If the python scalar function depends on third-party dependencies, you can specify the dependencies with the following table APIs or through <a href="{{ site.baseurl }}/ops/cli.html#usage">command line</a> directly when submitting the job.
 
 <table class="table table-bordered">
   <thead>
     <tr>
-      <th class="text-left" style="width: 20%">Dependencies</th>
+      <th class="text-left" style="width: 20%">APIs</th>
       <th class="text-left">Description</th>
     </tr>
   </thead>
 
   <tbody>
     <tr>
-      <td>files</td>
+      <td><strong>add_python_file</strong></td>
       <td>
         <p>Adds python file dependencies which could be python files, python packages or local directories. They will be added to the PYTHONPATH of the python UDF worker.</p>
 {% highlight python %}
@@ -233,7 +233,7 @@ table_env.add_python_file(file_path)
       </td>
     </tr>
     <tr>
-      <td>requirements</td>
+      <td><strong>set_python_requirements</strong></td>
       <td>
         <p>Specifies a requirements.txt file which defines the third-party dependencies. These dependencies will be installed to a temporary directory and added to the PYTHONPATH of the python UDF worker. For the dependencies which could not be accessed in the cluster, a directory which contains the installation packages of these dependencies could be specified using the parameter "requirements_cached_dir". It will be uploaded to the cluster to support offline installation.</p>
 {% highlight python %}
@@ -248,7 +248,7 @@ table_env.set_python_requirements("requirements.txt", "cached_dir")
       </td>
     </tr>
     <tr>
-      <td>archive</td>
+      <td><strong>add_python_archive</strong></td>
       <td>
         <p>Adds a python archive file dependency. The file will be extracted to the working directory of python UDF worker. If the parameter "target_dir" is specified, the archive file will be extracted to a directory named "target_dir". Otherwise, the archive file will be extracted to a directory with the same name of the archive file.</p>
 {% highlight python %}
@@ -258,17 +258,19 @@ zip -r py_env.zip py_env
 
 # python code
 table_env.add_python_archive("py_env.zip")
-table_env.get_config().set_python_executable("py_env.zip/py_env/bin/python")
-
 # or
 table_env.add_python_archive("py_env.zip", "myenv")
-table_env.get_config().set_python_executable("myenv/py_env/bin/python")
+
+# the files contained in the archive file can be accessed in UDF
+def my_udf():
+    with open("myenv/py_env/data/data.txt") as f:
+        ...
 {% endhighlight %}
         <p>Please make sure the uploaded python environment matches the platform that the cluster is running on and that the python version must be 3.5 or higher. Currently only zip-format is supported. i.e. zip, jar, whl, egg, etc.</p>
       </td>
     </tr>
     <tr>
-      <td>python interpreter</td>
+      <td><strong>set_python_executable</strong></td>
       <td>
         <p>Sets the path of the python interpreter which is used to execute the python udf workers, e.g., "/usr/local/bin/python3".</p>
 {% highlight python %}


### PR DESCRIPTION

## What is the purpose of the change

Add documentation about how to specify third-party dependencies via API for Python UDFs

## Brief change log

  - Add document about how to specify files, requirements, archives and python interpreter dependencies with Table API.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
