### PR TITLE
[FLINK-15009][table-common] Add a utility for creating type inference logic via reflection

### DIFF
--- a/flink-table/flink-table-api-scala/pom.xml
+++ b/flink-table/flink-table-api-scala/pom.xml
@@ -68,6 +68,13 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-common</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>

--- a/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/types/extraction/TypeInferenceExtractorScalaTest.scala
+++ b/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/types/extraction/TypeInferenceExtractorScalaTest.scala
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.extraction
+
+import java.util.Optional
+
+import org.apache.flink.table.annotation.{DataTypeHint, FunctionHint}
+import org.apache.flink.table.api.DataTypes
+import org.apache.flink.table.functions.ScalarFunction
+import org.apache.flink.table.types.extraction.TypeInferenceExtractorTest.TestSpec
+import org.apache.flink.table.types.inference.{ArgumentTypeStrategy, InputTypeStrategies, TypeStrategies}
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.Assert.assertThat
+import org.junit.rules.ExpectedException
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import org.junit.{Rule, Test}
+
+import scala.annotation.meta.getter
+
+/**
+ * Scala tests for [[TypeInferenceExtractor]].
+ */
+@RunWith(classOf[Parameterized])
+class TypeInferenceExtractorScalaTest(testSpec: TestSpec) {
+
+  @(Rule @getter)
+  var thrown: ExpectedException = ExpectedException.none
+
+  @Test
+  def testArgumentNames(): Unit = {
+    if (testSpec.expectedArgumentNames != null) {
+      assertThat(
+        testSpec.typeInferenceExtraction.get.getNamedArguments,
+        equalTo(Optional.of(testSpec.expectedArgumentNames)))
+    }
+  }
+
+  @Test
+  def testArgumentTypes(): Unit = {
+    if (testSpec.expectedArgumentTypes != null) {
+      assertThat(
+        testSpec.typeInferenceExtraction.get.getTypedArguments,
+        equalTo(Optional.of(testSpec.expectedArgumentTypes)))
+    }
+  }
+
+  @Test
+  def testOutputTypeStrategy(): Unit = {
+    if (!testSpec.expectedOutputStrategies.isEmpty) {
+      assertThat(
+        testSpec.typeInferenceExtraction.get.getOutputTypeStrategy,
+        equalTo(TypeStrategies.mapping(testSpec.expectedOutputStrategies)))
+    }
+  }
+}
+
+object TypeInferenceExtractorScalaTest {
+
+  @Parameters
+  def testData: Array[TestSpec] = Array(
+
+    // Scala function with data type hint
+    TestSpec.forScalarFunction(classOf[ScalaScalarFunction])
+      .expectNamedArguments("i", "s", "d")
+      .expectTypedArguments(
+        DataTypes.INT.notNull().bridgedTo(classOf[Int]),
+        DataTypes.STRING,
+        DataTypes.DECIMAL(10, 4))
+      .expectOutputMapping(
+        InputTypeStrategies.sequence(
+          Array[String]("i", "s", "d"),
+          Array[ArgumentTypeStrategy](
+            InputTypeStrategies.explicit(DataTypes.INT.notNull().bridgedTo(classOf[Int])),
+            InputTypeStrategies.explicit(DataTypes.STRING),
+            InputTypeStrategies.explicit(DataTypes.DECIMAL(10, 4)))),
+        TypeStrategies.explicit(DataTypes.BOOLEAN.notNull().bridgedTo(classOf[Boolean]))),
+
+    // global output hint with local input overloading
+    TestSpec.forScalarFunction(classOf[ScalaGlobalOutputFunctionHint])
+      .expectOutputMapping(
+        InputTypeStrategies.sequence(InputTypeStrategies.explicit(DataTypes.INT)),
+        TypeStrategies.explicit(DataTypes.INT))
+      .expectOutputMapping(
+        InputTypeStrategies.sequence(InputTypeStrategies.explicit(DataTypes.STRING)),
+        TypeStrategies.explicit(DataTypes.INT))
+  )
+
+  // ----------------------------------------------------------------------------------------------
+  // Test classes for extraction
+  // ----------------------------------------------------------------------------------------------
+
+  private class ScalaScalarFunction extends ScalarFunction {
+    def eval(
+      i: Int,
+      s: String,
+      @DataTypeHint("DECIMAL(10, 4)") d: java.math.BigDecimal): Boolean = false
+  }
+
+  @FunctionHint(output = new DataTypeHint("INT"))
+  private class ScalaGlobalOutputFunctionHint extends ScalarFunction {
+    @FunctionHint(input = Array(new DataTypeHint("INT")))
+    def eval(n: Integer): Integer = null
+
+    @FunctionHint(input = Array(new DataTypeHint("STRING")))
+    def eval(n: String): Integer = null
+  }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/annotation/FunctionHint.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/annotation/FunctionHint.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.annotation;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.functions.UserDefinedFunction;
+import org.apache.flink.table.types.inference.TypeInference;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A hint that influences the reflection-based extraction of input types, accumulator types, and output
+ * types for constructing the {@link TypeInference} logic of a {@link UserDefinedFunction}.
+ *
+ * <p>One or more annotations can be declared on top of a {@link UserDefinedFunction} class or individually
+ * for each {@code eval()/accumulate()} method for overloading function signatures. All hint parameters
+ * are optional. If a parameter is not defined, the default reflection-based extraction is used. Hint
+ * parameters defined on top of a {@link UserDefinedFunction} class are inherited by all {@code eval()/accumulate()}
+ * methods.
+ *
+ * <p>The following examples show how to explicitly specify function signatures as a whole or in part
+ * and let the default extraction do the rest:
+ *
+ * <pre>
+ * {@code
+ *   // accepts (INT, STRING) and returns BOOLEAN
+ *   @FunctionHint(
+ *     input = [@DataTypeHint("INT"), @DataTypeHint("STRING")],
+ *     output = @DataTypeHint("BOOLEAN")
+ *   )
+ *   class X extends ScalarFunction { ... }
+ *
+ *   // accepts (INT, STRING) or (BOOLEAN) and returns BOOLEAN
+ *   @FunctionHint(
+ *     input = [@DataTypeHint("INT"), @DataTypeHint("STRING")],
+ *     output = @DataTypeHint("BOOLEAN")
+ *   )
+ *   @FunctionHint(
+ *     input = [@DataTypeHint("BOOLEAN")],
+ *     output = @DataTypeHint("BOOLEAN")
+ *   )
+ *   class X extends ScalarFunction { ... }
+ *
+ *   // accepts (INT, STRING) or (BOOLEAN) and always returns BOOLEAN
+ *   @FunctionHint(
+ *     output = @DataTypeHint("BOOLEAN")
+ *   )
+ *   class X extends ScalarFunction {
+ *     @FunctionHint(
+ *       input = [@DataTypeHint("INT"), @DataTypeHint("STRING")]
+ *     )
+ *     @FunctionHint(
+ *       input = [@DataTypeHint("BOOLEAN")]
+ *     )
+ *     Object eval(Object... o) { ... }
+ *   }
+ *
+ *   // accepts (INT) or (BOOLEAN) and always returns ROW<f0 BOOLEAN, f1 INT>
+ *   @FunctionHint(
+ *     output = @DataTypeHint("ROW<f0 BOOLEAN, f1 INT>")
+ *   )
+ *   class X extends ScalarFunction {
+ *     Row eval(int i) { ... }
+ *     Row eval(boolean b) { ... }
+ *   }
+ *
+ *   // accepts (ROW<f BOOLEAN>...) or (BOOLEAN...) and returns INT
+ *   class X extends ScalarFunction {
+ *     @FunctionHint(
+ *       input = [@DataTypeHint("ROW<f BOOLEAN>")],
+ *       isVarArgs = true
+ *     )
+ *     int eval(Row... r) { ... }
+ *
+ *     int eval(boolean... b) { ... }
+ *   }
+ *
+ *   // accepts (INT) and returns INT but allows RAW types in the accumulator type
+ *   @FunctionHint(
+ *     accumulator = @DataTypeHint(bridgedTo = my.package.MyClass.class, allowRawPattern = "my.package")
+ *   )
+ *   class X extends AggregateFunction<Integer, MyClass> {
+ *     void accumulate(Row acc, int in) { ... }
+ *     // ...
+ *   }
+ * }
+ * </pre>
+ *
+ * @see DataTypeHint
+ */
+@PublicEvolving
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Repeatable(FunctionHints.class)
+public @interface FunctionHint {
+
+	// Note to implementers:
+	// Because "null" is not supported as an annotation value. Every annotation parameter *must* have
+	// some representation for unknown values in order to merge multi-level annotations.
+
+	/**
+	 * Explicitly lists the argument types that a function takes as input.
+	 *
+	 * <p>By default, explicit input types are undefined and the reflection-based extraction is
+	 * used.
+	 *
+	 * <p>Note: Specifying the input arguments manually disables the entire reflection-based extraction
+	 * around arguments. This means that also {@link #isVarArgs()} and {@link #argumentNames()} need to
+	 * be specified manually if required.
+	 */
+	DataTypeHint[] input() default @DataTypeHint();
+
+	/**
+	 * Defines that the last argument type defined in {@link #input()} should be treated as a
+	 * variable-length argument.
+	 *
+	 * <p>By default, if {@link #input()} is defined, the last argument type is not a var-arg. If
+	 * {@link #input()} is not defined, the reflection-based extraction is used to decide about the
+	 * var-arg flag, thus, this parameter is ignored.
+	 */
+	boolean isVarArgs() default false;
+
+	/**
+	 * Explicitly lists the argument names that a function takes as input.
+	 *
+	 * <p>By default, if {@link #input()} is defined, explicit argument names are undefined and this
+	 * parameter can be used to provide argument names. If {@link #input()} is not defined, the
+	 * reflection-based extraction is used, thus, this parameter is ignored.
+	 */
+	String[] argumentNames() default {""};
+
+	/**
+	 * Explicitly defines the intermediate result type that a function uses as accumulator.
+	 *
+	 * <p>By default, an explicit accumulator type is undefined and the reflection-based extraction
+	 * is used.
+	 */
+	DataTypeHint accumulator() default @DataTypeHint();
+
+	/**
+	 * Explicitly defines the result type that a function uses as output.
+	 *
+	 * <p>By default, an explicit output type is undefined and the reflection-based extraction
+	 * is used.
+	 */
+	DataTypeHint output() default @DataTypeHint();
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/annotation/FunctionHints.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/annotation/FunctionHints.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.annotation;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Helper annotation for repeatable {@link FunctionHint}s.
+ */
+@PublicEvolving
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface FunctionHints {
+
+	FunctionHint[] value();
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/TypeInferenceExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/TypeInferenceExtractor.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.extraction;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.annotation.FunctionHint;
+import org.apache.flink.table.catalog.DataTypeLookup;
+import org.apache.flink.table.functions.AggregateFunction;
+import org.apache.flink.table.functions.AsyncTableFunction;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.functions.TableAggregateFunction;
+import org.apache.flink.table.functions.TableFunction;
+import org.apache.flink.table.functions.UserDefinedFunction;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.extraction.utils.FunctionMappingExtractor;
+import org.apache.flink.table.types.extraction.utils.FunctionResultTemplate;
+import org.apache.flink.table.types.extraction.utils.FunctionSignatureTemplate;
+import org.apache.flink.table.types.inference.InputTypeStrategies;
+import org.apache.flink.table.types.inference.InputTypeStrategy;
+import org.apache.flink.table.types.inference.TypeInference;
+import org.apache.flink.table.types.inference.TypeStrategies;
+import org.apache.flink.table.types.inference.TypeStrategy;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.types.extraction.utils.ExtractionUtils.extractionError;
+import static org.apache.flink.table.types.extraction.utils.FunctionMappingExtractor.createGenericResultExtraction;
+import static org.apache.flink.table.types.extraction.utils.FunctionMappingExtractor.createParameterAndReturnTypeVerification;
+import static org.apache.flink.table.types.extraction.utils.FunctionMappingExtractor.createParameterSignatureExtraction;
+import static org.apache.flink.table.types.extraction.utils.FunctionMappingExtractor.createParameterVerification;
+import static org.apache.flink.table.types.extraction.utils.FunctionMappingExtractor.createParameterWithAccumulatorVerification;
+import static org.apache.flink.table.types.extraction.utils.FunctionMappingExtractor.createParameterWithArgumentVerification;
+import static org.apache.flink.table.types.extraction.utils.FunctionMappingExtractor.createReturnTypeResultExtraction;
+
+/**
+ * Reflection-based utility for extracting a {@link TypeInference} from a supported subclass of
+ * {@link UserDefinedFunction}.
+ *
+ * <p>The behavior of this utility can be influenced by {@link DataTypeHint}s and {@link FunctionHint}s
+ * which have higher precedence than the reflective information.
+ *
+ * <p>Note: This utility assumes that functions have been validated before regarding accessibility of
+ * class/methods and serializability.
+ */
+@Internal
+public final class TypeInferenceExtractor {
+
+	/**
+	 * Extracts a type inference from a {@link ScalarFunction}.
+	 */
+	public static TypeInference forScalarFunction(DataTypeLookup lookup, Class<? extends ScalarFunction> function) {
+		final FunctionMappingExtractor mappingExtractor = new FunctionMappingExtractor(
+			lookup,
+			function,
+			"eval",
+			createParameterSignatureExtraction(0),
+			null,
+			createReturnTypeResultExtraction(),
+			createParameterAndReturnTypeVerification());
+		return extractTypeInference(mappingExtractor);
+	}
+
+	/**
+	 * Extracts a type inference from a {@link AggregateFunction}.
+	 */
+	public static TypeInference forAggregateFunction(DataTypeLookup lookup, Class<? extends AggregateFunction<?, ?>> function) {
+		final FunctionMappingExtractor mappingExtractor = new FunctionMappingExtractor(
+			lookup,
+			function,
+			"accumulate",
+			createParameterSignatureExtraction(1),
+			createGenericResultExtraction(AggregateFunction.class, 1),
+			createGenericResultExtraction(AggregateFunction.class, 0),
+			createParameterWithAccumulatorVerification());
+		return extractTypeInference(mappingExtractor);
+	}
+
+	/**
+	 * Extracts a type inference from a {@link TableFunction}.
+	 */
+	public static TypeInference forTableFunction(DataTypeLookup lookup, Class<? extends TableFunction<?>> function) {
+		final FunctionMappingExtractor mappingExtractor = new FunctionMappingExtractor(
+			lookup,
+			function,
+			"eval",
+			createParameterSignatureExtraction(0),
+			null,
+			createGenericResultExtraction(TableFunction.class, 0),
+			createParameterVerification());
+		return extractTypeInference(mappingExtractor);
+	}
+
+	/**
+	 * Extracts a type inference from a {@link TableAggregateFunction}.
+	 */
+	public static TypeInference forTableAggregateFunction(DataTypeLookup lookup, Class<? extends TableAggregateFunction<?, ?>> function) {
+		final FunctionMappingExtractor mappingExtractor = new FunctionMappingExtractor(
+			lookup,
+			function,
+			"accumulate",
+			createParameterSignatureExtraction(1),
+			createGenericResultExtraction(TableAggregateFunction.class, 1),
+			createGenericResultExtraction(TableAggregateFunction.class, 0),
+			createParameterWithAccumulatorVerification());
+		return extractTypeInference(mappingExtractor);
+	}
+
+	/**
+	 * Extracts a type inference from a {@link AsyncTableFunction}.
+	 */
+	public static TypeInference forAsyncTableFunction(DataTypeLookup lookup, Class<? extends AsyncTableFunction<?>> function) {
+		final FunctionMappingExtractor mappingExtractor = new FunctionMappingExtractor(
+			lookup,
+			function,
+			"eval",
+			createParameterSignatureExtraction(1),
+			null,
+			createGenericResultExtraction(AsyncTableFunction.class, 0),
+			createParameterWithArgumentVerification(CompletableFuture.class));
+		return extractTypeInference(mappingExtractor);
+	}
+
+	private static TypeInference extractTypeInference(FunctionMappingExtractor mappingExtractor) {
+		try {
+			return extractTypeInferenceOrError(mappingExtractor);
+		} catch (Throwable t) {
+			throw extractionError(
+				t,
+				"Could not extract a valid type inference for function class '%s'. " +
+					"Please check for implementation mistakes and/or provide a corresponding hint.",
+				mappingExtractor.getFunction().getName());
+		}
+	}
+
+	private static TypeInference extractTypeInferenceOrError(FunctionMappingExtractor mappingExtractor) {
+		final Map<FunctionSignatureTemplate, FunctionResultTemplate> outputMapping =
+			mappingExtractor.extractOutputMapping();
+
+		if (!mappingExtractor.hasAccumulator()) {
+			return buildInference(null, outputMapping);
+		}
+
+		final Map<FunctionSignatureTemplate, FunctionResultTemplate> accumulatorMapping =
+			mappingExtractor.extractAccumulatorMapping();
+		return buildInference(accumulatorMapping, outputMapping);
+	}
+
+	private static TypeInference buildInference(
+			@Nullable Map<FunctionSignatureTemplate, FunctionResultTemplate> accumulatorMapping,
+			Map<FunctionSignatureTemplate, FunctionResultTemplate> outputMapping) {
+		final TypeInference.Builder builder = TypeInference.newBuilder();
+
+		configureNamedArguments(builder, outputMapping);
+		configureTypedArguments(builder, outputMapping);
+
+		builder.inputTypeStrategy(translateInputTypeStrategy(outputMapping));
+
+		if (accumulatorMapping != null) {
+			// verify that accumulator and output are derived from the same input strategy
+			if (!accumulatorMapping.keySet().equals(outputMapping.keySet())) {
+				throw extractionError(
+					"Mismatch between accumulator signature and output signature. " +
+						"Both intermediate and output results must be derived from the same input strategy.");
+			}
+			builder.accumulatorTypeStrategy(translateResultTypeStrategy(accumulatorMapping));
+		}
+
+		builder.outputTypeStrategy(translateResultTypeStrategy(outputMapping));
+		return builder.build();
+	}
+
+	private static void configureNamedArguments(
+			TypeInference.Builder builder,
+			Map<FunctionSignatureTemplate, FunctionResultTemplate> outputMapping) {
+		final Set<FunctionSignatureTemplate> signatures = outputMapping.keySet();
+		if (signatures.stream().anyMatch(s -> s.isVarArgs || s.argumentNames == null)) {
+			return;
+		}
+		final Set<List<String>> argumentNames = signatures.stream()
+			.map(s -> {
+				assert s.argumentNames != null;
+				return Arrays.asList(s.argumentNames);
+			})
+			.collect(Collectors.toSet());
+		if (argumentNames.size() != 1) {
+			return;
+		}
+		builder.namedArguments(argumentNames.iterator().next());
+	}
+
+	private static void configureTypedArguments(
+			TypeInference.Builder builder,
+			Map<FunctionSignatureTemplate, FunctionResultTemplate> outputMapping) {
+		if (outputMapping.size() != 1) {
+			return;
+		}
+		final FunctionSignatureTemplate signature = outputMapping.keySet().iterator().next();
+		final List<DataType> dataTypes = signature.argumentTemplates.stream()
+			.map(a -> a.dataType)
+			.collect(Collectors.toList());
+		if (!signature.isVarArgs && dataTypes.stream().allMatch(Objects::nonNull)) {
+			builder.typedArguments(dataTypes);
+		}
+	}
+
+	private static TypeStrategy translateResultTypeStrategy(Map<FunctionSignatureTemplate, FunctionResultTemplate> resultMapping) {
+		final Map<InputTypeStrategy, TypeStrategy> mappings = resultMapping.entrySet()
+			.stream()
+			.collect(
+				Collectors.toMap(
+					e -> e.getKey().toInputTypeStrategy(),
+					e -> e.getValue().toTypeStrategy()));
+		return TypeStrategies.mapping(mappings);
+	}
+
+	private static InputTypeStrategy translateInputTypeStrategy(Map<FunctionSignatureTemplate, FunctionResultTemplate> outputMapping) {
+		return outputMapping.keySet().stream()
+			.map(FunctionSignatureTemplate::toInputTypeStrategy)
+			.reduce(InputTypeStrategies::or)
+			.orElse(InputTypeStrategies.sequence());
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/utils/DataTypeTemplate.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/utils/DataTypeTemplate.java
@@ -27,11 +27,6 @@ import org.apache.flink.table.annotation.InputGroup;
 import org.apache.flink.table.catalog.DataTypeLookup;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.extraction.DataTypeExtractor;
-import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
-import org.apache.flink.table.types.inference.InputTypeStrategies;
-import org.apache.flink.table.types.inference.InputTypeStrategy;
-import org.apache.flink.table.types.inference.TypeStrategies;
-import org.apache.flink.table.types.inference.TypeStrategy;
 
 import javax.annotation.Nullable;
 
@@ -43,8 +38,7 @@ import static org.apache.flink.table.types.extraction.utils.ExtractionUtils.crea
 import static org.apache.flink.table.types.extraction.utils.ExtractionUtils.extractionError;
 
 /**
- * Internal representation of a {@link DataTypeHint} and template for creating a single {@link DataType}
- * or a {@link InputTypeStrategy} for groups of {@link DataType}s.
+ * Internal representation of a {@link DataTypeHint}.
  *
  * <p>All parameters of a template are optional. An empty annotation results in a template where all
  * members are {@code null}.
@@ -195,49 +189,6 @@ public final class DataTypeTemplate {
 			rightValueIfNotNull(defaultYearPrecision, otherTemplate.defaultYearPrecision),
 			rightValueIfNotNull(defaultSecondPrecision, otherTemplate.defaultSecondPrecision)
 		);
-	}
-
-	/**
-	 * Whether this template defines an explicit data type.
-	 */
-	public boolean hasDataTypeDefinition() {
-		return dataType != null;
-	}
-
-	/**
-	 * Whether this template defines a group of data types for an input argument.
-	 */
-	public boolean hasInputGroupDefinition() {
-		return inputGroup != null && inputGroup != InputGroup.UNKNOWN;
-	}
-
-	/**
-	 * Converts this template into an {@link ArgumentTypeStrategy}.
-	 */
-	public ArgumentTypeStrategy toArgumentTypeStrategy() {
-		// data type
-		if (hasDataTypeDefinition()) {
-			return InputTypeStrategies.explicit(dataType);
-		}
-		// input group
-		else if (hasInputGroupDefinition()) {
-			if (inputGroup == InputGroup.ANY) {
-				return InputTypeStrategies.ANY;
-			}
-		}
-		throw ExtractionUtils.extractionError(
-			"Data type hint does neither specify an explicit data type nor an input group.");
-	}
-
-	/**
-	 * Converts this template into a {@link TypeStrategy}.
-	 */
-	public TypeStrategy toTypeStrategy() {
-		if (hasDataTypeDefinition()) {
-			return TypeStrategies.explicit(dataType);
-		}
-		throw ExtractionUtils.extractionError(
-			"Data type hint does not specify an explicit data type.");
 	}
 
 	/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/utils/ExtractionUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/utils/ExtractionUtils.java
@@ -34,7 +34,9 @@ import org.apache.flink.shaded.asm7.org.objectweb.asm.Opcodes;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -43,13 +45,17 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.flink.shaded.asm7.org.objectweb.asm.Type.getConstructorDescriptor;
+import static org.apache.flink.shaded.asm7.org.objectweb.asm.Type.getMethodDescriptor;
 
 /**
  * Utilities for performing reflection tasks.
@@ -74,6 +80,15 @@ public final class ExtractionUtils {
 			),
 			cause
 		);
+	}
+
+	/**
+	 * Collects methods of the given name.
+	 */
+	public static List<Method> collectMethods(Class<?> function, String methodName) {
+		return Arrays.stream(function.getMethods())
+			.filter(method -> method.getName().equals(methodName))
+			.collect(Collectors.toList());
 	}
 
 	/**
@@ -117,7 +132,7 @@ public final class ExtractionUtils {
 	/**
 	 * Creates a raw data type.
 	 */
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	public static DataType createRawType(
 			DataTypeLookup lookup,
 			@Nullable Class<? extends TypeSerializer<?>> rawSerializer,
@@ -308,7 +323,7 @@ public final class ExtractionUtils {
 			// one parameter that has the same (or primitive) type of the field
 			final boolean hasParameter = method.getParameterCount() == 1 &&
 				(method.getGenericParameterTypes()[0].equals(field.getGenericType()) ||
-					boxPrimitive(method.getGenericParameterTypes()[0]).equals(field.getGenericType()));
+					primitiveToWrapper(method.getGenericParameterTypes()[0]).equals(field.getGenericType()));
 			if (!hasParameter) {
 				continue;
 			}
@@ -321,24 +336,12 @@ public final class ExtractionUtils {
 		return false;
 	}
 
-	private static final Map<Class<?>, Class<?>> primitiveWrapperMap = new HashMap<>();
-	static {
-		primitiveWrapperMap.put(Boolean.TYPE, Boolean.class);
-		primitiveWrapperMap.put(Byte.TYPE, Byte.class);
-		primitiveWrapperMap.put(Character.TYPE, Character.class);
-		primitiveWrapperMap.put(Short.TYPE, Short.class);
-		primitiveWrapperMap.put(Integer.TYPE, Integer.class);
-		primitiveWrapperMap.put(Long.TYPE, Long.class);
-		primitiveWrapperMap.put(Double.TYPE, Double.class);
-		primitiveWrapperMap.put(Float.TYPE, Float.class);
-	}
-
 	/**
 	 * Returns the boxed type of a primitive type.
 	 */
-	public static Type boxPrimitive(Type type) {
-		if (type instanceof Class && ((Class) type).isPrimitive()) {
-			return primitiveWrapperMap.get(type);
+	public static Type primitiveToWrapper(Type type) {
+		if (type instanceof Class) {
+			return primitiveToWrapper((Class<?>) type);
 		}
 		return type;
 	}
@@ -405,8 +408,65 @@ public final class ExtractionUtils {
 		return methods;
 	}
 
+	/**
+	 * Collects all annotations of the given type defined in the current class or superclasses. Duplicates
+	 * are ignored.
+	 */
+	public static <T extends Annotation> Set<T> collectAnnotationsOfClass(
+			Class<T> annotation,
+			Class<?> annotatedClass) {
+		final Set<T> collectedAnnotations = new HashSet<>();
+		Class<?> currentClass = annotatedClass;
+		while (currentClass != null) {
+			collectedAnnotations.addAll(Arrays.asList(currentClass.getAnnotationsByType(annotation)));
+			currentClass = currentClass.getSuperclass();
+		}
+		return collectedAnnotations;
+	}
+
+	/**
+	 * Collects all annotations of the given type defined in the given method. Duplicates are ignored.
+	 */
+	public static <T extends Annotation> Set<T> collectAnnotationsOfMethod(
+			Class<T> annotation,
+			Method annotatedMethod) {
+		return new HashSet<>(Arrays.asList(annotatedMethod.getAnnotationsByType(annotation)));
+	}
+
+	/**
+	 * Checks whether a method can be called with the given argument classes. This includes type
+	 * widening and vararg. {@code null} is a wildcard.
+	 *
+	 * <p>E.g., {@code (int.class, int.class)} matches {@code f(Object...), f(int, int), f(Integer, Object)}
+	 * and so forth.
+	 */
+	public static boolean isMethodInvokable(Method method, Class<?>... classes) {
+		final int paramCount = method.getParameterCount();
+		final int classCount = classes.length;
+		if (paramCount != 0 & classCount == 0) {
+			return false;
+		}
+		int currentClass = 0;
+		for (int currentParam = 0; currentParam < paramCount; currentParam++) {
+			final Class<?> param = method.getParameterTypes()[currentParam];
+			// entire parameter matches
+			if (classes[currentClass] == null || ExtractionUtils.isAssignable(classes[currentClass], param, true)) {
+				currentClass++;
+			}
+			// last parameter is a vararg that consumes remaining classes
+			else if (currentParam == paramCount - 1 && method.isVarArgs()) {
+				final Class<?> paramComponent = method.getParameterTypes()[currentParam].getComponentType();
+				while (currentClass < classCount && ExtractionUtils.isAssignable(classes[currentClass], paramComponent, true)) {
+					currentClass++;
+				}
+			}
+		}
+		// check if all classes have been consumed
+		return currentClass == classCount;
+	}
+
 	// --------------------------------------------------------------------------------------------
-	// Assignable Constructor Utilities
+	// Parameter Extraction Utilities
 	// --------------------------------------------------------------------------------------------
 
 	/**
@@ -436,7 +496,7 @@ public final class ExtractionUtils {
 			if (!qualifyingConstructor) {
 				continue;
 			}
-			final List<String> parameterNames = extractConstructorParameterNames(clazz, constructor, fields);
+			final List<String> parameterNames = extractConstructorParameterNames(constructor, fields);
 			if (parameterNames != null) {
 				if (foundConstructor != null) {
 					throw extractionError(
@@ -450,34 +510,23 @@ public final class ExtractionUtils {
 	}
 
 	/**
+	 * Extracts the parameter names of a method if possible.
+	 */
+	public static @Nullable List<String> extractMethodParameterNames(Method method) {
+		return extractExecutableNames(method);
+	}
+
+	/**
 	 * Extracts ordered parameter names from a constructor that takes all of the given fields with
 	 * matching (possibly primitive) type and name.
 	 */
 	private static @Nullable List<String> extractConstructorParameterNames(
-			Class<?> clazz,
 			Constructor<?> constructor,
 			List<Field> fields) {
 		final Type[] parameterTypes = constructor.getGenericParameterTypes();
 
-		// by default parameter names are "arg0, arg1, arg2, ..." if compiler flag is not set
-		// so we need to extract them manually if possible
-		List<String> parameterNames = Stream.of(constructor.getParameters())
-			.map(Parameter::getName)
-			.collect(Collectors.toList());
-		if (parameterNames.stream().allMatch(n -> n.startsWith("arg"))) {
-			final ParameterExtractor extractor = new ParameterExtractor(constructor);
-			getClassReader(clazz).accept(extractor, 0);
-
-			final List<String> extractedNames = extractor.getParameterNames();
-			if (extractedNames.size() == 0 || !extractedNames.get(0).equals("this")) {
-				return null;
-			}
-			// remove "this" and additional local variables
-			// select less names if class file has not the required information
-			parameterNames = extractedNames.subList(1, Math.min(fields.size() + 1, extractedNames.size()));
-		}
-
-		if (parameterNames.size() != fields.size()) {
+		List<String> parameterNames = extractExecutableNames(constructor);
+		if (parameterNames == null) {
 			return null;
 		}
 
@@ -491,9 +540,49 @@ public final class ExtractionUtils {
 			final Type parameterType = parameterTypes[i];
 			// we are tolerant here because frameworks such as Avro accept a boxed type even though
 			// the field is primitive
-			if (!boxPrimitive(parameterType).equals(boxPrimitive(fieldType))) {
+			if (!primitiveToWrapper(parameterType).equals(primitiveToWrapper(fieldType))) {
 				return null;
 			}
+		}
+
+		return parameterNames;
+	}
+
+	private static @Nullable List<String> extractExecutableNames(Executable executable) {
+		final int offset;
+		if (!Modifier.isStatic(executable.getModifiers())) {
+			// remove "this" as first parameter
+			offset = 1;
+		} else {
+			offset = 0;
+		}
+		// by default parameter names are "arg0, arg1, arg2, ..." if compiler flag is not set
+		// so we need to extract them manually if possible
+		List<String> parameterNames = Stream.of(executable.getParameters())
+			.map(Parameter::getName)
+			.collect(Collectors.toList());
+		if (parameterNames.stream().allMatch(n -> n.startsWith("arg"))) {
+			final ParameterExtractor extractor;
+			if (executable instanceof Constructor) {
+				extractor = new ParameterExtractor((Constructor<?>) executable);
+			} else {
+				extractor = new ParameterExtractor((Method) executable);
+			}
+			getClassReader(executable.getDeclaringClass()).accept(extractor, 0);
+
+			final List<String> extractedNames = extractor.getParameterNames();
+			if (extractedNames.size() == 0) {
+				return null;
+			}
+			// remove "this" and additional local variables
+			// select less names if class file has not the required information
+			parameterNames = extractedNames.subList(
+				offset,
+				Math.min(executable.getParameterCount() + offset, extractedNames.size()));
+		}
+
+		if (parameterNames.size() != executable.getParameterCount()) {
+			return null;
 		}
 
 		return parameterNames;
@@ -509,7 +598,7 @@ public final class ExtractionUtils {
 	}
 
 	/**
-	 * Extracts the parameter names and descriptors from a constructor. Assuming the existence of a
+	 * Extracts the parameter names and descriptors from a constructor or method. Assuming the existence of a
 	 * local variable table.
 	 *
 	 * <p>For example:
@@ -527,13 +616,20 @@ public final class ExtractionUtils {
 	 */
 	private static class ParameterExtractor extends ClassVisitor {
 
-		private final String constructorDescriptor;
+		private static final int OPCODE = Opcodes.ASM7;
+
+		private final String methodDescriptor;
 
 		private final List<String> parameterNames = new ArrayList<>();
 
-		public ParameterExtractor(Constructor constructor) {
-			super(Opcodes.ASM7);
-			constructorDescriptor = getConstructorDescriptor(constructor);
+		public ParameterExtractor(Constructor<?> constructor) {
+			super(OPCODE);
+			methodDescriptor = getConstructorDescriptor(constructor);
+		}
+
+		public ParameterExtractor(Method method) {
+			super(OPCODE);
+			methodDescriptor = getMethodDescriptor(method);
 		}
 
 		public List<String> getParameterNames() {
@@ -547,8 +643,8 @@ public final class ExtractionUtils {
 				String descriptor,
 				String signature,
 				String[] exceptions) {
-			if (descriptor.equals(constructorDescriptor)) {
-				return new MethodVisitor(Opcodes.ASM7) {
+			if (descriptor.equals(methodDescriptor)) {
+				return new MethodVisitor(OPCODE) {
 					@Override
 					public void visitLocalVariable(
 							String name,
@@ -563,6 +659,181 @@ public final class ExtractionUtils {
 			}
 			return super.visitMethod(access, name, descriptor, signature, exceptions);
 		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Class Assignment and Boxing
+	//
+	// copied from o.a.commons.lang3.ClassUtils (commons-lang3:3.3.2)
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * <p>Checks if one {@code Class} can be assigned to a variable of
+	 * another {@code Class}.</p>
+	 *
+	 * <p>Unlike the {@link Class#isAssignableFrom(java.lang.Class)} method,
+	 * this method takes into account widenings of primitive classes and
+	 * {@code null}s.</p>
+	 *
+	 * <p>Primitive widenings allow an int to be assigned to a long, float or
+	 * double. This method returns the correct result for these cases.</p>
+	 *
+	 * <p>{@code Null} may be assigned to any reference type. This method
+	 * will return {@code true} if {@code null} is passed in and the
+	 * toClass is non-primitive.</p>
+	 *
+	 * <p>Specifically, this method tests whether the type represented by the
+	 * specified {@code Class} parameter can be converted to the type
+	 * represented by this {@code Class} object via an identity conversion
+	 * widening primitive or widening reference conversion. See
+	 * <em><a href="http://docs.oracle.com/javase/specs/">The Java Language Specification</a></em>,
+	 * sections 5.1.1, 5.1.2 and 5.1.4 for details.</p>
+	 *
+	 * @param cls  the Class to check, may be null
+	 * @param toClass  the Class to try to assign into, returns false if null
+	 * @param autoboxing  whether to use implicit autoboxing/unboxing between primitives and wrappers
+	 * @return {@code true} if assignment possible
+	 */
+	public static boolean isAssignable(Class<?> cls, final Class<?> toClass, final boolean autoboxing) {
+		if (toClass == null) {
+			return false;
+		}
+		// have to check for null, as isAssignableFrom doesn't
+		if (cls == null) {
+			return !toClass.isPrimitive();
+		}
+		//autoboxing:
+		if (autoboxing) {
+			if (cls.isPrimitive() && !toClass.isPrimitive()) {
+				cls = primitiveToWrapper(cls);
+				if (cls == null) {
+					return false;
+				}
+			}
+			if (toClass.isPrimitive() && !cls.isPrimitive()) {
+				cls = wrapperToPrimitive(cls);
+				if (cls == null) {
+					return false;
+				}
+			}
+		}
+		if (cls.equals(toClass)) {
+			return true;
+		}
+		if (cls.isPrimitive()) {
+			if (!toClass.isPrimitive()) {
+				return false;
+			}
+			if (Integer.TYPE.equals(cls)) {
+				return Long.TYPE.equals(toClass)
+					|| Float.TYPE.equals(toClass)
+					|| Double.TYPE.equals(toClass);
+			}
+			if (Long.TYPE.equals(cls)) {
+				return Float.TYPE.equals(toClass)
+					|| Double.TYPE.equals(toClass);
+			}
+			if (Boolean.TYPE.equals(cls)) {
+				return false;
+			}
+			if (Double.TYPE.equals(cls)) {
+				return false;
+			}
+			if (Float.TYPE.equals(cls)) {
+				return Double.TYPE.equals(toClass);
+			}
+			if (Character.TYPE.equals(cls)) {
+				return Integer.TYPE.equals(toClass)
+					|| Long.TYPE.equals(toClass)
+					|| Float.TYPE.equals(toClass)
+					|| Double.TYPE.equals(toClass);
+			}
+			if (Short.TYPE.equals(cls)) {
+				return Integer.TYPE.equals(toClass)
+					|| Long.TYPE.equals(toClass)
+					|| Float.TYPE.equals(toClass)
+					|| Double.TYPE.equals(toClass);
+			}
+			if (Byte.TYPE.equals(cls)) {
+				return Short.TYPE.equals(toClass)
+					|| Integer.TYPE.equals(toClass)
+					|| Long.TYPE.equals(toClass)
+					|| Float.TYPE.equals(toClass)
+					|| Double.TYPE.equals(toClass);
+			}
+			// should never get here
+			return false;
+		}
+		return toClass.isAssignableFrom(cls);
+	}
+
+	/**
+	 * Maps primitive {@code Class}es to their corresponding wrapper {@code Class}.
+	 */
+	private static final Map<Class<?>, Class<?>> primitiveWrapperMap = new HashMap<>();
+	static {
+		primitiveWrapperMap.put(Boolean.TYPE, Boolean.class);
+		primitiveWrapperMap.put(Byte.TYPE, Byte.class);
+		primitiveWrapperMap.put(Character.TYPE, Character.class);
+		primitiveWrapperMap.put(Short.TYPE, Short.class);
+		primitiveWrapperMap.put(Integer.TYPE, Integer.class);
+		primitiveWrapperMap.put(Long.TYPE, Long.class);
+		primitiveWrapperMap.put(Double.TYPE, Double.class);
+		primitiveWrapperMap.put(Float.TYPE, Float.class);
+		primitiveWrapperMap.put(Void.TYPE, Void.TYPE);
+	}
+
+	/**
+	 * Maps wrapper {@code Class}es to their corresponding primitive types.
+	 */
+	private static final Map<Class<?>, Class<?>> wrapperPrimitiveMap = new HashMap<>();
+	static {
+		for (final Class<?> primitiveClass : primitiveWrapperMap.keySet()) {
+			final Class<?> wrapperClass = primitiveWrapperMap.get(primitiveClass);
+			if (!primitiveClass.equals(wrapperClass)) {
+				wrapperPrimitiveMap.put(wrapperClass, primitiveClass);
+			}
+		}
+	}
+
+	/**
+	 * <p>Converts the specified primitive Class object to its corresponding
+	 * wrapper Class object.</p>
+	 *
+	 * <p>NOTE: From v2.2, this method handles {@code Void.TYPE},
+	 * returning {@code Void.TYPE}.</p>
+	 *
+	 * @param cls  the class to convert, may be null
+	 * @return the wrapper class for {@code cls} or {@code cls} if
+	 * {@code cls} is not a primitive. {@code null} if null input.
+	 * @since 2.1
+	 */
+	public static Class<?> primitiveToWrapper(final Class<?> cls) {
+		Class<?> convertedClass = cls;
+		if (cls != null && cls.isPrimitive()) {
+			convertedClass = primitiveWrapperMap.get(cls);
+		}
+		return convertedClass;
+	}
+
+	/**
+	 * <p>Converts the specified wrapper class to its corresponding primitive
+	 * class.</p>
+	 *
+	 * <p>This method is the counter part of {@code primitiveToWrapper()}.
+	 * If the passed in class is a wrapper class for a primitive type, this
+	 * primitive type will be returned (e.g. {@code Integer.TYPE} for
+	 * {@code Integer.class}). For other classes, or if the parameter is
+	 * <b>null</b>, the return value is <b>null</b>.</p>
+	 *
+	 * @param cls the class to convert, may be <b>null</b>
+	 * @return the corresponding primitive type if {@code cls} is a
+	 * wrapper class, <b>null</b> otherwise
+	 * @see #primitiveToWrapper(Class)
+	 * @since 2.4
+	 */
+	public static Class<?> wrapperToPrimitive(final Class<?> cls) {
+		return wrapperPrimitiveMap.get(cls);
 	}
 
 	private ExtractionUtils() {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/utils/FunctionArgumentTemplate.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/utils/FunctionArgumentTemplate.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.extraction.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.annotation.InputGroup;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
+import org.apache.flink.table.types.inference.InputTypeStrategies;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+
+import static org.apache.flink.table.types.extraction.utils.ExtractionUtils.extractionError;
+
+/**
+ * Template of a function argument. It can either be backed by a single or a group of {@link DataType}s.
+ */
+@Internal
+public final class FunctionArgumentTemplate {
+
+	public final @Nullable DataType dataType;
+
+	public final @Nullable InputGroup inputGroup;
+
+	private FunctionArgumentTemplate(@Nullable DataType dataType, @Nullable InputGroup inputGroup) {
+		this.dataType = dataType;
+		this.inputGroup = inputGroup;
+	}
+
+	public static FunctionArgumentTemplate of(DataType dataType) {
+		return new FunctionArgumentTemplate(dataType, null);
+	}
+
+	public static FunctionArgumentTemplate of(InputGroup inputGroup) {
+		return new FunctionArgumentTemplate(null, inputGroup);
+	}
+
+	public ArgumentTypeStrategy toArgumentTypeStrategy() {
+		if (dataType != null) {
+			return InputTypeStrategies.explicit(dataType);
+		}
+		assert inputGroup != null;
+		switch (inputGroup) {
+			case ANY:
+				return InputTypeStrategies.ANY;
+			case UNKNOWN:
+			default:
+				throw extractionError("Unsupported input group.");
+		}
+	}
+
+	public Class<?> toConversionClass() {
+		if (dataType != null) {
+			return dataType.getConversionClass();
+		}
+		assert inputGroup != null;
+		switch (inputGroup) {
+			case ANY:
+				return Object.class;
+			case UNKNOWN:
+			default:
+				throw extractionError("Unsupported input group.");
+		}
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		FunctionArgumentTemplate that = (FunctionArgumentTemplate) o;
+		return Objects.equals(dataType, that.dataType) && inputGroup == that.inputGroup;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(dataType, inputGroup);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/utils/FunctionMappingExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/utils/FunctionMappingExtractor.java
@@ -1,0 +1,486 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.extraction.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.annotation.FunctionHint;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.DataTypeLookup;
+import org.apache.flink.table.functions.UserDefinedFunction;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.extraction.DataTypeExtractor;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.apache.flink.table.types.extraction.utils.ExtractionUtils.collectMethods;
+import static org.apache.flink.table.types.extraction.utils.ExtractionUtils.extractionError;
+import static org.apache.flink.table.types.extraction.utils.ExtractionUtils.isAssignable;
+import static org.apache.flink.table.types.extraction.utils.ExtractionUtils.isMethodInvokable;
+import static org.apache.flink.table.types.extraction.utils.TemplateUtils.extractGlobalFunctionTemplates;
+import static org.apache.flink.table.types.extraction.utils.TemplateUtils.extractLocalFunctionTemplates;
+import static org.apache.flink.table.types.extraction.utils.TemplateUtils.findInputOnlyTemplates;
+import static org.apache.flink.table.types.extraction.utils.TemplateUtils.findResultMappingTemplates;
+import static org.apache.flink.table.types.extraction.utils.TemplateUtils.findResultOnlyTemplate;
+import static org.apache.flink.table.types.extraction.utils.TemplateUtils.findResultOnlyTemplates;
+
+/**
+ * Utility for extracting function mappings from signature to result, e.g. from (INT, STRING) to BOOLEAN.
+ *
+ * <p>Both the signature and result can either come from local or global {@link FunctionHint}s, or are
+ * extracted reflectively using the implementation methods and/or function generics.
+ */
+@Internal
+public final class FunctionMappingExtractor {
+
+	private final DataTypeLookup lookup;
+
+	private final Class<? extends UserDefinedFunction> function;
+
+	private final String methodName;
+
+	private final SignatureExtraction signatureExtraction;
+
+	private final @Nullable ResultExtraction accumulatorExtraction;
+
+	private final ResultExtraction outputExtraction;
+
+	private final MethodVerification verification;
+
+	public FunctionMappingExtractor(
+			DataTypeLookup lookup,
+			Class<? extends UserDefinedFunction> function,
+			String methodName,
+			SignatureExtraction signatureExtraction,
+			@Nullable ResultExtraction accumulatorExtraction,
+			ResultExtraction outputExtraction,
+			MethodVerification verification) {
+		this.lookup = lookup;
+		this.function = function;
+		this.methodName = methodName;
+		this.signatureExtraction = signatureExtraction;
+		this.accumulatorExtraction = accumulatorExtraction;
+		this.outputExtraction = outputExtraction;
+		this.verification = verification;
+	}
+
+	public Class<? extends UserDefinedFunction> getFunction() {
+		return function;
+	}
+
+	public boolean hasAccumulator() {
+		return accumulatorExtraction != null;
+	}
+
+	public Map<FunctionSignatureTemplate, FunctionResultTemplate> extractOutputMapping() {
+		try {
+			return extractResultMappings(
+				outputExtraction,
+				FunctionTemplate::getOutputTemplate,
+				verification);
+		} catch (Throwable t) {
+			throw extractionError(t, "Error in extracting a signature to output mapping.");
+		}
+	}
+
+	public Map<FunctionSignatureTemplate, FunctionResultTemplate> extractAccumulatorMapping() {
+		Preconditions.checkState(hasAccumulator());
+		try {
+			return extractResultMappings(
+				accumulatorExtraction,
+				FunctionTemplate::getAccumulatorTemplate,
+				(method, signature, result) -> {
+					// put the result into the signature for accumulators
+					final List<Class<?>> arguments = Stream.concat(Stream.of(result), signature.stream())
+						.collect(Collectors.toList());
+					verification.verify(method, arguments, null);
+				});
+		} catch (Throwable t) {
+			throw extractionError(t, "Error in extracting a signature to accumulator mapping.");
+		}
+	}
+
+	/**
+	 * Extracts mappings from signature to result (either accumulator or output) for the entire
+	 * function. Verifies if the extracted inference matches with the implementation.
+	 *
+	 * <p>For example, from {@code (INT, BOOLEAN, ANY) -> INT}. It does this by going through all implementation
+	 * methods and collecting all "per-method" mappings. The function mapping is the union of all "per-method"
+	 * mappings.
+	 */
+	private Map<FunctionSignatureTemplate, FunctionResultTemplate> extractResultMappings(
+			ResultExtraction resultExtraction,
+			Function<FunctionTemplate, FunctionResultTemplate> accessor,
+			MethodVerification verification) {
+		final Set<FunctionTemplate> global = extractGlobalFunctionTemplates(lookup, function);
+		final Set<FunctionResultTemplate> globalResultOnly = findResultOnlyTemplates(global, accessor);
+
+		// for each method find a signature that maps to results
+		final Map<FunctionSignatureTemplate, FunctionResultTemplate> collectedMappings = new HashMap<>();
+		final List<Method> methods = collectMethods(function, methodName);
+		if (methods.size() == 0) {
+			throw extractionError(
+				"Could not find a publicly accessible method named '%s'.",
+				methodName);
+		}
+		for (Method method : methods) {
+			try {
+				final Map<FunctionSignatureTemplate, FunctionResultTemplate> collectedMappingsPerMethod =
+					collectMethodMappings(method, global, globalResultOnly, resultExtraction, accessor);
+
+				// check if the method can be called
+				verifyMappingForMethod(method, collectedMappingsPerMethod, verification);
+
+				// check if method strategies conflict with function strategies
+				collectedMappingsPerMethod.forEach((signature, result) -> putMapping(collectedMappings, signature, result));
+			} catch (Throwable t) {
+				throw extractionError(
+					t,
+					"Unable to extract a type inference from method:\n%s",
+					method.toString());
+			}
+		}
+		return collectedMappings;
+	}
+
+	/**
+	 * Extracts mappings from signature to result (either accumulator or output) for the given method. It
+	 * considers both global hints for the entire function and local hints just for this method.
+	 *
+	 * <p>The algorithm aims to find an input signature for every declared result. If no result is
+	 * declared, it will be extracted. If no input signature is declared, it will be extracted.
+	 */
+	private Map<FunctionSignatureTemplate, FunctionResultTemplate> collectMethodMappings(
+			Method method,
+			Set<FunctionTemplate> global,
+			Set<FunctionResultTemplate> globalResultOnly,
+			ResultExtraction resultExtraction,
+			Function<FunctionTemplate, FunctionResultTemplate> accessor) {
+		final Map<FunctionSignatureTemplate, FunctionResultTemplate> collectedMappingsPerMethod = new HashMap<>();
+		final Set<FunctionTemplate> local = extractLocalFunctionTemplates(lookup, method);
+
+		final Set<FunctionResultTemplate> localResultOnly = findResultOnlyTemplates(
+			local,
+			accessor);
+
+		final Set<FunctionTemplate> explicitMappings = findResultMappingTemplates(
+			global,
+			local,
+			accessor);
+
+		final FunctionResultTemplate resultOnly = findResultOnlyTemplate(
+			globalResultOnly,
+			localResultOnly,
+			explicitMappings,
+			accessor);
+
+		final Set<FunctionSignatureTemplate> inputOnly = findInputOnlyTemplates(global, local, accessor);
+
+		// add all explicit mappings because they contain complete signatures
+		putExplicitMappings(collectedMappingsPerMethod, explicitMappings, inputOnly, accessor);
+		// add result only template with explicit or extracted signatures
+		putUniqueResultMappings(collectedMappingsPerMethod, resultOnly, inputOnly, method);
+		// handle missing result by extraction with explicit or extracted signatures
+		putExtractedResultMappings(collectedMappingsPerMethod, inputOnly, resultExtraction, method);
+
+		return collectedMappingsPerMethod;
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Helper methods (ordered by invocation order)
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Explicit mappings with complete signature to result declaration.
+	 */
+	private void putExplicitMappings(
+			Map<FunctionSignatureTemplate, FunctionResultTemplate> collectedMappings,
+			Set<FunctionTemplate> explicitMappings,
+			Set<FunctionSignatureTemplate> signatureOnly,
+			Function<FunctionTemplate, FunctionResultTemplate> accessor) {
+		explicitMappings.forEach(t -> {
+			// signature templates are valid everywhere and are added to the explicit mapping
+			Stream.concat(signatureOnly.stream(), Stream.of(t.getSignatureTemplate()))
+				.forEach(v -> putMapping(collectedMappings, v, accessor.apply(t)));
+		});
+	}
+
+	/**
+	 * Result only template with explicit or extracted signatures.
+	 */
+	private void putUniqueResultMappings(
+			Map<FunctionSignatureTemplate, FunctionResultTemplate> collectedMappings,
+			@Nullable FunctionResultTemplate uniqueResult,
+			Set<FunctionSignatureTemplate> signatureOnly,
+			Method method) {
+		if (uniqueResult == null) {
+			return;
+		}
+		// input only templates are valid everywhere if they don't exist fallback to extraction
+		if (!signatureOnly.isEmpty()) {
+			signatureOnly.forEach(s -> putMapping(collectedMappings, s, uniqueResult));
+		} else {
+			putMapping(
+				collectedMappings,
+				signatureExtraction.extract(this, method),
+				uniqueResult);
+		}
+	}
+
+	/**
+	 * Missing result by extraction with explicit or extracted signatures.
+	 */
+	private void putExtractedResultMappings(
+			Map<FunctionSignatureTemplate, FunctionResultTemplate> collectedMappings,
+			Set<FunctionSignatureTemplate> inputOnly,
+			ResultExtraction resultExtraction,
+			Method method) {
+		if (!collectedMappings.isEmpty()) {
+			return;
+		}
+		final FunctionResultTemplate result = resultExtraction.extract(this, method);
+		// input only validators are valid everywhere if they don't exist fallback to extraction
+		if (!inputOnly.isEmpty()) {
+			inputOnly.forEach(signature -> putMapping(collectedMappings, signature, result));
+		} else {
+			final FunctionSignatureTemplate signature = signatureExtraction.extract(this, method);
+			putMapping(collectedMappings, signature, result);
+		}
+	}
+
+	private void putMapping(
+			Map<FunctionSignatureTemplate, FunctionResultTemplate> collectedMappings,
+			FunctionSignatureTemplate signature,
+			FunctionResultTemplate result) {
+		final FunctionResultTemplate existingResult = collectedMappings.get(signature);
+		if (existingResult == null) {
+			collectedMappings.put(signature, result);
+		}
+		// template must not conflict with same input
+		else if (!existingResult.equals(result)) {
+			throw extractionError(
+				"Function hints with same input definition but different result types are not allowed.");
+		}
+	}
+
+	/**
+	 * Checks if the given method can be called and returns what hints declare.
+	 */
+	private void verifyMappingForMethod(
+			Method method,
+			Map<FunctionSignatureTemplate, FunctionResultTemplate> collectedMappingsPerMethod,
+			MethodVerification verification) {
+		collectedMappingsPerMethod.forEach((signature, result) ->
+			verification.verify(method, signature.toClass(), result.toClass()));
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Context sensitive extraction and verification logic
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Extraction that uses the method parameters for producing a {@link FunctionSignatureTemplate}.
+	 */
+	public static SignatureExtraction createParameterSignatureExtraction(int offset) {
+		return (extractor, method) -> {
+			final List<FunctionArgumentTemplate> parameterTypes = extractArgumentTemplates(
+				extractor.lookup,
+				extractor.function,
+				method,
+				offset);
+
+			final String[] argumentNames = extractArgumentNames(method, offset);
+
+			return FunctionSignatureTemplate.of(parameterTypes, method.isVarArgs(), argumentNames);
+		};
+	}
+
+	private static List<FunctionArgumentTemplate> extractArgumentTemplates(
+			DataTypeLookup lookup,
+			Class<? extends UserDefinedFunction> function,
+			Method method,
+			int offset) {
+		return IntStream.range(offset, method.getParameterCount())
+			.mapToObj(i -> {
+				final DataType type = DataTypeExtractor.extractFromMethodParameter(lookup, function, method, i);
+				// unwrap from ARRAY data type in case of varargs
+				if (method.isVarArgs() && i == method.getParameterCount() - 1 && type instanceof CollectionDataType) {
+					return ((CollectionDataType) type).getElementDataType();
+				} else {
+					return type;
+				}
+			})
+			.map(FunctionArgumentTemplate::of)
+			.collect(Collectors.toList());
+	}
+
+	private static @Nullable String[] extractArgumentNames(Method method, int offset) {
+		final List<String> methodParameterNames = ExtractionUtils.extractMethodParameterNames(method);
+		if (methodParameterNames != null) {
+			return methodParameterNames.subList(offset, methodParameterNames.size())
+				.toArray(new String[0]);
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * Extraction that uses the method return type for producing a {@link FunctionResultTemplate}.
+	 */
+	public static ResultExtraction createReturnTypeResultExtraction() {
+		return (extractor, method) -> {
+			final DataType dataType = DataTypeExtractor.extractFromMethodOutput(
+				extractor.lookup,
+				extractor.function,
+				method);
+			return FunctionResultTemplate.of(dataType);
+		};
+	}
+
+	/**
+	 * Extraction that uses a generic type variable for producing a {@link FunctionResultTemplate}.
+	 */
+	public static ResultExtraction createGenericResultExtraction(Class<? extends UserDefinedFunction> baseClass, int genericPos) {
+		return (extractor, method) -> {
+			final DataType dataType = DataTypeExtractor.extractFromGeneric(
+				extractor.lookup,
+				baseClass,
+				genericPos,
+				extractor.function);
+			return FunctionResultTemplate.of(dataType);
+		};
+	}
+
+	/**
+	 * Verification that checks a method by parameters and return type.
+	 */
+	public static MethodVerification createParameterAndReturnTypeVerification() {
+		return (method, signature, result) -> {
+			final Class<?>[] parameters = signature.toArray(new Class[0]);
+			final Class<?> returnType = method.getReturnType();
+			final boolean isValid = isMethodInvokable(method, parameters) &&
+				isAssignable(result, returnType, true);
+			if (!isValid) {
+				throw createMethodNotFoundError(method.getName(), parameters, result);
+			}
+		};
+	}
+
+	/**
+	 * Verification that checks a method by parameters including an accumulator.
+	 */
+	public static MethodVerification createParameterWithAccumulatorVerification() {
+		return (method, signature, result) -> {
+			if (result != null) {
+				// ignore the accumulator in the first argument
+				createParameterWithArgumentVerification(null).verify(method, signature, result);
+			} else {
+				// check the signature only
+				createParameterVerification().verify(method, signature, null);
+			}
+		};
+	}
+
+	/**
+	 * Verification that checks a method by parameters including an additional first parameter.
+	 */
+	public static MethodVerification createParameterWithArgumentVerification(@Nullable Class<?> argumentClass) {
+		return (method, signature, result) -> {
+			final Class<?>[] parameters = Stream.concat(Stream.of(argumentClass), signature.stream())
+				.toArray(Class<?>[]::new);
+			if (!isMethodInvokable(method, parameters)) {
+				throw createMethodNotFoundError(method.getName(), parameters, null);
+			}
+		};
+	}
+
+	/**
+	 * Verification that checks a method by parameters.
+	 */
+	public static MethodVerification createParameterVerification() {
+		return (method, signature, result) -> {
+			final Class<?>[] parameters = signature.toArray(new Class[0]);
+			if (!isMethodInvokable(method, parameters)) {
+				throw createMethodNotFoundError(method.getName(), parameters, null);
+			}
+		};
+	}
+
+	private static ValidationException createMethodNotFoundError(
+			String methodName,
+			Class<?>[] parameters,
+			@Nullable Class<?> returnType) {
+		final StringBuilder builder = new StringBuilder();
+		if (returnType != null) {
+			builder.append(returnType.getName()).append(" ");
+		}
+		builder
+			.append(methodName)
+			.append(
+				Stream.of(parameters)
+					.map(parameter -> {
+						// in case we don't know the parameter at this location (i.e. for accumulators)
+						if (parameter == null) {
+							return "_";
+						} else {
+							return parameter.getName();
+						}
+					})
+					.collect(Collectors.joining(", ", "(", ")")));
+		return extractionError(
+			"Considering all hints, the method should comply with the signature:\n%s",
+			builder.toString());
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Helper interfaces
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Extracts a {@link FunctionSignatureTemplate} from a method.
+	 */
+	public interface SignatureExtraction {
+		FunctionSignatureTemplate extract(FunctionMappingExtractor extractor, Method method);
+	}
+
+	/**
+	 * Extracts a {@link FunctionResultTemplate} from a class or method.
+	 */
+	public interface ResultExtraction {
+		@Nullable FunctionResultTemplate extract(FunctionMappingExtractor extractor, Method method);
+	}
+
+	/**
+	 * Verifies the signature of a method.
+	 */
+	public interface MethodVerification {
+		void verify(Method method, List<Class<?>> arguments, Class<?> result);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/utils/FunctionResultTemplate.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/utils/FunctionResultTemplate.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.extraction.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.TypeStrategies;
+import org.apache.flink.table.types.inference.TypeStrategy;
+
+import java.util.Objects;
+
+/**
+ * Template of a function intermediate result (i.e. accumulator) or final result (i.e. output).
+ */
+@Internal
+public final class FunctionResultTemplate {
+
+	public final DataType dataType;
+
+	private FunctionResultTemplate(DataType dataType) {
+		this.dataType = dataType;
+	}
+
+	public static FunctionResultTemplate of(DataType dataType) {
+		return new FunctionResultTemplate(dataType);
+	}
+
+	public TypeStrategy toTypeStrategy() {
+		return TypeStrategies.explicit(dataType);
+	}
+
+	public Class<?> toClass() {
+		return dataType.getConversionClass();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		FunctionResultTemplate that = (FunctionResultTemplate) o;
+		return dataType.equals(that.dataType);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(dataType);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/utils/FunctionSignatureTemplate.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/utils/FunctionSignatureTemplate.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.extraction.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
+import org.apache.flink.table.types.inference.InputTypeStrategies;
+import org.apache.flink.table.types.inference.InputTypeStrategy;
+
+import javax.annotation.Nullable;
+
+import java.lang.reflect.Array;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.table.types.extraction.utils.ExtractionUtils.extractionError;
+
+/**
+ * Template of a function signature with argument types and argument names.
+ */
+@Internal
+public final class FunctionSignatureTemplate {
+
+	public final List<FunctionArgumentTemplate> argumentTemplates;
+
+	public final boolean isVarArgs;
+
+	public final @Nullable String[] argumentNames;
+
+	private FunctionSignatureTemplate(
+			List<FunctionArgumentTemplate> argumentTemplates,
+			boolean isVarArgs,
+			@Nullable String[] argumentNames) {
+		this.argumentTemplates = argumentTemplates;
+		this.isVarArgs = isVarArgs;
+		this.argumentNames = argumentNames;
+	}
+
+	public static FunctionSignatureTemplate of(
+			List<FunctionArgumentTemplate> argumentTemplates,
+			boolean isVarArgs,
+			@Nullable String[] argumentNames) {
+		if (argumentNames != null && argumentNames.length != argumentTemplates.size()) {
+			throw extractionError(
+				"Mismatch between number of argument names '%s' and argument types '%s'.",
+				argumentNames.length,
+				argumentTemplates.size());
+		}
+		return new FunctionSignatureTemplate(argumentTemplates, isVarArgs, argumentNames);
+	}
+
+	public InputTypeStrategy toInputTypeStrategy() {
+		final ArgumentTypeStrategy[] argumentStrategies = argumentTemplates.stream()
+			.map(FunctionArgumentTemplate::toArgumentTypeStrategy)
+			.toArray(ArgumentTypeStrategy[]::new);
+
+		final InputTypeStrategy strategy;
+		if (isVarArgs) {
+			if (argumentNames == null) {
+				strategy = InputTypeStrategies.varyingSequence(argumentStrategies);
+			} else {
+				strategy = InputTypeStrategies.varyingSequence(
+					argumentNames,
+					argumentStrategies);
+			}
+		} else {
+			if (argumentNames == null) {
+				strategy = InputTypeStrategies.sequence(argumentStrategies);
+			} else {
+				strategy = InputTypeStrategies.sequence(argumentNames, argumentStrategies);
+			}
+		}
+		return strategy;
+	}
+
+	public List<Class<?>> toClass() {
+		return IntStream.range(0, argumentTemplates.size())
+			.mapToObj(i -> {
+				final Class<?> clazz = argumentTemplates.get(i).toConversionClass();
+				if (i == argumentTemplates.size() - 1 && isVarArgs) {
+					return Array.newInstance(clazz, 0).getClass();
+				}
+				return clazz;
+			})
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		FunctionSignatureTemplate that = (FunctionSignatureTemplate) o;
+		// argument names are not part of equality
+		return isVarArgs == that.isVarArgs &&
+			argumentTemplates.equals(that.argumentTemplates);
+	}
+
+	@Override
+	public int hashCode() {
+		// argument names are not part of equality
+		return Objects.hash(argumentTemplates, isVarArgs);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/utils/FunctionTemplate.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/utils/FunctionTemplate.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.extraction.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.annotation.FunctionHint;
+import org.apache.flink.table.catalog.DataTypeLookup;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.types.extraction.utils.ExtractionUtils.extractionError;
+
+/**
+ * Internal representation of a {@link FunctionHint}.
+ *
+ * <p>All parameters of a template are optional. An empty annotation results in a template where all
+ * members are {@code null}.
+ */
+@Internal
+public final class FunctionTemplate {
+
+	private static final FunctionHint DEFAULT_ANNOTATION = getDefaultAnnotation();
+
+	private final @Nullable FunctionSignatureTemplate signatureTemplate;
+
+	private final @Nullable FunctionResultTemplate accumulatorTemplate;
+
+	private final @Nullable FunctionResultTemplate outputTemplate;
+
+	private FunctionTemplate(
+			@Nullable FunctionSignatureTemplate signatureTemplate,
+			@Nullable FunctionResultTemplate accumulatorTemplate,
+			@Nullable FunctionResultTemplate outputTemplate) {
+		this.signatureTemplate = signatureTemplate;
+		this.accumulatorTemplate = accumulatorTemplate;
+		this.outputTemplate = outputTemplate;
+	}
+
+	/**
+	 * Creates an instance using the given {@link FunctionHint}. It resolves explicitly defined data
+	 * types.
+	 */
+	public static FunctionTemplate fromAnnotation(DataTypeLookup lookup, FunctionHint hint) {
+		return new FunctionTemplate(
+			createSignatureTemplate(
+				lookup,
+				defaultAsNull(hint, FunctionHint::input),
+				defaultAsNull(hint, FunctionHint::argumentNames),
+				hint.isVarArgs()),
+			createResultTemplate(lookup, defaultAsNull(hint, FunctionHint::accumulator)),
+			createResultTemplate(lookup, defaultAsNull(hint, FunctionHint::output))
+		);
+	}
+
+	public @Nullable FunctionSignatureTemplate getSignatureTemplate() {
+		return signatureTemplate;
+	}
+
+	public @Nullable FunctionResultTemplate getAccumulatorTemplate() {
+		return accumulatorTemplate;
+	}
+
+	public @Nullable FunctionResultTemplate getOutputTemplate() {
+		return outputTemplate;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		FunctionTemplate template = (FunctionTemplate) o;
+		return Objects.equals(signatureTemplate, template.signatureTemplate) &&
+			Objects.equals(accumulatorTemplate, template.accumulatorTemplate) &&
+			Objects.equals(outputTemplate, template.outputTemplate);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(signatureTemplate, accumulatorTemplate, outputTemplate);
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	@FunctionHint
+	private static class DefaultAnnotationHelper {
+		// no implementation
+	}
+
+	private static FunctionHint getDefaultAnnotation() {
+		return DefaultAnnotationHelper.class.getAnnotation(FunctionHint.class);
+	}
+
+	private static <T> T defaultAsNull(FunctionHint hint, Function<FunctionHint, T> accessor) {
+		final T defaultValue = accessor.apply(DEFAULT_ANNOTATION);
+		final T actualValue = accessor.apply(hint);
+		if (Objects.deepEquals(defaultValue, actualValue)) {
+			return null;
+		}
+		return actualValue;
+	}
+
+	private static @Nullable FunctionSignatureTemplate createSignatureTemplate(
+			DataTypeLookup lookup,
+			@Nullable DataTypeHint[] input,
+			@Nullable String[] argumentNames,
+			boolean isVarArg) {
+		if (input == null) {
+			return null;
+		}
+		return FunctionSignatureTemplate.of(
+			Arrays.stream(input)
+				.map(dataTypeHint -> createArgumentTemplate(lookup, dataTypeHint))
+				.collect(Collectors.toList()),
+			isVarArg,
+			argumentNames);
+	}
+
+	private static @Nullable FunctionResultTemplate createResultTemplate(
+			DataTypeLookup lookup,
+			@Nullable DataTypeHint hint) {
+		if (hint == null) {
+			return null;
+		}
+		final DataTypeTemplate template;
+		try {
+			template = DataTypeTemplate.fromAnnotation(lookup, hint);
+		} catch (Throwable t) {
+			throw extractionError(t, "Error in data type hint annotation.");
+		}
+		if (template.dataType != null) {
+			return FunctionResultTemplate.of(template.dataType);
+		}
+		throw extractionError(
+			"Data type hint does not specify a data type for use as function result.");
+	}
+
+	private static FunctionArgumentTemplate createArgumentTemplate(
+			DataTypeLookup lookup,
+			DataTypeHint hint) {
+		final DataTypeTemplate template = DataTypeTemplate.fromAnnotation(lookup, hint);
+		if (template.dataType != null) {
+			return FunctionArgumentTemplate.of(template.dataType);
+		} else if (template.inputGroup != null) {
+			return FunctionArgumentTemplate.of(template.inputGroup);
+		}
+		throw extractionError(
+			"Data type hint does neither specify a data type nor input group for use as function argument.");
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/utils/TemplateUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/utils/TemplateUtils.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.extraction.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.annotation.FunctionHint;
+import org.apache.flink.table.catalog.DataTypeLookup;
+import org.apache.flink.table.functions.UserDefinedFunction;
+
+import javax.annotation.Nullable;
+
+import java.lang.reflect.Method;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.flink.table.types.extraction.utils.ExtractionUtils.collectAnnotationsOfClass;
+import static org.apache.flink.table.types.extraction.utils.ExtractionUtils.collectAnnotationsOfMethod;
+import static org.apache.flink.table.types.extraction.utils.ExtractionUtils.extractionError;
+
+/**
+ * Utilities for extracting and dealing with templates.
+ */
+@Internal
+final class TemplateUtils {
+
+	/**
+	 * Retrieve global templates from function class.
+	 */
+	static Set<FunctionTemplate> extractGlobalFunctionTemplates(
+			DataTypeLookup lookup,
+			Class<? extends UserDefinedFunction> function) {
+		return asFunctionTemplates(lookup, collectAnnotationsOfClass(FunctionHint.class, function));
+	}
+
+	/**
+	 * Retrieve local templates from function method.
+	 */
+	static Set<FunctionTemplate> extractLocalFunctionTemplates(DataTypeLookup lookup, Method method) {
+		return asFunctionTemplates(lookup, collectAnnotationsOfMethod(FunctionHint.class, method));
+	}
+
+	/**
+	 * Converts {@link FunctionHint}s to {@link FunctionTemplate}.
+	 */
+	static Set<FunctionTemplate> asFunctionTemplates(DataTypeLookup lookup, Set<FunctionHint> hints) {
+		return hints.stream()
+			.map(hint -> {
+				try {
+					return FunctionTemplate.fromAnnotation(lookup, hint);
+				} catch (Throwable t) {
+					throw extractionError(t, "Error in function hint annotation.");
+				}
+			})
+			.collect(Collectors.toSet());
+	}
+
+	/**
+	 * Find a template that only specifies a result.
+	 */
+	static Set<FunctionResultTemplate> findResultOnlyTemplates(
+			Set<FunctionTemplate> functionTemplates,
+			Function<FunctionTemplate, FunctionResultTemplate> accessor) {
+		return functionTemplates.stream()
+			.filter(t -> t.getSignatureTemplate() == null && accessor.apply(t) != null)
+			.map(accessor)
+			.collect(Collectors.toSet());
+	}
+
+	/**
+	 * Hints that only declare a result (either accumulator or output).
+	 */
+	static @Nullable FunctionResultTemplate findResultOnlyTemplate(
+			Set<FunctionResultTemplate> globalResultOnly,
+			Set<FunctionResultTemplate> localResultOnly,
+			Set<FunctionTemplate> explicitMappings,
+			Function<FunctionTemplate, FunctionResultTemplate> accessor) {
+		final Set<FunctionResultTemplate> resultOnly = Stream.concat(
+				globalResultOnly.stream(),
+				localResultOnly.stream())
+			.collect(Collectors.toSet());
+		final Set<FunctionResultTemplate> allResults = Stream.concat(
+				resultOnly.stream(),
+				explicitMappings.stream().map(accessor))
+			.collect(Collectors.toSet());
+		if (resultOnly.size() == 1 && allResults.size() == 1) {
+			return resultOnly.stream().findFirst().orElse(null);
+		}
+		// different results is only fine as long as those come from a mapping
+		if (resultOnly.size() > 1 || (!resultOnly.isEmpty() && !explicitMappings.isEmpty())) {
+			throw extractionError("Function hints that lead to ambiguous results are not allowed.");
+		}
+		return null;
+	}
+
+	/**
+	 * Hints that map a signature to a result.
+	 */
+	static Set<FunctionTemplate> findResultMappingTemplates(
+			Set<FunctionTemplate> globalTemplates,
+			Set<FunctionTemplate> localTemplates,
+			Function<FunctionTemplate, FunctionResultTemplate> accessor) {
+		return Stream.concat(globalTemplates.stream(), localTemplates.stream())
+			.filter(t -> t.getSignatureTemplate() != null && accessor.apply(t) != null)
+			.collect(Collectors.toSet());
+	}
+
+	/**
+	 * Hints that only declare an input.
+	 */
+	static Set<FunctionSignatureTemplate> findInputOnlyTemplates(
+			Set<FunctionTemplate> global,
+			Set<FunctionTemplate> local,
+			Function<FunctionTemplate, FunctionResultTemplate> accessor) {
+		return Stream.concat(global.stream(), local.stream())
+			.filter(t ->
+				t.getSignatureTemplate() != null &&
+				accessor.apply(t) == null)
+			.map(FunctionTemplate::getSignatureTemplate)
+			.collect(Collectors.toSet());
+	}
+
+	private TemplateUtils() {
+		// no instantiation
+	}
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/DataTypeExtractorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/DataTypeExtractorTest.java
@@ -40,7 +40,9 @@ import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.StructuredType;
 import org.apache.flink.table.types.logical.TypeInformationRawType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.types.Row;
 
+import org.hamcrest.Matcher;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -97,12 +99,20 @@ public class DataTypeExtractorTest {
 				.forType(BigDecimal.class)
 				.expectErrorMessage("Values of 'java.math.BigDecimal' need fixed precision and scale."),
 
-			// unsupported type exception
+			// unsupported Object type exception
 			TestSpec
 				.forType(Object.class)
 				.expectErrorMessage(
-					"Could not extract a data type from 'class java.lang.Object'. " +
-						"Interpreting it as a structured type was also not successful."),
+					"Cannot extract a data type from a pure 'java.lang.Object' class. " +
+						"Usually, this indicates that class information is missing or got lost. " +
+						"Please specify a more concrete class or treat it as a RAW type."),
+
+			// unsupported Row type exception
+			TestSpec
+				.forType(Row.class)
+				.expectErrorMessage(
+					"Cannot extract a data type from a pure 'org.apache.flink.types.Row' class. " +
+						"Please use annotations to define field names and field types."),
 
 			// explicit precision/scale through data type
 			TestSpec
@@ -344,7 +354,22 @@ public class DataTypeExtractorTest {
 			TestSpec
 				.forType(ComplexPojoWithManyAnnotations.class)
 				.lookupExpects(Object.class)
-				.expectDataType(getComplexPojoDataType(ComplexPojoWithManyAnnotations.class, SimplePojo.class))
+				.expectDataType(getComplexPojoDataType(ComplexPojoWithManyAnnotations.class, SimplePojo.class)),
+
+			// method with varargs
+			TestSpec
+				.forMethodParameter(IntegerVarArg.class, 1)
+				.expectDataType(DataTypes.ARRAY(DataTypes.INT().notNull().bridgedTo(int.class))),
+
+			// method with generic parameter
+			TestSpec
+				.forMethodParameter(IntegerVarArg.class, 0)
+				.expectDataType(DataTypes.INT()),
+
+			// method with generic return type
+			TestSpec
+				.forMethodOutput(IntegerVarArg.class)
+				.expectDataType(DataTypes.INT())
 		);
 	}
 
@@ -358,16 +383,9 @@ public class DataTypeExtractorTest {
 	public void testExtraction() {
 		if (testSpec.expectedErrorMessage != null) {
 			thrown.expect(ValidationException.class);
-			thrown.expectCause(containsCause(new ValidationException(testSpec.expectedErrorMessage)));
+			thrown.expectCause(errorMatcher(testSpec));
 		}
 		runExtraction(testSpec);
-	}
-
-	static void runExtraction(TestSpec testSpec) {
-		final DataType dataType = testSpec.extractor.apply(testSpec.lookup);
-		if (testSpec.expectedDataType != null) {
-			assertThat(dataType, equalTo(testSpec.expectedDataType));
-		}
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -407,15 +425,19 @@ public class DataTypeExtractorTest {
 		}
 
 		static TestSpec forMethodParameter(Class<?> clazz, int paramPos) {
-			final Method method = clazz.getDeclaredMethods()[0];
+			final Method method = clazz.getMethods()[0];
 			return new TestSpec((lookup) ->
 				DataTypeExtractor.extractFromMethodParameter(lookup, clazz, method, paramPos));
 		}
 
 		static TestSpec forMethodOutput(Class<?> clazz) {
-			final Method method = clazz.getDeclaredMethods()[0];
+			final Method method = clazz.getMethods()[0];
 			return new TestSpec((lookup) ->
 				DataTypeExtractor.extractFromMethodOutput(lookup, clazz, method));
+		}
+
+		boolean hasErrorMessage() {
+			return expectedErrorMessage != null;
 		}
 
 		TestSpec lookupExpects(Class<?> lookupClass) {
@@ -433,6 +455,17 @@ public class DataTypeExtractorTest {
 			this.expectedErrorMessage = expectedErrorMessage;
 			return this;
 		}
+	}
+
+	static void runExtraction(TestSpec testSpec) {
+		final DataType dataType = testSpec.extractor.apply(testSpec.lookup);
+		if (testSpec.expectedDataType != null) {
+			assertThat(dataType, equalTo(testSpec.expectedDataType));
+		}
+	}
+
+	static Matcher<Throwable> errorMatcher(TestSpec testSpec) {
+		return containsCause(new ValidationException(testSpec.expectedErrorMessage));
 	}
 
 	/**
@@ -811,5 +844,24 @@ public class DataTypeExtractorTest {
 		public @DataTypeHint("MAP<STRING, INT>") Object mapField;
 		public SimplePojo simplePojoField;
 		public Object someObject;
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Generic Varargs in parameters.
+	 */
+	public static class VarArgMethod<T> {
+		@SuppressWarnings("unused")
+		public T eval(T i, int... more) {
+			return null;
+		}
+	}
+
+	/**
+	 * Resolvable parameters.
+	 */
+	public static class IntegerVarArg extends VarArgMethod<Integer> {
+		// nothing to do
 	}
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/TypeInferenceExtractorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/TypeInferenceExtractorTest.java
@@ -1,0 +1,731 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.extraction;
+
+import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.annotation.FunctionHint;
+import org.apache.flink.table.annotation.InputGroup;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.DataTypeLookup;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
+import org.apache.flink.table.functions.AggregateFunction;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.functions.TableAggregateFunction;
+import org.apache.flink.table.functions.TableFunction;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
+import org.apache.flink.table.types.inference.InputTypeStrategies;
+import org.apache.flink.table.types.inference.InputTypeStrategy;
+import org.apache.flink.table.types.inference.TypeInference;
+import org.apache.flink.table.types.inference.TypeStrategies;
+import org.apache.flink.table.types.inference.TypeStrategy;
+import org.apache.flink.table.types.logical.utils.LogicalTypeParser;
+import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.types.Row;
+
+import org.hamcrest.Matcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.apache.flink.util.CoreMatchers.containsCause;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link TypeInferenceExtractor}.
+ */
+@RunWith(Parameterized.class)
+@SuppressWarnings("unused")
+public class TypeInferenceExtractorTest {
+
+	@Parameters
+	public static List<TestSpec> testData() {
+		return Arrays.asList(
+			// function hint defines everything
+			TestSpec
+				.forScalarFunction(FullFunctionHint.class)
+				.expectNamedArguments("i", "s")
+				.expectTypedArguments(DataTypes.INT(), DataTypes.STRING())
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(
+						new String[] {"i", "s"},
+						new ArgumentTypeStrategy[] {
+							InputTypeStrategies.explicit(DataTypes.INT()),
+							InputTypeStrategies.explicit(DataTypes.STRING())}
+					),
+					TypeStrategies.explicit(DataTypes.BOOLEAN())),
+
+			// function hint defines everything with overloading
+			TestSpec
+				.forScalarFunction(FullFunctionHints.class)
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(InputTypeStrategies.explicit(DataTypes.INT())),
+					TypeStrategies.explicit(DataTypes.INT()))
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(InputTypeStrategies.explicit(DataTypes.BIGINT())),
+					TypeStrategies.explicit(DataTypes.BIGINT())),
+
+			// global output hint with local input overloading
+			TestSpec
+				.forScalarFunction(GlobalOutputFunctionHint.class)
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(InputTypeStrategies.explicit(DataTypes.INT())),
+					TypeStrategies.explicit(DataTypes.INT()))
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(InputTypeStrategies.explicit(DataTypes.STRING())),
+					TypeStrategies.explicit(DataTypes.INT())),
+
+			// unsupported output overloading
+			TestSpec
+				.forScalarFunction(InvalidSingleOutputFunctionHint.class)
+				.expectErrorMessage("Function hints that lead to ambiguous results are not allowed."),
+
+			// global and local overloading
+			TestSpec
+				.forScalarFunction(SplitFullFunctionHints.class)
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(InputTypeStrategies.explicit(DataTypes.INT())),
+					TypeStrategies.explicit(DataTypes.INT()))
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(InputTypeStrategies.explicit(DataTypes.BIGINT())),
+					TypeStrategies.explicit(DataTypes.BIGINT())),
+
+			// global and local overloading with unsupported output overloading
+			TestSpec
+				.forScalarFunction(InvalidFullOutputFunctionHint.class)
+				.expectErrorMessage("Function hints with same input definition but different result types are not allowed."),
+
+			// ignore argument names during overloading
+			TestSpec
+				.forScalarFunction(InvalidFullOutputFunctionWithArgNamesHint.class)
+				.expectErrorMessage("Function hints with same input definition but different result types are not allowed."),
+
+			// invalid data type hint
+			TestSpec
+				.forScalarFunction(IncompleteFunctionHint.class)
+				.expectErrorMessage("Data type hint does neither specify a data type nor input group for use as function argument."),
+
+			// varargs and ANY input group
+			TestSpec
+				.forScalarFunction(ComplexFunctionHint.class)
+				.expectOutputMapping(
+					InputTypeStrategies.varyingSequence(
+						new String[]{"myInt", "myAny"},
+						new ArgumentTypeStrategy[]{InputTypeStrategies.explicit(DataTypes.INT()), InputTypeStrategies.ANY}),
+					TypeStrategies.explicit(DataTypes.BOOLEAN())),
+
+			// global input hints and local output hints
+			TestSpec
+				.forScalarFunction(GlobalInputFunctionHints.class)
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(InputTypeStrategies.explicit(DataTypes.INT())),
+					TypeStrategies.explicit(DataTypes.INT()))
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(InputTypeStrategies.explicit(DataTypes.BIGINT())),
+					TypeStrategies.explicit(DataTypes.INT())),
+
+			// no arguments
+			TestSpec
+				.forScalarFunction(ZeroArgFunction.class)
+				.expectNamedArguments()
+				.expectTypedArguments()
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(new String[0], new ArgumentTypeStrategy[0]),
+					TypeStrategies.explicit(DataTypes.INT())),
+
+			// test primitive arguments extraction
+			TestSpec
+				.forScalarFunction(MixedArgFunction.class)
+				.expectNamedArguments("i", "d")
+				.expectTypedArguments(
+					DataTypes.INT().notNull().bridgedTo(int.class),
+					DataTypes.DOUBLE())
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(
+						new String[]{"i", "d"},
+						new ArgumentTypeStrategy[]{
+							InputTypeStrategies.explicit(DataTypes.INT().notNull().bridgedTo(int.class)),
+							InputTypeStrategies.explicit(DataTypes.DOUBLE())}),
+					TypeStrategies.explicit(DataTypes.INT())),
+
+			// test overloaded arguments extraction
+			TestSpec
+				.forScalarFunction(OverloadedFunction.class)
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(
+						new String[]{"i", "d"},
+						new ArgumentTypeStrategy[]{
+							InputTypeStrategies.explicit(DataTypes.INT().notNull().bridgedTo(int.class)),
+							InputTypeStrategies.explicit(DataTypes.DOUBLE())}),
+					TypeStrategies.explicit(DataTypes.INT()))
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(
+						new String[]{"s"},
+						new ArgumentTypeStrategy[]{
+							InputTypeStrategies.explicit(DataTypes.STRING())
+						}),
+					TypeStrategies.explicit(DataTypes.BIGINT().notNull().bridgedTo(long.class))),
+
+			// test varying arguments extraction
+			TestSpec
+				.forScalarFunction(VarArgFunction.class)
+				.expectOutputMapping(
+					InputTypeStrategies.varyingSequence(
+						new String[]{"i", "more"},
+						new ArgumentTypeStrategy[]{
+							InputTypeStrategies.explicit(DataTypes.INT().notNull().bridgedTo(int.class)),
+							InputTypeStrategies.explicit(DataTypes.INT().notNull().bridgedTo(int.class))
+						}),
+					TypeStrategies.explicit(DataTypes.STRING())),
+
+			// output hint with input extraction
+			TestSpec
+				.forScalarFunction(ExtractWithOutputHintFunction.class)
+				.expectNamedArguments("i")
+				.expectTypedArguments(DataTypes.INT())
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(
+						new String[]{"i"},
+						new ArgumentTypeStrategy[]{
+							InputTypeStrategies.explicit(DataTypes.INT())
+						}),
+					TypeStrategies.explicit(DataTypes.INT())),
+
+			// output extraction with input hints
+			TestSpec
+				.forScalarFunction(ExtractWithInputHintFunction.class)
+				.expectNamedArguments("i", "b")
+				.expectTypedArguments(DataTypes.INT(), DataTypes.BOOLEAN())
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(
+						new String[]{"i", "b"},
+						new ArgumentTypeStrategy[]{
+							InputTypeStrategies.explicit(DataTypes.INT()),
+							InputTypeStrategies.explicit(DataTypes.BOOLEAN())
+						}),
+					TypeStrategies.explicit(DataTypes.DOUBLE().notNull().bridgedTo(double.class))),
+
+			// different accumulator depending on input
+			TestSpec
+				.forAggregateFunction(InputDependentAccumulatorFunction.class)
+				.expectAccumulatorMapping(
+					InputTypeStrategies.sequence(InputTypeStrategies.explicit(DataTypes.STRING())),
+					TypeStrategies.explicit(DataTypes.ROW(DataTypes.FIELD("f", DataTypes.STRING()))))
+				.expectAccumulatorMapping(
+					InputTypeStrategies.sequence(InputTypeStrategies.explicit(DataTypes.BIGINT())),
+					TypeStrategies.explicit(DataTypes.ROW(DataTypes.FIELD("f", DataTypes.BIGINT()))))
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(InputTypeStrategies.explicit(DataTypes.STRING())),
+					TypeStrategies.explicit(DataTypes.STRING()))
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(InputTypeStrategies.explicit(DataTypes.BIGINT())),
+					TypeStrategies.explicit(DataTypes.STRING())),
+
+			// input, accumulator, and output are spread across the function
+			TestSpec
+				.forAggregateFunction(AggregateFunctionWithManyAnnotations.class)
+				.expectNamedArguments("r")
+				.expectTypedArguments(
+					DataTypes.ROW(
+						DataTypes.FIELD("i", DataTypes.INT()),
+						DataTypes.FIELD("b", DataTypes.BOOLEAN())))
+				.expectAccumulatorMapping(
+					InputTypeStrategies.sequence(
+						new String[]{"r"},
+						new ArgumentTypeStrategy[]{
+							InputTypeStrategies.explicit(DataTypes.ROW(
+								DataTypes.FIELD("i", DataTypes.INT()),
+								DataTypes.FIELD("b", DataTypes.BOOLEAN())))
+						}),
+					TypeStrategies.explicit(DataTypes.ROW(DataTypes.FIELD("b", DataTypes.BOOLEAN()))))
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(
+						new String[]{"r"},
+						new ArgumentTypeStrategy[]{
+							InputTypeStrategies.explicit(DataTypes.ROW(
+								DataTypes.FIELD("i", DataTypes.INT()),
+								DataTypes.FIELD("b", DataTypes.BOOLEAN())))
+						}),
+					TypeStrategies.explicit(DataTypes.STRING())),
+
+			// test for table functions
+			TestSpec
+				.forTableFunction(OutputHintTableFunction.class)
+				.expectNamedArguments("i")
+				.expectTypedArguments(DataTypes.INT().notNull().bridgedTo(int.class))
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(
+						new String[]{"i"},
+						new ArgumentTypeStrategy[]{
+							InputTypeStrategies.explicit(DataTypes.INT().notNull().bridgedTo(int.class))
+						}),
+					TypeStrategies.explicit(
+						DataTypes.ROW(
+							DataTypes.FIELD("i", DataTypes.INT()),
+							DataTypes.FIELD("b", DataTypes.BOOLEAN())))),
+
+			// mismatch between hints and implementation regarding return type
+			TestSpec
+				.forScalarFunction(InvalidMethodScalarFunction.class)
+				.expectErrorMessage("Considering all hints, the method should comply with the signature:\n" +
+					"java.lang.String eval(int)"),
+
+			// mismatch between hints and implementation regarding accumulator
+			TestSpec
+				.forAggregateFunction(InvalidMethodAggregateFunction.class)
+				.expectErrorMessage("Considering all hints, the method should comply with the signature:\n" +
+					"accumulate(java.lang.Integer, int, boolean)"),
+
+			// no implementation
+			TestSpec
+				.forTableFunction(MissingMethodTableFunction.class)
+				.expectErrorMessage("Could not find a publicly accessible method named 'eval'."),
+
+			// named arguments with overloaded function
+			TestSpec
+				.forScalarFunction(NamedArgumentsScalarFunction.class)
+				.expectNamedArguments("n")
+		);
+	}
+
+	@Parameter
+	public TestSpec testSpec;
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testArgumentNames() {
+		if (testSpec.expectedArgumentNames != null) {
+			assertThat(
+				testSpec.typeInferenceExtraction.get().getNamedArguments(),
+				equalTo(Optional.of(testSpec.expectedArgumentNames)));
+		} else if (testSpec.expectedErrorMessage == null) {
+			assertThat(
+				testSpec.typeInferenceExtraction.get().getNamedArguments(),
+				equalTo(Optional.empty()));
+		}
+	}
+
+	@Test
+	public void testArgumentTypes() {
+		if (testSpec.expectedArgumentTypes != null) {
+			assertThat(
+				testSpec.typeInferenceExtraction.get().getTypedArguments(),
+				equalTo(Optional.of(testSpec.expectedArgumentTypes)));
+		} else if (testSpec.expectedErrorMessage == null) {
+			assertThat(
+				testSpec.typeInferenceExtraction.get().getTypedArguments(),
+				equalTo(Optional.empty()));
+		}
+	}
+
+	@Test
+	public void testAccumulatorTypeStrategy() {
+		if (!testSpec.expectedAccumulatorStrategies.isEmpty()) {
+			assertThat(
+				testSpec.typeInferenceExtraction.get().getAccumulatorTypeStrategy().isPresent(),
+				equalTo(true));
+			assertThat(
+				testSpec.typeInferenceExtraction.get().getAccumulatorTypeStrategy().get(),
+				equalTo(TypeStrategies.mapping(testSpec.expectedAccumulatorStrategies)));
+		}
+	}
+
+	@Test
+	public void testOutputTypeStrategy() {
+		if (!testSpec.expectedOutputStrategies.isEmpty()) {
+			assertThat(
+				testSpec.typeInferenceExtraction.get().getOutputTypeStrategy(),
+				equalTo(TypeStrategies.mapping(testSpec.expectedOutputStrategies)));
+		}
+	}
+
+	@Test
+	public void testErrorMessage() {
+		if (testSpec.expectedErrorMessage != null) {
+			thrown.expect(ValidationException.class);
+			thrown.expectCause(errorMatcher(testSpec));
+			testSpec.typeInferenceExtraction.get();
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Test utilities
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Test specification shared with the Scala tests.
+	 */
+	static class TestSpec {
+
+		final Supplier<TypeInference> typeInferenceExtraction;
+
+		@Nullable List<String> expectedArgumentNames;
+
+		@Nullable List<DataType> expectedArgumentTypes;
+
+		Map<InputTypeStrategy, TypeStrategy> expectedAccumulatorStrategies;
+
+		Map<InputTypeStrategy, TypeStrategy> expectedOutputStrategies;
+
+		@Nullable String expectedErrorMessage;
+
+		private TestSpec(Supplier<TypeInference> typeInferenceExtraction) {
+			this.typeInferenceExtraction = typeInferenceExtraction;
+			this.expectedAccumulatorStrategies = new HashMap<>();
+			this.expectedOutputStrategies = new HashMap<>();
+		}
+
+		static TestSpec forScalarFunction(Class<? extends ScalarFunction> function) {
+			return new TestSpec(() ->
+				TypeInferenceExtractor.forScalarFunction(new DataTypeLookupMock(), function));
+		}
+
+		static TestSpec forAggregateFunction(Class<? extends AggregateFunction<?, ?>> function) {
+			return new TestSpec(() ->
+				TypeInferenceExtractor.forAggregateFunction(new DataTypeLookupMock(), function));
+		}
+
+		static TestSpec forTableFunction(Class<? extends TableFunction<?>> function) {
+			return new TestSpec(() ->
+				TypeInferenceExtractor.forTableFunction(new DataTypeLookupMock(), function));
+		}
+
+		static TestSpec forTableAggregateFunction(Class<? extends TableAggregateFunction<?, ?>> function) {
+			return new TestSpec(() ->
+				TypeInferenceExtractor.forTableAggregateFunction(new DataTypeLookupMock(), function));
+		}
+
+		TestSpec expectNamedArguments(String... expectedArgumentNames) {
+			this.expectedArgumentNames = Arrays.asList(expectedArgumentNames);
+			return this;
+		}
+
+		TestSpec expectTypedArguments(DataType... expectedArgumentTypes) {
+			this.expectedArgumentTypes = Arrays.asList(expectedArgumentTypes);
+			return this;
+		}
+
+		TestSpec expectAccumulatorMapping(InputTypeStrategy validator, TypeStrategy accumulatorStrategy) {
+			this.expectedAccumulatorStrategies.put(validator, accumulatorStrategy);
+			return this;
+		}
+
+		TestSpec expectOutputMapping(InputTypeStrategy validator, TypeStrategy outputStrategy) {
+			this.expectedOutputStrategies.put(validator, outputStrategy);
+			return this;
+		}
+
+		TestSpec expectErrorMessage(String expectedErrorMessage) {
+			this.expectedErrorMessage = expectedErrorMessage;
+			return this;
+		}
+	}
+
+	private static class DataTypeLookupMock implements DataTypeLookup {
+
+		@Override
+		public Optional<DataType> lookupDataType(String name) {
+			return Optional.of(TypeConversions.fromLogicalToDataType(LogicalTypeParser.parse(name)));
+		}
+
+		@Override
+		public Optional<DataType> lookupDataType(UnresolvedIdentifier identifier) {
+			return Optional.empty();
+		}
+
+		@Override
+		public DataType resolveRawDataType(Class<?> clazz) {
+			return null;
+		}
+	}
+
+	static Matcher<Throwable> errorMatcher(TestSpec testSpec) {
+		return containsCause(new ValidationException(testSpec.expectedErrorMessage));
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Test classes for extraction
+	// --------------------------------------------------------------------------------------------
+
+	@FunctionHint(
+		input = {@DataTypeHint("INT"), @DataTypeHint("STRING")},
+		argumentNames = {"i", "s"},
+		output = @DataTypeHint("BOOLEAN")
+	)
+	private static class FullFunctionHint extends ScalarFunction {
+		public Boolean eval(Integer i, String s) {
+			return null;
+		}
+	}
+
+	private static class ComplexFunctionHint extends ScalarFunction {
+		@FunctionHint(
+			input = {@DataTypeHint("INT"), @DataTypeHint(inputGroup = InputGroup.ANY)},
+			argumentNames = {"myInt", "myAny"},
+			output = @DataTypeHint("BOOLEAN"),
+			isVarArgs = true
+		)
+		public Boolean eval(Object... o) {
+			return null;
+		}
+	}
+
+	@FunctionHint(input = @DataTypeHint("INT"), output = @DataTypeHint("INT"))
+	@FunctionHint(input = @DataTypeHint("BIGINT"), output = @DataTypeHint("BIGINT"))
+	private static class FullFunctionHints extends ScalarFunction {
+		public Number eval(Number n) {
+			return null;
+		}
+	}
+
+	@FunctionHint(output = @DataTypeHint("INT"))
+	private static class GlobalOutputFunctionHint extends ScalarFunction {
+		@FunctionHint(input = @DataTypeHint("INT"))
+		public Integer eval(Integer n) {
+			return null;
+		}
+
+		@FunctionHint(input = @DataTypeHint("STRING"))
+		public Integer eval(String n) {
+			return null;
+		}
+	}
+
+	@FunctionHint(output = @DataTypeHint("INT"))
+	private static class InvalidSingleOutputFunctionHint extends ScalarFunction {
+		@FunctionHint(output = @DataTypeHint("TINYINT"))
+		public Integer eval(Number n) {
+			return null;
+		}
+	}
+
+	@FunctionHint(input = @DataTypeHint("INT"), output = @DataTypeHint("INT"))
+	private static class SplitFullFunctionHints extends ScalarFunction {
+		@FunctionHint(input = @DataTypeHint("BIGINT"), output = @DataTypeHint("BIGINT"))
+		public Number eval(Number n) {
+			return null;
+		}
+	}
+
+	@FunctionHint(input = @DataTypeHint("INT"), output = @DataTypeHint("INT"))
+	private static class InvalidFullOutputFunctionHint extends ScalarFunction {
+		@FunctionHint(input = @DataTypeHint("INT"), output = @DataTypeHint("BIGINT"))
+		public Number eval(Integer i) {
+			return null;
+		}
+	}
+
+	@FunctionHint(
+		input = @DataTypeHint("INT"),
+		argumentNames = "a",
+		output = @DataTypeHint("INT"))
+	private static class InvalidFullOutputFunctionWithArgNamesHint extends ScalarFunction {
+		@FunctionHint(
+			input = @DataTypeHint("INT"),
+			argumentNames = "b",
+			output = @DataTypeHint("BIGINT"))
+		public Number eval(Integer i) {
+			return null;
+		}
+	}
+
+	@FunctionHint(input = @DataTypeHint("INT"))
+	private static class InvalidLocalOutputFunctionHint extends ScalarFunction {
+		@FunctionHint(output = @DataTypeHint("INT"))
+		public Integer eval(Integer n) {
+			return null;
+		}
+
+		@FunctionHint(output = @DataTypeHint("STRING"))
+		public Integer eval(String n) {
+			return null;
+		}
+	}
+
+	@FunctionHint(input = {@DataTypeHint("INT"), @DataTypeHint()}, output = @DataTypeHint("BOOLEAN"))
+	private static class IncompleteFunctionHint extends ScalarFunction {
+		public Boolean eval(Integer i1, Integer i2) {
+			return null;
+		}
+	}
+
+	@FunctionHint(input = @DataTypeHint("INT"))
+	@FunctionHint(input = @DataTypeHint("BIGINT"))
+	private static class GlobalInputFunctionHints extends ScalarFunction {
+		@FunctionHint(output = @DataTypeHint("INT"))
+		public Integer eval(Number n) {
+			return null;
+		}
+	}
+
+	private static class ZeroArgFunction extends ScalarFunction {
+		public Integer eval() {
+			return null;
+		}
+	}
+
+	private static class MixedArgFunction extends ScalarFunction {
+		public Integer eval(int i, Double d) {
+			return null;
+		}
+	}
+
+	private static class OverloadedFunction extends ScalarFunction {
+		public Integer eval(int i, Double d) {
+			return null;
+		}
+
+		public long eval(String s) {
+			return 0L;
+		}
+	}
+
+	private static class VarArgFunction extends ScalarFunction {
+		public String eval(int i, int... more) {
+			return null;
+		}
+	}
+
+	@FunctionHint(output = @DataTypeHint("INT"))
+	private static class ExtractWithOutputHintFunction extends ScalarFunction {
+		public Object eval(Integer i) {
+			return null;
+		}
+	}
+
+	@FunctionHint(
+		input = {@DataTypeHint("INT"), @DataTypeHint("BOOLEAN")},
+		argumentNames = {"i", "b"}
+	)
+	private static class ExtractWithInputHintFunction extends ScalarFunction {
+		public double eval(Object... o) {
+			return 0.0;
+		}
+	}
+
+	@FunctionHint(
+		input = @DataTypeHint("BIGINT"),
+		accumulator = @DataTypeHint("ROW<f BIGINT>")
+	)
+	@FunctionHint(
+		input = @DataTypeHint("STRING"),
+		accumulator = @DataTypeHint("ROW<f STRING>")
+	)
+	private static class InputDependentAccumulatorFunction extends AggregateFunction<String, Row> {
+
+		public void accumulate(Row accumulator, Object o) {
+			// nothing to do
+		}
+
+		@Override
+		public String getValue(Row accumulator) {
+			return null;
+		}
+
+		@Override
+		public Row createAccumulator() {
+			return null;
+		}
+	}
+
+	@FunctionHint(output = @DataTypeHint("STRING"))
+	private static class AggregateFunctionWithManyAnnotations extends AggregateFunction<String, Row> {
+		@FunctionHint(accumulator = @DataTypeHint("ROW<b BOOLEAN>"))
+		public void accumulate(Row accumulator, @DataTypeHint("ROW<i INT, b BOOLEAN>") Row r) {
+			// nothing to do
+		}
+
+		@Override
+		public String getValue(Row accumulator) {
+			return null;
+		}
+
+		@Override
+		public Row createAccumulator() {
+			return null;
+		}
+	}
+
+	@FunctionHint(output = @DataTypeHint("ROW<i INT, b BOOLEAN>"))
+	private static class OutputHintTableFunction extends TableFunction<Row> {
+		public void eval(int i) {
+			// nothing to do
+		}
+	}
+
+	@FunctionHint(output = @DataTypeHint("STRING"))
+	private static class InvalidMethodScalarFunction extends ScalarFunction {
+		public Long eval(int i) {
+			return null;
+		}
+	}
+
+	@FunctionHint(accumulator = @DataTypeHint("INT"))
+	private static class InvalidMethodAggregateFunction extends AggregateFunction<String, Boolean> {
+
+		public void accumulate(Boolean acc, int a, boolean b) {
+			// nothing to do
+		}
+
+		@Override
+		public String getValue(Boolean accumulator) {
+			return null;
+		}
+
+		@Override
+		public Boolean createAccumulator() {
+			return null;
+		}
+	}
+
+	private static class MissingMethodTableFunction extends TableFunction<String> {
+		// nothing to do
+	}
+
+	private static class NamedArgumentsScalarFunction extends ScalarFunction {
+		public Integer eval(int n) {
+			return null;
+		}
+
+		public Integer eval(long n) {
+			return null;
+		}
+
+		public Integer eval(@DataTypeHint("DECIMAL(10, 2)") Object n) {
+			return null;
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarFunctionCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarFunctionCallGen.scala
@@ -77,7 +77,7 @@ class ScalarFunctionCallGen(scalarFunction: ScalarFunction) extends CallGenerato
       } else {
         val javaTerm = newName("javaResult")
         // it maybe a Internal class, so use resultClass is most safety.
-        val boxedResultClass = ExtractionUtils.boxPrimitive(resultClass).asInstanceOf[Class[_]]
+        val boxedResultClass = ExtractionUtils.primitiveToWrapper(resultClass)
         val javaTypeTerm = boxedResultClass.getCanonicalName
         val resultExternalTypeWithResultClass =
           if (LogicalTypeDataTypeConverter.fromDataTypeToLogicalType(resultExternalType)
@@ -152,7 +152,7 @@ object ScalarFunctionCallGen {
       if (paramClass.isPrimitive && isInternalClass(signatureTypes(i))) {
         operandExpr
       } else {
-        val boxedParamClass = ExtractionUtils.boxPrimitive(paramClass).asInstanceOf[Class[_]]
+        val boxedParamClass = ExtractionUtils.primitiveToWrapper(paramClass)
         val signatureType =
           if (signatureTypes(i)
               .getLogicalType


### PR DESCRIPTION
## What is the purpose of the change

This implements the full annotation and extraction logic mentioned in FLIP-65. The utility takes any of the currently supported functions and returns a `TypeInference` instance.

For more information, the documentation of the `FunctionHint` annotation should clarify the semantics:

```
/**
 * A hint that influences the reflection-based extraction of input types, accumulator types, and output
 * types for constructing the {@link TypeInference} logic of a {@link UserDefinedFunction}.
 *
 * <p>One or more annotations can be declared on top of a {@link UserDefinedFunction} class or individually
 * for each {@code eval()/accumulate()} method for overloading function signatures. All hint parameters
 * are optional. If a parameter is not defined, the default reflection-based extraction is used. Hint
 * parameters defined on top of a {@link UserDefinedFunction} class are inherited by all {@code eval()/accumulate()}
 * methods.
 *
 * <p>The following examples show how to explicitly specify function signatures as a whole or in part
 * and let the default extraction do the rest:
 *
 * <pre>
 * {@code
 *   // accepts (INT, STRING) and returns BOOLEAN
 *   @FunctionHint(
 *     input = [@DataTypeHint("INT"), @DataTypeHint("STRING")],
 *     output = @DataTypeHint("BOOLEAN")
 *   )
 *   class X extends ScalarFunction { ... }
 *
 *   // accepts (INT, STRING) or (BOOLEAN) and returns BOOLEAN
 *   @FunctionHint(
 *     input = [@DataTypeHint("INT"), @DataTypeHint("STRING")],
 *     output = @DataTypeHint("BOOLEAN")
 *   )
 *   @FunctionHint(
 *     input = [@DataTypeHint("BOOLEAN")],
 *     output = @DataTypeHint("BOOLEAN")
 *   )
 *   class X extends ScalarFunction { ... }
 *
 *   // accepts (INT, STRING) or (BOOLEAN) and always returns BOOLEAN
 *   @FunctionHint(
 *     output = @DataTypeHint("BOOLEAN")
 *   )
 *   class X extends ScalarFunction {
 *     @FunctionHint(
 *       input = [@DataTypeHint("INT"), @DataTypeHint("STRING")]
 *     )
 *     @FunctionHint(
 *       input = [@DataTypeHint("BOOLEAN")]
 *     )
 *     Object eval(Object... o) { ... }
 *   }
 *
 *   // accepts (INT) or (BOOLEAN) and always returns ROW<f0 BOOLEAN, f1 INT>
 *   @FunctionHint(
 *     output = @DataTypeHint("ROW<f0 BOOLEAN, f1 INT>")
 *   )
 *   class X extends ScalarFunction {
 *     Row eval(int i) { ... }
 *     Row eval(boolean b) { ... }
 *   }
 *
 *   // accepts (ROW<f BOOLEAN>...) or (BOOLEAN...) and returns INT
 *   class X extends ScalarFunction {
 *     @FunctionHint(
 *       input = [@DataTypeHint("ROW<f BOOLEAN>")],
 *       isVarArgs = true
 *     )
 *     int eval(Row... r) { ... }
 *
 *     int eval(boolean... b) { ... }
 *   }
 *
 *   // accepts (INT) and returns INT but allows RAW types in the accumulator type
 *   @FunctionHint(
 *     accumulator = @DataTypeHint(bridgedTo = MyClass.class, allowRawGlobally = TRUE)
 *   )
 *   class X extends AggregateFunction<Integer, MyClass> {
 *     void accumulate(Row acc, int in) { ... }
 *     // ...
 *   }
 * }
 * </pre>
 *
 * @see DataTypeHint
 */
```

The PR is based on FLINK-15149.

The concept of `DataView`s for accumulating functions is not supported yet.

## Brief change log

- Addition of the `FunctionHint` annotation
- Implementation of the `TypeInferenceExtractor`

## Verifying this change

This change added tests and can be verified as follows: `TypeInferenceExtractorTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
