### PR TITLE
[hotfix][runtime] Remove unused IOManager parameter while constructing BufferStorage

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
@@ -21,13 +21,10 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
 import org.apache.flink.streaming.api.CheckpointingMode;
-
-import java.io.IOException;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -41,15 +38,14 @@ public class InputProcessorUtil {
 	public static CheckpointedInputGate createCheckpointedInputGate(
 			AbstractInvokable toNotifyOnCheckpoint,
 			CheckpointingMode checkpointMode,
-			IOManager ioManager,
 			InputGate inputGate,
 			Configuration taskManagerConfig,
-			String taskName) throws IOException {
+			String taskName) {
 
 		int pageSize = ConfigurationParserUtils.getPageSize(taskManagerConfig);
 
 		BufferStorage bufferStorage = createBufferStorage(
-			checkpointMode, ioManager, pageSize, taskManagerConfig, taskName);
+			checkpointMode, pageSize, taskManagerConfig, taskName);
 		CheckpointBarrierHandler barrierHandler = createCheckpointBarrierHandler(
 			checkpointMode, inputGate.getNumberOfInputChannels(), taskName, toNotifyOnCheckpoint);
 		return new CheckpointedInputGate(inputGate, bufferStorage, barrierHandler);
@@ -62,18 +58,17 @@ public class InputProcessorUtil {
 	public static CheckpointedInputGate[] createCheckpointedInputGatePair(
 			AbstractInvokable toNotifyOnCheckpoint,
 			CheckpointingMode checkpointMode,
-			IOManager ioManager,
 			InputGate inputGate1,
 			InputGate inputGate2,
 			Configuration taskManagerConfig,
-			String taskName) throws IOException {
+			String taskName) {
 
 		int pageSize = ConfigurationParserUtils.getPageSize(taskManagerConfig);
 
 		BufferStorage mainBufferStorage1 = createBufferStorage(
-			checkpointMode, ioManager, pageSize, taskManagerConfig, taskName);
+			checkpointMode, pageSize, taskManagerConfig, taskName);
 		BufferStorage mainBufferStorage2 = createBufferStorage(
-			checkpointMode, ioManager, pageSize, taskManagerConfig, taskName);
+			checkpointMode, pageSize, taskManagerConfig, taskName);
 		checkState(mainBufferStorage1.getMaxBufferedBytes() == mainBufferStorage2.getMaxBufferedBytes());
 
 		BufferStorage linkedBufferStorage1 = new LinkedBufferStorage(
@@ -116,7 +111,6 @@ public class InputProcessorUtil {
 
 	private static BufferStorage createBufferStorage(
 			CheckpointingMode checkpointMode,
-			IOManager ioManager,
 			int pageSize,
 			Configuration taskManagerConfig,
 			String taskName) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -45,8 +45,6 @@ import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 
 import javax.annotation.Nullable;
 
-import java.io.IOException;
-
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -106,14 +104,13 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 		getEnvironment().getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_WATERMARK, this.inputWatermarkGauge::getValue);
 	}
 
-	private CheckpointedInputGate createCheckpointedInputGate() throws IOException {
+	private CheckpointedInputGate createCheckpointedInputGate() {
 		InputGate[] inputGates = getEnvironment().getAllInputGates();
 		InputGate inputGate = InputGateUtil.createInputGate(inputGates);
 
 		return InputProcessorUtil.createCheckpointedInputGate(
 			this,
 			configuration.getCheckpointMode(),
-			getEnvironment().getIOManager(),
 			inputGate,
 			getEnvironment().getTaskManagerInfo().getConfiguration(),
 			getTaskNameWithSubtaskAndId());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -29,7 +29,6 @@ import org.apache.flink.streaming.runtime.io.InputProcessorUtil;
 import org.apache.flink.streaming.runtime.io.StreamTwoInputProcessor;
 import org.apache.flink.streaming.runtime.io.TwoInputSelectionHandler;
 
-import java.io.IOException;
 import java.util.Collection;
 
 import static org.apache.flink.util.Preconditions.checkState;
@@ -50,7 +49,7 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
 		Collection<InputGate> inputGates1,
 		Collection<InputGate> inputGates2,
 		TypeSerializer<IN1> inputDeserializer1,
-		TypeSerializer<IN2> inputDeserializer2) throws IOException {
+		TypeSerializer<IN2> inputDeserializer2) {
 
 		TwoInputSelectionHandler twoInputSelectionHandler = new TwoInputSelectionHandler(
 			headOperator instanceof InputSelectable ? (InputSelectable) headOperator : null);
@@ -62,7 +61,6 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
 		CheckpointedInputGate[] checkpointedInputGates = InputProcessorUtil.createCheckpointedInputGatePair(
 			this,
 			getConfiguration().getCheckpointMode(),
-			getEnvironment().getIOManager(),
 			unionedInputGate1,
 			unionedInputGate2,
 			getEnvironment().getTaskManagerInfo().getConfiguration(),


### PR DESCRIPTION
## What is the purpose of the change

*After removing the code path of noncredit-based flow control, the `IOManager` parameter would never be used for constructing the `BufferStorage`, so we can remove it along with the related code path.*

## Brief change log

  - *Remove `IOManager` parameter from related methods in `InputProcessorUtil`*
  - *Remove `IOException` throwable from related methods*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
