### PR TITLE
[FLINK-15320][runtime] Increment versions of all vertices when failing/canceling/suspending a job

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -88,8 +88,6 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 
 	private final SchedulingStrategy schedulingStrategy;
 
-	private final ExecutionVertexVersioner executionVertexVersioner;
-
 	private final ExecutionVertexOperations executionVertexOperations;
 
 	public DefaultScheduler(
@@ -133,6 +131,7 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 			slotRequestTimeout,
 			shuffleMaster,
 			partitionTracker,
+			executionVertexVersioner,
 			false);
 
 		this.log = log;
@@ -140,7 +139,6 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 		this.delayExecutor = checkNotNull(delayExecutor);
 		this.userCodeLoader = checkNotNull(userCodeLoader);
 		this.executionVertexOperations = checkNotNull(executionVertexOperations);
-		this.executionVertexVersioner = checkNotNull(executionVertexVersioner);
 
 		final FailoverStrategy failoverStrategy = failoverStrategyFactory.create(
 			getFailoverTopology(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexVersioner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexVersioner.java
@@ -59,11 +59,16 @@ public class ExecutionVertexVersioner {
 	}
 
 	public boolean isModified(final ExecutionVertexVersion executionVertexVersion) {
-		final Long currentVersion = executionVertexToVersion.get(executionVertexVersion.getExecutionVertexId());
+		final Long currentVersion = getCurrentVersion(executionVertexVersion.getExecutionVertexId());
+		return currentVersion != executionVertexVersion.getVersion();
+	}
+
+	private Long getCurrentVersion(ExecutionVertexID executionVertexId) {
+		final Long currentVersion = executionVertexToVersion.get(executionVertexId);
 		Preconditions.checkState(currentVersion != null,
 			"Execution vertex %s does not have a recorded version",
-			executionVertexVersion.getExecutionVertexId());
-		return currentVersion != executionVertexVersion.getVersion();
+			executionVertexId);
+		return currentVersion;
 	}
 
 	public Set<ExecutionVertexID> getUnmodifiedExecutionVertices(final Set<ExecutionVertexVersion> executionVertexVersions) {
@@ -73,4 +78,10 @@ public class ExecutionVertexVersioner {
 			.collect(Collectors.toSet());
 	}
 
+	ExecutionVertexVersion getExecutionVertexVersion(ExecutionVertexID executionVertexId) {
+		final long currentVersion = getCurrentVersion(executionVertexId);
+		return new ExecutionVertexVersion(
+			executionVertexId,
+			currentVersion);
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
@@ -79,6 +79,7 @@ public class LegacyScheduler extends SchedulerBase {
 			slotRequestTimeout,
 			shuffleMaster,
 			partitionTracker,
+			new ExecutionVertexVersioner(),
 			true);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -19,7 +19,6 @@
 
 package org.apache.flink.runtime.scheduler;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
@@ -412,11 +411,6 @@ public abstract class SchedulerBase implements SchedulerNG {
 			IterableUtils.toStream(schedulingTopology.getVertices())
 				.map(SchedulingExecutionVertex::getId)
 				.collect(Collectors.toSet()));
-	}
-
-	@VisibleForTesting
-	ExecutionVertexVersioner getExecutionVertexVersioner() {
-		return executionVertexVersioner;
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change
 
JM crashes may happen when an external job cancel request comes when the job is still allocating slots.
The root cause is that, the version of the canceled vertices are not incremented in the case of external job cancel request, and the pending slot requests are also not canceled in this case, so that the returned slot can be used to fulfill an outdated deployment, which finally triggers the fatal error.

## Brief change log

  - *increment all vertex versions in #failJob(), #cancel(), #suspend() in SchedulerBase*

## Verifying this change

  - *Added unit tests for job failing/canceling/suspending cases*
  - *manually verified the change by canceling a job when it is allocating slots*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
