### PR TITLE
[FLINK-14843][e2e] Refactor bucketing sink test to make it more stable and comprehensible

### DIFF
--- a/flink-end-to-end-tests/flink-bucketing-sink-test/src/main/java/org/apache/flink/streaming/tests/BucketingSinkTestProgram.java
+++ b/flink-end-to-end-tests/flink-bucketing-sink-test/src/main/java/org/apache/flink/streaming/tests/BucketingSinkTestProgram.java
@@ -74,8 +74,8 @@ public class BucketingSinkTestProgram {
 				.setBucketer(new KeyBucketer())
 				.setBatchSize(Long.MAX_VALUE)
 				.setBatchRolloverInterval(Long.MAX_VALUE)
-				.setInactiveBucketCheckInterval(2000)
-				.setInactiveBucketThreshold(4000);
+				.setInactiveBucketCheckInterval(50)
+				.setInactiveBucketThreshold(1000);
 
 		// generate data, shuffle, perform stateful operation, sink
 		sEnv.addSource(new Generator(10, idlenessMs, 60))

--- a/flink-end-to-end-tests/flink-bucketing-sink-test/src/main/java/org/apache/flink/streaming/tests/BucketingSinkTestProgram.java
+++ b/flink-end-to-end-tests/flink-bucketing-sink-test/src/main/java/org/apache/flink/streaming/tests/BucketingSinkTestProgram.java
@@ -74,8 +74,8 @@ public class BucketingSinkTestProgram {
 				.setBucketer(new KeyBucketer())
 				.setBatchSize(Long.MAX_VALUE)
 				.setBatchRolloverInterval(Long.MAX_VALUE)
-				.setInactiveBucketCheckInterval(Long.MAX_VALUE)
-				.setInactiveBucketThreshold(Long.MAX_VALUE);
+				.setInactiveBucketCheckInterval(2000)
+				.setInactiveBucketThreshold(4000);
 
 		// generate data, shuffle, perform stateful operation, sink
 		sEnv.addSource(new Generator(10, idlenessMs, 60))

--- a/flink-end-to-end-tests/test-scripts/test_streaming_bucketing.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_bucketing.sh
@@ -27,7 +27,7 @@ function get_total_number_of_valid_lines {
   # this method assumes that pending files contain valid data.
   # That is because close() cannot move files to FINAL state but moves them to PENDING.
   # Given this, the job of the test has bucket size = Long.MAX
-  find ${TEST_DATA_DIR}/out -type f \( -iname "*.pending" -or -iname "*.in-progress" -or -iname "part-*" \) -exec cat {} + | sort -g | wc -l
+  find ${TEST_DATA_DIR}/out -type f \( -iname "part-*" \) -exec cat {} + | sort -g | wc -l
 }
 
 function wait_for_complete_result {
@@ -124,8 +124,6 @@ echo "Restarting 1 TM"
 $FLINK_DIR/bin/taskmanager.sh start
 wait_for_number_of_running_tms 4
 
-sleep 10
-
 echo "Killing 2 TMs"
 kill_random_taskmanager
 kill_random_taskmanager
@@ -150,7 +148,7 @@ wait_job_terminal_state ${JOB_ID} "CANCELED"
 echo "Job $JOB_ID was cancelled, time to verify"
 
 # get all lines in pending or part files
-find ${TEST_DATA_DIR}/out -type f \( -iname "*.pending" -or -iname "part-*" \) -exec cat {} + > ${TEST_DATA_DIR}/complete_result
+find ${TEST_DATA_DIR}/out -type f \( -iname "part-*" \) -exec cat {} + > ${TEST_DATA_DIR}/complete_result
 
 # for debugging purposes
 #echo "Checking proper result..."

--- a/flink-end-to-end-tests/test-scripts/test_streaming_bucketing.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_bucketing.sh
@@ -24,9 +24,6 @@ JOB_OUTPUT_DIR=${TEST_DATA_DIR}/out/result
 LOG_DIR=${FLINK_DIR}/log
 
 function get_total_number_of_valid_lines {
-  # this method assumes that pending files contain valid data.
-  # That is because close() cannot move files to FINAL state but moves them to PENDING.
-  # Given this, the job of the test has bucket size = Long.MAX
   find ${TEST_DATA_DIR}/out -type f \( -iname "part-*" \) -exec cat {} + | sort -g | wc -l
 }
 
@@ -147,7 +144,7 @@ wait_job_terminal_state ${JOB_ID} "CANCELED"
 
 echo "Job $JOB_ID was cancelled, time to verify"
 
-# get all lines in pending or part files
+# get all lines in part files
 find ${TEST_DATA_DIR}/out -type f \( -iname "part-*" \) -exec cat {} + > ${TEST_DATA_DIR}/complete_result
 
 # for debugging purposes


### PR DESCRIPTION
## What is the purpose of the change
Refactor bucketing sink e2e test to make it more stable and comprehensible.

## Brief change log

- For `BucketingSinkTestProgram`, set inactiveBucketCheckInterval and inactiveBucketThreshold to 2000 and 4000 respectively
- only count records in part-* files to get total valid data
- remove "sleep 10" between two failover to make it comprehensible

## Verifying this change

Existing e2e test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
