### PR TITLE
[FLINK-15402][Formats (CSV)]Add disable quote character feature for serializing row to csv format

### DIFF
--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1356,6 +1356,8 @@ The CSV format can be used as follows:
     .fieldDelimiter(';')         // optional: field delimiter character (',' by default)
     .lineDelimiter("\r\n")       // optional: line delimiter ("\n" by default;
                                  //   otherwise "\r", "\r\n", or "" are allowed)
+    .disableQuoteCharacter()     // optional: disabled quote character for enclosing field values;
+                                 //   cannot define a quote character and disabled quote character at the same time
     .quoteCharacter('\'')        // optional: quote character for enclosing field values ('"' by default)
     .allowComments()             // optional: ignores comment lines that start with '#' (disabled by default);
                                  //   if enabled, make sure to also ignore parse errors to allow empty rows
@@ -1412,6 +1414,8 @@ format:
   field-delimiter: ";"         # optional: field delimiter character (',' by default)
   line-delimiter: "\r\n"       # optional: line delimiter ("\n" by default;
                                #   otherwise "\r", "\r\n", or "" are allowed)
+  disable-quote-character = true # optional: disabled quote character for enclosing field values (false by default)
+                               # if true, quote-character can not be set
   quote-character: "'"         # optional: quote character for enclosing field values ('"' by default)
   allow-comments: true         # optional: ignores comment lines that start with "#" (disabled by default);
                                #   if enabled, make sure to also ignore parse errors to allow empty rows
@@ -1442,7 +1446,7 @@ CREATE TABLE MyUserTable (
   'format.field-delimiter' = ';',         -- optional: field delimiter character (',' by default)
   'format.line-delimiter' = '\r\n',       -- optional: line delimiter ("\n" by default; otherwise
                                           -- "\r" or "\r\n" are allowed)
-  'format.disable-quote-character' = true,-- optional: disabled quote character for enclosing field values (false by default)
+  'format.disable-quote-character' = 'true',-- optional: disabled quote character for enclosing field values (false by default)
                                           -- if true, format.quote-character can not be set
   'format.quote-character' = '''',        -- optional: quote character for enclosing field values ('"' by default)
   'format.allow-comments' = true,         -- optional: ignores comment lines that start with "#" 
@@ -1921,8 +1925,6 @@ CREATE TABLE MyUserTable (
 
   'format.field-delimiter' = ',',         -- optional: string delimiter "," by default
   'format.line-delimiter' = '\n',         -- optional: string delimiter "\n" by default
-  'format.disable-quote-character' = true,-- optional: disabled quote character for enclosing field values (false by default)
-                                          -- if true, format.quote-character can not be set
   'format.quote-character' = '"',         -- optional: single character for string values, empty by default
   'format.comment-prefix' = '#',          -- optional: string to indicate comments, empty by default
   'format.ignore-first-line' = 'false',   -- optional: boolean flag to ignore the first line, by default it is not skipped

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1442,6 +1442,8 @@ CREATE TABLE MyUserTable (
   'format.field-delimiter' = ';',         -- optional: field delimiter character (',' by default)
   'format.line-delimiter' = '\r\n',       -- optional: line delimiter ("\n" by default; otherwise
                                           -- "\r" or "\r\n" are allowed)
+  'format.disable-quote-character' = true,-- optional: disabled quote character for enclosing field values (false by default)
+                                          -- if true, format.quote-character can not be set
   'format.quote-character' = '''',        -- optional: quote character for enclosing field values ('"' by default)
   'format.allow-comments' = true,         -- optional: ignores comment lines that start with "#" 
                                           -- (disabled by default);
@@ -1919,6 +1921,8 @@ CREATE TABLE MyUserTable (
 
   'format.field-delimiter' = ',',         -- optional: string delimiter "," by default
   'format.line-delimiter' = '\n',         -- optional: string delimiter "\n" by default
+  'format.disable-quote-character' = true,-- optional: disabled quote character for enclosing field values (false by default)
+                                          -- if true, format.quote-character can not be set
   'format.quote-character' = '"',         -- optional: single character for string values, empty by default
   'format.comment-prefix' = '#',          -- optional: string to indicate comments, empty by default
   'format.ignore-first-line' = 'false',   -- optional: boolean flag to ignore the first line, by default it is not skipped

--- a/docs/dev/table/connect.zh.md
+++ b/docs/dev/table/connect.zh.md
@@ -1442,6 +1442,8 @@ CREATE TABLE MyUserTable (
   'format.field-delimiter' = ';',         -- optional: field delimiter character (',' by default)
   'format.line-delimiter' = '\r\n',       -- optional: line delimiter ("\n" by default; otherwise
                                           -- "\r" or "\r\n" are allowed)
+  'format.disable-quote-character' = true,-- optional: disabled quote character for enclosing field values (false by default)
+                                          -- if true, format.quote-character can not be set
   'format.quote-character' = '''',        -- optional: quote character for enclosing field values ('"' by default)
   'format.allow-comments' = true,         -- optional: ignores comment lines that start with "#"
                                           -- (disabled by default);
@@ -1915,6 +1917,8 @@ CREATE TABLE MyUserTable (
 
   'format.field-delimiter' = ',',         -- optional: string delimiter "," by default
   'format.line-delimiter' = '\n',         -- optional: string delimiter "\n" by default
+  'format.disable-quote-character' = true,-- optional: disabled quote character for enclosing field values (false by default)
+                                          -- if true, format.quote-character can not be set
   'format.quote-character' = '"',         -- optional: single character for string values, empty by default
   'format.comment-prefix' = '#',          -- optional: string to indicate comments, empty by default
   'format.ignore-first-line' = 'false',   -- optional: boolean flag to ignore the first line, by default it is not skipped

--- a/docs/dev/table/connect.zh.md
+++ b/docs/dev/table/connect.zh.md
@@ -1356,6 +1356,8 @@ The CSV format can be used as follows:
     .fieldDelimiter(';')         // optional: field delimiter character (',' by default)
     .lineDelimiter("\r\n")       // optional: line delimiter ("\n" by default;
                                  //   otherwise "\r", "\r\n", or "" are allowed)
+    .disableQuoteCharacter()     // optional: disabled quote character for enclosing field values;
+                                 //   cannot define a quote character and disabled quote character at the same time
     .quoteCharacter('\'')        // optional: quote character for enclosing field values ('"' by default)
     .allowComments()             // optional: ignores comment lines that start with '#' (disabled by default);
                                  //   if enabled, make sure to also ignore parse errors to allow empty rows
@@ -1412,6 +1414,8 @@ format:
   field-delimiter: ";"         # optional: field delimiter character (',' by default)
   line-delimiter: "\r\n"       # optional: line delimiter ("\n" by default;
                                #   otherwise "\r", "\r\n", or "" are allowed)
+  disable-quote-character = true # optional: disabled quote character for enclosing field values (false by default)
+                               # if true, quote-character can not be set
   quote-character: "'"         # optional: quote character for enclosing field values ('"' by default)
   allow-comments: true         # optional: ignores comment lines that start with "#" (disabled by default);
                                #   if enabled, make sure to also ignore parse errors to allow empty rows
@@ -1442,7 +1446,7 @@ CREATE TABLE MyUserTable (
   'format.field-delimiter' = ';',         -- optional: field delimiter character (',' by default)
   'format.line-delimiter' = '\r\n',       -- optional: line delimiter ("\n" by default; otherwise
                                           -- "\r" or "\r\n" are allowed)
-  'format.disable-quote-character' = true,-- optional: disabled quote character for enclosing field values (false by default)
+  'format.disable-quote-character' = 'true',-- optional: disabled quote character for enclosing field values (false by default)
                                           -- if true, format.quote-character can not be set
   'format.quote-character' = '''',        -- optional: quote character for enclosing field values ('"' by default)
   'format.allow-comments' = true,         -- optional: ignores comment lines that start with "#"
@@ -1917,8 +1921,6 @@ CREATE TABLE MyUserTable (
 
   'format.field-delimiter' = ',',         -- optional: string delimiter "," by default
   'format.line-delimiter' = '\n',         -- optional: string delimiter "\n" by default
-  'format.disable-quote-character' = true,-- optional: disabled quote character for enclosing field values (false by default)
-                                          -- if true, format.quote-character can not be set
   'format.quote-character' = '"',         -- optional: single character for string values, empty by default
   'format.comment-prefix' = '#',          -- optional: string to indicate comments, empty by default
   'format.ignore-first-line' = 'false',   -- optional: boolean flag to ignore the first line, by default it is not skipped

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowFormatFactory.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowFormatFactory.java
@@ -49,6 +49,7 @@ public final class CsvRowFormatFactory extends TableFormatFactoryBase<Row>
 		final List<String> properties = new ArrayList<>();
 		properties.add(CsvValidator.FORMAT_FIELD_DELIMITER);
 		properties.add(CsvValidator.FORMAT_LINE_DELIMITER);
+		properties.add(CsvValidator.FORMAT_DISABLE_QUOTE_CHARACTER);
 		properties.add(CsvValidator.FORMAT_QUOTE_CHARACTER);
 		properties.add(CsvValidator.FORMAT_ALLOW_COMMENTS);
 		properties.add(CsvValidator.FORMAT_IGNORE_PARSE_ERRORS);
@@ -103,8 +104,11 @@ public final class CsvRowFormatFactory extends TableFormatFactoryBase<Row>
 		descriptorProperties.getOptionalString(CsvValidator.FORMAT_LINE_DELIMITER)
 			.ifPresent(schemaBuilder::setLineDelimiter);
 
-		descriptorProperties.getOptionalCharacter(CsvValidator.FORMAT_QUOTE_CHARACTER)
-			.ifPresent(schemaBuilder::setQuoteCharacter);
+		if (descriptorProperties.getOptionalBoolean(CsvValidator.FORMAT_DISABLE_QUOTE_CHARACTER).orElse(false)) {
+			schemaBuilder.disableQuoteCharacter();
+		} else {
+			descriptorProperties.getOptionalCharacter(CsvValidator.FORMAT_QUOTE_CHARACTER).ifPresent(schemaBuilder::setQuoteCharacter);
+		}
 
 		descriptorProperties.getOptionalString(CsvValidator.FORMAT_ARRAY_ELEMENT_DELIMITER)
 			.ifPresent(schemaBuilder::setArrayElementDelimiter);

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowSerializationSchema.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowSerializationSchema.java
@@ -130,6 +130,11 @@ public final class CsvRowSerializationSchema implements SerializationSchema<Row>
 			return this;
 		}
 
+		public Builder disableQuoteCharacter() {
+			this.csvSchema = this.csvSchema.rebuild().disableQuoteChar().build();
+			return this;
+		}
+
 		public Builder setQuoteCharacter(char c) {
 			this.csvSchema = this.csvSchema.rebuild().setQuoteChar(c).build();
 			return this;

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/table/descriptors/Csv.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/table/descriptors/Csv.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import static org.apache.flink.table.descriptors.CsvValidator.FORMAT_ALLOW_COMMENTS;
 import static org.apache.flink.table.descriptors.CsvValidator.FORMAT_ARRAY_ELEMENT_DELIMITER;
+import static org.apache.flink.table.descriptors.CsvValidator.FORMAT_DISABLE_QUOTE_CHARACTER;
 import static org.apache.flink.table.descriptors.CsvValidator.FORMAT_ESCAPE_CHARACTER;
 import static org.apache.flink.table.descriptors.CsvValidator.FORMAT_FIELD_DELIMITER;
 import static org.apache.flink.table.descriptors.CsvValidator.FORMAT_IGNORE_PARSE_ERRORS;
@@ -82,6 +83,14 @@ public class Csv extends FormatDescriptor {
 	public Csv lineDelimiter(String delimiter) {
 		Preconditions.checkNotNull(delimiter);
 		internalProperties.putString(FORMAT_LINE_DELIMITER, delimiter);
+		return this;
+	}
+
+	/**
+	 * Disable the quote character for enclosing field values.
+	 */
+	public Csv disableQuoteCharacter() {
+		internalProperties.putBoolean(FORMAT_DISABLE_QUOTE_CHARACTER, true);
 		return this;
 	}
 

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/table/descriptors/CsvValidator.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/table/descriptors/CsvValidator.java
@@ -67,5 +67,14 @@ public class CsvValidator extends FormatDescriptorValidator {
 			throw new ValidationException(
 				"A definition of a schema or derivation from the table's schema is required.");
 		}
+
+		final boolean hasQuoteCharacter = properties.containsKey(FORMAT_QUOTE_CHARACTER);
+		final boolean isDisabledQuoteCharacter = properties
+			.getOptionalBoolean(FORMAT_DISABLE_QUOTE_CHARACTER)
+			.orElse(false);
+		if (isDisabledQuoteCharacter && hasQuoteCharacter){
+			throw new ValidationException(
+				"Format cannot define a quote character and disabled quote character at the same time.");
+		}
 	}
 }

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/table/descriptors/CsvValidator.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/table/descriptors/CsvValidator.java
@@ -32,6 +32,7 @@ public class CsvValidator extends FormatDescriptorValidator {
 	public static final String FORMAT_TYPE_VALUE = "csv";
 	public static final String FORMAT_FIELD_DELIMITER = "format.field-delimiter";
 	public static final String FORMAT_LINE_DELIMITER = "format.line-delimiter";
+	public static final String FORMAT_DISABLE_QUOTE_CHARACTER = "format.disable-quote-character";
 	public static final String FORMAT_QUOTE_CHARACTER = "format.quote-character";
 	public static final String FORMAT_ALLOW_COMMENTS = "format.allow-comments";
 	public static final String FORMAT_IGNORE_PARSE_ERRORS = "format.ignore-parse-errors";
@@ -45,6 +46,7 @@ public class CsvValidator extends FormatDescriptorValidator {
 		super.validate(properties);
 		properties.validateString(FORMAT_FIELD_DELIMITER, true, 1, 1);
 		properties.validateEnumValues(FORMAT_LINE_DELIMITER, true, Arrays.asList("\r", "\n", "\r\n", ""));
+		properties.validateBoolean(FORMAT_DISABLE_QUOTE_CHARACTER, true);
 		properties.validateString(FORMAT_QUOTE_CHARACTER, true, 1, 1);
 		properties.validateBoolean(FORMAT_ALLOW_COMMENTS, true);
 		properties.validateBoolean(FORMAT_IGNORE_PARSE_ERRORS, true);

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDeSerializationSchemaTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDeSerializationSchemaTest.java
@@ -166,6 +166,18 @@ public class CsvRowDeSerializationSchemaTest {
 		assertArrayEquals(
 			"Test,12,Hello\r".getBytes(),
 			serialize(serSchemaBuilder, Row.of("Test", 12, "Hello")));
+
+		serSchemaBuilder.setQuoteCharacter('#');
+
+		assertArrayEquals(
+			"Test,12,#2019-12-26 12:12:12#\r".getBytes(),
+			serialize(serSchemaBuilder, Row.of("Test", 12, "2019-12-26 12:12:12")));
+
+		serSchemaBuilder.disableQuoteCharacter();
+
+		assertArrayEquals(
+			"Test,12,2019-12-26 12:12:12\r".getBytes(),
+			serialize(serSchemaBuilder, Row.of("Test", 12, "2019-12-26 12:12:12")));
 	}
 
 	@Test

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowFormatFactoryTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowFormatFactoryTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.Types;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.descriptors.Csv;
 import org.apache.flink.table.descriptors.Schema;
 import org.apache.flink.table.factories.DeserializationSchemaFactory;
@@ -31,7 +32,9 @@ import org.apache.flink.table.factories.TableFactoryService;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -42,6 +45,8 @@ import static org.junit.Assert.assertEquals;
  * Tests for {@link CsvRowFormatFactory}.
  */
 public class CsvRowFormatFactoryTest extends TestLogger {
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
 
 	private static final TypeInformation<Row> SCHEMA = Types.ROW(
 		new String[]{"a", "b", "c"},
@@ -147,5 +152,27 @@ public class CsvRowFormatFactoryTest extends TestLogger {
 			.createSerializationSchema(properties);
 
 		assertEquals(expectedSer, actualSer);
+	}
+
+	@Test
+	public void testDisableQuoteCharacterException() {
+		thrown.expect(ValidationException.class);
+		thrown.expectMessage("Format cannot define a quote character and disabled quote character at the same time.");
+		final Map<String, String> properties = new Csv()
+			.schema(SCHEMA)
+			.fieldDelimiter(';')
+			.lineDelimiter("\r\n")
+			.allowComments()
+			.ignoreParseErrors()
+			.arrayElementDelimiter("|")
+			.escapeCharacter('\\')
+			.nullLiteral("n/a")
+			.quoteCharacter('#')
+			.disableQuoteCharacter()
+			.toProperties();
+
+		TableFactoryService
+			.find(SerializationSchemaFactory.class, properties)
+			.createSerializationSchema(properties);
 	}
 }

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowFormatFactoryTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowFormatFactoryTest.java
@@ -118,4 +118,34 @@ public class CsvRowFormatFactoryTest extends TestLogger {
 
 		assertEquals(expectedDeser, actualDeser);
 	}
+
+	@Test
+	public void testDisableQuoteCharacter() {
+		final Map<String, String> properties = new Csv()
+			.schema(SCHEMA)
+			.fieldDelimiter(';')
+			.lineDelimiter("\r\n")
+			.allowComments()
+			.ignoreParseErrors()
+			.arrayElementDelimiter("|")
+			.escapeCharacter('\\')
+			.nullLiteral("n/a")
+			.disableQuoteCharacter()
+			.toProperties();
+
+		final CsvRowSerializationSchema expectedSer = new CsvRowSerializationSchema.Builder(SCHEMA)
+			.setFieldDelimiter(';')
+			.setLineDelimiter("\r\n")
+			.setArrayElementDelimiter("|")
+			.setEscapeCharacter('\\')
+			.setNullLiteral("n/a")
+			.disableQuoteCharacter()
+			.build();
+
+		final SerializationSchema<?> actualSer = TableFactoryService
+			.find(SerializationSchemaFactory.class, properties)
+			.createSerializationSchema(properties);
+
+		assertEquals(expectedSer, actualSer);
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change

*Add disable quote character feature for serializing row to csv format*


## Brief change log

  - *Add a new property "format.disable-quote-character" in CsvValidator.java*
  - *Modify createSerializationSchema method in CsvRowFormatFactory to decide whether to disable quote character*
  - *Add disableQuoteCharacter method in CsvRowSerializationSchema.java*
  - *Add disableQuoteCharacter method in Csv.java*
  - *Add test in CsvRowDeSerializationSchemaTest.java and CsvRowFormatFactoryTest.java*


## Verifying this change

This change is already covered by existing tests, and add new test case in CsvRowDeSerializationSchemaTest.java and CsvRowFormatFactoryTest.java

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)