### PR TITLE
[FLINK-15343][API/DataStream] Add Watermarks options for TwoInputStreamOpe…

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastConnectedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastConnectedStream.java
@@ -116,7 +116,7 @@ public class BroadcastConnectedStream<IN1, IN2> {
 	}
 
 	/**
-	 * Sets the watermarkOption of the stream
+	 * Sets the watermarkOption of the stream.
 	 *
 	 * @param watermarkOption The WatermarkOption of the stream
 	 */
@@ -236,7 +236,7 @@ public class BroadcastConnectedStream<IN1, IN2> {
 		inputStream2.getType();
 
 		if (watermarkOption != null){
-			((AbstractStreamOperator)operator).setWatermarkOption(watermarkOption);
+			((AbstractStreamOperator) operator).setWatermarkOption(watermarkOption);
 		}
 
 		TwoInputTransformation<IN1, IN2, OUT> transform = new TwoInputTransformation<>(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastConnectedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastConnectedStream.java
@@ -27,7 +27,9 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.co.BroadcastProcessFunction;
 import org.apache.flink.streaming.api.functions.co.KeyedBroadcastProcessFunction;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.operators.WatermarkOption;
 import org.apache.flink.streaming.api.operators.co.CoBroadcastWithKeyedOperator;
 import org.apache.flink.streaming.api.operators.co.CoBroadcastWithNonKeyedOperator;
 import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
@@ -60,6 +62,7 @@ public class BroadcastConnectedStream<IN1, IN2> {
 	private final DataStream<IN1> inputStream1;
 	private final BroadcastStream<IN2> inputStream2;
 	private final List<MapStateDescriptor<?, ?>> broadcastStateDescriptors;
+	private WatermarkOption watermarkOption;
 
 	protected BroadcastConnectedStream(
 			final StreamExecutionEnvironment env,
@@ -110,6 +113,16 @@ public class BroadcastConnectedStream<IN1, IN2> {
 	 */
 	public TypeInformation<IN2> getType2() {
 		return inputStream2.getType();
+	}
+
+	/**
+	 * Sets the watermarkOption of the stream
+	 *
+	 * @param watermarkOption The WatermarkOption of the stream
+	 */
+	public BroadcastConnectedStream<IN1, IN2> watermarkOption(WatermarkOption watermarkOption){
+		this.watermarkOption = watermarkOption;
+		return this;
 	}
 
 	/**
@@ -221,6 +234,10 @@ public class BroadcastConnectedStream<IN1, IN2> {
 		// read the output type of the input Transforms to coax out errors about MissingTypeInfo
 		inputStream1.getType();
 		inputStream2.getType();
+
+		if (watermarkOption != null){
+			((AbstractStreamOperator)operator).setWatermarkOption(watermarkOption);
+		}
 
 		TwoInputTransformation<IN1, IN2, OUT> transform = new TwoInputTransformation<>(
 				inputStream1.getTransformation(),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/ConnectedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/ConnectedStreams.java
@@ -113,7 +113,7 @@ public class ConnectedStreams<IN1, IN2> {
 	}
 
 	/**
-	 * Sets the watermarkOption of the stream
+	 * Sets the watermarkOption of the stream.
 	 *
 	 * @param watermarkOption The WatermarkOption of the stream
 	 */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -814,9 +814,9 @@ public abstract class AbstractStreamOperator<OUT>
 		long newMin;
 		if (watermarkOption == WatermarkOption.ALL) {
 			newMin = Math.min(input1Watermark, input2Watermark);
-		}else if (watermarkOption == WatermarkOption.STREAM1){
+		} else if (watermarkOption == WatermarkOption.STREAM1){
 			newMin = input1Watermark;
-		}else {
+		} else {
 			throw new RuntimeException("WatermarkOption only support ALL,STREAM1,STREAM2");
 		}
 		if (newMin > combinedWatermark) {
@@ -833,9 +833,9 @@ public abstract class AbstractStreamOperator<OUT>
 		long newMin;
 		if (watermarkOption == WatermarkOption.ALL) {
 			newMin = Math.min(input1Watermark, input2Watermark);
-		}else if (watermarkOption == WatermarkOption.STREAM2){
+		} else if (watermarkOption == WatermarkOption.STREAM2){
 			newMin = input2Watermark;
-		}else {
+		} else {
 			throw new RuntimeException("WatermarkOption only support ALL,STREAM1,STREAM2");
 		}
 		if (newMin > combinedWatermark) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/WatermarkOption.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/WatermarkOption.java
@@ -18,9 +18,7 @@
 package org.apache.flink.streaming.api.operators;
 
 /**
- *
  * Defines the watermark options for all "TwoInputStreamOperator".
- *
  * The default value used by the StreamOperator is {@link #ALL}, which means that
  * the operator receive two stream watermark. {@link #STREAM1} and {@link #STREAM2} mean that
  * the operator receive one stream watermatrk.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/WatermarkOption.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/WatermarkOption.java
@@ -1,0 +1,16 @@
+package org.apache.flink.streaming.api.operators;
+
+/**
+ *
+ * Defines the watermark options for all "TwoInputStreamOperator".
+ *
+ * The default value used by the StreamOperator is {@link #ALL}, which means that
+ * the operator receive two stream watermark. {@link #STREAM1} and {@link #STREAM2} mean that
+ * the operator receive one stream watermatrk.
+ *
+ */
+public enum WatermarkOption {
+	STREAM1,
+	STREAM2,
+	ALL
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/WatermarkOption.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/WatermarkOption.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.streaming.api.operators;
 
 /**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
@@ -44,8 +44,8 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
-
 import org.apache.flink.streaming.util.TwoInputStreamOperatorTestHarness;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
@@ -659,8 +659,7 @@ public class AbstractStreamOperatorTest {
 	}
 
 	/**
-	 * Check the watermark in case that WatermarkOption is ALL,STREAM1,STREAM2
-	 * @throws Exception
+	 * Check the watermark in case that WatermarkOption is ALL,STREAM1,STREAM2.
 	 */
 	@Test
 	public void testWatermarkOption() throws Exception {
@@ -794,7 +793,7 @@ public class AbstractStreamOperatorTest {
 	}
 
 	/**
-	 *Testing TwoInputStreamOperator WatermarkOption
+	 *Testing TwoInputStreamOperator WatermarkOption.
 	 */
 	private static class TestWatermarkOptionOperator
 		extends AbstractStreamOperator<Long>

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
@@ -39,12 +39,13 @@ import org.apache.flink.runtime.state.StateSnapshotContextSynchronousImpl;
 import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory;
+import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
-import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 
+import org.apache.flink.streaming.util.TwoInputStreamOperatorTestHarness;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
@@ -658,10 +659,57 @@ public class AbstractStreamOperatorTest {
 	}
 
 	/**
+	 * Check the watermark in case that WatermarkOption is ALL,STREAM1,STREAM2
+	 * @throws Exception
+	 */
+	@Test
+	public void testWatermarkOption() throws Exception {
+		TestWatermarkOptionOperator testOperator = new TestWatermarkOptionOperator();
+
+		TwoInputStreamOperatorTestHarness<Object, Object, Long> testHarness =
+			new TwoInputStreamOperatorTestHarness<>(testOperator);
+
+		testHarness.open();
+
+		/////////////////////////////////////////////////////////////
+		// ALL
+		////////////////////////////////////////////////////////////
+		testOperator.setWatermarkOption(WatermarkOption.ALL);
+		testHarness.processWatermark1(new Watermark(0L));
+		testHarness.processWatermark2(new Watermark(1L));
+		assertThat(
+			extractResult(testHarness),
+			contains(0L)
+			);
+
+		/////////////////////////////////////////////////////////////
+		// STREAM1
+		////////////////////////////////////////////////////////////
+		testOperator.setWatermarkOption(WatermarkOption.STREAM1);
+		testHarness.processWatermark1(new Watermark(3L));
+		testHarness.processWatermark2(new Watermark(2L));
+		assertThat(
+			extractResult(testHarness),
+			contains(3L)
+		);
+
+		/////////////////////////////////////////////////////////////
+		// STREAM2
+		////////////////////////////////////////////////////////////
+		testOperator.setWatermarkOption(WatermarkOption.STREAM2);
+		testHarness.processWatermark1(new Watermark(4L));
+		testHarness.processWatermark2(new Watermark(5L));
+		assertThat(
+			extractResult(testHarness),
+			contains(5L)
+		);
+	}
+
+	/**
 	 * Extracts the result values form the test harness and clear the output queue.
 	 */
 	@SuppressWarnings({"unchecked", "rawtypes"})
-	private <T> List<T> extractResult(OneInputStreamOperatorTestHarness<?, T> testHarness) {
+	private <T> List<T> extractResult(AbstractStreamOperatorTestHarness<T> testHarness) {
 		List<StreamRecord<? extends T>> streamRecords = testHarness.extractOutputStreamRecords();
 		List<T> result = new ArrayList<>();
 		for (Object in : streamRecords) {
@@ -742,6 +790,29 @@ public class AbstractStreamOperatorTest {
 		public void onProcessingTime(InternalTimer<Integer, VoidNamespace> timer) throws Exception {
 			String stateValue = getPartitionedState(stateDescriptor).value();
 			output.collect(new StreamRecord<>("ON_PROC_TIME:" + stateValue));
+		}
+	}
+
+	/**
+	 *Testing TwoInputStreamOperator WatermarkOption
+	 */
+	private static class TestWatermarkOptionOperator
+		extends AbstractStreamOperator<Long>
+		implements TwoInputStreamOperator<Object, Object, Long> {
+
+		@Override
+		public void processElement1(StreamRecord element) throws Exception {
+
+		}
+
+		@Override
+		public void processElement2(StreamRecord element) throws Exception {
+
+		}
+
+		@Override
+		public void processWatermark(Watermark mark) throws Exception {
+			output.collect(new StreamRecord<>(mark.getTimestamp()));
 		}
 	}
 


### PR DESCRIPTION
…rator

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Add Watermarks options for TwoInputStreamOperator, user can choose one watermark not only two.
There are many use case only need one strem watermark


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change
Added unit tests for watermark option is stream1,stream2,all cases
*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
