### PR TITLE
[FLINK-15306][network] Adjust the default netty transport option from nio to auto

### DIFF
--- a/docs/_includes/generated/network_netty_configuration.html
+++ b/docs/_includes/generated/network_netty_configuration.html
@@ -46,9 +46,9 @@
         </tr>
         <tr>
             <td><h5>taskmanager.network.netty.transport</h5></td>
-            <td style="word-wrap: break-word;">"nio"</td>
+            <td style="word-wrap: break-word;">"auto"</td>
             <td>String</td>
-            <td>The Netty transport type, either "nio" or "epoll"</td>
+            <td>The Netty transport type, either "nio" or "epoll". The "auto" means selecting the property mode automatically based on the platform. Note that the "epoll" mode can get better performance, less GC and have more advanced features which are only available on modern Linux.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -224,9 +224,11 @@ public class NettyShuffleEnvironmentOptions {
 
 	public static final ConfigOption<String> TRANSPORT_TYPE =
 		key("taskmanager.network.netty.transport")
-			.defaultValue("nio")
+			.defaultValue("auto")
 			.withDeprecatedKeys("taskmanager.net.transport")
-			.withDescription("The Netty transport type, either \"nio\" or \"epoll\"");
+			.withDescription("The Netty transport type, either \"nio\" or \"epoll\". The \"auto\" means selecting the property mode automatically" +
+				" based on the platform. Note that the \"epoll\" mode can get better performance, less GC and have more advanced features which are" +
+				" only available on modern Linux.");
 
 	// ------------------------------------------------------------------------
 	//  Partition Request Options


### PR DESCRIPTION

## What is the purpose of the change

*The default option of `taskmanager.network.netty.transport` in `NettyShuffleEnvironmentOptions` is `nio` now. As we know, the `epoll` mode can get better performance, less GC and have more advanced features which are only available on linux. Therefore it is better to adjust the default option to `auto` instead, and then the framework would automatically choose the proper mode based on the platform.*

## Brief change log

  - *Modify the default option value for `NettyShuffleEnvironmentOptions#taskmanager.network.netty.transport`*
  - *Re-generates the related html files*

## Verifying this change

via micro-benchmark

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
