### PR TITLE
[FLINK-15288] Starting jobmanager pod should respect containerized.heap-cutoff

### DIFF
--- a/docs/_includes/generated/resource_manager_configuration.html
+++ b/docs/_includes/generated/resource_manager_configuration.html
@@ -18,7 +18,7 @@
             <td><h5>containerized.heap-cutoff-ratio</h5></td>
             <td style="word-wrap: break-word;">0.25</td>
             <td>Float</td>
-            <td>Percentage of heap space to remove from containers (YARN / Mesos), to compensate for other JVM memory usage.</td>
+            <td>Percentage of heap space to remove from containers (YARN / Mesos / Kubernetes), to compensate for other JVM memory usage.</td>
         </tr>
         <tr>
             <td><h5>local.number-resourcemanager</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -370,7 +370,7 @@ public final class ConfigConstants {
 	// -------- Common Resource Framework Configuration (YARN & Mesos) --------
 
 	/**
-	 * Percentage of heap space to remove from containers (YARN / Mesos), to compensate
+	 * Percentage of heap space to remove from containers (YARN / Mesos / Kubernetes), to compensate
 	 * for other JVM memory usage.
 	 * @deprecated Use {@link ResourceManagerOptions#CONTAINERIZED_HEAP_CUTOFF_RATIO} instead.
 	 */

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -56,14 +56,14 @@ public class ResourceManagerOptions {
 			" Its not possible to use this configuration key to define port ranges.");
 
 	/**
-	 * Percentage of heap space to remove from containers (YARN / Mesos), to compensate
+	 * Percentage of heap space to remove from containers (YARN / Mesos/ Kubernetes), to compensate
 	 * for other JVM memory usage.
 	 */
 	public static final ConfigOption<Float> CONTAINERIZED_HEAP_CUTOFF_RATIO = ConfigOptions
 		.key("containerized.heap-cutoff-ratio")
 		.defaultValue(0.25f)
 		.withDeprecatedKeys("yarn.heap-cutoff-ratio")
-		.withDescription("Percentage of heap space to remove from containers (YARN / Mesos), to compensate" +
+		.withDescription("Percentage of heap space to remove from containers (YARN / Mesos / Kubernetes), to compensate" +
 			" for other JVM memory usage.");
 
 	/**

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -126,7 +126,8 @@ public class KubernetesUtils {
 			boolean hasLog4j,
 			String mainClass,
 			@Nullable String mainArgs) {
-		final String jvmMemOpts = String.format("-Xms%sm -Xmx%sm", jobManagerMemoryMb, jobManagerMemoryMb);
+		final int heapSize = BootstrapTools.calculateHeapSize(jobManagerMemoryMb, flinkConfig);
+		final String jvmMemOpts = String.format("-Xms%sm -Xmx%sm", heapSize, heapSize);
 		return getCommonStartCommand(
 			flinkConfig,
 			ClusterComponent.JOB_MANAGER,

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
@@ -102,10 +102,6 @@ public class KubernetesClusterDescriptorTest extends KubernetesTestBase {
 		final KubernetesClusterDescriptor descriptor = new KubernetesClusterDescriptor(FLINK_CONFIG, flinkKubeClient);
 
 		final ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
-			.setMasterMemoryMB(1)
-			.setTaskManagerMemoryMB(1)
-			.setNumberTaskManagers(1)
-			.setSlotsPerTaskManager(1)
 			.createClusterSpecification();
 
 		descriptor.deploySessionCluster(clusterSpecification);

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesUtilsTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesUtilsTest.java
@@ -65,7 +65,7 @@ public class KubernetesUtilsTest extends TestLogger {
 
 	// Memory variables
 	private static final int jobManagerMem = 768;
-	private static final String jmJvmMem = String.format("-Xms%dm -Xmx%dm", jobManagerMem, jobManagerMem);
+	private static final String jmJvmMem = "-Xms168m -Xmx168m";
 
 	private static final TaskExecutorResourceSpec taskExecutorResourceSpec = new TaskExecutorResourceSpec(
 		new CPUResource(1.0),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.util.ExceptionUtils;
@@ -31,6 +32,7 @@ import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.CheckedSupplier;
 
 import akka.actor.ActorSystem;
+import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -422,5 +424,57 @@ public class BootstrapToolsTest extends TestLogger {
 
 		String dynamicProperties = BootstrapTools.getDynamicProperties(baseConfig, targetConfig);
 		assertEquals("-Dkey.b=b2 -Dkey.c=c", dynamicProperties);
+	}
+
+	@Test
+	public void testHeapCutoff() {
+		Configuration conf = new Configuration();
+		conf.setFloat(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO, 0.15F);
+		conf.setInteger(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_MIN, 384);
+
+		Assert.assertEquals(616, BootstrapTools.calculateHeapSize(1000, conf));
+		Assert.assertEquals(8500, BootstrapTools.calculateHeapSize(10000, conf));
+
+		// test different configuration
+		Assert.assertEquals(3400, BootstrapTools.calculateHeapSize(4000, conf));
+
+		conf.setString(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_MIN.key(), "1000");
+		conf.setString(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO.key(), "0.1");
+		Assert.assertEquals(3000, BootstrapTools.calculateHeapSize(4000, conf));
+
+		conf.setString(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO.key(), "0.5");
+		Assert.assertEquals(2000, BootstrapTools.calculateHeapSize(4000, conf));
+
+		conf.setString(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO.key(), "1");
+		Assert.assertEquals(0, BootstrapTools.calculateHeapSize(4000, conf));
+
+		// test also deprecated keys
+		conf = new Configuration();
+		conf.setDouble(ConfigConstants.YARN_HEAP_CUTOFF_RATIO, 0.15);
+		conf.setInteger(ConfigConstants.YARN_HEAP_CUTOFF_MIN, 384);
+
+		Assert.assertEquals(616, BootstrapTools.calculateHeapSize(1000, conf));
+		Assert.assertEquals(8500, BootstrapTools.calculateHeapSize(10000, conf));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void illegalArgument() {
+		final Configuration conf = new Configuration();
+		conf.setString(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO.key(), "1.1");
+		BootstrapTools.calculateHeapSize(4000, conf);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void illegalArgumentNegative() {
+		final Configuration conf = new Configuration();
+		conf.setString(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO.key(), "-0.01");
+		BootstrapTools.calculateHeapSize(4000, conf);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void tooMuchCutoff() {
+		final Configuration conf = new Configuration();
+		conf.setString(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO.key(), "6000");
+		BootstrapTools.calculateHeapSize(4000, conf);
 	}
 }

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/UtilsTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/UtilsTest.java
@@ -18,10 +18,8 @@
 
 package org.apache.flink.yarn;
 
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
 import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
@@ -80,62 +78,6 @@ public class UtilsTest extends TestLogger {
 		Assert.assertTrue(files.contains("lib"));
 		Assert.assertTrue(files.contains("bin"));
 		Assert.assertTrue(files.contains("conf"));
-	}
-
-	/**
-	 * Remove 15% of the heap, at least 384MB.
-	 *
-	 */
-	@Test
-	public void testHeapCutoff() {
-		Configuration conf = new Configuration();
-		conf.setFloat(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO, 0.15F);
-		conf.setInteger(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_MIN, 384);
-
-		Assert.assertEquals(616, Utils.calculateHeapSize(1000, conf));
-		Assert.assertEquals(8500, Utils.calculateHeapSize(10000, conf));
-
-		// test different configuration
-		Assert.assertEquals(3400, Utils.calculateHeapSize(4000, conf));
-
-		conf.setString(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_MIN.key(), "1000");
-		conf.setString(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO.key(), "0.1");
-		Assert.assertEquals(3000, Utils.calculateHeapSize(4000, conf));
-
-		conf.setString(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO.key(), "0.5");
-		Assert.assertEquals(2000, Utils.calculateHeapSize(4000, conf));
-
-		conf.setString(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO.key(), "1");
-		Assert.assertEquals(0, Utils.calculateHeapSize(4000, conf));
-
-		// test also deprecated keys
-		conf = new Configuration();
-		conf.setDouble(ConfigConstants.YARN_HEAP_CUTOFF_RATIO, 0.15);
-		conf.setInteger(ConfigConstants.YARN_HEAP_CUTOFF_MIN, 384);
-
-		Assert.assertEquals(616, Utils.calculateHeapSize(1000, conf));
-		Assert.assertEquals(8500, Utils.calculateHeapSize(10000, conf));
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void illegalArgument() {
-		Configuration conf = new Configuration();
-		conf.setString(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO.key(), "1.1");
-		Assert.assertEquals(0, Utils.calculateHeapSize(4000, conf));
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void illegalArgumentNegative() {
-		Configuration conf = new Configuration();
-		conf.setString(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO.key(), "-0.01");
-		Assert.assertEquals(0, Utils.calculateHeapSize(4000, conf));
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void tooMuchCutoff() {
-		Configuration conf = new Configuration();
-		conf.setString(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO.key(), "6000");
-		Assert.assertEquals(0, Utils.calculateHeapSize(4000, conf));
 	}
 
 	@Test

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -19,7 +19,6 @@
 package org.apache.flink.yarn;
 
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
 import org.apache.flink.runtime.util.HadoopUtils;
@@ -86,32 +85,6 @@ public final class Utils {
 
 	/** Time to wait in milliseconds between each remote resources fetch in case of FileNotFoundException. */
 	public static final int REMOTE_RESOURCES_FETCH_WAIT_IN_MILLI = 100;
-
-	/**
-	 * See documentation.
-	 */
-	public static int calculateHeapSize(int memory, org.apache.flink.configuration.Configuration conf) {
-
-		float memoryCutoffRatio = conf.getFloat(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO);
-		int minCutoff = conf.getInteger(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_MIN);
-
-		if (memoryCutoffRatio > 1 || memoryCutoffRatio < 0) {
-			throw new IllegalArgumentException("The configuration value '"
-				+ ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO.key()
-				+ "' must be between 0 and 1. Value given=" + memoryCutoffRatio);
-		}
-		if (minCutoff > memory) {
-			throw new IllegalArgumentException("The configuration value '"
-				+ ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_MIN.key()
-				+ "' is higher (" + minCutoff + ") than the requested amount of memory " + memory);
-		}
-
-		int heapLimit = (int) ((float) memory * memoryCutoffRatio);
-		if (heapLimit < minCutoff) {
-			heapLimit = minCutoff;
-		}
-		return memory - heapLimit;
-	}
 
 	public static void setupYarnClassPath(Configuration conf, Map<String, String> appMasterEnv) {
 		addToEnvironment(

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -1647,7 +1647,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		final  Map<String, String> startCommandValues = new HashMap<>();
 		startCommandValues.put("java", "$JAVA_HOME/bin/java");
 
-		int heapSize = Utils.calculateHeapSize(jobManagerMemoryMb, flinkConfiguration);
+		int heapSize = BootstrapTools.calculateHeapSize(jobManagerMemoryMb, flinkConfiguration);
 		String jvmHeapMem = String.format("-Xms%sm -Xmx%sm", heapSize, heapSize);
 		startCommandValues.put("jvmmem", jvmHeapMem);
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Starting jobmanager pod should respect containerized.heap-cutoff. The cutoff will be used to leave some memory for jvm off-heap, for example meta space, thread native memory and etc.

This ticket will not introduce new config options for cutoff, we will reuse the `ResourceManagerOptions#CONTAINERIZED_HEAP_CUTOFF_RATIO`. And we will keep the same behavior with Yarn/Mesos.

## Brief change log

* Move yarn Utils#calculateHeapSize to BootstrapTools
* Starting jobmanager pod should respect containerized.heap-cutoff


## Verifying this change

* The changes is covered by unit test `KubernetesUtilsTest#testGetJobManagerStartCommand`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
