### PR TITLE
[FLINK-15370][state backends] Make sure sharedResources takes effect in RocksDBResourceContainer

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
@@ -20,9 +20,13 @@ package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.runtime.memory.OpaqueMemoryResource;
 import org.apache.flink.util.IOUtils;
+import org.apache.flink.util.Preconditions;
 
+import org.rocksdb.BlockBasedTableConfig;
+import org.rocksdb.Cache;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
+import org.rocksdb.TableFormatConfig;
 
 import javax.annotation.Nullable;
 
@@ -89,6 +93,7 @@ public final class RocksDBResourceContainer implements AutoCloseable {
 		// add necessary default options
 		opt = opt.setCreateIfMissing(true);
 
+		// if sharedResources is non-null, use the write buffer manager from it.
 		if (sharedResources != null) {
 			opt.setWriteBufferManager(sharedResources.getResourceHandle().getWriteBufferManager());
 		}
@@ -107,6 +112,27 @@ public final class RocksDBResourceContainer implements AutoCloseable {
 		// add user-defined options, if specified
 		if (optionsFactory != null) {
 			opt = optionsFactory.createColumnOptions(opt, handlesToClose);
+		}
+
+		// if sharedResources is non-null, use the block cache from it and
+		// set necessary options for performance consideration with memory control
+		if (sharedResources != null) {
+			final RocksDBSharedResources rocksResources = sharedResources.getResourceHandle();
+			final Cache blockCache = rocksResources.getCache();
+			TableFormatConfig tableFormatConfig = opt.tableFormatConfig();
+			BlockBasedTableConfig blockBasedTableConfig;
+			if (tableFormatConfig == null) {
+				blockBasedTableConfig = new BlockBasedTableConfig();
+			} else {
+				Preconditions.checkArgument(tableFormatConfig instanceof BlockBasedTableConfig,
+					"We currently only support BlockBasedTableConfig When bounding total memory.");
+				blockBasedTableConfig = (BlockBasedTableConfig) tableFormatConfig;
+			}
+			blockBasedTableConfig.setBlockCache(blockCache);
+			blockBasedTableConfig.setCacheIndexAndFilterBlocks(true);
+			blockBasedTableConfig.setCacheIndexAndFilterBlocksWithHighPriority(true);
+			blockBasedTableConfig.setPinL0FilterAndIndexBlocksInCache(true);
+			opt.setTableFormatConfig(blockBasedTableConfig);
 		}
 
 		return opt;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
@@ -89,6 +89,10 @@ public final class RocksDBResourceContainer implements AutoCloseable {
 		// add necessary default options
 		opt = opt.setCreateIfMissing(true);
 
+		if (sharedResources != null) {
+			opt.setWriteBufferManager(sharedResources.getResourceHandle().getWriteBufferManager());
+		}
+
 		return opt;
 	}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -55,7 +55,6 @@ import org.apache.flink.util.TernaryBoolean;
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.Cache;
 import org.rocksdb.ColumnFamilyOptions;
-import org.rocksdb.DBOptions;
 import org.rocksdb.NativeLibraryLoader;
 import org.rocksdb.RocksDB;
 import org.rocksdb.TableFormatConfig;
@@ -509,7 +508,6 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 
 		final RocksDBResourceContainer resourceContainer = createOptionsAndResourceContainer(sharedResources);
 
-		final DBOptions dbOptions = resourceContainer.getDbOptions();
 		final Function<String, ColumnFamilyOptions> createColumnOptions;
 
 		if (sharedResources != null) {
@@ -517,8 +515,6 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 
 			final RocksDBSharedResources rocksResources = sharedResources.getResourceHandle();
 			final Cache blockCache = rocksResources.getCache();
-
-			dbOptions.setWriteBufferManager(rocksResources.getWriteBufferManager());
 
 			createColumnOptions = stateName -> {
 				ColumnFamilyOptions columnOptions = resourceContainer.getColumnOptions();

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainerTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainerTest.java
@@ -25,6 +25,8 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.rocksdb.BlockBasedTableConfig;
+import org.rocksdb.Cache;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
 import org.rocksdb.LRUCache;
@@ -78,15 +80,33 @@ public class RocksDBResourceContainerTest {
 		}
 	}
 
+	/**
+	 * Guard the shared resources will be released after {@link RocksDBResourceContainer#close()} when the
+	 * {@link RocksDBResourceContainer} instance is initiated with {@link OpaqueMemoryResource}.
+	 *
+	 * @throws Exception if unexpected error happened.
+	 */
 	@Test
-	public void testSharedResources() throws Exception {
+	public void testSharedResourcesAfterClose() throws Exception {
+		OpaqueMemoryResource<RocksDBSharedResources> sharedResources = getSharedResources();
+		RocksDBResourceContainer container =
+			new RocksDBResourceContainer(PredefinedOptions.DEFAULT, null, sharedResources);
+		container.close();
+		RocksDBSharedResources rocksDBSharedResources = sharedResources.getResourceHandle();
+		assertThat(rocksDBSharedResources.getCache().isOwningHandle(), is(false));
+		assertThat(rocksDBSharedResources.getWriteBufferManager().isOwningHandle(), is(false));
+	}
+
+	/**
+	 * Guard that {@link RocksDBResourceContainer#getDbOptions()} shares the same {@link WriteBufferManager} instance
+	 * if the {@link RocksDBResourceContainer} instance is initiated with {@link OpaqueMemoryResource}.
+	 *
+	 * @throws Exception if unexpected error happened.
+	 */
+	@Test
+	public void testGetDbOptionsWithSharedResources() throws Exception {
 		final int optionNumber = 20;
-		final long cacheSize = 1024L, writeBufferSize = 512L;
-		final LRUCache cache = new LRUCache(cacheSize, -1, false, 0.1);
-		final WriteBufferManager wbm = new WriteBufferManager(writeBufferSize, cache);
-		RocksDBSharedResources rocksDBSharedResources = new RocksDBSharedResources(cache, wbm);
-		OpaqueMemoryResource<RocksDBSharedResources> sharedResources =
-			new OpaqueMemoryResource<>(rocksDBSharedResources, cacheSize, rocksDBSharedResources::close);
+		OpaqueMemoryResource<RocksDBSharedResources> sharedResources = getSharedResources();
 		RocksDBResourceContainer container =
 			new RocksDBResourceContainer(PredefinedOptions.DEFAULT, null, sharedResources);
 		HashSet<WriteBufferManager> writeBufferManagers = new HashSet<>();
@@ -96,10 +116,63 @@ public class RocksDBResourceContainerTest {
 			writeBufferManagers.add(writeBufferManager);
 		}
 		assertThat(writeBufferManagers.size(), is(1));
-		assertThat(writeBufferManagers.iterator().next(), is(rocksDBSharedResources.getWriteBufferManager()));
+		assertThat(writeBufferManagers.iterator().next(),
+			is(sharedResources.getResourceHandle().getWriteBufferManager()));
 		container.close();
-		assertThat(rocksDBSharedResources.getCache().isOwningHandle(), is(false));
-		assertThat(rocksDBSharedResources.getWriteBufferManager().isOwningHandle(), is(false));
+	}
+
+	/**
+	 * Guard that {@link RocksDBResourceContainer#getColumnOptions()} shares the same {@link Cache} instance
+	 * if the {@link RocksDBResourceContainer} instance is initiated with {@link OpaqueMemoryResource}.
+	 *
+	 * @throws Exception if unexpected error happened.
+	 */
+	@Test
+	public void testGetColumnFamilyOptionsWithSharedResources() throws Exception {
+		final int optionNumber = 20;
+		OpaqueMemoryResource<RocksDBSharedResources> sharedResources = getSharedResources();
+		RocksDBResourceContainer container =
+			new RocksDBResourceContainer(PredefinedOptions.DEFAULT, null, sharedResources);
+		HashSet<Cache> caches = new HashSet<>();
+		for (int i = 0; i < optionNumber; i++) {
+			ColumnFamilyOptions columnOptions = container.getColumnOptions();
+			Cache cache = getBlockCache(columnOptions);
+			caches.add(cache);
+		}
+		assertThat(caches.size(), is(1));
+		assertThat(caches.iterator().next(),
+			is(sharedResources.getResourceHandle().getCache()));
+		container.close();
+	}
+
+	private OpaqueMemoryResource<RocksDBSharedResources> getSharedResources() {
+		final long cacheSize = 1024L, writeBufferSize = 512L;
+		final LRUCache cache = new LRUCache(cacheSize, -1, false, 0.1);
+		final WriteBufferManager wbm = new WriteBufferManager(writeBufferSize, cache);
+		RocksDBSharedResources rocksDBSharedResources = new RocksDBSharedResources(cache, wbm);
+		return new OpaqueMemoryResource<>(rocksDBSharedResources, cacheSize, rocksDBSharedResources::close);
+	}
+
+	private Cache getBlockCache(ColumnFamilyOptions columnOptions) {
+		BlockBasedTableConfig blockBasedTableConfig = null;
+		try {
+			blockBasedTableConfig = (BlockBasedTableConfig) columnOptions.tableFormatConfig();
+		} catch (ClassCastException e) {
+			fail("Table config got from ColumnFamilyOptions is not BlockBasedTableConfig");
+		}
+		Field cacheField = null;
+		try {
+			cacheField = BlockBasedTableConfig.class.getDeclaredField("blockCache_");
+		} catch (NoSuchFieldException e) {
+			fail("blockCache_ is not defined");
+		}
+		cacheField.setAccessible(true);
+		try {
+			return (Cache) cacheField.get(blockBasedTableConfig);
+		} catch (IllegalAccessException e) {
+			fail("Cannot access blockCache_ field.");
+			return null;
+		}
 	}
 
 	private WriteBufferManager getWriteBufferManager(DBOptions dbOptions) {


### PR DESCRIPTION

## What is the purpose of the change

Currently we never uses the `sharedResources` in `RocksDBResourceContainer`, and in `RocksDBStateBackend.createKeyedStateBackend` we set the shared write buffer manager to the `dbOptions` but never pass/use it in `RocksDBKeyedStateBackendBuilder`, which leads to the result that different RocksDB backends actually are using separate write buffer managers thus the total memory control is invalid.


## Brief change log

Always set write buffer manager to the one from `sharedResources` if it's non-null, in `RocksDBResourceContainer.getDbOptions`.


## Verifying this change

This change added a new `testSharedResources` test case to cover the problematic case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
