### PR TITLE
[FLINK-15356][metric] Add applicationId to flink metrics running on yarn

### DIFF
--- a/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/runtime/jobmanager/JMXJobManagerMetricTest.java
+++ b/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/runtime/jobmanager/JMXJobManagerMetricTest.java
@@ -61,6 +61,7 @@ import static org.junit.Assert.assertEquals;
  * Tests to verify JMX reporter functionality on the JobManager.
  */
 public class JMXJobManagerMetricTest extends TestLogger {
+	private static final String APPLICATION_ID = "yarn.application.id";
 
 	@ClassRule
 	public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE = new MiniClusterWithClientResource(
@@ -75,6 +76,7 @@ public class JMXJobManagerMetricTest extends TestLogger {
 
 		flinkConfiguration.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, JMXReporter.class.getName());
 		flinkConfiguration.setString(MetricOptions.SCOPE_NAMING_JM_JOB, "jobmanager.<job_name>");
+		flinkConfiguration.setString(APPLICATION_ID, "app1");
 
 		return flinkConfiguration;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultDispatcherResourceManagerComponentFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultDispatcherResourceManagerComponentFactory.java
@@ -186,7 +186,7 @@ public class DefaultDispatcherResourceManagerComponentFactory implements Dispatc
 				resourceManagerGatewayRetriever,
 				blobServer,
 				heartbeatServices,
-				() -> MetricUtils.instantiateJobManagerMetricGroup(metricRegistry, hostname),
+				() -> MetricUtils.instantiateJobManagerMetricGroup(metricRegistry, hostname, configuration),
 				archivedExecutionGraphStore,
 				fatalErrorHandler,
 				historyServerArchivist,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerMetricGroup.java
@@ -25,6 +25,9 @@ import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,14 +38,23 @@ import java.util.Map;
  * not contain tasks any more
  */
 public class JobManagerMetricGroup extends ComponentMetricGroup<JobManagerMetricGroup> {
+	protected static final Logger LOG = LoggerFactory.getLogger(JobManagerMetricGroup.class);
 
 	private final Map<JobID, JobManagerJobMetricGroup> jobs = new HashMap<>();
 
 	private final String hostname;
+	private final String appId;
 
 	public JobManagerMetricGroup(MetricRegistry registry, String hostname) {
 		super(registry, registry.getScopeFormats().getJobManagerFormat().formatScope(hostname), null);
 		this.hostname = hostname;
+		this.appId = "";
+	}
+
+	public JobManagerMetricGroup(MetricRegistry registry, String hostname, String appId) {
+		super(registry, registry.getScopeFormats().getJobManagerFormat().formatScope(hostname), null);
+		this.hostname = hostname;
+		this.appId = appId;
 	}
 
 	public String hostname() {
@@ -102,6 +114,7 @@ public class JobManagerMetricGroup extends ComponentMetricGroup<JobManagerMetric
 	@Override
 	protected void putVariables(Map<String, String> variables) {
 		variables.put(ScopeFormat.SCOPE_HOST, hostname);
+		variables.put(ScopeFormat.SCOPE_APP_ID, appId);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerMetricGroup.java
@@ -46,10 +46,20 @@ public class TaskManagerMetricGroup extends ComponentMetricGroup<TaskManagerMetr
 
 	private final String taskManagerId;
 
+	private final String appID;
+
 	public TaskManagerMetricGroup(MetricRegistry registry, String hostname, String taskManagerId) {
 		super(registry, registry.getScopeFormats().getTaskManagerFormat().formatScope(hostname, taskManagerId), null);
 		this.hostname = hostname;
 		this.taskManagerId = taskManagerId;
+		this.appID = "";
+	}
+
+	public TaskManagerMetricGroup(MetricRegistry registry, String hostname, String taskManagerId, String appId) {
+		super(registry, registry.getScopeFormats().getTaskManagerFormat().formatScope(hostname, taskManagerId), null);
+		this.hostname = hostname;
+		this.taskManagerId = taskManagerId;
+		this.appID = appId;
 	}
 
 	public String hostname() {
@@ -143,6 +153,7 @@ public class TaskManagerMetricGroup extends ComponentMetricGroup<TaskManagerMetr
 	protected void putVariables(Map<String, String> variables) {
 		variables.put(ScopeFormat.SCOPE_HOST, hostname);
 		variables.put(ScopeFormat.SCOPE_TASKMANAGER_ID, taskManagerId);
+		variables.put(ScopeFormat.SCOPE_APP_ID, appID);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormat.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormat.java
@@ -77,6 +77,7 @@ public abstract class ScopeFormat {
 	// ----- Job -----
 
 	public static final String SCOPE_JOB_ID = asVariable("job_id");
+	public static final String SCOPE_APP_ID = asVariable("app_id");
 	public static final String SCOPE_JOB_NAME = asVariable("job_name");
 
 	// ----- Task ----

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
@@ -66,6 +66,7 @@ public class MetricUtils {
 	private static final Logger LOG = LoggerFactory.getLogger(MetricUtils.class);
 	private static final String METRIC_GROUP_STATUS_NAME = "Status";
 	private static final String METRICS_ACTOR_SYSTEM_NAME = "flink-metrics";
+	private static final String METRICS_GROUP_APP_ID = "yarn.application.id";
 
 	static final String METRIC_GROUP_HEAP_NAME = "Heap";
 	static final String METRIC_GROUP_NONHEAP_NAME = "NonHeap";
@@ -88,10 +89,13 @@ public class MetricUtils {
 
 	public static JobManagerMetricGroup instantiateJobManagerMetricGroup(
 			final MetricRegistry metricRegistry,
-			final String hostname) {
+			final String hostname,
+			final Configuration configuration) {
+		String appId = configuration.toMap().get(METRICS_GROUP_APP_ID);
 		final JobManagerMetricGroup jobManagerMetricGroup = new JobManagerMetricGroup(
 			metricRegistry,
-			hostname);
+			hostname,
+			appId);
 
 		return jobManagerMetricGroup;
 	}
@@ -100,11 +104,14 @@ public class MetricUtils {
 			MetricRegistry metricRegistry,
 			String hostName,
 			ResourceID resourceID,
-			Optional<Time> systemResourceProbeInterval) {
+			Optional<Time> systemResourceProbeInterval,
+			Configuration configuration) {
+		String appId = configuration.toMap().get(METRICS_GROUP_APP_ID);
 		final TaskManagerMetricGroup taskManagerMetricGroup = new TaskManagerMetricGroup(
 			metricRegistry,
 			hostName,
-			resourceID.toString());
+			resourceID.toString(),
+			appId);
 
 		MetricGroup statusGroup = createAndInitializeStatusMetricGroup(taskManagerMetricGroup);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -370,7 +370,8 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 			metricRegistry,
 			TaskManagerLocation.getHostName(remoteAddress),
 			resourceID,
-			taskManagerServicesConfiguration.getSystemResourceMetricsProbingInterval());
+			taskManagerServicesConfiguration.getSystemResourceMetricsProbingInterval(),
+			configuration);
 
 		TaskManagerServices taskManagerServices = TaskManagerServices.fromConfiguration(
 			taskManagerServicesConfiguration,


### PR DESCRIPTION
## What is the purpose of the change

*When sending metrics to Prometheus, these systems have only the Flink job ID, and the Flink job ID is UUID, which cannot be associated with the application job on the yarn. Therefore, we need to increase the applicationId when running on yarn. This helps us to accurately find the corresponding job on yarn when the metric is abnormal.*


## Brief change log

  - *DefaultDispatcherResourceManagerComponentFactory.java*
  - *JobManagerMetricGroup.java*
  - *TaskManagerMetricGroup.java*
  - *UnregisteredMetricGroups.java*
  - *ScopeFormat.java*
  - *MetricUtils.java*
  - *TaskManagerRunner.java*


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
