### PR TITLE
[FLINK-15373][core][config] Update descriptions for framework / task off-heap memory config options

### DIFF
--- a/docs/_includes/generated/task_manager_memory_configuration.html
+++ b/docs/_includes/generated/task_manager_memory_configuration.html
@@ -90,7 +90,7 @@
             <td><h5>taskmanager.memory.task.off-heap.size</h5></td>
             <td style="word-wrap: break-word;">"0b"</td>
             <td>String</td>
-            <td>Task Heap Memory size for TaskExecutors. This is the size of off heap memory (JVM direct memory or native memory) reserved for user code.</td>
+            <td>Task Off-Heap Memory size for TaskExecutors. This is the size of off heap memory (JVM direct memory and native memory) reserved for user code. The configured value will be fully counted when Flink calculates the JVM max direct memory size parameter.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.total-flink.size</h5></td>

--- a/docs/_includes/generated/task_manager_memory_configuration.html
+++ b/docs/_includes/generated/task_manager_memory_configuration.html
@@ -84,13 +84,13 @@
             <td><h5>taskmanager.memory.task.heap.size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>Task Heap Memory size for TaskExecutors. This is the size of JVM heap memory reserved for user code. If not specified, it will be derived as Total Flink Memory minus Framework Heap Memory, Task Off-Heap Memory, Managed Memory and Shuffle Memory.</td>
+            <td>Task Heap Memory size for TaskExecutors. This is the size of JVM heap memory reserved for tasks. If not specified, it will be derived as Total Flink Memory minus Framework Heap Memory, Task Off-Heap Memory, Managed Memory and Shuffle Memory.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.task.off-heap.size</h5></td>
             <td style="word-wrap: break-word;">"0b"</td>
             <td>String</td>
-            <td>Task Off-Heap Memory size for TaskExecutors. This is the size of off heap memory (JVM direct memory and native memory) reserved for user code. The configured value will be fully counted when Flink calculates the JVM max direct memory size parameter.</td>
+            <td>Task Off-Heap Memory size for TaskExecutors. This is the size of off heap memory (JVM direct memory and native memory) reserved for tasks. The configured value will be fully counted when Flink calculates the JVM max direct memory size parameter.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.total-flink.size</h5></td>

--- a/docs/_includes/generated/task_manager_memory_configuration.html
+++ b/docs/_includes/generated/task_manager_memory_configuration.html
@@ -18,7 +18,7 @@
             <td><h5>taskmanager.memory.framework.off-heap.size</h5></td>
             <td style="word-wrap: break-word;">"128m"</td>
             <td>String</td>
-            <td>Framework Off-Heap Memory size for TaskExecutors. This is the size of off-heap memory (JVM direct memory or native memory) reserved for TaskExecutor framework, which will not be allocated to task slots. It will be accounted as part of the JVM max direct memory size limit.</td>
+            <td>Framework Off-Heap Memory size for TaskExecutors. This is the size of off-heap memory (JVM direct memory and native memory) reserved for TaskExecutor framework, which will not be allocated to task slots. The configured value will be fully counted when Flink calculates the JVM max direct memory size parameter.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.jvm-metaspace.size</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -267,7 +267,7 @@ public class TaskManagerOptions {
 		key("taskmanager.memory.task.heap.size")
 			.noDefaultValue()
 			.withDescription("Task Heap Memory size for TaskExecutors. This is the size of JVM heap memory reserved for"
-				+ " user code. If not specified, it will be derived as Total Flink Memory minus Framework Heap Memory,"
+				+ " tasks. If not specified, it will be derived as Total Flink Memory minus Framework Heap Memory,"
 				+ " Task Off-Heap Memory, Managed Memory and Shuffle Memory.");
 
 	/**
@@ -277,7 +277,7 @@ public class TaskManagerOptions {
 		key("taskmanager.memory.task.off-heap.size")
 			.defaultValue("0b")
 			.withDescription("Task Off-Heap Memory size for TaskExecutors. This is the size of off heap memory (JVM"
-				+ " direct memory and native memory) reserved for user code. The configured value will be fully counted"
+				+ " direct memory and native memory) reserved for tasks. The configured value will be fully counted"
 				+ " when Flink calculates the JVM max direct memory size parameter.");
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -256,8 +256,9 @@ public class TaskManagerOptions {
 		key("taskmanager.memory.framework.off-heap.size")
 			.defaultValue("128m")
 			.withDescription("Framework Off-Heap Memory size for TaskExecutors. This is the size of off-heap memory"
-				+ " (JVM direct memory or native memory) reserved for TaskExecutor framework, which will not be"
-				+ " allocated to task slots. It will be accounted as part of the JVM max direct memory size limit.");
+				+ " (JVM direct memory and native memory) reserved for TaskExecutor framework, which will not be"
+				+ " allocated to task slots. The configured value will be fully counted when Flink calculates the JVM"
+				+ " max direct memory size parameter.");
 
 	/**
 	 * Task Heap Memory size for TaskExecutors.

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -276,8 +276,9 @@ public class TaskManagerOptions {
 	public static final ConfigOption<String> TASK_OFF_HEAP_MEMORY =
 		key("taskmanager.memory.task.off-heap.size")
 			.defaultValue("0b")
-			.withDescription("Task Heap Memory size for TaskExecutors. This is the size of off heap memory (JVM direct"
-				+ " memory or native memory) reserved for user code.");
+			.withDescription("Task Off-Heap Memory size for TaskExecutors. This is the size of off heap memory (JVM"
+				+ " direct memory and native memory) reserved for user code. The configured value will be fully counted"
+				+ " when Flink calculates the JVM max direct memory size parameter.");
 
 	/**
 	 * Managed Memory size for TaskExecutors.


### PR DESCRIPTION
## What is the purpose of the change

This PR updates the description of framework / task off-heap memory config options, to explicitly state:
- Both direct and native memory are accounted
- Will be fully counted into MaxDirectMemorySize

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
