### PR TITLE
[FLINK-15387] Expose missing RocksDB properties out via RocksDBNativeMetricOptions

### DIFF
--- a/docs/_includes/generated/rocks_db_native_metric_configuration.html
+++ b/docs/_includes/generated/rocks_db_native_metric_configuration.html
@@ -21,6 +21,24 @@
             <td>Monitor the number of background errors in RocksDB.</td>
         </tr>
         <tr>
+            <td><h5>state.backend.rocksdb.metrics.block-cache-capacity</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Monitor block cache capacity.</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.rocksdb.metrics.block-cache-pinned-usage</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Monitor the memory size for the entries being pinned in block cache.</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.rocksdb.metrics.block-cache-usage</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Monitor the memory size for the entries residing in block cache.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.rocksdb.metrics.column-family-as-variable</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
@@ -67,6 +85,12 @@
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>Estimate the memory used for reading SST tables, excluding memory used in block cache (e.g.,filter and index blocks) in bytes.</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.rocksdb.metrics.is-write-stopped</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Monitor whether write has been stopped. 1 means that has been stopped.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.mem-table-flush-pending</h5></td>

--- a/docs/_includes/generated/rocks_db_native_metric_configuration.html
+++ b/docs/_includes/generated/rocks_db_native_metric_configuration.html
@@ -90,7 +90,7 @@
             <td><h5>state.backend.rocksdb.metrics.is-write-stopped</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Monitor whether write has been stopped. 1 means that has been stopped.</td>
+            <td>Track whether write has been stopped in RocksDB. Returns 1 if write has been stopped, 0 otherwise.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.mem-table-flush-pending</h5></td>

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricOptions.java
@@ -157,7 +157,7 @@ public class RocksDBNativeMetricOptions implements Serializable {
 		.key(RocksDBProperty.IsWriteStopped.getConfigKey())
 		.booleanType()
 		.defaultValue(false)
-		.withDescription("Monitor whether write has been stopped. 1 means that has been stopped.");
+		.withDescription("Track whether write has been stopped in RocksDB. Returns 1 if write has been stopped, 0 otherwise.");
 
 	public static final ConfigOption<Boolean> BLOCK_CACHE_CAPACITY = ConfigOptions
 		.key(RocksDBProperty.BlockCacheCapacity.getConfigKey())

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricOptions.java
@@ -153,6 +153,30 @@ public class RocksDBNativeMetricOptions implements Serializable {
 		.defaultValue(false)
 		.withDescription("Monitor the current actual delayed write rate. 0 means no delay.");
 
+	public static final ConfigOption<Boolean> IS_WRITE_STOPPED = ConfigOptions
+		.key(RocksDBProperty.IsWriteStopped.getConfigKey())
+		.booleanType()
+		.defaultValue(false)
+		.withDescription("Monitor whether write has been stopped. 1 means that has been stopped.");
+
+	public static final ConfigOption<Boolean> BLOCK_CACHE_CAPACITY = ConfigOptions
+		.key(RocksDBProperty.BlockCacheCapacity.getConfigKey())
+		.booleanType()
+		.defaultValue(false)
+		.withDescription("Monitor block cache capacity.");
+
+	public static final ConfigOption<Boolean> BLOCK_CACHE_USAGE = ConfigOptions
+		.key(RocksDBProperty.BlockCacheUsage.getConfigKey())
+		.booleanType()
+		.defaultValue(false)
+		.withDescription("Monitor the memory size for the entries residing in block cache.");
+
+	public static final ConfigOption<Boolean> BLOCK_CACHE_PINNED_USAGE = ConfigOptions
+		.key(RocksDBProperty.BlockCachePinnedUsage.getConfigKey())
+		.booleanType()
+		.defaultValue(false)
+		.withDescription("Monitor the memory size for the entries being pinned in block cache.");
+
 	public static final ConfigOption<Boolean> COLUMN_FAMILY_AS_VARIABLE = ConfigOptions
 		.key(METRICS_COLUMN_FAMILY_AS_VARIABLE_KEY)
 		.defaultValue(false)
@@ -246,6 +270,22 @@ public class RocksDBNativeMetricOptions implements Serializable {
 
 		if (config.getBoolean(MONITOR_ACTUAL_DELAYED_WRITE_RATE)) {
 			options.enableActualDelayedWriteRate();
+		}
+
+		if (config.getBoolean(IS_WRITE_STOPPED)) {
+			options.enableIsWriteStopped();
+		}
+
+		if (config.getBoolean(BLOCK_CACHE_CAPACITY)) {
+			options.enableBlockCacheCapacity();
+		}
+
+		if (config.getBoolean(BLOCK_CACHE_USAGE)) {
+			options.enableBlockCacheUsage();
+		}
+
+		if (config.getBoolean(BLOCK_CACHE_PINNED_USAGE)) {
+			options.enableBlockCachePinnedUsage();
 		}
 
 		options.setColumnFamilyAsVariable(config.getBoolean(COLUMN_FAMILY_AS_VARIABLE));
@@ -411,6 +451,34 @@ public class RocksDBNativeMetricOptions implements Serializable {
 	 */
 	public void enableActualDelayedWriteRate() {
 		this.properties.add(RocksDBProperty.ActualDelayedWriteRate.getRocksDBProperty());
+	}
+
+	/**
+	 * Returns 1 if write has been stopped.
+	 */
+	public void enableIsWriteStopped() {
+		this.properties.add(RocksDBProperty.IsWriteStopped.getRocksDBProperty());
+	}
+
+	/**
+	 * Returns block cache capacity.
+	 */
+	public void enableBlockCacheCapacity() {
+		this.properties.add(RocksDBProperty.BlockCacheCapacity.getRocksDBProperty());
+	}
+
+	/**
+	 * Returns the memory size for the entries residing in block cache.
+	 */
+	public void enableBlockCacheUsage() {
+		this.properties.add(RocksDBProperty.BlockCacheUsage.getRocksDBProperty());
+	}
+
+	/**
+	 * Returns the memory size for the entries being pinned in block cache.
+	 */
+	public void enableBlockCachePinnedUsage() {
+		this.properties.add(RocksDBProperty.BlockCachePinnedUsage.getRocksDBProperty());
 	}
 
 	/**

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBProperty.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBProperty.java
@@ -52,7 +52,11 @@ public enum RocksDBProperty {
 	EstimatePendingCompactionBytes("estimate-pending-compaction-bytes"),
 	NumRunningCompactions("num-running-compactions"),
 	NumRunningFlushes("num-running-flushes"),
-	ActualDelayedWriteRate("actual-delayed-write-rate");
+	ActualDelayedWriteRate("actual-delayed-write-rate"),
+	IsWriteStopped("is-write-stopped"),
+	BlockCacheCapacity("block-cache-capacity"),
+	BlockCacheUsage("block-cache-usage"),
+	BlockCachePinnedUsage("block-cache-pinned-usage");
 
 	private static final String ROCKS_DB_PROPERTY_FORMAT = "rocksdb.%s";
 


### PR DESCRIPTION

## What is the purpose of the change

Expose missing RocksDB properties out via `RocksDBNativeMetricOptions`, e.g block cache related properties.

## Brief change log

Add `is-write-stopped`, `block-cache-capacity`, `block-cache-usage` and `block-cache-pinned-usage`.
Other string format rocksdb property is not added.

## Verifying this change

This change is already covered by existing tests, such as `RocksDBPropertyTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
