### PR TITLE
[FLINK-14364] [flink-formats] Add validation when format.allow-comments is used with format.ignore-parse-errors in CsvValidator

### DIFF
--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/table/descriptors/CsvValidator.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/table/descriptors/CsvValidator.java
@@ -70,9 +70,17 @@ public class CsvValidator extends FormatDescriptorValidator {
 		final boolean isDisabledQuoteCharacter = properties
 			.getOptionalBoolean(FORMAT_DISABLE_QUOTE_CHARACTER)
 			.orElse(false);
-		if (isDisabledQuoteCharacter && hasQuoteCharacter){
+		if (isDisabledQuoteCharacter && hasQuoteCharacter) {
 			throw new ValidationException(
-				"Format cannot define a quote character and disabled quote character at the same time.");
+					"Format cannot define a quote character and disabled quote character at the same time.");
+		}
+
+		final boolean allowComments = properties.getOptionalBoolean(FORMAT_ALLOW_COMMENTS).orElse(false);
+		final boolean ignoreParseError = properties.getOptionalBoolean(FORMAT_IGNORE_PARSE_ERRORS).orElse(false);
+
+		if (allowComments && !ignoreParseError) {
+			throw new ValidationException(
+					"Property " + FORMAT_IGNORE_PARSE_ERRORS + " must be set when using " + FORMAT_ALLOW_COMMENTS);
 		}
 	}
 }

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/table/descriptors/CsvTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/table/descriptors/CsvTest.java
@@ -62,6 +62,11 @@ public class CsvTest extends DescriptorTestBase {
 		addPropertyAndVerify(CUSTOM_DESCRIPTOR_WITH_SCHEMA, "format.allow-comments", "DDD");
 	}
 
+	@Test(expected = ValidationException.class)
+	public void testAllowCommentsWithoutIgnoreParseErrors() {
+		addPropertyAndVerify(CUSTOM_DESCRIPTOR_WITH_SCHEMA, "format.ignore-parse-errors", "false");
+	}
+
 	// --------------------------------------------------------------------------------------------
 
 	@Override


### PR DESCRIPTION

## What is the purpose of the change

As described in [FLINK-14364](https://issues.apache.org/jira/browse/FLINK-14364), we can only use `format.allow-comments` when  `format.ignore-parse-errors` is set. So we add a validation here to improve the usability.


## Brief change log

Add a new check in `CsvValidator`.


## Verifying this change

Unit testing.