### PR TITLE
[FLINK-15319][e2e] flink-end-to-end-tests-common-kafka fails due to t…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,9 @@ env:
   global:
     - cache-dir: $HOME/flink_download_cache
     - cache-btl: 30
+    - cache-download-max-retries: 3
+    - cache-download-attempt-timeout: 5
+    - cache-download-global-timeout: 10
     # Global variable to avoid hanging travis builds when downloading cache archives.
     - MALLOC_ARENA_MAX=2
     - DOCKER_COMPOSE_VERSION=1.22.0

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/AutoClosableProcess.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/AutoClosableProcess.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.tests.util;
 
+import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -111,6 +112,25 @@ public class AutoClosableProcess implements AutoCloseable {
 					}
 				} catch (TimeoutException | InterruptedException e) {
 					throw new IOException("Process failed due to timeout.");
+				}
+			}
+		}
+
+		public void runBlockingWithRetry(final int maxRetries, final Duration attemptTimeout, final Duration globalTimeout) throws IOException {
+			int retries = 0;
+			final Deadline globalDeadline = Deadline.fromNow(globalTimeout);
+
+			while (true) {
+				try {
+					runBlocking(attemptTimeout);
+					break;
+				} catch (Exception e) {
+					if (++retries > maxRetries || !globalDeadline.hasTimeLeft()) {
+						String errMsg = String.format(
+							"Process (%s) exceeded timeout (%s) or number of retries (%s).",
+							Arrays.toString(commands), maxRetries, globalTimeout.toMillis());
+						throw new IOException(errMsg, e);
+					}
 				}
 			}
 		}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/cache/AbstractDownloadCache.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/cache/AbstractDownloadCache.java
@@ -21,6 +21,8 @@ package org.apache.flink.tests.util.cache;
 import org.apache.flink.tests.util.AutoClosableProcess;
 import org.apache.flink.tests.util.CommandLineWrapper;
 import org.apache.flink.tests.util.TestUtils;
+import org.apache.flink.tests.util.parameters.ParameterProperty;
+import org.apache.flink.util.TimeUtils;
 
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -43,14 +45,28 @@ abstract class AbstractDownloadCache implements DownloadCache {
 
 	protected final Logger log = LoggerFactory.getLogger(getClass());
 
+	private static final ParameterProperty<Duration> DOWNLOAD_ATTEMPT_TIMEOUT = new ParameterProperty<>("cache-download-attempt-timeout", TimeUtils::parseDuration);
+	private static final ParameterProperty<Duration> DOWNLOAD_GLOBAL_TIMEOUT = new ParameterProperty<>("cache-download-global-timeout", TimeUtils::parseDuration);
+	private static final ParameterProperty<Integer> DOWNLOAD_MAX_RETRIES = new ParameterProperty<>("cache-download-max-retries", Integer::parseInt);
+
 	private final Path tmpDir;
 	private final Path downloadsDir;
 	private final Path cacheFilesDir;
+
+	private final Duration downloadAttemptTimeout;
+	private final Duration downloadGlobalTimeout;
+	private final int downloadMaxRetries;
 
 	AbstractDownloadCache(final Path tmpDir) {
 		this.tmpDir = tmpDir;
 		this.downloadsDir = tmpDir.resolve("downloads");
 		this.cacheFilesDir = tmpDir.resolve("cachefiles");
+
+		this.downloadAttemptTimeout = DOWNLOAD_ATTEMPT_TIMEOUT.get(Duration.ofMinutes(2));
+		this.downloadGlobalTimeout = DOWNLOAD_GLOBAL_TIMEOUT.get(Duration.ofMinutes(2));
+		this.downloadMaxRetries = DOWNLOAD_MAX_RETRIES.get(1);
+
+		log.info("Download configuration: maxAttempts={}, attemptTimeout={}, globalTimeout={}", downloadMaxRetries, downloadAttemptTimeout, downloadGlobalTimeout);
 	}
 
 	@Override
@@ -108,7 +124,7 @@ abstract class AbstractDownloadCache implements DownloadCache {
 					CommandLineWrapper.wget(url)
 						.targetDir(scopedDownloadDir)
 						.build())
-				.runBlocking(Duration.ofMinutes(2));
+				.runBlockingWithRetry(downloadMaxRetries, downloadAttemptTimeout, downloadGlobalTimeout);
 
 			final Path download;
 			try (Stream<Path> files = Files.list(scopedDownloadDir)) {


### PR DESCRIPTION
## What is the purpose of the change

Make the e2e package download timeout to be configurable. For example, we can tuning the timeout by the following command: 

```bash
mvn verify \
-pl org.apache.flink:flink-end-to-end-tests-common-kafka  \
-DdistDir=/Users/openinx/software/flink/build-target \
-DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup1
-DdownloadTimeout=180000 # set it to 3 min
```

BTW, if you don't set the `downloadTimeout` property, then it will use the default 5min.

## Brief change log

- Increase the default package download timeout to 5min and make it to be configurable.


## Verifying this change

This change does not have a test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)