### PR TITLE
[FLINK-15378][flink-core]support_different_filesystem_plugin between user code and flink default

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystemFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystemFactory.java
@@ -40,6 +40,13 @@ public interface FileSystemFactory extends Plugin {
 	String getScheme();
 
 	/**
+	 * Gets the identify of the file system created by this factory, default is for exist plugins.
+	 */
+	default String getIdentify() {
+		return "default";
+	}
+
+	/**
 	 * Creates a new file system for the given file system URI.
 	 * The URI describes the type of file system (via its scheme) and optionally the
 	 * authority (for example the host) of the file system.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
@@ -191,6 +191,8 @@ public class StreamingFileSink<IN>
 
 		protected static final long DEFAULT_BUCKET_CHECK_INTERVAL = 60L * 1000L;
 
+		protected static final String DEFAULT_FILESYSTEM_IDENTIFY = "default";
+
 		@SuppressWarnings("unchecked")
 		protected T self() {
 			return (T) this;
@@ -221,8 +223,10 @@ public class StreamingFileSink<IN>
 
 		private OutputFileConfig outputFileConfig;
 
+		private String factoryIdentify;
+
 		protected RowFormatBuilder(Path basePath, Encoder<IN> encoder, BucketAssigner<IN, BucketID> bucketAssigner) {
-			this(basePath, encoder, bucketAssigner, DefaultRollingPolicy.builder().build(), DEFAULT_BUCKET_CHECK_INTERVAL, new DefaultBucketFactoryImpl<>(), OutputFileConfig.builder().build());
+			this(basePath, encoder, bucketAssigner, DefaultRollingPolicy.builder().build(), DEFAULT_BUCKET_CHECK_INTERVAL, DEFAULT_FILESYSTEM_IDENTIFY, new DefaultBucketFactoryImpl<>(), OutputFileConfig.builder().build());
 		}
 
 		protected RowFormatBuilder(
@@ -231,6 +235,7 @@ public class StreamingFileSink<IN>
 				BucketAssigner<IN, BucketID> assigner,
 				RollingPolicy<IN, BucketID> policy,
 				long bucketCheckInterval,
+				String factoryIdentify,
 				BucketFactory<IN, BucketID> bucketFactory,
 				OutputFileConfig outputFileConfig) {
 			this.basePath = Preconditions.checkNotNull(basePath);
@@ -238,6 +243,7 @@ public class StreamingFileSink<IN>
 			this.bucketAssigner = Preconditions.checkNotNull(assigner);
 			this.rollingPolicy = Preconditions.checkNotNull(policy);
 			this.bucketCheckInterval = bucketCheckInterval;
+			this.factoryIdentify = factoryIdentify;
 			this.bucketFactory = Preconditions.checkNotNull(bucketFactory);
 			this.outputFileConfig = Preconditions.checkNotNull(outputFileConfig);
 		}
@@ -266,9 +272,14 @@ public class StreamingFileSink<IN>
 			return self();
 		}
 
+		public T withFactoryIdentify(final String factoryIdentify) {
+			this.factoryIdentify = factoryIdentify;
+			return self();
+		}
+
 		public <ID> StreamingFileSink.RowFormatBuilder<IN, ID, ? extends RowFormatBuilder<IN, ID, ?>> withNewBucketAssignerAndPolicy(final BucketAssigner<IN, ID> assigner, final RollingPolicy<IN, ID> policy) {
 			Preconditions.checkState(bucketFactory.getClass() == DefaultBucketFactoryImpl.class, "newBuilderWithBucketAssignerAndPolicy() cannot be called after specifying a customized bucket factory");
-			return new RowFormatBuilder<>(basePath, encoder, Preconditions.checkNotNull(assigner), Preconditions.checkNotNull(policy), bucketCheckInterval, new DefaultBucketFactoryImpl<>(), outputFileConfig);
+			return new RowFormatBuilder<>(basePath, encoder, Preconditions.checkNotNull(assigner), Preconditions.checkNotNull(policy), bucketCheckInterval, factoryIdentify, new DefaultBucketFactoryImpl<>(), outputFileConfig);
 		}
 
 		/** Creates the actual sink. */
@@ -291,6 +302,7 @@ public class StreamingFileSink<IN>
 					new RowWisePartWriter.Factory<>(encoder),
 					rollingPolicy,
 					subtaskIndex,
+					factoryIdentify,
 					outputFileConfig);
 		}
 	}
@@ -313,10 +325,12 @@ public class StreamingFileSink<IN>
 
 		private BucketFactory<IN, BucketID> bucketFactory;
 
+		private String factoryIndentify;
+
 		private OutputFileConfig outputFileConfig;
 
 		protected BulkFormatBuilder(Path basePath, BulkWriter.Factory<IN> writerFactory, BucketAssigner<IN, BucketID> assigner) {
-			this(basePath, writerFactory, assigner, DEFAULT_BUCKET_CHECK_INTERVAL, new DefaultBucketFactoryImpl<>(), OutputFileConfig.builder().build());
+			this(basePath, writerFactory, assigner, DEFAULT_BUCKET_CHECK_INTERVAL, DEFAULT_FILESYSTEM_IDENTIFY, new DefaultBucketFactoryImpl<>(), OutputFileConfig.builder().build());
 		}
 
 		protected BulkFormatBuilder(
@@ -324,12 +338,14 @@ public class StreamingFileSink<IN>
 				BulkWriter.Factory<IN> writerFactory,
 				BucketAssigner<IN, BucketID> assigner,
 				long bucketCheckInterval,
+				String factoryIndentify,
 				BucketFactory<IN, BucketID> bucketFactory,
 				OutputFileConfig outputFileConfig) {
 			this.basePath = Preconditions.checkNotNull(basePath);
 			this.writerFactory = writerFactory;
 			this.bucketAssigner = Preconditions.checkNotNull(assigner);
 			this.bucketCheckInterval = bucketCheckInterval;
+			this.factoryIndentify = factoryIndentify;
 			this.bucketFactory = Preconditions.checkNotNull(bucketFactory);
 			this.outputFileConfig = Preconditions.checkNotNull(outputFileConfig);
 		}
@@ -359,9 +375,14 @@ public class StreamingFileSink<IN>
 			return self();
 		}
 
+		public T withFactoryIdentify(final String indentify) {
+			this.factoryIndentify = indentify;
+			return self();
+		}
+
 		public <ID> StreamingFileSink.BulkFormatBuilder<IN, ID, ? extends BulkFormatBuilder<IN, ID, ?>> withNewBucketAssigner(final BucketAssigner<IN, ID> assigner) {
 			Preconditions.checkState(bucketFactory.getClass() == DefaultBucketFactoryImpl.class, "newBuilderWithBucketAssigner() cannot be called after specifying a customized bucket factory");
-			return new BulkFormatBuilder<>(basePath, writerFactory, Preconditions.checkNotNull(assigner), bucketCheckInterval, new DefaultBucketFactoryImpl<>(), outputFileConfig);
+			return new BulkFormatBuilder<>(basePath, writerFactory, Preconditions.checkNotNull(assigner), bucketCheckInterval, factoryIndentify, new DefaultBucketFactoryImpl<>(), outputFileConfig);
 		}
 
 		/** Creates the actual sink. */
@@ -378,6 +399,7 @@ public class StreamingFileSink<IN>
 					new BulkPartWriter.Factory<>(writerFactory),
 					OnCheckpointRollingPolicy.build(),
 					subtaskIndex,
+				factoryIndentify,
 					outputFileConfig);
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketAssignerITCases.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketAssignerITCases.java
@@ -57,6 +57,7 @@ public class BucketAssignerITCases {
 			new RowWisePartWriter.Factory<>(new SimpleStringEncoder<>()),
 			rollingPolicy,
 			0,
+			"default",
 			OutputFileConfig.builder().build()
 		);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketsTest.java
@@ -392,6 +392,7 @@ public class BucketsTest {
 				new RowWisePartWriter.Factory<>(new SimpleStringEncoder<>()),
 				rollingPolicy,
 				subtaskIdx,
+				"default",
 				outputFileConfig
 		);
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/RollingPolicyTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/RollingPolicyTest.java
@@ -204,6 +204,7 @@ public class RollingPolicyTest {
 				new RowWisePartWriter.Factory<>(new SimpleStringEncoder<>()),
 				rollingPolicyToTest,
 				0,
+				"default",
 				OutputFileConfig.builder().build()
 		);
 	}


### PR DESCRIPTION
## What is the purpose of the change

support diff filesystem plugins for flink dependecy and user code need.

## Brief change log

Add FileSystemFactory#getIdentify() for support diff FileSystem cluster which schema is same. Add StreamingFileSink#RowFormatBuilder#withFactoryIdentify and StreamingFileSink#BulkFormatBuilder#withFactoryIdentify for give user config diff filesystem plugin in one job. 

## Verifying this change

*(Please pick either of the following options)*

This change is already covered by existing tests, such as *(please describe tests)*.
*FileSystemTest*
*BucketsTests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes )
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (yes)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? ( docs )