### PR TITLE
[FLINK-14683] Fix RemoteStreamEnvironment's constructor

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -111,7 +111,7 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 	 *            The protocol must be supported by the {@link java.net.URLClassLoader}.
 	 */
 	public RemoteStreamEnvironment(String host, int port, Configuration clientConfiguration, String[] jarFiles, URL[] globalClasspaths) {
-		this(host, port, clientConfiguration, jarFiles, null, null);
+		this(host, port, clientConfiguration, jarFiles, globalClasspaths, null);
 	}
 
 	/**


### PR DESCRIPTION
This is a trivial fix to be merged on `release-1.10` and `master`