### PR TITLE
[FLINK-15286][state-backend-rocksdb] Read option whether to use managed memory from configuration

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMemoryConfiguration.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMemoryConfiguration.java
@@ -181,6 +181,10 @@ public final class RocksDBMemoryConfiguration implements Serializable {
 
 		final RocksDBMemoryConfiguration newConfig = new RocksDBMemoryConfiguration();
 
+		newConfig.useManagedMemory = other.useManagedMemory != null
+				? other.useManagedMemory
+				: config.getBoolean(RocksDBOptions.USE_MANAGED_MEMORY);
+
 		newConfig.fixedMemoryPerSlot = other.fixedMemoryPerSlot != null
 				? other.fixedMemoryPerSlot
 				: config.get(RocksDBOptions.FIX_PER_SLOT_MEMORY_SIZE);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -625,6 +625,7 @@ public class RocksDBStateBackendConfigTest {
 	@Test
 	public void testDefaultMemoryControlParameters() {
 		RocksDBMemoryConfiguration memSettings = new RocksDBMemoryConfiguration();
+		assertFalse(memSettings.isUsingManagedMemory());
 		assertFalse(memSettings.isUsingFixedMemoryPerSlot());
 		assertEquals(RocksDBOptions.HIGH_PRIORITY_POOL_RATIO.defaultValue(), memSettings.getHighPriorityPoolRatio(), 0.0);
 		assertEquals(RocksDBOptions.WRITE_BUFFER_RATIO.defaultValue(), memSettings.getWriteBufferRatio(), 0.0);
@@ -633,6 +634,17 @@ public class RocksDBStateBackendConfigTest {
 		assertFalse(configured.isUsingFixedMemoryPerSlot());
 		assertEquals(RocksDBOptions.HIGH_PRIORITY_POOL_RATIO.defaultValue(), configured.getHighPriorityPoolRatio(), 0.0);
 		assertEquals(RocksDBOptions.WRITE_BUFFER_RATIO.defaultValue(), configured.getWriteBufferRatio(), 0.0);
+	}
+
+	@Test
+	public void testConfigureManagedMemory() {
+		final Configuration config = new Configuration();
+		config.setBoolean(RocksDBOptions.USE_MANAGED_MEMORY, true);
+
+		final RocksDBMemoryConfiguration memSettings = RocksDBMemoryConfiguration.fromOtherAndConfiguration(
+			new RocksDBMemoryConfiguration(), config);
+
+		assertTrue(memSettings.isUsingManagedMemory());
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

Fixes the bug that RocksDB did not pick up the value for `state.backend.rocksdb.memory.managed` from the configuration.

## Verifying this change

  - Reviewers can set the `state.backend.rocksdb.memory.managed: true` option manually on a standalone cluster and check the log that RocksDB uses managed memory.
  - This PR also adds a unit test tat covers this case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
