### PR TITLE
[FLINK-15308][runtime] Remove data compression for pipelined shuffle.

### DIFF
--- a/docs/_includes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/_includes/generated/netty_shuffle_environment_configuration.html
@@ -51,12 +51,6 @@
             <td>Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate). In credit-based flow control mode, this indicates how many floating credits are shared among all the input channels. The floating buffers are distributed based on backlog (real-time output buffers in the subpartition) feedback, and can help relieve back-pressure caused by unbalanced data distribution among the subpartitions. This value should be increased in case of higher round trip times between nodes and/or larger number of machines in the cluster.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.network.pipelined-shuffle.compression.enabled</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>Boolean flag indicating whether the shuffle data will be compressed for pipelined shuffle mode. Note that data is compressed per sliced buffer and compression is disabled for operators using broadcast partitioner. Because of the extra CPU overhead, it is not recommended to enable compression if network is not the bottleneck or compression ratio is low. Currently, shuffle data compression is an experimental feature and the config option can be changed in the future.</td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.network.request-backoff.initial</h5></td>
             <td style="word-wrap: break-word;">100</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -70,23 +70,6 @@ public class NettyShuffleEnvironmentOptions {
 				"compression is an experimental feature and the config option can be changed in the future.");
 
 	/**
-	 * Boolean flag indicating whether the shuffle data will be compressed for pipelined shuffle mode.
-	 *
-	 * <p>Note: Data is compressed per sliced buffer and compression is disabled for operators using broadcast partitioner.
-	 * Because of the extra CPU overhead, it is not recommended to enable compression if network is not the bottleneck or
-	 * compression ratio is low. Currently, shuffle data compression is an experimental feature and the config option can
-	 * be changed in the future.
-	 */
-	public static final ConfigOption<Boolean> PIPELINED_SHUFFLE_COMPRESSION_ENABLED =
-		key("taskmanager.network.pipelined-shuffle.compression.enabled")
-			.defaultValue(false)
-			.withDescription("Boolean flag indicating whether the shuffle data will be compressed for pipelined shuffle" +
-				" mode. Note that data is compressed per sliced buffer and compression is disabled for operators using " +
-				"broadcast partitioner. Because of the extra CPU overhead, it is not recommended to enable compression " +
-				"if network is not the bottleneck or compression ratio is low. Currently, shuffle data compression is " +
-				"an experimental feature and the config option can be changed in the future.");
-
-	/**
 	 * The codec to be used when compressing shuffle data.
 	 */
 	@Documentation.ExcludeFromDocumentation("Currently, LZ4 is the only legal option.")

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -107,7 +107,6 @@ public class NettyShuffleServiceFactory implements ShuffleServiceFactory<NettySh
 			config.networkBufferSize(),
 			config.isForcePartitionReleaseOnConsumption(),
 			config.isBlockingShuffleCompressionEnabled(),
-			config.isPipelinedShuffleCompressionEnabled(),
 			config.getCompressionCodec());
 
 		SingleInputGateFactory singleInputGateFactory = new SingleInputGateFactory(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
@@ -284,12 +284,12 @@ public class EventSerializer {
 		return buffer;
 	}
 
-	public static BufferConsumer toBufferConsumer(AbstractEvent event, boolean isShareable) throws IOException {
+	public static BufferConsumer toBufferConsumer(AbstractEvent event) throws IOException {
 		final ByteBuffer serializedEvent = EventSerializer.toSerializedEvent(event);
 
 		MemorySegment data = MemorySegmentFactory.wrap(serializedEvent.array());
 
-		return new BufferConsumer(data, FreeingBufferRecycler.INSTANCE, false, isShareable);
+		return new BufferConsumer(data, FreeingBufferRecycler.INSTANCE, false);
 	}
 
 	public static AbstractEvent fromBuffer(Buffer buffer, ClassLoader classLoader) throws IOException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/BroadcastRecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/BroadcastRecordWriter.java
@@ -84,7 +84,7 @@ public final class BroadcastRecordWriter<T extends IOReadableWritable> extends R
 		if (bufferBuilder != null) {
 			for (int index = 0; index < numberOfChannels; index++) {
 				if (index != targetChannelIndex) {
-					targetPartition.addBufferConsumer(bufferBuilder.createBufferConsumer(true), index);
+					targetPartition.addBufferConsumer(bufferBuilder.createBufferConsumer(), index);
 				}
 			}
 		}
@@ -130,9 +130,9 @@ public final class BroadcastRecordWriter<T extends IOReadableWritable> extends R
 
 		BufferBuilder builder = targetPartition.getBufferBuilder();
 		if (randomTriggered) {
-			targetPartition.addBufferConsumer(builder.createBufferConsumer(true), targetChannel);
+			targetPartition.addBufferConsumer(builder.createBufferConsumer(), targetChannel);
 		} else {
-			try (BufferConsumer bufferConsumer = builder.createBufferConsumer(true)) {
+			try (BufferConsumer bufferConsumer = builder.createBufferConsumer()) {
 				for (int channel = 0; channel < numberOfChannels; channel++) {
 					targetPartition.addBufferConsumer(bufferConsumer.copy(), channel);
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ChannelSelectorRecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ChannelSelectorRecordWriter.java
@@ -101,7 +101,7 @@ public final class ChannelSelectorRecordWriter<T extends IOReadableWritable> ext
 		checkState(bufferBuilders[targetChannel] == null || bufferBuilders[targetChannel].isFinished());
 
 		BufferBuilder bufferBuilder = targetPartition.getBufferBuilder();
-		targetPartition.addBufferConsumer(bufferBuilder.createBufferConsumer(false), targetChannel);
+		targetPartition.addBufferConsumer(bufferBuilder.createBufferConsumer(), targetChannel);
 		bufferBuilders[targetChannel] = bufferBuilder;
 		return bufferBuilder;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
@@ -154,7 +154,7 @@ public abstract class RecordWriter<T extends IOReadableWritable> implements Avai
 	}
 
 	public void broadcastEvent(AbstractEvent event) throws IOException {
-		try (BufferConsumer eventBufferConsumer = EventSerializer.toBufferConsumer(event, true)) {
+		try (BufferConsumer eventBufferConsumer = EventSerializer.toBufferConsumer(event)) {
 			for (int targetChannel = 0; targetChannel < numberOfChannels; targetChannel++) {
 				tryFinishCurrentBufferBuilder(targetChannel);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferBuilder.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.io.network.buffer;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.memory.MemorySegment;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -50,21 +49,14 @@ public class BufferBuilder {
 	 * This method always creates a {@link BufferConsumer} starting from the current writer offset. Data written to
 	 * {@link BufferBuilder} before creation of {@link BufferConsumer} won't be visible for that {@link BufferConsumer}.
 	 *
-	 * @param isShareable whether the created {@link BufferConsumer} is shareable.
 	 * @return created matching instance of {@link BufferConsumer} to this {@link BufferBuilder}.
 	 */
-	public BufferConsumer createBufferConsumer(boolean isShareable) {
+	public BufferConsumer createBufferConsumer() {
 		return new BufferConsumer(
 			memorySegment,
 			recycler,
 			positionMarker,
-			positionMarker.cachedPosition,
-			isShareable);
-	}
-
-	@VisibleForTesting
-	public BufferConsumer createBufferConsumer() {
-		return createBufferConsumer(false);
+			positionMarker.cachedPosition);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferConsumer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferConsumer.java
@@ -44,9 +44,6 @@ public class BufferConsumer implements Closeable {
 
 	private int currentReaderPosition;
 
-	/** Whether the underlying {@link Buffer} can be shared by multi {@link BufferConsumer} instances. */
-	private final boolean isShareable;
-
 	/**
 	 * Constructs {@link BufferConsumer} instance with the initial reader position.
 	 */
@@ -54,48 +51,35 @@ public class BufferConsumer implements Closeable {
 			MemorySegment memorySegment,
 			BufferRecycler recycler,
 			PositionMarker currentWriterPosition,
-			int currentReaderPosition,
-			boolean isShareable) {
+			int currentReaderPosition) {
 		this(
 			new NetworkBuffer(checkNotNull(memorySegment), checkNotNull(recycler), true),
 			currentWriterPosition,
-			currentReaderPosition,
-			isShareable);
+			currentReaderPosition);
 	}
 
 	/**
 	 * Constructs {@link BufferConsumer} instance with static content.
 	 */
-	public BufferConsumer(MemorySegment memorySegment, BufferRecycler recycler, boolean isBuffer, boolean isShareable) {
-		this(memorySegment, recycler, memorySegment.size(), isBuffer, isShareable);
+	public BufferConsumer(MemorySegment memorySegment, BufferRecycler recycler, boolean isBuffer) {
+		this(memorySegment, recycler, memorySegment.size(), isBuffer);
 	}
 
 	/**
 	 * Constructs {@link BufferConsumer} instance with static content of a certain size.
 	 */
-	public BufferConsumer(
-			MemorySegment memorySegment,
-			BufferRecycler recycler,
-			int size,
-			boolean isBuffer,
-			boolean isShareable) {
+	public BufferConsumer(MemorySegment memorySegment, BufferRecycler recycler, int size, boolean isBuffer) {
 		this(new NetworkBuffer(checkNotNull(memorySegment), checkNotNull(recycler), isBuffer),
 				() -> -size,
-				0,
-				isShareable);
+				0);
 		checkState(memorySegment.size() > 0);
 		checkState(isFinished(), "BufferConsumer with static size must be finished after construction!");
 	}
 
-	private BufferConsumer(
-			Buffer buffer,
-			BufferBuilder.PositionMarker currentWriterPosition,
-			int currentReaderPosition,
-			boolean isShareable) {
+	private BufferConsumer(Buffer buffer, BufferBuilder.PositionMarker currentWriterPosition, int currentReaderPosition) {
 		this.buffer = checkNotNull(buffer);
 		this.writerPosition = new CachedPositionMarker(checkNotNull(currentWriterPosition));
 		this.currentReaderPosition = currentReaderPosition;
-		this.isShareable = isShareable;
 	}
 
 	/**
@@ -126,14 +110,12 @@ public class BufferConsumer implements Closeable {
 	 * Returns a retained copy with separate indexes. This allows to read from the same {@link MemorySegment} twice.
 	 *
 	 * <p>WARNING: the newly returned {@link BufferConsumer} will have its reader index copied from the original buffer.
-	 * In other words, data already consumed before copying will not be visible to the returned copies. In addition, only
-	 * shareable {@link BufferConsumer} can be copied.
+	 * In other words, data already consumed before copying will not be visible to the returned copies.
 	 *
 	 * @return a retained copy of self with separate indexes
 	 */
 	public BufferConsumer copy() {
-		checkState(isShareable, "The underlying buffer is not shareable.");
-		return new BufferConsumer(buffer.retainBuffer(), writerPosition.positionMarker, currentReaderPosition, true);
+		return new BufferConsumer(buffer.retainBuffer(), writerPosition.positionMarker, currentReaderPosition);
 	}
 
 	public boolean isBuffer() {
@@ -157,10 +139,6 @@ public class BufferConsumer implements Closeable {
 
 	int getCurrentReaderPosition() {
 		return currentReaderPosition;
-	}
-
-	public boolean isShareable() {
-		return isShareable;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
@@ -165,7 +165,7 @@ class CreditBasedSequenceNumberingViewReader implements BufferAvailabilityListen
 
 	@Override
 	public BufferAndAvailability getNextBuffer() throws IOException, InterruptedException {
-		BufferAndBacklog next = subpartitionView.getNextBuffer(false);
+		BufferAndBacklog next = subpartitionView.getNextBuffer();
 		if (next != null) {
 			sequenceNumber++;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
@@ -180,7 +180,7 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
 
 		isFinished = true;
 		flushCurrentBuffer();
-		writeAndCloseBufferConsumer(EventSerializer.toBufferConsumer(EndOfPartitionEvent.INSTANCE, false));
+		writeAndCloseBufferConsumer(EventSerializer.toBufferConsumer(EndOfPartitionEvent.INSTANCE));
 		data.finishWrite();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionReader.java
@@ -78,7 +78,7 @@ final class BoundedBlockingSubpartitionReader implements ResultSubpartitionView 
 
 	@Nullable
 	@Override
-	public BufferAndBacklog getNextBuffer(boolean isLocalChannel) throws IOException {
+	public BufferAndBacklog getNextBuffer() throws IOException {
 		final Buffer current = nextBuffer; // copy reference to stack
 
 		if (current == null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/NoOpResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/NoOpResultSubpartitionView.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
 public class NoOpResultSubpartitionView implements ResultSubpartitionView {
 
 	@Nullable
-	public ResultSubpartition.BufferAndBacklog getNextBuffer(boolean isLocalChannel) {
+	public ResultSubpartition.BufferAndBacklog getNextBuffer() {
 		return null;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -44,9 +44,9 @@ import static org.apache.flink.util.Preconditions.checkState;
  * {@link PipelinedSubpartitionView#notifyDataAvailable() notify} a read view created via
  * {@link #createReadView(BufferAvailabilityListener)} of new data availability. Except by calling
  * {@link #flush()} explicitly, we always only notify when the first finished buffer turns up and
- * then, the reader has to drain the buffers via {@link #pollBuffer(boolean)} until its return value
- * shows no more buffers being available. This results in a buffer queue which is either empty or has
- * an unfinished {@link BufferConsumer} left from which the notifications will eventually start again.
+ * then, the reader has to drain the buffers via {@link #pollBuffer()} until its return value shows
+ * no more buffers being available. This results in a buffer queue which is either empty or has an
+ * unfinished {@link BufferConsumer} left from which the notifications will eventually start again.
  *
  * <p>Explicit calls to {@link #flush()} will force this
  * {@link PipelinedSubpartitionView#notifyDataAvailable() notification} for any
@@ -96,7 +96,7 @@ class PipelinedSubpartition extends ResultSubpartition {
 
 	@Override
 	public void finish() throws IOException {
-		add(EventSerializer.toBufferConsumer(EndOfPartitionEvent.INSTANCE, false), true);
+		add(EventSerializer.toBufferConsumer(EndOfPartitionEvent.INSTANCE), true);
 		LOG.debug("{}: Finished {}.", parent.getOwningTaskName(), this);
 	}
 
@@ -157,7 +157,7 @@ class PipelinedSubpartition extends ResultSubpartition {
 	}
 
 	@Nullable
-	BufferAndBacklog pollBuffer(boolean isLocalChannel) {
+	BufferAndBacklog pollBuffer() {
 		synchronized (buffers) {
 			Buffer buffer = null;
 
@@ -169,9 +169,6 @@ class PipelinedSubpartition extends ResultSubpartition {
 				BufferConsumer bufferConsumer = buffers.peek();
 
 				buffer = bufferConsumer.build();
-				if (!isLocalChannel && !bufferConsumer.isShareable() && canBeCompressed(buffer)) {
-					buffer = parent.bufferCompressor.compressToOriginalBuffer(buffer);
-				}
 
 				checkState(bufferConsumer.isFinished() || buffers.size() == 1,
 					"When there are multiple buffers, an unfinished bufferConsumer can not be at the head of the buffers queue.");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -47,8 +47,8 @@ class PipelinedSubpartitionView implements ResultSubpartitionView {
 
 	@Nullable
 	@Override
-	public BufferAndBacklog getNextBuffer(boolean isLocalChannel) {
-		return parent.pollBuffer(isLocalChannel);
+	public BufferAndBacklog getNextBuffer() {
+		return parent.pollBuffer();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -62,8 +62,6 @@ public class ResultPartitionFactory {
 
 	private final boolean blockingShuffleCompressionEnabled;
 
-	private final boolean pipelinedShuffleCompressionEnabled;
-
 	private final String compressionCodec;
 
 	public ResultPartitionFactory(
@@ -76,7 +74,6 @@ public class ResultPartitionFactory {
 		int networkBufferSize,
 		boolean forcePartitionReleaseOnConsumption,
 		boolean blockingShuffleCompressionEnabled,
-		boolean pipelinedShuffleCompressionEnabled,
 		String compressionCodec) {
 
 		this.partitionManager = partitionManager;
@@ -88,7 +85,6 @@ public class ResultPartitionFactory {
 		this.networkBufferSize = networkBufferSize;
 		this.forcePartitionReleaseOnConsumption = forcePartitionReleaseOnConsumption;
 		this.blockingShuffleCompressionEnabled = blockingShuffleCompressionEnabled;
-		this.pipelinedShuffleCompressionEnabled = pipelinedShuffleCompressionEnabled;
 		this.compressionCodec = compressionCodec;
 	}
 
@@ -113,8 +109,7 @@ public class ResultPartitionFactory {
 			int maxParallelism,
 			FunctionWithException<BufferPoolOwner, BufferPool, IOException> bufferPoolFactory) {
 		BufferCompressor bufferCompressor = null;
-		if (type.isBlocking() && blockingShuffleCompressionEnabled
-			|| type.isPipelined() && pipelinedShuffleCompressionEnabled) {
+		if (type.isBlocking() && blockingShuffleCompressionEnabled) {
 			bufferCompressor = new BufferCompressor(networkBufferSize, compressionCodec);
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
@@ -40,11 +40,9 @@ public interface ResultSubpartitionView {
 	 * <p><strong>Important</strong>: The consumer has to make sure that each
 	 * buffer instance will eventually be recycled with {@link Buffer#recycleBuffer()}
 	 * after it has been consumed.
-	 *
-	 * @param isLocalChannel whether we are getting buffers from a local input channel or not.
 	 */
 	@Nullable
-	BufferAndBacklog getNextBuffer(boolean isLocalChannel) throws IOException, InterruptedException;
+	BufferAndBacklog getNextBuffer() throws IOException, InterruptedException;
 
 	void notifyDataAvailable();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -183,7 +183,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 			subpartitionView = checkAndWaitForSubpartitionView();
 		}
 
-		BufferAndBacklog next = subpartitionView.getNextBuffer(true);
+		BufferAndBacklog next = subpartitionView.getNextBuffer();
 
 		if (next == null) {
 			if (subpartitionView.isReleased()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -78,8 +78,6 @@ public class SingleInputGateFactory {
 
 	private final boolean blockingShuffleCompressionEnabled;
 
-	private final boolean pipelinedShuffleCompressionEnabled;
-
 	private final String compressionCodec;
 
 	private final int networkBufferSize;
@@ -97,7 +95,6 @@ public class SingleInputGateFactory {
 		this.networkBuffersPerChannel = networkConfig.networkBuffersPerChannel();
 		this.floatingNetworkBuffersPerGate = networkConfig.floatingNetworkBuffersPerGate();
 		this.blockingShuffleCompressionEnabled = networkConfig.isBlockingShuffleCompressionEnabled();
-		this.pipelinedShuffleCompressionEnabled = networkConfig.isPipelinedShuffleCompressionEnabled();
 		this.compressionCodec = networkConfig.getCompressionCodec();
 		this.networkBufferSize = networkConfig.networkBufferSize();
 		this.connectionManager = connectionManager;
@@ -122,8 +119,7 @@ public class SingleInputGateFactory {
 			igdd.getConsumedPartitionType());
 
 		BufferDecompressor bufferDecompressor = null;
-		if (igdd.getConsumedPartitionType().isBlocking() && blockingShuffleCompressionEnabled
-			|| igdd.getConsumedPartitionType().isPipelined() && pipelinedShuffleCompressionEnabled) {
+		if (igdd.getConsumedPartitionType().isBlocking() && blockingShuffleCompressionEnabled) {
 			bufferDecompressor = new BufferDecompressor(networkBufferSize, compressionCodec);
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -72,8 +72,6 @@ public class NettyShuffleEnvironmentConfiguration {
 
 	private final boolean blockingShuffleCompressionEnabled;
 
-	private final boolean pipelinedShuffleCompressionEnabled;
-
 	private final String compressionCodec;
 
 	public NettyShuffleEnvironmentConfiguration(
@@ -90,7 +88,6 @@ public class NettyShuffleEnvironmentConfiguration {
 			BoundedBlockingSubpartitionType blockingSubpartitionType,
 			boolean forcePartitionReleaseOnConsumption,
 			boolean blockingShuffleCompressionEnabled,
-			boolean pipelinedShuffleCompressionEnabled,
 			String compressionCodec) {
 
 		this.numNetworkBuffers = numNetworkBuffers;
@@ -106,7 +103,6 @@ public class NettyShuffleEnvironmentConfiguration {
 		this.blockingSubpartitionType = Preconditions.checkNotNull(blockingSubpartitionType);
 		this.forcePartitionReleaseOnConsumption = forcePartitionReleaseOnConsumption;
 		this.blockingShuffleCompressionEnabled = blockingShuffleCompressionEnabled;
-		this.pipelinedShuffleCompressionEnabled = pipelinedShuffleCompressionEnabled;
 		this.compressionCodec = Preconditions.checkNotNull(compressionCodec);
 	}
 
@@ -164,10 +160,6 @@ public class NettyShuffleEnvironmentConfiguration {
 		return blockingShuffleCompressionEnabled;
 	}
 
-	public boolean isPipelinedShuffleCompressionEnabled() {
-		return pipelinedShuffleCompressionEnabled;
-	}
-
 	public String getCompressionCodec() {
 		return compressionCodec;
 	}
@@ -221,8 +213,6 @@ public class NettyShuffleEnvironmentConfiguration {
 
 		boolean blockingShuffleCompressionEnabled =
 			configuration.get(NettyShuffleEnvironmentOptions.BLOCKING_SHUFFLE_COMPRESSION_ENABLED);
-		boolean pipelinedShuffleCompressionEnabled =
-			configuration.get(NettyShuffleEnvironmentOptions.PIPELINED_SHUFFLE_COMPRESSION_ENABLED);
 		String compressionCodec = configuration.getString(NettyShuffleEnvironmentOptions.SHUFFLE_COMPRESSION_CODEC);
 
 		return new NettyShuffleEnvironmentConfiguration(
@@ -239,7 +229,6 @@ public class NettyShuffleEnvironmentConfiguration {
 			blockingSubpartitionType,
 			forcePartitionReleaseOnConsumption,
 			blockingShuffleCompressionEnabled,
-			pipelinedShuffleCompressionEnabled,
 			compressionCodec);
 	}
 
@@ -352,7 +341,6 @@ public class NettyShuffleEnvironmentConfiguration {
 		result = 31 * result + Arrays.hashCode(tempDirs);
 		result = 31 * result + (forcePartitionReleaseOnConsumption ? 1 : 0);
 		result = 31 * result + (blockingShuffleCompressionEnabled ? 1 : 0);
-		result = 31 * result + (pipelinedShuffleCompressionEnabled ? 1 : 0);
 		result = 31 * result + Objects.hashCode(compressionCodec);
 		return result;
 	}
@@ -379,7 +367,6 @@ public class NettyShuffleEnvironmentConfiguration {
 					Arrays.equals(this.tempDirs, that.tempDirs) &&
 					this.forcePartitionReleaseOnConsumption == that.forcePartitionReleaseOnConsumption &&
 					this.blockingShuffleCompressionEnabled == that.blockingShuffleCompressionEnabled &&
-					this.pipelinedShuffleCompressionEnabled == that.pipelinedShuffleCompressionEnabled &&
 					Objects.equals(this.compressionCodec, that.compressionCodec);
 		}
 	}
@@ -398,7 +385,6 @@ public class NettyShuffleEnvironmentConfiguration {
 				", tempDirs=" + Arrays.toString(tempDirs) +
 				", forcePartitionReleaseOnConsumption=" + forcePartitionReleaseOnConsumption +
 				", blockingShuffleCompressionEnabled=" + blockingShuffleCompressionEnabled +
-				", pipelinedShuffleCompressionEnabled=" + pipelinedShuffleCompressionEnabled +
 				", compressionCodec=" + compressionCodec +
 				'}';
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -51,8 +51,6 @@ public class NettyShuffleEnvironmentBuilder {
 
 	private boolean blockingShuffleCompressionEnabled = false;
 
-	private boolean pipelinedShuffleCompressionEnabled = false;
-
 	private String compressionCodec = "LZ4";
 
 	private ResourceID taskManagerLocation = ResourceID.generate();
@@ -96,11 +94,6 @@ public class NettyShuffleEnvironmentBuilder {
 		return this;
 	}
 
-	public NettyShuffleEnvironmentBuilder setPipelinedShuffleCompressionEnabled(boolean pipelinedShuffleCompressionEnabled) {
-		this.pipelinedShuffleCompressionEnabled = pipelinedShuffleCompressionEnabled;
-		return this;
-	}
-
 	public NettyShuffleEnvironmentBuilder setCompressionCodec(String compressionCodec) {
 		this.compressionCodec = compressionCodec;
 		return this;
@@ -132,7 +125,6 @@ public class NettyShuffleEnvironmentBuilder {
 				BoundedBlockingSubpartitionType.AUTO,
 				false,
 				blockingShuffleCompressionEnabled,
-				pipelinedShuffleCompressionEnabled,
 				compressionCodec),
 			taskManagerLocation,
 			new TaskEventDispatcher(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderAndConsumerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderAndConsumerTest.java
@@ -137,7 +137,7 @@ public class BufferBuilderAndConsumerTest {
 	@Test
 	public void copy() {
 		BufferBuilder bufferBuilder = createBufferBuilder();
-		BufferConsumer bufferConsumer1 = bufferBuilder.createBufferConsumer(true);
+		BufferConsumer bufferConsumer1 = bufferBuilder.createBufferConsumer();
 
 		bufferBuilder.appendAndCommit(toByteBuffer(0, 1));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderTestUtils.java
@@ -67,22 +67,18 @@ public class BufferBuilderTestUtils {
 	}
 
 	public static BufferConsumer createFilledFinishedBufferConsumer(int dataSize) {
-		return createFilledBufferConsumer(dataSize, dataSize, true, false);
-	}
-
-	public static BufferConsumer createFilledFinishedBufferConsumer(int dataSize, boolean isShareable) {
-		return createFilledBufferConsumer(dataSize, dataSize, true, isShareable);
+		return createFilledBufferConsumer(dataSize, dataSize, true);
 	}
 
 	public static BufferConsumer createFilledUnfinishedBufferConsumer(int dataSize) {
-		return createFilledBufferConsumer(dataSize, dataSize, false, false);
+		return createFilledBufferConsumer(dataSize, dataSize, false);
 	}
 
-	public static BufferConsumer createFilledBufferConsumer(int size, int dataSize, boolean isFinished, boolean isShareable) {
+	public static BufferConsumer createFilledBufferConsumer(int size, int dataSize, boolean isFinished) {
 		checkArgument(size >= dataSize);
 
 		BufferBuilder bufferBuilder = createBufferBuilder(size);
-		BufferConsumer bufferConsumer = bufferBuilder.createBufferConsumer(isShareable);
+		BufferConsumer bufferConsumer = bufferBuilder.createBufferConsumer();
 		fillBufferBuilder(bufferBuilder, dataSize);
 
 		if (isFinished) {
@@ -96,7 +92,6 @@ public class BufferBuilderTestUtils {
 		return new BufferConsumer(
 			MemorySegmentFactory.allocateUnpooledSegment(size),
 			FreeingBufferRecycler.INSTANCE,
-			false,
 			false);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
@@ -186,7 +186,7 @@ public class CancelPartitionRequestTest {
 
 		@Nullable
 		@Override
-		public BufferAndBacklog getNextBuffer(boolean isLocalChannel) throws IOException {
+		public BufferAndBacklog getNextBuffer() throws IOException {
 			Buffer buffer = bufferProvider.requestBuffer();
 			if (buffer != null) {
 				buffer.setSize(buffer.getMaxCapacity()); // fake some data

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
@@ -195,7 +195,7 @@ public class PartitionRequestQueueTest {
 	}
 
 	private static class DefaultBufferResultSubpartitionView extends NoOpResultSubpartitionView {
-		/** Number of buffer in the backlog to report with every {@link #getNextBuffer(boolean)} call. */
+		/** Number of buffer in the backlog to report with every {@link #getNextBuffer()} call. */
 		private final AtomicInteger buffersInBacklog;
 
 		private DefaultBufferResultSubpartitionView(int buffersInBacklog) {
@@ -204,7 +204,7 @@ public class PartitionRequestQueueTest {
 
 		@Nullable
 		@Override
-		public BufferAndBacklog getNextBuffer(boolean isLocalChannel) {
+		public BufferAndBacklog getNextBuffer() {
 			int buffers = buffersInBacklog.decrementAndGet();
 			return new BufferAndBacklog(
 				TestBufferFactory.createBuffer(10),
@@ -226,8 +226,8 @@ public class PartitionRequestQueueTest {
 
 		@Nullable
 		@Override
-		public BufferAndBacklog getNextBuffer(boolean isLocalChannel) {
-			BufferAndBacklog nextBuffer = super.getNextBuffer(isLocalChannel);
+		public BufferAndBacklog getNextBuffer() {
+			BufferAndBacklog nextBuffer = super.getNextBuffer();
 			return new BufferAndBacklog(
 				nextBuffer.buffer().readOnlySlice(),
 				nextBuffer.isMoreAvailable(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionAvailabilityTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionAvailabilityTest.java
@@ -142,7 +142,7 @@ public class BoundedBlockingSubpartitionAvailabilityTest {
 		final ArrayList<BufferAndBacklog> list = new ArrayList<>();
 
 		BufferAndBacklog bab;
-		while ((bab = reader.getNextBuffer(true)) != null) {
+		while ((bab = reader.getNextBuffer()) != null) {
 			list.add(bab);
 		}
 
@@ -151,7 +151,7 @@ public class BoundedBlockingSubpartitionAvailabilityTest {
 
 	private static void drainAllData(ResultSubpartitionView reader) throws Exception {
 		BufferAndBacklog bab;
-		while ((bab = reader.getNextBuffer(true)) != null) {
+		while ((bab = reader.getNextBuffer()) != null) {
 			bab.buffer().recycleBuffer();
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionWriteReadTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionWriteReadTest.java
@@ -173,7 +173,7 @@ public class BoundedBlockingSubpartitionWriteReadTest {
 		long expectedNextLong = 0L;
 		int nextExpectedBacklog = numBuffers - 1;
 
-		while ((next = reader.getNextBuffer(true)) != null && next.buffer().isBuffer()) {
+		while ((next = reader.getNextBuffer()) != null && next.buffer().isBuffer()) {
 			assertTrue(next.isMoreAvailable());
 			assertEquals(nextExpectedBacklog, next.buffersInBacklog());
 
@@ -210,7 +210,7 @@ public class BoundedBlockingSubpartitionWriteReadTest {
 				nums--;
 			}
 
-			partition.add(new BufferConsumer(memory, (ignored) -> {}, pos, true, false));
+			partition.add(new BufferConsumer(memory, (ignored) -> {}, pos, true));
 
 			// we need to flush after every buffer as long as the add() contract is that
 			// buffer are immediately added and can be filled further after that (for low latency

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/FileChannelBoundedDataTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/FileChannelBoundedDataTest.java
@@ -137,8 +137,8 @@ public class FileChannelBoundedDataTest extends BoundedDataTestBase {
 		listener.resetAvailable();
 		assertFalse(listener.isAvailable);
 
-		final BufferAndBacklog buffer1 = subpartitionView.getNextBuffer(true);
-		final BufferAndBacklog buffer2 = subpartitionView.getNextBuffer(true);
+		final BufferAndBacklog buffer1 = subpartitionView.getNextBuffer();
+		final BufferAndBacklog buffer2 = subpartitionView.getNextBuffer();
 		assertNotNull(buffer1);
 		assertNotNull(buffer2);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
@@ -68,7 +68,7 @@ public class InputGateFairnessTest {
 		final int buffersPerChannel = 27;
 
 		final ResultPartition resultPartition = mock(ResultPartition.class);
-		final BufferConsumer bufferConsumer = createFilledFinishedBufferConsumer(42, true);
+		final BufferConsumer bufferConsumer = createFilledFinishedBufferConsumer(42);
 
 		// ----- create some source channels and fill them with buffers -----
 
@@ -122,7 +122,7 @@ public class InputGateFairnessTest {
 		final int buffersPerChannel = 27;
 
 		final ResultPartition resultPartition = mock(ResultPartition.class);
-		try (BufferConsumer bufferConsumer = createFilledFinishedBufferConsumer(42, true)) {
+		try (BufferConsumer bufferConsumer = createFilledFinishedBufferConsumer(42)) {
 
 			// ----- create some source channels and fill them with one buffer each -----
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
@@ -67,7 +67,6 @@ public enum PartitionTestUtils {
 			.setResultPartitionType(type)
 			.setFileChannelManager(channelManager)
 			.setBlockingShuffleCompressionEnabled(compressionEnabled)
-			.setPipelinedShuffleCompressionEnabled(compressionEnabled)
 			.setNetworkBufferSize(networkBufferSize)
 			.build();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
@@ -316,8 +316,8 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
 		ResultSubpartitionView view = partition.createReadView(listener);
 
 		// The added bufferConsumer and end-of-partition event
-		assertNotNull(view.getNextBuffer(true));
-		assertNotNull(view.getNextBuffer(true));
+		assertNotNull(view.getNextBuffer());
+		assertNotNull(view.getNextBuffer());
 
 		// Release the parent
 		assertFalse(view.isReleased());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
@@ -41,7 +41,6 @@ import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.
 import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.createFilledUnfinishedBufferConsumer;
 import static org.apache.flink.runtime.io.network.util.TestBufferFactory.BUFFER_SIZE;
 import static org.apache.flink.util.Preconditions.checkArgument;
-import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -94,7 +93,7 @@ public class PipelinedSubpartitionWithReadViewTest {
 	public void testAddTwoNonFinishedBuffer() {
 		subpartition.add(createBufferBuilder().createBufferConsumer());
 		subpartition.add(createBufferBuilder().createBufferConsumer());
-		assertNull(readView.getNextBuffer(true));
+		assertNull(readView.getNextBuffer());
 	}
 
 	@Test
@@ -105,7 +104,7 @@ public class PipelinedSubpartitionWithReadViewTest {
 		subpartition.add(bufferBuilder.createBufferConsumer());
 
 		assertEquals(0, availablityListener.getNumNotifications());
-		assertNull(readView.getNextBuffer(true));
+		assertNull(readView.getNextBuffer());
 
 		bufferBuilder.finish();
 		bufferBuilder = createBufferBuilder();
@@ -113,7 +112,7 @@ public class PipelinedSubpartitionWithReadViewTest {
 
 		assertEquals(1, subpartition.getBuffersInBacklog());
 		assertEquals(1, availablityListener.getNumNotifications()); // notification from finishing previous buffer.
-		assertNull(readView.getNextBuffer(true));
+		assertNull(readView.getNextBuffer());
 		assertEquals(0, subpartition.getBuffersInBacklog());
 	}
 
@@ -316,17 +315,6 @@ public class PipelinedSubpartitionWithReadViewTest {
 		testBacklogConsistentWithNumberOfConsumableBuffers(false, true);
 	}
 
-	@Test
-	public void testBufferCompression() {
-		subpartition.add(createFilledFinishedBufferConsumer(BUFFER_SIZE, false));
-		subpartition.add(createFilledFinishedBufferConsumer(BUFFER_SIZE, false));
-		subpartition.add(createFilledFinishedBufferConsumer(BUFFER_SIZE, true));
-
-		assertFalse(checkNotNull(readView.getNextBuffer(true)).buffer().isCompressed());
-		assertThat(checkNotNull(readView.getNextBuffer(false)).buffer().isCompressed(), is(compressionEnabled));
-		assertFalse(checkNotNull(readView.getNextBuffer(false)).buffer().isCompressed());
-	}
-
 	private void testBacklogConsistentWithNumberOfConsumableBuffers(boolean isFlushRequested, boolean isFinished) throws Exception {
 		final int numberOfAddedBuffers = 5;
 
@@ -351,7 +339,7 @@ public class PipelinedSubpartitionWithReadViewTest {
 		int numberOfConsumableBuffers = 0;
 		try (final CloseableRegistry closeableRegistry = new CloseableRegistry()) {
 			while (readView.isAvailable()) {
-				ResultSubpartition.BufferAndBacklog bufferAndBacklog = readView.getNextBuffer(true);
+				ResultSubpartition.BufferAndBacklog bufferAndBacklog = readView.getNextBuffer();
 				assertNotNull(bufferAndBacklog);
 
 				if (bufferAndBacklog.buffer().isBuffer()) {
@@ -415,7 +403,7 @@ public class PipelinedSubpartitionWithReadViewTest {
 			boolean expectedRecycledAfterRecycle) throws IOException, InterruptedException {
 		checkArgument(expectedEventClass == null || !expectedIsBuffer);
 
-		ResultSubpartition.BufferAndBacklog bufferAndBacklog = readView.getNextBuffer(true);
+		ResultSubpartition.BufferAndBacklog bufferAndBacklog = readView.getNextBuffer();
 		assertNotNull(bufferAndBacklog);
 		try {
 			assertEquals("buffer size", expectedReadableBufferSize,
@@ -444,6 +432,6 @@ public class PipelinedSubpartitionWithReadViewTest {
 	}
 
 	static void assertNoNextBuffer(ResultSubpartitionView readView) throws IOException, InterruptedException {
-		assertNull(readView.getNextBuffer(true));
+		assertNull(readView.getNextBuffer());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
@@ -63,8 +63,6 @@ public class ResultPartitionBuilder {
 
 	private boolean blockingShuffleCompressionEnabled = false;
 
-	private boolean pipelinedShuffleCompressionEnabled = false;
-
 	private String compressionCodec = "LZ4";
 
 	public ResultPartitionBuilder setResultPartitionId(ResultPartitionID partitionId) {
@@ -140,11 +138,6 @@ public class ResultPartitionBuilder {
 		return this;
 	}
 
-	public ResultPartitionBuilder setPipelinedShuffleCompressionEnabled(boolean pipelinedShuffleCompressionEnabled) {
-		this.pipelinedShuffleCompressionEnabled = pipelinedShuffleCompressionEnabled;
-		return this;
-	}
-
 	public ResultPartitionBuilder setCompressionCodec(String compressionCodec) {
 		this.compressionCodec = compressionCodec;
 		return this;
@@ -167,7 +160,6 @@ public class ResultPartitionBuilder {
 			networkBufferSize,
 			releasedOnConsumption,
 			blockingShuffleCompressionEnabled,
-			pipelinedShuffleCompressionEnabled,
 			compressionCodec);
 
 		FunctionWithException<BufferPoolOwner, BufferPool, IOException> factory = bufferPoolFactory.orElseGet(() ->

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -100,7 +100,6 @@ public class ResultPartitionFactoryTest extends TestLogger {
 			SEGMENT_SIZE,
 			releasePartitionOnConsumption,
 			false,
-			false,
 			"LZ4");
 
 		final ResultPartitionDeploymentDescriptor descriptor = new ResultPartitionDeploymentDescriptor(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
@@ -143,7 +143,7 @@ public abstract class SubpartitionTestBase extends TestLogger {
 		reader.releaseAllResources();
 
 		// the reader must not throw an exception
-		reader.getNextBuffer(true);
+		reader.getNextBuffer();
 
 		// ideally, we want this to be null, but the pipelined partition still serves data
 		// after dispose (which is unintuitive, but does not affect correctness)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestSubpartitionConsumer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestSubpartitionConsumer.java
@@ -91,7 +91,7 @@ public class TestSubpartitionConsumer implements Callable<Boolean>, BufferAvaila
 					}
 				}
 
-				final BufferAndBacklog bufferAndBacklog = subpartitionView.getNextBuffer(true);
+				final BufferAndBacklog bufferAndBacklog = subpartitionView.getNextBuffer();
 
 				if (isSlowConsumer) {
 					Thread.sleep(random.nextInt(MAX_SLEEP_TIME_MS + 1));

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/ShuffleCompressionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/ShuffleCompressionITCase.java
@@ -55,7 +55,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 /**
- * Tests pipeline/blocking shuffle when data compression is enabled.
+ * Tests network shuffle when data compression is enabled.
  */
 @RunWith(Parameterized.class)
 public class ShuffleCompressionITCase {
@@ -69,7 +69,11 @@ public class ShuffleCompressionITCase {
 	/** We plus 1 to guarantee that the last buffer contains no more than one record and can not be compressed. */
 	private static final int NUM_RECORDS_TO_SEND = NUM_BUFFERS_TO_SEND * BUFFER_SIZE / BYTES_PER_RECORD + 1;
 
-	private static final int PARALLELISM = 2;
+	private static final int NUM_TASKMANAGERS = 2;
+
+	private static final int NUM_SLOTS = 4;
+
+	private static final int PARALLELISM = NUM_TASKMANAGERS * NUM_SLOTS;
 
 	private static final LongValue RECORD_TO_SEND = new LongValue(4387942071694473832L);
 
@@ -82,11 +86,6 @@ public class ShuffleCompressionITCase {
 	}
 
 	@Test
-	public void testDataCompressionForPipelineShuffle() throws Exception {
-		executeTest(createJobGraph(ScheduleMode.EAGER, ResultPartitionType.PIPELINED, ExecutionMode.PIPELINED));
-	}
-
-	@Test
 	public void testDataCompressionForBlockingShuffle() throws Exception {
 		executeTest(createJobGraph(ScheduleMode.LAZY_FROM_SOURCES, ResultPartitionType.BLOCKING, ExecutionMode.BATCH));
 	}
@@ -95,12 +94,11 @@ public class ShuffleCompressionITCase {
 		Configuration configuration = new Configuration();
 		configuration.setString(TaskManagerOptions.TOTAL_FLINK_MEMORY, "1g");
 		configuration.setBoolean(NettyShuffleEnvironmentOptions.BLOCKING_SHUFFLE_COMPRESSION_ENABLED, true);
-		configuration.setBoolean(NettyShuffleEnvironmentOptions.PIPELINED_SHUFFLE_COMPRESSION_ENABLED, true);
 
 		final MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder()
 			.setConfiguration(configuration)
-			.setNumTaskManagers(PARALLELISM)
-			.setNumSlotsPerTaskManager(1)
+			.setNumTaskManagers(NUM_TASKMANAGERS)
+			.setNumSlotsPerTaskManager(NUM_SLOTS)
 			.build();
 
 		try (MiniCluster miniCluster = new MiniCluster(miniClusterConfiguration)) {


### PR DESCRIPTION
## What is the purpose of the change
This PR removes data compression for pipelined shuffle mode. The feature may be added in the future version of Flink if there is a better solution.


## Brief change log

  - The code and document relevant to data compression for pipeline mode is removed.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
