### PR TITLE
[FLINK-15374][core][config] Update descriptions for jvm overhead config options

### DIFF
--- a/docs/_includes/generated/task_manager_memory_configuration.html
+++ b/docs/_includes/generated/task_manager_memory_configuration.html
@@ -30,19 +30,19 @@
             <td><h5>taskmanager.memory.jvm-overhead.fraction</h5></td>
             <td style="word-wrap: break-word;">0.1</td>
             <td>Float</td>
-            <td>Fraction of Total Process Memory to be reserved for JVM Overhead. This is off-heap memory reserved for JVM overhead, such as thread stack space, I/O direct memory, compile cache, etc. The size of JVM Overhead is derived to make up the configured fraction of the Total Process Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of JVM Overhead can be explicitly specified by setting the min/max size to the same value.</td>
+            <td>Fraction of Total Process Memory to be reserved for JVM Overhead. This is off-heap memory reserved for JVM overhead, such as thread stack space, compile cache, etc. This includes native memory but not direct memory, and will not be counted when Flink calculates JVM max direct memory size parameter. The size of JVM Overhead is derived to make up the configured fraction of the Total Process Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of JVM Overhead can be explicitly specified by setting the min/max size to the same value.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.jvm-overhead.max</h5></td>
             <td style="word-wrap: break-word;">"1g"</td>
             <td>String</td>
-            <td>Max JVM Overhead size for the TaskExecutors. This is off-heap memory reserved for JVM overhead, such as thread stack space, I/O direct memory, compile cache, etc. The size of JVM Overhead is derived to make up the configured fraction of the Total Process Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of JVM Overhead can be explicitly specified by setting the min/max size to the same value.</td>
+            <td>Max JVM Overhead size for the TaskExecutors. This is off-heap memory reserved for JVM overhead, such as thread stack space, compile cache, etc. This includes native memory but not direct memory, and will not be counted when Flink calculates JVM max direct memory size parameter. The size of JVM Overhead is derived to make up the configured fraction of the Total Process Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of JVM Overhead can be explicitly specified by setting the min/max size to the same value.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.jvm-overhead.min</h5></td>
             <td style="word-wrap: break-word;">"128m"</td>
             <td>String</td>
-            <td>Min JVM Overhead size for the TaskExecutors. This is off-heap memory reserved for JVM overhead, such as thread stack space, I/O direct memory, compile cache, etc. The size of JVM Overhead is derived to make up the configured fraction of the Total Process Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of JVM Overhead can be explicitly specified by setting the min/max size to the same value.</td>
+            <td>Min JVM Overhead size for the TaskExecutors. This is off-heap memory reserved for JVM overhead, such as thread stack space, compile cache, etc. This includes native memory but not direct memory, and will not be counted when Flink calculates JVM max direct memory size parameter. The size of JVM Overhead is derived to make up the configured fraction of the Total Process Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of JVM Overhead can be explicitly specified by setting the min/max size to the same value.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.managed.fraction</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -355,10 +355,11 @@ public class TaskManagerOptions {
 		key("taskmanager.memory.jvm-overhead.min")
 			.defaultValue("128m")
 			.withDescription("Min JVM Overhead size for the TaskExecutors. This is off-heap memory reserved for JVM"
-				+ " overhead, such as thread stack space, I/O direct memory, compile cache, etc. The size of JVM"
-				+ " Overhead is derived to make up the configured fraction of the Total Process Memory. If the derived"
-				+ " size is less/greater than the configured min/max size, the min/max size will be used. The exact size"
-				+ " of JVM Overhead can be explicitly specified by setting the min/max size to the same value.");
+				+ " overhead, such as thread stack space, compile cache, etc. This includes native memory but not direct"
+				+ " memory, and will not be counted when Flink calculates JVM max direct memory size parameter. The size"
+				+ " of JVM Overhead is derived to make up the configured fraction of the Total Process Memory. If the"
+				+ " derived size is less/greater than the configured min/max size, the min/max size will be used. The"
+				+ " exact size of JVM Overhead can be explicitly specified by setting the min/max size to the same value.");
 
 	/**
 	 * Max JVM Overhead size for the TaskExecutors.
@@ -367,10 +368,11 @@ public class TaskManagerOptions {
 		key("taskmanager.memory.jvm-overhead.max")
 			.defaultValue("1g")
 			.withDescription("Max JVM Overhead size for the TaskExecutors. This is off-heap memory reserved for JVM"
-				+ " overhead, such as thread stack space, I/O direct memory, compile cache, etc. The size of JVM"
-				+ " Overhead is derived to make up the configured fraction of the Total Process Memory. If the derived"
-				+ " size is less/greater than the configured min/max size, the min/max size will be used. The exact size"
-				+ " of JVM Overhead can be explicitly specified by setting the min/max size to the same value.");
+				+ " overhead, such as thread stack space, compile cache, etc. This includes native memory but not direct"
+				+ " memory, and will not be counted when Flink calculates JVM max direct memory size parameter. The size"
+				+ " of JVM Overhead is derived to make up the configured fraction of the Total Process Memory. If the"
+				+ " derived size is less/greater than the configured min/max size, the min/max size will be used. The"
+				+ " exact size of JVM Overhead can be explicitly specified by setting the min/max size to the same value.");
 
 	/**
 	 * Fraction of Total Process Memory to be reserved for JVM Overhead.
@@ -379,11 +381,12 @@ public class TaskManagerOptions {
 		key("taskmanager.memory.jvm-overhead.fraction")
 			.defaultValue(0.1f)
 			.withDescription("Fraction of Total Process Memory to be reserved for JVM Overhead. This is off-heap memory"
-				+ " reserved for JVM overhead, such as thread stack space, I/O direct memory, compile cache, etc. The"
-				+ " size of JVM Overhead is derived to make up the configured fraction of the Total Process Memory. If"
-				+ " the derived size is less/greater than the configured min/max size, the min/max size will be used."
-				+ " The exact size of JVM Overhead can be explicitly specified by setting the min/max size to the same"
-				+ " value.");
+				+ " reserved for JVM overhead, such as thread stack space, compile cache, etc. This includes native"
+				+ " memory but not direct memory, and will not be counted when Flink calculates JVM max direct memory"
+				+ " size parameter. The size of JVM Overhead is derived to make up the configured fraction of the Total"
+				+ " Process Memory. If the derived size is less/greater than the configured min/max size, the min/max"
+				+ " size will be used. The exact size of JVM Overhead can be explicitly specified by setting the min/max"
+				+ " size to the same value.");
 
 	// ------------------------------------------------------------------------
 	//  Task Options


### PR DESCRIPTION
## What is the purpose of the change

This PR updates descriptions for JVM overhead config options, to remove "I/O direct memory" and explicitly state that it's not counted into MaxDirectMemorySize.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
