### PR TITLE
[FLINK-14081][table-planner-blink] Support precision of TimeType

### DIFF
--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseConnectorITCase.java
@@ -345,13 +345,15 @@ public class HBaseConnectorITCase extends HBaseTestBase {
 		tEnv.registerDataStream("src", ds);
 
 		// register hbase table
+		// TODO: HBase connector should use new type system to suppport precision/scale
+		//  https://issues.apache.org/jira/browse/FLINK-15525
 		String quorum = getZookeeperQuorum();
 		String ddl = "CREATE TABLE hbase (\n" +
 			"    rowkey INT," +
 			"    family1 ROW<col1 INT>,\n" +
 			"    family2 ROW<col1 VARCHAR, col2 BIGINT>,\n" +
 			"    family3 ROW<col1 DOUBLE, col2 BOOLEAN, col3 VARCHAR>,\n" +
-			"    family4 ROW<col1 TIMESTAMP(3), col2 DATE, col3 TIME(3)>\n" +
+			"    family4 ROW<col1 TIMESTAMP(3), col2 DATE, col3 TIME(0)>\n" +
 			") WITH (\n" +
 			"    'connector.type' = 'hbase',\n" +
 			"    'connector.version' = '1.4.3',\n" +

--- a/flink-python/pyflink/fn_execution/coder_impl.py
+++ b/flink-python/pyflink/fn_execution/coder_impl.py
@@ -266,24 +266,25 @@ class DateCoderImpl(StreamCoderImpl):
 class TimeCoderImpl(StreamCoderImpl):
 
     def encode_to_stream(self, value, out_stream, nested):
-        out_stream.write_bigendian_int32(self.time_to_internal(value))
+        out_stream.write_bigendian_int64(self.time_to_internal(value))
 
     def decode_from_stream(self, in_stream, nested):
-        value = in_stream.read_bigendian_int32()
+        value = in_stream.read_bigendian_int64()
         return self.internal_to_time(value)
 
     def time_to_internal(self, t):
-        milliseconds = (t.hour * 3600000
-                        + t.minute * 60000
-                        + t.second * 1000
-                        + t.microsecond // 1000)
-        return milliseconds
+        microseconds = (t.hour * 3600000000
+                        + t.minute * 60000000
+                        + t.second * 1000000
+                        + t.microsecond)
+        return microseconds * 1000
 
     def internal_to_time(self, v):
-        seconds, milliseconds = divmod(v, 1000)
+        v = v // 1000
+        seconds, microseconds = divmod(v, 1000000)
         minutes, seconds = divmod(seconds, 60)
         hours, minutes = divmod(minutes, 60)
-        return datetime.time(hours, minutes, seconds, milliseconds * 1000)
+        return datetime.time(hours, minutes, seconds, microseconds)
 
 
 class TimestampCoderImpl(StreamCoderImpl):

--- a/flink-python/pyflink/table/tests/test_udf.py
+++ b/flink-python/pyflink/table/tests/test_udf.py
@@ -321,7 +321,7 @@ class UserDefinedFunctionTests(object):
 
         def time_func(time_param):
             from datetime import time
-            assert time_param == time(hour=12, minute=0, second=0, microsecond=123000), \
+            assert time_param == time(hour=12, minute=0, second=0), \
                 'time_param is wrong value %s !' % time_param
             return time_param
 
@@ -424,7 +424,7 @@ class UserDefinedFunctionTests(object):
         t = self.t_env.from_elements(
             [(1, None, 1, True, 32767, -2147483648, 1.23, 1.98932,
               bytearray(b'flink'), 'pyflink', datetime.date(2014, 9, 13),
-              datetime.time(hour=12, minute=0, second=0, microsecond=123000),
+              datetime.time(hour=12, minute=0, second=0),
               datetime.datetime(2018, 3, 11, 3, 0, 0, 123000), [[1, 2, 3]],
               {1: 'flink', 2: 'pyflink'}, decimal.Decimal('1000000000000000000.05'),
               decimal.Decimal('1000000000000000000.05999999999999999899999999999'))],

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtils.java
@@ -264,7 +264,7 @@ public final class PythonTypeUtils {
 
 		@Override
 		public TypeSerializer visit(TimeType timeType) {
-			return IntSerializer.INSTANCE;
+			return LongSerializer.INSTANCE;
 		}
 
 		@Override

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/serializers/python/TimeSerializerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/serializers/python/TimeSerializerTest.java
@@ -34,7 +34,7 @@ public class TimeSerializerTest extends SerializerTestBase<Time> {
 
 	@Override
 	protected int getLength() {
-		return 4;
+		return 8;
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverter.java
@@ -37,6 +37,7 @@ import org.apache.flink.table.planner.expressions.converter.CallExpressionConver
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 
 import org.apache.calcite.avatica.util.TimeUnit;
@@ -49,11 +50,11 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.DateString;
-import org.apache.calcite.util.TimeString;
 
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
@@ -63,7 +64,8 @@ import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromDataTypeToLogicalType;
-import static org.apache.flink.table.util.TimestampStringUtils.fromLocalDateTime;
+import static org.apache.flink.table.util.DateTimeStringUtils.fromLocalDateTime;
+import static org.apache.flink.table.util.DateTimeStringUtils.fromLocalTime;
 
 /**
  * Visit expression to generator {@link RexNode}.
@@ -133,8 +135,10 @@ public class ExpressionConverter implements ExpressionVisitor<RexNode> {
 				return relBuilder.getRexBuilder().makeDateLiteral(DateString.fromCalendarFields(
 						valueAsCalendar(extractValue(valueLiteral, java.sql.Date.class))));
 			case TIME_WITHOUT_TIME_ZONE:
-				return relBuilder.getRexBuilder().makeTimeLiteral(TimeString.fromCalendarFields(
-						valueAsCalendar(extractValue(valueLiteral, java.sql.Time.class))), 0);
+				TimeType timeType = (TimeType) type;
+				LocalTime time = extractValue(valueLiteral, LocalTime.class);
+				return relBuilder.getRexBuilder().makeTimeLiteral(
+					fromLocalTime(time), timeType.getPrecision());
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
 				TimestampType timestampType = (TimestampType) type;
 				LocalDateTime datetime = extractValue(valueLiteral, LocalDateTime.class);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LeadLagAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LeadLagAggFunction.java
@@ -265,13 +265,16 @@ public abstract class LeadLagAggFunction extends DeclarativeAggregateFunction {
 	 */
 	public static class TimeLeadLagAggFunction extends LeadLagAggFunction {
 
-		public TimeLeadLagAggFunction(int operandCount) {
+		private final TimeType type;
+
+		public TimeLeadLagAggFunction(int operandCount, TimeType type) {
 			super(operandCount);
+			this.type = type;
 		}
 
 		@Override
 		public DataType getResultType() {
-			return DataTypes.TIME(TimeType.DEFAULT_PRECISION);
+			return DataTypes.TIME(type.getPrecision());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MaxAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MaxAggFunction.java
@@ -203,9 +203,16 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Time Max aggregate function.
 	 */
 	public static class TimeMaxAggFunction extends MaxAggFunction {
+
+		private final TimeType type;
+
+		public TimeMaxAggFunction(TimeType type) {
+			this.type = type;
+		}
+
 		@Override
 		public DataType getResultType() {
-			return DataTypes.TIME(TimeType.DEFAULT_PRECISION);
+			return DataTypes.TIME(type.getPrecision());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MinAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MinAggFunction.java
@@ -203,9 +203,16 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 	 * Built-in Time Min aggregate function.
 	 */
 	public static class TimeMinAggFunction extends MinAggFunction {
+
+		private final TimeType type;
+
+		public TimeMinAggFunction(TimeType type) {
+			this.type = type;
+		}
+
 		@Override
 		public DataType getResultType() {
-			return DataTypes.TIME(TimeType.DEFAULT_PRECISION);
+			return DataTypes.TIME(type.getPrecision());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/SingleValueAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/SingleValueAggFunction.java
@@ -272,9 +272,15 @@ public abstract class SingleValueAggFunction extends DeclarativeAggregateFunctio
 
 		private static final long serialVersionUID = 320495723666949978L;
 
+		private final TimeType type;
+
+		public TimeSingleValueAggFunction(TimeType type) {
+			this.type = type;
+		}
+
 		@Override
 		public DataType getResultType() {
-			return DataTypes.TIME(TimeType.DEFAULT_PRECISION);
+			return DataTypes.TIME(type.getPrecision());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/util/DateTimeStringUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/util/DateTimeStringUtils.java
@@ -25,9 +25,9 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 /**
- * Utility functions for calcite's {@link TimestampString}.
+ * Utility functions for calcite's {@link TimestampString}, {@link TimeString}.
  */
-public class TimestampStringUtils {
+public class DateTimeStringUtils {
 
 	public static TimestampString fromLocalDateTime(LocalDateTime ldt) {
 		return new TimestampString(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/util/TimestampStringUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/util/TimestampStringUtils.java
@@ -18,9 +18,11 @@
 
 package org.apache.flink.table.util;
 
+import org.apache.calcite.util.TimeString;
 import org.apache.calcite.util.TimestampString;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 /**
  * Utility functions for calcite's {@link TimestampString}.
@@ -47,6 +49,22 @@ public class TimestampStringUtils {
 		final int s = Integer.valueOf(v.substring(17, 19));
 		final int nano = getNanosInSecond(v);
 		return LocalDateTime.of(year, month, day, h, m, s, nano);
+	}
+
+	public static TimeString fromLocalTime(LocalTime lt) {
+		return new TimeString(
+			lt.getHour(),
+			lt.getMinute(),
+			lt.getSecond()).withNanos(lt.getNano());
+	}
+
+	public static LocalTime toLocalTime(TimeString timeString) {
+		final String v = timeString.toString();
+		final int h = Integer.valueOf(v.substring(0, 2));
+		final int m = Integer.valueOf(v.substring(3, 5));
+		final int s = Integer.valueOf(v.substring(6, 8));
+		final int nano = getNanosInSecond("0000-00-00 " + v);
+		return LocalTime.of(h, m, s, nano);
 	}
 
 	private static int getNanosInSecond(String v) {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
@@ -76,7 +76,9 @@ class FlinkTypeFactory(typeSystem: RelDataTypeSystem) extends JavaTypeFactoryImp
 
       // temporal types
       case LogicalTypeRoot.DATE => createSqlType(DATE)
-      case LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE => createSqlType(TIME)
+      case LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE =>
+        val timeType = t.asInstanceOf[TimeType]
+        createSqlType(TIME, timeType.getPrecision)
       case LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
         val lzTs = t.asInstanceOf[LocalZonedTimestampType]
         createSqlType(TIMESTAMP_WITH_LOCAL_TIME_ZONE, lzTs.getPrecision)
@@ -432,12 +434,7 @@ object FlinkTypeFactory {
       // temporal types
       case DATE => new DateType()
       case TIME =>
-        if (relDataType.getPrecision > 3) {
-          throw new TableException(
-            s"TIME precision is not supported: ${relDataType.getPrecision}")
-        }
-        // blink runner support precision 3, but for consistent with flink runner, we set to 0.
-        new TimeType()
+        new TimeType(relDataType.getPrecision)
       case TIMESTAMP =>
         new TimestampType(relDataType.getPrecision)
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeSystem.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeSystem.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.calcite
 
 import org.apache.flink.table.runtime.typeutils.TypeCheckUtils
-import org.apache.flink.table.types.logical.{DecimalType, LocalZonedTimestampType, LogicalType, TimestampType}
+import org.apache.flink.table.types.logical.{DecimalType, LocalZonedTimestampType, LogicalType, TimeType, TimestampType}
 import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeFactory, RelDataTypeSystemImpl}
 import org.apache.calcite.sql.`type`.{SqlTypeName, SqlTypeUtil}
 
@@ -64,6 +64,10 @@ class FlinkTypeSystem extends RelDataTypeSystemImpl {
     // The maximum precision of TIMESTAMP_WITH_LOCAL_TIME_ZONE is 3 in Calcite,
     // change it to 9 to support nanoseconds precision
     case SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE => LocalZonedTimestampType.MAX_PRECISION
+
+    // The maximum precision of TIME is 3 in Calcite,
+    // change it to 9 to support nanoseconds precision
+    case SqlTypeName.TIME => TimeType.MAX_PRECISION
 
     case _ =>
       super.getMaxPrecision(typeName)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -134,7 +134,7 @@ object CodeGenUtils {
     case BOOLEAN => "boolean"
 
     case DATE => "int"
-    case TIME_WITHOUT_TIME_ZONE => "int"
+    case TIME_WITHOUT_TIME_ZONE => "long"
     case INTERVAL_YEAR_MONTH => "int"
     case INTERVAL_DAY_TIME => "long"
 
@@ -151,7 +151,7 @@ object CodeGenUtils {
     case BOOLEAN => className[JBoolean]
 
     case DATE => className[JInt]
-    case TIME_WITHOUT_TIME_ZONE => className[JInt]
+    case TIME_WITHOUT_TIME_ZONE => className[JLong]
     case INTERVAL_YEAR_MONTH => className[JInt]
     case INTERVAL_DAY_TIME => className[JLong]
 
@@ -190,7 +190,8 @@ object CodeGenUtils {
     case BOOLEAN => "false"
     case VARCHAR | CHAR => s"$BINARY_STRING.EMPTY_UTF8"
 
-    case DATE | TIME_WITHOUT_TIME_ZONE => "-1"
+    case DATE => "-1"
+    case TIME_WITHOUT_TIME_ZONE => "-1L"
     case INTERVAL_YEAR_MONTH => "-1"
     case INTERVAL_DAY_TIME => "-1L"
 
@@ -222,7 +223,7 @@ object CodeGenUtils {
       s"$term, $BYTE_ARRAY_BASE_OFFSET, $term.length)"
     case DECIMAL => s"$term.hashCode()"
     case DATE => s"${className[JInt]}.hashCode($term)"
-    case TIME_WITHOUT_TIME_ZONE => s"${className[JInt]}.hashCode($term)"
+    case TIME_WITHOUT_TIME_ZONE => s"${className[JLong]}.hashCode($term)"
     case TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
       s"$term.hashCode()"
     case INTERVAL_YEAR_MONTH => s"${className[JInt]}.hashCode($term)"
@@ -413,7 +414,7 @@ object CodeGenUtils {
 
       // temporal types
       case DATE => s"$rowTerm.getInt($indexTerm)"
-      case TIME_WITHOUT_TIME_ZONE => s"$rowTerm.getInt($indexTerm)"
+      case TIME_WITHOUT_TIME_ZONE => s"$rowTerm.getLong($indexTerm)"
       case TIMESTAMP_WITHOUT_TIME_ZONE =>
         val dt = t.asInstanceOf[TimestampType]
         s"$rowTerm.getTimestamp($indexTerm, ${dt.getPrecision})"
@@ -546,7 +547,7 @@ object CodeGenUtils {
       case DOUBLE => s"$binaryRowTerm.setDouble($index, $fieldValTerm)"
       case BOOLEAN => s"$binaryRowTerm.setBoolean($index, $fieldValTerm)"
       case DATE =>  s"$binaryRowTerm.setInt($index, $fieldValTerm)"
-      case TIME_WITHOUT_TIME_ZONE =>  s"$binaryRowTerm.setInt($index, $fieldValTerm)"
+      case TIME_WITHOUT_TIME_ZONE =>  s"$binaryRowTerm.setLong($index, $fieldValTerm)"
       case TIMESTAMP_WITHOUT_TIME_ZONE =>
         val dt = t.asInstanceOf[TimestampType]
         s"$binaryRowTerm.setTimestamp($index, $fieldValTerm, ${dt.getPrecision})"
@@ -579,7 +580,7 @@ object CodeGenUtils {
       case DOUBLE => s"$rowTerm.setDouble($indexTerm, $fieldTerm)"
       case BOOLEAN => s"$rowTerm.setBoolean($indexTerm, $fieldTerm)"
       case DATE =>  s"$rowTerm.setInt($indexTerm, $fieldTerm)"
-      case TIME_WITHOUT_TIME_ZONE =>  s"$rowTerm.setInt($indexTerm, $fieldTerm)"
+      case TIME_WITHOUT_TIME_ZONE =>  s"$rowTerm.setLong($indexTerm, $fieldTerm)"
       case INTERVAL_YEAR_MONTH => s"$rowTerm.setInt($indexTerm, $fieldTerm)"
       case INTERVAL_DAY_TIME => s"$rowTerm.setLong($indexTerm, $fieldTerm)"
       case _ => s"$rowTerm.setNonPrimitiveValue($indexTerm, $fieldTerm)"
@@ -597,7 +598,6 @@ object CodeGenUtils {
     case INTEGER => s"$arrayTerm.setNullInt($index)"
     case FLOAT => s"$arrayTerm.setNullFloat($index)"
     case DOUBLE => s"$arrayTerm.setNullDouble($index)"
-    case TIME_WITHOUT_TIME_ZONE => s"$arrayTerm.setNullInt($index)"
     case DATE => s"$arrayTerm.setNullInt($index)"
     case INTERVAL_YEAR_MONTH => s"$arrayTerm.setNullInt($index)"
     case _ => s"$arrayTerm.setNullLong($index)"
@@ -649,7 +649,7 @@ object CodeGenUtils {
         val dt = t.asInstanceOf[DecimalType]
         s"$writerTerm.writeDecimal($indexTerm, $fieldValTerm, ${dt.getPrecision})"
       case DATE => s"$writerTerm.writeInt($indexTerm, $fieldValTerm)"
-      case TIME_WITHOUT_TIME_ZONE => s"$writerTerm.writeInt($indexTerm, $fieldValTerm)"
+      case TIME_WITHOUT_TIME_ZONE => s"$writerTerm.writeLong($indexTerm, $fieldValTerm)"
       case TIMESTAMP_WITHOUT_TIME_ZONE =>
         val dt = t.asInstanceOf[TimestampType]
         s"$writerTerm.writeTimestamp($indexTerm, $fieldValTerm, ${dt.getPrecision})"

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
@@ -451,16 +451,17 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
     val timestamp = addReusableTimestamp()
 
     // declaration
-    reusableMemberStatements.add(s"private int $fieldTerm;")
+    reusableMemberStatements.add(s"private long $fieldTerm;")
 
     // assignment
     // adopted from org.apache.calcite.runtime.SqlFunctions.currentTime()
     val field =
       s"""
-         |$fieldTerm = (int) ($timestamp.getMillisecond() % ${DateTimeUtils.MILLIS_PER_DAY});
+         |$fieldTerm = $timestamp.getMillisecond() % ${DateTimeUtils.MILLIS_PER_DAY};
          |if (time < 0) {
          |  time += ${DateTimeUtils.MILLIS_PER_DAY};
          |}
+         |time = time * 1000000L + $timestamp.getNanoOfMillisecond();
          |""".stripMargin
     reusablePerRecordStatements.add(field)
     fieldTerm
@@ -497,14 +498,18 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
     val localtimestamp = addReusableLocalDateTime()
 
     // declaration
-    reusableMemberStatements.add(s"private int $fieldTerm;")
+    reusableMemberStatements.add(s"private long $fieldTerm;")
 
     // assignment
     // adopted from org.apache.calcite.runtime.SqlFunctions.localTime()
     val field =
     s"""
-       |$fieldTerm = (int) ($localtimestamp.getMillisecond() % ${DateTimeUtils.MILLIS_PER_DAY});
-       |""".stripMargin
+       |$fieldTerm = $localtimestamp.getMillisecond() % ${DateTimeUtils.MILLIS_PER_DAY};
+       |if (localtime < 0) {
+       |  localtime += ${DateTimeUtils.MILLIS_PER_DAY};
+       |}
+       |localtime = localtime * 1000000L + $localtimestamp.getNanoOfMillisecond();
+     """.stripMargin
     reusablePerRecordStatements.add(field)
     fieldTerm
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
@@ -40,7 +40,7 @@ import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
 import org.apache.calcite.rex._
 import org.apache.calcite.sql.SqlOperator
 import org.apache.calcite.sql.`type`.{ReturnTypes, SqlTypeName}
-import org.apache.calcite.util.TimestampString
+import org.apache.calcite.util.{TimeString, TimestampString}
 
 import scala.collection.JavaConversions._
 
@@ -413,6 +413,8 @@ class ExprCodeGenerator(ctx: CodeGeneratorContext, nullableInput: Boolean)
       case LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE |
            LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
         literal.getValueAs(classOf[TimestampString])
+      case LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE =>
+        literal.getValueAs(classOf[TimeString])
       case _ =>
         literal.getValue3
     }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
@@ -29,13 +29,13 @@ import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.codegen.FunctionCodeGenerator.generateFunction
 import org.apache.flink.table.planner.plan.utils.PythonUtil.containsPythonCall
 import org.apache.flink.table.types.logical.RowType
-import org.apache.flink.table.util.TimestampStringUtils.fromLocalDateTime
+import org.apache.flink.table.util.TimestampStringUtils.{fromLocalDateTime, fromLocalTime}
 import org.apache.calcite.avatica.util.ByteString
 import org.apache.calcite.rex.{RexBuilder, RexExecutor, RexNode}
 import org.apache.calcite.sql.`type`.SqlTypeName
 import org.apache.commons.lang3.StringEscapeUtils
 import java.io.File
-import java.time.LocalDateTime
+import java.time.{LocalDateTime, LocalTime}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
@@ -176,6 +176,16 @@ class ExpressionReducer(
             val value = if (reducedValue != null) {
               val dt = reducedValue.asInstanceOf[SqlTimestamp].toLocalDateTime
               fromLocalDateTime(dt)
+            } else {
+              reducedValue
+            }
+            reducedValues.add(maySkipNullLiteralReduce(rexBuilder, value, unreduced))
+            reducedIdx += 1
+          case SqlTypeName.TIME =>
+            val reducedValue = reduced.getField(reducedIdx)
+            val value = if (reducedValue != null) {
+              val lt = LocalTime.ofNanoOfDay(reducedValue.asInstanceOf[Long])
+              fromLocalTime(lt)
             } else {
               reducedValue
             }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.codegen.FunctionCodeGenerator.generateFunction
 import org.apache.flink.table.planner.plan.utils.PythonUtil.containsPythonCall
 import org.apache.flink.table.types.logical.RowType
-import org.apache.flink.table.util.TimestampStringUtils.{fromLocalDateTime, fromLocalTime}
+import org.apache.flink.table.util.DateTimeStringUtils.{fromLocalDateTime, fromLocalTime}
 import org.apache.calcite.avatica.util.ByteString
 import org.apache.calcite.rex.{RexBuilder, RexExecutor, RexNode}
 import org.apache.calcite.sql.`type`.SqlTypeName

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -31,11 +31,11 @@ import org.apache.flink.table.runtime.typeutils.TypeCheckUtils.{isCharacterStrin
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical._
 import org.apache.calcite.avatica.util.ByteString
-import org.apache.calcite.util.TimestampString
+import org.apache.calcite.util.{TimeString, TimestampString}
 import org.apache.commons.lang3.StringEscapeUtils
 import java.math.{BigDecimal => JBigDecimal}
 
-import org.apache.flink.table.util.TimestampStringUtils.toLocalDateTime
+import org.apache.flink.table.util.TimestampStringUtils.{toLocalDateTime, toLocalTime}
 
 import scala.collection.mutable
 
@@ -363,7 +363,14 @@ object GenerateUtils {
         generateNonNullLiteral(literalType, literalValue.toString, literalValue)
 
       case TIME_WITHOUT_TIME_ZONE =>
-        generateNonNullLiteral(literalType, literalValue.toString, literalValue)
+        val fieldTerm = newName("time")
+        val lt = toLocalTime(literalValue.asInstanceOf[TimeString])
+        val fieldTime =
+          s"""
+             |long $fieldTerm = ${lt.toNanoOfDay}L;
+           """.stripMargin
+        ctx.addReusableMember(fieldTime)
+        generateNonNullLiteral(literalType, fieldTerm, literalValue)
 
       case TIMESTAMP_WITHOUT_TIME_ZONE =>
         val fieldTerm = newName("timestamp")

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -35,7 +35,7 @@ import org.apache.calcite.util.{TimeString, TimestampString}
 import org.apache.commons.lang3.StringEscapeUtils
 import java.math.{BigDecimal => JBigDecimal}
 
-import org.apache.flink.table.util.TimestampStringUtils.{toLocalDateTime, toLocalTime}
+import org.apache.flink.table.util.DateTimeStringUtils.{toLocalDateTime, toLocalTime}
 
 import scala.collection.mutable
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -210,10 +210,10 @@ object BuiltInMethods {
 
   // SQL DATE TIME FUNCTIONS
 
-  val UNIX_TIME_TO_STRING = Types.lookupMethod(
+  val TIME_TO_STRING = Types.lookupMethod(
     classOf[SqlDateTimeUtils],
-    "unixTimeToString",
-    classOf[Int])
+    "timeToString",
+    classOf[Long])
 
   val TIMESTAMP_TO_STRING = Types.lookupMethod(
     classOf[SqlDateTimeUtils],

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -432,7 +432,7 @@ object BuiltInMethods {
     classOf[SqlDateTimeUtils], "dateStringToUnixDate", classOf[String])
 
   val STRING_TO_TIME = Types.lookupMethod(
-    classOf[SqlDateTimeUtils], "timeStringToUnixDate", classOf[String])
+    classOf[SqlDateTimeUtils], "timeStringToTime", classOf[String])
 
   val TRUNCATE_DOUBLE_ONE = Types.lookupMethod(classOf[SqlFunctions], "struncate",
     classOf[Double])

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -376,7 +376,7 @@ object BuiltInMethods {
   val TIMESTAMP_WITH_LOCAL_TIME_ZONE_TO_TIME = Types.lookupMethod(
     classOf[SqlDateTimeUtils],
     "timestampWithLocalZoneToTime",
-    classOf[Long], classOf[TimeZone])
+    classOf[SqlTimestamp], classOf[TimeZone])
 
   val DATE_TO_TIMESTAMP_WITH_LOCAL_TIME_ZONE = Types.lookupMethod(
     classOf[SqlDateTimeUtils],
@@ -386,7 +386,7 @@ object BuiltInMethods {
   val TIME_TO_TIMESTAMP_WITH_LOCAL_TIME_ZONE = Types.lookupMethod(
     classOf[SqlDateTimeUtils],
     "timeToTimestampWithLocalZone",
-    classOf[Int], classOf[TimeZone])
+    classOf[Long], classOf[TimeZone])
 
   val TIMESTAMP_TO_BIGINT = Types.lookupMethod(
     classOf[SqlDateTimeUtils],
@@ -463,4 +463,7 @@ object BuiltInMethods {
 
   val TRUNCATE_SQL_TIMESTAMP = Types.lookupMethod(classOf[SqlDateTimeUtils], "truncate",
     classOf[SqlTimestamp], classOf[Int])
+
+  val TRUNCATE_SQL_TIME = Types.lookupMethod(classOf[SqlDateTimeUtils], "truncateTime",
+    classOf[Long], classOf[Int])
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ExtractCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ExtractCallGen.scala
@@ -73,6 +73,7 @@ class ExtractCallGen(method: Method)
         val factor = getFactor(unit)
         val longTerm = tpe.getTypeRoot match {
           case LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE => s"${terms(1)}.getMillisecond()"
+          case LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE => s"${terms(1)} / 1000000"
           case _ => s"${terms(1)}"
         }
         unit match {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ExtractCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ExtractCallGen.scala
@@ -88,6 +88,11 @@ class ExtractCallGen(method: Method)
                 s"""
                    |($longTerm % $factor) * 1000 + $nanoOfMilliTerm / 1000
                  """.stripMargin
+              case LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE =>
+                val nanoOfMilliTerm = s"${terms(1)} % 1000000"
+                s"""
+                   |($longTerm % $factor) * 1000 + $nanoOfMilliTerm / 1000
+                 """.stripMargin
               case _ =>
                 throw new ValidationException(
                   "unit " + unit + " can not be applied to " + tpe.toString + " variable")
@@ -96,6 +101,11 @@ class ExtractCallGen(method: Method)
             tpe.getTypeRoot match {
               case LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE =>
                 val nanoOfMilliTerm = s"${terms(1)}.getNanoOfMillisecond()"
+                s"""
+                   |($longTerm % $factor) * 1000000 + $nanoOfMilliTerm
+                 """.stripMargin
+              case LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE =>
+                val nanoOfMilliTerm = s"${terms(1)} % 1000000"
                 s"""
                    |($longTerm % $factor) * 1000000 + $nanoOfMilliTerm
                  """.stripMargin

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FloorCeilCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FloorCeilCallGen.scala
@@ -102,6 +102,13 @@ class FloorCeilCallGen(
                      |  $longTerm,
                      |  (long) ${unit.startUnit.multiplier.intValue()}))
                    """.stripMargin
+                case LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE =>
+                  val longTerm = s"${terms.head} / 1000000"
+                  s"""
+                     |${qualifyMethod(arithmeticMethod)}(
+                     |  $longTerm,
+                     |  ($internalType) ${unit.startUnit.multiplier.intValue()}) * 1000000L
+                   """.stripMargin
                 case _ =>
                   s"""
                      |${qualifyMethod(arithmeticMethod)}(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1038,7 +1038,7 @@ object ScalarOperatorGens {
         operand, 
         resultNullable = true) {
         operandTerm =>
-          s"${qualifyMethod(BuiltInMethods.STRING_TO_TIME)}($operandTerm.toString()) * 1000000L"
+          s"${qualifyMethod(BuiltInMethods.STRING_TO_TIME)}($operandTerm.toString())"
       }
 
     // String -> Timestamp
@@ -2380,7 +2380,7 @@ object ScalarOperatorGens {
       case DATE =>
         s"${qualifyMethod(BuiltInMethods.STRING_TO_DATE)}($operandTerm.toString())"
       case TIME_WITHOUT_TIME_ZONE =>
-        s"${qualifyMethod(BuiltInMethods.STRING_TO_TIME)}($operandTerm.toString()) * 1000000L"
+        s"${qualifyMethod(BuiltInMethods.STRING_TO_TIME)}($operandTerm.toString())"
       case TIMESTAMP_WITHOUT_TIME_ZONE =>
         s"""
            |${qualifyMethod(BuiltInMethods.STRING_TO_TIMESTAMP)}($operandTerm.toString())

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/over/RangeBoundComparatorCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/over/RangeBoundComparatorCodeGenerator.scala
@@ -128,11 +128,15 @@ class RangeBoundComparatorCodeGenerator(
   private def getComparatorCode(inputValue: String, currentValue: String): String = {
     val (realBoundValue, realKeyType) = keyType.getTypeRoot match {
       case LogicalTypeRoot.DATE =>
-        //The constant about time is expressed based millisecond unit in calcite, but
+        //The constant bound time is expressed based millisecond unit in calcite, but
         //the field about date is expressed based day unit. So here should keep the same unit for
         // comparator.
         (bound.asInstanceOf[Long] / DateTimeUtils.MILLIS_PER_DAY, new IntType())
-      case LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE => (bound, new IntType())
+      case LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE =>
+        //The constant bound time is expressed based millisecond unit in calcite, but
+        //the field about Time is expressed based nanosecond. So here should keep the same unit for
+        //comparator.
+        (bound.asInstanceOf[Long] * 1000000, new BigIntType())
       case LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE => (bound, new BigIntType())
       case _ => (bound, keyType)
     }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/sort/SortCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/sort/SortCodeGenerator.scala
@@ -416,7 +416,7 @@ class SortCodeGenerator(
     case VARBINARY | BINARY => "Binary"
     case DECIMAL => "Decimal"
     case DATE => "Int"
-    case TIME_WITHOUT_TIME_ZONE => "Int"
+    case TIME_WITHOUT_TIME_ZONE => "Long"
     case TIMESTAMP_WITHOUT_TIME_ZONE => "Timestamp"
     case INTERVAL_YEAR_MONTH => "Int"
     case INTERVAL_DAY_TIME => "Long"

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/sort/SortCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/sort/SortCodeGenerator.scala
@@ -462,7 +462,7 @@ class SortCodeGenerator(
       case INTERVAL_YEAR_MONTH => 4
       case INTERVAL_DAY_TIME => 8
       case DATE => 4
-      case TIME_WITHOUT_TIME_ZONE => 4
+      case TIME_WITHOUT_TIME_ZONE => 8
       case DECIMAL if Decimal.isCompact(t.asInstanceOf[DecimalType].getPrecision) => 8
       case VARCHAR | CHAR | VARBINARY | BINARY => Int.MaxValue
     }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/time.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/time.scala
@@ -27,8 +27,8 @@ import org.apache.flink.table.planner.typeutils.TypeInfoCheckUtils
 import org.apache.flink.table.planner.typeutils.TypeInfoCheckUtils.isTimeInterval
 import org.apache.flink.table.planner.validate.{ValidationFailure, ValidationResult, ValidationSuccess}
 import org.apache.flink.table.typeutils.TimeIntervalTypeInfo
-
 import org.apache.calcite.rex._
+import org.apache.flink.table.runtime.typeutils.LegacyLocalTimeTypeInfo
 
 case class Extract(timeIntervalUnit: PlannerExpression, temporal: PlannerExpression)
   extends PlannerExpression {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/UserDefinedFunctionUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/UserDefinedFunctionUtils.scala
@@ -45,7 +45,7 @@ import org.apache.calcite.rex.{RexLiteral, RexNode}
 import org.apache.calcite.sql.`type`.SqlTypeName
 import org.apache.calcite.sql.{SqlFunction, SqlOperatorBinding}
 import java.lang.reflect.{Method, Modifier}
-import java.lang.{Integer => JInt, Long => JLong}
+import java.lang.{Integer => JInt}
 import java.sql.{Date, Time, Timestamp}
 import java.time.{Instant, LocalDateTime}
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
@@ -302,7 +302,9 @@ class AggFunctionFactory(
         case DECIMAL =>
           val d = argTypes(0).asInstanceOf[DecimalType]
           new DecimalMinWithRetractAggFunction(DecimalTypeInfo.of(d.getPrecision, d.getScale))
-        case TIME_WITHOUT_TIME_ZONE =>
+        case TIME_WITHOUT_TIME_ZONE
+            if argTypes(0).asInstanceOf[TimeType].getPrecision == TimeType.DEFAULT_PRECISION =>
+          // TODO: support TimeMinWithRetractAggFunction for high precision time
           new TimeMinWithRetractAggFunction
         case DATE =>
           new DateMinWithRetractAggFunction
@@ -334,7 +336,8 @@ class AggFunctionFactory(
         case DATE =>
           new MinAggFunction.DateMinAggFunction
         case TIME_WITHOUT_TIME_ZONE =>
-          new MinAggFunction.TimeMinAggFunction
+          val d = argTypes(0).asInstanceOf[TimeType]
+          new MinAggFunction.TimeMinAggFunction(d)
         case TIMESTAMP_WITHOUT_TIME_ZONE =>
           val d = argTypes(0).asInstanceOf[TimestampType]
           new MinAggFunction.TimestampMinAggFunction(d)
@@ -370,7 +373,8 @@ class AggFunctionFactory(
       case DATE =>
         new LeadLagAggFunction.DateLeadLagAggFunction(argTypes.length)
       case TIME_WITHOUT_TIME_ZONE =>
-        new LeadLagAggFunction.TimeLeadLagAggFunction(argTypes.length)
+        val d = argTypes(0).asInstanceOf[TimeType]
+        new LeadLagAggFunction.TimeLeadLagAggFunction(argTypes.length, d)
       case TIMESTAMP_WITHOUT_TIME_ZONE =>
         val d = argTypes(0).asInstanceOf[TimestampType]
         new LeadLagAggFunction.TimestampLeadLagAggFunction(argTypes.length, d)
@@ -406,7 +410,9 @@ class AggFunctionFactory(
         case DECIMAL =>
           val d = argTypes(0).asInstanceOf[DecimalType]
           new DecimalMaxWithRetractAggFunction(DecimalTypeInfo.of(d.getPrecision, d.getScale))
-        case TIME_WITHOUT_TIME_ZONE =>
+        case TIME_WITHOUT_TIME_ZONE
+            if argTypes(0).asInstanceOf[TimeType].getPrecision == TimeType.DEFAULT_PRECISION =>
+          // TODO: support TimeMaxWithRetractAggFunction for high precision time
           new TimeMaxWithRetractAggFunction
         case DATE =>
           new DateMaxWithRetractAggFunction
@@ -438,7 +444,8 @@ class AggFunctionFactory(
         case DATE =>
           new MaxAggFunction.DateMaxAggFunction
         case TIME_WITHOUT_TIME_ZONE =>
-          new MaxAggFunction.TimeMaxAggFunction
+          val d = argTypes(0).asInstanceOf[TimeType]
+          new MaxAggFunction.TimeMaxAggFunction(d)
         case TIMESTAMP_WITHOUT_TIME_ZONE =>
           val d = argTypes(0).asInstanceOf[TimestampType]
           new MaxAggFunction.TimestampMaxAggFunction(d)
@@ -481,7 +488,8 @@ class AggFunctionFactory(
       case DATE =>
         new DateSingleValueAggFunction
       case TIME_WITHOUT_TIME_ZONE =>
-        new TimeSingleValueAggFunction
+        val d = argTypes(0).asInstanceOf[TimeType]
+        new TimeSingleValueAggFunction(d)
       case TIMESTAMP_WITHOUT_TIME_ZONE =>
         val d = argTypes(0).asInstanceOf[TimestampType]
         new TimestampSingleValueAggFunction(d)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
@@ -493,7 +493,7 @@ object AggregateUtil extends Enumeration {
       case BOOLEAN => DataTypes.BOOLEAN
 
       case DATE => DataTypes.INT
-      case TIME_WITHOUT_TIME_ZONE => DataTypes.INT
+      case TIME_WITHOUT_TIME_ZONE => DataTypes.BIGINT
       case TIMESTAMP_WITHOUT_TIME_ZONE =>
         val dt = argTypes(0).asInstanceOf[TimestampType]
         DataTypes.TIMESTAMP(dt.getPrecision).bridgedTo(classOf[SqlTimestamp])

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/PartitionPruner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/PartitionPruner.scala
@@ -178,7 +178,7 @@ object PartitionPruner {
         val decimalType = t.asInstanceOf[DecimalType]
         Decimal.castFrom(v, decimalType.getPrecision, decimalType.getScale)
       case DATE => SqlDateTimeUtils.dateStringToUnixDate(v)
-      case TIME_WITHOUT_TIME_ZONE => SqlDateTimeUtils.timeStringToUnixDate(v) * 1000000L
+      case TIME_WITHOUT_TIME_ZONE => SqlDateTimeUtils.timeStringToTime(v)
       case TIMESTAMP_WITHOUT_TIME_ZONE => SqlDateTimeUtils.toSqlTimestamp(v)
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE => SqlTimestamp.fromInstant(
         SqlDateTimeUtils.toSqlTimestamp(v).toLocalDateTime.atZone(timeZone).toInstant)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/PartitionPruner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/PartitionPruner.scala
@@ -178,7 +178,7 @@ object PartitionPruner {
         val decimalType = t.asInstanceOf[DecimalType]
         Decimal.castFrom(v, decimalType.getPrecision, decimalType.getScale)
       case DATE => SqlDateTimeUtils.dateStringToUnixDate(v)
-      case TIME_WITHOUT_TIME_ZONE => SqlDateTimeUtils.timeStringToUnixDate(v)
+      case TIME_WITHOUT_TIME_ZONE => SqlDateTimeUtils.timeStringToUnixDate(v) * 1000000L
       case TIMESTAMP_WITHOUT_TIME_ZONE => SqlDateTimeUtils.toSqlTimestamp(v)
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE => SqlTimestamp.fromInstant(
         SqlDateTimeUtils.toSqlTimestamp(v).toLocalDateTime.atZone(timeZone).toInstant)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
@@ -30,15 +30,13 @@ import org.apache.flink.table.planner.utils.Logging
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromLogicalTypeToDataType
 import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
-import org.apache.flink.table.util.TimestampStringUtils.toLocalDateTime
+import org.apache.flink.table.util.DateTimeStringUtils.{toLocalDateTime, toLocalTime}
 import org.apache.flink.util.Preconditions
-
 import org.apache.calcite.plan.RelOptUtil
 import org.apache.calcite.rex._
 import org.apache.calcite.sql.fun.{SqlStdOperatorTable, SqlTrimFunction}
 import org.apache.calcite.sql.{SqlFunction, SqlPostfixOperator}
-import org.apache.calcite.util.{TimestampString, Util}
-
+import org.apache.calcite.util.{TimeString, TimestampString, Util}
 import java.util
 import java.util.{TimeZone, List => JList}
 
@@ -351,8 +349,8 @@ class RexNodeToExpressionConverter(
         LocalDateConverter.INSTANCE.toExternal(v)
 
       case TIME_WITHOUT_TIME_ZONE =>
-        val v = literal.getValueAs(classOf[Integer])
-        new LocalTimeConverter(3).toExternal(v * 1000000L)
+        val v = literal.getValueAs(classOf[TimeString])
+        toLocalTime(v)
 
       case TIMESTAMP_WITHOUT_TIME_ZONE =>
         val v = literal.getValueAs(classOf[TimestampString])

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
@@ -352,7 +352,7 @@ class RexNodeToExpressionConverter(
 
       case TIME_WITHOUT_TIME_ZONE =>
         val v = literal.getValueAs(classOf[Integer])
-        LocalTimeConverter.INSTANCE.toExternal(v)
+        new LocalTimeConverter(3).toExternal(v * 1000000L)
 
       case TIMESTAMP_WITHOUT_TIME_ZONE =>
         val v = literal.getValueAs(classOf[TimestampString])

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -398,9 +398,9 @@ public class SqlToOperationConverterTest {
 			createTestItem("TIME", DataTypes.TIME()),
 			createTestItem("TIME WITHOUT TIME ZONE", DataTypes.TIME()),
 			// Expect to be TIME(3).
-			createTestItem("TIME(3)", DataTypes.TIME()),
+			createTestItem("TIME(3)", DataTypes.TIME(3)),
 			// Expect to be TIME(3).
-			createTestItem("TIME(3) WITHOUT TIME ZONE", DataTypes.TIME()),
+			createTestItem("TIME(3) WITHOUT TIME ZONE", DataTypes.TIME(3)),
 			createTestItem("TIMESTAMP", DataTypes.TIMESTAMP(6)),
 			createTestItem("TIMESTAMP WITHOUT TIME ZONE", DataTypes.TIMESTAMP(6)),
 			createTestItem("TIMESTAMP(3)", DataTypes.TIMESTAMP(3)),

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
@@ -83,7 +83,7 @@ public class JavaUserDefinedScalarFunctions {
 	 * Concatenate inputs as strings.
 	 */
 	public static class JavaFunc1 extends ScalarFunction {
-		public String eval(Integer a, int b,  SqlTimestamp c) {
+		public String eval(Integer a, Long b,  SqlTimestamp c) {
 			Long ts = (c == null) ? null : c.getMillisecond();
 			return a + " and " + b + " and " + ts;
 		}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ArrayTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ArrayTypeTest.scala
@@ -23,7 +23,7 @@ import org.apache.flink.table.api.scala._
 import org.apache.flink.table.planner.expressions.utils.ArrayTypeTestBase
 import org.apache.flink.table.planner.utils.DateTimeTestUtil.{localDate, localDateTime, localTime => gLocalTime}
 
-import java.time.{LocalDateTime => JLocalDateTime}
+import java.time.{LocalDateTime => JLocalDateTime, LocalTime => JLocalTime}
 
 import org.junit.Test
 
@@ -90,14 +90,34 @@ class ArrayTypeTest extends ArrayTypeTestBase {
       "ARRAY[TIME '14:15:16', TIME '17:18:19']",
       "[14:15:16, 17:18:19]")
 
+    testTableApi(
+      Array(gLocalTime("14:15:16.123456789"), gLocalTime("17:18:19.123456789")),
+      "[14:15:16.123456789, 17:18:19.123456789]")
+
+    testTableApi(
+      Array(gLocalTime("14:15:16.1234567"), gLocalTime("17:18:19.1234567")),
+      "[14:15:16.1234567, 17:18:19.1234567]")
+
+    testTableApi(
+      Array(gLocalTime("14:15:16.123456"), gLocalTime("17:18:19.123456")),
+      "[14:15:16.123456, 17:18:19.123456]")
+
+    testTableApi(
+      Array(gLocalTime("14:15:16.1234"), gLocalTime("17:18:19.1234")),
+      "[14:15:16.1234, 17:18:19.1234]")
+
+    testTableApi(
+      Array(
+        JLocalTime.of(14, 15, 16, 123456789),
+        JLocalTime.of(17, 18, 19, 123456789)),
+      "[14:15:16.123456789, 17:18:19.123456789]")
+
     testAllApis(
       Array(localDateTime("1985-04-11 14:15:16"), localDateTime("2018-07-26 17:18:19")),
       "array('1985-04-11 14:15:16'.toTimestamp, '2018-07-26 17:18:19'.toTimestamp)",
       "ARRAY[TIMESTAMP '1985-04-11 14:15:16', TIMESTAMP '2018-07-26 17:18:19']",
       "[1985-04-11 14:15:16, 2018-07-26 17:18:19]")
 
-    // localDateTime use DateTimeUtils.timestampStringToUnixDate to parse a time string,
-    // which only support millisecond's precision.
     testTableApi(
       Array(
         JLocalDateTime.of(1985, 4, 11, 14, 15, 16, 123456789),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -121,6 +121,22 @@ class TemporalTypesTest extends ExpressionTestBase {
       "CAST('1999-9-10 05:20:10.123456' AS TIMESTAMP)",
       "1999-09-10 05:20:10.123456"
     )
+
+    testSqlApi(
+      "TIME '14:15:16.123456789'",
+      "14:15:16.123456789")
+
+    testSqlApi(
+      "TIME '14:15:16.1234567'",
+      "14:15:16.1234567")
+
+    testSqlApi(
+      "TIME '14:15:16.123456'",
+      "14:15:16.123456")
+
+    testSqlApi(
+      "TIME '14:15:16.1234'",
+      "14:15:16.1234")
   }
 
   @Test
@@ -1147,7 +1163,6 @@ class TemporalTypesTest extends ExpressionTestBase {
       s"CAST(f24 AS TIMESTAMP(6) WITH LOCAL TIME ZONE)",
       "1970-01-01 00:00:00.123456"
     )
-
 
     // DATETIME +/- INTERVAL should support nanosecond
     testSqlApi(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -228,13 +228,7 @@ class TemporalTypesTest extends ExpressionTestBase {
       'f2.cast(DataTypes.TIME),
       "f2.cast(SQL_TIME)",
       "CAST(f2 AS TIME)",
-      "10:20:45")
-
-    testAllApis(
-      'f2.cast(DataTypes.TIME),
-      "f2.cast(SQL_TIME)",
-      "CAST(f2 AS TIME)",
-      "10:20:45")
+      "10:20:45.123")
 
     testTableApi(
       'f7.cast(DataTypes.DATE),
@@ -755,7 +749,7 @@ class TemporalTypesTest extends ExpressionTestBase {
       "2018-03-14")
     testSqlApi(
       "TIME '19:01:02.123'",
-      "19:01:02")
+      "19:01:02.123")
 
     // DATE & TIME
     testSqlApi("CAST('12:44:31' AS TIME)", "12:44:31")

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -136,6 +136,15 @@ class TemporalTypesTest extends ExpressionTestBase {
     testSqlApi(
       "TIME '14:15:16.1234'",
       "14:15:16.1234")
+
+    testSqlApi(
+      "CAST('14:15:16.123456789' AS TIME(9))",
+      "14:15:16.123456789")
+
+    // by default, it's TIME(0)
+    testSqlApi(
+      "CAST('14:15:16.123456789' AS TIME)",
+      "14:15:16")
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/UserDefinedScalarFunctionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/UserDefinedScalarFunctionTest.scala
@@ -34,17 +34,6 @@ import java.time.ZoneId
 class UserDefinedScalarFunctionTest extends ExpressionTestBase {
 
   @Test
-  def test(): Unit = {
-    val JavaFunc1 = new JavaFunc1()
-
-    testAllApis(
-      JavaFunc1(nullOf(DataTypes.TIME), 15, nullOf(DataTypes.TIMESTAMP(3))),
-      "JavaFunc1(Null(SQL_TIME), 15, Null(SQL_TIMESTAMP))",
-      "JavaFunc1(NULL, 15, NULL)",
-      "null and 15 and null")
-  }
-
-  @Test
   def testParameters(): Unit = {
     testAllApis(
       Func0('f0),
@@ -242,7 +231,7 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       Func9('f4, 'f5, 'f6),
       "Func9(f4, f5, f6)",
       "Func9(f4, f5, f6)",
-      "7591 and 43810000 and 655906210000")
+      "7591 and 43810000000000 and 655906210000")
 
     testAllApis(
       Func10('f6),
@@ -434,13 +423,13 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       JavaFunc1('f4, 'f5, 'f6),
       "JavaFunc1(f4, f5, f6)",
       "JavaFunc1(f4, f5, f6)",
-      "7591 and 43810000 and 655906210000")
+      "7591 and 43810000000000 and 655906210000")
 
     testAllApis(
-      JavaFunc1(nullOf(DataTypes.TIME), 15, nullOf(DataTypes.TIMESTAMP(3))),
-      "JavaFunc1(Null(SQL_TIME), 15, Null(SQL_TIMESTAMP))",
-      "JavaFunc1(NULL, 15, NULL)",
-      "null and 15 and null")
+      JavaFunc1(15, nullOf(DataTypes.TIME), nullOf(DataTypes.TIMESTAMP(3))),
+      "JavaFunc1(15, Null(SQL_TIME), Null(SQL_TIMESTAMP))",
+      "JavaFunc1(15, NULL, NULL)",
+      "15 and null and null")
 
     testAllApis(
       JavaFunc4('f10, array("a", "b", "c")),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/userDefinedScalarFunctions.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/userDefinedScalarFunctions.scala
@@ -118,7 +118,7 @@ object Func8 extends ScalarFunction {
 
 @SerialVersionUID(1L)
 object Func9 extends ScalarFunction {
-  def eval(a: Int, b: Int, c: SqlTimestamp): String = {
+  def eval(a: Int, b: Long, c: SqlTimestamp): String = {
     val ts = if (c == null) null else c.getMillisecond
     s"$a and $b and $ts"
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
@@ -307,7 +307,7 @@ object TestData {
       localDateTime("2017-11-20 09:00:00")),
     row(4,  3.15, "DEF",  localDate("2017-02-06"), localTime("06:00:00"),
       localDateTime("2015-11-19 10:00:00")),
-    row(4,  3.14, "EFG",  localDate("2017-05-20"), localTime("09:45:78"),
+    row(4,  3.14, "EFG",  localDate("2017-05-20"), localTime("09:46:18"),
       localDateTime("2015-11-19 10:00:01")),
     row(4,  3.16, "FGH",  localDate("2017-05-19"), localTime("11:11:11"),
       localDateTime("2015-11-20 08:59:59")),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
@@ -307,7 +307,7 @@ object TestData {
       localDateTime("2017-11-20 09:00:00")),
     row(4,  3.15, "DEF",  localDate("2017-02-06"), localTime("06:00:00"),
       localDateTime("2015-11-19 10:00:00")),
-    row(4,  3.14, "EFG",  localDate("2017-05-20"), localTime("09:46:18"),
+    row(4,  3.14, "EFG",  localDate("2017-05-20"), localTime("09:45:78"),
       localDateTime("2015-11-19 10:00:01")),
     row(4,  3.16, "FGH",  localDate("2017-05-19"), localTime("11:11:11"),
       localDateTime("2015-11-20 08:59:59")),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/DateTimeTestUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/DateTimeTestUtil.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.utils
 
 import org.apache.flink.table.dataformat.DataFormatConverters.LocalDateConverter
-import org.apache.flink.table.runtime.functions.SqlDateTimeUtils.{timeStringToLocalTime, toSqlTimestamp}
+import org.apache.flink.table.runtime.functions.SqlDateTimeUtils.{timeStringToTime, toSqlTimestamp}
 import org.apache.calcite.avatica.util.DateTimeUtils.dateStringToUnixDate
 import java.time.{LocalDate, LocalDateTime, LocalTime}
 
@@ -37,7 +37,12 @@ object DateTimeTestUtil {
     if (s == null) {
       null
     } else {
-      timeStringToLocalTime(s)
+      val time = timeStringToTime(s)
+      if (time == null) {
+        null
+      } else {
+        LocalTime.ofNanoOfDay(time)
+      }
     }
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/DateTimeTestUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/DateTimeTestUtil.scala
@@ -18,9 +18,8 @@
 
 package org.apache.flink.table.planner.utils
 
-import org.apache.flink.table.dataformat.DataFormatConverters.{LocalDateConverter, LocalTimeConverter}
-import org.apache.flink.table.runtime.functions.SqlDateTimeUtils
-import org.apache.calcite.avatica.util.DateTimeUtils
+import org.apache.flink.table.dataformat.DataFormatConverters.LocalDateConverter
+import org.apache.flink.table.runtime.functions.SqlDateTimeUtils.{timeStringToLocalTime, toSqlTimestamp}
 import org.apache.calcite.avatica.util.DateTimeUtils.dateStringToUnixDate
 import java.time.{LocalDate, LocalDateTime, LocalTime}
 
@@ -38,7 +37,7 @@ object DateTimeTestUtil {
     if (s == null) {
       null
     } else {
-      new LocalTimeConverter(3).toExternal(DateTimeUtils.timeStringToUnixDate(s) * 1000000L)
+      timeStringToLocalTime(s)
     }
   }
 
@@ -46,7 +45,7 @@ object DateTimeTestUtil {
     if (s == null) {
       null
     } else {
-      SqlDateTimeUtils.toSqlTimestamp(s).toLocalDateTime
+      toSqlTimestamp(s).toLocalDateTime
     }
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/DateTimeTestUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/DateTimeTestUtil.scala
@@ -38,7 +38,7 @@ object DateTimeTestUtil {
     if (s == null) {
       null
     } else {
-      LocalTimeConverter.INSTANCE.toExternal(DateTimeUtils.timeStringToUnixDate(s))
+      new LocalTimeConverter(3).toExternal(DateTimeUtils.timeStringToUnixDate(s) * 1000000L)
     }
   }
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryArray.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryArray.java
@@ -66,7 +66,6 @@ public final class BinaryArray extends BinarySection implements BaseArray {
 			case INTEGER:
 			case FLOAT:
 			case DATE:
-			case TIME_WITHOUT_TIME_ZONE:
 			case INTERVAL_YEAR_MONTH:
 				return 4;
 			default:

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryArrayWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryArrayWriter.java
@@ -120,13 +120,13 @@ public final class BinaryArrayWriter extends AbstractBinaryWriter {
 				break;
 			case INTEGER:
 			case DATE:
-			case TIME_WITHOUT_TIME_ZONE:
 			case INTERVAL_YEAR_MONTH:
 				setNullInt(pos);
 				break;
 			case BIGINT:
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
 			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+			case TIME_WITHOUT_TIME_ZONE:
 			case INTERVAL_DAY_TIME:
 				setNullLong(pos);
 				break;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryWriter.java
@@ -94,12 +94,12 @@ public interface BinaryWriter {
 				break;
 			case INTEGER:
 			case DATE:
-			case TIME_WITHOUT_TIME_ZONE:
 			case INTERVAL_YEAR_MONTH:
 				writer.writeInt(pos, (int) o);
 				break;
 			case BIGINT:
 			case INTERVAL_DAY_TIME:
+			case TIME_WITHOUT_TIME_ZONE:
 				writer.writeLong(pos, (long) o);
 				break;
 			case TIMESTAMP_WITHOUT_TIME_ZONE:

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
@@ -37,6 +37,7 @@ import org.apache.flink.table.runtime.typeutils.BinaryStringTypeInfo;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 import org.apache.flink.table.runtime.typeutils.LegacyInstantTypeInfo;
 import org.apache.flink.table.runtime.typeutils.LegacyLocalDateTimeTypeInfo;
+import org.apache.flink.table.runtime.typeutils.LegacyLocalTimeTypeInfo;
 import org.apache.flink.table.runtime.typeutils.LegacyTimestampTypeInfo;
 import org.apache.flink.table.runtime.typeutils.SqlTimestampTypeInfo;
 import org.apache.flink.table.types.CollectionDataType;
@@ -182,7 +183,7 @@ public class DataFormatConverters {
 					return new SqlTimestampConverter(precisionOfLZTS);
 				}
 			case TIME_WITHOUT_TIME_ZONE:
-				int precisionOfTime = getDateTimePrecision(logicalType);
+				int precisionOfTime = getTimePrecision(logicalType);
 				if (clazz == LocalTime.class) {
 					return new LocalTimeConverter(precisionOfTime);
 				} else if (clazz == Time.class) {
@@ -275,6 +276,9 @@ public class DataFormatConverters {
 				} else if (typeInfo instanceof LegacyInstantTypeInfo) {
 					LegacyInstantTypeInfo instantTypeInfo = (LegacyInstantTypeInfo) typeInfo;
 					return new InstantConverter(instantTypeInfo.getPrecision());
+				} else if (typeInfo instanceof LegacyLocalTimeTypeInfo) {
+					LegacyLocalTimeTypeInfo localTimeTypeInfo = (LegacyLocalTimeTypeInfo) typeInfo;
+					return new LocalTimeConverter(localTimeTypeInfo.getPrecision());
 				}
 
 				if (clazz == BinaryGeneric.class) {
@@ -324,6 +328,19 @@ public class DataFormatConverters {
 			} else {
 				// TimestampType.DEFAULT_PRECISION == LocalZonedTimestampType.DEFAULT_PRECISION == 6
 				return TimestampType.DEFAULT_PRECISION;
+			}
+		}
+	}
+
+	private static int getTimePrecision(LogicalType logicalType) {
+		if (logicalType instanceof TimeType) {
+			return ((TimeType) logicalType).getPrecision();
+		} else {
+			TypeInformation typeInfo = ((LegacyTypeInformationType) logicalType).getTypeInformation();
+			if (typeInfo instanceof LegacyLocalTimeTypeInfo) {
+				return ((LegacyLocalTimeTypeInfo) typeInfo).getPrecision();
+			} else {
+				return TimeType.DEFAULT_PRECISION;
 			}
 		}
 	}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
@@ -47,7 +47,6 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LegacyTypeInformationType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TypeInformationRawType;
 import org.apache.flink.table.types.utils.TypeConversions;
@@ -183,13 +182,12 @@ public class DataFormatConverters {
 					return new SqlTimestampConverter(precisionOfLZTS);
 				}
 			case TIME_WITHOUT_TIME_ZONE:
-				int precisionOfTime = getTimePrecision(logicalType);
 				if (clazz == LocalTime.class) {
-					return new LocalTimeConverter(precisionOfTime);
+					return new LocalTimeConverter();
 				} else if (clazz == Time.class) {
-					return new TimeConverter(precisionOfTime);
+					return new TimeConverter();
 				} else if (clazz == Integer.class || clazz == int.class) {
-					return new IntTimeConverter(precisionOfTime);
+					return new IntTimeConverter();
 				} else {
 					return new LongConverter();
 				}
@@ -277,8 +275,7 @@ public class DataFormatConverters {
 					LegacyInstantTypeInfo instantTypeInfo = (LegacyInstantTypeInfo) typeInfo;
 					return new InstantConverter(instantTypeInfo.getPrecision());
 				} else if (typeInfo instanceof LegacyLocalTimeTypeInfo) {
-					LegacyLocalTimeTypeInfo localTimeTypeInfo = (LegacyLocalTimeTypeInfo) typeInfo;
-					return new LocalTimeConverter(localTimeTypeInfo.getPrecision());
+					return new LocalTimeConverter();
 				}
 
 				if (clazz == BinaryGeneric.class) {
@@ -328,19 +325,6 @@ public class DataFormatConverters {
 			} else {
 				// TimestampType.DEFAULT_PRECISION == LocalZonedTimestampType.DEFAULT_PRECISION == 6
 				return TimestampType.DEFAULT_PRECISION;
-			}
-		}
-	}
-
-	private static int getTimePrecision(LogicalType logicalType) {
-		if (logicalType instanceof TimeType) {
-			return ((TimeType) logicalType).getPrecision();
-		} else {
-			TypeInformation typeInfo = ((LegacyTypeInformationType) logicalType).getTypeInformation();
-			if (typeInfo instanceof LegacyLocalTimeTypeInfo) {
-				return ((LegacyLocalTimeTypeInfo) typeInfo).getPrecision();
-			} else {
-				return TimeType.DEFAULT_PRECISION;
 			}
 		}
 	}
@@ -740,11 +724,7 @@ public class DataFormatConverters {
 
 		private static final long serialVersionUID = 1L;
 
-		private final int precision;
-
-		public LocalTimeConverter(int precision) {
-			this.precision = precision;
-		}
+		public LocalTimeConverter() {}
 
 		@Override
 		Long toInternalImpl(LocalTime value) {
@@ -854,11 +834,7 @@ public class DataFormatConverters {
 
 		private static final long serialVersionUID = -8061475784916442483L;
 
-		private final int precision;
-
-		public TimeConverter(int precision) {
-			this.precision = precision;
-		}
+		public TimeConverter() {}
 
 		@Override
 		Long toInternalImpl(Time value) {
@@ -1539,11 +1515,7 @@ public class DataFormatConverters {
 
 		private static final long serialVersionUID = 1L;
 
-		private final int precision;
-
-		public IntTimeConverter(int precision) {
-			this.precision = precision;
-		}
+		public IntTimeConverter() {}
 
 		@Override
 		Long toInternalImpl(Integer value) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/TypeGetterSetters.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/TypeGetterSetters.java
@@ -187,11 +187,11 @@ public interface TypeGetterSetters {
 				return row.getShort(ordinal);
 			case INTEGER:
 			case DATE:
-			case TIME_WITHOUT_TIME_ZONE:
 			case INTERVAL_YEAR_MONTH:
 				return row.getInt(ordinal);
 			case BIGINT:
 			case INTERVAL_DAY_TIME:
+			case TIME_WITHOUT_TIME_ZONE:
 				return row.getLong(ordinal);
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
 				TimestampType timestampType = (TimestampType) type;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
@@ -1415,6 +1415,27 @@ public class SqlDateTimeUtils {
 		return timestampToString(timestampWithLocalZoneToTimestamp(ts, tz));
 	}
 
+	public static String timeToString(long nanosecond) {
+		LocalTime lt = LocalTime.ofNanoOfDay(nanosecond);
+
+		String fraction = pad(9, (long) lt.getNano());
+		while (fraction.endsWith("0")) {
+			fraction = fraction.substring(0, fraction.length() - 1);
+		}
+
+		StringBuilder hms = hms(
+			new StringBuilder(),
+			lt.getHour(),
+			lt.getMinute(),
+			lt.getSecond());
+
+		if (fraction.length() > 0) {
+			hms.append(".").append(fraction);
+		}
+
+		return hms.toString();
+	}
+
 	private static String pad(int length, long v) {
 		StringBuilder s = new StringBuilder(Long.toString(v));
 		while (s.length() < length) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
@@ -112,6 +112,19 @@ public class SqlDateTimeUtils {
 		"yyyy-MM-dd HH:mm:ss.SSSSSSSSS"
 	};
 
+	private static final String[] DEFAULT_TIME_FORMATS = new String[]{
+		"HH:mm:ss",
+		"HH:mm:ss.S",
+		"HH:mm:ss.SS",
+		"HH:mm:ss.SSS",
+		"HH:mm:ss.SSSS",
+		"HH:mm:ss.SSSSS",
+		"HH:mm:ss.SSSSSS",
+		"HH:mm:ss.SSSSSSS",
+		"HH:mm:ss.SSSSSSSS",
+		"HH:mm:ss.SSSSSSSSS"
+	};
+
 	/**
 	 * A ThreadLocal cache map for SimpleDateFormat, because SimpleDateFormat is not thread-safe.
 	 * (string_format) => formatter
@@ -1413,6 +1426,28 @@ public class SqlDateTimeUtils {
 
 	public static String timestampToString(SqlTimestamp ts, TimeZone tz) {
 		return timestampToString(timestampWithLocalZoneToTimestamp(ts, tz));
+	}
+
+	public static LocalTime timeStringToLocalTime(String timeString) {
+		int length = timeString.length();
+		String format;
+
+		if (length >= 10 && length <= 18) {
+			format = DEFAULT_TIME_FORMATS[length - 9];
+		} else {
+			// otherwise fall back to second's precision
+			format = DEFAULT_TIME_FORMATS[0];
+		}
+		return timeStringToLocalTime(timeString, format);
+	}
+
+	public static LocalTime timeStringToLocalTime(String timeString, String format) {
+		DateTimeFormatter formatter = DATETIME_FORMATTER_CACHE.get(format);
+		try {
+			return LocalTime.parse(timeString, formatter);
+		} catch (DateTimeParseException e) {
+			return null;
+		}
 	}
 
 	public static String timeToString(long nanosecond) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
@@ -1185,6 +1185,22 @@ public class SqlDateTimeUtils {
 		return SqlTimestamp.fromLocalDateTime(LocalDateTime.ofInstant(ts.toInstant(), tz.toZoneId()));
 	}
 
+	public static long timestampWithLocalZoneToTime(SqlTimestamp ts, TimeZone tz) {
+		return SqlTimestamp
+			.fromLocalDateTime(LocalDateTime.ofInstant(ts.toInstant(), tz.toZoneId()))
+			.toLocalDateTime()
+			.toLocalTime()
+			.toNanoOfDay();
+	}
+
+	public static SqlTimestamp timeToTimestampWithLocalZone(long time, TimeZone tz) {
+		return SqlTimestamp.fromInstant(
+			LocalDateTime.of(
+				LocalDate.of(1970, 1, 1), LocalTime.ofNanoOfDay(time))
+			.atZone(tz.toZoneId())
+			.toInstant());
+	}
+
 	public static int timestampWithLocalZoneToDate(long ts, TimeZone tz) {
 		return localDateToUnixDate(LocalDateTime.ofInstant(
 				Instant.ofEpochMilli(ts), tz.toZoneId()).toLocalDate());
@@ -1534,6 +1550,21 @@ public class SqlDateTimeUtils {
 				return SqlTimestamp.fromEpochMillis(
 					ts.getMillisecond(), (int) zeroLastDigits(ts.getNanoOfMillisecond(), 9 - precision));
 			}
+		}
+	}
+
+	public static long truncateTime(long time, int precision) {
+		final LocalTime localTime = LocalTime.ofNanoOfDay(time);
+		String fraction = Integer.toString(localTime.getNano());
+		if (fraction.length() <= precision) {
+			return time;
+		} else {
+			// need to truncate
+			int nano = (int) zeroLastDigits(localTime.getNano(), 9 - precision);
+			return LocalTime.of(
+				localTime.getHour(),
+				localTime.getMinute(),
+				localTime.getSecond(), nano).toNanoOfDay();
 		}
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/ClassLogicalTypeConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/ClassLogicalTypeConverter.java
@@ -51,11 +51,11 @@ public class ClassLogicalTypeConverter {
 				return Short.class;
 			case INTEGER:
 			case DATE:
-			case TIME_WITHOUT_TIME_ZONE:
 			case INTERVAL_YEAR_MONTH:
 				return Integer.class;
 			case BIGINT:
 			case INTERVAL_DAY_TIME:
+			case TIME_WITHOUT_TIME_ZONE:
 				return Long.class;
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
 			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/InternalSerializers.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/InternalSerializers.java
@@ -61,11 +61,11 @@ public class InternalSerializers {
 				return ShortSerializer.INSTANCE;
 			case INTEGER:
 			case DATE:
-			case TIME_WITHOUT_TIME_ZONE:
 			case INTERVAL_YEAR_MONTH:
 				return IntSerializer.INSTANCE;
 			case BIGINT:
 			case INTERVAL_DAY_TIME:
+			case TIME_WITHOUT_TIME_ZONE:
 				return LongSerializer.INSTANCE;
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
 				TimestampType timestampType = (TimestampType) type;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/LogicalTypeDataTypeConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/LogicalTypeDataTypeConverter.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.runtime.typeutils.BinaryStringTypeInfo;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 import org.apache.flink.table.runtime.typeutils.LegacyInstantTypeInfo;
 import org.apache.flink.table.runtime.typeutils.LegacyLocalDateTimeTypeInfo;
+import org.apache.flink.table.runtime.typeutils.LegacyLocalTimeTypeInfo;
 import org.apache.flink.table.runtime.typeutils.LegacyTimestampTypeInfo;
 import org.apache.flink.table.runtime.typeutils.SqlTimestampTypeInfo;
 import org.apache.flink.table.types.DataType;
@@ -40,6 +41,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TypeInformationRawType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeDefaultVisitor;
@@ -116,6 +118,9 @@ public class LogicalTypeDataTypeConverter {
 				} else if (typeInfo instanceof LegacyInstantTypeInfo) {
 					LegacyInstantTypeInfo instantTypeInfo = (LegacyInstantTypeInfo) typeInfo;
 					return new LocalZonedTimestampType(instantTypeInfo.getPrecision());
+				} else if (typeInfo instanceof LegacyLocalTimeTypeInfo) {
+					LegacyLocalTimeTypeInfo localTimeType = (LegacyLocalTimeTypeInfo) typeInfo;
+					return new TimeType(localTimeType.getPrecision());
 				} else {
 					return new TypeInformationRawType<>(typeInfo);
 				}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/TypeInfoDataTypeConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/TypeInfoDataTypeConverter.java
@@ -39,6 +39,7 @@ import org.apache.flink.table.runtime.typeutils.BinaryStringTypeInfo;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 import org.apache.flink.table.runtime.typeutils.LegacyInstantTypeInfo;
 import org.apache.flink.table.runtime.typeutils.LegacyLocalDateTimeTypeInfo;
+import org.apache.flink.table.runtime.typeutils.LegacyLocalTimeTypeInfo;
 import org.apache.flink.table.runtime.typeutils.LegacyTimestampTypeInfo;
 import org.apache.flink.table.runtime.typeutils.SqlTimestampTypeInfo;
 import org.apache.flink.table.types.CollectionDataType;
@@ -49,6 +50,7 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampKind;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.utils.TypeConversions;
@@ -58,6 +60,7 @@ import org.apache.flink.util.Preconditions;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -130,7 +133,12 @@ public class TypeInfoDataTypeConverter {
 					(clazz == Instant.class ?
 						((3 == precisionLzTs) ? Types.INSTANT : new LegacyInstantTypeInfo(precisionLzTs)) :
 						TypeConversions.fromDataTypeToLegacyInfo(dataType));
-
+			case TIME_WITHOUT_TIME_ZONE:
+				TimeType timeType = (TimeType) logicalType;
+				int precisionOfTime = timeType.getPrecision();
+				return clazz == LocalTime.class ?
+					(3 == precisionOfTime) ? Types.LOCAL_TIME : new LegacyLocalTimeTypeInfo(precisionOfTime) :
+					TypeConversions.fromDataTypeToLegacyInfo(dataType);
 			case DECIMAL:
 				DecimalType decimalType = (DecimalType) logicalType;
 				return clazz == Decimal.class ?

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/TypeInfoDataTypeConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/TypeInfoDataTypeConverter.java
@@ -137,7 +137,7 @@ public class TypeInfoDataTypeConverter {
 				TimeType timeType = (TimeType) logicalType;
 				int precisionOfTime = timeType.getPrecision();
 				return clazz == LocalTime.class ?
-					(3 == precisionOfTime) ? Types.LOCAL_TIME : new LegacyLocalTimeTypeInfo(precisionOfTime) :
+					(0 == precisionOfTime) ? Types.LOCAL_TIME : new LegacyLocalTimeTypeInfo(precisionOfTime) :
 					TypeConversions.fromDataTypeToLegacyInfo(dataType);
 			case DECIMAL:
 				DecimalType decimalType = (DecimalType) logicalType;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/LegacyLocalTimeTypeInfo.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/LegacyLocalTimeTypeInfo.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils;
+
+import org.apache.flink.api.common.typeinfo.LocalTimeTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.base.LocalTimeComparator;
+import org.apache.flink.api.common.typeutils.base.LocalTimeSerializer;
+
+import java.time.LocalTime;
+import java.util.Objects;
+
+/**
+ * {@link TypeInformation} for {@link LocalTime}.
+ *
+ * <p>The different between Types.LOCAL_TIME is the TypeInformation holds a precision
+ * Reminder: Conversion from DateType to TypeInformation (and back) exists in
+ * TableSourceUtil.computeIndexMapping, which should be fixed after we remove Legacy TypeInformation
+ * TODO: https://issues.apache.org/jira/browse/FLINK-14927
+ */
+
+public class LegacyLocalTimeTypeInfo extends LocalTimeTypeInfo<LocalTime> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final int precision;
+
+	public LegacyLocalTimeTypeInfo(int precision) {
+		super(
+			LocalTime.class,
+			LocalTimeSerializer.INSTANCE,
+			LocalTimeComparator.class);
+		this.precision = precision;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof LegacyLocalTimeTypeInfo)) {
+			return false;
+		}
+		LegacyLocalTimeTypeInfo that = (LegacyLocalTimeTypeInfo) obj;
+		return this.precision == that.precision;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("TIME(%d)", precision);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.getClass().getCanonicalName(), precision);
+	}
+
+	public int getPrecision() {
+		return this.precision;
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Now blink planner only support TimeType with precision zero. We need support precision of TimeType. This PR use Long(instead of Int) as internal representation of TimeType, and support nanosecond's precision.


## Brief change log

- f14df29 Use Long as internal representation of TimeType
- 5c289ec Fix failure of cases
- 6042559 Support precision of TimeType in literals
- 6a1f60f Support precision of TimeType in table source
- b8555ee Support precision of TimeType in CAST/Extract/DATETIME +/- INTERVAL
- 210649f Support precision of TimeType in max/min/lead/lag/single_value
- 140543d Support precision of TimeType in cast('timestring' as timestamp(p))
## Verifying this change

This change added tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
