### PR TITLE
[FLINK-15361][parquet] ParquetTableSource should pass predicate in projectFields

### DIFF
--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetTableSource.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetTableSource.java
@@ -156,7 +156,7 @@ public class ParquetTableSource
 
 	@Override
 	public TableSource<Row> projectFields(int[] fields) {
-		return new ParquetTableSource(path, parquetSchema, parquetConfig, recursiveEnumeration, fields, null);
+		return new ParquetTableSource(path, parquetSchema, parquetConfig, recursiveEnumeration, fields, predicate);
 	}
 
 	@Override


### PR DESCRIPTION

## What is the purpose of the change

After projectFields, ParquetTableSource will loose predicates.
Since this is only performance related, the test did not fail.

## Brief change log

pass  predicate in `ParquetTableSource.projectFields`.

## Verifying this change

Since volcano, it is hard to verify it.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no