### PR TITLE
[FLINK-15125][table-planner-blink] PROCTIME() computed column defined…

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/BatchLogicalWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/BatchLogicalWindowAggregateRule.scala
@@ -18,11 +18,10 @@
 
 package org.apache.flink.table.planner.plan.rules.logical
 
-import org.apache.flink.table.api.TableException
+import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.expressions.FieldReferenceExpression
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory.toLogicalType
-import org.apache.flink.table.planner.plan.nodes.calcite.LogicalWindowAggregate
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromLogicalTypeToDataType
 
 import org.apache.calcite.rel.`type`.RelDataType
@@ -33,7 +32,9 @@ import _root_.java.math.{BigDecimal => JBigDecimal}
 
 /**
   * Planner rule that transforms simple [[LogicalAggregate]] on a [[LogicalProject]]
-  * with windowing expression to [[LogicalWindowAggregate]] for batch.
+  * with windowing expression to
+ * [[org.apache.flink.table.planner.plan.nodes.calcite.LogicalWindowAggregate]]
+ * for batch.
   */
 class BatchLogicalWindowAggregateRule
   extends LogicalWindowAggregateRuleBase("BatchLogicalWindowAggregateRule") {
@@ -56,6 +57,10 @@ class BatchLogicalWindowAggregateRule
       operand: RexNode,
       windowExprIdx: Int,
       rowType: RelDataType): FieldReferenceExpression = {
+    if (FlinkTypeFactory.isProctimeIndicatorType(operand.getType)) {
+      throw new ValidationException("Window can not be defined over "
+        + "a proctime attribute column for batch mode")
+    }
     operand match {
       // match TUMBLE_ROWTIME and TUMBLE_PROCTIME
       case c: RexCall if c.getOperands.size() == 1 &&

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/StreamLogicalWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/StreamLogicalWindowAggregateRule.scala
@@ -22,7 +22,6 @@ import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.expressions.FieldReferenceExpression
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory.toLogicalType
-import org.apache.flink.table.planner.plan.nodes.calcite.LogicalWindowAggregate
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromLogicalTypeToDataType
 
 import org.apache.calcite.rel.`type`.RelDataType
@@ -34,7 +33,9 @@ import _root_.java.math.{BigDecimal => JBigDecimal}
 
 /**
   * Planner rule that transforms simple [[LogicalAggregate]] on a [[LogicalProject]]
-  * with windowing expression to [[LogicalWindowAggregate]] for stream.
+  * with windowing expression to
+ * [[org.apache.flink.table.planner.plan.nodes.calcite.LogicalWindowAggregate]]
+ * for stream.
   */
 class StreamLogicalWindowAggregateRule
   extends LogicalWindowAggregateRuleBase("StreamLogicalWindowAggregateRule") {
@@ -55,7 +56,8 @@ class StreamLogicalWindowAggregateRule
   override private[table] def getOutAggregateGroupExpression(
       rexBuilder: RexBuilder,
       windowExpression: RexCall): RexNode = {
-
+    // Create a literal with normal SqlTypeName.TIMESTAMP
+    // in case we reference a rowtime field.
     rexBuilder.makeLiteral(
       0L,
       rexBuilder.getTypeFactory.createSqlType(

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.xml
@@ -134,6 +134,30 @@ Calc(select=[EXPR$0, wAvg, w$start AS EXPR$2, w$end AS EXPR$3])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testHopWindowWithProctime">
+    <Resource name="sql">
+      <![CDATA[
+select sum(a), max(b)
+from MyTable1
+group by HOP(c, INTERVAL '1' SECOND, INTERVAL '1' MINUTE)
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[$1], EXPR$1=[$2])
++- LogicalAggregate(group=[{0}], EXPR$0=[SUM($1)], EXPR$1=[MAX($2)])
+   +- LogicalProject($f0=[HOP(PROCTIME(), 1000:INTERVAL SECOND, 60000:INTERVAL MINUTE)], a=[$0], b=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1, source: [CollectionTableSource(a, b)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+GroupWindowAggregate(window=[SlidingGroupWindow('w$, $f2, 60000, 1000)], select=[SUM(a) AS EXPR$0, MAX(b) AS EXPR$1])
++- Exchange(distribution=[single])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable1, source: [CollectionTableSource(a, b)]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testIntervalDay">
     <Resource name="sql">
       <![CDATA[SELECT COUNT(*) FROM MyTable GROUP BY TUMBLE(proctime, INTERVAL '35' DAY)]]>
@@ -425,6 +449,30 @@ Calc(select=[EXPR$0, wAvg, w$start AS EXPR$2, w$end AS EXPR$3])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testSessionWindowWithProctime">
+    <Resource name="sql">
+      <![CDATA[
+select sum(a), max(b)
+from MyTable1
+group by SESSION(c, INTERVAL '1' MINUTE)
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[$1], EXPR$1=[$2])
++- LogicalAggregate(group=[{0}], EXPR$0=[SUM($1)], EXPR$1=[MAX($2)])
+   +- LogicalProject($f0=[SESSION(PROCTIME(), 60000:INTERVAL MINUTE)], a=[$0], b=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1, source: [CollectionTableSource(a, b)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+GroupWindowAggregate(window=[SessionGroupWindow('w$, $f2, 60000)], select=[SUM(a) AS EXPR$0, MAX(b) AS EXPR$1])
++- Exchange(distribution=[single])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable1, source: [CollectionTableSource(a, b)]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testTumbleFunAndRegularAggFunInGroupBy">
     <Resource name="sql">
       <![CDATA[
@@ -520,6 +568,26 @@ Calc(select=[EXPR$0, wAvg, w$start AS EXPR$2, w$end AS EXPR$3])
    +- Exchange(distribution=[single])
       +- Calc(select=[rowtime, c, a])
          +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTumblingWindowWithProctime">
+    <Resource name="sql">
+      <![CDATA[select sum(a), max(b) from MyTable1 group by TUMBLE(c, INTERVAL '1' SECOND)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[$1], EXPR$1=[$2])
++- LogicalAggregate(group=[{0}], EXPR$0=[SUM($1)], EXPR$1=[MAX($2)])
+   +- LogicalProject($f0=[TUMBLE(PROCTIME(), 1000:INTERVAL SECOND)], a=[$0], b=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1, source: [CollectionTableSource(a, b)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+GroupWindowAggregate(window=[TumblingGroupWindow('w$, $f2, 1000)], select=[SUM(a) AS EXPR$0, MAX(b) AS EXPR$1])
++- Exchange(distribution=[single])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable1, source: [CollectionTableSource(a, b)]]], fields=[a, b])
 ]]>
     </Resource>
   </TestCase>


### PR DESCRIPTION
… in CREATE TABLE doesn't work

## What is the purpose of the change

Fix the support of `PROCTIME` window grouping for blink-planner.

## Brief change log

Add a rewrite logic for `LogicalWindowAggregateRuleBase` to change plan with pattern
```xml
LogicalProject($f0=[TUMBLE(PROCTIME(), 1000:INTERVAL SECOND)], a=[$0], b=[$1])
     +- LogicalTableScan
```
to
```xml
LogicalProject($f0=[TUMBLE($2, 1000:INTERVAL SECOND)], a=[$0], b=[$1])
   +- LogicalProject(a=[$0], b=[$1], $f2=[PROCTIME()])
   +- LogicalTableScan
```
in order to simplify the subsequent rewrite.

## Verifying this change

See tests in CatalogTableITCase.