### PR TITLE
[FLINK-15175]Fix CTES not supported in SQL CLI

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
@@ -120,7 +120,7 @@ public final class SqlCommandParser {
 			SINGLE_OPERAND),
 
 		SELECT(
-			"(WITH.*|SELECT.*)",
+			"(WITH.*SELECT.*|SELECT.*)",
 			SINGLE_OPERAND),
 
 		INSERT_INTO(

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
@@ -120,7 +120,7 @@ public final class SqlCommandParser {
 			SINGLE_OPERAND),
 
 		SELECT(
-			"(SELECT.*)",
+			"(WITH.*|SELECT.*)",
 			SINGLE_OPERAND),
 
 		INSERT_INTO(

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
@@ -56,6 +56,12 @@ public class SqlCommandParserTest {
 			"   SELECT  complicated FROM table    ",
 			new SqlCommandCall(SqlCommand.SELECT, new String[]{"SELECT  complicated FROM table"}));
 		testValidSqlCommand(
+			"WITH t as (select complicated from table) select complicated from t",
+			new SqlCommandCall(SqlCommand.SELECT, new String[]{"WITH t as (select complicated from table) select complicated from t"}));
+		testValidSqlCommand(
+			"   WITH t as (select complicated from table) select complicated from t    ",
+			new SqlCommandCall(SqlCommand.SELECT, new String[]{"WITH t as (select complicated from table) select complicated from t"}));
+		testValidSqlCommand(
 			"INSERT INTO other SELECT 1+1",
 			new SqlCommandCall(SqlCommand.INSERT_INTO, new String[]{"INSERT INTO other SELECT 1+1"}));
 		testValidSqlCommand(


### PR DESCRIPTION

## What is the purpose of the change

Currently, flink sql cli not suported ctes syntax(akka. WITH...SELECT), This PR will fix it as a temporary solution.

## Brief change log

  - Update SELECT regex expressions to support ctes in Sql cli


## Verifying this change

Real cluster test with TPCDS.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
