### PR TITLE
[FLINK-15317][runtime][1.10] Handle closed input gates more gracefully during

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.event.TaskEvent;
+import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
@@ -480,7 +481,7 @@ public class SingleInputGate extends InputGate {
 		}
 
 		if (closeFuture.isDone()) {
-			throw new IllegalStateException("Released");
+			throw new CancelTaskException("Input gate is already closed.");
 		}
 
 		Optional<InputWithData<InputChannel, BufferAndAvailability>> next = waitAndGetNextData(blocking);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -503,6 +503,11 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 				throw e;
 			}
 		}
+		catch (CancelTaskException e) {
+			if (!canceled) {
+				LOG.error("Received CancelTaskException while we are not canceled. This is a bug and should be reported", e);
+			}
+		}
 		catch (Exception e) {
 			if (canceled) {
 				LOG.warn("Error while canceling task.", e);


### PR DESCRIPTION
Backport of https://github.com/apache/flink/pull/10621 with no changes.