### PR TITLE
[FLINK-15311][runtime] Remove shade of org.lz4:lz4-java to make lz4 block compression use native implementation by default.

### DIFF
--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -546,7 +546,6 @@ under the License.
 									<include>io.netty:netty</include>
 									<include>org.uncommons.maths:uncommons-maths</include>
 									<include>org.apache.zookeeper:*</include>
-									<include>org.lz4:lz4-java</include>
 								</includes>
 							</artifactSet>
 							<relocations combine.children="append">
@@ -577,11 +576,6 @@ under the License.
 								<relocation>
 									<pattern>org.apache.jute</pattern>
 									<shadedPattern>org.apache.flink.shaded.zookeeper.org.apache.zookeeper.jute</shadedPattern>
-								</relocation>
-								<relocation>
-									<!-- Relocate org.lz4:lz4-java -->
-									<pattern>net.jpountz</pattern>
-									<shadedPattern>org.apache.flink.runtime.shaded.net.jpountz</shadedPattern>
 								</relocation>
 							</relocations>
 							<filters>


### PR DESCRIPTION
## What is the purpose of the change
Currently, org.lz4:lz4-java library is used by runtime and table module for data compression to reduce disk and network IO. To avoid potential conflict, the library is shaded. However, shading changes the class name, which prevents JVM to find the more performant native implementation. To boost the performance, this commit removes the shade of org.lz4:lz4-java library. Note that this change can improve the probability of potential class conflict and to solve the problem, we can make it a plugin in the future.


## Brief change log

  - Shade of org.lz4:lz4-java library is removed.


## Verifying this change

  - The change can be verified by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
