### PR TITLE
[FLINK-15298][docs] Fix dependences in the DataStream API Tutorial doc

### DIFF
--- a/docs/getting-started/tutorials/datastream_api.md
+++ b/docs/getting-started/tutorials/datastream_api.md
@@ -93,16 +93,13 @@ use it in our program. Edit the `dependencies` section of the `pom.xml` so that 
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-java</artifactId>
         <version>${flink.version}</version>
+        <scope>provided</scope>
     </dependency>
     <dependency>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-streaming-java_2.11</artifactId>
         <version>${flink.version}</version>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.flink</groupId>
-        <artifactId>flink-clients_2.11</artifactId>
-        <version>${flink.version}</version>
+        <scope>provided</scope>
     </dependency>
     <dependency>
         <groupId>org.apache.flink</groupId>

--- a/docs/getting-started/tutorials/datastream_api.md
+++ b/docs/getting-started/tutorials/datastream_api.md
@@ -331,21 +331,21 @@ use the Kafka sink. Add this to the `pom.xml` file in the dependencies section:
 </dependency>
 {% endhighlight %}
 
-Also, set the scope of `flink-java` and `flink-streaming-java_${scala.binary.version}` to `provided` because those 
-classes are provided in the cluster and they should not be packaged into the JAR file:
+Also, set the maven dependency scope of `flink-java` and `flink-streaming-java_${scala.binary.version}` to `provided`  
+because those classes are provided in the cluster and they should not be packaged into the JAR file:
 
 {% highlight xml %}
 <dependency>
     <groupId>org.apache.flink</groupId>
     <artifactId>flink-java</artifactId>
     <version>${flink.version}</version>
-    <scope>provided</scope>
+    <scope>provided</scope>      <!-- the line to be added -->
 </dependency>
 <dependency>
     <groupId>org.apache.flink</groupId>
     <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
     <version>${flink.version}</version>
-    <scope>provided</scope>
+    <scope>provided</scope>      <!-- the line to be added -->
 </dependency>
 {% endhighlight %}
 

--- a/docs/getting-started/tutorials/datastream_api.md
+++ b/docs/getting-started/tutorials/datastream_api.md
@@ -93,17 +93,15 @@ use it in our program. Edit the `dependencies` section of the `pom.xml` so that 
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-java</artifactId>
         <version>${flink.version}</version>
-        <scope>provided</scope>
     </dependency>
     <dependency>
         <groupId>org.apache.flink</groupId>
-        <artifactId>flink-streaming-java_2.11</artifactId>
+        <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
         <version>${flink.version}</version>
-        <scope>provided</scope>
     </dependency>
     <dependency>
         <groupId>org.apache.flink</groupId>
-        <artifactId>flink-connector-wikiedits_2.11</artifactId>
+        <artifactId>flink-connector-wikiedits_${scala.binary.version}</artifactId>
         <version>${flink.version}</version>
     </dependency>
 </dependencies>
@@ -330,6 +328,24 @@ use the Kafka sink. Add this to the `pom.xml` file in the dependencies section:
     <groupId>org.apache.flink</groupId>
     <artifactId>flink-connector-kafka-0.11_2.11</artifactId>
     <version>${flink.version}</version>
+</dependency>
+{% endhighlight %}
+
+Also, set the scope of `flink-java` and `flink-streaming-java_${scala.binary.version}` to `provided` because those 
+classes are provided in the cluster and they should not be packaged into the JAR file:
+
+{% highlight xml %}
+<dependency>
+    <groupId>org.apache.flink</groupId>
+    <artifactId>flink-java</artifactId>
+    <version>${flink.version}</version>
+    <scope>provided</scope>
+</dependency>
+<dependency>
+    <groupId>org.apache.flink</groupId>
+    <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+    <version>${flink.version}</version>
+    <scope>provided</scope>
 </dependency>
 {% endhighlight %}
 

--- a/docs/getting-started/tutorials/datastream_api.zh.md
+++ b/docs/getting-started/tutorials/datastream_api.zh.md
@@ -93,16 +93,13 @@ use it in our program. Edit the `dependencies` section of the `pom.xml` so that 
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-java</artifactId>
         <version>${flink.version}</version>
+        <scope>provided</scope>
     </dependency>
     <dependency>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-streaming-java_2.11</artifactId>
         <version>${flink.version}</version>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.flink</groupId>
-        <artifactId>flink-clients_2.11</artifactId>
-        <version>${flink.version}</version>
+        <scope>provided</scope>
     </dependency>
     <dependency>
         <groupId>org.apache.flink</groupId>

--- a/docs/getting-started/tutorials/datastream_api.zh.md
+++ b/docs/getting-started/tutorials/datastream_api.zh.md
@@ -331,21 +331,21 @@ use the Kafka sink. Add this to the `pom.xml` file in the dependencies section:
 </dependency>
 {% endhighlight %}
 
-Also, set the scope of `flink-java` and `flink-streaming-java_${scala.binary.version}` to `provided` because those 
-classes are provided in the cluster and they should not be packaged into the JAR file:
+Also, set the maven dependency scope of `flink-java` and `flink-streaming-java_${scala.binary.version}` to `provided`  
+because those classes are provided in the cluster and they should not be packaged into the JAR file:
 
 {% highlight xml %}
 <dependency>
     <groupId>org.apache.flink</groupId>
     <artifactId>flink-java</artifactId>
     <version>${flink.version}</version>
-    <scope>provided</scope>
+    <scope>provided</scope>      <!-- the line to be added -->
 </dependency>
 <dependency>
     <groupId>org.apache.flink</groupId>
     <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
     <version>${flink.version}</version>
-    <scope>provided</scope>
+    <scope>provided</scope>      <!-- the line to be added -->
 </dependency>
 {% endhighlight %}
 

--- a/docs/getting-started/tutorials/datastream_api.zh.md
+++ b/docs/getting-started/tutorials/datastream_api.zh.md
@@ -93,17 +93,15 @@ use it in our program. Edit the `dependencies` section of the `pom.xml` so that 
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-java</artifactId>
         <version>${flink.version}</version>
-        <scope>provided</scope>
     </dependency>
     <dependency>
         <groupId>org.apache.flink</groupId>
-        <artifactId>flink-streaming-java_2.11</artifactId>
+        <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
         <version>${flink.version}</version>
-        <scope>provided</scope>
     </dependency>
     <dependency>
         <groupId>org.apache.flink</groupId>
-        <artifactId>flink-connector-wikiedits_2.11</artifactId>
+        <artifactId>flink-connector-wikiedits_${scala.binary.version}</artifactId>
         <version>${flink.version}</version>
     </dependency>
 </dependencies>
@@ -330,6 +328,24 @@ use the Kafka sink. Add this to the `pom.xml` file in the dependencies section:
     <groupId>org.apache.flink</groupId>
     <artifactId>flink-connector-kafka-0.11_2.11</artifactId>
     <version>${flink.version}</version>
+</dependency>
+{% endhighlight %}
+
+Also, set the scope of `flink-java` and `flink-streaming-java_${scala.binary.version}` to `provided` because those 
+classes are provided in the cluster and they should not be packaged into the JAR file:
+
+{% highlight xml %}
+<dependency>
+    <groupId>org.apache.flink</groupId>
+    <artifactId>flink-java</artifactId>
+    <version>${flink.version}</version>
+    <scope>provided</scope>
+</dependency>
+<dependency>
+    <groupId>org.apache.flink</groupId>
+    <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+    <version>${flink.version}</version>
+    <scope>provided</scope>
 </dependency>
 {% endhighlight %}
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes the maven dependence issues in the DataStream API tutorial doc where:
- The scope should be 'provided' for flink-java and flink-streaming-java
- The dependency flink-client is not needed

## Brief change log

- Added <scope>provided</scope>
- Removed the flink-client dependency


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
