### PR TITLE
[FLINK-15380][scala-shell]. Unable to set number of TM and number of Slot for MiniCluster in Scala shell

### DIFF
--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -25,7 +25,7 @@ import org.apache.flink.client.cli.{CliFrontend, CliFrontendParser}
 import org.apache.flink.client.deployment.executors.RemoteExecutor
 import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader
 import org.apache.flink.client.program.{ClusterClient, MiniClusterClient}
-import org.apache.flink.configuration.{Configuration, DeploymentOptions, GlobalConfiguration, JobManagerOptions, RestOptions}
+import org.apache.flink.configuration.{ConfigConstants, Configuration, DeploymentOptions, GlobalConfiguration, JobManagerOptions, RestOptions, TaskManagerOptions}
 import org.apache.flink.runtime.minicluster.{MiniCluster, MiniClusterConfiguration}
 
 import scala.collection.mutable.ArrayBuffer
@@ -342,8 +342,15 @@ object FlinkShell {
   }
 
   private def createLocalCluster(flinkConfig: Configuration) = {
+
+    val numTaskManagers = flinkConfig.getInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER,
+      ConfigConstants.DEFAULT_LOCAL_NUMBER_TASK_MANAGER)
+    val numSlotsPerTaskManager = flinkConfig.getInteger(TaskManagerOptions.NUM_TASK_SLOTS)
+
     val miniClusterConfig = new MiniClusterConfiguration.Builder()
       .setConfiguration(flinkConfig)
+      .setNumSlotsPerTaskManager(numSlotsPerTaskManager)
+      .setNumTaskManagers(numTaskManagers)
       .build()
 
     val cluster = new MiniCluster(miniClusterConfig)


### PR DESCRIPTION
# What is the purpose of the change

User often do testing in local mode(especially in flink scala shell), but for now in scala shell it is uanble to set number of TM and number of Slot, that means we always get 1 TM with 1 slot which is usually doesn't work for streaming job.  This PR is a straightforward fix for this issue. 

## Brief change log

This PR just set number of TM and slot per TM in MiniClusterConfiguration before creating MiniCluster.


## Verifying this change

*(Please pick either of the following options)*

Verify it manually in scala shell.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
