### PR TITLE
[FLINK-15279][doc] Document new executeAsync() method and the newly introduced JobClient

### DIFF
--- a/docs/dev/api_concepts.md
+++ b/docs/dev/api_concepts.md
@@ -216,8 +216,19 @@ Once you specified the complete program you need to **trigger the program execut
 Depending on the type of the `ExecutionEnvironment` the execution will be triggered on your local
 machine or submit your program for execution on a cluster.
 
-The `execute()` method is returning a `JobExecutionResult`, this contains execution
+The `execute()` method will wait for the job to finish and then return a `JobExecutionResult`, this contains execution
 times and accumulator results.
+
+If you don't want to wait for the job to finish, you can trigger asynchronous job execution by calling
+`executeAysnc()` on the `StreamExecutionEnvironment`. It will return a `JobClient` with which you can
+communicate with the job you just submitted. For instance, here is how to implement the semantics
+of `execute()` by using `executeAsync()`.
+
+{% highlight java %}
+final JobClient jobClient = env.executeAsync();
+
+final JobExecutionResult jobExecutionResult = jobClient.getJobExecutionResult(userClassloader).get();
+{% endhighlight %}
 
 Please see the [Streaming Guide]({{ site.baseurl }}/dev/datastream_api.html)
 for information about streaming data sources and sink and for more in-depths information

--- a/docs/dev/api_concepts.zh.md
+++ b/docs/dev/api_concepts.zh.md
@@ -160,6 +160,14 @@ print()
 
 `execute()` 方法返回 `JobExecutionResult`，它包括执行耗时和一个累加器的结果。
 
+如果你不需要等待作业的结束，只是想要触发程序执行，你可以调用 `StreamExecutionEnvironment` 的 `executeAsync()` 方法。这个方法将返回一个 `JobClient` 对象，通过 `JobClient` 能够与程序对应的作业进行交互。作为例子，这里介绍通过 `executeAsync()` 实现与 `execute()` 相同行为的方法。
+
+{% highlight java %}
+final JobClient jobClient = env.executeAsync();
+
+final JobExecutionResult jobExecutionResult = jobClient.getJobExecutionResult(userClassloader).get();
+{% endhighlight %}
+
 有关流数据的 source 和 sink 以及有关 DataStream 支持的转换操作的详细信息请参阅[流处理指南]({{ site.baseurl }}/zh/dev/datastream_api.html)。
 
 有关批数据的 source 和 sink 以及有关 DataSet 支持的转换操作的详细信息请参阅[批处理指南]({{ site.baseurl }}/zh/dev/batch/index.html)。


### PR DESCRIPTION
This pull request introduces a simple introduction of new `executeAsync()` method and the newly introduced `JobClient`. In order to enrich the content I'd like to ask how to link the api document of `JobClient` from within the document I touched.

I'll appreciate it and be willing to integrate them if you have any other document ideas for this part.

cc @aljoscha @kl0u @wuchong 