### PR TITLE
[FLINK-15220][Connector/Kafka][Table] Add startFromTimestamp in KafkaTableSource

### DIFF
--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -779,11 +779,14 @@ CREATE TABLE MyUserTable (
   'connector.properties.bootstrap.servers' = 'localhost:9092',
   -- required for Kafka source, optional for Kafka sink, specify consumer group
   'connector.properties.group.id' = 'testGroup',
-  -- optional: valid modes are "earliest-offset", "latest-offset", "group-offsets", or "specific-offsets"
+  -- optional: valid modes are "earliest-offset", "latest-offset", "group-offsets", "specific-offsets" or "timestamp"
   'connector.startup-mode' = 'earliest-offset',
 
   -- optional: used in case of startup mode with specific offsets
   'connector.specific-offsets' = 'partition:0,offset:42;partition:1,offset:300',
+
+  -- optional: used in case of startup mode with timestamp
+  'connector.startup-timestamp-millis' = '1578538374471',
 
   'connector.sink-partitioner' = '...',  -- optional: output partitioning from Flink's partitions 
                                          -- into Kafka's partitions valid are "fixed" 
@@ -849,6 +852,7 @@ CREATE TABLE MyUserTable (
     .start_from_earliest()
     .start_from_latest()
     .start_from_specific_offsets(...)
+    .startFromTimestamp(...)
 
     # optional: output partitioning from Flink's partitions into Kafka's partitions
     .sink_partitioner_fixed()        # each Flink partition ends up in at-most one Kafka partition (default)
@@ -875,9 +879,10 @@ connector:
     group.id: testGroup                # optional: required in Kafka consumer, specify consumer group
 
   startup-mode: ...                                               # optional: valid modes are "earliest-offset", "latest-offset",
-                                                                  # "group-offsets", or "specific-offsets"
+                                                                  # "group-offsets", "specific-offsets" or "timestamp"
   specific-offsets: partition:0,offset:42;partition:1,offset:300  # optional: used in case of startup mode with specific offsets
-  
+  startup-timestamp-millis: 1578538374471                         # optional: used in case of startup mode with timestamp
+
   sink-partitioner: ...    # optional: output partitioning from Flink's partitions into Kafka's partitions
                            # valid are "fixed" (each Flink partition ends up in at most one Kafka partition),
                            # "round-robin" (a Flink partition is distributed to Kafka partitions round-robin)

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -819,6 +819,7 @@ CREATE TABLE MyUserTable (
     .startFromEarliest()
     .startFromLatest()
     .startFromSpecificOffsets(...)
+    .startFromTimestamp(...)
 
     // optional: output partitioning from Flink's partitions into Kafka's partitions
     .sinkPartitionerFixed()         // each Flink partition ends up in at-most one Kafka partition (default)

--- a/docs/dev/table/connect.zh.md
+++ b/docs/dev/table/connect.zh.md
@@ -779,11 +779,14 @@ CREATE TABLE MyUserTable (
   'connector.properties.bootstrap.servers' = 'localhost:9092',
   -- required for Kafka source, optional for Kafka sink, specify consumer group
   'connector.properties.group.id' = 'testGroup',
-  -- optional: valid modes are "earliest-offset", "latest-offset", "group-offsets", or "specific-offsets"
+  -- optional: valid modes are "earliest-offset", "latest-offset", "group-offsets", "specific-offsets" or "timestamp"
   'connector.startup-mode' = 'earliest-offset',
 
   -- optional: used in case of startup mode with specific offsets
   'connector.specific-offsets' = 'partition:0,offset:42;partition:1,offset:300',
+
+  -- optional: used in case of startup mode with timestamp
+  'connector.startup-timestamp-millis' = '1578538374471',
 
   'connector.sink-partitioner' = '...',  -- optional: output partitioning from Flink's partitions
                                          -- into Kafka's partitions valid are "fixed"
@@ -849,6 +852,7 @@ CREATE TABLE MyUserTable (
     .start_from_earliest()
     .start_from_latest()
     .start_from_specific_offsets(...)
+    .startFromTimestamp(...)
 
     # optional: output partitioning from Flink's partitions into Kafka's partitions
     .sink_partitioner_fixed()        # each Flink partition ends up in at-most one Kafka partition (default)
@@ -875,8 +879,10 @@ connector:
     group.id: testGroup                # optional: required in Kafka consumer, specify consumer group
 
   startup-mode: ...                                               # optional: valid modes are "earliest-offset", "latest-offset",
-                                                                  # "group-offsets", or "specific-offsets"
+                                                                  # "group-offsets", "specific-offsets" or "timestamp"
   specific-offsets: partition:0,offset:42;partition:1,offset:300  # optional: used in case of startup mode with specific offsets
+  startup-timestamp-millis: 1578538374471                         # optional: used in case of startup mode with timestamp
+
 
   sink-partitioner: ...    # optional: output partitioning from Flink's partitions into Kafka's partitions
                            # valid are "fixed" (each Flink partition ends up in at most one Kafka partition),

--- a/docs/dev/table/connect.zh.md
+++ b/docs/dev/table/connect.zh.md
@@ -819,6 +819,7 @@ CREATE TABLE MyUserTable (
     .startFromEarliest()
     .startFromLatest()
     .startFromSpecificOffsets(...)
+    .startFromTimestamp(...)
 
     // optional: output partitioning from Flink's partitions into Kafka's partitions
     .sinkPartitionerFixed()         // each Flink partition ends up in at-most one Kafka partition (default)

--- a/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka010TableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka010TableSource.java
@@ -52,6 +52,8 @@ public class Kafka010TableSource extends KafkaTableSourceBase {
 	 * @param startupMode                 Startup mode for the contained consumer.
 	 * @param specificStartupOffsets      Specific startup offsets; only relevant when startup
 	 *                                    mode is {@link StartupMode#SPECIFIC_OFFSETS}.
+	 * @param startupTimestampMillis	  Startup timestamp for offsets; only relevant when startup
+	 *                                    mode is {@link StartupMode#TIMESTAMP}.
 	 */
 	public Kafka010TableSource(
 			TableSchema schema,
@@ -62,7 +64,8 @@ public class Kafka010TableSource extends KafkaTableSourceBase {
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
 			StartupMode startupMode,
-			Map<KafkaTopicPartition, Long> specificStartupOffsets) {
+			Map<KafkaTopicPartition, Long> specificStartupOffsets,
+			long startupTimestampMillis) {
 
 		super(
 			schema,
@@ -73,7 +76,8 @@ public class Kafka010TableSource extends KafkaTableSourceBase {
 			properties,
 			deserializationSchema,
 			startupMode,
-			specificStartupOffsets);
+			specificStartupOffsets,
+			startupTimestampMillis);
 	}
 
 	/**

--- a/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka010TableSourceSinkFactory.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka010TableSourceSinkFactory.java
@@ -58,7 +58,8 @@ public class Kafka010TableSourceSinkFactory extends KafkaTableSourceSinkFactoryB
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
 			StartupMode startupMode,
-			Map<KafkaTopicPartition, Long> specificStartupOffsets) {
+			Map<KafkaTopicPartition, Long> specificStartupOffsets,
+			long startupTimestampMillis) {
 
 		return new Kafka010TableSource(
 			schema,
@@ -69,7 +70,8 @@ public class Kafka010TableSourceSinkFactory extends KafkaTableSourceSinkFactoryB
 			properties,
 			deserializationSchema,
 			startupMode,
-			specificStartupOffsets);
+			specificStartupOffsets,
+			startupTimestampMillis);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka010TableSourceSinkFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka010TableSourceSinkFactoryTest.java
@@ -65,7 +65,8 @@ public class Kafka010TableSourceSinkFactoryTest extends KafkaTableSourceSinkFact
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
 			StartupMode startupMode,
-			Map<KafkaTopicPartition, Long> specificStartupOffsets) {
+			Map<KafkaTopicPartition, Long> specificStartupOffsets,
+			long startupTimestampMillis) {
 
 		return new Kafka010TableSource(
 			schema,
@@ -76,7 +77,8 @@ public class Kafka010TableSourceSinkFactoryTest extends KafkaTableSourceSinkFact
 			properties,
 			deserializationSchema,
 			startupMode,
-			specificStartupOffsets
+			specificStartupOffsets,
+			startupTimestampMillis
 		);
 	}
 

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka011TableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka011TableSource.java
@@ -52,6 +52,8 @@ public class Kafka011TableSource extends KafkaTableSourceBase {
 	 * @param startupMode                 Startup mode for the contained consumer.
 	 * @param specificStartupOffsets      Specific startup offsets; only relevant when startup
 	 *                                    mode is {@link StartupMode#SPECIFIC_OFFSETS}.
+	 * @param startupTimestampMillis	  Startup timestamp for offsets; only relevant when startup
+	 *                                    mode is {@link StartupMode#TIMESTAMP}.
 	 */
 	public Kafka011TableSource(
 			TableSchema schema,
@@ -62,7 +64,8 @@ public class Kafka011TableSource extends KafkaTableSourceBase {
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
 			StartupMode startupMode,
-			Map<KafkaTopicPartition, Long> specificStartupOffsets) {
+			Map<KafkaTopicPartition, Long> specificStartupOffsets,
+			long startupTimestampMillis) {
 
 		super(
 			schema,
@@ -73,7 +76,8 @@ public class Kafka011TableSource extends KafkaTableSourceBase {
 			properties,
 			deserializationSchema,
 			startupMode,
-			specificStartupOffsets);
+			specificStartupOffsets,
+			startupTimestampMillis);
 	}
 
 	/**

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka011TableSourceSinkFactory.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka011TableSourceSinkFactory.java
@@ -58,7 +58,8 @@ public class Kafka011TableSourceSinkFactory extends KafkaTableSourceSinkFactoryB
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
 			StartupMode startupMode,
-			Map<KafkaTopicPartition, Long> specificStartupOffsets) {
+			Map<KafkaTopicPartition, Long> specificStartupOffsets,
+			long startupTimestampMillis) {
 
 		return new Kafka011TableSource(
 			schema,
@@ -69,7 +70,8 @@ public class Kafka011TableSourceSinkFactory extends KafkaTableSourceSinkFactoryB
 			properties,
 			deserializationSchema,
 			startupMode,
-			specificStartupOffsets);
+			specificStartupOffsets,
+			startupTimestampMillis);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka011TableSourceSinkFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka011TableSourceSinkFactoryTest.java
@@ -65,7 +65,8 @@ public class Kafka011TableSourceSinkFactoryTest extends KafkaTableSourceSinkFact
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
 			StartupMode startupMode,
-			Map<KafkaTopicPartition, Long> specificStartupOffsets) {
+			Map<KafkaTopicPartition, Long> specificStartupOffsets,
+			long startupTimestampMillis) {
 
 		return new Kafka011TableSource(
 			schema,
@@ -76,7 +77,8 @@ public class Kafka011TableSourceSinkFactoryTest extends KafkaTableSourceSinkFact
 			properties,
 			deserializationSchema,
 			startupMode,
-			specificStartupOffsets
+			specificStartupOffsets,
+			startupTimestampMillis
 		);
 	}
 

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceBase.java
@@ -90,6 +90,12 @@ public abstract class KafkaTableSourceBase implements
 	/** Specific startup offsets; only relevant when startup mode is {@link StartupMode#SPECIFIC_OFFSETS}. */
 	private final Map<KafkaTopicPartition, Long> specificStartupOffsets;
 
+	/** The start timestamp to locate partition offsets; only relevant when startup mode is {@link StartupMode#TIMESTAMP}.*/
+	private final long startupTimestampMillis;
+
+	/** The default value when startup timestamp is not used.*/
+	private static final long DEFAULT_STARTUP_TIMESTAMP_MILLIS = -1L;
+
 	/**
 	 * Creates a generic Kafka {@link StreamTableSource}.
 	 *
@@ -104,6 +110,8 @@ public abstract class KafkaTableSourceBase implements
 	 * @param startupMode                 Startup mode for the contained consumer.
 	 * @param specificStartupOffsets      Specific startup offsets; only relevant when startup
 	 *                                    mode is {@link StartupMode#SPECIFIC_OFFSETS}.
+	 * @param startupTimestampMillis	  Startup timestamp for offsets; only relevant when startup
+	 *                                    mode is {@link StartupMode#TIMESTAMP}.
 	 */
 	protected KafkaTableSourceBase(
 			TableSchema schema,
@@ -114,7 +122,8 @@ public abstract class KafkaTableSourceBase implements
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
 			StartupMode startupMode,
-			Map<KafkaTopicPartition, Long> specificStartupOffsets) {
+			Map<KafkaTopicPartition, Long> specificStartupOffsets,
+			long startupTimestampMillis) {
 		this.schema = TableSchemaUtils.checkNoGeneratedColumns(schema);
 		this.proctimeAttribute = validateProctimeAttribute(proctimeAttribute);
 		this.rowtimeAttributeDescriptors = validateRowtimeAttributeDescriptors(rowtimeAttributeDescriptors);
@@ -126,6 +135,7 @@ public abstract class KafkaTableSourceBase implements
 		this.startupMode = Preconditions.checkNotNull(startupMode, "Startup mode must not be null.");
 		this.specificStartupOffsets = Preconditions.checkNotNull(
 			specificStartupOffsets, "Specific offsets must not be null.");
+		this.startupTimestampMillis = startupTimestampMillis;
 	}
 
 	/**
@@ -149,7 +159,8 @@ public abstract class KafkaTableSourceBase implements
 			topic, properties,
 			deserializationSchema,
 			StartupMode.GROUP_OFFSETS,
-			Collections.emptyMap());
+			Collections.emptyMap(),
+			DEFAULT_STARTUP_TIMESTAMP_MILLIS);
 	}
 
 	/**
@@ -230,7 +241,8 @@ public abstract class KafkaTableSourceBase implements
 			Objects.equals(properties, that.properties) &&
 			Objects.equals(deserializationSchema, that.deserializationSchema) &&
 			startupMode == that.startupMode &&
-			Objects.equals(specificStartupOffsets, that.specificStartupOffsets);
+			Objects.equals(specificStartupOffsets, that.specificStartupOffsets) &&
+			startupTimestampMillis == that.startupTimestampMillis;
 	}
 
 	@Override
@@ -244,7 +256,8 @@ public abstract class KafkaTableSourceBase implements
 			properties,
 			deserializationSchema,
 			startupMode,
-			specificStartupOffsets);
+			specificStartupOffsets,
+			startupTimestampMillis);
 	}
 
 	/**
@@ -273,6 +286,9 @@ public abstract class KafkaTableSourceBase implements
 				break;
 			case SPECIFIC_OFFSETS:
 				kafkaConsumer.setStartFromSpecificOffsets(specificStartupOffsets);
+				break;
+			case TIMESTAMP:
+				kafkaConsumer.setStartFromTimestamp(startupTimestampMillis);
 				break;
 		}
 		return kafkaConsumer;

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceBase.java
@@ -94,7 +94,7 @@ public abstract class KafkaTableSourceBase implements
 	private final long startupTimestampMillis;
 
 	/** The default value when startup timestamp is not used.*/
-	private static final long DEFAULT_STARTUP_TIMESTAMP_MILLIS = -1L;
+	private static final long DEFAULT_STARTUP_TIMESTAMP_MILLIS = 0L;
 
 	/**
 	 * Creates a generic Kafka {@link StreamTableSource}.

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
@@ -41,8 +41,6 @@ import org.apache.flink.table.utils.TableSchemaUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.InstantiationUtil;
 
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -72,7 +70,6 @@ import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SPECIF
 import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SPECIFIC_OFFSETS_OFFSET;
 import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_SPECIFIC_OFFSETS_PARTITION;
 import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_STARTUP_MODE;
-import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_STARTUP_TIMESTAMP;
 import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_STARTUP_TIMESTAMP_MILLIS;
 import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_TOPIC;
 import static org.apache.flink.table.descriptors.KafkaValidator.CONNECTOR_TYPE_VALUE_KAFKA;
@@ -124,7 +121,6 @@ public abstract class KafkaTableSourceSinkFactoryBase implements
 		properties.add(CONNECTOR_SPECIFIC_OFFSETS);
 		properties.add(CONNECTOR_SPECIFIC_OFFSETS + ".#." + CONNECTOR_SPECIFIC_OFFSETS_PARTITION);
 		properties.add(CONNECTOR_SPECIFIC_OFFSETS + ".#." + CONNECTOR_SPECIFIC_OFFSETS_OFFSET);
-		properties.add(CONNECTOR_STARTUP_TIMESTAMP);
 		properties.add(CONNECTOR_STARTUP_TIMESTAMP_MILLIS);
 		properties.add(CONNECTOR_SINK_PARTITIONER);
 		properties.add(CONNECTOR_SINK_PARTITIONER_CLASS);
@@ -354,7 +350,7 @@ public abstract class KafkaTableSourceSinkFactoryBase implements
 		options.startupMode = startupMode;
 		options.specificOffsets = specificOffsets;
 		if (startupMode == StartupMode.TIMESTAMP) {
-			options.startupTimestampMillis = getStartupTimestamp(descriptorProperties);
+			options.startupTimestampMillis = descriptorProperties.getLong(CONNECTOR_STARTUP_TIMESTAMP_MILLIS);
 		}
 		return options;
 	}
@@ -376,15 +372,6 @@ public abstract class KafkaTableSourceSinkFactoryBase implements
 				final KafkaTopicPartition topicPartition = new KafkaTopicPartition(topic, partition);
 				specificOffsets.put(topicPartition, offset);
 			});
-		}
-	}
-
-	private long getStartupTimestamp(DescriptorProperties descriptorProperties) {
-		if (descriptorProperties.containsKey(CONNECTOR_STARTUP_TIMESTAMP)) {
-			LocalDateTime startupTimestamp = descriptorProperties.getLocalDateTime(CONNECTOR_STARTUP_TIMESTAMP);
-			return startupTimestamp.atZone(ZoneOffset.UTC).toInstant().toEpochMilli();
-		} else {
-			return descriptorProperties.getLong(CONNECTOR_STARTUP_TIMESTAMP_MILLIS);
 		}
 	}
 

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaValidator.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaValidator.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.table.api.ValidationException;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -47,9 +48,12 @@ public class KafkaValidator extends ConnectorDescriptorValidator {
 	public static final String CONNECTOR_STARTUP_MODE_VALUE_LATEST = "latest-offset";
 	public static final String CONNECTOR_STARTUP_MODE_VALUE_GROUP_OFFSETS = "group-offsets";
 	public static final String CONNECTOR_STARTUP_MODE_VALUE_SPECIFIC_OFFSETS = "specific-offsets";
+	public static final String CONNECTOR_STARTUP_MODE_VALUE_TIMESTAMP = "timestamp";
 	public static final String CONNECTOR_SPECIFIC_OFFSETS = "connector.specific-offsets";
 	public static final String CONNECTOR_SPECIFIC_OFFSETS_PARTITION = "partition";
 	public static final String CONNECTOR_SPECIFIC_OFFSETS_OFFSET = "offset";
+	public static final String CONNECTOR_STARTUP_TIMESTAMP = "connector.startup-timestamp";
+	public static final String CONNECTOR_STARTUP_TIMESTAMP_MILLIS = "connector.startup-timestamp-millis";
 	public static final String CONNECTOR_PROPERTIES = "connector.properties";
 	public static final String CONNECTOR_PROPERTIES_ZOOKEEPER_CONNECT = "connector.properties.zookeeper.connect";
 	public static final String CONNECTOR_PROPERTIES_BOOTSTRAP_SERVER = "connector.properties.bootstrap.servers";
@@ -108,6 +112,31 @@ public class KafkaValidator extends ConnectorDescriptorValidator {
 				key -> properties.validateFixedIndexedProperties(CONNECTOR_SPECIFIC_OFFSETS, false, specificOffsetValidators));
 		}
 
+		startupModeValidation.put(CONNECTOR_STARTUP_MODE_VALUE_TIMESTAMP,
+			key -> {
+				boolean hasStartupTimestampMillis = properties.containsKey(CONNECTOR_STARTUP_TIMESTAMP_MILLIS);
+				boolean hasStartupTimestamp = properties.containsKey(CONNECTOR_STARTUP_TIMESTAMP);
+				if (hasStartupTimestampMillis == hasStartupTimestamp) {
+					throw new ValidationException(String.format("One and only one of `%s` or `%s` should be provided.",
+						CONNECTOR_STARTUP_TIMESTAMP_MILLIS,
+						CONNECTOR_STARTUP_TIMESTAMP
+					));
+				}
+				try {
+					properties.validateEnumValues(
+						CONNECTOR_VERSION,
+						false,
+						Arrays.asList(CONNECTOR_VERSION_VALUE_010, CONNECTOR_VERSION_VALUE_011, CONNECTOR_VERSION_VALUE_UNIVERSAL));
+				} catch (ValidationException e) {
+					throw new ValidationException("Starting from timestamp requires Kafka 0.10 above.");
+				}
+			});
+
+		startupModeValidation.put(CONNECTOR_STARTUP_TIMESTAMP_MILLIS,
+			key -> properties.validateLong(key, true, 0L, Long.MAX_VALUE));
+		startupModeValidation.put(CONNECTOR_STARTUP_TIMESTAMP,
+			key -> properties.validateLocalTimestamp(key, true, 0L, Long.MAX_VALUE));
+
 		properties.validateEnum(CONNECTOR_STARTUP_MODE, true, startupModeValidation);
 	}
 
@@ -154,6 +183,8 @@ public class KafkaValidator extends ConnectorDescriptorValidator {
 				return CONNECTOR_STARTUP_MODE_VALUE_GROUP_OFFSETS;
 			case SPECIFIC_OFFSETS:
 				return CONNECTOR_STARTUP_MODE_VALUE_SPECIFIC_OFFSETS;
+			case TIMESTAMP:
+				return CONNECTOR_STARTUP_MODE_VALUE_TIMESTAMP;
 		}
 		throw new IllegalArgumentException("Invalid startup mode.");
 	}

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaValidator.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaValidator.java
@@ -52,7 +52,6 @@ public class KafkaValidator extends ConnectorDescriptorValidator {
 	public static final String CONNECTOR_SPECIFIC_OFFSETS = "connector.specific-offsets";
 	public static final String CONNECTOR_SPECIFIC_OFFSETS_PARTITION = "partition";
 	public static final String CONNECTOR_SPECIFIC_OFFSETS_OFFSET = "offset";
-	public static final String CONNECTOR_STARTUP_TIMESTAMP = "connector.startup-timestamp";
 	public static final String CONNECTOR_STARTUP_TIMESTAMP_MILLIS = "connector.startup-timestamp-millis";
 	public static final String CONNECTOR_PROPERTIES = "connector.properties";
 	public static final String CONNECTOR_PROPERTIES_ZOOKEEPER_CONNECT = "connector.properties.zookeeper.connect";
@@ -115,11 +114,9 @@ public class KafkaValidator extends ConnectorDescriptorValidator {
 		startupModeValidation.put(CONNECTOR_STARTUP_MODE_VALUE_TIMESTAMP,
 			key -> {
 				boolean hasStartupTimestampMillis = properties.containsKey(CONNECTOR_STARTUP_TIMESTAMP_MILLIS);
-				boolean hasStartupTimestamp = properties.containsKey(CONNECTOR_STARTUP_TIMESTAMP);
-				if (hasStartupTimestampMillis == hasStartupTimestamp) {
-					throw new ValidationException(String.format("One and only one of `%s` or `%s` should be provided.",
-						CONNECTOR_STARTUP_TIMESTAMP_MILLIS,
-						CONNECTOR_STARTUP_TIMESTAMP
+				if (!hasStartupTimestampMillis) {
+					throw new ValidationException(String.format("`%s` is required in timestamp startup mode but missing.",
+						CONNECTOR_STARTUP_TIMESTAMP_MILLIS
 					));
 				}
 				try {
@@ -128,14 +125,12 @@ public class KafkaValidator extends ConnectorDescriptorValidator {
 						false,
 						Arrays.asList(CONNECTOR_VERSION_VALUE_010, CONNECTOR_VERSION_VALUE_011, CONNECTOR_VERSION_VALUE_UNIVERSAL));
 				} catch (ValidationException e) {
-					throw new ValidationException("Starting from timestamp requires Kafka 0.10 above.");
+					throw new ValidationException("Timestamp startup mode requires Kafka 0.10 or above.");
 				}
 			});
 
 		startupModeValidation.put(CONNECTOR_STARTUP_TIMESTAMP_MILLIS,
 			key -> properties.validateLong(key, true, 0L, Long.MAX_VALUE));
-		startupModeValidation.put(CONNECTOR_STARTUP_TIMESTAMP,
-			key -> properties.validateLocalTimestamp(key, true, 0L, Long.MAX_VALUE));
 
 		properties.validateEnum(CONNECTOR_STARTUP_MODE, true, startupModeValidation);
 	}

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
@@ -146,7 +146,7 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 			deserializationSchema,
 			StartupMode.SPECIFIC_OFFSETS,
 			specificOffsets,
-			-1L);
+			0L);
 
 		TableSourceValidation.validateTableSource(expected, schema);
 

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
@@ -145,7 +145,8 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 			KAFKA_PROPERTIES,
 			deserializationSchema,
 			StartupMode.SPECIFIC_OFFSETS,
-			specificOffsets);
+			specificOffsets,
+			-1L);
 
 		TableSourceValidation.validateTableSource(expected, schema);
 
@@ -212,7 +213,8 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 			KAFKA_PROPERTIES,
 			deserializationSchema,
 			StartupMode.SPECIFIC_OFFSETS,
-			specificOffsets);
+			specificOffsets,
+			0L);
 
 		TableSourceValidation.validateTableSource(expected, schema);
 
@@ -439,7 +441,8 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 		Properties properties,
 		DeserializationSchema<Row> deserializationSchema,
 		StartupMode startupMode,
-		Map<KafkaTopicPartition, Long> specificStartupOffsets);
+		Map<KafkaTopicPartition, Long> specificStartupOffsets,
+		long startupTimestampMillis);
 
 	protected abstract KafkaTableSinkBase getExpectedKafkaTableSink(
 		TableSchema schema,

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/table/descriptors/KafkaTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/table/descriptors/KafkaTest.java
@@ -64,7 +64,13 @@ public class KafkaTest extends DescriptorTestBase {
 				.properties(properties)
 				.sinkPartitionerCustom(FlinkFixedPartitioner.class);
 
-		return Arrays.asList(earliestDesc, specificOffsetsDesc, specificOffsetsMapDesc);
+		final Descriptor timestampDesc =
+			new Kafka()
+				.version("0.11")
+				.topic("MyTable")
+				.startFromTimestamp(1577014729000L);
+
+		return Arrays.asList(earliestDesc, specificOffsetsDesc, specificOffsetsMapDesc, timestampDesc);
 	}
 
 	@Override
@@ -98,7 +104,15 @@ public class KafkaTest extends DescriptorTestBase {
 		props3.put("connector.sink-partitioner", "custom");
 		props3.put("connector.sink-partitioner-class", FlinkFixedPartitioner.class.getName());
 
-		return Arrays.asList(props1, props2, props3);
+		final Map<String, String> props4 = new HashMap<>();
+		props4.put("connector.property-version", "1");
+		props4.put("connector.type", "kafka");
+		props4.put("connector.version", "0.11");
+		props4.put("connector.topic", "MyTable");
+		props4.put("connector.startup-mode", "timestamp");
+		props4.put("connector.startup-timestamp-millis", "1577014729000");
+
+		return Arrays.asList(props1, props2, props3, props4);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/table/descriptors/KafkaValidatorTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/table/descriptors/KafkaValidatorTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.descriptors;
+
+import org.apache.flink.util.ExceptionUtils;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the {@link KafkaValidator}.
+ */
+public class KafkaValidatorTest {
+
+	@Test
+	public void testValidateTimestampStartupMode() {
+		// start from timestamp with old Kafka version
+		final Map<String, String> props1 = new HashMap<>();
+		props1.put("connector.property-version", "1");
+		props1.put("connector.type", "kafka");
+		props1.put("connector.version", "0.8");
+		props1.put("connector.topic", "MyTopic");
+		props1.put("connector.startup-mode", "timestamp");
+		props1.put("connector.startup-timestamp", "2019-12-20 20:11:38.221");
+
+		final DescriptorProperties descriptorProperties1 = new DescriptorProperties();
+		descriptorProperties1.putProperties(props1);
+		try {
+			new KafkaValidator().validate(descriptorProperties1);
+		} catch (Exception e) {
+			Optional<Throwable> throwable =
+				ExceptionUtils.findThrowableWithMessage(e, "Starting from timestamp requires Kafka 0.10 above");
+			assertTrue(throwable.isPresent());
+		}
+
+		// start from timestamp with duplicate timestamp properties
+		final Map<String, String> props2 = new HashMap<>();
+		props2.put("connector.property-version", "1");
+		props2.put("connector.type", "kafka");
+		props2.put("connector.version", "0.11");
+		props2.put("connector.topic", "MyTopic");
+		props2.put("connector.startup-mode", "timestamp");
+		props2.put("connector.startup-timestamp", "2019-12-20 20:11:38.221");
+		props2.put("connector.startup-timestamp-millis", "1577087582000");
+
+		final DescriptorProperties descriptorProperties2 = new DescriptorProperties();
+		descriptorProperties2.putProperties(props2);
+		try {
+			new KafkaValidator().validate(descriptorProperties2);
+		} catch (Exception e) {
+			Optional<Throwable> throwable =
+				ExceptionUtils.findThrowableWithMessage(e, "One and only one of `connector.startup-" +
+					"timestamp-millis` or `connector.startup-timestamp` should be provided.");
+			assertTrue(throwable.isPresent());
+		}
+
+		// start from timestamp without timestamp property
+		final Map<String, String> props3 = new HashMap<>();
+		props3.put("connector.property-version", "1");
+		props3.put("connector.type", "kafka");
+		props3.put("connector.version", "0.10");
+		props3.put("connector.topic", "MyTopic");
+		props3.put("connector.startup-mode", "timestamp");
+
+		final DescriptorProperties descriptorProperties3 = new DescriptorProperties();
+		descriptorProperties3.putProperties(props3);
+		try {
+			new KafkaValidator().validate(descriptorProperties3);
+		} catch (Exception e) {
+			Optional<Throwable> throwable =
+				ExceptionUtils.findThrowableWithMessage(e, "One and only one of `connector.startup-" +
+					"timestamp-millis` or `connector.startup-timestamp` should be provided.");
+			assertTrue(throwable.isPresent());
+		}
+	}
+}

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/table/descriptors/KafkaValidatorTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/table/descriptors/KafkaValidatorTest.java
@@ -42,7 +42,7 @@ public class KafkaValidatorTest {
 		props1.put("connector.version", "0.8");
 		props1.put("connector.topic", "MyTopic");
 		props1.put("connector.startup-mode", "timestamp");
-		props1.put("connector.startup-timestamp", "2019-12-20 20:11:38.221");
+		props1.put("connector.startup-timestamp-millis", "1578538374471");
 
 		final DescriptorProperties descriptorProperties1 = new DescriptorProperties();
 		descriptorProperties1.putProperties(props1);
@@ -50,28 +50,7 @@ public class KafkaValidatorTest {
 			new KafkaValidator().validate(descriptorProperties1);
 		} catch (Exception e) {
 			Optional<Throwable> throwable =
-				ExceptionUtils.findThrowableWithMessage(e, "Starting from timestamp requires Kafka 0.10 above");
-			assertTrue(throwable.isPresent());
-		}
-
-		// start from timestamp with duplicate timestamp properties
-		final Map<String, String> props2 = new HashMap<>();
-		props2.put("connector.property-version", "1");
-		props2.put("connector.type", "kafka");
-		props2.put("connector.version", "0.11");
-		props2.put("connector.topic", "MyTopic");
-		props2.put("connector.startup-mode", "timestamp");
-		props2.put("connector.startup-timestamp", "2019-12-20 20:11:38.221");
-		props2.put("connector.startup-timestamp-millis", "1577087582000");
-
-		final DescriptorProperties descriptorProperties2 = new DescriptorProperties();
-		descriptorProperties2.putProperties(props2);
-		try {
-			new KafkaValidator().validate(descriptorProperties2);
-		} catch (Exception e) {
-			Optional<Throwable> throwable =
-				ExceptionUtils.findThrowableWithMessage(e, "One and only one of `connector.startup-" +
-					"timestamp-millis` or `connector.startup-timestamp` should be provided.");
+				ExceptionUtils.findThrowableWithMessage(e, "Timestamp startup mode requires Kafka 0.10 or above.");
 			assertTrue(throwable.isPresent());
 		}
 
@@ -89,8 +68,8 @@ public class KafkaValidatorTest {
 			new KafkaValidator().validate(descriptorProperties3);
 		} catch (Exception e) {
 			Optional<Throwable> throwable =
-				ExceptionUtils.findThrowableWithMessage(e, "One and only one of `connector.startup-" +
-					"timestamp-millis` or `connector.startup-timestamp` should be provided.");
+				ExceptionUtils.findThrowableWithMessage(e,
+					"`connector.startup-timestamp-millis` is required in timestamp startup mode but missing.");
 			assertTrue(throwable.isPresent());
 		}
 	}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSource.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSource.java
@@ -61,7 +61,8 @@ public class KafkaTableSource extends KafkaTableSourceBase {
 		Properties properties,
 		DeserializationSchema<Row> deserializationSchema,
 		StartupMode startupMode,
-		Map<KafkaTopicPartition, Long> specificStartupOffsets) {
+		Map<KafkaTopicPartition, Long> specificStartupOffsets,
+		long startupTimestampMillis) {
 
 		super(
 			schema,
@@ -72,7 +73,8 @@ public class KafkaTableSource extends KafkaTableSourceBase {
 			properties,
 			deserializationSchema,
 			startupMode,
-			specificStartupOffsets);
+			specificStartupOffsets,
+			startupTimestampMillis);
 	}
 
 	/**

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactory.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactory.java
@@ -57,7 +57,8 @@ public class KafkaTableSourceSinkFactory extends KafkaTableSourceSinkFactoryBase
 		Properties properties,
 		DeserializationSchema<Row> deserializationSchema,
 		StartupMode startupMode,
-		Map<KafkaTopicPartition, Long> specificStartupOffsets) {
+		Map<KafkaTopicPartition, Long> specificStartupOffsets,
+		long startupTimestampMillis) {
 
 		return new KafkaTableSource(
 			schema,
@@ -68,7 +69,8 @@ public class KafkaTableSourceSinkFactory extends KafkaTableSourceSinkFactoryBase
 			properties,
 			deserializationSchema,
 			startupMode,
-			specificStartupOffsets);
+			specificStartupOffsets,
+			startupTimestampMillis);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTest.java
@@ -63,7 +63,8 @@ public class KafkaTableSourceSinkFactoryTest extends KafkaTableSourceSinkFactory
 		Properties properties,
 		DeserializationSchema<Row> deserializationSchema,
 		StartupMode startupMode,
-		Map<KafkaTopicPartition, Long> specificStartupOffsets) {
+		Map<KafkaTopicPartition, Long> specificStartupOffsets,
+		long startupTimestamp) {
 
 		return new KafkaTableSource(
 			schema,
@@ -74,7 +75,8 @@ public class KafkaTableSourceSinkFactoryTest extends KafkaTableSourceSinkFactory
 			properties,
 			deserializationSchema,
 			startupMode,
-			specificStartupOffsets);
+			specificStartupOffsets,
+			startupTimestamp);
 	}
 
 	@Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/DescriptorProperties.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/DescriptorProperties.java
@@ -39,9 +39,6 @@ import org.apache.flink.util.TimeUtils;
 
 import java.math.BigDecimal;
 import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -98,20 +95,15 @@ public class DescriptorProperties {
 
 	public static final String WATERMARK_STRATEGY_DATA_TYPE = "strategy.data-type";
 
-	public static final String DEFAULT_TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss[.SSS]";
-
 	private static final Consumer<String> EMPTY_CONSUMER = (value) -> {};
 
 	private final boolean normalizeKeys;
 
 	private final Map<String, String> properties;
 
-	private final DateTimeFormatter dateTimeFormatter;
-
 	public DescriptorProperties(boolean normalizeKeys) {
 		this.properties = new HashMap<>();
 		this.normalizeKeys = normalizeKeys;
-		this.dateTimeFormatter = DateTimeFormatter.ofPattern(DEFAULT_TIMESTAMP_FORMAT);
 	}
 
 	public DescriptorProperties() {
@@ -712,26 +704,6 @@ public class DescriptorProperties {
 	}
 
 	/**
-	 * Returns a Java {@link LocalDateTime} under the given key if it exists.
-	 */
-	public Optional<LocalDateTime> getOptionalLocalDateTime(String key) {
-		return optionalGet(key).map((value) -> {
-			try {
-				return LocalDateTime.parse(value, dateTimeFormatter);
-			} catch (Exception e) {
-				throw new ValidationException("Invalid local datetime value for key '" + key + "'.", e);
-			}
-		});
-	}
-
-	/**
-	 * Returns a java {@link LocalDateTime} under the given existing key.
-	 */
-	public LocalDateTime getLocalDateTime(String key) {
-		return getOptionalLocalDateTime(key).orElseThrow(exceptionSupplier(key));
-	}
-
-	/**
 	 * Returns the property keys of fixed indexed properties.
 	 *
 	 * <p>For example:
@@ -1266,20 +1238,6 @@ public class DescriptorProperties {
 				return ms;
 			}
 		);
-	}
-
-	/**
-	 * Validates a {@link LocalDateTime}. The boundaries are inclusive and in milliseconds.
-	 */
-	public void validateLocalTimestamp(String key, boolean isOptional, long min, long max) {
-		validateComparable(
-			key,
-			isOptional,
-			min,
-			max,
-			"timestamp (with format [yyyy-MM-dd HH:mm:ss[.SSS])",
-			(value) -> LocalDateTime.parse(value, dateTimeFormatter).atZone(ZoneOffset.UTC).toInstant().toEpochMilli()
-			);
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

KafkaTableSource supports all startup modes in DataStream API except `startFromTimestamp`, but `startFromTimestamp` is a common and valid use case in Table/SQL API as well. 

## Brief change log

- Add `startFromTimestamp(long)` to Kafka descriptor API.
- Add new keys `connector.startup-timestamp-millis` and `connector.startup-timestamp` to Kafka connector properties.
- Add new value `timestamp` to `connector.startup-mode` in Kafka connector properties.
- Add startup timestamp parameter to KafkaTableSource and KafkaTableSourceSinkFactory.

## Verifying this change

This change added tests and can be verified as follows:

- Added tests to verify Kafka descriptor API generated properties.
- Added tests to verify the validation of new properties of timestamp startup mode in KafkaValidator. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
