### PR TITLE
[FLINK-15301] [kinesis] Exception propagation from record emitter to source thread

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/RecordEmitter.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/RecordEmitter.java
@@ -170,7 +170,14 @@ public abstract class RecordEmitter<T extends TimestampedValue> implements Runna
 	@Override
 	public void run() {
 		LOG.info("Starting emitter with maxLookaheadMillis: {}", this.maxLookaheadMillis);
+		emitRecords();
+	}
 
+	public void stop() {
+		running = false;
+	}
+
+	protected void emitRecords() {
 		// emit available records, ordered by timestamp
 		AsyncRecordQueue<T> min = heads.poll();
 		runLoop:
@@ -248,12 +255,8 @@ public abstract class RecordEmitter<T extends TimestampedValue> implements Runna
 		}
 	}
 
-	public void stop() {
-		running = false;
-	}
-
 	/** Emit the record. This is specific to a connector, like the Kinesis data fetcher. */
-	public abstract void emit(T record, RecordQueue<T> source);
+	protected abstract void emit(T record, RecordQueue<T> source);
 
 	/** Summary of emit queues that can be used for logging. */
 	public String printInfo() {


### PR DESCRIPTION


## What is the purpose of the change

* Exceptions encountered in the asynchronous record emitter need to be propagated to the source thread. This will allow the source to fail with the error instead of just the record emitter thread terminating, causing shard consumption to stop silently.

## Brief change log

*(for example:)*
  - *Handover exception to source thread*
  - *Test coverage*

## Verifying this change

This change added unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / *no*)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / *no*)
  - The serializers: (yes / *no* / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / *no* / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / *no* / don't know)
  - The S3 file system connector: (yes / *no* / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / *no*)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
