### PR TITLE
[FLINK-14944][python] Fix pip install ConnectionResetError

### DIFF
--- a/flink-python/dev/install_command.sh
+++ b/flink-python/dev/install_command.sh
@@ -17,14 +17,15 @@
 # limitations under the License.
 ################################################################################
 retry_times=3
-python -m pip install "$@"
-while [[ $? -ne 0 ]] && [[ ${retry_times} -gt 0 ]]; do
+install_command="python -m pip install $@"
+${install_command}
+status=$?
+while [[ ${status} -ne 0 ]] && [[ ${retry_times} -gt 0 ]]; do
     retry_times=$((retry_times-1))
     # sleep 3 seconds and then reinstall.
     sleep 3
-    python -m pip install "$@"
+    ${install_command}
+    status=$?
 done
 
-if [[ ${retry_times} -eq 0 ]]; then
-    exit 1
-fi
+exit ${status}

--- a/flink-python/dev/install_command.sh
+++ b/flink-python/dev/install_command.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+retry_times=3
+python -m pip install "$@"
+while [[ $? -ne 0 ]] && [[ ${retry_times} -gt 0 ]]; do
+    retry_times=$((retry_times-1))
+    # sleep 3 seconds and then reinstall.
+    sleep 3
+    python -m pip install "$@"
+done
+
+if [[ ${retry_times} -eq 0 ]]; then
+    exit 1
+fi

--- a/flink-python/tox.ini
+++ b/flink-python/tox.ini
@@ -28,10 +28,14 @@ whitelist_externals=
     /bin/bash
 deps =
     pytest
+    grpcio-tools>=1.3.5,<=1.14.2
 commands =
     python --version
     pytest --durations=0
     bash ./dev/run_pip_test.sh
+# Replace the default installation command with a custom retry installation script, because on high-speed
+# networks, downloading a package may raise a ConnectionResetError: [Errno 104] Peer reset connection.
+install_command = {toxinidir}/dev/install_command.sh {opts} {packages}
 
 [flake8]
 # We follow PEP 8 (https://www.python.org/dev/peps/pep-0008/) with one exception: lines can be


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fix the possible ConnectionResetError when downloading python packages on high-speed networks*

## Brief change log

  - *Replace install_command in tox.ini with install_command.sh*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
