### PR TITLE
[FLINK-15327][walkthroughs] Replace InterruptedException by running flag

### DIFF
--- a/flink-walkthroughs/flink-walkthrough-common/src/main/java/org/apache/flink/walkthrough/common/source/TransactionSource.java
+++ b/flink-walkthroughs/flink-walkthrough-common/src/main/java/org/apache/flink/walkthrough/common/source/TransactionSource.java
@@ -43,13 +43,15 @@ public class TransactionSource extends FromIteratorFunction<Transaction> {
 
 		private final Iterator<T> inner;
 
+		private boolean running = true;
+
 		private RateLimitedIterator(Iterator<T> inner) {
 			this.inner = inner;
 		}
 
 		@Override
 		public boolean hasNext() {
-			return inner.hasNext();
+			return running && inner.hasNext();
 		}
 
 		@Override
@@ -57,7 +59,7 @@ public class TransactionSource extends FromIteratorFunction<Transaction> {
 			try {
 				Thread.sleep(100);
 			} catch (InterruptedException e) {
-				throw new RuntimeException(e);
+				running = false;
 			}
 			return inner.next();
 		}

--- a/tools/travis/splits/split_misc.sh
+++ b/tools/travis/splits/split_misc.sh
@@ -84,5 +84,10 @@ run_test "Dependency shading of table modules test" "$END_TO_END_DIR/test-script
 
 run_test "Shaded Hadoop S3A with credentials provider end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_wordcount.sh hadoop_with_provider"
 
+run_test "Walkthrough Table Java nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_table_walkthroughs.sh java"
+run_test "Walkthrough Table Scala nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_table_walkthroughs.sh scala"
+run_test "Walkthrough DataStream Java nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_datastream_walkthroughs.sh java"
+run_test "Walkthrough DataStream Scala nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_datastream_walkthroughs.sh scala"
+
 printf "\n[PASS] All tests passed\n"
 exit 0


### PR DESCRIPTION
## What is the purpose of the change

The end to end tests sometimes fail because a RuntimeException is logged when cancelling the TransactionSource.
