### PR TITLE
[FLINK-15377][e2e] Mesos WordCount test fails on travis

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -323,6 +323,7 @@ function check_logs_for_errors {
       | grep -v "NoAvailableBrokersException" \
       | grep -v "Async Kafka commit failed" \
       | grep -v "DisconnectException" \
+      | grep -v "Cannot connect to ResourceManager right now" \
       | grep -v "AskTimeoutException" \
       | grep -v "Error while loading kafka-version.properties" \
       | grep -v "WARN  akka.remote.transport.netty.NettyTransport" \
@@ -354,6 +355,7 @@ function check_logs_for_exceptions {
    | grep -v "NoAvailableBrokersException" \
    | grep -v "Async Kafka commit failed" \
    | grep -v "DisconnectException" \
+   | grep -v "Cannot connect to ResourceManager right now" \
    | grep -v "AskTimeoutException" \
    | grep -v "WARN  akka.remote.transport.netty.NettyTransport" \
    | grep -v  "WARN  org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline" \

--- a/flink-end-to-end-tests/test-scripts/common_mesos_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_mesos_docker.sh
@@ -52,7 +52,7 @@ function start_flink_cluster_with_mesos() {
     set_config_key "jobmanager.rpc.address" "mesos-master"
     set_config_key "rest.address" "mesos-master"
 
-    docker exec -it mesos-master nohup bash -c "${FLINK_DIR}/bin/mesos-appmaster.sh -Dmesos.master=mesos-master:5050 &"
+    docker exec -itd mesos-master bash -c "${FLINK_DIR}/bin/mesos-appmaster.sh -Dmesos.master=mesos-master:5050"
     wait_rest_endpoint_up "http://${NODENAME}:8081/taskmanagers" "Dispatcher" "\{\"taskmanagers\":\[.*\]\}"
     return 0
 }

--- a/flink-end-to-end-tests/test-scripts/common_mesos_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_mesos_docker.sh
@@ -26,8 +26,6 @@ MAX_RETRY_SECONDS=120
 IMAGE_BUILD_RETRIES=5
 NODENAME=${NODENAME:-`hostname -f`}
 
-export INPUT_VOLUME=${END_TO_END_DIR}/test-scripts/test-data
-
 echo "End-to-end directory $END_TO_END_DIR"
 
 start_time=$(date +%s)
@@ -35,8 +33,6 @@ start_time=$(date +%s)
 # make sure we stop our cluster at the end
 function cluster_shutdown {
   docker-compose -f $END_TO_END_DIR/test-scripts/docker-mesos-cluster/docker-compose.yml down
-  rm -rf ${INPUT_VOLUME}/log
-  rm -rf ${INPUT_VOLUME}/tmp
 }
 on_exit cluster_shutdown
 

--- a/flink-end-to-end-tests/test-scripts/docker-mesos-cluster/docker-compose.yml
+++ b/flink-end-to-end-tests/test-scripts/docker-mesos-cluster/docker-compose.yml
@@ -34,8 +34,6 @@ services:
       - "8081:8081"
       - "5050:5050"
     volumes:
-      - ${INPUT_VOLUME}/log/mesos:/var/log/mesos
-      - ${INPUT_VOLUME}/tmp/mesos:/var/tmp/mesos
       - ${END_TO_END_DIR}:${END_TO_END_DIR}
       - ${FLINK_DIR}:${FLINK_DIR}
     environment:
@@ -55,8 +53,6 @@ services:
     networks:
       - docker-mesos-cluster-network
     volumes:
-      - ${INPUT_VOLUME}/log/mesos-sl:/var/log/mesos
-      - ${INPUT_VOLUME}/tmp/mesos-sl:/var/tmp/mesos
       - /var/run/docker.sock:/var/run/docker.sock
       - ${END_TO_END_DIR}:${END_TO_END_DIR}
     environment:


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, we wait the Flink rest endpoint up by periodically requesting taskmanager info. However, at the very beginning, if we request before MesosResourceManager setting up, "Cannot connect to ResourceManager right now" Exception will be throw. This exception does not affect the correctness of any test. We could add this to the whitelist.

Also, there are some permission errors occurred, we could remove the redundant mounting command and let docker clean-up the file itself.

## Brief change log

 - 7b05db3: Remove the redundant mounting command in docker-compose file. Let docker clean-up the filesystem of container by itself. Thus we will not encounter the permission issue and the temporary file could be clean-up properly.
 - f36b0d0: Appending the "Cannot connect to ResourceManager right now" Exception to whitelist.
 - 049a265: Change the way to execute a command in detach mode. Previously we used `nohup` to realize it. However, Docker has `-d` options to support it.

## Verifying this change

Trigger Mesos e2e test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no

cc @GJL @tillrohrmann @zhuzhurk 
