### PR TITLE
[FLINK-15214] Introduce multiple submission e2e test

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -119,6 +119,7 @@ run_test "Run kubernetes session test" "$END_TO_END_DIR/test-scripts/test_kubern
 ################################################################################
 
 run_test "Run Mesos WordCount test" "$END_TO_END_DIR/test-scripts/test_mesos_wordcount.sh"
+run_test "Run Mesos multiple submission test" "$END_TO_END_DIR/test-scripts/test_mesos_multiple_submissions.sh"
 
 ################################################################################
 # Miscellaneous

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -633,12 +633,7 @@ function wait_oper_metric_num_in_records {
 function wait_num_of_occurence_in_logs {
     local text=$1
     local number=$2
-    local logs
-    if [ -z "$3" ]; then
-        logs="standalonesession"
-    else
-        logs="$3"
-    fi
+    local logs=${3:-standalonesession}
 
     echo "Waiting for text ${text} to appear ${number} of times in logs..."
 

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -459,11 +459,12 @@ function wait_job_running {
 function wait_job_terminal_state {
   local job=$1
   local expected_terminal_state=$2
+  local log_file_name=${3:-standalonesession}
 
   echo "Waiting for job ($job) to reach terminal state $expected_terminal_state ..."
 
   while : ; do
-    local N=$(grep -o "Job $job reached globally terminal state .*" $FLINK_DIR/log/*standalonesession*.log | tail -1 || true)
+    local N=$(grep -o "Job $job reached globally terminal state .*" $FLINK_DIR/log/*$log_file_name*.log | tail -1 || true)
     if [[ -z $N ]]; then
       sleep 1
     else

--- a/flink-end-to-end-tests/test-scripts/common_mesos_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_mesos_docker.sh
@@ -66,3 +66,9 @@ function build_image() {
         exit 1
     fi
 }
+
+function wait_job_terminal_state_mesos {
+  local job=$1
+  local expected_terminal_state=$2
+  wait_job_terminal_state $1 $2 "mesos-appmaster"
+}

--- a/flink-end-to-end-tests/test-scripts/common_mesos_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_mesos_docker.sh
@@ -25,6 +25,7 @@ source "$(dirname "$0")"/common_docker.sh
 MAX_RETRY_SECONDS=120
 IMAGE_BUILD_RETRIES=5
 NODENAME=${NODENAME:-`hostname -f`}
+export MESOS_AGENT_CPU=1
 
 echo "End-to-end directory $END_TO_END_DIR"
 

--- a/flink-end-to-end-tests/test-scripts/common_mesos_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_mesos_docker.sh
@@ -72,3 +72,9 @@ function wait_job_terminal_state_mesos {
   local expected_terminal_state=$2
   wait_job_terminal_state $1 $2 "mesos-appmaster"
 }
+
+function wait_num_of_occurence_in_logs_mesos() {
+    local text=$1
+    local number=$2
+    wait_num_of_occurence_in_logs $1 $2 "mesos-appmaster"
+}

--- a/flink-end-to-end-tests/test-scripts/docker-mesos-cluster/docker-compose.yml
+++ b/flink-end-to-end-tests/test-scripts/docker-mesos-cluster/docker-compose.yml
@@ -55,6 +55,7 @@ services:
     volumes:
       - ${END_TO_END_DIR}:${END_TO_END_DIR}
     environment:
+      MESOS_RESOURCES: "cpus:${MESOS_AGENT_CPU}"
       MESOS_PORT: 5051
       MESOS_MASTER: mesos-master:5050
       MESOS_SWITCH_USER: 0

--- a/flink-end-to-end-tests/test-scripts/test_mesos_multiple_submissions.sh
+++ b/flink-end-to-end-tests/test-scripts/test_mesos_multiple_submissions.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+set -o pipefail
+
+source "$(dirname "$0")"/common.sh
+source "$(dirname "$0")"/common_mesos_docker.sh
+
+DURATION=5
+FIRST_OUTPUT_LOCATION="${TEST_DATA_DIR}/out/first_out"
+SECOND_OUTPUT_LOCATION="${TEST_DATA_DIR}/out/second_out"
+TEST_PROGRAM_JAR=$END_TO_END_DIR/flink-cli-test/target/PeriodicStreamingJob.jar
+
+function submit_job {
+    local output_path=$1
+    docker exec -it mesos-master bash -c "${FLINK_DIR}/bin/flink run -d -p 1 ${TEST_PROGRAM_JAR} --durationInSecond ${DURATION} --outputPath ${output_path}" \
+        | grep "Job has been submitted with JobID" | sed 's/.* //g' | tr -d '\r'
+}
+
+
+mkdir -p "${TEST_DATA_DIR}"
+
+# There should be only one TaskManager with one slot; Thus, there are not enough resources to allocate a complete new set of slots for the second job.
+# To ensure the old slots are being reused.
+set_config_key "mesos.resourcemanager.tasks.cpus" "${MESOS_AGENT_CPU}"
+
+start_flink_cluster_with_mesos
+
+JOB1_ID=$(submit_job ${FIRST_OUTPUT_LOCATION})
+
+JOB2_ID=$(submit_job ${SECOND_OUTPUT_LOCATION})
+
+wait_job_terminal_state_mesos "${JOB1_ID}" "FINISHED"
+wait_job_terminal_state_mesos "${JOB2_ID}" "FINISHED"

--- a/tools/travis/splits/split_container.sh
+++ b/tools/travis/splits/split_container.sh
@@ -51,6 +51,7 @@ run_test "Run kubernetes test" "$END_TO_END_DIR/test-scripts/test_kubernetes_emb
 run_test "Run kubernetes session test" "$END_TO_END_DIR/test-scripts/test_kubernetes_session.sh"
 if [[ "${HADOOP_INTEGRATION}" = "with-hadoop" ]]; then
     run_test "Run Mesos WordCount test" "$END_TO_END_DIR/test-scripts/test_mesos_wordcount.sh"
+    run_test "Run Mesos multiple submission test" "$END_TO_END_DIR/test-scripts/test_mesos_multiple_submissions.sh"
 fi
 
 printf "\n[PASS] All tests passed\n"


### PR DESCRIPTION
## What is the purpose of the change

Introduce multiple submission e2e test for Flink's Mesos integration.


## Brief change log

 - 43b1425..2885bab: Hotfixes, refactors and code clean-ups.
 - ab3c8ac: Introduce multiple submission e2e test
 - cc596f9: Enable it in Travis and nightly script


## Verifying this change

 - Run multiple submission e2e test 
`./run-single-test.sh test-scripts/test_mesos_multi_submission.sh`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
