### PR TITLE
[FLINK-10938] Add e2e test for natively running flink session cluster on kubernetes(Backport to 1.10)

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -112,6 +112,7 @@ run_test "Running HA per-job cluster (rocks, incremental) end-to-end test" "$END
 ################################################################################
 
 run_test "Run Kubernetes test" "$END_TO_END_DIR/test-scripts/test_kubernetes_embedded_job.sh"
+run_test "Run kubernetes session test" "$END_TO_END_DIR/test-scripts/test_kubernetes_session.sh"
 
 ################################################################################
 # Miscellaneous

--- a/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
+++ b/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+source "$(dirname "$0")"/common.sh
+
+DOCKER_MODULE_DIR=${END_TO_END_DIR}/../flink-container/docker
+KUBERNETES_MODULE_DIR=${END_TO_END_DIR}/../flink-container/kubernetes
+CONTAINER_SCRIPTS=${END_TO_END_DIR}/test-scripts/container-scripts
+MINIKUBE_START_RETRIES=3
+MINIKUBE_START_BACKOFF=5
+RESULT_HASH="e682ec6622b5e83f2eb614617d5ab2cf"
+
+function check_kubernetes_status {
+    minikube status
+    return $?
+}
+
+function start_kubernetes_if_not_running {
+    if ! check_kubernetes_status; then
+        minikube start
+    fi
+
+    check_kubernetes_status
+    return $?
+}
+
+function start_kubernetes {
+    if ! retry_times ${MINIKUBE_START_RETRIES} ${MINIKUBE_START_BACKOFF} start_kubernetes_if_not_running; then
+        echo "Minikube not running. Could not start minikube. Aborting..."
+        exit 1
+    fi
+}
+
+on_exit cleanup
+
+eval $(minikube docker-env)

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_embedded_job.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_embedded_job.sh
@@ -17,13 +17,7 @@
 # limitations under the License.
 ################################################################################
 
-source "$(dirname "$0")"/common.sh
-
-DOCKER_MODULE_DIR=${END_TO_END_DIR}/../flink-container/docker
-KUBERNETES_MODULE_DIR=${END_TO_END_DIR}/../flink-container/kubernetes
-CONTAINER_SCRIPTS=${END_TO_END_DIR}/test-scripts/container-scripts
-MINIKUBE_START_RETRIES=3
-MINIKUBE_START_BACKOFF=5
+source "$(dirname "$0")"/common_kubernetes.sh
 
 export FLINK_JOB=org.apache.flink.examples.java.wordcount.WordCount
 export FLINK_IMAGE_NAME=test_kubernetes_embedded_job
@@ -39,30 +33,10 @@ function cleanup {
     rm -rf ${OUTPUT_VOLUME}
 }
 
-function check_kubernetes_status {
-    minikube status
-    return $?
-}
-
-function start_kubernetes_if_not_running {
-    if ! check_kubernetes_status; then
-        minikube start
-    fi
-
-    check_kubernetes_status
-    return $?
-}
-
-on_exit cleanup
+start_kubernetes
 
 mkdir -p $OUTPUT_VOLUME
 
-if ! retry_times ${MINIKUBE_START_RETRIES} ${MINIKUBE_START_BACKOFF} start_kubernetes_if_not_running; then
-    echo "Minikube not running. Could not start minikube. Aborting..."
-    exit 1
-fi
-
-eval $(minikube docker-env)
 cd "$DOCKER_MODULE_DIR"
 ./build.sh --from-local-dist --job-artifacts ${FLINK_DIR}/examples/batch/WordCount.jar --image-name ${FLINK_IMAGE_NAME}
 cd "$END_TO_END_DIR"
@@ -74,4 +48,4 @@ envsubst '${FLINK_IMAGE_NAME} ${FLINK_JOB_PARALLELISM}' < ${CONTAINER_SCRIPTS}/t
 kubectl wait --for=condition=complete job/flink-job-cluster --timeout=1h
 kubectl cp `kubectl get pods | awk '/task-manager/ {print $1}'`:/cache/${OUTPUT_FILE} ${OUTPUT_VOLUME}/${OUTPUT_FILE}
 
-check_result_hash "WordCount" ${OUTPUT_VOLUME}/${OUTPUT_FILE} "e682ec6622b5e83f2eb614617d5ab2cf"
+check_result_hash "WordCount" ${OUTPUT_VOLUME}/${OUTPUT_FILE} "${RESULT_HASH}"

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_session.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_session.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+source "$(dirname "$0")"/common_kubernetes.sh
+
+CLUSTER_ROLE_BINDING="flink-role-binding-default"
+CLUSTER_ID="flink-native-k8s-session-1"
+FLINK_IMAGE_NAME="test_kubernetes_session"
+LOCAL_OUTPUT_PATH="${TEST_DATA_DIR}/out/wc_out"
+OUTPUT_PATH="/tmp/wc_out"
+ARGS="--output ${OUTPUT_PATH}"
+
+function cleanup {
+    kubectl delete service ${CLUSTER_ID}
+    kubectl delete clusterrolebinding ${CLUSTER_ROLE_BINDING}
+}
+
+start_kubernetes
+
+cd "$DOCKER_MODULE_DIR"
+# Build a Flink image without any user jars
+./build.sh --from-local-dist --job-artifacts ${TEST_INFRA_DIR}/test-data/words --image-name ${FLINK_IMAGE_NAME}
+
+kubectl create clusterrolebinding ${CLUSTER_ROLE_BINDING} --clusterrole=edit --serviceaccount=default:default --namespace=default
+
+mkdir -p "$(dirname $LOCAL_OUTPUT_PATH)"
+
+# Set the memory and cpu smaller than default, so that the jobmanager and taskmanager pods could be allocated in minikube.
+"$FLINK_DIR"/bin/kubernetes-session.sh -Dkubernetes.cluster-id=${CLUSTER_ID} \
+    -Dkubernetes.container.image=${FLINK_IMAGE_NAME} \
+    -Djobmanager.heap.size=512m \
+    -Dcontainerized.heap-cutoff-min=100 \
+    -Dkubernetes.jobmanager.cpu=0.5 \
+    -Dkubernetes.taskmanager.cpu=0.5
+
+"$FLINK_DIR"/bin/flink run -e kubernetes-session \
+    -Dkubernetes.cluster-id=${CLUSTER_ID} \
+    ${FLINK_DIR}/examples/batch/WordCount.jar ${ARGS}
+
+kubectl cp `kubectl get pods | awk '/taskmanager/ {print $1}'`:${OUTPUT_PATH} ${LOCAL_OUTPUT_PATH}
+
+check_result_hash "WordCount" "${LOCAL_OUTPUT_PATH}" "${RESULT_HASH}"

--- a/tools/travis/splits/split_container.sh
+++ b/tools/travis/splits/split_container.sh
@@ -47,6 +47,7 @@ run_test "Wordcount on Docker test (custom fs plugin)" "$END_TO_END_DIR/test-scr
 run_test "Running Kerberized YARN on Docker test (default input)" "$END_TO_END_DIR/test-scripts/test_yarn_kerberos_docker.sh"
 run_test "Running Kerberized YARN on Docker test (custom fs plugin)" "$END_TO_END_DIR/test-scripts/test_yarn_kerberos_docker.sh dummy-fs"
 run_test "Run kubernetes test" "$END_TO_END_DIR/test-scripts/test_kubernetes_embedded_job.sh"
+run_test "Run kubernetes session test" "$END_TO_END_DIR/test-scripts/test_kubernetes_session.sh"
 
 printf "\n[PASS] All tests passed\n"
 exit 0


### PR DESCRIPTION
Backport #10602 to 1.10 branch.