### PR TITLE
[FLINK-15248][FileSystems] Allow FileUtils#compressDirectory to process relative directories.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
@@ -497,8 +497,9 @@ public final class FileUtils {
 		FileSystem sourceFs = directory.getFileSystem();
 		FileSystem targetFs = target.getFileSystem();
 
+		Path absolutePath = absolutizePath(directory);
 		try (ZipOutputStream out = new ZipOutputStream(targetFs.create(target, FileSystem.WriteMode.NO_OVERWRITE))) {
-			addToZip(directory, sourceFs, directory.getParent(), out);
+			addToZip(absolutePath, sourceFs, absolutePath.getParent(), out);
 		}
 		return target;
 	}
@@ -578,6 +579,21 @@ public final class FileUtils {
 			filterFileVisitor);
 
 		return filterFileVisitor.getFiles();
+	}
+
+	/**
+	 * Absolutize the given path if it is relative.
+	 *
+	 * @param pathToAbsolutize path which is being absolutized if it is a relative path
+	 * @return the absolutized path
+	 */
+	public static Path absolutizePath(Path pathToAbsolutize) throws IOException {
+		if (!pathToAbsolutize.isAbsolute()) {
+			FileSystem fs = pathToAbsolutize.getFileSystem();
+			return new Path(fs.getWorkingDirectory(), pathToAbsolutize);
+		} else {
+			return pathToAbsolutize;
+		}
 	}
 
 	/**

--- a/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
@@ -241,46 +241,17 @@ public class FileUtilsTest extends TestLogger {
 	}
 
 	@Test
-	public void testCompression() throws IOException {
-		final String testFileContent = "Goethe - Faust: Der Tragoedie erster Teil\n" + "Prolog im Himmel.\n"
-			+ "Der Herr. Die himmlischen Heerscharen. Nachher Mephistopheles. Die drei\n" + "Erzengel treten vor.\n"
-			+ "RAPHAEL: Die Sonne toent, nach alter Weise, In Brudersphaeren Wettgesang,\n"
-			+ "Und ihre vorgeschriebne Reise Vollendet sie mit Donnergang. Ihr Anblick\n"
-			+ "gibt den Engeln Staerke, Wenn keiner Sie ergruenden mag; die unbegreiflich\n"
-			+ "hohen Werke Sind herrlich wie am ersten Tag.\n"
-			+ "GABRIEL: Und schnell und unbegreiflich schnelle Dreht sich umher der Erde\n"
-			+ "Pracht; Es wechselt Paradieseshelle Mit tiefer, schauervoller Nacht. Es\n"
-			+ "schaeumt das Meer in breiten Fluessen Am tiefen Grund der Felsen auf, Und\n"
-			+ "Fels und Meer wird fortgerissen Im ewig schnellem Sphaerenlauf.\n"
-			+ "MICHAEL: Und Stuerme brausen um die Wette Vom Meer aufs Land, vom Land\n"
-			+ "aufs Meer, und bilden wuetend eine Kette Der tiefsten Wirkung rings umher.\n"
-			+ "Da flammt ein blitzendes Verheeren Dem Pfade vor des Donnerschlags. Doch\n"
-			+ "deine Boten, Herr, verehren Das sanfte Wandeln deines Tags.";
+	public void testCompressionOnAbsolutePath() throws IOException {
+		verifyDirectoryCompression(tmp.newFolder("compressDir").toPath());
+	}
 
+	@Test
+	public void testCompressionOnRelativePath() throws IOException {
 		final java.nio.file.Path compressDir = tmp.newFolder("compressDir").toPath();
-		final java.nio.file.Path extractDir = tmp.newFolder("extractDir").toPath();
+		final java.nio.file.Path relativeCompressDir =
+			Paths.get(new File("").getAbsolutePath()).relativize(compressDir);
 
-		final java.nio.file.Path originalDir = Paths.get("rootDir");
-		final java.nio.file.Path emptySubDir = originalDir.resolve("emptyDir");
-		final java.nio.file.Path fullSubDir = originalDir.resolve("fullDir");
-		final java.nio.file.Path file1 = originalDir.resolve("file1");
-		final java.nio.file.Path file2 = originalDir.resolve("file2");
-		final java.nio.file.Path file3 = fullSubDir.resolve("file3");
-
-		Files.createDirectory(compressDir.resolve(originalDir));
-		Files.createDirectory(compressDir.resolve(emptySubDir));
-		Files.createDirectory(compressDir.resolve(fullSubDir));
-		Files.copy(new ByteArrayInputStream(testFileContent.getBytes(StandardCharsets.UTF_8)), compressDir.resolve(file1));
-		Files.createFile(compressDir.resolve(file2));
-		Files.copy(new ByteArrayInputStream(testFileContent.getBytes(StandardCharsets.UTF_8)), compressDir.resolve(file3));
-
-		final Path zip = FileUtils.compressDirectory(
-			new Path(compressDir.resolve(originalDir).toString()),
-			new Path(compressDir.resolve(originalDir) + ".zip"));
-
-		FileUtils.expandDirectory(zip, new Path(extractDir.toAbsolutePath().toString()));
-
-		assertDirEquals(compressDir.resolve(originalDir), extractDir.resolve(originalDir));
+		verifyDirectoryCompression(relativeCompressDir);
 	}
 
 	@Test
@@ -427,6 +398,54 @@ public class FileUtilsTest extends TestLogger {
 		jarFiles.add(jarFile3);
 		jarFiles.add(jarFile4);
 		return jarFiles;
+	}
+
+	/**
+	 * Generate some directories in a original directory based on the {@code compressDir}.
+	 * @param compressDir the path of the directory where the test directories are generated
+	 * @throws IOException if I/O error occurs while generating the directories
+	 */
+	private void verifyDirectoryCompression(final java.nio.file.Path compressDir) throws IOException {
+		final String testFileContent = "Goethe - Faust: Der Tragoedie erster Teil\n" + "Prolog im Himmel.\n"
+			+ "Der Herr. Die himmlischen Heerscharen. Nachher Mephistopheles. Die drei\n" + "Erzengel treten vor.\n"
+			+ "RAPHAEL: Die Sonne toent, nach alter Weise, In Brudersphaeren Wettgesang,\n"
+			+ "Und ihre vorgeschriebne Reise Vollendet sie mit Donnergang. Ihr Anblick\n"
+			+ "gibt den Engeln Staerke, Wenn keiner Sie ergruenden mag; die unbegreiflich\n"
+			+ "hohen Werke Sind herrlich wie am ersten Tag.\n"
+			+ "GABRIEL: Und schnell und unbegreiflich schnelle Dreht sich umher der Erde\n"
+			+ "Pracht; Es wechselt Paradieseshelle Mit tiefer, schauervoller Nacht. Es\n"
+			+ "schaeumt das Meer in breiten Fluessen Am tiefen Grund der Felsen auf, Und\n"
+			+ "Fels und Meer wird fortgerissen Im ewig schnellem Sphaerenlauf.\n"
+			+ "MICHAEL: Und Stuerme brausen um die Wette Vom Meer aufs Land, vom Land\n"
+			+ "aufs Meer, und bilden wuetend eine Kette Der tiefsten Wirkung rings umher.\n"
+			+ "Da flammt ein blitzendes Verheeren Dem Pfade vor des Donnerschlags. Doch\n"
+			+ "deine Boten, Herr, verehren Das sanfte Wandeln deines Tags.";
+
+		final java.nio.file.Path extractDir = tmp.newFolder("extractDir").toPath();
+
+		final java.nio.file.Path originalDir = Paths.get("rootDir");
+		final java.nio.file.Path emptySubDir = originalDir.resolve("emptyDir");
+		final java.nio.file.Path fullSubDir = originalDir.resolve("fullDir");
+		final java.nio.file.Path file1 = originalDir.resolve("file1");
+		final java.nio.file.Path file2 = originalDir.resolve("file2");
+		final java.nio.file.Path file3 = fullSubDir.resolve("file3");
+
+		Files.createDirectory(compressDir.resolve(originalDir));
+		Files.createDirectory(compressDir.resolve(emptySubDir));
+		Files.createDirectory(compressDir.resolve(fullSubDir));
+		Files.copy(
+			new ByteArrayInputStream(testFileContent.getBytes(StandardCharsets.UTF_8)), compressDir.resolve(file1));
+		Files.createFile(compressDir.resolve(file2));
+		Files.copy(
+			new ByteArrayInputStream(testFileContent.getBytes(StandardCharsets.UTF_8)), compressDir.resolve(file3));
+
+		final Path zip = FileUtils.compressDirectory(
+			new Path(compressDir.resolve(originalDir).toString()),
+			new Path(compressDir.resolve(originalDir) + ".zip"));
+
+		FileUtils.expandDirectory(zip, new Path(extractDir.toAbsolutePath().toString()));
+
+		assertDirEquals(compressDir.resolve(originalDir), extractDir.resolve(originalDir));
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

*FileUtils#compressDirectory behaves buggy when processing relative directory path. If the path of target directory is a relative path, the relative path inside the target zip file can not be constructed correctly. Convert the relative path to absolute path before compressing it.*


## Brief change log

  - *Convert the relative path to absolute path before compressing it.*
  - *Add test for the change.*


## Verifying this change

This change is already covered by existing tests, such as *FileUtilsTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
