### PR TITLE
[FLINK-13027][streaming]: StreamingFileSink bulk-encoded writer supports customized checkpoint policy

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/rollingpolicies/CheckpointRollingPolicy.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/rollingpolicies/CheckpointRollingPolicy.java
@@ -22,27 +22,30 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.streaming.api.functions.sink.filesystem.PartFileInfo;
 import org.apache.flink.streaming.api.functions.sink.filesystem.RollingPolicy;
 
+import java.io.IOException;
+
 /**
- * A {@link RollingPolicy} which rolls (ONLY) on every checkpoint.
+ * An abstract {@link RollingPolicy} which rolls on every checkpoint.
  */
 @PublicEvolving
-public final class OnCheckpointRollingPolicy<IN, BucketID> extends CheckpointRollingPolicy<IN, BucketID> {
-
-	private static final long serialVersionUID = 1L;
-
-	private OnCheckpointRollingPolicy() {}
-
-	@Override
-	public boolean shouldRollOnEvent(PartFileInfo<BucketID> partFileState, IN element) {
-		return false;
+public abstract class CheckpointRollingPolicy<IN, BucketID> implements RollingPolicy<IN, BucketID> {
+	public boolean shouldRollOnCheckpoint(PartFileInfo<BucketID> partFileState) {
+		return true;
 	}
 
-	@Override
-	public boolean shouldRollOnProcessingTime(PartFileInfo<BucketID> partFileState, long currentTime) {
-		return false;
-	}
+	public abstract boolean shouldRollOnEvent(final PartFileInfo<BucketID> partFileState, IN element) throws IOException;
 
-	public static <IN, BucketID> OnCheckpointRollingPolicy<IN, BucketID> build() {
-		return new OnCheckpointRollingPolicy<>();
+	public abstract boolean shouldRollOnProcessingTime(final PartFileInfo<BucketID> partFileState, final long currentTime) throws IOException;
+
+	/**
+	 * The base abstract builder class for {@link CheckpointRollingPolicy}.
+	 */
+	public abstract static class PolicyBuilder<IN, BucketID, T extends PolicyBuilder<IN, BucketID, T>> {
+		@SuppressWarnings("unchecked")
+		protected T self() {
+			return (T) this;
+		}
+
+		public abstract CheckpointRollingPolicy<IN, BucketID> build();
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
@@ -27,6 +27,7 @@ import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
 import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.DefaultRollingPolicy;
+import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.OnCheckpointRollingPolicy;
 import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 
@@ -157,6 +158,7 @@ public class TestUtils {
 			.forBulkFormat(new Path(outDir.toURI()), writer)
 			.withBucketAssigner(bucketer)
 			.withBucketCheckInterval(bucketCheckInterval)
+			.withRollingPolicy(OnCheckpointRollingPolicy.build())
 			.withBucketFactory(bucketFactory)
 			.withOutputFileConfig(outputFileConfig)
 			.build();
@@ -197,6 +199,7 @@ public class TestUtils {
 		StreamingFileSink<Tuple2<String, Integer>> sink = StreamingFileSink
 				.forBulkFormat(new Path(outDir.toURI()), writer)
 				.withNewBucketAssigner(bucketer)
+				.withRollingPolicy(OnCheckpointRollingPolicy.build())
 				.withBucketCheckInterval(bucketCheckInterval)
 				.withBucketFactory(bucketFactory)
 				.withOutputFileConfig(outputFileConfig)


### PR DESCRIPTION
## What is the purpose of the change

This PR allows bulk-encoded `StreamingFileSink` to instantiate from a generic family of rolling policies that roll files at checkpoint time.  A base *CheckpointRollingPolicy* class is defined, which is extended by the existing `OnCheckpointRollingPolicy` and a new rolling policy `FSizeCheckpointRollingPolicy`. The latter policy rolls file not only at the checkpoint time, but also possibly before file size reaches a certain limit, which is useful for preventing file sizes from growing too big.   Recurrent builder pattern described in [[1](https://community.oracle.com/blogs/emcmanus/2010/10/24/using-builder-pattern-subclasses)] and [[2](https://stackoverflow.com/questions/17164375/subclassing-a-java-builder-class)] are used to instantiate the rolling policies whenever appropriate, making individual rolling policy also extensible.

## Brief change log

**CheckpointRollingPolicy**
  - An abstract class implementing the base rolling policy which rolls file at every checkpoint.

**FSizeCheckpointRollingPolicy**
  - A new rolling policy implementation which rolls part file both when size exceeds a limit, *in addition to* during a checkpoint event.

**StreamingFileSink**
  - Bulk-encoded sink writer (*forBulkFormat()*) takes a generic `CheckpointRollingPolicy` during instantiation. `OnCheckpointRollingPolicy` is still the default, but won't be the only option.

## Verifying this change

This change is an interface change and already covered by existing tests, such as *BulkWriterTest*. A new test case on the new `FSizeCheckpointRollingPolicy` has also been added to the `RollingPolicyTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (yes) minor interface change to `StreamingFileSink`.

## Documentation

  - Does this pull request introduce a new feature? (no)
