### PR TITLE
[FLINK-14270][web]: support more metric display at once

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/drawer/job-overview-drawer.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/drawer/job-overview-drawer.component.ts
@@ -22,6 +22,7 @@ import { combineLatest, Subject } from 'rxjs';
 import { map, takeUntil } from 'rxjs/operators';
 import { JobService } from 'services';
 import { trigger, animate, style, transition } from '@angular/animations';
+import { JobChartService } from 'share/customize/job-chart/job-chart.service';
 
 @Component({
   selector: 'flink-job-overview-drawer',
@@ -62,6 +63,7 @@ export class JobOverviewDrawerComponent implements OnInit, OnDestroy {
   closeDrawer() {
     if (this.fullScreen) {
       this.fullScreen = false;
+      this.jobChartService.resize();
     } else {
       this.router.navigate(['../../'], { relativeTo: this.activatedRoute }).then();
     }
@@ -69,9 +71,15 @@ export class JobOverviewDrawerComponent implements OnInit, OnDestroy {
 
   fullDrawer() {
     this.fullScreen = true;
+    this.jobChartService.resize();
   }
 
-  constructor(private activatedRoute: ActivatedRoute, private router: Router, private jobService: JobService) {}
+  constructor(
+    private activatedRoute: ActivatedRoute,
+    private router: Router,
+    private jobService: JobService,
+    private jobChartService: JobChartService
+  ) {}
 
   ngOnInit() {
     const nodeId$ = this.activatedRoute.params.pipe(map(item => item.vertexId));

--- a/flink-runtime-web/web-dashboard/src/app/share/common/resize/resize.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/share/common/resize/resize.component.ts
@@ -78,7 +78,7 @@ export class ResizeComponent implements OnInit, OnDestroy {
       return innerOffsetTop;
     };
     const offsetTop = getOffsetTop(this.baseElement.nativeElement);
-    const maxResize = 560;
+    const maxResize = 900;
     let newTop = e.pageY - offsetTop;
     if (newTop > maxResize) {
       newTop = maxResize;

--- a/flink-runtime-web/web-dashboard/src/app/share/customize/job-chart/job-chart.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/share/customize/job-chart/job-chart.component.html
@@ -18,7 +18,7 @@
 
 <div class="chart">
   <div class="title">
-    <div class="text">{{title}}</div>
+    <div class="text" [attr.title]="title">{{title}}</div>
     <div class="operate">
       <nz-button-group [nzSize]="'small'">
         <button nz-button [nzType]="size === 'big' ? 'primary' : 'default'" (click)="resize('big')">Big</button>

--- a/flink-runtime-web/web-dashboard/src/app/share/customize/job-chart/job-chart.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/share/customize/job-chart/job-chart.service.ts
@@ -15,58 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import "theme";
 
-:host {
-  padding: 12px;
-  margin-bottom: 12px;
-  float: left;
-  width: 33.33%;
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
 
-  &.big {
-    width: 100%;
+@Injectable({ providedIn: 'root' })
+export class JobChartService {
+  resize$ = new Subject();
+  resize() {
+    this.resize$.next();
   }
-}
-
-.close {
-  margin-left: 8px;
-}
-
-.chart {
-  position: relative;
-  border: 1px solid @border-color-split;
-}
-
-.title {
-  padding: 12px;
-  position: relative;
-  border-bottom: 1px solid @border-color-split;
-}
-
-.text {
-  font-size: 12px;
-  line-height: 24px;
-  overflow: hidden;
-  max-width: calc(~"100% - 128px");
-  text-overflow: ellipsis;
-}
-
-.operate {
-  position: absolute;
-  top: 12px;
-  right: 12px;
-}
-
-.content {
-  padding: 12px;
-
-  .numeric {
-    line-height: 150px;
-    font-size: 32px;
-    text-align: center;
-  }
-}
-
-button {
-  transition: none;
 }


### PR DESCRIPTION
## What is the purpose of the change

fix https://issues.apache.org/jira/browse/FLINK-14270

## Brief change log

support more metric display at once

## Verifying this change

  - *Go to the metric tabs*
  - *Add more than 4 metrics*
  - *All metrics can display at once*


before:
![before](https://user-images.githubusercontent.com/1506722/71445356-ee2e4500-2753-11ea-86bd-547700b94cff.png)

after:
![after](https://user-images.githubusercontent.com/1506722/71445360-f2f2f900-2753-11ea-9378-3fe1333d57db.png)


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
