### PR TITLE
[FLINK-13910] Add missing serialVersionUID for serializable classes

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraOutputFormat.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraOutputFormat.java
@@ -30,6 +30,8 @@ import org.apache.flink.streaming.connectors.cassandra.ClusterBuilder;
 @Deprecated
 public class CassandraOutputFormat<OUT extends Tuple> extends CassandraTupleOutputFormat<OUT> {
 
+	private static final long serialVersionUID = -6756968811688679493L;
+
 	public CassandraOutputFormat(String insertQuery, ClusterBuilder builder) {
 		super(insertQuery, builder);
 	}

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraOutputFormatBase.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraOutputFormatBase.java
@@ -42,6 +42,7 @@ import java.io.IOException;
  */
 public abstract class CassandraOutputFormatBase<OUT> extends RichOutputFormat<OUT> {
 	private static final Logger LOG = LoggerFactory.getLogger(CassandraOutputFormatBase.class);
+	private static final long serialVersionUID = 244469903341197377L;
 
 	private final String insertQuery;
 	private final ClusterBuilder builder;

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraRowOutputFormat.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraRowOutputFormat.java
@@ -25,6 +25,8 @@ import org.apache.flink.types.Row;
  */
 public class CassandraRowOutputFormat extends CassandraOutputFormatBase<Row> {
 
+	private static final long serialVersionUID = -5480741611859511134L;
+
 	public CassandraRowOutputFormat(String insertQuery, ClusterBuilder builder) {
 		super(insertQuery, builder);
 	}

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraTupleOutputFormat.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraTupleOutputFormat.java
@@ -27,6 +27,8 @@ import org.apache.flink.streaming.connectors.cassandra.ClusterBuilder;
  */
 public class CassandraTupleOutputFormat<OUT extends Tuple> extends CassandraOutputFormatBase<OUT> {
 
+	private static final long serialVersionUID = 5369355990630264803L;
+
 	public CassandraTupleOutputFormat(String insertQuery, ClusterBuilder builder) {
 		super(insertQuery, builder);
 	}

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/AbstractCassandraTupleSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/AbstractCassandraTupleSink.java
@@ -30,6 +30,7 @@ import com.google.common.util.concurrent.ListenableFuture;
  * @param <IN> Type of the elements emitted by this sink
  */
 public abstract class AbstractCassandraTupleSink<IN> extends CassandraSinkBase<IN, ResultSet> {
+	private static final long serialVersionUID = -3126040262398754184L;
 	private final String insertQuery;
 	private transient PreparedStatement ps;
 	private final boolean ignoreNullFields;

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraRowSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraRowSink.java
@@ -24,6 +24,7 @@ import org.apache.flink.types.Row;
  */
 public class CassandraRowSink extends AbstractCassandraTupleSink<Row> {
 
+	private static final long serialVersionUID = 8865719024504099001L;
 	private final int rowArity;
 
 	public CassandraRowSink(

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraScalaProductSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraScalaProductSink.java
@@ -26,6 +26,8 @@ import scala.Product;
  * @param <IN> Type of the elements emitted by this sink, it must extend {@link Product}
  */
 public class CassandraScalaProductSink<IN extends Product> extends AbstractCassandraTupleSink<IN> {
+	private static final long serialVersionUID = -5376500445760059736L;
+
 	public CassandraScalaProductSink(
 			String insertQuery,
 			ClusterBuilder builder) {

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBase.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBase.java
@@ -47,6 +47,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @param <IN> Type of the elements emitted by this sink
  */
 public abstract class CassandraSinkBase<IN, V> extends RichSinkFunction<IN> implements CheckpointedFunction {
+	private static final long serialVersionUID = -1288128514287207518L;
 	protected final Logger log = LoggerFactory.getLogger(getClass());
 
 	protected transient Cluster cluster;

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseConfig.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseConfig.java
@@ -42,6 +42,7 @@ public final class CassandraSinkBaseConfig implements Serializable  {
 	 * The default option to ignore null fields on insertion. By default, {@code false}.
 	 */
 	public static final boolean DEFAULT_IGNORE_NULL_FIELDS = false;
+	private static final long serialVersionUID = -3484907604563195878L;
 
 
 	// ------------------------- Configuration Fields -------------------------

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraTupleSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraTupleSink.java
@@ -25,6 +25,8 @@ import org.apache.flink.api.java.tuple.Tuple;
  * @param <IN> Type of the elements emitted by this sink, it must extend {@link Tuple}
  */
 public class CassandraTupleSink<IN extends Tuple> extends AbstractCassandraTupleSink<IN> {
+	private static final long serialVersionUID = 1714637141759426844L;
+
 	public CassandraTupleSink(
 			String insertQuery,
 			ClusterBuilder builder) {

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/ClusterBuilder.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/ClusterBuilder.java
@@ -28,6 +28,8 @@ import java.io.Serializable;
  */
 public abstract class ClusterBuilder implements Serializable {
 
+	private static final long serialVersionUID = 1785274396901081238L;
+
 	public Cluster getCluster() {
 		return buildCluster(Cluster.builder());
 	}

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkBase.java
@@ -419,6 +419,7 @@ public abstract class ElasticsearchUpsertTableSinkBase implements UpsertStreamTa
 	 */
 	public static class ElasticsearchUpsertSinkFunction implements ElasticsearchSinkFunction<Tuple2<Boolean, Row>> {
 
+		private static final long serialVersionUID = -4182715273950026220L;
 		private final String index;
 		private final String docType;
 		private final String keyDelimiter;

--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch6/Elasticsearch6UpsertTableSink.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch6/Elasticsearch6UpsertTableSink.java
@@ -195,6 +195,7 @@ public class Elasticsearch6UpsertTableSink extends ElasticsearchUpsertTableSinkB
 	@VisibleForTesting
 	static class DefaultRestClientFactory implements RestClientFactory {
 
+		private static final long serialVersionUID = -408722606272427743L;
 		private Integer maxRetryTimeout;
 		private String pathPrefix;
 
@@ -238,6 +239,8 @@ public class Elasticsearch6UpsertTableSink extends ElasticsearchUpsertTableSinkB
 	 * Version-specific creation of {@link org.elasticsearch.action.ActionRequest}s used by the sink.
 	 */
 	private static class Elasticsearch6RequestFactory implements RequestFactory {
+
+		private static final long serialVersionUID = 1174778546726595123L;
 
 		@Override
 		public UpdateRequest createUpdateRequest(

--- a/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch7/Elasticsearch7UpsertTableSink.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch7/Elasticsearch7UpsertTableSink.java
@@ -217,6 +217,7 @@ public class Elasticsearch7UpsertTableSink extends ElasticsearchUpsertTableSinkB
 	@VisibleForTesting
 	static class DefaultRestClientFactory implements RestClientFactory {
 
+		private static final long serialVersionUID = -978121354999200275L;
 		private String pathPrefix;
 
 		public DefaultRestClientFactory(@Nullable String pathPrefix) {
@@ -252,6 +253,8 @@ public class Elasticsearch7UpsertTableSink extends ElasticsearchUpsertTableSinkB
 	 * Version-specific creation of {@link org.elasticsearch.action.ActionRequest}s used by the sink.
 	 */
 	private static class Elasticsearch7RequestFactory implements RequestFactory {
+
+		private static final long serialVersionUID = 8752524850219874857L;
 
 		@Override
 		public UpdateRequest createUpdateRequest(

--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/DefaultPubSubSubscriberFactory.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/DefaultPubSubSubscriberFactory.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.time.Duration;
 
 class DefaultPubSubSubscriberFactory implements PubSubSubscriberFactory {
+	private static final long serialVersionUID = -564357440396263173L;
 	private final int retries;
 	private final Duration timeout;
 	private final int maxMessagesPerPull;

--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/DeserializationSchemaWrapper.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/DeserializationSchemaWrapper.java
@@ -28,6 +28,7 @@ import com.google.pubsub.v1.PubsubMessage;
  * This class wraps a {@link DeserializationSchema} so it can be used in a {@link PubSubSource} as a {@link PubSubDeserializationSchema}.
  */
 class DeserializationSchemaWrapper<T> implements PubSubDeserializationSchema<T> {
+	private static final long serialVersionUID = 7674034872914451009L;
 	private final DeserializationSchema<T> deserializationSchema;
 
 	DeserializationSchemaWrapper(DeserializationSchema<T> deserializationSchema) {

--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSink.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSink.java
@@ -60,6 +60,7 @@ import static org.apache.flink.runtime.concurrent.Executors.directExecutor;
  */
 public class PubSubSink<IN> extends RichSinkFunction<IN> implements CheckpointedFunction {
 	private static final Logger LOG = LoggerFactory.getLogger(PubSubSink.class);
+	private static final long serialVersionUID = 5385934931003868806L;
 
 	private final AtomicReference<Exception> exceptionAtomicReference;
 	private final ApiFutureCallback<String> failureHandler;
@@ -310,6 +311,8 @@ public class PubSubSink<IN> extends RichSinkFunction<IN> implements Checkpointed
 	}
 
 	private class FailureHandler implements ApiFutureCallback<String>, Serializable {
+		private static final long serialVersionUID = -3879159333179685838L;
+
 		@Override
 		public void onFailure(Throwable t) {
 			ackAndMaybeNotifyNoPendingFutures();

--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSource.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSource.java
@@ -57,6 +57,7 @@ import static com.google.cloud.pubsub.v1.SubscriptionAdminSettings.defaultCreden
  */
 public class PubSubSource<OUT> extends RichSourceFunction<OUT>
 	implements ResultTypeQueryable<OUT>, ParallelSourceFunction<OUT>, CheckpointListener, ListCheckpointed<AcknowledgeIdsForCheckpoint<String>> {
+	private static final long serialVersionUID = -4632132495654043191L;
 	protected final PubSubDeserializationSchema<OUT> deserializationSchema;
 	protected final PubSubSubscriberFactory pubSubSubscriberFactory;
 	protected final Credentials credentials;
@@ -337,6 +338,8 @@ public class PubSubSource<OUT> extends RichSourceFunction<OUT>
 	}
 
 	static class AcknowledgeOnCheckpointFactory implements Serializable {
+		private static final long serialVersionUID = 5749050168729741665L;
+
 		AcknowledgeOnCheckpoint<String> create(Acknowledger<String> acknowledger) {
 			return new AcknowledgeOnCheckpoint<>(acknowledger);
 		}

--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSubscriberFactoryForEmulator.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSubscriberFactoryForEmulator.java
@@ -35,6 +35,7 @@ import java.time.Duration;
  * The PubSub emulators do not support SSL or Credentials and as such this SubscriberStub does not require or provide this.
  */
 public class PubSubSubscriberFactoryForEmulator implements PubSubSubscriberFactory {
+	private static final long serialVersionUID = -824683780443890033L;
 	private final String hostAndPort;
 	private final String projectSubscriptionName;
 	private final int retries;

--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/common/AcknowledgeIdsForCheckpoint.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/common/AcknowledgeIdsForCheckpoint.java
@@ -26,6 +26,7 @@ import java.util.List;
  * @param <AcknowledgeId> Type of the Ids used for acknowledging.
  */
 public class AcknowledgeIdsForCheckpoint<AcknowledgeId> implements Serializable {
+	private static final long serialVersionUID = 4974453492787143690L;
 	private long checkpointId;
 	private List<AcknowledgeId> acknowledgeIds;
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/FlinkHiveException.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/FlinkHiveException.java
@@ -25,6 +25,8 @@ import org.apache.flink.annotation.PublicEvolving;
 @PublicEvolving
 public class FlinkHiveException extends RuntimeException {
 
+	private static final long serialVersionUID = -7447148076053645991L;
+
 	public FlinkHiveException(Throwable cause) {
 		super(cause);
 	}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOutputFormatFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOutputFormatFactory.java
@@ -177,6 +177,7 @@ public class HiveOutputFormatFactory implements OutputFormatFactory<Row> {
 
 	private class HiveOutputFormat implements org.apache.flink.api.common.io.OutputFormat<Row> {
 
+		private static final long serialVersionUID = -7937381103700063977L;
 		private final RecordWriter recordWriter;
 
 		private HiveOutputFormat(RecordWriter recordWriter) {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputSplit.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputSplit.java
@@ -31,6 +31,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * Right now, it contains info about the partition of the split.
  */
 public class HiveTableInputSplit extends HadoopInputSplit {
+	private static final long serialVersionUID = 4923431667026917848L;
 	private final HiveTablePartition hiveTablePartition;
 
 	public HiveTableInputSplit(

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV100.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV100.java
@@ -93,6 +93,8 @@ import java.util.Set;
  */
 public class HiveShimV100 implements HiveShim {
 
+	private static final long serialVersionUID = -5782044317660017047L;
+
 	@Override
 	public IMetaStoreClient getHiveMetastoreClient(HiveConf hiveConf) {
 		try {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV101.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV101.java
@@ -22,4 +22,5 @@ package org.apache.flink.table.catalog.hive.client;
  * Shim for Hive version 1.0.1.
  */
 public class HiveShimV101 extends HiveShimV100 {
+	private static final long serialVersionUID = 9111399565326723195L;
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV110.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV110.java
@@ -42,6 +42,8 @@ import java.util.Properties;
  */
 public class HiveShimV110 extends HiveShimV101 {
 
+	private static final long serialVersionUID = -3742878403082996025L;
+
 	@Override
 	public FileSinkOperator.RecordWriter getHiveRecordWriter(JobConf jobConf, String outputFormatClzName,
 			Class<? extends Writable> outValClz, boolean isCompressed, Properties tableProps, Path outPath) {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV111.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV111.java
@@ -23,4 +23,5 @@ package org.apache.flink.table.catalog.hive.client;
  */
 public class HiveShimV111 extends HiveShimV110 {
 
+	private static final long serialVersionUID = 1759684936758665935L;
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV120.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV120.java
@@ -51,6 +51,8 @@ import java.util.stream.Collectors;
  */
 public class HiveShimV120 extends HiveShimV111 {
 
+	private static final long serialVersionUID = 643650084521928198L;
+
 	@Override
 	public IMetaStoreClient getHiveMetastoreClient(HiveConf hiveConf) {
 		try {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV121.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV121.java
@@ -23,4 +23,5 @@ package org.apache.flink.table.catalog.hive.client;
  */
 public class HiveShimV121 extends HiveShimV120 {
 
+	private static final long serialVersionUID = -4034483246496214366L;
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV122.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV122.java
@@ -23,4 +23,5 @@ package org.apache.flink.table.catalog.hive.client;
  */
 public class HiveShimV122 extends HiveShimV121 {
 
+	private static final long serialVersionUID = 8774140728985265030L;
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV200.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV200.java
@@ -32,6 +32,8 @@ import java.lang.reflect.Method;
  */
 public class HiveShimV200 extends HiveShimV122 {
 
+	private static final long serialVersionUID = -5509026393005378947L;
+
 	@Override
 	public IMetaStoreClient getHiveMetastoreClient(HiveConf hiveConf) {
 		try {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV201.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV201.java
@@ -23,4 +23,5 @@ package org.apache.flink.table.catalog.hive.client;
  */
 public class HiveShimV201 extends HiveShimV200 {
 
+	private static final long serialVersionUID = -7636146372161212606L;
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV210.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV210.java
@@ -41,6 +41,8 @@ import java.util.Optional;
  */
 public class HiveShimV210 extends HiveShimV201 {
 
+	private static final long serialVersionUID = -3539453915201580102L;
+
 	@Override
 	public void alterPartition(IMetaStoreClient client, String databaseName, String tableName, Partition partition)
 			throws InvalidOperationException, MetaException, TException {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV211.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV211.java
@@ -23,4 +23,5 @@ package org.apache.flink.table.catalog.hive.client;
  */
 public class HiveShimV211 extends HiveShimV210 {
 
+	private static final long serialVersionUID = 4944296725612295106L;
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV220.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV220.java
@@ -23,4 +23,5 @@ package org.apache.flink.table.catalog.hive.client;
  */
 public class HiveShimV220 extends HiveShimV211 {
 
+	private static final long serialVersionUID = -4605576986250058774L;
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV230.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV230.java
@@ -47,6 +47,8 @@ import java.util.List;
  */
 public class HiveShimV230 extends HiveShimV220 {
 
+	private static final long serialVersionUID = 1232379464447020838L;
+
 	@Override
 	public IMetaStoreClient getHiveMetastoreClient(HiveConf hiveConf) {
 		try {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV231.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV231.java
@@ -23,4 +23,5 @@ package org.apache.flink.table.catalog.hive.client;
  */
 public class HiveShimV231 extends HiveShimV230 {
 
+	private static final long serialVersionUID = 4147734803106251337L;
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV232.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV232.java
@@ -23,4 +23,5 @@ package org.apache.flink.table.catalog.hive.client;
  */
 public class HiveShimV232 extends HiveShimV231 {
 
+	private static final long serialVersionUID = 5125265936126450266L;
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV233.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV233.java
@@ -23,4 +23,5 @@ package org.apache.flink.table.catalog.hive.client;
  */
 public class HiveShimV233 extends HiveShimV232 {
 
+	private static final long serialVersionUID = 2275359443630503206L;
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV234.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV234.java
@@ -23,4 +23,5 @@ package org.apache.flink.table.catalog.hive.client;
  */
 public class HiveShimV234 extends HiveShimV233 {
 
+	private static final long serialVersionUID = 1810799633813958787L;
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV235.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV235.java
@@ -23,4 +23,5 @@ package org.apache.flink.table.catalog.hive.client;
  */
 public class HiveShimV235 extends HiveShimV234 {
 
+	private static final long serialVersionUID = -2001642650631613395L;
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV236.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV236.java
@@ -23,4 +23,5 @@ package org.apache.flink.table.catalog.hive.client;
  */
 public class HiveShimV236 extends HiveShimV235 {
 
+	private static final long serialVersionUID = -5152610377559200678L;
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV310.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV310.java
@@ -52,6 +52,7 @@ import java.util.Set;
  */
 public class HiveShimV310 extends HiveShimV235 {
 
+	private static final long serialVersionUID = 3272951189049817952L;
 	// timestamp classes
 	private static Class hiveTimestampClz;
 	private static Constructor hiveTimestampConstructor;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV311.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV311.java
@@ -23,4 +23,5 @@ package org.apache.flink.table.catalog.hive.client;
  */
 public class HiveShimV311 extends HiveShimV310 {
 
+	private static final long serialVersionUID = 3184520298048545752L;
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV312.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV312.java
@@ -23,4 +23,5 @@ package org.apache.flink.table.catalog.hive.client;
  */
 public class HiveShimV312 extends HiveShimV311 {
 
+	private static final long serialVersionUID = -2429434671387296156L;
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/FlinkHiveUDFException.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/FlinkHiveUDFException.java
@@ -24,6 +24,8 @@ import org.apache.flink.util.FlinkRuntimeException;
  * Hive UDF related exceptions in Flink.
  */
 public class FlinkHiveUDFException extends FlinkRuntimeException {
+	private static final long serialVersionUID = 4839531415536776224L;
+
 	/**
 	 * @param message the detail message.
 	 */

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDAF.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDAF.java
@@ -48,6 +48,7 @@ import java.util.Arrays;
 public class HiveGenericUDAF
 	extends AggregateFunction<Object, GenericUDAFEvaluator.AggregationBuffer> implements HiveFunction {
 
+	private static final long serialVersionUID = 2671847488564849250L;
 	private final HiveFunctionWrapper hiveFunctionWrapper;
 	// Flag that indicates whether a bridge between GenericUDAF and UDAF is required.
 	// Old UDAF can be used with the GenericUDAF infrastructure through bridging.

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDF.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDF.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 public class HiveGenericUDF extends HiveScalarFunction<GenericUDF> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(HiveGenericUDF.class);
+	private static final long serialVersionUID = 60055592617907218L;
 
 	private transient GenericUDF.DeferredObject[] deferredObjects;
 	private HiveShim hiveShim;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDTF.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDTF.java
@@ -52,6 +52,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 @Internal
 public class HiveGenericUDTF extends TableFunction<Row> implements HiveFunction {
 	private static final Logger LOG = LoggerFactory.getLogger(HiveGenericUDTF.class);
+	private static final long serialVersionUID = 3042837274633311463L;
 
 	private final HiveFunctionWrapper<GenericUDTF> hiveFunctionWrapper;
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveScalarFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveScalarFunction.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 @Internal
 public abstract class HiveScalarFunction<UDFType> extends ScalarFunction implements HiveFunction {
 
+	private static final long serialVersionUID = -1854813360292429791L;
 	protected final HiveFunctionWrapper<UDFType> hiveFunctionWrapper;
 
 	protected Object[] constantArguments;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveSimpleUDF.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveSimpleUDF.java
@@ -52,6 +52,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 public class HiveSimpleUDF extends HiveScalarFunction<UDF> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(HiveSimpleUDF.class);
+	private static final long serialVersionUID = 7985797460021311671L;
 
 	private transient Method method;
 	private transient GenericUDFUtils.ConversionHelper conversionHelper;

--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
@@ -33,6 +33,8 @@ import java.util.Properties;
 @Deprecated
 public class FlinkKafkaProducer<IN> extends FlinkKafkaProducer08<IN>  {
 
+	private static final long serialVersionUID = 8068884287839281794L;
+
 	/**
 	 * @deprecated Use {@link FlinkKafkaProducer08#FlinkKafkaProducer08(String, String, SerializationSchema)}
 	 */

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/partitioner/FlinkKafkaDelegatePartitioner.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/partitioner/FlinkKafkaDelegatePartitioner.java
@@ -29,6 +29,7 @@ import org.apache.flink.annotation.Internal;
 @Deprecated
 @Internal
 public class FlinkKafkaDelegatePartitioner<T> extends FlinkKafkaPartitioner<T> {
+	private static final long serialVersionUID = 9135749030818355530L;
 	private final KafkaPartitioner<T> kafkaPartitioner;
 	private int[] partitions;
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer.java
@@ -78,6 +78,7 @@ public class FlinkKafkaConsumer<T> extends FlinkKafkaConsumerBase<T> {
 	/** From Kafka's Javadoc: The time, in milliseconds, spent waiting in poll if data is not
 	 * available. If 0, returns immediately with any records that are available now. */
 	public static final long DEFAULT_POLL_TIMEOUT = 100L;
+	private static final long serialVersionUID = 112715543611990610L;
 
 	// ------------------------------------------------------------------------
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkDynamoDBStreamsConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkDynamoDBStreamsConsumer.java
@@ -37,6 +37,7 @@ import java.util.Properties;
  */
 public class FlinkDynamoDBStreamsConsumer<T> extends FlinkKinesisConsumer<T> {
 	private static final Logger LOG = LoggerFactory.getLogger(FlinkDynamoDBStreamsConsumer.class);
+	private static final long serialVersionUID = -6516053598608212763L;
 
 	/**
 	 * Constructor of FlinkDynamoDBStreamsConsumer.

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/serialization/DynamoDBStreamsSchema.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/serialization/DynamoDBStreamsSchema.java
@@ -29,6 +29,7 @@ import java.io.IOException;
  */
 public class DynamoDBStreamsSchema implements KinesisDeserializationSchema<Record> {
 	private static final ObjectMapper MAPPER = new ObjectMapper();
+	private static final long serialVersionUID = 5220324099354550279L;
 
 	@Override
 	public Record deserialize(byte[] message, String partitionKey, String seqNum,

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/JobManagerWatermarkTracker.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/JobManagerWatermarkTracker.java
@@ -39,6 +39,7 @@ import java.util.Map;
 @PublicEvolving
 public class JobManagerWatermarkTracker extends WatermarkTracker {
 
+	private static final long serialVersionUID = 3382374318338509442L;
 	private GlobalAggregateManager aggregateManager;
 	private final String aggregateName;
 	private final WatermarkAggregateFunction aggregateFunction = new WatermarkAggregateFunction();
@@ -88,12 +89,14 @@ public class JobManagerWatermarkTracker extends WatermarkTracker {
 
 	/** Watermark aggregation input. */
 	protected static class WatermarkUpdate implements Serializable {
+		private static final long serialVersionUID = -7451163146871423192L;
 		protected long watermark = Long.MIN_VALUE;
 		protected String id;
 	}
 
 	/** Watermark aggregation result. */
 	protected static class WatermarkResult implements Serializable {
+		private static final long serialVersionUID = 7535287240699859461L;
 		protected long watermark = Long.MIN_VALUE;
 		protected long updateTimeoutCount = 0;
 	}
@@ -104,6 +107,7 @@ public class JobManagerWatermarkTracker extends WatermarkTracker {
 	private static class WatermarkAggregateFunction implements
 		AggregateFunction<byte[], Map<String, WatermarkState>, byte[]> {
 
+		private static final long serialVersionUID = 2326169984294476170L;
 		private long updateTimeoutMillis = DEFAULT_UPDATE_TIMEOUT_MILLIS;
 		private long logAccumulatorIntervalMillis = -1;
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/WatermarkTracker.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/WatermarkTracker.java
@@ -35,6 +35,7 @@ import java.io.Serializable;
 public abstract class WatermarkTracker implements Closeable, Serializable {
 
 	public static final long DEFAULT_UPDATE_TIMEOUT_MILLIS = 60_000;
+	private static final long serialVersionUID = 2491201615708948753L;
 
 	/**
 	 * Subtasks that have not provided a watermark update within the configured interval will be

--- a/flink-connectors/flink-connector-nifi/src/main/java/org/apache/flink/streaming/connectors/nifi/NiFiSink.java
+++ b/flink-connectors/flink-connector-nifi/src/main/java/org/apache/flink/streaming/connectors/nifi/NiFiSink.java
@@ -32,6 +32,7 @@ import org.apache.nifi.remote.client.SiteToSiteClientConfig;
  */
 public class NiFiSink<T> extends RichSinkFunction<T> {
 
+	private static final long serialVersionUID = 8597922288733968579L;
 	private SiteToSiteClient client;
 	private SiteToSiteClientConfig clientConfig;
 	private NiFiDataPacketBuilder<T> builder;

--- a/flink-connectors/flink-connector-twitter/src/main/java/org/apache/flink/streaming/connectors/twitter/TwitterSource.java
+++ b/flink-connectors/flink-connector-twitter/src/main/java/org/apache/flink/streaming/connectors/twitter/TwitterSource.java
@@ -195,6 +195,8 @@ public class TwitterSource extends RichSourceFunction<String> {
 	 * Default endpoint initializer returning the {@see StatusesSampleEndpoint}.
 	 */
 	private static class SampleStatusesEndpoint implements EndpointInitializer, Serializable {
+		private static final long serialVersionUID = -7861794360728331505L;
+
 		@Override
 		public StreamingEndpoint createEndpoint() {
 			// this default endpoint initializer returns the sample endpoint: Returning a sample from the firehose (all tweets)

--- a/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/common/HadoopInputFormatCommonBase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/common/HadoopInputFormatCommonBase.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Method;
  */
 @Internal
 public abstract class HadoopInputFormatCommonBase<T, SPITTYPE extends InputSplit> extends RichInputFormat<T, SPITTYPE> {
+	private static final long serialVersionUID = 6086933155466805136L;
 	protected transient Credentials credentials;
 
 	protected HadoopInputFormatCommonBase(Credentials creds) {

--- a/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/common/HadoopOutputFormatCommonBase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/common/HadoopOutputFormatCommonBase.java
@@ -34,6 +34,7 @@ import java.io.ObjectOutputStream;
  */
 @Internal
 public abstract class HadoopOutputFormatCommonBase<T> extends RichOutputFormat<T> {
+	private static final long serialVersionUID = -3302636760439510032L;
 	protected transient Credentials credentials;
 
 	protected HadoopOutputFormatCommonBase(Credentials creds) {

--- a/flink-connectors/flink-hbase/src/main/java/org/apache/flink/addons/hbase/AbstractTableInputFormat.java
+++ b/flink-connectors/flink-hbase/src/main/java/org/apache/flink/addons/hbase/AbstractTableInputFormat.java
@@ -44,6 +44,7 @@ import java.util.List;
 public abstract class AbstractTableInputFormat<T> extends RichInputFormat<T, TableInputSplit> {
 
 	protected static final Logger LOG = LoggerFactory.getLogger(AbstractTableInputFormat.class);
+	private static final long serialVersionUID = -4532804238984610207L;
 
 	// helper variable to decide whether the input is exhausted or not
 	protected boolean endReached = false;

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCLookupOptions.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCLookupOptions.java
@@ -28,6 +28,7 @@ import static org.apache.flink.api.java.io.jdbc.JDBCUpsertOutputFormat.DEFAULT_M
  */
 public class JDBCLookupOptions implements Serializable {
 
+	private static final long serialVersionUID = 6563613109302556887L;
 	private final long cacheMaxSize;
 	private final long cacheExpireMs;
 	private final int maxRetryTimes;

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCReadOptions.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCReadOptions.java
@@ -27,6 +27,7 @@ import java.util.Optional;
  */
 public class JDBCReadOptions implements Serializable {
 
+	private static final long serialVersionUID = 7013312912845812026L;
 	private final String partitionColumnName;
 	private final Long partitionLowerBound;
 	private final Long partitionUpperBound;

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCSinkFunction.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCSinkFunction.java
@@ -27,6 +27,7 @@ import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.types.Row;
 
 class JDBCSinkFunction extends RichSinkFunction<Row> implements CheckpointedFunction {
+	private static final long serialVersionUID = 9043423985460001948L;
 	final JDBCOutputFormat outputFormat;
 
 	JDBCSinkFunction(JDBCOutputFormat outputFormat) {

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertSinkFunction.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertSinkFunction.java
@@ -28,6 +28,7 @@ import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.types.Row;
 
 class JDBCUpsertSinkFunction extends RichSinkFunction<Tuple2<Boolean, Row>> implements CheckpointedFunction {
+	private static final long serialVersionUID = -2385786502399475270L;
 	private final JDBCUpsertOutputFormat outputFormat;
 
 	JDBCUpsertSinkFunction(JDBCUpsertOutputFormat outputFormat) {

--- a/flink-contrib/flink-connector-wikiedits/src/main/java/org/apache/flink/streaming/connectors/wikiedits/WikipediaEditsSource.java
+++ b/flink-contrib/flink-connector-wikiedits/src/main/java/org/apache/flink/streaming/connectors/wikiedits/WikipediaEditsSource.java
@@ -37,6 +37,7 @@ public class WikipediaEditsSource extends RichSourceFunction<WikipediaEditEvent>
 
 	/** IRC channel to join. */
 	public static final String DEFAULT_CHANNEL = "#en.wikipedia";
+	private static final long serialVersionUID = 7270262261396401702L;
 
 	private final String host;
 	private final int port;

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -1259,6 +1259,7 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	}
 
 	private static class MapBasedJobParameters extends GlobalJobParameters {
+		private static final long serialVersionUID = 3938712852270213484L;
 		private final Map<String, String> properties;
 
 		private MapBasedJobParameters(Map<String, String> properties) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/cache/DistributedCache.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/cache/DistributedCache.java
@@ -51,6 +51,7 @@ public class DistributedCache {
 	 */
 	public static class DistributedCacheEntry implements Serializable {
 
+		private static final long serialVersionUID = 6828132952673506807L;
 		public String filePath;
 		public Boolean isExecutable;
 		public boolean isZipped;

--- a/flink-core/src/main/java/org/apache/flink/api/common/distributions/CommonRangeBoundaries.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/distributions/CommonRangeBoundaries.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.typeutils.TypeComparator;
 
 @Internal
 public class CommonRangeBoundaries<T> implements RangeBoundaries<T> {
+	private static final long serialVersionUID = 8579872341097673539L;
 	private final TypeComparator<T> typeComparator;
 	private final Object[][] boundaries;
 	private final TypeComparator[] flatComparators;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/LocalDateComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/LocalDateComparator.java
@@ -35,6 +35,7 @@ import java.time.LocalDate;
 @Internal
 public final class LocalDateComparator extends TypeComparator<LocalDate> implements Serializable {
 
+	private static final long serialVersionUID = 302235524643029061L;
 	private transient LocalDate reference;
 
 	protected final boolean ascendingComparison;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/LocalDateTimeComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/LocalDateTimeComparator.java
@@ -35,6 +35,7 @@ import java.time.LocalDateTime;
 @Internal
 public final class LocalDateTimeComparator extends TypeComparator<LocalDateTime> implements Serializable {
 
+	private static final long serialVersionUID = -6270856986836321684L;
 	private transient LocalDateTime reference;
 
 	protected final boolean ascendingComparison;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArrayComparator.java
@@ -25,6 +25,8 @@ import org.apache.flink.api.common.typeutils.base.BooleanComparator;
 
 @Internal
 public class BooleanPrimitiveArrayComparator extends PrimitiveArrayComparator<boolean[], BooleanComparator> {
+	private static final long serialVersionUID = -7572287510840826192L;
+
 	public BooleanPrimitiveArrayComparator(boolean ascending) {
 		super(ascending, new BooleanComparator(ascending));
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArrayComparator.java
@@ -25,6 +25,8 @@ import org.apache.flink.api.common.typeutils.base.ByteComparator;
 
 @Internal
 public class BytePrimitiveArrayComparator extends PrimitiveArrayComparator<byte[], ByteComparator> {
+	private static final long serialVersionUID = 7459464394481654961L;
+
 	public BytePrimitiveArrayComparator(boolean ascending) {
 		super(ascending, new ByteComparator(ascending));
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArrayComparator.java
@@ -25,6 +25,8 @@ import org.apache.flink.api.common.typeutils.base.CharComparator;
 
 @Internal
 public class CharPrimitiveArrayComparator extends PrimitiveArrayComparator<char[], CharComparator> {
+	private static final long serialVersionUID = 3385624087234024631L;
+
 	public CharPrimitiveArrayComparator(boolean ascending) {
 		super(ascending, new CharComparator(ascending));
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArrayComparator.java
@@ -25,6 +25,8 @@ import org.apache.flink.api.common.typeutils.base.DoubleComparator;
 
 @Internal
 public class DoublePrimitiveArrayComparator extends PrimitiveArrayComparator<double[], DoubleComparator> {
+	private static final long serialVersionUID = 6816286676410360253L;
+
 	public DoublePrimitiveArrayComparator(boolean ascending) {
 		super(ascending, new DoubleComparator(ascending));
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArrayComparator.java
@@ -25,6 +25,8 @@ import org.apache.flink.api.common.typeutils.base.FloatComparator;
 
 @Internal
 public class FloatPrimitiveArrayComparator extends PrimitiveArrayComparator<float[], FloatComparator> {
+	private static final long serialVersionUID = 6686150039407546620L;
+
 	public FloatPrimitiveArrayComparator(boolean ascending) {
 		super(ascending, new FloatComparator(ascending));
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArrayComparator.java
@@ -25,6 +25,8 @@ import org.apache.flink.api.common.typeutils.base.IntComparator;
 
 @Internal
 public class IntPrimitiveArrayComparator extends PrimitiveArrayComparator<int[], IntComparator> {
+	private static final long serialVersionUID = -7560238082167098946L;
+
 	public IntPrimitiveArrayComparator(boolean ascending) {
 		super(ascending, new IntComparator(ascending));
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArrayComparator.java
@@ -25,6 +25,8 @@ import org.apache.flink.api.common.typeutils.base.LongComparator;
 
 @Internal
 public class LongPrimitiveArrayComparator extends PrimitiveArrayComparator<long[], LongComparator> {
+	private static final long serialVersionUID = 592454068128859435L;
+
 	public LongPrimitiveArrayComparator(boolean ascending) {
 		super(ascending, new LongComparator(ascending));
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/PrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/PrimitiveArrayComparator.java
@@ -29,6 +29,7 @@ import org.apache.flink.core.memory.MemorySegment;
 
 @Internal
 public abstract class PrimitiveArrayComparator<T, C extends BasicTypeComparator> extends TypeComparator<T> {
+	private static final long serialVersionUID = 746422412399158186L;
 	// For use by getComparators
 	@SuppressWarnings("rawtypes")
 	private final TypeComparator[] comparators = new TypeComparator[]{this};

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArrayComparator.java
@@ -25,6 +25,8 @@ import org.apache.flink.api.common.typeutils.base.ShortComparator;
 
 @Internal
 public class ShortPrimitiveArrayComparator extends PrimitiveArrayComparator<short[], ShortComparator> {
+	private static final long serialVersionUID = 3438427829335256220L;
+
 	public ShortPrimitiveArrayComparator(boolean ascending) {
 		super(ascending, new ShortComparator(ascending));
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/MapTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/MapTypeInfo.java
@@ -38,6 +38,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @PublicEvolving
 public class MapTypeInfo<K, V> extends TypeInformation<Map<K, V>> {
 
+	private static final long serialVersionUID = 35220134511141190L;
 	/* The type information for the keys in the map*/
 	private final TypeInformation<K> keyTypeInfo;
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/KryoRegistrationSerializerConfigSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/KryoRegistrationSerializerConfigSnapshot.java
@@ -218,7 +218,9 @@ public abstract class KryoRegistrationSerializerConfigSnapshot<T> extends Generi
 	/**
 	 * Placeholder dummy for a previously registered class that can no longer be found in classpath on restore.
 	 */
-	public static class DummyRegisteredClass implements Serializable {}
+	public static class DummyRegisteredClass implements Serializable {
+		private static final long serialVersionUID = 5378926714157340019L;
+	}
 
 	/**
 	 * Placeholder dummy for a previously registered Kryo serializer that is no longer valid or in classpath on restore.

--- a/flink-core/src/main/java/org/apache/flink/configuration/ReadableConfigToConfigurationAdapter.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ReadableConfigToConfigurationAdapter.java
@@ -37,6 +37,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 @Internal
 public class ReadableConfigToConfigurationAdapter extends Configuration {
+	private static final long serialVersionUID = 8761618358427966928L;
 	private final ReadableConfig backingConfig;
 
 	public ReadableConfigToConfigurationAdapter(ReadableConfig backingConfig) {

--- a/flink-docs/src/main/java/org/apache/flink/docs/rest/RestAPIDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/rest/RestAPIDocGenerator.java
@@ -266,6 +266,7 @@ public class RestAPIDocGenerator {
 	 * <p>This is to avoid exception when generating JSON with Field schema contains generic types.
 	 */
 	private static class HTMLCharacterEscapes extends CharacterEscapes {
+		private static final long serialVersionUID = 140276792385761588L;
 		private final int[] asciiEscapes;
 		private final Map<Integer, SerializableString> escapeSequences;
 

--- a/flink-end-to-end-tests/flink-bucketing-sink-test/src/main/java/org/apache/flink/streaming/tests/BucketingSinkTestProgram.java
+++ b/flink-end-to-end-tests/flink-bucketing-sink-test/src/main/java/org/apache/flink/streaming/tests/BucketingSinkTestProgram.java
@@ -91,6 +91,8 @@ public class BucketingSinkTestProgram {
 	 */
 	public static class KeyBucketer implements Bucketer<Tuple4<Integer, Long, Integer, String>> {
 
+		private static final long serialVersionUID = 1726443270555998545L;
+
 		@Override
 		public Path getBucketPath(Clock clock, Path basePath, Tuple4<Integer, Long, Integer, String> element) {
 			return basePath.suffix(String.valueOf(element.f0));
@@ -102,6 +104,7 @@ public class BucketingSinkTestProgram {
 	 */
 	public static class SubtractingMapper extends RichMapFunction<Tuple3<Integer, Long, String>, Tuple4<Integer, Long, Integer, String>> {
 
+		private static final long serialVersionUID = 3877440429386829765L;
 		private final long initialValue;
 
 		private ValueState<Integer> counter;
@@ -142,6 +145,7 @@ public class BucketingSinkTestProgram {
 	 */
 	public static class Generator implements SourceFunction<Tuple3<Integer, Long, String>>, ListCheckpointed<Long> {
 
+		private static final long serialVersionUID = -1652624616463669257L;
 		private final int numKeys;
 		private final int idlenessMs;
 		private final int durationMs;

--- a/flink-end-to-end-tests/flink-cli-test/src/main/java/org/apache/flink/streaming/tests/PeriodicStreamingJob.java
+++ b/flink-end-to-end-tests/flink-cli-test/src/main/java/org/apache/flink/streaming/tests/PeriodicStreamingJob.java
@@ -80,6 +80,7 @@ public class PeriodicStreamingJob {
 	 * Data-generating source function.
 	 */
 	public static class PeriodicSourceGenerator implements SourceFunction<Tuple>, ResultTypeQueryable<Tuple>, ListCheckpointed<Long> {
+		private static final long serialVersionUID = 3989214487554964061L;
 		private final int sleepMs;
 		private final int durationMs;
 		private final int offsetSeconds;

--- a/flink-end-to-end-tests/flink-dataset-allround-test/src/main/java/org/apache/flink/batch/tests/Generator.java
+++ b/flink-end-to-end-tests/flink-dataset-allround-test/src/main/java/org/apache/flink/batch/tests/Generator.java
@@ -38,6 +38,7 @@ import java.io.IOException;
  */
 public class Generator implements InputFormat<Tuple2<String, Integer>, GenericInputSplit> {
 
+	private static final long serialVersionUID = 3193020098818540963L;
 	// total number of records
 	private final long numRecords;
 	// total number of keys

--- a/flink-end-to-end-tests/flink-dataset-fine-grained-recovery-test/src/main/java/org/apache/flink/batch/tests/BlockingIncrementingMapFunction.java
+++ b/flink-end-to-end-tests/flink-dataset-fine-grained-recovery-test/src/main/java/org/apache/flink/batch/tests/BlockingIncrementingMapFunction.java
@@ -34,6 +34,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class BlockingIncrementingMapFunction extends RichMapFunction<Long, Long> {
 
+	private static final long serialVersionUID = 571455632438819994L;
 	private final String latchFilePath;
 
 	private transient FileBasedOneShotLatch latch;

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
@@ -539,6 +539,7 @@ public class DataStreamAllroundTestJobFactory {
 	private static class EventIdentityFunctionWithCustomEventTypeInformation
 		implements MapFunction<Event, Event>, ResultTypeQueryable<Event> {
 
+		private static final long serialVersionUID = -4192873101804231891L;
 		private final SingleThreadAccessCheckingTypeInfo<Event> typeInformation = new SingleThreadAccessCheckingTypeInfo<>(Event.class);
 
 		@Override
@@ -555,6 +556,7 @@ public class DataStreamAllroundTestJobFactory {
 	private static class EventKeySelectorWithCustomKeyTypeInformation
 		implements KeySelector<Event, Integer>, ResultTypeQueryable<Integer> {
 
+		private static final long serialVersionUID = -4170275032537957202L;
 		private final SingleThreadAccessCheckingTypeInfo<Integer> typeInformation = new SingleThreadAccessCheckingTypeInfo<>(Integer.class);
 
 		@Override

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/SingleThreadAccessCheckingTypeInfo.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/SingleThreadAccessCheckingTypeInfo.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 
 /** Custom {@link TypeInformation} to test custom {@link TypeSerializer}. */
 public class SingleThreadAccessCheckingTypeInfo<T> extends TypeInformation<T> {
+	private static final long serialVersionUID = 5462489225834247537L;
 	private final TypeInformation<T> originalTypeInformation;
 
 	SingleThreadAccessCheckingTypeInfo(Class<T> clazz) {

--- a/flink-end-to-end-tests/flink-distributed-cache-via-blob-test/src/main/java/org/apache/flink/streaming/tests/DistributedCacheViaBlobTestProgram.java
+++ b/flink-end-to-end-tests/flink-distributed-cache-via-blob-test/src/main/java/org/apache/flink/streaming/tests/DistributedCacheViaBlobTestProgram.java
@@ -66,6 +66,7 @@ public class DistributedCacheViaBlobTestProgram {
 
 	static class TestMapFunction extends RichMapFunction<Integer, String> {
 
+		private static final long serialVersionUID = -3229923870731983320L;
 		private final String initialPath;
 		private final long fileSize;
 

--- a/flink-end-to-end-tests/flink-sql-client-test/src/main/java/org/apache/flink/table/toolbox/StringRegexReplaceFunction.java
+++ b/flink-end-to-end-tests/flink-sql-client-test/src/main/java/org/apache/flink/table/toolbox/StringRegexReplaceFunction.java
@@ -25,6 +25,8 @@ import org.apache.flink.table.functions.ScalarFunction;
  */
 public class StringRegexReplaceFunction extends ScalarFunction {
 
+	private static final long serialVersionUID = -5622993192965747511L;
+
 	public String eval(String input, String regex, String replacement) {
 		return input.replaceAll(regex, replacement);
 	}

--- a/flink-end-to-end-tests/flink-stream-sql-test/src/main/java/org/apache/flink/sql/tests/StreamSQLTestProgram.java
+++ b/flink-end-to-end-tests/flink-stream-sql-test/src/main/java/org/apache/flink/sql/tests/StreamSQLTestProgram.java
@@ -257,6 +257,7 @@ public class StreamSQLTestProgram {
 	 */
 	public static class Generator implements SourceFunction<Row>, ResultTypeQueryable<Row>, ListCheckpointed<Long> {
 
+		private static final long serialVersionUID = 7288512672964709462L;
 		private final int numKeys;
 		private final int offsetSeconds;
 
@@ -314,6 +315,7 @@ public class StreamSQLTestProgram {
 	 */
 	public static class KillMapper implements MapFunction<Row, Row>, ListCheckpointed<Integer>, ResultTypeQueryable {
 
+		private static final long serialVersionUID = 7387229384966380992L;
 		// counts all processed records of all previous execution attempts
 		private int saveRecordCnt = 0;
 		// counts all processed records of this execution attempt

--- a/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/verify/TtlUpdateContext.java
+++ b/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/verify/TtlUpdateContext.java
@@ -25,6 +25,7 @@ import java.io.Serializable;
 /** Contains context relevant for state update with TTL. */
 public class TtlUpdateContext<UV, GV> implements Serializable {
 
+	private static final long serialVersionUID = -8224039775664223044L;
 	private final GV valueBeforeUpdate;
 	private final UV update;
 	private final GV valueAfterUpdate;

--- a/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/verify/TtlVerificationContext.java
+++ b/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/verify/TtlVerificationContext.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 /** Data to verify state update with TTL. */
 public class TtlVerificationContext<UV, GV> implements Serializable {
+	private static final long serialVersionUID = -3592820724410479982L;
 	private final int key;
 	@Nonnull
 	private final String  verifierId;

--- a/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/wordcount/WordCount.java
+++ b/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/wordcount/WordCount.java
@@ -109,6 +109,8 @@ public class WordCount {
 	 */
 	public static final class Tokenizer implements FlatMapFunction<String, Tuple2<String, Integer>> {
 
+		private static final long serialVersionUID = 8279483828280364175L;
+
 		@Override
 		public void flatMap(String value, Collector<Tuple2<String, Integer>> out) {
 			// normalize and split the line

--- a/flink-examples/flink-examples-build-helper/flink-examples-streaming-gcp-pubsub/src/main/java/org/apache/flink/streaming/examples/gcp/pubsub/IntegerSerializer.java
+++ b/flink-examples/flink-examples-build-helper/flink-examples-streaming-gcp-pubsub/src/main/java/org/apache/flink/streaming/examples/gcp/pubsub/IntegerSerializer.java
@@ -32,6 +32,8 @@ import java.math.BigInteger;
  */
 class IntegerSerializer implements PubSubDeserializationSchema<Integer>, SerializationSchema<Integer> {
 
+	private static final long serialVersionUID = -4824584938574745660L;
+
 	@Override
 	public Integer deserialize(PubsubMessage message) throws IOException {
 		return new BigInteger(message.getData().toByteArray()).intValue();

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/GroupedProcessingTimeWindowExample.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/GroupedProcessingTimeWindowExample.java
@@ -67,6 +67,8 @@ public class GroupedProcessingTimeWindowExample {
 
 	private static class FirstFieldKeyExtractor<Type extends Tuple, Key> implements KeySelector<Type, Key> {
 
+		private static final long serialVersionUID = -2206637769311139829L;
+
 		@Override
 		@SuppressWarnings("unchecked")
 		public Key getKey(Type value) {
@@ -75,6 +77,8 @@ public class GroupedProcessingTimeWindowExample {
 	}
 
 	private static class SummingWindowFunction implements WindowFunction<Tuple2<Long, Long>, Tuple2<Long, Long>, Long, Window> {
+
+		private static final long serialVersionUID = 4005861691636220453L;
 
 		@Override
 		public void apply(Long key, Window window, Iterable<Tuple2<Long, Long>> values, Collector<Tuple2<Long, Long>> out) {
@@ -89,6 +93,8 @@ public class GroupedProcessingTimeWindowExample {
 
 	private static class SummingReducer implements ReduceFunction<Tuple2<Long, Long>> {
 
+		private static final long serialVersionUID = 4606917273551892212L;
+
 		@Override
 		public Tuple2<Long, Long> reduce(Tuple2<Long, Long> value1, Tuple2<Long, Long> value2) {
 			return new Tuple2<>(value1.f0, value1.f1 + value2.f1);
@@ -100,6 +106,7 @@ public class GroupedProcessingTimeWindowExample {
 	 */
 	private static class DataSource extends RichParallelSourceFunction<Tuple2<Long, Long>> {
 
+		private static final long serialVersionUID = -6531794481189317093L;
 		private volatile boolean running = true;
 
 		@Override

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/WordCount.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/WordCount.java
@@ -108,6 +108,8 @@ public class WordCount {
 	 */
 	public static final class Tokenizer implements FlatMapFunction<String, Tuple2<String, Integer>> {
 
+		private static final long serialVersionUID = -1738705177256360405L;
+
 		@Override
 		public void flatMap(String value, Collector<Tuple2<String, Integer>> out) {
 			// normalize and split the line

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDeserializationSchema.java
@@ -82,6 +82,7 @@ public class AvroRowDeserializationSchema extends AbstractDeserializationSchema<
 	 * Used for time conversions into SQL types.
 	 */
 	private static final TimeZone LOCAL_TZ = TimeZone.getDefault();
+	private static final long serialVersionUID = -7558680930501336219L;
 
 	/**
 	 * Avro record class for deserialization. Might be null if record class is not available.

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowSerializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowSerializationSchema.java
@@ -69,6 +69,7 @@ public class AvroRowSerializationSchema implements SerializationSchema<Row> {
 	 * Used for time conversions from SQL types.
 	 */
 	private static final TimeZone LOCAL_TZ = TimeZone.getDefault();
+	private static final long serialVersionUID = 3858272711273359551L;
 
 	/**
 	 * Avro record class for serialization. Might be null if record class is not available.

--- a/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/CompressWriterFactory.java
+++ b/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/CompressWriterFactory.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 @PublicEvolving
 public class CompressWriterFactory<IN> implements BulkWriter.Factory<IN> {
 
+	private static final long serialVersionUID = 1206620912859697343L;
 	private Extractor<IN> extractor;
 	private CompressionCodec hadoopCodec;
 

--- a/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/extractor/DefaultExtractor.java
+++ b/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/extractor/DefaultExtractor.java
@@ -25,6 +25,8 @@ package org.apache.flink.formats.compress.extractor;
  */
 public class DefaultExtractor<T> implements Extractor<T> {
 
+	private static final long serialVersionUID = -834054923153076851L;
+
 	@Override
 	public byte[] extract(T element) {
 		return (element.toString() + System.lineSeparator()).getBytes();

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcInputFormat.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcInputFormat.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
  */
 public abstract class OrcInputFormat<T> extends FileInputFormat<T> {
 
+	private static final long serialVersionUID = 5137465603745790751L;
 	// the number of fields rows to read in a batch
 	protected int batchSize;
 	// the configuration to read with

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcRowInputFormat.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcRowInputFormat.java
@@ -41,6 +41,7 @@ public class OrcRowInputFormat extends OrcInputFormat<Row> implements ResultType
 
 	// the number of rows read in a batch
 	private static final int DEFAULT_BATCH_SIZE = 1000;
+	private static final long serialVersionUID = 5688676312441693509L;
 
 	// the type information of the Rows returned by this InputFormat.
 	private transient RowTypeInfo rowType;

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcSplitReader.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcSplitReader.java
@@ -233,10 +233,13 @@ public abstract class OrcSplitReader<T> implements Closeable {
 	 * A filter predicate that can be evaluated by the OrcInputFormat.
 	 */
 	public abstract static class Predicate implements Serializable {
+		private static final long serialVersionUID = -3231441573055918159L;
+
 		protected abstract SearchArgument.Builder add(SearchArgument.Builder builder);
 	}
 
 	abstract static class ColumnPredicate extends Predicate {
+		private static final long serialVersionUID = 6932613768669024672L;
 		final String columnName;
 		final PredicateLeaf.Type literalType;
 
@@ -310,6 +313,7 @@ public abstract class OrcSplitReader<T> implements Closeable {
 	}
 
 	abstract static class BinaryPredicate extends ColumnPredicate {
+		private static final long serialVersionUID = 9095067571087689173L;
 		final Serializable literal;
 
 		BinaryPredicate(String columnName, PredicateLeaf.Type literalType, Serializable literal) {
@@ -322,6 +326,8 @@ public abstract class OrcSplitReader<T> implements Closeable {
 	 * An EQUALS predicate that can be evaluated by the OrcInputFormat.
 	 */
 	public static class Equals extends BinaryPredicate {
+		private static final long serialVersionUID = -8875584791628145509L;
+
 		/**
 		 * Creates an EQUALS predicate.
 		 *
@@ -348,6 +354,8 @@ public abstract class OrcSplitReader<T> implements Closeable {
 	 * An EQUALS predicate that can be evaluated with Null safety by the OrcInputFormat.
 	 */
 	public static class NullSafeEquals extends BinaryPredicate {
+		private static final long serialVersionUID = 3878774705745475219L;
+
 		/**
 		 * Creates a null-safe EQUALS predicate.
 		 *
@@ -374,6 +382,8 @@ public abstract class OrcSplitReader<T> implements Closeable {
 	 * A LESS_THAN predicate that can be evaluated by the OrcInputFormat.
 	 */
 	public static class LessThan extends BinaryPredicate {
+		private static final long serialVersionUID = 8667552437106551780L;
+
 		/**
 		 * Creates a LESS_THAN predicate.
 		 *
@@ -400,6 +410,8 @@ public abstract class OrcSplitReader<T> implements Closeable {
 	 * A LESS_THAN_EQUALS predicate that can be evaluated by the OrcInputFormat.
 	 */
 	public static class LessThanEquals extends BinaryPredicate {
+		private static final long serialVersionUID = -541809532957991775L;
+
 		/**
 		 * Creates a LESS_THAN_EQUALS predicate.
 		 *
@@ -426,6 +438,8 @@ public abstract class OrcSplitReader<T> implements Closeable {
 	 * An IS_NULL predicate that can be evaluated by the OrcInputFormat.
 	 */
 	public static class IsNull extends ColumnPredicate {
+		private static final long serialVersionUID = -2535524137578746141L;
+
 		/**
 		 * Creates an IS_NULL predicate.
 		 *
@@ -451,6 +465,7 @@ public abstract class OrcSplitReader<T> implements Closeable {
 	 * An BETWEEN predicate that can be evaluated by the OrcInputFormat.
 	 */
 	public static class Between extends ColumnPredicate {
+		private static final long serialVersionUID = 7548303851324187703L;
 		private Serializable lowerBound;
 		private Serializable upperBound;
 
@@ -483,6 +498,7 @@ public abstract class OrcSplitReader<T> implements Closeable {
 	 * An IN predicate that can be evaluated by the OrcInputFormat.
 	 */
 	public static class In extends ColumnPredicate {
+		private static final long serialVersionUID = 9172591492788854614L;
 		private Serializable[] literals;
 
 		/**
@@ -516,6 +532,7 @@ public abstract class OrcSplitReader<T> implements Closeable {
 	 * A NOT predicate to negate a predicate that can be evaluated by the OrcInputFormat.
 	 */
 	public static class Not extends Predicate {
+		private static final long serialVersionUID = 7121557331405880983L;
 		private final Predicate pred;
 
 		/**
@@ -545,6 +562,7 @@ public abstract class OrcSplitReader<T> implements Closeable {
 	 * An OR predicate that can be evaluated by the OrcInputFormat.
 	 */
 	public static class Or extends Predicate {
+		private static final long serialVersionUID = 8420110100450808908L;
 		private final Predicate[] preds;
 
 		/**

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetMapInputFormat.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetMapInputFormat.java
@@ -40,6 +40,8 @@ import java.util.Map;
  */
 public class ParquetMapInputFormat extends ParquetInputFormat<Map> {
 
+	private static final long serialVersionUID = 2555206696325929391L;
+
 	public ParquetMapInputFormat(Path path, MessageType messageType) {
 		super(path, messageType);
 	}

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetPojoInputFormat.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetPojoInputFormat.java
@@ -44,6 +44,7 @@ import java.util.Map;
 public class ParquetPojoInputFormat<E> extends ParquetInputFormat<E> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ParquetPojoInputFormat.class);
+	private static final long serialVersionUID = -3189818369467392774L;
 	private final Class<E> pojoTypeClass;
 	private final TypeSerializer<E> typeSerializer;
 	private transient Field[] pojoFields;

--- a/flink-java/src/main/java/org/apache/flink/api/java/functions/SampleInCoordinator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/functions/SampleInCoordinator.java
@@ -40,6 +40,7 @@ import java.util.Iterator;
 @Internal
 public class SampleInCoordinator<T> implements GroupReduceFunction<IntermediateSampleData<T>, T> {
 
+	private static final long serialVersionUID = 2224101917531517071L;
 	private boolean withReplacement;
 	private int numSample;
 	private long seed;

--- a/flink-java/src/main/java/org/apache/flink/api/java/functions/SampleInPartition.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/functions/SampleInPartition.java
@@ -37,6 +37,7 @@ import java.util.Iterator;
 @Internal
 public class SampleInPartition<T> extends RichMapPartitionFunction<T, IntermediateSampleData<T>> {
 
+	private static final long serialVersionUID = -2321866603041229097L;
 	private boolean withReplacement;
 	private int numSample;
 	private long seed;

--- a/flink-java/src/main/java/org/apache/flink/api/java/functions/SampleWithFraction.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/functions/SampleWithFraction.java
@@ -36,6 +36,7 @@ import java.util.Iterator;
 @Internal
 public class SampleWithFraction<T> extends RichMapPartitionFunction<T, T> {
 
+	private static final long serialVersionUID = -608309297128360022L;
 	private boolean withReplacement;
 	private double fraction;
 	private long seed;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/translation/CombineToGroupCombineWrapper.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/translation/CombineToGroupCombineWrapper.java
@@ -33,6 +33,7 @@ import org.apache.flink.util.Preconditions;
 public class CombineToGroupCombineWrapper<IN, OUT, F extends CombineFunction<IN, IN> & GroupReduceFunction<IN, OUT>>
 	implements GroupCombineFunction<IN, IN>, GroupReduceFunction<IN, OUT> {
 
+	private static final long serialVersionUID = 2175356562174699271L;
 	private final F wrappedFunction;
 
 	public CombineToGroupCombineWrapper(F wrappedFunction) {

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/translation/RichCombineToGroupCombineWrapper.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/translation/RichCombineToGroupCombineWrapper.java
@@ -34,6 +34,7 @@ import org.apache.flink.util.Preconditions;
 public class RichCombineToGroupCombineWrapper<IN, OUT, F extends RichGroupReduceFunction<IN, OUT> & CombineFunction<IN, IN>>
 	extends RichGroupCombineFunction<IN, IN> implements GroupReduceFunction<IN, OUT> {
 
+	private static final long serialVersionUID = 8676131895387991529L;
 	private final F wrappedFunction;
 
 	public RichCombineToGroupCombineWrapper(F wrappedFunction) {

--- a/flink-java/src/main/java/org/apache/flink/api/java/summarize/aggregation/BooleanSummaryAggregator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/summarize/aggregation/BooleanSummaryAggregator.java
@@ -27,6 +27,7 @@ import org.apache.flink.api.java.summarize.BooleanColumnSummary;
 @Internal
 public class BooleanSummaryAggregator implements Aggregator<Boolean, BooleanColumnSummary> {
 
+	private static final long serialVersionUID = -449438378954330557L;
 	private long trueCount = 0L;
 	private long falseCount = 0L;
 	private long nullCount = 0L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/summarize/aggregation/DoubleSummaryAggregator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/summarize/aggregation/DoubleSummaryAggregator.java
@@ -27,6 +27,7 @@ import static org.apache.flink.api.java.summarize.aggregation.CompensatedSum.ZER
  */
 @Internal
 public class DoubleSummaryAggregator extends NumericSummaryAggregator<Double> {
+	private static final long serialVersionUID = -5026059034545910489L;
 
 	// Nested classes are only "public static" for Kryo serialization, otherwise they'd be private
 
@@ -35,6 +36,7 @@ public class DoubleSummaryAggregator extends NumericSummaryAggregator<Double> {
 	 */
 	public static class MinDoubleAggregator implements Aggregator<Double, Double> {
 
+		private static final long serialVersionUID = 2689752307059003971L;
 		private double min = Double.POSITIVE_INFINITY;
 
 		@Override
@@ -58,6 +60,7 @@ public class DoubleSummaryAggregator extends NumericSummaryAggregator<Double> {
 	 */
 	public static class MaxDoubleAggregator implements Aggregator<Double, Double> {
 
+		private static final long serialVersionUID = -6032037153285198413L;
 		private double max = Double.NEGATIVE_INFINITY;
 
 		@Override
@@ -81,6 +84,7 @@ public class DoubleSummaryAggregator extends NumericSummaryAggregator<Double> {
 	 */
 	public static class SumDoubleAggregator implements Aggregator<Double, Double> {
 
+		private static final long serialVersionUID = -732089052771926119L;
 		private CompensatedSum sum = ZERO;
 
 		@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/summarize/aggregation/FloatSummaryAggregator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/summarize/aggregation/FloatSummaryAggregator.java
@@ -37,6 +37,7 @@ public class FloatSummaryAggregator extends NumericSummaryAggregator<Float> {
 	 */
 	public static class MinFloatAggregator implements Aggregator<Float, Float> {
 
+		private static final long serialVersionUID = -744825865286066628L;
 		private float min = Float.POSITIVE_INFINITY;
 
 		@Override
@@ -60,6 +61,7 @@ public class FloatSummaryAggregator extends NumericSummaryAggregator<Float> {
 	 */
 	public static class MaxFloatAggregator implements Aggregator<Float, Float> {
 
+		private static final long serialVersionUID = -7700926790300525141L;
 		private float max = Float.NEGATIVE_INFINITY;
 
 		@Override
@@ -83,6 +85,7 @@ public class FloatSummaryAggregator extends NumericSummaryAggregator<Float> {
 	 */
 	public static class SumFloatAggregator implements Aggregator<Float, Float> {
 
+		private static final long serialVersionUID = 8641403513293653379L;
 		private CompensatedSum sum = ZERO;
 
 		@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/summarize/aggregation/IntegerSummaryAggregator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/summarize/aggregation/IntegerSummaryAggregator.java
@@ -35,6 +35,7 @@ public class IntegerSummaryAggregator extends NumericSummaryAggregator<Integer> 
 	 */
 	public static class MinIntegerAggregator implements Aggregator<Integer, Integer> {
 
+		private static final long serialVersionUID = 9135900098137262751L;
 		private int min = Integer.MAX_VALUE;
 
 		@Override
@@ -58,6 +59,7 @@ public class IntegerSummaryAggregator extends NumericSummaryAggregator<Integer> 
 	 */
 	public static class MaxIntegerAggregator implements Aggregator<Integer, Integer> {
 
+		private static final long serialVersionUID = 3251917108531040932L;
 		private int max = Integer.MIN_VALUE;
 
 		@Override
@@ -81,6 +83,7 @@ public class IntegerSummaryAggregator extends NumericSummaryAggregator<Integer> 
 	 */
 	public static class SumIntegerAggregator implements Aggregator<Integer, Integer> {
 
+		private static final long serialVersionUID = 8428346897959190521L;
 		private int sum = 0;
 
 		@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/summarize/aggregation/LongSummaryAggregator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/summarize/aggregation/LongSummaryAggregator.java
@@ -35,6 +35,7 @@ public class LongSummaryAggregator extends NumericSummaryAggregator<Long> {
 	 */
 	public static class MinLongAggregator implements Aggregator<Long, Long> {
 
+		private static final long serialVersionUID = 514281453171585970L;
 		private long min = Long.MAX_VALUE;
 
 		@Override
@@ -58,6 +59,7 @@ public class LongSummaryAggregator extends NumericSummaryAggregator<Long> {
 	 */
 	public static class MaxLongAggregator implements Aggregator<Long, Long> {
 
+		private static final long serialVersionUID = 3792028253356538772L;
 		private long max = Long.MIN_VALUE;
 
 		@Override
@@ -81,6 +83,7 @@ public class LongSummaryAggregator extends NumericSummaryAggregator<Long> {
 	 */
 	private static class SumLongAggregator implements Aggregator<Long, Long> {
 
+		private static final long serialVersionUID = 3765601046799901149L;
 		private long sum = 0;
 
 		@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/summarize/aggregation/ObjectSummaryAggregator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/summarize/aggregation/ObjectSummaryAggregator.java
@@ -27,6 +27,7 @@ import org.apache.flink.api.java.summarize.ObjectColumnSummary;
 @Internal
 public class ObjectSummaryAggregator implements Aggregator<Object, ObjectColumnSummary> {
 
+	private static final long serialVersionUID = -6144918380587393289L;
 	private long nonNullCount;
 	private long nullCount;
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/summarize/aggregation/ShortSummaryAggregator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/summarize/aggregation/ShortSummaryAggregator.java
@@ -49,6 +49,7 @@ public class ShortSummaryAggregator extends NumericSummaryAggregator<Short> {
 	 */
 	public static class MinShortAggregator implements Aggregator<Short, Short> {
 
+		private static final long serialVersionUID = 8716322369129950232L;
 		private short min = Short.MAX_VALUE;
 
 		@Override
@@ -72,6 +73,7 @@ public class ShortSummaryAggregator extends NumericSummaryAggregator<Short> {
 	 */
 	public static class MaxShortAggregator implements Aggregator<Short, Short> {
 
+		private static final long serialVersionUID = 8365161266527260476L;
 		private short max = Short.MIN_VALUE;
 
 		@Override
@@ -95,6 +97,7 @@ public class ShortSummaryAggregator extends NumericSummaryAggregator<Short> {
 	 */
 	public static class SumShortAggregator implements Aggregator<Short, Short> {
 
+		private static final long serialVersionUID = 8677541176139250849L;
 		private short sum = 0;
 
 		@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/summarize/aggregation/StringSummaryAggregator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/summarize/aggregation/StringSummaryAggregator.java
@@ -27,6 +27,7 @@ import org.apache.flink.api.java.summarize.StringColumnSummary;
 @Internal
 public class StringSummaryAggregator implements Aggregator<String, StringColumnSummary> {
 
+	private static final long serialVersionUID = -1345782816387656227L;
 	private long nonNullCount = 0L;
 	private long nullCount = 0L;
 	private long emptyCount = 0L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/summarize/aggregation/ValueSummaryAggregator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/summarize/aggregation/ValueSummaryAggregator.java
@@ -43,6 +43,7 @@ import org.apache.flink.types.Value;
 @Internal
 public abstract class ValueSummaryAggregator<VT extends Value, PT, R, A extends Aggregator<PT, R>> implements Aggregator<VT, R> {
 
+	private static final long serialVersionUID = -6835466975792994719L;
 	private A aggregator = initPrimitiveAggregator();
 
 	@Override
@@ -88,6 +89,8 @@ public abstract class ValueSummaryAggregator<VT extends Value, PT, R, A extends 
 	 */
 	public static class ShortValueSummaryAggregator extends ValueSummaryAggregator<ShortValue, Short, NumericColumnSummary<Short>, ShortSummaryAggregator> {
 
+		private static final long serialVersionUID = -659178223678094509L;
+
 		@Override
 		protected ShortSummaryAggregator initPrimitiveAggregator() {
 			return new ShortSummaryAggregator();
@@ -103,6 +106,8 @@ public abstract class ValueSummaryAggregator<VT extends Value, PT, R, A extends 
 	 * A {@link ValueSummaryAggregator} for {@link Integer}.
 	 */
 	public static class IntegerValueSummaryAggregator extends ValueSummaryAggregator<IntValue, Integer, NumericColumnSummary<Integer>, IntegerSummaryAggregator> {
+
+		private static final long serialVersionUID = -2318523858191880470L;
 
 		@Override
 		protected IntegerSummaryAggregator initPrimitiveAggregator() {
@@ -120,6 +125,8 @@ public abstract class ValueSummaryAggregator<VT extends Value, PT, R, A extends 
 	 */
 	public static class LongValueSummaryAggregator extends ValueSummaryAggregator<LongValue, Long, NumericColumnSummary<Long>, LongSummaryAggregator> {
 
+		private static final long serialVersionUID = -4647929669380683713L;
+
 		@Override
 		protected LongSummaryAggregator initPrimitiveAggregator() {
 			return new LongSummaryAggregator();
@@ -135,6 +142,8 @@ public abstract class ValueSummaryAggregator<VT extends Value, PT, R, A extends 
 	 * A {@link ValueSummaryAggregator} for {@link Float}.
 	 */
 	public static class FloatValueSummaryAggregator extends ValueSummaryAggregator<FloatValue, Float, NumericColumnSummary<Float>, FloatSummaryAggregator> {
+
+		private static final long serialVersionUID = -6074779720727109283L;
 
 		@Override
 		protected FloatSummaryAggregator initPrimitiveAggregator() {
@@ -152,6 +161,8 @@ public abstract class ValueSummaryAggregator<VT extends Value, PT, R, A extends 
 	 */
 	public static class DoubleValueSummaryAggregator extends ValueSummaryAggregator<DoubleValue, Double, NumericColumnSummary<Double>, DoubleSummaryAggregator> {
 
+		private static final long serialVersionUID = -7523800503923293478L;
+
 		@Override
 		protected DoubleSummaryAggregator initPrimitiveAggregator() {
 			return new DoubleSummaryAggregator();
@@ -168,6 +179,8 @@ public abstract class ValueSummaryAggregator<VT extends Value, PT, R, A extends 
 	 */
 	public static class BooleanValueSummaryAggregator extends ValueSummaryAggregator<BooleanValue, Boolean, BooleanColumnSummary, BooleanSummaryAggregator> {
 
+		private static final long serialVersionUID = 5139428946277898714L;
+
 		@Override
 		protected BooleanSummaryAggregator initPrimitiveAggregator() {
 			return new BooleanSummaryAggregator();
@@ -183,6 +196,8 @@ public abstract class ValueSummaryAggregator<VT extends Value, PT, R, A extends 
 	 * A {@link ValueSummaryAggregator} for {@link String}.
 	 */
 	public static class StringValueSummaryAggregator extends ValueSummaryAggregator<StringValue, String, StringColumnSummary, StringSummaryAggregator> {
+
+		private static final long serialVersionUID = 7528290924109553230L;
 
 		@Override
 		protected StringSummaryAggregator initPrimitiveAggregator() {

--- a/flink-java/src/main/java/org/apache/flink/api/java/utils/RequiredParametersException.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/utils/RequiredParametersException.java
@@ -30,6 +30,7 @@ import java.util.List;
 @Deprecated
 public class RequiredParametersException extends Exception {
 
+	private static final long serialVersionUID = 3452003018479335016L;
 	private List<String> missingArguments;
 
 	public RequiredParametersException() {

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/functions/PatternProcessFunction.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/functions/PatternProcessFunction.java
@@ -43,6 +43,8 @@ import java.util.Map;
 @PublicEvolving
 public abstract class PatternProcessFunction<IN, OUT> extends AbstractRichFunction {
 
+	private static final long serialVersionUID = 6791628565084605197L;
+
 	/**
 	 * Generates resulting elements given a map of detected pattern events. The events
 	 * are identified by their specified names.

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/functions/adaptors/PatternFlatSelectAdapter.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/functions/adaptors/PatternFlatSelectAdapter.java
@@ -36,6 +36,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Internal
 public class PatternFlatSelectAdapter<IN, OUT> extends PatternProcessFunction<IN, OUT> {
 
+	private static final long serialVersionUID = 6498969885184279473L;
 	private final PatternFlatSelectFunction<IN, OUT> flatSelectFunction;
 
 	public PatternFlatSelectAdapter(final PatternFlatSelectFunction<IN, OUT> flatSelectFunction) {

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/functions/adaptors/PatternSelectAdapter.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/functions/adaptors/PatternSelectAdapter.java
@@ -36,6 +36,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Internal
 public class PatternSelectAdapter<IN, OUT> extends PatternProcessFunction<IN, OUT> {
 
+	private static final long serialVersionUID = 2402537750755801765L;
 	private final PatternSelectFunction<IN, OUT> selectFunction;
 
 	public PatternSelectAdapter(final PatternSelectFunction<IN, OUT> selectFunction) {

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/functions/adaptors/PatternTimeoutFlatSelectAdapter.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/functions/adaptors/PatternTimeoutFlatSelectAdapter.java
@@ -42,6 +42,7 @@ public class PatternTimeoutFlatSelectAdapter<IN, OUT, T>
 		extends PatternFlatSelectAdapter<IN, OUT>
 		implements TimedOutPartialMatchHandler<IN> {
 
+	private static final long serialVersionUID = -4878589360111326982L;
 	private final PatternFlatTimeoutFunction<IN, T> flatTimeoutFunction;
 	private final OutputTag<T> timedOutPartialMatchesTag;
 

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/functions/adaptors/PatternTimeoutSelectAdapter.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/functions/adaptors/PatternTimeoutSelectAdapter.java
@@ -41,6 +41,7 @@ public class PatternTimeoutSelectAdapter<IN, OUT, T>
 		extends PatternSelectAdapter<IN, OUT>
 		implements TimedOutPartialMatchHandler<IN> {
 
+	private static final long serialVersionUID = -9183431970241398047L;
 	private final PatternTimeoutFunction<IN, T> timeoutFunction;
 	private final OutputTag<T> timedOutPartialMatchesTag;
 

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/ConnectedComponents.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/ConnectedComponents.java
@@ -59,6 +59,8 @@ extends DriverBase<K, VV, EV> {
 	 */
 	private static final class MapVertices<T, VT>
 	implements MapFunction<Vertex<T, VT>, T> {
+		private static final long serialVersionUID = -7922066103145885286L;
+
 		@Override
 		public T map(Vertex<T, VT> value) throws Exception {
 			return value.f0;

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/transform/GraphKeyTypeTransform.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/transform/GraphKeyTypeTransform.java
@@ -324,6 +324,7 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	static class LongValueToUnsignedByteValue
 	implements TranslateFunction<LongValue, ByteValue> {
 		public static final long MAX_VERTEX_COUNT = 1L << 8;
+		private static final long serialVersionUID = -2406530252844670003L;
 
 		@Override
 		public ByteValue translate(LongValue value, ByteValue reuse)
@@ -351,6 +352,7 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	static class LongValueToUnsignedByte
 	implements TranslateFunction<LongValue, Byte> {
 		public static final long MAX_VERTEX_COUNT = 1L << 8;
+		private static final long serialVersionUID = -7878347713954678404L;
 
 		@Override
 		public Byte translate(LongValue value, Byte reuse)
@@ -373,6 +375,7 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	static class LongValueToUnsignedShortValue
 	implements TranslateFunction<LongValue, ShortValue> {
 		public static final long MAX_VERTEX_COUNT = 1L << 16;
+		private static final long serialVersionUID = -8354395811271477627L;
 
 		@Override
 		public ShortValue translate(LongValue value, ShortValue reuse)
@@ -400,6 +403,7 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	static class LongValueToUnsignedShort
 	implements TranslateFunction<LongValue, Short> {
 		public static final long MAX_VERTEX_COUNT = 1L << 16;
+		private static final long serialVersionUID = 2479409848619378590L;
 
 		@Override
 		public Short translate(LongValue value, Short reuse)
@@ -422,6 +426,7 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	static class LongValueToCharValue
 	implements TranslateFunction<LongValue, CharValue> {
 		public static final long MAX_VERTEX_COUNT = 1L << 16;
+		private static final long serialVersionUID = 8940463328783703207L;
 
 		@Override
 		public CharValue translate(LongValue value, CharValue reuse)
@@ -449,6 +454,7 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	static class LongValueToChar
 	implements TranslateFunction<LongValue, Character> {
 		public static final long MAX_VERTEX_COUNT = 1L << 16;
+		private static final long serialVersionUID = -1075906019053065366L;
 
 		@Override
 		public Character translate(LongValue value, Character reuse)
@@ -471,6 +477,7 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	static class LongValueToUnsignedInt
 	implements TranslateFunction<LongValue, Integer> {
 		public static final long MAX_VERTEX_COUNT = 1L << 32;
+		private static final long serialVersionUID = -2184336647010533873L;
 
 		@Override
 		public Integer translate(LongValue value, Integer reuse)
@@ -490,6 +497,8 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	 */
 	static class LongValueToLong
 	implements TranslateFunction<LongValue, Long> {
+		private static final long serialVersionUID = 6153168284490048848L;
+
 		@Override
 		public Long translate(LongValue value, Long reuse)
 				throws Exception {
@@ -503,6 +512,7 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	static class LongValueToUnsignedFloatValue
 	implements TranslateFunction<LongValue, FloatValue> {
 		public static final long MAX_VERTEX_COUNT = 1L << 32;
+		private static final long serialVersionUID = 3636711874525503690L;
 
 		@Override
 		public FloatValue translate(LongValue value, FloatValue reuse)
@@ -528,6 +538,7 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	static class LongValueToUnsignedFloat
 	implements TranslateFunction<LongValue, Float> {
 		public static final long MAX_VERTEX_COUNT = 1L << 32;
+		private static final long serialVersionUID = 8661526586991879585L;
 
 		@Override
 		public Float translate(LongValue value, Float reuse)
@@ -547,6 +558,8 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	 */
 	static class LongValueToDoubleValue
 	implements TranslateFunction<LongValue, DoubleValue> {
+		private static final long serialVersionUID = -944847969693995201L;
+
 		@Override
 		public DoubleValue translate(LongValue value, DoubleValue reuse)
 				throws Exception {
@@ -564,6 +577,8 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	 */
 	static class LongValueToDouble
 	implements TranslateFunction<LongValue, Double> {
+		private static final long serialVersionUID = -4603440010317593155L;
+
 		@Override
 		public Double translate(LongValue value, Double reuse)
 				throws Exception {
@@ -576,6 +591,8 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	 */
 	static class LongValueToString
 	implements TranslateFunction<LongValue, String> {
+		private static final long serialVersionUID = -1845569399252784607L;
+
 		@Override
 		public String translate(LongValue value, String reuse)
 				throws Exception {
@@ -591,6 +608,7 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	 */
 	private static class TranslateResultIDs<T, U>
 	implements FlatMapFunction<TranslatableResult<T>, TranslatableResult<U>> {
+		private static final long serialVersionUID = -3998494184461662803L;
 		private final TranslateFunction<T, U> translator;
 
 		private transient TranslatableResult<U> reuse = null;
@@ -612,6 +630,7 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	static class UnsignedByteValueToLongValueWithProperHashCode
 	implements TranslateFunction<ByteValue, LongValueWithProperHashCode> {
 		public static final long MIN_VERTEX_COUNT = Byte.MAX_VALUE + 2;
+		private static final long serialVersionUID = -8438321274335417744L;
 
 		@Override
 		public LongValueWithProperHashCode translate(ByteValue value, LongValueWithProperHashCode reuse)
@@ -631,6 +650,7 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	static class UnsignedByteToLongValueWithProperHashCode
 	implements TranslateFunction<Byte, LongValueWithProperHashCode> {
 		public static final long MIN_VERTEX_COUNT = Byte.MAX_VALUE + 2;
+		private static final long serialVersionUID = -3380907257342803728L;
 
 		@Override
 		public LongValueWithProperHashCode translate(Byte value, LongValueWithProperHashCode reuse)
@@ -650,6 +670,7 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	static class UnsignedShortValueToLongValueWithProperHashCode
 	implements TranslateFunction<ShortValue, LongValueWithProperHashCode> {
 		public static final long MIN_VERTEX_COUNT = Short.MAX_VALUE + 2;
+		private static final long serialVersionUID = 6377100877582384198L;
 
 		@Override
 		public LongValueWithProperHashCode translate(ShortValue value, LongValueWithProperHashCode reuse)
@@ -669,6 +690,7 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	static class UnsignedShortToLongValueWithProperHashCode
 	implements TranslateFunction<Short, LongValueWithProperHashCode> {
 		public static final long MIN_VERTEX_COUNT = Short.MAX_VALUE + 2;
+		private static final long serialVersionUID = -2615886486469875687L;
 
 		@Override
 		public LongValueWithProperHashCode translate(Short value, LongValueWithProperHashCode reuse)
@@ -688,6 +710,7 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	static class UnsignedIntValueToLongValueWithProperHashCode
 	implements TranslateFunction<IntValue, LongValueWithProperHashCode> {
 		public static final long MIN_VERTEX_COUNT = Integer.MAX_VALUE + 2L;
+		private static final long serialVersionUID = -7276323904203111791L;
 
 		@Override
 		public LongValueWithProperHashCode translate(IntValue value, LongValueWithProperHashCode reuse)
@@ -707,6 +730,7 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	static class UnsignedIntToLongValueWithProperHashCode
 	implements TranslateFunction<Integer, LongValueWithProperHashCode> {
 		public static final long MIN_VERTEX_COUNT = Integer.MAX_VALUE + 2L;
+		private static final long serialVersionUID = -8215921966502569201L;
 
 		@Override
 		public LongValueWithProperHashCode translate(Integer value, LongValueWithProperHashCode reuse)
@@ -725,6 +749,8 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	 */
 	static class LongValueToLongValueWithProperHashCode
 	implements TranslateFunction<LongValue, LongValueWithProperHashCode> {
+		private static final long serialVersionUID = -3929825801911741830L;
+
 		@Override
 		public LongValueWithProperHashCode translate(LongValue value, LongValueWithProperHashCode reuse)
 				throws Exception {
@@ -742,6 +768,8 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	 */
 	static class UnsignedFloatValueToLongValueWithProperHashCode
 	implements TranslateFunction<FloatValue, LongValueWithProperHashCode> {
+		private static final long serialVersionUID = -4895528039833462027L;
+
 		@Override
 		public LongValueWithProperHashCode translate(FloatValue value, LongValueWithProperHashCode reuse)
 				throws Exception {
@@ -759,6 +787,8 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	 */
 	static class UnsignedFloatToLongValueWithProperHashCode
 	implements TranslateFunction<Float, LongValueWithProperHashCode> {
+		private static final long serialVersionUID = -4458490839837022058L;
+
 		@Override
 		public LongValueWithProperHashCode translate(Float value, LongValueWithProperHashCode reuse)
 				throws Exception {
@@ -776,6 +806,8 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	 */
 	static class DoubleValueToLongValueWithProperHashCode
 	implements TranslateFunction<DoubleValue, LongValueWithProperHashCode> {
+		private static final long serialVersionUID = -8156667844418789795L;
+
 		@Override
 		public LongValueWithProperHashCode translate(DoubleValue value, LongValueWithProperHashCode reuse)
 				throws Exception {
@@ -793,6 +825,8 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	 */
 	static class DoubleToLongValueWithProperHashCode
 	implements TranslateFunction<Double, LongValueWithProperHashCode> {
+		private static final long serialVersionUID = -4256439510573934264L;
+
 		@Override
 		public LongValueWithProperHashCode translate(Double value, LongValueWithProperHashCode reuse)
 				throws Exception {
@@ -810,6 +844,8 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	 */
 	static class StringValueToLongValueWithProperHashCode
 	implements TranslateFunction<StringValue, LongValueWithProperHashCode> {
+		private static final long serialVersionUID = -8879586945452656821L;
+
 		@Override
 		public LongValueWithProperHashCode translate(StringValue value, LongValueWithProperHashCode reuse)
 				throws Exception {
@@ -827,6 +863,8 @@ implements Transform<Graph<LongValue, VV, EV>, Graph<?, VV, EV>, DataSet<Transla
 	 */
 	static class StringToLongValueWithProperHashCode
 	implements TranslateFunction<String, LongValueWithProperHashCode> {
+		private static final long serialVersionUID = 1254052166399269935L;
+
 		@Override
 		public LongValueWithProperHashCode translate(String value, LongValueWithProperHashCode reuse)
 				throws Exception {

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/transform/LongValueWithProperHashCode.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/transform/LongValueWithProperHashCode.java
@@ -47,6 +47,8 @@ import java.util.Map;
 public class LongValueWithProperHashCode
 extends LongValue {
 
+	private static final long serialVersionUID = -5293251049218517143L;
+
 	@Override
 	public int hashCode() {
 		return (int) (this.getValue() ^ this.getValue() >>> 32);

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/AnalyticHelper.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/AnalyticHelper.java
@@ -46,6 +46,7 @@ public abstract class AnalyticHelper<T>
 extends RichOutputFormat<T> {
 
 	private static final String SEPARATOR = "-";
+	private static final long serialVersionUID = -8852626333920623373L;
 
 	private String id = new AbstractID().toString();
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/dataset/ChecksumHashCode.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/dataset/ChecksumHashCode.java
@@ -68,6 +68,7 @@ extends DataSetAnalyticBase<T, Checksum> {
 	 */
 	private static class ChecksumHashCodeHelper<U>
 	extends AnalyticHelper<U> {
+		private static final long serialVersionUID = 3996139559337509916L;
 		private long count;
 		private long checksum;
 
@@ -89,6 +90,7 @@ extends DataSetAnalyticBase<T, Checksum> {
 	 */
 	public static class Checksum
 	implements SimpleAccumulator<Checksum> {
+		private static final long serialVersionUID = -6115043402625117658L;
 		private long count;
 
 		private long checksum;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/dataset/Collect.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/dataset/Collect.java
@@ -80,6 +80,7 @@ extends DataSetAnalyticBase<T, List<T>> {
 	 */
 	private static class CollectHelper<U>
 	extends AnalyticHelper<U> {
+		private static final long serialVersionUID = -1501501893127529020L;
 		private SerializedListAccumulator<U> accumulator;
 
 		private final TypeSerializer<U> serializer;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/dataset/Count.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/dataset/Count.java
@@ -62,6 +62,7 @@ extends DataSetAnalyticBase<T, Long> {
 	 */
 	private static class CountHelper<U>
 	extends AnalyticHelper<U> {
+		private static final long serialVersionUID = 3089823113364047119L;
 		private long count;
 
 		@Override

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/DegreeAnnotationFunctions.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/DegreeAnnotationFunctions.java
@@ -50,6 +50,7 @@ public class DegreeAnnotationFunctions {
 	@ForwardedFields("0")
 	public static class MapEdgeToSourceId<K, EV>
 	implements MapFunction<Edge<K, EV>, Vertex<K, LongValue>> {
+		private static final long serialVersionUID = 7575557653118575869L;
 		private Vertex<K, LongValue> output = new Vertex<>(null, new LongValue(1));
 
 		@Override
@@ -68,6 +69,7 @@ public class DegreeAnnotationFunctions {
 	@ForwardedFields("1->0")
 	public static class MapEdgeToTargetId<K, EV>
 	implements MapFunction<Edge<K, EV>, Vertex<K, LongValue>> {
+		private static final long serialVersionUID = -5860084247717680304L;
 		private Vertex<K, LongValue> output = new Vertex<>(null, new LongValue(1));
 
 		@Override
@@ -85,6 +87,8 @@ public class DegreeAnnotationFunctions {
 	@ForwardedFields("0")
 	public static class DegreeCount<K>
 	implements ReduceFunction<Vertex<K, LongValue>> {
+		private static final long serialVersionUID = 1126586008446188177L;
+
 		@Override
 		public Vertex<K, LongValue> reduce(Vertex<K, LongValue> left, Vertex<K, LongValue> right)
 				throws Exception {
@@ -105,6 +109,7 @@ public class DegreeAnnotationFunctions {
 	@ForwardedFieldsSecond("0")
 	public static class JoinVertexWithVertexDegree<K, VV>
 	implements JoinFunction<Vertex<K, VV>, Vertex<K, LongValue>, Vertex<K, LongValue>> {
+		private static final long serialVersionUID = -3568332157014978719L;
 		private LongValue zero = new LongValue(0);
 
 		private Vertex<K, LongValue> output = new Vertex<>();
@@ -134,6 +139,7 @@ public class DegreeAnnotationFunctions {
 	@ForwardedFieldsSecond("0; 1->2.1")
 	public static class JoinEdgeWithVertexDegree<K, EV, D>
 	implements JoinFunction<Edge<K, EV>, Vertex<K, D>, Edge<K, Tuple2<EV, D>>> {
+		private static final long serialVersionUID = 2762343497325262373L;
 		private Tuple2<EV, D> valueAndDegree = new Tuple2<>();
 
 		private Edge<K, Tuple2<EV, D>> output = new Edge<>(null, null, valueAndDegree);
@@ -160,6 +166,7 @@ public class DegreeAnnotationFunctions {
 	@ForwardedFieldsSecond("0; 1->2.2")
 	public static class JoinEdgeDegreeWithVertexDegree<K, EV, D>
 	implements JoinFunction<Edge<K, Tuple2<EV, D>>, Vertex<K, D>, Edge<K, Tuple3<EV, D, D>>> {
+		private static final long serialVersionUID = -7603235910757263769L;
 		private Tuple3<EV, D, D> valueAndDegrees = new Tuple3<>();
 
 		private Edge<K, Tuple3<EV, D, D>> output = new Edge<>(null, null, valueAndDegrees);

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/VertexDegrees.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/VertexDegrees.java
@@ -129,6 +129,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Vertex<K, Degrees>> {
 	 */
 	private static class EmitAndFlipEdge<T, TV>
 	implements FlatMapFunction<Edge<T, TV>, Tuple3<T, T, ByteValue>> {
+		private static final long serialVersionUID = -7951917126998347276L;
 		private Tuple3<T, T, ByteValue> forward = new Tuple3<>(null, null, new ByteValue(EdgeOrder.FORWARD.getBitmask()));
 
 		private Tuple3<T, T, ByteValue> reverse = new Tuple3<>(null, null, new ByteValue(EdgeOrder.REVERSE.getBitmask()));
@@ -154,6 +155,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Vertex<K, Degrees>> {
 	@ForwardedFields("0")
 	private static final class ReduceBitmask<T>
 	implements GroupReduceFunction<Tuple3<T, T, ByteValue>, Tuple2<T, ByteValue>> {
+		private static final long serialVersionUID = 9154073810536462705L;
 		private Tuple2<T, ByteValue> output = new Tuple2<>(null, new ByteValue());
 
 		@Override
@@ -179,6 +181,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Vertex<K, Degrees>> {
 	@ForwardedFields("0")
 	private static class DegreeCount<T>
 	implements GroupReduceFunction<Tuple2<T, ByteValue>, Vertex<T, Degrees>> {
+		private static final long serialVersionUID = -6717509823456041675L;
 		private Vertex<T, Degrees> output = new Vertex<>(null, new Degrees());
 
 		@Override
@@ -224,6 +227,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Vertex<K, Degrees>> {
 	@ForwardedFieldsSecond("0")
 	private static class JoinVertexWithVertexDegrees<T, TV>
 	implements JoinFunction<Vertex<T, TV>, Vertex<T, Degrees>, Vertex<T, Degrees>> {
+		private static final long serialVersionUID = 5766710654350522341L;
 		private Vertex<T, Degrees> output = new Vertex<>(null, new Degrees());
 
 		@Override
@@ -244,6 +248,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Vertex<K, Degrees>> {
 	public static class Degrees
 	extends Tuple3<LongValue, LongValue, LongValue> {
 		private static final int HASH_SEED = 0x3a12fc31;
+		private static final long serialVersionUID = 311326927327964814L;
 
 		private MurmurHash hasher = new MurmurHash(HASH_SEED);
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/filter/undirected/MaximumDegree.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/filter/undirected/MaximumDegree.java
@@ -182,6 +182,7 @@ extends GraphAlgorithmWrappingGraph<K, VV, EV, K, VV, EV> {
 	@ForwardedFields("0")
 	private static class DegreeFilter<K>
 	implements FlatMapFunction<Vertex<K, LongValue>, Tuple1<K>> {
+		private static final long serialVersionUID = 6968889645498964451L;
 		private long maximumDegree;
 
 		private Tuple1<K> output = new Tuple1<>();
@@ -209,6 +210,8 @@ extends GraphAlgorithmWrappingGraph<K, VV, EV, K, VV, EV> {
 	@ForwardedFieldsFirst("0; 1")
 	private static class ProjectVertex<T, VT>
 	implements FlatJoinFunction<Vertex<T, VT>, Tuple1<T>, Vertex<T, VT>> {
+		private static final long serialVersionUID = 6746776597807865656L;
+
 		@Override
 		public void join(Vertex<T, VT> vertex, Tuple1<T> id, Collector<Vertex<T, VT>> out)
 				throws Exception {
@@ -227,6 +230,8 @@ extends GraphAlgorithmWrappingGraph<K, VV, EV, K, VV, EV> {
 	@ForwardedFieldsFirst("0; 1; 2")
 	private static class ProjectEdge<T, ET>
 	implements FlatJoinFunction<Edge<T, ET>, Tuple1<T>, Edge<T, ET>> {
+		private static final long serialVersionUID = 135727270102993436L;
+
 		@Override
 		public void join(Edge<T, ET> edge, Tuple1<T> id, Collector<Edge<T, ET>> out)
 				throws Exception {

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/result/BinaryResult.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/result/BinaryResult.java
@@ -68,6 +68,8 @@ extends Serializable {
 	 */
 	class MirrorResult<T, RT extends BinaryResult<T>>
 	implements FlatMapFunction<RT, RT> {
+		private static final long serialVersionUID = -8958650324639012243L;
+
 		@Override
 		public void flatMap(RT value, Collector<RT> out)
 				throws Exception {

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/result/BinaryResultBase.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/result/BinaryResultBase.java
@@ -30,6 +30,7 @@ public abstract class BinaryResultBase<K>
 extends ResultBase
 implements BinaryResult<K>, TranslatableResult<K> {
 
+	private static final long serialVersionUID = 8256611274287888920L;
 	private K vertexId0;
 
 	private K vertexId1;
@@ -87,6 +88,8 @@ implements BinaryResult<K>, TranslatableResult<K> {
 	 */
 	private static class BasicBinaryResult<U>
 	extends BinaryResultBase<U> {
+		private static final long serialVersionUID = 2794411548602199796L;
+
 		@Override
 		public String toString() {
 			return "(" + getVertexId0() + "," + getVertexId1() + ")";

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/result/TertiaryResultBase.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/result/TertiaryResultBase.java
@@ -31,6 +31,7 @@ public abstract class TertiaryResultBase<K>
 extends ResultBase
 implements TertiaryResult<K>, TranslatableResult<K> {
 
+	private static final long serialVersionUID = -5684696568687845626L;
 	private K vertexId0;
 
 	private K vertexId1;
@@ -103,6 +104,8 @@ implements TertiaryResult<K>, TranslatableResult<K> {
 	 */
 	private static class BasicTertiaryResult<U>
 	extends TertiaryResultBase<U> {
+		private static final long serialVersionUID = 6939298480032055113L;
+
 		@Override
 		public String toString() {
 			return "(" + getVertexId0() + "," + getVertexId1() + "," + getVertexId2() + ")";

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/result/UnaryResultBase.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/result/UnaryResultBase.java
@@ -31,6 +31,7 @@ public abstract class UnaryResultBase<K>
 extends ResultBase
 implements UnaryResult<K>, TranslatableResult<K> {
 
+	private static final long serialVersionUID = 2774057038221540371L;
 	private K vertexId0;
 
 	@Override
@@ -73,6 +74,8 @@ implements UnaryResult<K>, TranslatableResult<K> {
 	 */
 	private static class BasicUnaryResult<U>
 	extends UnaryResultBase<U> {
+		private static final long serialVersionUID = 3412375945241516802L;
+
 		@Override
 		public String toString() {
 			return "(" + getVertexId0() + ")";

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/simple/directed/Simplify.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/simple/directed/Simplify.java
@@ -61,6 +61,8 @@ extends GraphAlgorithmWrappingGraph<K, VV, EV, K, VV, EV> {
 	 */
 	private static class RemoveSelfLoops<T extends Comparable<T>, ET>
 	implements FilterFunction<Edge<T, ET>> {
+		private static final long serialVersionUID = -8849829675745741232L;
+
 		@Override
 		public boolean filter(Edge<T, ET> value) throws Exception {
 			return (value.f0.compareTo(value.f1) != 0);

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/simple/undirected/Simplify.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/simple/undirected/Simplify.java
@@ -92,6 +92,7 @@ extends GraphAlgorithmWrappingGraph<K, VV, EV, K, VV, EV> {
 	 */
 	private static class SymmetrizeAndRemoveSelfLoops<T extends Comparable<T>, ET>
 	implements FlatMapFunction<Edge<T, ET>, Edge<T, ET>> {
+		private static final long serialVersionUID = -3504965248232506117L;
 		private boolean clipAndFlip;
 
 		public SymmetrizeAndRemoveSelfLoops(boolean clipAndFlip) {

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/Translate.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/Translate.java
@@ -104,6 +104,7 @@ public class Translate {
 	private static class TranslateVertexId<OLD, NEW, VV>
 	extends WrappingFunction<TranslateFunction<OLD, NEW>>
 	implements MapFunction<Vertex<OLD, VV>, Vertex<NEW, VV>> {
+		private static final long serialVersionUID = -3478028873586652153L;
 		private Vertex<NEW, VV> vertex = new Vertex<>();
 
 		public TranslateVertexId(TranslateFunction<OLD, NEW> translator) {
@@ -187,6 +188,7 @@ public class Translate {
 	private static class TranslateEdgeId<OLD, NEW, EV>
 	extends WrappingFunction<TranslateFunction<OLD, NEW>>
 	implements MapFunction<Edge<OLD, EV>, Edge<NEW, EV>> {
+		private static final long serialVersionUID = -2731588017019693197L;
 		private Edge<NEW, EV> edge = new Edge<>();
 
 		public TranslateEdgeId(TranslateFunction<OLD, NEW> translator) {
@@ -271,6 +273,7 @@ public class Translate {
 	private static class TranslateVertexValue<K, OLD, NEW>
 	extends WrappingFunction<TranslateFunction<OLD, NEW>>
 	implements MapFunction<Vertex<K, OLD>, Vertex<K, NEW>> {
+		private static final long serialVersionUID = 3709412350253698930L;
 		private Vertex<K, NEW> vertex = new Vertex<>();
 
 		public TranslateVertexValue(TranslateFunction<OLD, NEW> translator) {
@@ -354,6 +357,7 @@ public class Translate {
 	private static class TranslateEdgeValue<K, OLD, NEW>
 	extends WrappingFunction<TranslateFunction<OLD, NEW>>
 	implements MapFunction<Edge<K, OLD>, Edge<K, NEW>> {
+		private static final long serialVersionUID = -4478695462001900326L;
 		private Edge<K, NEW> edge = new Edge<>();
 
 		public TranslateEdgeValue(TranslateFunction<OLD, NEW> translator) {

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/translators/LongToLongValue.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/translators/LongToLongValue.java
@@ -27,6 +27,8 @@ import org.apache.flink.types.LongValue;
 public class LongToLongValue
 implements TranslateFunction<Long, LongValue> {
 
+	private static final long serialVersionUID = -9007957175870441287L;
+
 	@Override
 	public LongValue translate(Long value, LongValue reuse)
 			throws Exception {

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/translators/LongValueAddOffset.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/translators/LongValueAddOffset.java
@@ -27,6 +27,7 @@ import org.apache.flink.types.LongValue;
 public class LongValueAddOffset
 implements TranslateFunction<LongValue, LongValue> {
 
+	private static final long serialVersionUID = 4552213355052494932L;
 	private final long offset;
 
 	/**

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/translators/LongValueToSignedIntValue.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/translators/LongValueToSignedIntValue.java
@@ -32,6 +32,7 @@ public class LongValueToSignedIntValue
 implements TranslateFunction<LongValue, IntValue> {
 
 	public static final long MAX_VERTEX_COUNT = 1L << 32;
+	private static final long serialVersionUID = 8006647007934087911L;
 
 	@Override
 	public IntValue translate(LongValue value, IntValue reuse)

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/translators/LongValueToStringValue.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/translators/LongValueToStringValue.java
@@ -28,6 +28,8 @@ import org.apache.flink.types.StringValue;
 public class LongValueToStringValue
 implements TranslateFunction<LongValue, StringValue> {
 
+	private static final long serialVersionUID = -3739374195985324712L;
+
 	@Override
 	public StringValue translate(LongValue value, StringValue reuse)
 			throws Exception {

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/translators/LongValueToUnsignedIntValue.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/translators/LongValueToUnsignedIntValue.java
@@ -31,6 +31,7 @@ public class LongValueToUnsignedIntValue
 implements TranslateFunction<LongValue, IntValue> {
 
 	public static final long MAX_VERTEX_COUNT = 1L << 32;
+	private static final long serialVersionUID = 2064800381410119651L;
 
 	@Override
 	public IntValue translate(LongValue value, IntValue reuse)

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/translators/ToNullValue.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/translators/ToNullValue.java
@@ -29,6 +29,8 @@ import org.apache.flink.types.NullValue;
 public class ToNullValue<T>
 implements TranslateFunction<T, NullValue> {
 
+	private static final long serialVersionUID = -6866691428976893849L;
+
 	@Override
 	public NullValue translate(T value, NullValue reuse)
 			throws Exception {

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/bipartite/BipartiteGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/bipartite/BipartiteGraph.java
@@ -138,6 +138,7 @@ public class BipartiteGraph<KT, KB, VVT, VVB, EV> {
 	@ForwardedFieldsSecond("0->1; 2->2.1")
 	private static class ProjectionTopSimple<KT, KB, EV>
 	implements FlatJoinFunction<BipartiteEdge<KT, KB, EV>, BipartiteEdge<KT, KB, EV>, Edge<KT, Tuple2<EV, EV>>> {
+		private static final long serialVersionUID = -4530076610205499774L;
 		private Tuple2<EV, EV> edgeValues = new Tuple2<>();
 
 		private Edge<KT, Tuple2<EV, EV>> edge = new Edge<>(null, null, edgeValues);
@@ -182,6 +183,7 @@ public class BipartiteGraph<KT, KB, VVT, VVB, EV> {
 	@ForwardedFieldsSecond("1; 2->2.1")
 	private static class ProjectionBottomSimple<KT, KB, EV>
 	implements FlatJoinFunction<BipartiteEdge<KT, KB, EV>, BipartiteEdge<KT, KB, EV>, Edge<KB, Tuple2<EV, EV>>> {
+		private static final long serialVersionUID = 7795549768662455367L;
 		private Tuple2<EV, EV> edgeValues = new Tuple2<>();
 
 		private Edge<KB, Tuple2<EV, EV>> edge = new Edge<>(null, null, edgeValues);
@@ -244,6 +246,7 @@ public class BipartiteGraph<KT, KB, VVT, VVB, EV> {
 	@ForwardedFieldsSecond("0->1; 2->2.5; 3->2.3")
 	private static class ProjectionTopFull<KT, KB, EV, VVT, VVB>
 	implements FlatJoinFunction<Tuple5<KT, KB, EV, VVT, VVB>, Tuple5<KT, KB, EV, VVT, VVB>, Edge<KT, Projection<KB, VVB, VVT, EV>>> {
+		private static final long serialVersionUID = -1512953903428309443L;
 		private Projection<KB, VVB, VVT, EV> projection = new Projection<>();
 
 		private Edge<KT, Projection<KB, VVB, VVT, EV>> edge = new Edge<>(null, null, projection);
@@ -294,6 +297,7 @@ public class BipartiteGraph<KT, KB, VVT, VVB, EV> {
 	@ForwardedFieldsSecond("1; 2->2.5; 4->2.3")
 	private static class ProjectionBottomFull<KT, KB, EV, VVT, VVB>
 	implements FlatJoinFunction<Tuple5<KT, KB, EV, VVT, VVB>, Tuple5<KT, KB, EV, VVT, VVB>, Edge<KB, Projection<KT, VVT, VVB, EV>>> {
+		private static final long serialVersionUID = -4110554471187884304L;
 		private Projection<KT, VVT, VVB, EV> projection = new Projection<>();
 
 		private Edge<KB, Projection<KT, VVT, VVB, EV>> edge = new Edge<>(null, null, projection);

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/bipartite/Projection.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/bipartite/Projection.java
@@ -36,6 +36,8 @@ import org.apache.flink.graph.Vertex;
   */
 public class Projection<KC, VVC, VV, EV> extends Tuple6<KC, VVC, VV, VV, EV, EV> {
 
+	private static final long serialVersionUID = -8216722383905429738L;
+
 	public Projection() {}
 
 	public Projection(

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/CirculantGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/CirculantGraph.java
@@ -127,6 +127,7 @@ extends GraphGeneratorBase<LongValue, NullValue, NullValue> {
 	@FunctionAnnotation.ForwardedFields("*->f0")
 	private static class LinkVertexToOffsets
 	implements FlatMapFunction<LongValue, Edge<LongValue, NullValue>> {
+		private static final long serialVersionUID = -2898318514607022032L;
 		private final long vertexCount;
 
 		private final List<OffsetRange> offsetRanges;
@@ -162,6 +163,7 @@ extends GraphGeneratorBase<LongValue, NullValue, NullValue> {
 	 * Stores the start offset and length configuration for an offset range.
 	 */
 	public static class OffsetRange implements Serializable, Comparable<OffsetRange> {
+		private static final long serialVersionUID = 2699469332846065690L;
 		private long offset;
 
 		private long length;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/GraphGeneratorUtils.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/GraphGeneratorUtils.java
@@ -79,6 +79,7 @@ public class GraphGeneratorUtils {
 	@ForwardedFields("*->f0")
 	private static class CreateVertex
 	implements MapFunction<LongValue, Vertex<LongValue, NullValue>> {
+		private static final long serialVersionUID = 5744217329577236646L;
 		private Vertex<LongValue, NullValue> vertex = new Vertex<>(null, NullValue.getInstance());
 
 		@Override
@@ -121,6 +122,7 @@ public class GraphGeneratorUtils {
 	 */
 	private static final class EmitSrcAndTarget<K, EV>
 	implements FlatMapFunction<Edge<K, EV>, Vertex<K, NullValue>> {
+		private static final long serialVersionUID = 2039092901277641351L;
 		private Vertex<K, NullValue> output = new Vertex<>(null, new NullValue());
 
 		@Override

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/GridGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/GridGraph.java
@@ -109,6 +109,7 @@ extends GraphGeneratorBase<LongValue, NullValue, NullValue> {
 	private static class LinkVertexToNeighbors
 	implements FlatMapFunction<LongValue, Edge<LongValue, NullValue>> {
 
+		private static final long serialVersionUID = -6371265630081827915L;
 		private long vertexCount;
 
 		private List<Tuple2<Long, Boolean>> dimensions;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/RMatGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/RMatGraph.java
@@ -170,6 +170,7 @@ extends GraphGeneratorBase<LongValue, NullValue, NullValue> {
 	private static class GenerateEdges<T extends RandomGenerator>
 	implements FlatMapFunction<BlockInfo<T>, Edge<LongValue, NullValue>> {
 
+		private static final long serialVersionUID = -2977209149805514340L;
 		// Configuration
 		private final long vertexCount;
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/SingletonEdgeGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/SingletonEdgeGraph.java
@@ -88,6 +88,7 @@ extends GraphGeneratorBase<LongValue, NullValue, NullValue> {
 	private static class LinkVertexToSingletonNeighbor
 	implements MapFunction<LongValue, Edge<LongValue, NullValue>> {
 
+		private static final long serialVersionUID = 7760655655945632199L;
 		private LongValue source = new LongValue();
 
 		private LongValue target = new LongValue();

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/StarGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/StarGraph.java
@@ -87,6 +87,7 @@ extends GraphGeneratorBase<LongValue, NullValue, NullValue> {
 	private static class LinkVertexToCenter
 	implements FlatMapFunction<LongValue, Edge<LongValue, NullValue>> {
 
+		private static final long serialVersionUID = -6016480863001657480L;
 		private LongValue center = new LongValue(0);
 
 		private Edge<LongValue, NullValue> centerToLeaf = new Edge<>(center, null, NullValue.getInstance());

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/GSAConnectedComponents.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/GSAConnectedComponents.java
@@ -91,6 +91,7 @@ public class GSAConnectedComponents<K, VV extends Comparable<VV>, EV>
 		extends GatherFunction<VV, NullValue, VV>
 		implements ResultTypeQueryable<VV> {
 
+		private static final long serialVersionUID = 6443298412123486414L;
 		private final TypeInformation<VV> typeInformation;
 
 		private GatherNeighborIds(TypeInformation<VV> typeInformation) {
@@ -111,6 +112,7 @@ public class GSAConnectedComponents<K, VV extends Comparable<VV>, EV>
 		extends SumFunction<VV, NullValue, VV>
 		implements ResultTypeQueryable<VV> {
 
+		private static final long serialVersionUID = 2902313105389364577L;
 		private final TypeInformation<VV> typeInformation;
 
 		private SelectMinId(TypeInformation<VV> typeInformation) {
@@ -131,6 +133,7 @@ public class GSAConnectedComponents<K, VV extends Comparable<VV>, EV>
 		extends ApplyFunction<K, VV, VV>
 		implements ResultTypeQueryable<VV> {
 
+		private static final long serialVersionUID = -4157180591460128823L;
 		private final TypeInformation<VV> typeInformation;
 
 		private UpdateComponentId(TypeInformation<VV> typeInformation) {

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/AverageClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/AverageClusteringCoefficient.java
@@ -90,6 +90,7 @@ extends GraphAnalyticBase<K, VV, EV, Result> {
 	 */
 	private static class AverageClusteringCoefficientHelper<T>
 	extends AnalyticHelper<LocalClusteringCoefficient.Result<T>> {
+		private static final long serialVersionUID = -6701479613500551741L;
 		private long vertexCount;
 		private double sumOfLocalClusteringCoefficient;
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/LocalClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/LocalClusteringCoefficient.java
@@ -153,6 +153,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	 */
 	private static class SplitTriangles<T>
 	implements FlatMapFunction<TriangleListing.Result<T>, Tuple2<T, LongValue>> {
+		private static final long serialVersionUID = 8296790264121957415L;
 		private LongValue one = new LongValue(1);
 
 		private LongValue two = new LongValue(2);
@@ -186,6 +187,8 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFields("0")
 	private static class CountTriangles<T>
 	implements ReduceFunction<Tuple2<T, LongValue>> {
+		private static final long serialVersionUID = 2444507123679389032L;
+
 		@Override
 		public Tuple2<T, LongValue> reduce(Tuple2<T, LongValue> left, Tuple2<T, LongValue> right)
 				throws Exception {
@@ -203,6 +206,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFieldsSecond("0->vertexId0")
 	private static class JoinVertexDegreeWithTriangleCount<T>
 	implements JoinFunction<Vertex<T, Degrees>, Tuple2<T, LongValue>, Result<T>> {
+		private static final long serialVersionUID = -5437549547757332734L;
 		private LongValue zero = new LongValue(0);
 
 		private Result<T> output = new Result<>();
@@ -226,6 +230,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	public static class Result<T>
 	extends UnaryResultBase<T>
 	implements PrintableResult {
+		private static final long serialVersionUID = 116137595770686929L;
 		private LongValue degree;
 
 		private LongValue triangleCount;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/TriadicCensus.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/TriadicCensus.java
@@ -190,6 +190,7 @@ extends GraphAnalyticBase<K, VV, EV, Result> {
 	 */
 	private static class TriangleListingHelper<T>
 	extends AnalyticHelper<TriangleListing.Result<T>> {
+		private static final long serialVersionUID = 5118383180984366560L;
 		private long[] triangleCount = new long[64];
 
 		@Override
@@ -257,6 +258,7 @@ extends GraphAnalyticBase<K, VV, EV, Result> {
 	 */
 	private static class VertexDegreesHelper<T>
 	extends AnalyticHelper<Vertex<T, Degrees>> {
+		private static final long serialVersionUID = -6009446876174180932L;
 		private long vertexCount;
 		private long unidirectionalEdgeCount;
 		private long bidirectionalEdgeCount;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/TriangleListing.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/TriangleListing.java
@@ -145,6 +145,7 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 	 */
 	private static final class OrderByID<T extends Comparable<T>, ET>
 	implements MapFunction<Edge<T, ET>, Tuple3<T, T, ByteValue>> {
+		private static final long serialVersionUID = 7553067298681086988L;
 		private ByteValue forward = new ByteValue(EdgeOrder.FORWARD.getBitmask());
 
 		private ByteValue reverse = new ByteValue(EdgeOrder.REVERSE.getBitmask());
@@ -176,6 +177,8 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 	@ForwardedFields("0; 1")
 	private static final class ReduceBitmask<T>
 	implements GroupReduceFunction<Tuple3<T, T, ByteValue>, Tuple3<T, T, ByteValue>> {
+		private static final long serialVersionUID = -877036512873894248L;
+
 		@Override
 		public void reduce(Iterable<Tuple3<T, T, ByteValue>> values, Collector<Tuple3<T, T, ByteValue>> out)
 				throws Exception {
@@ -205,6 +208,7 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 	 */
 	private static final class OrderByDegree<T extends Comparable<T>, ET>
 	implements MapFunction<Edge<T, Tuple3<ET, Degrees, Degrees>>, Tuple3<T, T, ByteValue>> {
+		private static final long serialVersionUID = 7090893366941322046L;
 		private ByteValue forward = new ByteValue((byte) (EdgeOrder.FORWARD.getBitmask() << 2));
 
 		private ByteValue reverse = new ByteValue((byte) (EdgeOrder.REVERSE.getBitmask() << 2));
@@ -244,6 +248,7 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 	@ForwardedFields("0")
 	private static final class GenerateTriplets<T extends CopyableValue<T>>
 	implements GroupReduceFunction<Tuple3<T, T, ByteValue>, Tuple4<T, T, T, ByteValue>> {
+		private static final long serialVersionUID = 736804889310604964L;
 		private Tuple4<T, T, T, ByteValue> output = new Tuple4<>(null, null, null, new ByteValue());
 
 		private List<Tuple2<T, ByteValue>> visited = new ArrayList<>();
@@ -300,6 +305,7 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 	@ForwardedFieldsSecond("0->vertexId0; 1->vertexId1")
 	private static final class ProjectTriangles<T>
 	implements JoinFunction<Tuple4<T, T, T, ByteValue>, Tuple3<T, T, ByteValue>, Result<T>> {
+		private static final long serialVersionUID = 5966968893003251893L;
 		private Result<T> output = new Result<>();
 
 		@Override
@@ -321,6 +327,8 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 	 */
 	private static class PermuteResult<T>
 	implements FlatMapFunction<Result<T>, Result<T>> {
+		private static final long serialVersionUID = 8657862429558479674L;
+
 		@Override
 		public void flatMap(Result<T> value, Collector<Result<T>> out)
 				throws Exception {
@@ -413,6 +421,8 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 	 */
 	private static final class SortTriangleVertices<T extends Comparable<T>>
 	implements MapFunction<Result<T>, Result<T>> {
+		private static final long serialVersionUID = 4069426993840154912L;
+
 		@Override
 		public Result<T> map(Result<T> value)
 				throws Exception {
@@ -455,6 +465,7 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 	public static class Result<T>
 	extends TertiaryResultBase<T>
 	implements PrintableResult {
+		private static final long serialVersionUID = 800127515485938115L;
 		private ByteValue bitmask = new ByteValue();
 
 		/**

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/AverageClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/AverageClusteringCoefficient.java
@@ -90,6 +90,7 @@ extends GraphAnalyticBase<K, VV, EV, Result> {
 	 */
 	private static class AverageClusteringCoefficientHelper<T>
 	extends AnalyticHelper<LocalClusteringCoefficient.Result<T>> {
+		private static final long serialVersionUID = 3116344309265635987L;
 		private long vertexCount;
 		private double sumOfLocalClusteringCoefficient;
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/LocalClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/LocalClusteringCoefficient.java
@@ -152,6 +152,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	 */
 	private static class SplitTriangles<T>
 	implements FlatMapFunction<TriangleListing.Result<T>, Tuple2<T, LongValue>> {
+		private static final long serialVersionUID = -8768004825686498327L;
 		private Tuple2<T, LongValue> output = new Tuple2<>(null, new LongValue(1));
 
 		@Override
@@ -176,6 +177,8 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFields("0")
 	private static class CountTriangles<T>
 	implements ReduceFunction<Tuple2<T, LongValue>> {
+		private static final long serialVersionUID = 6104172585734913014L;
+
 		@Override
 		public Tuple2<T, LongValue> reduce(Tuple2<T, LongValue> left, Tuple2<T, LongValue> right)
 				throws Exception {
@@ -193,6 +196,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFieldsSecond("0->vertexId0")
 	private static class JoinVertexDegreeWithTriangleCount<T>
 	implements JoinFunction<Vertex<T, LongValue>, Tuple2<T, LongValue>, Result<T>> {
+		private static final long serialVersionUID = 732345978977566379L;
 		private LongValue zero = new LongValue(0);
 
 		private Result<T> output = new Result<>();
@@ -216,6 +220,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	public static class Result<T>
 	extends UnaryResultBase<T>
 	implements PrintableResult {
+		private static final long serialVersionUID = -4233914808677541651L;
 		private LongValue degree;
 
 		private LongValue triangleCount;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/TriangleListing.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/TriangleListing.java
@@ -139,6 +139,7 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 	@ForwardedFields("0; 1")
 	private static final class FilterByID<T extends Comparable<T>, ET>
 	implements FlatMapFunction<Edge<T, ET>, Tuple2<T, T>> {
+		private static final long serialVersionUID = 5693093318242979774L;
 		private Tuple2<T, T> edge = new Tuple2<>();
 
 		@Override
@@ -166,6 +167,7 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 	@ForwardedFields("0; 1")
 	private static final class FilterByDegree<T extends Comparable<T>, ET>
 	implements FlatMapFunction<Edge<T, Tuple3<ET, LongValue, LongValue>>, Tuple2<T, T>> {
+		private static final long serialVersionUID = -7190879712639913363L;
 		private Tuple2<T, T> edge = new Tuple2<>();
 
 		@Override
@@ -195,6 +197,7 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 	@ForwardedFields("0")
 	private static final class GenerateTriplets<T extends CopyableValue<T>>
 	implements GroupReduceFunction<Tuple2<T, T>, Tuple3<T, T, T>> {
+		private static final long serialVersionUID = 6717237711363148310L;
 		private Tuple3<T, T, T> output = new Tuple3<>();
 
 		private List<T> visited = new ArrayList<>();
@@ -241,6 +244,7 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 	@ForwardedFieldsSecond("0->vertexId0; 1->vertexId1")
 	private static final class ProjectTriangles<T>
 	implements JoinFunction<Tuple3<T, T, T>, Tuple2<T, T>, Result<T>> {
+		private static final long serialVersionUID = 9095397414284913655L;
 		private Result<T> output = new Result<>();
 
 		@Override
@@ -261,6 +265,8 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 	 */
 	private static class PermuteResult<T>
 	implements FlatMapFunction<Result<T>, Result<T>> {
+		private static final long serialVersionUID = 5007849644436406417L;
+
 		@Override
 		public void flatMap(Result<T> value, Collector<Result<T>> out)
 				throws Exception {
@@ -314,6 +320,8 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 	 */
 	private static final class SortTriangleVertices<T extends Comparable<T>>
 	implements MapFunction<Result<T>, Result<T>> {
+		private static final long serialVersionUID = 3922254216965337177L;
+
 		@Override
 		public Result<T> map(Result<T> value)
 				throws Exception {
@@ -342,6 +350,8 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 	public static class Result<T>
 	extends TertiaryResultBase<T>
 	implements PrintableResult {
+		private static final long serialVersionUID = -8365704866804113619L;
+
 		@Override
 		public String toString() {
 			return "(" + getVertexId0()

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/linkanalysis/Functions.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/linkanalysis/Functions.java
@@ -35,6 +35,8 @@ class Functions {
 	@ForwardedFields("0")
 	protected static final class SumScore<T>
 		implements ReduceFunction<Tuple2<T, DoubleValue>> {
+		private static final long serialVersionUID = 2602334430961427102L;
+
 		@Override
 		public Tuple2<T, DoubleValue> reduce(Tuple2<T, DoubleValue> left, Tuple2<T, DoubleValue> right)
 			throws Exception {

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/linkanalysis/HITS.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/linkanalysis/HITS.java
@@ -240,6 +240,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFields("0; 1")
 	private static class ExtractEdgeIDs<T, ET>
 	implements MapFunction<Edge<T, ET>, Tuple2<T, T>> {
+		private static final long serialVersionUID = -3314178233145721330L;
 		private Tuple2<T, T> output = new Tuple2<>();
 
 		@Override
@@ -263,6 +264,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFields("1->0")
 	private static class InitializeScores<T>
 	implements MapFunction<Tuple2<T, T>, Tuple3<T, DoubleValue, DoubleValue>> {
+		private static final long serialVersionUID = 1613415426394967712L;
 		private Tuple3<T, DoubleValue, DoubleValue> output = new Tuple3<>(null, new DoubleValue(0.0), new DoubleValue(1.0));
 
 		@Override
@@ -280,6 +282,8 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFields("0")
 	private static class SumScores<T>
 	implements ReduceFunction<Tuple3<T, DoubleValue, DoubleValue>> {
+		private static final long serialVersionUID = -4251318017132528649L;
+
 		@Override
 		public Tuple3<T, DoubleValue, DoubleValue> reduce(Tuple3<T, DoubleValue, DoubleValue> left, Tuple3<T, DoubleValue, DoubleValue> right)
 				throws Exception {
@@ -298,6 +302,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFieldsSecond("0")
 	private static class Hubbiness<T>
 	implements CoGroupFunction<Tuple3<T, DoubleValue, DoubleValue>, Tuple2<T, T>, Tuple2<T, DoubleValue>> {
+		private static final long serialVersionUID = -7173287094371447511L;
 		private Tuple2<T, DoubleValue> output = new Tuple2<>();
 
 		@Override
@@ -321,6 +326,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFieldsSecond("1->0")
 	private static class Authority<T>
 	implements CoGroupFunction<Tuple2<T, DoubleValue>, Tuple2<T, T>, Tuple2<T, DoubleValue>> {
+		private static final long serialVersionUID = -3489328807388210962L;
 		private Tuple2<T, DoubleValue> output = new Tuple2<>();
 
 		@Override
@@ -342,6 +348,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	 */
 	private static class Square<T>
 	implements MapFunction<Tuple2<T, DoubleValue>, DoubleValue> {
+		private static final long serialVersionUID = 2281904211260595951L;
 		private DoubleValue output = new DoubleValue();
 
 		@Override
@@ -359,6 +366,8 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	 */
 	private static class Sum
 	implements ReduceFunction<DoubleValue> {
+		private static final long serialVersionUID = -4896948553079527176L;
+
 		@Override
 		public DoubleValue reduce(DoubleValue first, DoubleValue second)
 				throws Exception {
@@ -376,6 +385,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFieldsSecond("0")
 	private static class JoinAndNormalizeHubAndAuthority<T>
 	extends RichJoinFunction<Tuple2<T, DoubleValue>, Tuple2<T, DoubleValue>, Tuple3<T, DoubleValue, DoubleValue>> {
+		private static final long serialVersionUID = -1942612594195747140L;
 		private Tuple3<T, DoubleValue, DoubleValue> output = new Tuple3<>(null, new DoubleValue(), new DoubleValue());
 
 		private double hubbinessRootSumSquared;
@@ -416,6 +426,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFieldsSecond("*")
 	private static class ChangeInScores<T>
 	extends RichJoinFunction<Tuple3<T, DoubleValue, DoubleValue>, Tuple3<T, DoubleValue, DoubleValue>, Tuple3<T, DoubleValue, DoubleValue>> {
+		private static final long serialVersionUID = 359118048496465521L;
 		private boolean isInitialSuperstep;
 
 		private double changeInScores;
@@ -462,6 +473,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	 */
 	private static class ScoreConvergence
 	implements ConvergenceCriterion<DoubleValue> {
+		private static final long serialVersionUID = -3069099992613451470L;
 		private double convergenceThreshold;
 
 		public ScoreConvergence(double convergenceThreshold) {
@@ -483,6 +495,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFields("0->vertexId0; 1->hubScore; 2->authorityScore")
 	private static class TranslateResult<T>
 	implements MapFunction<Tuple3<T, DoubleValue, DoubleValue>, Result<T>> {
+		private static final long serialVersionUID = 817310924332782825L;
 		private Result<T> output = new Result<>();
 
 		@Override
@@ -502,6 +515,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	public static class Result<T>
 	extends UnaryResultBase<T>
 	implements PrintableResult {
+		private static final long serialVersionUID = -4549871438807958726L;
 		private DoubleValue hubScore;
 
 		private DoubleValue authorityScore;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/linkanalysis/PageRank.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/linkanalysis/PageRank.java
@@ -274,6 +274,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFields("0; 1")
 	private static class ExtractSourceDegree<T, ET>
 	implements MapFunction<Edge<T, Tuple2<ET, Degrees>>, Edge<T, LongValue>> {
+		private static final long serialVersionUID = 913316666439638164L;
 		Edge<T, LongValue> output = new Edge<>();
 
 		@Override
@@ -294,6 +295,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFields("0")
 	private static class InitializeSourceVertices<T>
 	implements FlatMapFunction<Vertex<T, Degrees>, Tuple2<T, DoubleValue>> {
+		private static final long serialVersionUID = 4977711114569878505L;
 		private Tuple2<T, DoubleValue> output = new Tuple2<>(null, new DoubleValue(0.0));
 
 		@Override
@@ -315,6 +317,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFields("0")
 	private static class InitializeVertexScores<T>
 	extends RichMapFunction<Vertex<T, Degrees>, Tuple2<T, DoubleValue>> {
+		private static final long serialVersionUID = -4672067055886314108L;
 		private Tuple2<T, DoubleValue> output = new Tuple2<>();
 
 		@Override
@@ -344,6 +347,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFieldsSecond("1->0")
 	private static class SendScore<T>
 	implements CoGroupFunction<Tuple2<T, DoubleValue>, Edge<T, LongValue>, Tuple2<T, DoubleValue>> {
+		private static final long serialVersionUID = -513973862177575339L;
 		private Tuple2<T, DoubleValue> output = new Tuple2<>(null, new DoubleValue());
 
 		@Override
@@ -376,6 +380,8 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFields("0")
 	private static class SumVertexScores<T>
 	implements ReduceFunction<Tuple2<T, DoubleValue>> {
+		private static final long serialVersionUID = 4000782292779403309L;
+
 		@Override
 		public Tuple2<T, DoubleValue> reduce(Tuple2<T, DoubleValue> first, Tuple2<T, DoubleValue> second)
 				throws Exception {
@@ -400,6 +406,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFields("0")
 	private static class AdjustScores<T>
 	extends RichMapFunction<Tuple2<T, DoubleValue>, Tuple2<T, DoubleValue>> {
+		private static final long serialVersionUID = -7229129825047011704L;
 		private double dampingFactor;
 
 		private long vertexCount;
@@ -443,6 +450,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFieldsSecond("*")
 	private static class ChangeInScores<T>
 	extends RichJoinFunction<Tuple2<T, DoubleValue>, Tuple2<T, DoubleValue>, Tuple2<T, DoubleValue>> {
+		private static final long serialVersionUID = 4109651860087681366L;
 		private double changeInScores;
 
 		@Override
@@ -476,6 +484,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	 */
 	private static class ScoreConvergence
 	implements ConvergenceCriterion<DoubleValue> {
+		private static final long serialVersionUID = -1535281973316550895L;
 		private double convergenceThreshold;
 
 		public ScoreConvergence(double convergenceThreshold) {
@@ -497,6 +506,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFields("0->vertexId0; 1->pageRankScore")
 	private static class TranslateResult<T>
 		implements MapFunction<Tuple2<T, DoubleValue>, Result<T>> {
+		private static final long serialVersionUID = -6636466076283088091L;
 		private Result<T> output = new Result<>();
 
 		@Override
@@ -515,6 +525,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	public static class Result<T>
 	extends UnaryResultBase<T>
 	implements PrintableResult {
+		private static final long serialVersionUID = -1288878995825630137L;
 		private DoubleValue pageRankScore;
 
 		/**

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/directed/EdgeMetrics.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/directed/EdgeMetrics.java
@@ -142,6 +142,7 @@ extends GraphAnalyticBase<K, VV, EV, Result> {
 	 */
 	private static final class EdgeStats<T extends Comparable<T>, ET>
 	implements FlatMapFunction<Edge<T, Tuple3<ET, Degrees, Degrees>>, Tuple4<T, T, Degrees, LongValue>> {
+		private static final long serialVersionUID = 8312929085982632660L;
 		private LongValue zero = new LongValue(0);
 
 		private LongValue one = new LongValue(1);
@@ -180,6 +181,7 @@ extends GraphAnalyticBase<K, VV, EV, Result> {
 	@ForwardedFields("0")
 	private static final class ReduceEdgeStats<T>
 	implements GroupReduceFunction<Tuple4<T, T, Degrees, LongValue>, Tuple3<T, Degrees, LongValue>> {
+		private static final long serialVersionUID = -7577399527885566241L;
 		Tuple3<T, Degrees, LongValue> output = new Tuple3<>();
 
 		@Override
@@ -202,6 +204,8 @@ extends GraphAnalyticBase<K, VV, EV, Result> {
 	 */
 	private static class SumEdgeStats<T>
 	implements ReduceFunction<Tuple3<T, Degrees, LongValue>> {
+		private static final long serialVersionUID = -3416878774209934912L;
+
 		@Override
 		public Tuple3<T, Degrees, LongValue> reduce(Tuple3<T, Degrees, LongValue> value1, Tuple3<T, Degrees, LongValue> value2)
 				throws Exception {
@@ -217,6 +221,7 @@ extends GraphAnalyticBase<K, VV, EV, Result> {
 	 */
 	private static class EdgeMetricsHelper<T extends Comparable<T>>
 	extends AnalyticHelper<Tuple3<T, Degrees, LongValue>> {
+		private static final long serialVersionUID = -6670622320487267005L;
 		private long triangleTripletCount;
 		private long rectangleTripletCount;
 		private long maximumTriangleTriplets;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/directed/VertexMetrics.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/directed/VertexMetrics.java
@@ -134,6 +134,7 @@ extends GraphAnalyticBase<K, VV, EV, Result> {
 	 */
 	private static class VertexMetricsHelper<T>
 	extends AnalyticHelper<Vertex<T, Degrees>> {
+		private static final long serialVersionUID = 4947199896207971813L;
 		private long vertexCount;
 		private long unidirectionalEdgeCount;
 		private long bidirectionalEdgeCount;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/undirected/EdgeMetrics.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/undirected/EdgeMetrics.java
@@ -147,6 +147,7 @@ extends GraphAnalyticBase<K, VV, EV, Result> {
 	@FunctionAnnotation.ForwardedFields("0; 2.1->1")
 	private static class EdgeStats<T extends Comparable<T>, ET>
 	implements MapFunction<Edge<T, Tuple3<ET, LongValue, LongValue>>, Tuple3<T, LongValue, LongValue>> {
+		private static final long serialVersionUID = -1272636397427613689L;
 		private LongValue zero = new LongValue(0);
 
 		private LongValue one = new LongValue(1);
@@ -182,6 +183,8 @@ extends GraphAnalyticBase<K, VV, EV, Result> {
 	 */
 	private static class SumEdgeStats<T>
 	implements ReduceFunction<Tuple3<T, LongValue, LongValue>> {
+		private static final long serialVersionUID = 7466313659549547701L;
+
 		@Override
 		public Tuple3<T, LongValue, LongValue> reduce(Tuple3<T, LongValue, LongValue> value1, Tuple3<T, LongValue, LongValue> value2)
 				throws Exception {
@@ -197,6 +200,7 @@ extends GraphAnalyticBase<K, VV, EV, Result> {
 	 */
 	private static class EdgeMetricsHelper<T extends Comparable<T>>
 	extends AnalyticHelper<Tuple3<T, LongValue, LongValue>> {
+		private static final long serialVersionUID = 6355499338370084506L;
 		private long triangleTripletCount;
 		private long rectangleTripletCount;
 		private long maximumTriangleTriplets;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/undirected/VertexMetrics.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/undirected/VertexMetrics.java
@@ -138,6 +138,7 @@ extends GraphAnalyticBase<K, VV, EV, Result> {
 	 */
 	private static class VertexMetricsHelper<T>
 	extends AnalyticHelper<Vertex<T, LongValue>> {
+		private static final long serialVersionUID = 5816458025125469288L;
 		private long vertexCount;
 		private long edgeCount;
 		private long tripletCount;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/similarity/AdamicAdar.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/similarity/AdamicAdar.java
@@ -230,6 +230,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFields("0; 1")
 	private static class VertexInverseLogDegree<T>
 	implements MapFunction<Vertex<T, LongValue>, Tuple3<T, LongValue, FloatValue>> {
+		private static final long serialVersionUID = 3464944486956974177L;
 		private Tuple3<T, LongValue, FloatValue> output = new Tuple3<>(null, null, new FloatValue());
 
 		@Override
@@ -255,6 +256,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFields("0->1; 1->2; 2->3")
 	private static class GenerateGroupSpans<T>
 	implements GroupReduceFunction<Tuple3<T, T, FloatValue>, Tuple4<IntValue, T, T, FloatValue>> {
+		private static final long serialVersionUID = -992070502274511153L;
 		private IntValue groupSpansValue = new IntValue();
 
 		private Tuple4<IntValue, T, T, FloatValue> output = new Tuple4<>(groupSpansValue, null, null, null);
@@ -290,6 +292,8 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFields("1; 2; 3")
 	private static class GenerateGroups<T>
 	implements FlatMapFunction<Tuple4<IntValue, T, T, FloatValue>, Tuple4<IntValue, T, T, FloatValue>> {
+		private static final long serialVersionUID = 2236198000920191685L;
+
 		@Override
 		public void flatMap(Tuple4<IntValue, T, T, FloatValue> value, Collector<Tuple4<IntValue, T, T, FloatValue>> out)
 				throws Exception {
@@ -310,6 +314,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFields("3->2")
 	private static class GenerateGroupPairs<T extends CopyableValue<T>>
 	implements GroupReduceFunction<Tuple4<IntValue, T, T, FloatValue>, Tuple3<T, T, FloatValue>> {
+		private static final long serialVersionUID = -9056300650948932331L;
 		private Tuple3<T, T, FloatValue> output = new Tuple3<>();
 
 		private boolean initialized = false;
@@ -354,6 +359,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	 */
 	private static class ComputeScoreFromVertex<T>
 	implements MapFunction<Tuple3<T, LongValue, FloatValue>, Tuple2<FloatValue, LongValue>> {
+		private static final long serialVersionUID = 4708367461052869271L;
 		private FloatValue sumOfScores = new FloatValue();
 
 		private LongValue numberOfNeighborPairs = new LongValue();
@@ -381,6 +387,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFields("0->vertexId0; 1->vertexId1")
 	private static class ComputeScores<T>
 	extends RichGroupReduceFunction<Tuple3<T, T, FloatValue>, Result<T>> {
+		private static final long serialVersionUID = 378506140977883296L;
 		private float minimumScore;
 
 		private float minimumRatio;
@@ -435,6 +442,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	public static class Result<T>
 	extends BinaryResultBase<T>
 	implements PrintableResult, Comparable<Result<T>> {
+		private static final long serialVersionUID = 6985841416997493905L;
 		private FloatValue adamicAdarScore = new FloatValue();
 
 		/**

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/similarity/JaccardIndex.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/similarity/JaccardIndex.java
@@ -256,6 +256,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFields("0->1; 1->2")
 	private static class GenerateGroupSpans<T, ET>
 	implements GroupReduceFunction<Edge<T, Tuple2<ET, LongValue>>, Tuple4<IntValue, T, T, IntValue>> {
+		private static final long serialVersionUID = -6207366877191732626L;
 		private final int groupSize;
 
 		private IntValue groupSpansValue = new IntValue();
@@ -305,6 +306,8 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFields("1; 2; 3")
 	private static class GenerateGroups<T>
 	implements FlatMapFunction<Tuple4<IntValue, T, T, IntValue>, Tuple4<IntValue, T, T, IntValue>> {
+		private static final long serialVersionUID = -2943573820445621555L;
+
 		@Override
 		public void flatMap(Tuple4<IntValue, T, T, IntValue> value, Collector<Tuple4<IntValue, T, T, IntValue>> out)
 				throws Exception {
@@ -329,6 +332,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	 */
 	private static class GenerateGroupPairs<T extends CopyableValue<T>>
 	implements GroupReduceFunction<Tuple4<IntValue, T, T, IntValue>, Tuple3<T, T, IntValue>> {
+		private static final long serialVersionUID = 2757065088941786717L;
 		private final int groupSize;
 
 		private boolean initialized = false;
@@ -401,6 +405,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFields("0->vertexId0; 1->vertexId1")
 	private static class ComputeScores<T>
 	implements GroupReduceFunction<Tuple3<T, T, IntValue>, Result<T>> {
+		private static final long serialVersionUID = -4626625308418114826L;
 		private boolean unboundedScores;
 
 		private long minimumScoreNumerator;
@@ -456,6 +461,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	public static class Result<T>
 	extends BinaryResultBase<T>
 	implements PrintableResult, Comparable<Result<T>> {
+		private static final long serialVersionUID = -3396016746636989035L;
 		private IntValue sharedNeighborCount = new IntValue();
 
 		private IntValue distinctNeighborCount = new IntValue();

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/ByteValueArray.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/ByteValueArray.java
@@ -43,6 +43,7 @@ implements ValueArray<ByteValue> {
 
 	// see note in ArrayList, HashTable, ...
 	private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+	private static final long serialVersionUID = -7584358560674167821L;
 
 	private boolean isBounded;
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/CharValueArray.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/CharValueArray.java
@@ -43,6 +43,7 @@ implements ValueArray<CharValue> {
 
 	// see note in ArrayList, HashTable, ...
 	private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+	private static final long serialVersionUID = -9052813943870139412L;
 
 	private boolean isBounded;
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/DoubleValueArray.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/DoubleValueArray.java
@@ -43,6 +43,7 @@ implements ValueArray<DoubleValue> {
 
 	// see note in ArrayList, HashTable, ...
 	private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+	private static final long serialVersionUID = 6103789189908857768L;
 
 	private boolean isBounded;
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/FloatValueArray.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/FloatValueArray.java
@@ -43,6 +43,7 @@ implements ValueArray<FloatValue> {
 
 	// see note in ArrayList, HashTable, ...
 	private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+	private static final long serialVersionUID = -207009928944331374L;
 
 	private boolean isBounded;
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/IntValueArray.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/IntValueArray.java
@@ -41,6 +41,7 @@ implements ValueArray<IntValue> {
 
 	// see note in ArrayList, HashTable, ...
 	private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+	private static final long serialVersionUID = -9168543482761245444L;
 
 	private boolean isBounded;
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/LongValueArray.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/LongValueArray.java
@@ -42,6 +42,7 @@ implements ValueArray<LongValue> {
 
 	// see note in ArrayList, HashTable, ...
 	private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+	private static final long serialVersionUID = 1399765939623729010L;
 
 	private boolean isBounded;
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/NullValueArray.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/NullValueArray.java
@@ -33,6 +33,7 @@ import java.util.Iterator;
 public class NullValueArray
 implements ValueArray<NullValue> {
 
+	private static final long serialVersionUID = 8015871858046107138L;
 	// the number of elements currently stored
 	private int position;
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/ShortValueArray.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/ShortValueArray.java
@@ -43,6 +43,7 @@ implements ValueArray<ShortValue> {
 
 	// see note in ArrayList, HashTable, ...
 	private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+	private static final long serialVersionUID = -2576720473260130301L;
 
 	private boolean isBounded;
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/StringValueArray.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/StringValueArray.java
@@ -53,6 +53,7 @@ implements ValueArray<StringValue> {
 	private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
 
 	protected static final int HIGH_BIT = 0x1 << 7;
+	private static final long serialVersionUID = 3696815037160483396L;
 
 	private boolean isBounded;
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/GraphUtils.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/GraphUtils.java
@@ -61,6 +61,8 @@ public class GraphUtils {
 	@ForwardedFields("*")
 	public static final class IdentityMapper<T>
 	implements MapFunction<T, T> {
+		private static final long serialVersionUID = 6051244519833480951L;
+
 		public T map(T value) {
 			return value;
 		}
@@ -75,6 +77,8 @@ public class GraphUtils {
 	 */
 	public static final class NonForwardingIdentityMapper<T>
 	implements MapFunction<T, T> {
+		private static final long serialVersionUID = -4653411506006004538L;
+
 		public T map(T value) {
 			return value;
 		}
@@ -88,6 +92,7 @@ public class GraphUtils {
 	 */
 	public static class MapTo<I, O>
 	implements MapFunction<I, O>, ResultTypeQueryable<O>, TranslateFunction<I, O> {
+		private static final long serialVersionUID = 1679351648125767732L;
 		private final O value;
 
 		/**
@@ -121,6 +126,8 @@ public class GraphUtils {
 	 */
 	public static class AddLongValue
 	implements ReduceFunction<LongValue> {
+		private static final long serialVersionUID = 2547280389440318158L;
+
 		@Override
 		public LongValue reduce(LongValue value1, LongValue value2)
 				throws Exception {

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/KeyedStateReaderOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/KeyedStateReaderOperator.java
@@ -53,6 +53,7 @@ public class KeyedStateReaderOperator<KEY, OUT>
 	extends StateReaderOperator<KeyedStateReaderFunction<KEY, OUT>, KEY, VoidNamespace, OUT> {
 
 	private static final String USER_TIMERS_NAME = "user-timers";
+	private static final long serialVersionUID = 2459434768653500863L;
 
 	private transient Context<KEY> context;
 

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/MetricConfig.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/MetricConfig.java
@@ -25,6 +25,8 @@ import java.util.Properties;
  */
 public class MetricConfig extends Properties {
 
+	private static final long serialVersionUID = -8926691810470308071L;
+
 	public String getString(String key, String defaultValue) {
 		return getProperty(key, defaultValue);
 	}

--- a/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/common/linalg/DenseMatrix.java
+++ b/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/common/linalg/DenseMatrix.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
  */
 public class DenseMatrix implements Serializable {
 
+	private static final long serialVersionUID = -7169688994624998724L;
 	/**
 	 * Row dimension.
 	 *

--- a/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/common/linalg/DenseVector.java
+++ b/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/common/linalg/DenseVector.java
@@ -26,6 +26,7 @@ import java.util.Random;
  * A dense vector represented by a values array.
  */
 public class DenseVector extends Vector {
+	private static final long serialVersionUID = -6732689218681603099L;
 	/**
 	 * The array holding the vector data.
 	 * <p>
@@ -364,6 +365,7 @@ public class DenseVector extends Vector {
 	}
 
 	private class DenseVectorIterator implements VectorIterator {
+		private static final long serialVersionUID = 471946444890268610L;
 		private int cursor = 0;
 
 		@Override

--- a/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/common/linalg/SparseVector.java
+++ b/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/common/linalg/SparseVector.java
@@ -31,6 +31,7 @@ import java.util.TreeMap;
  */
 public class SparseVector extends Vector {
 
+	private static final long serialVersionUID = 8893897738465646990L;
 	/**
 	 * Size of the vector. n = -1 indicates that the vector size is undetermined.
 	 *
@@ -564,6 +565,7 @@ public class SparseVector extends Vector {
 	}
 
 	private class SparseVectorVectorIterator implements VectorIterator {
+		private static final long serialVersionUID = -7254954640120436147L;
 		private int cursor = 0;
 
 		@Override

--- a/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/common/linalg/Vector.java
+++ b/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/common/linalg/Vector.java
@@ -26,6 +26,8 @@ import java.io.Serializable;
  * SparseVector.
  */
 public abstract class Vector implements Serializable {
+	private static final long serialVersionUID = 7954276304167056575L;
+
 	/**
 	 * Get the size of the vector.
 	 */

--- a/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/common/mapper/Mapper.java
+++ b/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/common/mapper/Mapper.java
@@ -31,6 +31,7 @@ import java.io.Serializable;
  */
 public abstract class Mapper implements Serializable {
 
+	private static final long serialVersionUID = 9176102990166402596L;
 	/**
 	 * Schema of the input rows.
 	 */

--- a/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/common/mapper/MapperAdapter.java
+++ b/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/common/mapper/MapperAdapter.java
@@ -27,6 +27,7 @@ import org.apache.flink.types.Row;
  */
 public class MapperAdapter implements MapFunction<Row, Row> {
 
+	private static final long serialVersionUID = -783958884371699316L;
 	private final Mapper mapper;
 
 	/**

--- a/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/common/mapper/ModelMapper.java
+++ b/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/common/mapper/ModelMapper.java
@@ -31,6 +31,7 @@ import java.util.List;
  */
 public abstract class ModelMapper extends Mapper {
 
+	private static final long serialVersionUID = 1400845893364130233L;
 	/**
 	 * Field names of the model rows.
 	 */

--- a/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/common/mapper/ModelMapperAdapter.java
+++ b/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/common/mapper/ModelMapperAdapter.java
@@ -35,6 +35,7 @@ import java.util.List;
  */
 public class ModelMapperAdapter extends RichMapFunction<Row, Row> {
 
+	private static final long serialVersionUID = 8822149427056915371L;
 	private final ModelMapper mapper;
 	private final ModelSource modelSource;
 

--- a/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/common/model/BroadcastVariableModelSource.java
+++ b/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/common/model/BroadcastVariableModelSource.java
@@ -29,6 +29,7 @@ import java.util.List;
  */
 public class BroadcastVariableModelSource implements ModelSource {
 
+	private static final long serialVersionUID = -1774172327687045103L;
 	/**
 	 * The name of the broadcast variable that hosts the model.
 	 */

--- a/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/common/model/RowsModelSource.java
+++ b/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/common/model/RowsModelSource.java
@@ -29,6 +29,7 @@ import java.util.List;
  */
 public class RowsModelSource implements ModelSource {
 
+	private static final long serialVersionUID = 1803135760776691121L;
 	/**
 	 * The rows that hosts the model.
 	 */

--- a/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/operator/AlgoOperator.java
+++ b/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/operator/AlgoOperator.java
@@ -45,6 +45,7 @@ import java.io.Serializable;
 public abstract class AlgoOperator<T extends AlgoOperator<T>>
 	implements WithParams<T>, HasMLEnvironmentId<T>, Serializable {
 
+	private static final long serialVersionUID = 2227168542601277188L;
 	/**
 	 * Params for algorithms.
 	 */

--- a/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/operator/batch/BatchOperator.java
+++ b/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/operator/batch/BatchOperator.java
@@ -31,6 +31,8 @@ import org.apache.flink.table.api.Table;
  */
 public abstract class BatchOperator<T extends BatchOperator<T>> extends AlgoOperator<T> {
 
+	private static final long serialVersionUID = 5218153343076605303L;
+
 	public BatchOperator() {
 		super();
 	}

--- a/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/operator/batch/source/TableSourceBatchOp.java
+++ b/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/operator/batch/source/TableSourceBatchOp.java
@@ -28,6 +28,8 @@ import org.apache.flink.util.Preconditions;
  */
 public final class TableSourceBatchOp extends BatchOperator<TableSourceBatchOp> {
 
+	private static final long serialVersionUID = -8151609873173679434L;
+
 	public TableSourceBatchOp(Table table) {
 		super(null);
 		Preconditions.checkArgument(table != null, "The source table cannot be null.");

--- a/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/operator/stream/StreamOperator.java
+++ b/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/operator/stream/StreamOperator.java
@@ -31,6 +31,8 @@ import org.apache.flink.table.api.Table;
  */
 public abstract class StreamOperator<T extends StreamOperator<T>> extends AlgoOperator<T> {
 
+	private static final long serialVersionUID = -313118467966623436L;
+
 	public StreamOperator() {
 		super();
 	}

--- a/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/operator/stream/source/TableSourceStreamOp.java
+++ b/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/operator/stream/source/TableSourceStreamOp.java
@@ -28,6 +28,8 @@ import org.apache.flink.util.Preconditions;
  */
 public final class TableSourceStreamOp extends StreamOperator<TableSourceStreamOp> {
 
+	private static final long serialVersionUID = 5410669383994877795L;
+
 	public TableSourceStreamOp(Table table) {
 		super(null);
 		Preconditions.checkArgument(table != null, "The source table cannot be null.");

--- a/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/pipeline/EstimatorBase.java
+++ b/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/pipeline/EstimatorBase.java
@@ -41,6 +41,8 @@ import org.apache.flink.util.Preconditions;
 public abstract class EstimatorBase<E extends EstimatorBase<E, M>, M extends ModelBase<M>>
 	extends PipelineStageBase<E> implements Estimator<E, M> {
 
+	private static final long serialVersionUID = -8905537832519687064L;
+
 	public EstimatorBase() {
 		super();
 	}

--- a/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/pipeline/ModelBase.java
+++ b/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/pipeline/ModelBase.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.api.Table;
 public abstract class ModelBase<M extends ModelBase<M>> extends TransformerBase<M>
 	implements Model<M> {
 
+	private static final long serialVersionUID = 32780894859354888L;
 	protected Table modelData;
 
 	public ModelBase() {

--- a/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/pipeline/TransformerBase.java
+++ b/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/pipeline/TransformerBase.java
@@ -39,6 +39,8 @@ import org.apache.flink.util.Preconditions;
 public abstract class TransformerBase<T extends TransformerBase<T>>
 	extends PipelineStageBase<T> implements Transformer<T> {
 
+	private static final long serialVersionUID = 6671658378828630006L;
+
 	public TransformerBase() {
 		super();
 	}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/BaseRowSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/BaseRowSerializer.java
@@ -46,6 +46,7 @@ import static org.apache.flink.api.java.typeutils.runtime.NullMaskUtils.readInto
 @Internal
 public class BaseRowSerializer extends org.apache.flink.table.runtime.typeutils.BaseRowSerializer {
 
+	private static final long serialVersionUID = 1735264878727916427L;
 	private final LogicalType[] fieldTypes;
 
 	private final TypeSerializer[] fieldSerializers;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobKey.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobKey.java
@@ -25,6 +25,8 @@ import org.apache.flink.annotation.VisibleForTesting;
  */
 public final class PermanentBlobKey extends BlobKey {
 
+	private static final long serialVersionUID = 5614035773213995269L;
+
 	/**
 	 * Constructs a new BLOB key.
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobKey.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobKey.java
@@ -25,6 +25,8 @@ import org.apache.flink.annotation.VisibleForTesting;
  */
 public final class TransientBlobKey extends BlobKey {
 
+	private static final long serialVersionUID = -289164012942554357L;
+
 	/**
 	 * Constructs a new BLOB key.
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/DuplicateJobSubmissionException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/DuplicateJobSubmissionException.java
@@ -26,6 +26,8 @@ import org.apache.flink.api.common.JobID;
  */
 public class DuplicateJobSubmissionException extends JobSubmissionException {
 
+	private static final long serialVersionUID = 2226804455137793520L;
+
 	public DuplicateJobSubmissionException(JobID jobID) {
 		super(jobID, "Job has already been submitted.");
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobStatusMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobStatusMessage.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.JobStatus;
  */
 public class JobStatusMessage implements java.io.Serializable {
 
+	private static final long serialVersionUID = -491766997559536031L;
 	private final JobID jobId;
 
 	private final String jobName;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceSpec.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceSpec.java
@@ -75,6 +75,7 @@ import java.io.Serializable;
  */
 public class TaskExecutorResourceSpec implements Serializable {
 
+	private static final long serialVersionUID = -4956707237145052214L;
 	private final CPUResource cpuCores;
 
 	private final MemorySize frameworkHeapSize;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/compression/DataCorruptionException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/compression/DataCorruptionException.java
@@ -24,6 +24,8 @@ package org.apache.flink.runtime.io.compression;
  */
 public class DataCorruptionException extends RuntimeException {
 
+	private static final long serialVersionUID = 4791111049330108622L;
+
 	public DataCorruptionException() {
 		super();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/compression/InsufficientBufferException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/compression/InsufficientBufferException.java
@@ -25,6 +25,8 @@ package org.apache.flink.runtime.io.compression;
  */
 public class InsufficientBufferException extends RuntimeException {
 
+	private static final long serialVersionUID = 7693926181700983625L;
+
 	public InsufficientBufferException() {
 		super();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/PartitionProducerDisposedException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/PartitionProducerDisposedException.java
@@ -26,6 +26,8 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
  */
 public class PartitionProducerDisposedException extends Exception {
 
+	private static final long serialVersionUID = 7646242700839305761L;
+
 	public PartitionProducerDisposedException(ResultPartitionID resultPartitionID) {
 		super(String.format("Execution %s producing partition %s has already been disposed.",
 			resultPartitionID.getProducerId(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/udf/AssignRangeIndex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/udf/AssignRangeIndex.java
@@ -34,6 +34,7 @@ import java.util.List;
  */
 public class AssignRangeIndex<IN> extends RichMapPartitionFunction<IN, Tuple2<Integer, IN>> {
 
+	private static final long serialVersionUID = 7056831712340214848L;
 	private TypeComparatorFactory<IN> typeComparator;
 
 	public AssignRangeIndex(TypeComparatorFactory<IN> typeComparator) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/udf/RangeBoundaryBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/udf/RangeBoundaryBuilder.java
@@ -35,6 +35,7 @@ import java.util.List;
  */
 public class RangeBoundaryBuilder<T> extends RichMapPartitionFunction<T, Object[][]> {
 
+	private static final long serialVersionUID = -4654326156903985265L;
 	private int parallelism;
 	private final TypeComparatorFactory<T> comparatorFactory;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/udf/RemoveRangeIndex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/udf/RemoveRangeIndex.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.java.tuple.Tuple2;
 
 public class RemoveRangeIndex<T> implements MapFunction<Tuple2<Integer,T>,T> {
 
+	private static final long serialVersionUID = 6553845496792045137L;
+
 	@Override
 	public T map(Tuple2<Integer, T> value) throws Exception {
 		return value.f1;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerException.java
@@ -24,6 +24,8 @@ import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerExcept
  * Base class for exceptions thrown by the {@link SlotManager}.
  */
 public class SlotManagerException extends ResourceManagerException {
+	private static final long serialVersionUID = -476281430195945166L;
+
 	public SlotManagerException(String message) {
 		super(message);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointConfigInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointConfigInfo.java
@@ -175,6 +175,8 @@ public class CheckpointConfigInfo implements ResponseBody {
 	 */
 	public static class ProcessingModeSerializer extends StdSerializer<ProcessingMode> {
 
+		private static final long serialVersionUID = -2408204888128041652L;
+
 		public ProcessingModeSerializer() {
 			super(ProcessingMode.class);
 		}
@@ -190,6 +192,8 @@ public class CheckpointConfigInfo implements ResponseBody {
 	 * Processing mode deserializer.
 	 */
 	public static class ProcessingModeDeserializer extends StdDeserializer<ProcessingMode> {
+
+		private static final long serialVersionUID = 2794582173200276810L;
 
 		public ProcessingModeDeserializer() {
 			super(ProcessingMode.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerDetailsInfo.java
@@ -37,6 +37,7 @@ import java.util.Objects;
 public class TaskManagerDetailsInfo extends TaskManagerInfo {
 
 	public static final String FIELD_NAME_METRICS = "metrics";
+	private static final long serialVersionUID = 8655914676001858667L;
 
 	@JsonProperty(FIELD_NAME_METRICS)
 	private final TaskManagerMetricsInfo taskManagerMetrics;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/BackendBuildingException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/BackendBuildingException.java
@@ -24,6 +24,8 @@ import java.io.IOException;
  * Exceptions which indicate that a state backend building has failed.
  */
 public class BackendBuildingException extends IOException {
+	private static final long serialVersionUID = -5298400221014395207L;
+
 	public BackendBuildingException(String message, Throwable cause) {
 		super(message, cause);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlAggregateFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlAggregateFunction.java
@@ -35,6 +35,7 @@ import org.apache.flink.util.function.ThrowingRunnable;
 class TtlAggregateFunction<IN, ACC, OUT>
 	extends AbstractTtlDecorator<AggregateFunction<IN, ACC, OUT>>
 	implements AggregateFunction<IN, TtlValue<ACC>, OUT> {
+	private static final long serialVersionUID = -4464388007791528260L;
 	ThrowingRunnable<Exception> stateClear;
 	ThrowingConsumer<TtlValue<ACC>, Exception> updater;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlFoldFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlFoldFunction.java
@@ -33,6 +33,7 @@ import org.apache.flink.api.common.state.StateTtlConfig;
 class TtlFoldFunction<T, ACC>
 	extends AbstractTtlDecorator<FoldFunction<T, ACC>>
 	implements FoldFunction<T, TtlValue<ACC>> {
+	private static final long serialVersionUID = -6078683479606899136L;
 	private final ACC defaultAccumulator;
 
 	TtlFoldFunction(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlReduceFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlReduceFunction.java
@@ -30,6 +30,8 @@ class TtlReduceFunction<T>
 	extends AbstractTtlDecorator<ReduceFunction<T>>
 	implements ReduceFunction<TtlValue<T>> {
 
+	private static final long serialVersionUID = -965149349481145015L;
+
 	TtlReduceFunction(
 		ReduceFunction<T> originalReduceFunction,
 		StateTtlConfig config,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/AccumulatorReport.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/AccumulatorReport.java
@@ -28,6 +28,7 @@ import java.util.List;
  * A report about the current values of all accumulators of the TaskExecutor for a given job.
  */
 public class AccumulatorReport implements Serializable {
+	private static final long serialVersionUID = -2824808641221982254L;
 	private final Collection<AccumulatorSnapshot> accumulatorSnapshots;
 
 	public AccumulatorReport(List<AccumulatorSnapshot> accumulatorSnapshots) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -134,4 +134,5 @@ public class RocksDBConfigurableOptions implements Serializable {
 			.withDescription("The amount of the cache for data blocks in RocksDB. " +
 				"RocksDB has default block-cache size as '8MB'.");
 
+	private static final long serialVersionUID = 5956179275155221805L;
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricOptions.java
@@ -157,6 +157,7 @@ public class RocksDBNativeMetricOptions implements Serializable {
 		.key(METRICS_COLUMN_FAMILY_AS_VARIABLE_KEY)
 		.defaultValue(false)
 		.withDescription("Whether to expose the column family as a variable.");
+	private static final long serialVersionUID = -1834342759249804744L;
 
 	/**
 	 * Creates a {@link RocksDBNativeMetricOptions} based on an

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/AscendingTimestampExtractor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/AscendingTimestampExtractor.java
@@ -37,4 +37,5 @@ import org.apache.flink.annotation.PublicEvolving;
 public abstract class AscendingTimestampExtractor<T>
 	extends org.apache.flink.streaming.api.functions.timestamps.AscendingTimestampExtractor<T> {
 
+	private static final long serialVersionUID = 9217202728304487605L;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/QueryableAppendingStateOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/QueryableAppendingStateOperator.java
@@ -31,6 +31,8 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 @Internal
 public class QueryableAppendingStateOperator<IN> extends AbstractQueryableStateOperator<AppendingState<IN, ?>, IN> {
 
+	private static final long serialVersionUID = 7893281100672692395L;
+
 	public QueryableAppendingStateOperator(
 			String registrationName,
 			StateDescriptor<? extends AppendingState<IN, ?>, ?> stateDescriptor) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/QueryableValueStateOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/QueryableValueStateOperator.java
@@ -31,6 +31,8 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 @Internal
 public class QueryableValueStateOperator<IN> extends AbstractQueryableStateOperator<ValueState<IN>, IN> {
 
+	private static final long serialVersionUID = 8883905222035666073L;
+
 	public QueryableValueStateOperator(
 			String registrationName,
 			StateDescriptor<ValueState<IN>, IN> stateDescriptor) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
@@ -79,6 +79,7 @@ public abstract class TwoPhaseCommitSinkFunction<IN, TXN, CONTEXT>
 		implements CheckpointedFunction, CheckpointListener {
 
 	private static final Logger LOG = LoggerFactory.getLogger(TwoPhaseCommitSinkFunction.class);
+	private static final long serialVersionUID = 5734292730589317840L;
 
 	protected final LinkedHashMap<Long, TransactionHolder<TXN>> pendingCommitTransactions = new LinkedHashMap<>();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/OutputFileConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/OutputFileConfig.java
@@ -29,6 +29,7 @@ import java.io.Serializable;
  */
 public class OutputFileConfig implements Serializable {
 
+	private static final long serialVersionUID = -273458732118900351L;
 	private final String partPrefix;
 
 	private final String partSuffix;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/TimestampedFileInputSplit.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/TimestampedFileInputSplit.java
@@ -34,6 +34,7 @@ import java.io.Serializable;
  * */
 public class TimestampedFileInputSplit extends FileInputSplit implements Comparable<TimestampedFileInputSplit>{
 
+	private static final long serialVersionUID = -8153252402661556005L;
 	/** The modification time of the file this split belongs to. */
 	private final long modificationTime;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/InternalProcessApplyWindowContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/InternalProcessApplyWindowContext.java
@@ -35,6 +35,7 @@ import org.apache.flink.util.OutputTag;
 public class InternalProcessApplyWindowContext<IN, OUT, KEY, W extends Window>
 	extends ProcessWindowFunction<IN, OUT, KEY, W>.Context {
 
+	private static final long serialVersionUID = -5162974810748550627L;
 	W window;
 	ProcessWindowFunction.Context context;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/ProcessWindowFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/ProcessWindowFunction.java
@@ -63,6 +63,8 @@ public abstract class ProcessWindowFunction<IN, OUT, KEY, W extends Window> exte
 	 * The context holding window metadata.
 	 */
 	public abstract class Context implements java.io.Serializable {
+		private static final long serialVersionUID = 1320353589804005921L;
+
 		/**
 		 * Returns the window that is being evaluated.
 		 */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SimpleInputFormatOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SimpleInputFormatOperatorFactory.java
@@ -30,6 +30,7 @@ import org.apache.flink.streaming.api.functions.source.InputFormatSourceFunction
 @Internal
 public class SimpleInputFormatOperatorFactory<OUT> extends SimpleOperatorFactory<OUT> implements InputFormatOperatorFactory<OUT> {
 
+	private static final long serialVersionUID = 5963536268930702104L;
 	private final StreamSource<OUT, InputFormatSourceFunction<OUT>> operator;
 
 	public SimpleInputFormatOperatorFactory(StreamSource<OUT, InputFormatSourceFunction<OUT>> operator) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SimpleOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SimpleOperatorFactory.java
@@ -37,6 +37,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Internal
 public class SimpleOperatorFactory<OUT> implements StreamOperatorFactory<OUT> {
 
+	private static final long serialVersionUID = -460056579757489654L;
 	private final StreamOperator<OUT> operator;
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SimpleOutputFormatOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SimpleOutputFormatOperatorFactory.java
@@ -32,6 +32,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 public class SimpleOutputFormatOperatorFactory<IN>
 	extends SimpleOperatorFactory<Object> implements OutputFormatOperatorFactory<IN> {
 
+	private static final long serialVersionUID = -7917121545657695037L;
 	private final StreamSink<IN> operator;
 
 	public SimpleOutputFormatOperatorFactory(StreamSink<IN> operator) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SimpleUdfStreamOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SimpleUdfStreamOperatorFactory.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.common.functions.Function;
 @Internal
 public class SimpleUdfStreamOperatorFactory<OUT> extends SimpleOperatorFactory<OUT> implements UdfStreamOperatorFactory<OUT> {
 
+	private static final long serialVersionUID = 888902327938671138L;
 	private final AbstractUdfStreamOperator<OUT, ?> operator;
 
 	public SimpleUdfStreamOperatorFactory(AbstractUdfStreamOperator<OUT, ?> operator) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceReaderOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceReaderOperator.java
@@ -31,4 +31,5 @@ import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
  */
 @Internal
 public abstract class SourceReaderOperator<OUT> extends AbstractStreamOperator<OUT> implements PushingAsyncDataInput<OUT> {
+	private static final long serialVersionUID = -6928116235815640905L;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorFactory.java
@@ -34,6 +34,7 @@ import org.apache.flink.streaming.runtime.tasks.StreamTask;
  * @param <OUT> The output type of the operator
  */
 public class AsyncWaitOperatorFactory<IN, OUT> implements OneInputStreamOperatorFactory<IN, OUT>, YieldingOperatorFactory<OUT> {
+	private static final long serialVersionUID = -9133957585343815450L;
 	private final AsyncFunction<IN, OUT> asyncFunction;
 	private final long timeout;
 	private final int capacity;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/CheckpointCommitter.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/CheckpointCommitter.java
@@ -43,6 +43,7 @@ import java.io.Serializable;
 public abstract class CheckpointCommitter implements Serializable {
 
 	protected static final Logger LOG = LoggerFactory.getLogger(CheckpointCommitter.class);
+	private static final long serialVersionUID = 8698594963661802743L;
 
 	protected String jobId;
 	protected String operatorId;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -732,6 +732,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 	 * {@code WindowContext}.
 	 */
 	public class WindowContext implements InternalWindowFunction.InternalWindowContext {
+		private static final long serialVersionUID = 7218287265613412560L;
 		protected W window;
 
 		protected AbstractPerWindowStateStore windowState;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/functions/InternalProcessWindowContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/functions/InternalProcessWindowContext.java
@@ -36,6 +36,7 @@ import org.apache.flink.util.OutputTag;
 public class InternalProcessWindowContext<IN, OUT, KEY, W extends Window>
 	extends ProcessWindowFunction<IN, OUT, KEY, W>.Context {
 
+	private static final long serialVersionUID = 7675868835443270567L;
 	W window;
 	InternalWindowFunction.InternalWindowContext internalContext;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/typeutils/FieldAccessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/typeutils/FieldAccessorFactory.java
@@ -41,6 +41,8 @@ import java.util.regex.Pattern;
 @Internal
 public class FieldAccessorFactory implements Serializable {
 
+	private static final long serialVersionUID = -4850338006897056408L;
+
 	/**
 	 * Creates a {@link FieldAccessor} for the given field position, which can be used to get and set
 	 * the specified field on instances of this type.

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/ConfigUtil.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/ConfigUtil.java
@@ -73,6 +73,8 @@ public class ConfigUtil {
 	 * Modified object mapper that converts to lower-case keys.
 	 */
 	public static class LowerCaseYamlMapper extends ObjectMapper {
+		private static final long serialVersionUID = -2393260723472252816L;
+
 		public LowerCaseYamlMapper() {
 			super(new YAMLFactory() {
 				@Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/error/SqlValidateException.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/error/SqlValidateException.java
@@ -26,6 +26,7 @@ import org.apache.calcite.sql.parser.SqlParserPos;
  */
 public class SqlValidateException extends Exception {
 
+	private static final long serialVersionUID = -8703502029162884172L;
 	private SqlParserPos errorPosition;
 
 	private String message;

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/wmstrategies/PeriodicWatermarkAssigner.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/wmstrategies/PeriodicWatermarkAssigner.java
@@ -27,6 +27,8 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 @PublicEvolving
 public abstract class PeriodicWatermarkAssigner extends WatermarkStrategy {
 
+	private static final long serialVersionUID = -8779511531638163656L;
+
 	/**
 	 * Updates the assigner with the next timestamp.
 	 *

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/wmstrategies/PunctuatedWatermarkAssigner.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/wmstrategies/PunctuatedWatermarkAssigner.java
@@ -28,6 +28,8 @@ import org.apache.flink.types.Row;
 @PublicEvolving
 public abstract class PunctuatedWatermarkAssigner extends WatermarkStrategy {
 
+	private static final long serialVersionUID = -9128287939314995468L;
+
 	/**
 	 * Returns the watermark for the current row or null if no watermark should be generated.
 	 *

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/BatchQueryConfig.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/BatchQueryConfig.java
@@ -29,4 +29,5 @@ import org.apache.flink.annotation.PublicEvolving;
 @PublicEvolving
 public class BatchQueryConfig implements QueryConfig {
 
+	private static final long serialVersionUID = 2782003186318976027L;
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/SqlParserException.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/SqlParserException.java
@@ -28,6 +28,8 @@ import org.apache.flink.annotation.PublicEvolving;
 @PublicEvolving
 public class SqlParserException extends RuntimeException {
 
+	private static final long serialVersionUID = -3388417866294028283L;
+
 	public SqlParserException(String message, Throwable cause) {
 		super(message, cause);
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/StreamQueryConfig.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/StreamQueryConfig.java
@@ -31,6 +31,7 @@ import org.apache.flink.api.common.time.Time;
 @PublicEvolving
 public class StreamQueryConfig implements QueryConfig {
 
+	private static final long serialVersionUID = 2169490578689986124L;
 	/**
 	 * The minimum time until state which was not updated will be retained.
 	 * State might be cleared and removed if it was not updated for the defined period of time.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/functions/TemporalTableFunctionImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/functions/TemporalTableFunctionImpl.java
@@ -36,6 +36,7 @@ import java.sql.Timestamp;
 @Internal
 public final class TemporalTableFunctionImpl extends TemporalTableFunction {
 
+	private static final long serialVersionUID = 4692326266525653366L;
 	private final transient QueryOperation underlyingHistoryTable;
 	private final transient Expression timeAttribute;
 	private final transient Expression primaryKey;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/annotation/UnknownSerializer.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/annotation/UnknownSerializer.java
@@ -27,6 +27,8 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 @Internal
 abstract class UnknownSerializer extends TypeSerializer<Object> {
 
+	private static final long serialVersionUID = 807333597331986513L;
+
 	private UnknownSerializer() {
 		// no instantiation
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/AmbiguousTableFactoryException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/AmbiguousTableFactoryException.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
  */
 public class AmbiguousTableFactoryException extends RuntimeException {
 
+	private static final long serialVersionUID = -2518345169211387683L;
 	// factories that match the properties
 	private final List<? extends TableFactory> matchingFactories;
 	// required factory class

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/CatalogNotExistException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/CatalogNotExistException.java
@@ -26,6 +26,8 @@ import org.apache.flink.annotation.PublicEvolving;
 @PublicEvolving
 public class CatalogNotExistException extends RuntimeException {
 
+	private static final long serialVersionUID = -2620826318518383902L;
+
 	public CatalogNotExistException(String catalogName) {
 		this(catalogName, null);
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/ExpressionParserException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/ExpressionParserException.java
@@ -23,6 +23,8 @@ package org.apache.flink.table.api;
  */
 public class ExpressionParserException extends RuntimeException {
 
+	private static final long serialVersionUID = -9030138977673176425L;
+
 	public ExpressionParserException(String msg) {
 		super(msg);
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/NoMatchingTableFactoryException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/NoMatchingTableFactoryException.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
  */
 public class NoMatchingTableFactoryException extends RuntimeException {
 
+	private static final long serialVersionUID = -8195248379425594801L;
 	// message that indicates the current matching step
 	private final String message;
 	// required factory class

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableException.java
@@ -29,6 +29,8 @@ import org.apache.flink.annotation.PublicEvolving;
 @PublicEvolving
 public class TableException extends RuntimeException {
 
+	private static final long serialVersionUID = 1087959503413835823L;
+
 	public TableException(String message, Throwable cause) {
 		super(message, cause);
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableNotExistException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableNotExistException.java
@@ -26,6 +26,8 @@ import org.apache.flink.annotation.PublicEvolving;
 @PublicEvolving
 public class TableNotExistException extends RuntimeException {
 
+	private static final long serialVersionUID = -5661750557659424532L;
+
 	public TableNotExistException(String catalogName, String tableName) {
 		this(catalogName, tableName, null);
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/UnresolvedException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/UnresolvedException.java
@@ -22,6 +22,8 @@ package org.apache.flink.table.api;
  * Exception for unwanted method calling on unresolved expression.
  */
 public class UnresolvedException extends RuntimeException {
+	private static final long serialVersionUID = -8342347751783231761L;
+
 	public UnresolvedException(String msg) {
 		super(msg);
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/ValidationException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/ValidationException.java
@@ -28,6 +28,8 @@ import org.apache.flink.annotation.PublicEvolving;
 @PublicEvolving
 public class ValidationException extends RuntimeException {
 
+	private static final long serialVersionUID = -6120834944361151343L;
+
 	public ValidationException(String message, Throwable cause) {
 		super(message, cause);
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ObjectIdentifier.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ObjectIdentifier.java
@@ -37,6 +37,7 @@ import static org.apache.flink.table.utils.EncodingUtils.escapeIdentifier;
  */
 public final class ObjectIdentifier implements Serializable {
 
+	private static final long serialVersionUID = -8260954128190215259L;
 	private final String catalogName;
 
 	private final String databaseName;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ObjectPath.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ObjectPath.java
@@ -29,6 +29,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  * A database name and object (table/view/function) name combo in a catalog.
  */
 public class ObjectPath implements Serializable {
+	private static final long serialVersionUID = -9008981384786934790L;
 	private final String databaseName;
 	private final String objectName;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/CatalogException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/CatalogException.java
@@ -22,6 +22,8 @@ package org.apache.flink.table.catalog.exceptions;
  * A catalog-related, runtime exception.
  */
 public class CatalogException extends RuntimeException {
+	private static final long serialVersionUID = -7850460857654362102L;
+
 	/**
 	 * @param   message   the detail message.
 	 */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/DatabaseAlreadyExistException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/DatabaseAlreadyExistException.java
@@ -23,6 +23,7 @@ package org.apache.flink.table.catalog.exceptions;
  */
 public class DatabaseAlreadyExistException extends Exception {
 	private static final String MSG = "Database %s already exists in Catalog %s.";
+	private static final long serialVersionUID = 7408976582250309886L;
 
 	public DatabaseAlreadyExistException(String catalog, String database, Throwable cause) {
 		super(String.format(MSG, database, catalog), cause);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/DatabaseNotEmptyException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/DatabaseNotEmptyException.java
@@ -24,6 +24,7 @@ package org.apache.flink.table.catalog.exceptions;
  */
 public class DatabaseNotEmptyException extends Exception {
 	private static final String MSG = "Database %s in catalog %s is not empty.";
+	private static final long serialVersionUID = 3825372436300237646L;
 
 	public DatabaseNotEmptyException(String catalog, String database, Throwable cause) {
 		super(String.format(MSG, database, catalog), cause);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/DatabaseNotExistException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/DatabaseNotExistException.java
@@ -23,6 +23,7 @@ package org.apache.flink.table.catalog.exceptions;
  */
 public class DatabaseNotExistException extends Exception {
 	private static final String MSG = "Database %s does not exist in Catalog %s.";
+	private static final long serialVersionUID = -4343014092379608802L;
 
 	public DatabaseNotExistException(String catalogName, String databaseName, Throwable cause) {
 		super(String.format(MSG, databaseName, catalogName), cause);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/FunctionAlreadyExistException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/FunctionAlreadyExistException.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.catalog.ObjectPath;
 public class FunctionAlreadyExistException extends Exception {
 
 	private static final String MSG = "Function %s already exists in Catalog %s.";
+	private static final long serialVersionUID = -7780613958492280473L;
 
 	public FunctionAlreadyExistException(String catalogName, ObjectPath functionPath) {
 		this(catalogName, functionPath, null);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/FunctionNotExistException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/FunctionNotExistException.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.catalog.ObjectPath;
 public class FunctionNotExistException extends Exception {
 
 	private static final String MSG = "Function %s does not exist in Catalog %s.";
+	private static final long serialVersionUID = 2661974921900843520L;
 
 	public FunctionNotExistException(String catalogName, ObjectPath functionPath) {
 		this(catalogName, functionPath, null);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/PartitionAlreadyExistsException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/PartitionAlreadyExistsException.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.catalog.ObjectPath;
  */
 public class PartitionAlreadyExistsException extends Exception {
 	private static final String MSG = "Partition %s of table %s in catalog %s already exists.";
+	private static final long serialVersionUID = -3901694239758596330L;
 
 	public PartitionAlreadyExistsException(
 		String catalogName,

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/PartitionNotExistException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/PartitionNotExistException.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.catalog.ObjectPath;
  */
 public class PartitionNotExistException extends Exception {
 	private static final String MSG = "Partition %s of table %s in catalog %s does not exist.";
+	private static final long serialVersionUID = -1681384754576190912L;
 
 	public PartitionNotExistException(
 		String catalogName,

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/PartitionSpecInvalidException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/PartitionSpecInvalidException.java
@@ -30,6 +30,7 @@ import java.util.List;
  */
 public class PartitionSpecInvalidException extends Exception {
 	private static final String MSG = "PartitionSpec %s does not match partition keys %s of table %s in catalog %s.";
+	private static final long serialVersionUID = 1934059378486532949L;
 
 	public PartitionSpecInvalidException(
 		String catalogName,

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/TableAlreadyExistException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/TableAlreadyExistException.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.catalog.ObjectPath;
 public class TableAlreadyExistException extends Exception {
 
 	private static final String MSG = "Table (or view) %s already exists in Catalog %s.";
+	private static final long serialVersionUID = 8007516829092595106L;
 
 	public TableAlreadyExistException(String catalogName, ObjectPath tablePath) {
 		this(catalogName, tablePath, null);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/TableNotExistException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/TableNotExistException.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.catalog.ObjectPath;
 public class TableNotExistException extends Exception {
 
 	private static final String MSG = "Table (or view) %s does not exist in Catalog %s.";
+	private static final long serialVersionUID = 5097273420879597470L;
 
 	public TableNotExistException(String catalogName, ObjectPath tablePath) {
 		this(catalogName, tablePath, null);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/TableNotPartitionedException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/TableNotPartitionedException.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.catalog.ObjectPath;
 public class TableNotPartitionedException extends Exception {
 
 	private static final String MSG = "Table %s in catalog %s is not partitioned.";
+	private static final long serialVersionUID = -4542452004732053369L;
 
 	public TableNotPartitionedException(String catalogName, ObjectPath tablePath) {
 		this(catalogName, tablePath, null);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/TablePartitionedException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/TablePartitionedException.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.catalog.ObjectPath;
 public class TablePartitionedException extends Exception {
 
 	private static final String MSG = "Table %s in catalog %s is partitioned.";
+	private static final long serialVersionUID = -3064991669565305373L;
 
 	public TablePartitionedException(String catalogName, ObjectPath tablePath) {
 		this(catalogName, tablePath, null);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/AggregateFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/AggregateFunction.java
@@ -113,6 +113,8 @@ import java.util.Set;
 @PublicEvolving
 public abstract class AggregateFunction<T, ACC> extends UserDefinedAggregateFunction<T, ACC> {
 
+	private static final long serialVersionUID = -1157133868603641483L;
+
 	/**
 	 * Called every time when an aggregation result should be materialized.
 	 * The returned value could be either an early and incomplete result

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/AsyncTableFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/AsyncTableFunction.java
@@ -88,6 +88,8 @@ import java.util.concurrent.CompletableFuture;
 @Experimental
 public abstract class AsyncTableFunction<T> extends UserDefinedFunction {
 
+	private static final long serialVersionUID = -3015463440803517150L;
+
 	/**
 	 * Returns the result type of the evaluation method with a given signature.
 	 *

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/ScalarFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/ScalarFunction.java
@@ -48,6 +48,8 @@ import org.apache.flink.table.api.ValidationException;
 @PublicEvolving
 public abstract class ScalarFunction extends UserDefinedFunction {
 
+	private static final long serialVersionUID = 7938994048415210252L;
+
 	/**
 	 * Returns the result type of the evaluation method with a given signature.
 	 *

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/TableAggregateFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/TableAggregateFunction.java
@@ -111,6 +111,8 @@ import org.apache.flink.util.Collector;
 @PublicEvolving
 public abstract class TableAggregateFunction<T, ACC> extends UserDefinedAggregateFunction<T, ACC> {
 
+	private static final long serialVersionUID = 2895885101279637970L;
+
 	/**
 	 * Collects a record and forwards it. The collector can output retract messages with the retract
 	 * method. Note: only use it in {@code emitUpdateWithRetract}.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/TableFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/TableFunction.java
@@ -84,6 +84,7 @@ import org.apache.flink.util.Collector;
 @PublicEvolving
 public abstract class TableFunction<T> extends UserDefinedFunction {
 
+	private static final long serialVersionUID = -615767533923752402L;
 	/**
 	 * The code generated collector used to emit rows.
 	 */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/TemporalTableFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/TemporalTableFunction.java
@@ -30,4 +30,5 @@ import org.apache.flink.types.Row;
 @PublicEvolving
 public abstract class TemporalTableFunction extends TableFunction<Row> {
 
+	private static final long serialVersionUID = 4650828237900532560L;
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/UserDefinedAggregateFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/UserDefinedAggregateFunction.java
@@ -27,6 +27,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 @PublicEvolving
 public abstract class UserDefinedAggregateFunction<T, ACC> extends UserDefinedFunction {
 
+	private static final long serialVersionUID = 104365049684027463L;
+
 	/**
 	 * Creates and initializes the accumulator for this {@link UserDefinedAggregateFunction}. The
 	 * accumulator is used to keep the aggregated values which are needed to compute an aggregation

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/UserDefinedFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/UserDefinedFunction.java
@@ -38,6 +38,8 @@ import java.io.Serializable;
 @PublicEvolving
 public abstract class UserDefinedFunction implements FunctionDefinition, Serializable {
 
+	private static final long serialVersionUID = -2915979617198831296L;
+
 	/**
 	 * Returns a unique, serialized representation for this function.
 	 */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/tsextractors/TimestampExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/tsextractors/TimestampExtractor.java
@@ -36,6 +36,8 @@ import java.util.Map;
 @PublicEvolving
 public abstract class TimestampExtractor implements FieldComputer<Long>, Serializable, Descriptor {
 
+	private static final long serialVersionUID = 6905582462430309400L;
+
 	@Override
 	public TypeInformation<Long> getReturnType() {
 		return Types.LONG;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/wmstrategies/WatermarkStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/wmstrategies/WatermarkStrategy.java
@@ -36,6 +36,8 @@ import java.util.Map;
 @PublicEvolving
 public abstract class WatermarkStrategy implements Serializable, Descriptor {
 
+	private static final long serialVersionUID = -2415197672377521858L;
+
 	/**
 	 * This method is a default implementation that uses java serialization and it is discouraged.
 	 * All implementation should provide a more specific set of properties.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/AtomicDataType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/AtomicDataType.java
@@ -33,6 +33,8 @@ import javax.annotation.Nullable;
 @PublicEvolving
 public final class AtomicDataType extends DataType {
 
+	private static final long serialVersionUID = 5339095160318608613L;
+
 	public AtomicDataType(LogicalType logicalType, @Nullable Class<?> conversionClass) {
 		super(logicalType, conversionClass);
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/CollectionDataType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/CollectionDataType.java
@@ -37,6 +37,7 @@ import java.util.Objects;
 @PublicEvolving
 public final class CollectionDataType extends DataType {
 
+	private static final long serialVersionUID = 5086757737530344147L;
 	private final DataType elementDataType;
 
 	public CollectionDataType(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/DataType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/DataType.java
@@ -52,6 +52,7 @@ import java.util.Objects;
 @PublicEvolving
 public abstract class DataType implements Serializable {
 
+	private static final long serialVersionUID = -3893864896762154062L;
 	protected final LogicalType logicalType;
 
 	protected final Class<?> conversionClass;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/FieldsDataType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/FieldsDataType.java
@@ -38,6 +38,7 @@ import java.util.Objects;
 @PublicEvolving
 public final class FieldsDataType extends DataType {
 
+	private static final long serialVersionUID = -7865917327793396623L;
 	private final Map<String, DataType> fieldDataTypes;
 
 	public FieldsDataType(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/KeyValueDataType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/KeyValueDataType.java
@@ -35,6 +35,7 @@ import java.util.Objects;
 @PublicEvolving
 public final class KeyValueDataType extends DataType {
 
+	private static final long serialVersionUID = -8117788168770993123L;
 	private final DataType keyDataType;
 
 	private final DataType valueDataType;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/ArrayType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/ArrayType.java
@@ -42,6 +42,7 @@ public final class ArrayType extends LogicalType {
 
 	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
 		"org.apache.flink.table.dataformat.BinaryArray");
+	private static final long serialVersionUID = 2952999056992019834L;
 
 	private final LogicalType elementType;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/BigIntType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/BigIntType.java
@@ -45,6 +45,7 @@ public final class BigIntType extends LogicalType {
 		long.class.getName());
 
 	private static final Class<?> DEFAULT_CONVERSION = Long.class;
+	private static final long serialVersionUID = -8691941180712940089L;
 
 	public BigIntType(boolean isNullable) {
 		super(isNullable, LogicalTypeRoot.BIGINT);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/BinaryType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/BinaryType.java
@@ -55,6 +55,7 @@ public final class BinaryType extends LogicalType {
 		"org.apache.flink.table.dataformat.BinaryArray");
 
 	private static final Class<?> DEFAULT_CONVERSION = byte[].class;
+	private static final long serialVersionUID = -2305907340612002544L;
 
 	private final int length;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/BooleanType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/BooleanType.java
@@ -42,6 +42,7 @@ public final class BooleanType extends LogicalType {
 		boolean.class.getName());
 
 	private static final Class<?> DEFAULT_CONVERSION = Boolean.class;
+	private static final long serialVersionUID = 3721976957965458190L;
 
 	public BooleanType(boolean isNullable) {
 		super(isNullable, LogicalTypeRoot.BOOLEAN);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/CharType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/CharType.java
@@ -58,6 +58,7 @@ public final class CharType extends LogicalType {
 		"org.apache.flink.table.dataformat.BinaryString");
 
 	private static final Class<?> DEFAULT_CONVERSION = String.class;
+	private static final long serialVersionUID = 60503938551394574L;
 
 	private final int length;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DateType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DateType.java
@@ -49,6 +49,7 @@ public final class DateType extends LogicalType {
 		int.class.getName());
 
 	private static final Class<?> DEFAULT_CONVERSION = java.time.LocalDate.class;
+	private static final long serialVersionUID = 2265378078859563505L;
 
 	public DateType(boolean isNullable) {
 		super(isNullable, LogicalTypeRoot.DATE);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DayTimeIntervalType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DayTimeIntervalType.java
@@ -98,6 +98,7 @@ public final class DayTimeIntervalType extends LogicalType {
 		long.class.getName());
 
 	private static final Class<?> DEFAULT_CONVERSION = java.time.Duration.class;
+	private static final long serialVersionUID = -6919454569070442150L;
 
 	/**
 	 * Supported resolutions of this type.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DecimalType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DecimalType.java
@@ -57,6 +57,7 @@ public final class DecimalType extends LogicalType {
 		"org.apache.flink.table.dataformat.Decimal");
 
 	private static final Class<?> DEFAULT_CONVERSION = BigDecimal.class;
+	private static final long serialVersionUID = 963037349486697940L;
 
 	private final int precision;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DistinctType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DistinctType.java
@@ -48,6 +48,8 @@ import java.util.Objects;
 @PublicEvolving
 public final class DistinctType extends UserDefinedType {
 
+	private static final long serialVersionUID = -2711757949675008506L;
+
 	/**
 	 * A builder for a {@link DistinctType}. Intended for future extensibility.
 	 */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DoubleType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DoubleType.java
@@ -43,6 +43,7 @@ public final class DoubleType extends LogicalType {
 		double.class.getName());
 
 	private static final Class<?> DEFAULT_CONVERSION = Double.class;
+	private static final long serialVersionUID = 5902234309332923522L;
 
 	public DoubleType(boolean isNullable) {
 		super(isNullable, LogicalTypeRoot.DOUBLE);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/FloatType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/FloatType.java
@@ -43,6 +43,7 @@ public final class FloatType extends LogicalType {
 		float.class.getName());
 
 	private static final Class<?> DEFAULT_CONVERSION = Float.class;
+	private static final long serialVersionUID = -3502430316635552504L;
 
 	public FloatType(boolean isNullable) {
 		super(isNullable, LogicalTypeRoot.FLOAT);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/IntType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/IntType.java
@@ -44,6 +44,7 @@ public final class IntType extends LogicalType {
 		int.class.getName());
 
 	private static final Class<?> DEFAULT_CONVERSION = Integer.class;
+	private static final long serialVersionUID = 599551545689420248L;
 
 	public IntType(boolean isNullable) {
 		super(isNullable, LogicalTypeRoot.INTEGER);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LegacyTypeInformationType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LegacyTypeInformationType.java
@@ -47,6 +47,7 @@ import java.util.Objects;
 public final class LegacyTypeInformationType<T> extends LogicalType {
 
 	private static final String FORMAT = "LEGACY('%s', '%s')";
+	private static final long serialVersionUID = 8451285230399670871L;
 
 	private final TypeInformation<T> typeInfo;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LocalZonedTimestampType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LocalZonedTimestampType.java
@@ -75,6 +75,7 @@ public final class LocalZonedTimestampType extends LogicalType {
 		long.class.getName());
 
 	private static final Class<?> DEFAULT_CONVERSION = java.time.Instant.class;
+	private static final long serialVersionUID = -5686763727428209249L;
 
 	private final TimestampKind kind;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalType.java
@@ -55,6 +55,7 @@ import java.util.Set;
 @PublicEvolving
 public abstract class LogicalType implements Serializable {
 
+	private static final long serialVersionUID = -7381419642101800907L;
 	private final boolean isNullable;
 
 	private final LogicalTypeRoot typeRoot;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/MapType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/MapType.java
@@ -47,6 +47,7 @@ public final class MapType extends LogicalType {
 		"org.apache.flink.table.dataformat.BinaryMap");
 
 	private static final Class<?> DEFAULT_CONVERSION = Map.class;
+	private static final long serialVersionUID = 1341382399327679152L;
 
 	private final LogicalType keyType;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/MultisetType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/MultisetType.java
@@ -49,6 +49,7 @@ public final class MultisetType extends LogicalType {
 		"org.apache.flink.table.dataformat.BinaryMap");
 
 	private static final Class<?> DEFAULT_CONVERSION = Map.class;
+	private static final long serialVersionUID = 2944753067645775624L;
 
 	private final LogicalType elementType;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/NullType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/NullType.java
@@ -42,6 +42,7 @@ public final class NullType extends LogicalType {
 	private static final Class<?> INPUT_CONVERSION = Object.class;
 
 	private static final Class<?> DEFAULT_CONVERSION = Object.class;
+	private static final long serialVersionUID = -6231350505988125500L;
 
 	public NullType() {
 		super(true, LogicalTypeRoot.NULL);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/RawType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/RawType.java
@@ -48,6 +48,7 @@ public final class RawType<T> extends LogicalType {
 	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
 		byte[].class.getName(),
 		"org.apache.flink.table.dataformat.BinaryGeneric");
+	private static final long serialVersionUID = 6908267822495093702L;
 
 	private final Class<T> clazz;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/RowType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/RowType.java
@@ -59,6 +59,7 @@ public final class RowType extends LogicalType {
 		"org.apache.flink.table.dataformat.BaseRow");
 
 	private static final Class<?> DEFAULT_CONVERSION = Row.class;
+	private static final long serialVersionUID = 5006143906767207516L;
 
 	/**
 	 * Describes a field of a {@link RowType}.
@@ -68,6 +69,7 @@ public final class RowType extends LogicalType {
 		private static final String FIELD_FORMAT_WITH_DESCRIPTION = "%s %s '%s'";
 
 		private static final String FIELD_FORMAT_NO_DESCRIPTION = "%s %s";
+		private static final long serialVersionUID = 6729245011235087085L;
 
 		private final String name;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/SmallIntType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/SmallIntType.java
@@ -44,6 +44,7 @@ public final class SmallIntType extends LogicalType {
 		short.class.getName());
 
 	private static final Class<?> DEFAULT_CONVERSION = Short.class;
+	private static final long serialVersionUID = 8602265720662291477L;
 
 	public SmallIntType(boolean isNullable) {
 		super(isNullable, LogicalTypeRoot.SMALLINT);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/StructuredType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/StructuredType.java
@@ -69,12 +69,14 @@ public final class StructuredType extends UserDefinedType {
 		"org.apache.flink.table.dataformat.BaseRow");
 
 	private static final Class<?> FALLBACK_CONVERSION = Row.class;
+	private static final long serialVersionUID = 2420513038724666867L;
 
 	/**
 	 * Defines an attribute of a {@link StructuredType}.
 	 */
 	public static final class StructuredAttribute implements Serializable {
 
+		private static final long serialVersionUID = -700319903741890193L;
 		private final String name;
 
 		private final LogicalType type;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/SymbolType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/SymbolType.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 public final class SymbolType<T extends TableSymbol> extends LogicalType {
 
 	private static final String FORMAT = "SYMBOL('%s')";
+	private static final long serialVersionUID = 1577628001209501797L;
 
 	private final Class<T> symbolClass;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TimeType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TimeType.java
@@ -67,6 +67,7 @@ public final class TimeType extends LogicalType {
 		long.class.getName());
 
 	private static final Class<?> DEFAULT_CONVERSION = java.time.LocalTime.class;
+	private static final long serialVersionUID = -5080782403277114847L;
 
 	private final int precision;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TimestampType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TimestampType.java
@@ -62,6 +62,7 @@ public final class TimestampType extends LogicalType {
 		"org.apache.flink.table.dataformat.SqlTimestamp");
 
 	private static final Class<?> DEFAULT_CONVERSION = java.time.LocalDateTime.class;
+	private static final long serialVersionUID = -4694655935319369854L;
 
 	private final TimestampKind kind;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TinyIntType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TinyIntType.java
@@ -44,6 +44,7 @@ public final class TinyIntType extends LogicalType {
 		byte.class.getName());
 
 	private static final Class<?> DEFAULT_CONVERSION = Byte.class;
+	private static final long serialVersionUID = 6486005562604273960L;
 
 	public TinyIntType(boolean isNullable) {
 		super(isNullable, LogicalTypeRoot.TINYINT);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TypeInformationRawType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TypeInformationRawType.java
@@ -56,6 +56,7 @@ public final class TypeInformationRawType<T> extends LogicalType {
 		"org.apache.flink.table.dataformat.BinaryGeneric");
 
 	private static final TypeInformation<?> DEFAULT_TYPE_INFO = Types.GENERIC(Object.class);
+	private static final long serialVersionUID = 5876285535579538576L;
 
 	private final TypeInformation<T> typeInfo;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/UnresolvedUserDefinedType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/UnresolvedUserDefinedType.java
@@ -39,6 +39,7 @@ import java.util.Objects;
 @PublicEvolving
 public final class UnresolvedUserDefinedType extends LogicalType {
 
+	private static final long serialVersionUID = 5250704960875970218L;
 	private final UnresolvedIdentifier unresolvedIdentifier;
 
 	public UnresolvedUserDefinedType(boolean isNullable, UnresolvedIdentifier unresolvedIdentifier) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/UserDefinedType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/UserDefinedType.java
@@ -44,6 +44,7 @@ import java.util.Optional;
 @PublicEvolving
 public abstract class UserDefinedType extends LogicalType {
 
+	private static final long serialVersionUID = 6434333267999149643L;
 	private final @Nullable ObjectIdentifier objectIdentifier;
 
 	private final boolean isFinal;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/VarBinaryType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/VarBinaryType.java
@@ -58,6 +58,7 @@ public final class VarBinaryType extends LogicalType {
 		"org.apache.flink.table.dataformat.BinaryArray");
 
 	private static final Class<?> DEFAULT_CONVERSION = byte[].class;
+	private static final long serialVersionUID = 9180599544658481469L;
 
 	private final int length;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/VarCharType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/VarCharType.java
@@ -61,6 +61,7 @@ public final class VarCharType extends LogicalType {
 		"org.apache.flink.table.dataformat.BinaryString");
 
 	private static final Class<?> DEFAULT_CONVERSION = String.class;
+	private static final long serialVersionUID = 6823118508245329501L;
 
 	private final int length;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/YearMonthIntervalType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/YearMonthIntervalType.java
@@ -71,6 +71,7 @@ public final class YearMonthIntervalType extends LogicalType {
 		int.class.getName());
 
 	private static final Class<?> DEFAULT_CONVERSION = java.time.Period.class;
+	private static final long serialVersionUID = 4443156320404336831L;
 
 	/**
 	 * Supported resolutions of this type.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/ZonedTimestampType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/ZonedTimestampType.java
@@ -65,6 +65,7 @@ public final class ZonedTimestampType extends LogicalType {
 		java.time.OffsetDateTime.class.getName());
 
 	private static final Class<?> DEFAULT_CONVERSION = java.time.OffsetDateTime.class;
+	private static final long serialVersionUID = -2389360616326023929L;
 
 	private final TimestampKind kind;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/typeutils/TimeIndicatorTypeInfo.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/typeutils/TimeIndicatorTypeInfo.java
@@ -42,6 +42,7 @@ import java.sql.Timestamp;
 @Deprecated
 public class TimeIndicatorTypeInfo extends SqlTimeTypeInfo<Timestamp> {
 
+	private static final long serialVersionUID = -646031288958270039L;
 	private final boolean isEventTime;
 
 	public static final int ROWTIME_STREAM_MARKER = -1;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/AvgAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/AvgAggFunction.java
@@ -44,6 +44,7 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.typeL
  */
 public abstract class AvgAggFunction extends DeclarativeAggregateFunction {
 
+	private static final long serialVersionUID = 975241249450305470L;
 	private UnresolvedReferenceExpression sum = unresolvedRef("sum");
 	private UnresolvedReferenceExpression count = unresolvedRef("count");
 
@@ -115,6 +116,8 @@ public abstract class AvgAggFunction extends DeclarativeAggregateFunction {
 	 */
 	public static class ByteAvgAggFunction extends AvgAggFunction {
 
+		private static final long serialVersionUID = -2029676029819666419L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.TINYINT();
@@ -130,6 +133,8 @@ public abstract class AvgAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Short Avg aggregate function.
 	 */
 	public static class ShortAvgAggFunction extends AvgAggFunction {
+
+		private static final long serialVersionUID = 8401643067662135801L;
 
 		@Override
 		public DataType getResultType() {
@@ -147,6 +152,8 @@ public abstract class AvgAggFunction extends DeclarativeAggregateFunction {
 	 */
 	public static class IntAvgAggFunction extends AvgAggFunction {
 
+		private static final long serialVersionUID = -4337455325008935781L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.INT();
@@ -163,6 +170,8 @@ public abstract class AvgAggFunction extends DeclarativeAggregateFunction {
 	 */
 	public static class LongAvgAggFunction extends AvgAggFunction {
 
+		private static final long serialVersionUID = -6633757591412900073L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.BIGINT();
@@ -178,6 +187,8 @@ public abstract class AvgAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Float Avg aggregate function.
 	 */
 	public static class FloatAvgAggFunction extends AvgAggFunction {
+
+		private static final long serialVersionUID = 1072944519036239545L;
 
 		@Override
 		public DataType getResultType() {
@@ -200,6 +211,8 @@ public abstract class AvgAggFunction extends DeclarativeAggregateFunction {
 	 */
 	public static class DoubleAvgAggFunction extends AvgAggFunction {
 
+		private static final long serialVersionUID = 7762401869968076341L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.DOUBLE();
@@ -221,6 +234,7 @@ public abstract class AvgAggFunction extends DeclarativeAggregateFunction {
 	 */
 	public static class DecimalAvgAggFunction extends AvgAggFunction {
 
+		private static final long serialVersionUID = -1267321500415712959L;
 		private final DecimalType type;
 
 		public DecimalAvgAggFunction(DecimalType type) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/Count1AggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/Count1AggFunction.java
@@ -34,6 +34,7 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.plus;
  * It differs in that null values are also counted.
  */
 public class Count1AggFunction extends DeclarativeAggregateFunction {
+	private static final long serialVersionUID = -1480880543293745965L;
 	private UnresolvedReferenceExpression count1 = unresolvedRef("count1");
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/CountAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/CountAggFunction.java
@@ -34,6 +34,7 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.plus;
  * built-in count aggregate function.
  */
 public class CountAggFunction extends DeclarativeAggregateFunction {
+	private static final long serialVersionUID = -1661755693573261699L;
 	private UnresolvedReferenceExpression count = unresolvedRef("count");
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/DeclarativeAggregateFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/DeclarativeAggregateFunction.java
@@ -52,6 +52,7 @@ import static org.apache.flink.table.expressions.utils.ApiExpressionUtils.unreso
  */
 public abstract class DeclarativeAggregateFunction extends UserDefinedFunction {
 
+	private static final long serialVersionUID = 8551911475496888962L;
 	private transient Set<String> aggBufferNamesCache;
 
 	/**

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/DenseRankAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/DenseRankAggFunction.java
@@ -39,6 +39,8 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.plus;
  */
 public class DenseRankAggFunction extends RankLikeAggFunctionBase {
 
+	private static final long serialVersionUID = -3811790869434872469L;
+
 	public DenseRankAggFunction(LogicalType[] orderKeyTypes) {
 		super(orderKeyTypes);
 	}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunction.java
@@ -37,6 +37,8 @@ import static org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.
  */
 public abstract class FirstValueAggFunction<T> extends AggregateFunction<T, GenericRow> {
 
+	private static final long serialVersionUID = -6799132930154055151L;
+
 	@Override
 	public boolean isDeterministic() {
 		return false;
@@ -97,6 +99,8 @@ public abstract class FirstValueAggFunction<T> extends AggregateFunction<T, Gene
 	 */
 	public static class ByteFirstValueAggFunction extends FirstValueAggFunction<Byte> {
 
+		private static final long serialVersionUID = 3936682589093183446L;
+
 		@Override
 		public TypeInformation<Byte> getResultType() {
 			return Types.BYTE;
@@ -107,6 +111,8 @@ public abstract class FirstValueAggFunction<T> extends AggregateFunction<T, Gene
 	 * Built-in Short FirstValue aggregate function.
 	 */
 	public static class ShortFirstValueAggFunction extends FirstValueAggFunction<Short> {
+
+		private static final long serialVersionUID = -154324226234651483L;
 
 		@Override
 		public TypeInformation<Short> getResultType() {
@@ -119,6 +125,8 @@ public abstract class FirstValueAggFunction<T> extends AggregateFunction<T, Gene
 	 */
 	public static class IntFirstValueAggFunction extends FirstValueAggFunction<Integer> {
 
+		private static final long serialVersionUID = 1535241164814113374L;
+
 		@Override
 		public TypeInformation<Integer> getResultType() {
 			return Types.INT;
@@ -129,6 +137,8 @@ public abstract class FirstValueAggFunction<T> extends AggregateFunction<T, Gene
 	 * Built-in Long FirstValue aggregate function.
 	 */
 	public static class LongFirstValueAggFunction extends FirstValueAggFunction<Long> {
+
+		private static final long serialVersionUID = 763352549277863209L;
 
 		@Override
 		public TypeInformation<Long> getResultType() {
@@ -141,6 +151,8 @@ public abstract class FirstValueAggFunction<T> extends AggregateFunction<T, Gene
 	 */
 	public static class FloatFirstValueAggFunction extends FirstValueAggFunction<Float> {
 
+		private static final long serialVersionUID = 434009975151949222L;
+
 		@Override
 		public TypeInformation<Float> getResultType() {
 			return Types.FLOAT;
@@ -151,6 +163,8 @@ public abstract class FirstValueAggFunction<T> extends AggregateFunction<T, Gene
 	 * Built-in Double FirstValue aggregate function.
 	 */
 	public static class DoubleFirstValueAggFunction extends FirstValueAggFunction<Double> {
+
+		private static final long serialVersionUID = -1499319409575049045L;
 
 		@Override
 		public TypeInformation<Double> getResultType() {
@@ -163,6 +177,8 @@ public abstract class FirstValueAggFunction<T> extends AggregateFunction<T, Gene
 	 */
 	public static class BooleanFirstValueAggFunction extends FirstValueAggFunction<Boolean> {
 
+		private static final long serialVersionUID = 4256890950594337079L;
+
 		@Override
 		public TypeInformation<Boolean> getResultType() {
 			return Types.BOOLEAN;
@@ -174,6 +190,7 @@ public abstract class FirstValueAggFunction<T> extends AggregateFunction<T, Gene
 	 */
 	public static class DecimalFirstValueAggFunction extends FirstValueAggFunction<Decimal> {
 
+		private static final long serialVersionUID = -1785743408763637461L;
 		private DecimalTypeInfo decimalTypeInfo;
 
 		public DecimalFirstValueAggFunction(DecimalTypeInfo decimalTypeInfo) {
@@ -199,6 +216,8 @@ public abstract class FirstValueAggFunction<T> extends AggregateFunction<T, Gene
 	 * Built-in String FirstValue aggregate function.
 	 */
 	public static class StringFirstValueAggFunction extends FirstValueAggFunction<BinaryString> {
+
+		private static final long serialVersionUID = -7711911518711017626L;
 
 		@Override
 		public TypeInformation<BinaryString> getResultType() {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunction.java
@@ -59,6 +59,8 @@ import static org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.
  */
 public abstract class FirstValueWithRetractAggFunction<T> extends AggregateFunction<T, GenericRow> {
 
+	private static final long serialVersionUID = -6696029753947016261L;
+
 	@Override
 	public GenericRow createAccumulator() {
 		// The accumulator schema:
@@ -238,6 +240,8 @@ public abstract class FirstValueWithRetractAggFunction<T> extends AggregateFunct
 	 */
 	public static class ByteFirstValueWithRetractAggFunction extends FirstValueWithRetractAggFunction<Byte> {
 
+		private static final long serialVersionUID = -2286901292206173650L;
+
 		@Override
 		public TypeInformation<Byte> getResultType() {
 			return Types.BYTE;
@@ -253,6 +257,8 @@ public abstract class FirstValueWithRetractAggFunction<T> extends AggregateFunct
 	 * Built-in Short FirstValue with retract aggregate function.
 	 */
 	public static class ShortFirstValueWithRetractAggFunction extends FirstValueWithRetractAggFunction<Short> {
+
+		private static final long serialVersionUID = 7206944069682218668L;
 
 		@Override
 		public TypeInformation<Short> getResultType() {
@@ -270,6 +276,8 @@ public abstract class FirstValueWithRetractAggFunction<T> extends AggregateFunct
 	 */
 	public static class IntFirstValueWithRetractAggFunction extends FirstValueWithRetractAggFunction<Integer> {
 
+		private static final long serialVersionUID = 43002922437426377L;
+
 		@Override
 		public TypeInformation<Integer> getResultType() {
 			return Types.INT;
@@ -285,6 +293,8 @@ public abstract class FirstValueWithRetractAggFunction<T> extends AggregateFunct
 	 * Built-in Long FirstValue with retract aggregate function.
 	 */
 	public static class LongFirstValueWithRetractAggFunction extends FirstValueWithRetractAggFunction<Long> {
+
+		private static final long serialVersionUID = -2894267535182093336L;
 
 		@Override
 		public TypeInformation<Long> getResultType() {
@@ -302,6 +312,8 @@ public abstract class FirstValueWithRetractAggFunction<T> extends AggregateFunct
 	 */
 	public static class FloatFirstValueWithRetractAggFunction extends FirstValueWithRetractAggFunction<Float> {
 
+		private static final long serialVersionUID = 7088689632228939504L;
+
 		@Override
 		public TypeInformation<Float> getResultType() {
 			return Types.FLOAT;
@@ -317,6 +329,8 @@ public abstract class FirstValueWithRetractAggFunction<T> extends AggregateFunct
 	 * Built-in Double FirstValue with retract aggregate function.
 	 */
 	public static class DoubleFirstValueWithRetractAggFunction extends FirstValueWithRetractAggFunction<Double> {
+
+		private static final long serialVersionUID = -5163339300069711629L;
 
 		@Override
 		public TypeInformation<Double> getResultType() {
@@ -334,6 +348,8 @@ public abstract class FirstValueWithRetractAggFunction<T> extends AggregateFunct
 	 */
 	public static class BooleanFirstValueWithRetractAggFunction extends FirstValueWithRetractAggFunction<Boolean> {
 
+		private static final long serialVersionUID = -3733147948107335945L;
+
 		@Override
 		public TypeInformation<Boolean> getResultType() {
 			return Types.BOOLEAN;
@@ -350,6 +366,7 @@ public abstract class FirstValueWithRetractAggFunction<T> extends AggregateFunct
 	 */
 	public static class DecimalFirstValueWithRetractAggFunction extends FirstValueWithRetractAggFunction<Decimal> {
 
+		private static final long serialVersionUID = -3156141385393507615L;
 		private DecimalTypeInfo decimalTypeInfo;
 
 		public DecimalFirstValueWithRetractAggFunction(DecimalTypeInfo decimalTypeInfo) {
@@ -379,6 +396,8 @@ public abstract class FirstValueWithRetractAggFunction<T> extends AggregateFunct
 	 * Built-in String FirstValue with retract aggregate function.
 	 */
 	public static class StringFirstValueWithRetractAggFunction extends FirstValueWithRetractAggFunction<BinaryString> {
+
+		private static final long serialVersionUID = -4841497792158314015L;
 
 		@Override
 		public TypeInformation<BinaryString> getResultType() {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/IncrSumAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/IncrSumAggFunction.java
@@ -40,6 +40,7 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.plus;
  * negative number is discarded to ensure the monotonicity.
  */
 public abstract class IncrSumAggFunction extends DeclarativeAggregateFunction {
+	private static final long serialVersionUID = 7933415886172485187L;
 	private UnresolvedReferenceExpression sum = unresolvedRef("sum");
 
 	@Override
@@ -97,6 +98,8 @@ public abstract class IncrSumAggFunction extends DeclarativeAggregateFunction {
 	 */
 	public static class IntIncrSumAggFunction extends IncrSumAggFunction {
 
+		private static final long serialVersionUID = -6243767185822938173L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.INT();
@@ -107,6 +110,8 @@ public abstract class IncrSumAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Byte IncrSum aggregate function.
 	 */
 	public static class ByteIncrSumAggFunction extends IncrSumAggFunction {
+		private static final long serialVersionUID = -8443171322810537172L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.TINYINT();
@@ -117,6 +122,8 @@ public abstract class IncrSumAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Short IncrSum aggregate function.
 	 */
 	public static class ShortIncrSumAggFunction extends IncrSumAggFunction {
+		private static final long serialVersionUID = 4018634816212971537L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.SMALLINT();
@@ -127,6 +134,8 @@ public abstract class IncrSumAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Long IncrSum aggregate function.
 	 */
 	public static class LongIncrSumAggFunction extends IncrSumAggFunction {
+		private static final long serialVersionUID = -5551726470340429761L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.BIGINT();
@@ -137,6 +146,8 @@ public abstract class IncrSumAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Float IncrSum aggregate function.
 	 */
 	public static class FloatIncrSumAggFunction extends IncrSumAggFunction {
+		private static final long serialVersionUID = -6374058267082628956L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.FLOAT();
@@ -147,6 +158,8 @@ public abstract class IncrSumAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Double IncrSum aggregate function.
 	 */
 	public static class DoubleIncrSumAggFunction extends IncrSumAggFunction {
+		private static final long serialVersionUID = 8486181972245586036L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.DOUBLE();
@@ -157,6 +170,7 @@ public abstract class IncrSumAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Decimal IncrSum aggregate function.
 	 */
 	public static class DecimalIncrSumAggFunction extends IncrSumAggFunction {
+		private static final long serialVersionUID = -7572527429193602022L;
 		private DecimalType decimalType;
 
 		public DecimalIncrSumAggFunction(DecimalType decimalType) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/IncrSumWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/IncrSumWithRetractAggFunction.java
@@ -41,6 +41,7 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.plus;
  * negative number is discarded to ensure the monotonicity.
  */
 public abstract class IncrSumWithRetractAggFunction extends DeclarativeAggregateFunction {
+	private static final long serialVersionUID = 1175878165210529805L;
 	private UnresolvedReferenceExpression sum = unresolvedRef("sum");
 	private UnresolvedReferenceExpression count = unresolvedRef("count");
 
@@ -115,6 +116,8 @@ public abstract class IncrSumWithRetractAggFunction extends DeclarativeAggregate
 	 */
 	public static class IntIncrSumWithRetractAggFunction extends IncrSumWithRetractAggFunction {
 
+		private static final long serialVersionUID = 484901200583089856L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.INT();
@@ -130,6 +133,8 @@ public abstract class IncrSumWithRetractAggFunction extends DeclarativeAggregate
 	 * Built-in Byte IncrSum with retract aggregate function.
 	 */
 	public static class ByteIncrSumWithRetractAggFunction extends IncrSumWithRetractAggFunction {
+		private static final long serialVersionUID = -2883870892267811758L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.TINYINT();
@@ -145,6 +150,8 @@ public abstract class IncrSumWithRetractAggFunction extends DeclarativeAggregate
 	 * Built-in Short IncrSum with retract aggregate function.
 	 */
 	public static class ShortIncrSumWithRetractAggFunction extends IncrSumWithRetractAggFunction {
+		private static final long serialVersionUID = -5770175705341113092L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.SMALLINT();
@@ -160,6 +167,8 @@ public abstract class IncrSumWithRetractAggFunction extends DeclarativeAggregate
 	 * Built-in Long IncrSum with retract aggregate function.
 	 */
 	public static class LongIncrSumWithRetractAggFunction extends IncrSumWithRetractAggFunction {
+		private static final long serialVersionUID = -4904006351435022959L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.BIGINT();
@@ -175,6 +184,8 @@ public abstract class IncrSumWithRetractAggFunction extends DeclarativeAggregate
 	 * Built-in Float IncrSum with retract aggregate function.
 	 */
 	public static class FloatIncrSumWithRetractAggFunction extends IncrSumWithRetractAggFunction {
+		private static final long serialVersionUID = -1393243863101871718L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.FLOAT();
@@ -190,6 +201,8 @@ public abstract class IncrSumWithRetractAggFunction extends DeclarativeAggregate
 	 * Built-in Double IncrSum with retract aggregate function.
 	 */
 	public static class DoubleIncrSumWithRetractAggFunction extends IncrSumWithRetractAggFunction {
+		private static final long serialVersionUID = 3819182686692649492L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.DOUBLE();
@@ -205,6 +218,7 @@ public abstract class IncrSumWithRetractAggFunction extends DeclarativeAggregate
 	 * Built-in Decimal IncrSum with retract aggregate function.
 	 */
 	public static class DecimalIncrSumWithRetractAggFunction extends IncrSumWithRetractAggFunction {
+		private static final long serialVersionUID = -881051610000454228L;
 		private DecimalType decimalType;
 
 		public DecimalIncrSumWithRetractAggFunction(DecimalType decimalType) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunction.java
@@ -37,6 +37,8 @@ import static org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.
  */
 public class LastValueAggFunction<T> extends AggregateFunction<T, GenericRow> {
 
+	private static final long serialVersionUID = -8816714068957450474L;
+
 	@Override
 	public boolean isDeterministic() {
 		return false;
@@ -96,6 +98,8 @@ public class LastValueAggFunction<T> extends AggregateFunction<T, GenericRow> {
 	 */
 	public static class ByteLastValueAggFunction extends LastValueAggFunction<Byte> {
 
+		private static final long serialVersionUID = 417017082825863448L;
+
 		@Override
 		public TypeInformation<Byte> getResultType() {
 			return Types.BYTE;
@@ -106,6 +110,8 @@ public class LastValueAggFunction<T> extends AggregateFunction<T, GenericRow> {
 	 * Built-in Short LastValue aggregate function.
 	 */
 	public static class ShortLastValueAggFunction extends LastValueAggFunction<Short> {
+
+		private static final long serialVersionUID = -5635478625204885184L;
 
 		@Override
 		public TypeInformation<Short> getResultType() {
@@ -118,6 +124,8 @@ public class LastValueAggFunction<T> extends AggregateFunction<T, GenericRow> {
 	 */
 	public static class IntLastValueAggFunction extends LastValueAggFunction<Integer> {
 
+		private static final long serialVersionUID = 272516742473320521L;
+
 		@Override
 		public TypeInformation<Integer> getResultType() {
 			return Types.INT;
@@ -128,6 +136,8 @@ public class LastValueAggFunction<T> extends AggregateFunction<T, GenericRow> {
 	 * Built-in Long LastValue aggregate function.
 	 */
 	public static class LongLastValueAggFunction extends LastValueAggFunction<Long> {
+
+		private static final long serialVersionUID = -7834962560399123016L;
 
 		@Override
 		public TypeInformation<Long> getResultType() {
@@ -140,6 +150,8 @@ public class LastValueAggFunction<T> extends AggregateFunction<T, GenericRow> {
 	 */
 	public static class FloatLastValueAggFunction extends LastValueAggFunction<Float> {
 
+		private static final long serialVersionUID = 5832992434888862894L;
+
 		@Override
 		public TypeInformation<Float> getResultType() {
 			return Types.FLOAT;
@@ -150,6 +162,8 @@ public class LastValueAggFunction<T> extends AggregateFunction<T, GenericRow> {
 	 * Built-in Double LastValue aggregate function.
 	 */
 	public static class DoubleLastValueAggFunction extends LastValueAggFunction<Double> {
+
+		private static final long serialVersionUID = -283443619151134487L;
 
 		@Override
 		public TypeInformation<Double> getResultType() {
@@ -162,6 +176,8 @@ public class LastValueAggFunction<T> extends AggregateFunction<T, GenericRow> {
 	 */
 	public static class BooleanLastValueAggFunction extends LastValueAggFunction<Boolean> {
 
+		private static final long serialVersionUID = -761436642496170737L;
+
 		@Override
 		public TypeInformation<Boolean> getResultType() {
 			return Types.BOOLEAN;
@@ -173,6 +189,7 @@ public class LastValueAggFunction<T> extends AggregateFunction<T, GenericRow> {
 	 */
 	public static class DecimalLastValueAggFunction extends LastValueAggFunction<Decimal> {
 
+		private static final long serialVersionUID = 1861138059380981485L;
 		private DecimalTypeInfo decimalTypeInfo;
 
 		public DecimalLastValueAggFunction(DecimalTypeInfo decimalTypeInfo) {
@@ -198,6 +215,8 @@ public class LastValueAggFunction<T> extends AggregateFunction<T, GenericRow> {
 	 * Built-in String LastValue aggregate function.
 	 */
 	public static class StringLastValueAggFunction extends LastValueAggFunction<BinaryString> {
+
+		private static final long serialVersionUID = 6711143997955182788L;
 
 		@Override
 		public TypeInformation<BinaryString> getResultType() {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunction.java
@@ -59,6 +59,8 @@ import static org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.
  */
 public abstract class LastValueWithRetractAggFunction<T> extends AggregateFunction<T, GenericRow> {
 
+	private static final long serialVersionUID = 4012281729080519375L;
+
 	@Override
 	public GenericRow createAccumulator() {
 		// The accumulator schema:
@@ -239,6 +241,8 @@ public abstract class LastValueWithRetractAggFunction<T> extends AggregateFuncti
 	 */
 	public static class ByteLastValueWithRetractAggFunction extends LastValueWithRetractAggFunction<Byte> {
 
+		private static final long serialVersionUID = -5642035542713438719L;
+
 		@Override
 		public TypeInformation<Byte> getResultType() {
 			return Types.BYTE;
@@ -254,6 +258,8 @@ public abstract class LastValueWithRetractAggFunction<T> extends AggregateFuncti
 	 * Built-in Short LastValue with retract aggregate function.
 	 */
 	public static class ShortLastValueWithRetractAggFunction extends LastValueWithRetractAggFunction<Short> {
+
+		private static final long serialVersionUID = 5986047323289312828L;
 
 		@Override
 		public TypeInformation<Short> getResultType() {
@@ -271,6 +277,8 @@ public abstract class LastValueWithRetractAggFunction<T> extends AggregateFuncti
 	 */
 	public static class IntLastValueWithRetractAggFunction extends LastValueWithRetractAggFunction<Integer> {
 
+		private static final long serialVersionUID = 6594033686363169825L;
+
 		@Override
 		public TypeInformation<Integer> getResultType() {
 			return Types.INT;
@@ -286,6 +294,8 @@ public abstract class LastValueWithRetractAggFunction<T> extends AggregateFuncti
 	 * Built-in Long LastValue with retract aggregate function.
 	 */
 	public static class LongLastValueWithRetractAggFunction extends LastValueWithRetractAggFunction<Long> {
+
+		private static final long serialVersionUID = 7766957448957176951L;
 
 		@Override
 		public TypeInformation<Long> getResultType() {
@@ -303,6 +313,8 @@ public abstract class LastValueWithRetractAggFunction<T> extends AggregateFuncti
 	 */
 	public static class FloatLastValueWithRetractAggFunction extends LastValueWithRetractAggFunction<Float> {
 
+		private static final long serialVersionUID = 7214991831769334683L;
+
 		@Override
 		public TypeInformation<Float> getResultType() {
 			return Types.FLOAT;
@@ -318,6 +330,8 @@ public abstract class LastValueWithRetractAggFunction<T> extends AggregateFuncti
 	 * Built-in Double LastValue with retract aggregate function.
 	 */
 	public static class DoubleLastValueWithRetractAggFunction extends LastValueWithRetractAggFunction<Double> {
+
+		private static final long serialVersionUID = -3033666303852235336L;
 
 		@Override
 		public TypeInformation<Double> getResultType() {
@@ -335,6 +349,8 @@ public abstract class LastValueWithRetractAggFunction<T> extends AggregateFuncti
 	 */
 	public static class BooleanLastValueWithRetractAggFunction extends LastValueWithRetractAggFunction<Boolean> {
 
+		private static final long serialVersionUID = 4978362707083792424L;
+
 		@Override
 		public TypeInformation<Boolean> getResultType() {
 			return Types.BOOLEAN;
@@ -351,6 +367,7 @@ public abstract class LastValueWithRetractAggFunction<T> extends AggregateFuncti
 	 */
 	public static class DecimalLastValueWithRetractAggFunction extends LastValueWithRetractAggFunction<Decimal> {
 
+		private static final long serialVersionUID = 5101603740793591992L;
 		private DecimalTypeInfo decimalTypeInfo;
 
 		public DecimalLastValueWithRetractAggFunction(DecimalTypeInfo decimalTypeInfo) {
@@ -380,6 +397,8 @@ public abstract class LastValueWithRetractAggFunction<T> extends AggregateFuncti
 	 * Built-in String LastValue with retract aggregate function.
 	 */
 	public static class StringLastValueWithRetractAggFunction extends LastValueWithRetractAggFunction<BinaryString> {
+
+		private static final long serialVersionUID = -6675623285238125754L;
 
 		@Override
 		public TypeInformation<BinaryString> getResultType() {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LeadLagAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LeadLagAggFunction.java
@@ -53,6 +53,7 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.typeL
  */
 public abstract class LeadLagAggFunction extends DeclarativeAggregateFunction {
 
+	private static final long serialVersionUID = 7652731621932551900L;
 	private int operandCount;
 
 	//If the length of function's args is 3, then the function has the default value.
@@ -112,6 +113,8 @@ public abstract class LeadLagAggFunction extends DeclarativeAggregateFunction {
 	 */
 	public static class IntLeadLagAggFunction extends LeadLagAggFunction {
 
+		private static final long serialVersionUID = -2060602850211643698L;
+
 		public IntLeadLagAggFunction(int operandCount) {
 			super(operandCount);
 		}
@@ -126,6 +129,8 @@ public abstract class LeadLagAggFunction extends DeclarativeAggregateFunction {
 	 * ByteLeadLagAggFunction.
 	 */
 	public static class ByteLeadLagAggFunction extends LeadLagAggFunction {
+
+		private static final long serialVersionUID = -8605047597484096002L;
 
 		public ByteLeadLagAggFunction(int operandCount) {
 			super(operandCount);
@@ -142,6 +147,8 @@ public abstract class LeadLagAggFunction extends DeclarativeAggregateFunction {
 	 */
 	public static class ShortLeadLagAggFunction extends LeadLagAggFunction {
 
+		private static final long serialVersionUID = -3208149822832947692L;
+
 		public ShortLeadLagAggFunction(int operandCount) {
 			super(operandCount);
 		}
@@ -156,6 +163,8 @@ public abstract class LeadLagAggFunction extends DeclarativeAggregateFunction {
 	 * LongLeadLagAggFunction.
 	 */
 	public static class LongLeadLagAggFunction extends LeadLagAggFunction {
+
+		private static final long serialVersionUID = -6206481734333687709L;
 
 		public LongLeadLagAggFunction(int operandCount) {
 			super(operandCount);
@@ -172,6 +181,8 @@ public abstract class LeadLagAggFunction extends DeclarativeAggregateFunction {
 	 */
 	public static class FloatLeadLagAggFunction extends LeadLagAggFunction {
 
+		private static final long serialVersionUID = 6508088598090291064L;
+
 		public FloatLeadLagAggFunction(int operandCount) {
 			super(operandCount);
 		}
@@ -186,6 +197,8 @@ public abstract class LeadLagAggFunction extends DeclarativeAggregateFunction {
 	 * DoubleLeadLagAggFunction.
 	 */
 	public static class DoubleLeadLagAggFunction extends LeadLagAggFunction {
+
+		private static final long serialVersionUID = -6162427441172058160L;
 
 		public DoubleLeadLagAggFunction(int operandCount) {
 			super(operandCount);
@@ -202,6 +215,8 @@ public abstract class LeadLagAggFunction extends DeclarativeAggregateFunction {
 	 */
 	public static class BooleanLeadLagAggFunction extends LeadLagAggFunction {
 
+		private static final long serialVersionUID = -6308510847074099342L;
+
 		public BooleanLeadLagAggFunction(int operandCount) {
 			super(operandCount);
 		}
@@ -217,6 +232,7 @@ public abstract class LeadLagAggFunction extends DeclarativeAggregateFunction {
 	 */
 	public static class DecimalLeadLagAggFunction extends LeadLagAggFunction {
 
+		private static final long serialVersionUID = -7935934589432215304L;
 		private final DecimalType decimalType;
 
 		public DecimalLeadLagAggFunction(int operandCount, DecimalType decimalType) {
@@ -235,6 +251,8 @@ public abstract class LeadLagAggFunction extends DeclarativeAggregateFunction {
 	 */
 	public static class StringLeadLagAggFunction extends LeadLagAggFunction {
 
+		private static final long serialVersionUID = -6191577270211530355L;
+
 		public StringLeadLagAggFunction(int operandCount) {
 			super(operandCount);
 		}
@@ -249,6 +267,8 @@ public abstract class LeadLagAggFunction extends DeclarativeAggregateFunction {
 	 * DateLeadLagAggFunction.
 	 */
 	public static class DateLeadLagAggFunction extends LeadLagAggFunction {
+
+		private static final long serialVersionUID = -4817040636555040281L;
 
 		public DateLeadLagAggFunction(int operandCount) {
 			super(operandCount);
@@ -265,6 +285,8 @@ public abstract class LeadLagAggFunction extends DeclarativeAggregateFunction {
 	 */
 	public static class TimeLeadLagAggFunction extends LeadLagAggFunction {
 
+		private static final long serialVersionUID = -1458918342641690396L;
+
 		public TimeLeadLagAggFunction(int operandCount) {
 			super(operandCount);
 		}
@@ -280,6 +302,7 @@ public abstract class LeadLagAggFunction extends DeclarativeAggregateFunction {
 	 */
 	public static class TimestampLeadLagAggFunction extends LeadLagAggFunction {
 
+		private static final long serialVersionUID = 4333065387205898842L;
 		private final TimestampType type;
 
 		public TimestampLeadLagAggFunction(int operandCount, TimestampType type) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/ListAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/ListAggFunction.java
@@ -35,6 +35,7 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.nullO
  * built-in listagg aggregate function.
  */
 public class ListAggFunction extends DeclarativeAggregateFunction {
+	private static final long serialVersionUID = -6893433965728144598L;
 	private int operandCount;
 	private UnresolvedReferenceExpression acc = unresolvedRef("concatAcc");
 	private UnresolvedReferenceExpression accDelimiter = unresolvedRef("accDelimiter");

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MaxAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MaxAggFunction.java
@@ -36,6 +36,7 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.nullO
  * built-in max aggregate function.
  */
 public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
+	private static final long serialVersionUID = -1021368827972131085L;
 	private UnresolvedReferenceExpression max = unresolvedRef("max");
 
 	@Override
@@ -97,6 +98,8 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 	 */
 	public static class IntMaxAggFunction extends MaxAggFunction {
 
+		private static final long serialVersionUID = -346973537330797486L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.INT();
@@ -107,6 +110,8 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Byte Max aggregate function.
 	 */
 	public static class ByteMaxAggFunction extends MaxAggFunction {
+		private static final long serialVersionUID = 2464999191564164262L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.TINYINT();
@@ -117,6 +122,8 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Short Max aggregate function.
 	 */
 	public static class ShortMaxAggFunction extends MaxAggFunction {
+		private static final long serialVersionUID = -6993549220463516194L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.SMALLINT();
@@ -127,6 +134,8 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Long Max aggregate function.
 	 */
 	public static class LongMaxAggFunction extends MaxAggFunction {
+		private static final long serialVersionUID = -6426489081313637174L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.BIGINT();
@@ -137,6 +146,8 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Float Max aggregate function.
 	 */
 	public static class FloatMaxAggFunction extends MaxAggFunction {
+		private static final long serialVersionUID = -7079825099097062325L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.FLOAT();
@@ -147,6 +158,8 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Double Max aggregate function.
 	 */
 	public static class DoubleMaxAggFunction extends MaxAggFunction {
+		private static final long serialVersionUID = 7622478335611977243L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.DOUBLE();
@@ -157,6 +170,7 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Decimal Max aggregate function.
 	 */
 	public static class DecimalMaxAggFunction extends MaxAggFunction {
+		private static final long serialVersionUID = -6972660255107602175L;
 		private DecimalType decimalType;
 
 		public DecimalMaxAggFunction(DecimalType decimalType) {
@@ -173,6 +187,8 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Boolean Max aggregate function.
 	 */
 	public static class BooleanMaxAggFunction extends MaxAggFunction {
+		private static final long serialVersionUID = 8583528286822289781L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.BOOLEAN();
@@ -183,6 +199,8 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in String Max aggregate function.
 	 */
 	public static class StringMaxAggFunction extends MaxAggFunction {
+		private static final long serialVersionUID = -6652260773775186990L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.STRING();
@@ -193,6 +211,8 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Date Max aggregate function.
 	 */
 	public static class DateMaxAggFunction extends MaxAggFunction {
+		private static final long serialVersionUID = 1333679646611975978L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.DATE();
@@ -203,6 +223,8 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Time Max aggregate function.
 	 */
 	public static class TimeMaxAggFunction extends MaxAggFunction {
+		private static final long serialVersionUID = -1830329255594027234L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.TIME(TimeType.DEFAULT_PRECISION);
@@ -214,6 +236,7 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 	 */
 	public static class TimestampMaxAggFunction extends MaxAggFunction {
 
+		private static final long serialVersionUID = 4039616257563422874L;
 		private final TimestampType type;
 
 		public TimestampMaxAggFunction(TimestampType type) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MinAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MinAggFunction.java
@@ -36,6 +36,7 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.nullO
  * built-in min aggregate function.
  */
 public abstract class MinAggFunction extends DeclarativeAggregateFunction {
+	private static final long serialVersionUID = 3674724683138964189L;
 	private UnresolvedReferenceExpression min = unresolvedRef("min");
 
 	@Override
@@ -97,6 +98,8 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 	 */
 	public static class IntMinAggFunction extends MinAggFunction {
 
+		private static final long serialVersionUID = -4607955890514445445L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.INT();
@@ -107,6 +110,8 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Byte Min aggregate function.
 	 */
 	public static class ByteMinAggFunction extends MinAggFunction {
+		private static final long serialVersionUID = -1831919297390344422L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.TINYINT();
@@ -117,6 +122,8 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Short Min aggregate function.
 	 */
 	public static class ShortMinAggFunction extends MinAggFunction {
+		private static final long serialVersionUID = 8558533668591177560L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.SMALLINT();
@@ -127,6 +134,8 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Long Min aggregate function.
 	 */
 	public static class LongMinAggFunction extends MinAggFunction {
+		private static final long serialVersionUID = 5304169477692989308L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.BIGINT();
@@ -137,6 +146,8 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Float Min aggregate function.
 	 */
 	public static class FloatMinAggFunction extends MinAggFunction {
+		private static final long serialVersionUID = -6777201532701947645L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.FLOAT();
@@ -147,6 +158,8 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Double Min aggregate function.
 	 */
 	public static class DoubleMinAggFunction extends MinAggFunction {
+		private static final long serialVersionUID = -7684340355510934352L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.DOUBLE();
@@ -157,6 +170,7 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Decimal Min aggregate function.
 	 */
 	public static class DecimalMinAggFunction extends MinAggFunction {
+		private static final long serialVersionUID = -547727868230316469L;
 		private DecimalType decimalType;
 
 		public DecimalMinAggFunction(DecimalType decimalType) {
@@ -173,6 +187,8 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Boolean Min aggregate function.
 	 */
 	public static class BooleanMinAggFunction extends MinAggFunction {
+		private static final long serialVersionUID = -1092575652544749688L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.BOOLEAN();
@@ -183,6 +199,8 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in String Min aggregate function.
 	 */
 	public static class StringMinAggFunction extends MinAggFunction {
+		private static final long serialVersionUID = 7786788048951000087L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.STRING();
@@ -193,6 +211,8 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Date Min aggregate function.
 	 */
 	public static class DateMinAggFunction extends MinAggFunction {
+		private static final long serialVersionUID = -868326618604086696L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.DATE();
@@ -203,6 +223,8 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Time Min aggregate function.
 	 */
 	public static class TimeMinAggFunction extends MinAggFunction {
+		private static final long serialVersionUID = -7436220934453882025L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.TIME(TimeType.DEFAULT_PRECISION);
@@ -214,6 +236,7 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 	 */
 	public static class TimestampMinAggFunction extends MinAggFunction {
 
+		private static final long serialVersionUID = -2384047607645725885L;
 		private final TimestampType type;
 
 		public TimestampMinAggFunction(TimestampType type) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/RankAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/RankAggFunction.java
@@ -40,6 +40,7 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.plus;
  */
 public class RankAggFunction extends RankLikeAggFunctionBase {
 
+	private static final long serialVersionUID = 5794518471315082213L;
 	private UnresolvedReferenceExpression currNumber = unresolvedRef("currNumber");
 
 	public RankAggFunction(LogicalType[] orderKeyTypes) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/RankLikeAggFunctionBase.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/RankLikeAggFunctionBase.java
@@ -45,6 +45,7 @@ import static org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.
  * built-in rank like aggregate function, e.g. rank, dense_rank
  */
 public abstract class RankLikeAggFunctionBase extends DeclarativeAggregateFunction {
+	private static final long serialVersionUID = -8045653866304133520L;
 	protected UnresolvedReferenceExpression sequence = unresolvedRef("sequence");
 	protected UnresolvedReferenceExpression[] lastValues;
 	protected LogicalType[] orderKeyTypes;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/RowNumberAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/RowNumberAggFunction.java
@@ -32,6 +32,7 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.plus;
  * built-in row_number aggregate function.
  */
 public class RowNumberAggFunction extends DeclarativeAggregateFunction {
+	private static final long serialVersionUID = -9089799228892124786L;
 	private UnresolvedReferenceExpression sequence = unresolvedRef("seq");
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/Sum0AggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/Sum0AggFunction.java
@@ -38,6 +38,7 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.plus;
  * built-in sum0 aggregate function.
  */
 public abstract class Sum0AggFunction extends DeclarativeAggregateFunction {
+	private static final long serialVersionUID = -5582025948586476752L;
 	private UnresolvedReferenceExpression sum0 = unresolvedRef("sum");
 
 	@Override
@@ -86,6 +87,8 @@ public abstract class Sum0AggFunction extends DeclarativeAggregateFunction {
 	 */
 	public static class IntSum0AggFunction extends Sum0AggFunction {
 
+		private static final long serialVersionUID = 7937751239693336948L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.INT();
@@ -103,6 +106,8 @@ public abstract class Sum0AggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Byte Sum0 aggregate function.
 	 */
 	public static class ByteSum0AggFunction extends Sum0AggFunction {
+		private static final long serialVersionUID = 776401386606727702L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.TINYINT();
@@ -120,6 +125,8 @@ public abstract class Sum0AggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Short Sum0 aggregate function.
 	 */
 	public static class ShortSum0AggFunction extends Sum0AggFunction {
+		private static final long serialVersionUID = -8750936580392780942L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.SMALLINT();
@@ -137,6 +144,8 @@ public abstract class Sum0AggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Long Sum0 aggregate function.
 	 */
 	public static class LongSum0AggFunction extends Sum0AggFunction {
+		private static final long serialVersionUID = 7635782017193705389L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.BIGINT();
@@ -154,6 +163,8 @@ public abstract class Sum0AggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Float Sum0 aggregate function.
 	 */
 	public static class FloatSum0AggFunction extends Sum0AggFunction {
+		private static final long serialVersionUID = 5107172578594068497L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.FLOAT();
@@ -171,6 +182,8 @@ public abstract class Sum0AggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Double Sum0 aggregate function.
 	 */
 	public static class DoubleSum0AggFunction extends Sum0AggFunction {
+		private static final long serialVersionUID = 3586731691994327856L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.DOUBLE();
@@ -188,6 +201,7 @@ public abstract class Sum0AggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Decimal Sum0 aggregate function.
 	 */
 	public static class DecimalSum0AggFunction extends Sum0AggFunction {
+		private static final long serialVersionUID = -1669010425688421148L;
 		private DecimalType decimalType;
 
 		public DecimalSum0AggFunction(DecimalType decimalType) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/SumAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/SumAggFunction.java
@@ -36,6 +36,7 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.plus;
  * built-in sum aggregate function.
  */
 public abstract class SumAggFunction extends DeclarativeAggregateFunction {
+	private static final long serialVersionUID = -5794849094339441184L;
 	private UnresolvedReferenceExpression sum = unresolvedRef("sum");
 
 	@Override
@@ -93,6 +94,8 @@ public abstract class SumAggFunction extends DeclarativeAggregateFunction {
 	 */
 	public static class IntSumAggFunction extends SumAggFunction {
 
+		private static final long serialVersionUID = 8365254761563089098L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.INT();
@@ -103,6 +106,8 @@ public abstract class SumAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Byte Sum aggregate function.
 	 */
 	public static class ByteSumAggFunction extends SumAggFunction {
+		private static final long serialVersionUID = 5867389554771338211L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.TINYINT();
@@ -113,6 +118,8 @@ public abstract class SumAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Short Sum aggregate function.
 	 */
 	public static class ShortSumAggFunction extends SumAggFunction {
+		private static final long serialVersionUID = 2530980739045756612L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.SMALLINT();
@@ -123,6 +130,8 @@ public abstract class SumAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Long Sum aggregate function.
 	 */
 	public static class LongSumAggFunction extends SumAggFunction {
+		private static final long serialVersionUID = -1837484488995718395L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.BIGINT();
@@ -133,6 +142,8 @@ public abstract class SumAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Float Sum aggregate function.
 	 */
 	public static class FloatSumAggFunction extends SumAggFunction {
+		private static final long serialVersionUID = -6366261260873715575L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.FLOAT();
@@ -143,6 +154,8 @@ public abstract class SumAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Double Sum aggregate function.
 	 */
 	public static class DoubleSumAggFunction extends SumAggFunction {
+		private static final long serialVersionUID = -6922567792476094301L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.DOUBLE();
@@ -153,6 +166,7 @@ public abstract class SumAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Decimal Sum aggregate function.
 	 */
 	public static class DecimalSumAggFunction extends SumAggFunction {
+		private static final long serialVersionUID = -3376895759033178090L;
 		private DecimalType decimalType;
 
 		public DecimalSumAggFunction(DecimalType decimalType) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/SumWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/SumWithRetractAggFunction.java
@@ -38,6 +38,7 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.plus;
  * built-in sum aggregate function with retraction.
  */
 public abstract class SumWithRetractAggFunction extends DeclarativeAggregateFunction {
+	private static final long serialVersionUID = -5572214974014080049L;
 	private UnresolvedReferenceExpression sum = unresolvedRef("sum");
 	private UnresolvedReferenceExpression count = unresolvedRef("count");
 
@@ -111,6 +112,8 @@ public abstract class SumWithRetractAggFunction extends DeclarativeAggregateFunc
 	 */
 	public static class IntSumWithRetractAggFunction extends SumWithRetractAggFunction {
 
+		private static final long serialVersionUID = -8785590716600466349L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.INT();
@@ -126,6 +129,8 @@ public abstract class SumWithRetractAggFunction extends DeclarativeAggregateFunc
 	 * Built-in Byte Sum with retract aggregate function.
 	 */
 	public static class ByteSumWithRetractAggFunction extends SumWithRetractAggFunction {
+		private static final long serialVersionUID = -1341816698738313033L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.TINYINT();
@@ -141,6 +146,8 @@ public abstract class SumWithRetractAggFunction extends DeclarativeAggregateFunc
 	 * Built-in Short Sum with retract aggregate function.
 	 */
 	public static class ShortSumWithRetractAggFunction extends SumWithRetractAggFunction {
+		private static final long serialVersionUID = 7205140045688545871L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.SMALLINT();
@@ -156,6 +163,8 @@ public abstract class SumWithRetractAggFunction extends DeclarativeAggregateFunc
 	 * Built-in Long Sum with retract aggregate function.
 	 */
 	public static class LongSumWithRetractAggFunction extends SumWithRetractAggFunction {
+		private static final long serialVersionUID = -3547413364214335132L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.BIGINT();
@@ -171,6 +180,8 @@ public abstract class SumWithRetractAggFunction extends DeclarativeAggregateFunc
 	 * Built-in Float Sum with retract aggregate function.
 	 */
 	public static class FloatSumWithRetractAggFunction extends SumWithRetractAggFunction {
+		private static final long serialVersionUID = 1523548017063617544L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.FLOAT();
@@ -186,6 +197,8 @@ public abstract class SumWithRetractAggFunction extends DeclarativeAggregateFunc
 	 * Built-in Double Sum with retract aggregate function.
 	 */
 	public static class DoubleSumWithRetractAggFunction extends SumWithRetractAggFunction {
+		private static final long serialVersionUID = 399952772420854478L;
+
 		@Override
 		public DataType getResultType() {
 			return DataTypes.DOUBLE();
@@ -201,6 +214,7 @@ public abstract class SumWithRetractAggFunction extends DeclarativeAggregateFunc
 	 * Built-in Decimal Sum with retract aggregate function.
 	 */
 	public static class DecimalSumWithRetractAggFunction extends SumWithRetractAggFunction {
+		private static final long serialVersionUID = 2108751914303356747L;
 		private DecimalType decimalType;
 
 		public DecimalSumWithRetractAggFunction(DecimalType decimalType) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/utils/HiveTableSqlFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/utils/HiveTableSqlFunction.java
@@ -209,6 +209,7 @@ public class HiveTableSqlFunction extends TableSqlFunction {
 	/** Thrown when a non-literal occurs in an argument to a user-defined
 	 * table macro. */
 	private static class NonLiteralException extends Exception {
+		private static final long serialVersionUID = 5765206484034890736L;
 	}
 
 	public static HiveOperandTypeChecker operandTypeChecker(

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/AbstractHeapVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/AbstractHeapVector.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
  */
 public abstract class AbstractHeapVector extends AbstractColumnVector {
 
+	private static final long serialVersionUID = -3356469726902177763L;
 	/*
 	 * If hasNulls is true, then this array contains true if the value
 	 * is null, otherwise false. The array is always allocated, so a batch can be re-used

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/generated/GeneratedClass.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/generated/GeneratedClass.java
@@ -28,6 +28,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public abstract class GeneratedClass<T> implements Serializable {
 
+	private static final long serialVersionUID = 6170410716745042722L;
 	private final String className;
 	private final String code;
 	private final Object[] references;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/AbstractProcessStreamOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/AbstractProcessStreamOperator.java
@@ -34,6 +34,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 public abstract class AbstractProcessStreamOperator<OUT> extends TableStreamOperator<OUT> {
 
+	private static final long serialVersionUID = 7531021943763779788L;
 	/** We listen to this ourselves because we don't have an {@link InternalTimerService}. */
 	protected long currentWatermark = Long.MIN_VALUE;
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/CodeGenOperatorFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/CodeGenOperatorFactory.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.runtime.generated.GeneratedClass;
  */
 public class CodeGenOperatorFactory<OUT> implements StreamOperatorFactory<OUT> {
 
+	private static final long serialVersionUID = 7979653931789036565L;
 	private final GeneratedClass<? extends StreamOperator<OUT>> generatedClass;
 	private ChainingStrategy strategy = ChainingStrategy.ALWAYS;
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/TableStreamOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/TableStreamOperator.java
@@ -26,6 +26,7 @@ import org.apache.flink.streaming.api.operators.ChainingStrategy;
  */
 public class TableStreamOperator<OUT> extends AbstractStreamOperator<OUT> {
 
+	private static final long serialVersionUID = -956312987598051891L;
 	private volatile boolean closed = false;
 
 	public TableStreamOperator() {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/bundle/trigger/CountCoBundleTrigger.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/bundle/trigger/CountCoBundleTrigger.java
@@ -26,6 +26,7 @@ import org.apache.flink.util.Preconditions;
  */
 public class CountCoBundleTrigger<IN1, IN2> implements CoBundleTrigger<IN1, IN2> {
 
+	private static final long serialVersionUID = -8531642947833842485L;
 	private final long maxCount;
 	private transient BundleTriggerCallback callback;
 	private transient long count = 0;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/HashJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/HashJoinOperator.java
@@ -60,6 +60,7 @@ public abstract class HashJoinOperator extends TableStreamOperator<BaseRow>
 		BoundedMultiInput, InputSelectable {
 
 	private static final Logger LOG = LoggerFactory.getLogger(HashJoinOperator.class);
+	private static final long serialVersionUID = -5155548304883122847L;
 
 	private final HashJoinParameter parameter;
 	private final boolean reverseJoinFunction;
@@ -259,6 +260,7 @@ public abstract class HashJoinOperator extends TableStreamOperator<BaseRow>
 	}
 
 	static class HashJoinParameter implements Serializable {
+		private static final long serialVersionUID = 3197273536526500680L;
 		HashJoinType type;
 		GeneratedJoinCondition condFuncCode;
 		boolean reverseJoinFunction;
@@ -298,6 +300,8 @@ public abstract class HashJoinOperator extends TableStreamOperator<BaseRow>
 	 */
 	private static class InnerHashJoinOperator extends HashJoinOperator {
 
+		private static final long serialVersionUID = -7303592457433096787L;
+
 		InnerHashJoinOperator(HashJoinParameter parameter) {
 			super(parameter);
 		}
@@ -319,6 +323,8 @@ public abstract class HashJoinOperator extends TableStreamOperator<BaseRow>
 	 * build side row and nulls.
 	 */
 	private static class BuildOuterHashJoinOperator extends HashJoinOperator {
+
+		private static final long serialVersionUID = 7757824713273865230L;
 
 		BuildOuterHashJoinOperator(HashJoinParameter parameter) {
 			super(parameter);
@@ -344,6 +350,8 @@ public abstract class HashJoinOperator extends TableStreamOperator<BaseRow>
 	 */
 	private static class ProbeOuterHashJoinOperator extends HashJoinOperator {
 
+		private static final long serialVersionUID = 6174945949776020291L;
+
 		ProbeOuterHashJoinOperator(HashJoinParameter parameter) {
 			super(parameter);
 		}
@@ -367,6 +375,8 @@ public abstract class HashJoinOperator extends TableStreamOperator<BaseRow>
 	 * nulls and probe side row.
 	 */
 	private static class FullOuterHashJoinOperator extends HashJoinOperator {
+
+		private static final long serialVersionUID = -1885722266784967780L;
 
 		FullOuterHashJoinOperator(HashJoinParameter parameter) {
 			super(parameter);
@@ -392,6 +402,8 @@ public abstract class HashJoinOperator extends TableStreamOperator<BaseRow>
 	 */
 	private static class SemiHashJoinOperator extends HashJoinOperator {
 
+		private static final long serialVersionUID = -3708173821094268955L;
+
 		SemiHashJoinOperator(HashJoinParameter parameter) {
 			super(parameter);
 		}
@@ -410,6 +422,8 @@ public abstract class HashJoinOperator extends TableStreamOperator<BaseRow>
 	 * Output probe side row when probe side row not matched build side row.
 	 */
 	private static class AntiHashJoinOperator extends HashJoinOperator {
+
+		private static final long serialVersionUID = 2101030404109248431L;
 
 		AntiHashJoinOperator(HashJoinParameter parameter) {
 			super(parameter);
@@ -430,6 +444,8 @@ public abstract class HashJoinOperator extends TableStreamOperator<BaseRow>
 	 * BuildLeftAntiJoin: Output build side row when build side row not matched probe side row.
 	 */
 	private static class BuildLeftSemiOrAntiHashJoinOperator extends HashJoinOperator {
+
+		private static final long serialVersionUID = 6747638273027931682L;
 
 		BuildLeftSemiOrAntiHashJoinOperator(HashJoinParameter parameter) {
 			super(parameter);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/SortMergeJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/SortMergeJoinOperator.java
@@ -64,6 +64,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class SortMergeJoinOperator extends TableStreamOperator<BaseRow>
 		implements TwoInputStreamOperator<BaseRow, BaseRow, BaseRow>, BoundedMultiInput {
 
+	private static final long serialVersionUID = 6323137265794479828L;
 	private final double externalBufferMemRatio;
 	private final FlinkJoinType type;
 	private final boolean leftIsSmaller;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/TimeBoundedStreamJoin.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/TimeBoundedStreamJoin.java
@@ -51,6 +51,7 @@ import java.util.Map;
  */
 abstract class TimeBoundedStreamJoin extends CoProcessFunction<BaseRow, BaseRow, BaseRow> {
 	private static final Logger LOGGER = LoggerFactory.getLogger(TimeBoundedStreamJoin.class);
+	private static final long serialVersionUID = 7938797945142392067L;
 	private final FlinkJoinType joinType;
 	protected final long leftRelativeSize;
 	protected final long rightRelativeSize;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/AbstractStreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/AbstractStreamingJoinOperator.java
@@ -128,6 +128,7 @@ public abstract class AbstractStreamingJoinOperator extends AbstractStreamOperat
 
 	private class JoinConditionWithNullFilters extends AbstractRichFunction implements JoinCondition {
 
+		private static final long serialVersionUID = 8912032248656195739L;
 		final JoinCondition backingJoinCondition;
 
 		private JoinConditionWithNullFilters(JoinCondition backingJoinCondition) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/BufferDataOverWindowOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/BufferDataOverWindowOperator.java
@@ -40,6 +40,7 @@ import org.apache.flink.table.runtime.util.StreamRecordCollector;
 public class BufferDataOverWindowOperator extends TableStreamOperator<BaseRow>
 		implements OneInputStreamOperator<BaseRow, BaseRow>, BoundedOneInput {
 
+	private static final long serialVersionUID = -5438540602758074254L;
 	private final OverWindowFrame[] overWindowFrames;
 	private GeneratedRecordComparator genComparator;
 	private final boolean isRowAllInFixedPart;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/NonBufferOverWindowOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/NonBufferOverWindowOperator.java
@@ -43,6 +43,7 @@ import org.apache.flink.table.runtime.util.StreamRecordCollector;
 public class NonBufferOverWindowOperator extends TableStreamOperator<BaseRow>
 		implements OneInputStreamOperator<BaseRow, BaseRow> {
 
+	private static final long serialVersionUID = 7967448806235990975L;
 	private GeneratedAggsHandleFunction[] aggsHandlers;
 	private GeneratedRecordComparator genComparator;
 	private final boolean[] resetAccumulators;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/InsensitiveOverFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/InsensitiveOverFrame.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.runtime.util.ResettableExternalBuffer;
  */
 public class InsensitiveOverFrame implements OverWindowFrame {
 
+	private static final long serialVersionUID = -5475432869417084615L;
 	private GeneratedAggsHandleFunction aggsHandleFunction;
 	private AggsHandleFunction processor;
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/OffsetOverFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/OffsetOverFrame.java
@@ -34,6 +34,7 @@ import java.io.Serializable;
  */
 public class OffsetOverFrame implements OverWindowFrame {
 
+	private static final long serialVersionUID = -5227394416929264870L;
 	private GeneratedAggsHandleFunction aggsHandleFunction;
 	private final Long offset;
 	private final CalcOffsetFunc calcOffsetFunc;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/RangeSlidingOverFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/RangeSlidingOverFrame.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.types.logical.RowType;
  */
 public class RangeSlidingOverFrame extends SlidingOverFrame {
 
+	private static final long serialVersionUID = -270458761628140847L;
 	private GeneratedRecordComparator lboundComparator;
 	private GeneratedRecordComparator rboundComparator;
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/RangeUnboundedFollowingOverFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/RangeUnboundedFollowingOverFrame.java
@@ -36,6 +36,7 @@ import org.apache.flink.table.types.logical.RowType;
  */
 public class RangeUnboundedFollowingOverFrame extends UnboundedFollowingOverFrame {
 
+	private static final long serialVersionUID = 4298273776270070197L;
 	private GeneratedRecordComparator boundComparator;
 	private RecordComparator lbound;
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/RangeUnboundedPrecedingOverFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/RangeUnboundedPrecedingOverFrame.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.runtime.generated.RecordComparator;
  */
 public class RangeUnboundedPrecedingOverFrame extends UnboundedPrecedingOverFrame {
 
+	private static final long serialVersionUID = -2757800141545417599L;
 	private GeneratedRecordComparator boundComparator;
 	private RecordComparator rbound;
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/RowSlidingOverFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/RowSlidingOverFrame.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.types.logical.RowType;
  */
 public class RowSlidingOverFrame extends SlidingOverFrame {
 
+	private static final long serialVersionUID = 753442589672349323L;
 	private final long leftBound;
 	private final long rightBound;
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/RowUnboundedFollowingOverFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/RowUnboundedFollowingOverFrame.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.types.logical.RowType;
  */
 public class RowUnboundedFollowingOverFrame extends UnboundedFollowingOverFrame {
 
+	private static final long serialVersionUID = -5477935598548574457L;
 	private long leftBound;
 
 	public RowUnboundedFollowingOverFrame(

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/RowUnboundedPrecedingOverFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/RowUnboundedPrecedingOverFrame.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.runtime.util.ResettableExternalBuffer;
  */
 public class RowUnboundedPrecedingOverFrame extends UnboundedPrecedingOverFrame {
 
+	private static final long serialVersionUID = -7691544183298171887L;
 	private long rightBound;
 
 	/**

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/SlidingOverFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/SlidingOverFrame.java
@@ -37,6 +37,7 @@ import java.util.ArrayDeque;
  */
 public abstract class SlidingOverFrame implements OverWindowFrame {
 
+	private static final long serialVersionUID = -5618243937987210918L;
 	private final RowType inputType;
 	private final RowType valueType;
 	private GeneratedAggsHandleFunction aggsHandleFunction;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/UnboundedFollowingOverFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/UnboundedFollowingOverFrame.java
@@ -34,6 +34,7 @@ import org.apache.flink.table.types.logical.RowType;
  */
 public abstract class UnboundedFollowingOverFrame implements OverWindowFrame {
 
+	private static final long serialVersionUID = -578937867598357659L;
 	private GeneratedAggsHandleFunction aggsHandleFunction;
 	private final RowType valueType;
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/UnboundedOverWindowFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/UnboundedOverWindowFrame.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.types.logical.RowType;
  */
 public class UnboundedOverWindowFrame implements OverWindowFrame {
 
+	private static final long serialVersionUID = -7592809824581428310L;
 	private GeneratedAggsHandleFunction aggsHandleFunction;
 	private final RowType valueType;
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/UnboundedPrecedingOverFrame.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/frame/UnboundedPrecedingOverFrame.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.runtime.util.ResettableExternalBuffer;
  */
 public abstract class UnboundedPrecedingOverFrame implements OverWindowFrame {
 
+	private static final long serialVersionUID = -737968983461915424L;
 	private GeneratedAggsHandleFunction aggsHandleFunction;
 
 	AggsHandleFunction processor;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AbstractTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AbstractTopNFunction.java
@@ -60,6 +60,7 @@ public abstract class AbstractTopNFunction extends KeyedProcessFunctionWithClean
 
 	// we set default topN size to 100
 	private static final long DEFAULT_TOPN_SIZE = 100;
+	private static final long serialVersionUID = -4519223263082176325L;
 
 	// The util to compare two sortKey equals to each other.
 	private GeneratedRecordComparator generatedSortKeyComparator;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/BaseTemporalSortOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/BaseTemporalSortOperator.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.dataformat.BaseRow;
 abstract class BaseTemporalSortOperator extends AbstractStreamOperator<BaseRow> implements
 		OneInputStreamOperator<BaseRow, BaseRow>, Triggerable<BaseRow, VoidNamespace> {
 
+	private static final long serialVersionUID = -5476479212328271128L;
 	protected transient TimerService timerService;
 	protected transient TimestampedCollector<BaseRow> collector;
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/LimitOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/LimitOperator.java
@@ -32,6 +32,7 @@ import org.apache.flink.util.Collector;
 public class LimitOperator extends TableStreamOperator<BaseRow>
 		implements OneInputStreamOperator<BaseRow, BaseRow> {
 
+	private static final long serialVersionUID = 1798262493242476740L;
 	private final boolean isGlobal;
 	private final long limitStart;
 	private final long limitEnd;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/RankOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/RankOperator.java
@@ -34,6 +34,7 @@ import org.apache.flink.table.runtime.util.StreamRecordCollector;
  */
 public class RankOperator extends TableStreamOperator<BaseRow> implements OneInputStreamOperator<BaseRow, BaseRow> {
 
+	private static final long serialVersionUID = 1671873695649249290L;
 	private GeneratedRecordComparator partitionByGenComp;
 	private GeneratedRecordComparator orderByGenComp;
 	private final long rankStart;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/SortLimitOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/SortLimitOperator.java
@@ -39,6 +39,7 @@ import java.util.PriorityQueue;
 public class SortLimitOperator extends TableStreamOperator<BaseRow>
 		implements OneInputStreamOperator<BaseRow, BaseRow>, BoundedOneInput {
 
+	private static final long serialVersionUID = -8230294163003490698L;
 	private final boolean isGlobal;
 	private final long limitStart;
 	private final long limitEnd;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/SortOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/SortOperator.java
@@ -45,6 +45,7 @@ public class SortOperator extends TableStreamOperator<BinaryRow>
 		implements OneInputStreamOperator<BaseRow, BinaryRow>, BoundedOneInput {
 
 	private static final Logger LOG = LoggerFactory.getLogger(SortOperator.class);
+	private static final long serialVersionUID = 2391615629357588770L;
 
 	private GeneratedNormalizedKeyComputer gComputer;
 	private GeneratedRecordComparator gComparator;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/values/ValuesInputFormat.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/values/ValuesInputFormat.java
@@ -39,6 +39,7 @@ public class ValuesInputFormat
 		implements NonParallelInput, ResultTypeQueryable<BaseRow> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ValuesInputFormat.class);
+	private static final long serialVersionUID = -1624541434787479954L;
 	private GeneratedInput<GenericInputFormat<BaseRow>> generatedInput;
 	private final BaseRowTypeInfo returnType;
 	private GenericInputFormat<BaseRow> format;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/partitioner/BinaryHashPartitioner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/partitioner/BinaryHashPartitioner.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
  */
 public class BinaryHashPartitioner extends StreamPartitioner<BaseRow> {
 
+	private static final long serialVersionUID = 2842626309321931914L;
 	private GeneratedHashFunction genHashFunc;
 
 	private transient HashFunction hashFunc;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/AbstractRowSerializer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/AbstractRowSerializer.java
@@ -31,6 +31,8 @@ import java.io.IOException;
  */
 public abstract class AbstractRowSerializer<T extends BaseRow> extends TypeSerializer<T> {
 
+	private static final long serialVersionUID = 8903372538380252564L;
+
 	/**
 	 * Get the number of fields.
 	 */

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/BaseArraySerializer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/BaseArraySerializer.java
@@ -50,6 +50,7 @@ import static org.apache.flink.table.runtime.types.ClassLogicalTypeConverter.get
  */
 public class BaseArraySerializer extends TypeSerializer<BaseArray> {
 
+	private static final long serialVersionUID = -8108681746715068803L;
 	private final LogicalType eleType;
 	private final TypeSerializer eleSer;
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/BaseMapSerializer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/BaseMapSerializer.java
@@ -52,6 +52,7 @@ import java.util.Map;
 public class BaseMapSerializer extends TypeSerializer<BaseMap> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(BaseMapSerializer.class);
+	private static final long serialVersionUID = 632078387425892216L;
 
 	private final LogicalType keyType;
 	private final LogicalType valueType;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/BaseRowSerializer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/BaseRowSerializer.java
@@ -49,6 +49,7 @@ import java.util.Arrays;
  */
 public class BaseRowSerializer extends AbstractRowSerializer<BaseRow> {
 
+	private static final long serialVersionUID = -3249924919701265651L;
 	private BinaryRowSerializer binarySerializer;
 	private final LogicalType[] types;
 	private final TypeSerializer[] fieldSerializers;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/BinaryStringTypeInfo.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/BinaryStringTypeInfo.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.dataformat.BinaryString;
 public class BinaryStringTypeInfo extends TypeInformation<BinaryString> {
 
 	public static final BinaryStringTypeInfo INSTANCE = new BinaryStringTypeInfo();
+	private static final long serialVersionUID = 1635704249625389299L;
 
 	private BinaryStringTypeInfo() {}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/DecimalTypeInfo.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/DecimalTypeInfo.java
@@ -30,6 +30,8 @@ import java.util.Arrays;
  */
 public class DecimalTypeInfo extends TypeInformation<Decimal> {
 
+	private static final long serialVersionUID = -361072108259983827L;
+
 	public static DecimalTypeInfo of(int precision, int scale) {
 		return new DecimalTypeInfo(precision, scale);
 	}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/JsonUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/JsonUtils.java
@@ -355,6 +355,8 @@ public class JsonUtils {
 	private AddingList jsonList = new AddingList();
 
 	private static class AddingList extends ArrayList<Object> {
+		private static final long serialVersionUID = -2527988009630012455L;
+
 		@Override
 		public java.util.Iterator<Object> iterator() {
 			return Iterators.forArray(toArray());


### PR DESCRIPTION
## What is the purpose of the change

Add `serialVersionUID` for all production serializable classes.

## Brief change log

All `serialVersionUID` of classes in this PR is auto generated by my customized intellij-IDEA (please refer to my [repo](https://github.com/Myasuka/intellij-community/tree/add-SerialVersionUID)).  Generally, we could use [serialver](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/serialver.html) to get the `serialVersionUID`, however, how to insert them into the classes become a bit complex, that's why I want to leverage intellj-IDEA's feature of [auto generating serialVersionUID](https://stackoverflow.com/questions/24573643/how-to-generate-serial-version-uid-in-intellij). 

However, both intellij and eclipse use different rules to generate `serialVersionUID` compared with JVM or serialver. To ensure these newly added `serialVersionUID`s are compatible with old ones, I have to use code class path to get SerialVersionUID from `ObjectStreamClass`. Eventually, I chose to modify and rebuild a customized IDE.

1. build Flink from source: 
~~~ shell
mvn clean package -DskipTests -Dfast -Pskip-webui-build -T 1C
~~~
2. Build and run my customized intellij IDEA, you could refer to the [README](https://github.com/Myasuka/intellij-community/tree/add-SerialVersionUID)
3. Run `Analyze` -> `Run inspection by name` -> select `serializable class without serialVersionUID` -> choose `Project Production Files` and click to `Ignore anonymous inner classes`. 
4. Then you will get the results for all production classes without `serialVersionUID` in the bottom window and click `Add 'serialVersionUID' field` on the right side.  Wait for a while to get the final result.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes**, add `serialVersionUID`
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no
## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
