### PR TITLE
[FLINK-15383][table sql / planner & legacy planner] Using sink schema field name instead of query schema field name for UpsertStreamTableSink.

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecSink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecSink.scala
@@ -99,7 +99,8 @@ class StreamExecSink[T](
             // Now we pick shortest one to sink
             // TODO UpsertStreamTableSink setKeyFields interface should be Array[Array[String]]
             val tableKeys = {
-              UpdatingPlanChecker.getUniqueKeyFields(getInput, planner) match {
+              val sinkFieldNames = upsertSink.getTableSchema.getFieldNames
+              UpdatingPlanChecker.getUniqueKeyFields(getInput, planner, sinkFieldNames) match {
                 case Some(keys) => keys.sortBy(_.length).headOption
                 case None => None
               }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/UpdatingPlanChecker.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/UpdatingPlanChecker.scala
@@ -38,12 +38,14 @@ object UpdatingPlanChecker {
   }
 
   /** Extracts the unique keys of the table produced by the plan. */
-  def getUniqueKeyFields(relNode: RelNode, planner: StreamPlanner): Option[Array[Array[String]]] = {
-    val rowType = relNode.getRowType
+  def getUniqueKeyFields(
+      relNode: RelNode,
+      planner: StreamPlanner,
+      sinkFieldNames: Array[String]): Option[Array[Array[String]]] = {
     val fmq = FlinkRelMetadataQuery.reuseOrCreate(planner.getRelBuilder.getCluster.getMetadataQuery)
     val uniqueKeys = fmq.getUniqueKeys(relNode)
     if (uniqueKeys != null && uniqueKeys.size() > 0) {
-      Some(uniqueKeys.filter(_.nonEmpty).map(_.toArray.map(rowType.getFieldNames.get)).toArray)
+      Some(uniqueKeys.filter(_.nonEmpty).map(_.toArray.map(sinkFieldNames)).toArray)
     } else {
       None
     }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
@@ -302,20 +302,19 @@ class TableSinkITCase extends AbstractTestBase {
       .assignAscendingTimestamps(_._1.toLong)
       .toTable(tEnv, 'id, 'num, 'text)
 
-    val sink = new TestingUpsertTableSink(Array(0, 2), TimeZone.getDefault)
+    val sink = new TestingUpsertTableSink(Array(0, 2), TimeZone.getDefault).configure(
+      Array[String]("cnt", "lencnt", "cTrue"),
+      Array[TypeInformation[_]](Types.LONG, Types.DECIMAL(), Types.BOOLEAN))
     sink.expectedKeys = Some(Array("cnt", "cTrue"))
     sink.expectedIsAppendOnly = Some(false)
-    tEnv.registerTableSink(
-      "upsertSink",
-      sink.configure(
-        Array[String]("cnt", "lencnt", "cTrue"),
-        Array[TypeInformation[_]](Types.LONG, Types.DECIMAL(), Types.BOOLEAN)))
+    tEnv.registerTableSink("upsertSink", sink)
 
     t.select('id, 'num, 'text.charLength() as 'len, ('id > 0) as 'cTrue)
       .groupBy('len, 'cTrue)
-      .select('len, 'id.count as 'cnt, 'cTrue)
-      .groupBy('cnt, 'cTrue)
-      .select('cnt, 'len.count as 'lencnt, 'cTrue)
+      // test query field name is different with registered sink field name
+      .select('len, 'id.count as 'count, 'cTrue)
+      .groupBy('count, 'cTrue)
+      .select('count, 'len.count as 'lencnt, 'cTrue)
       .insertInto("upsertSink")
 
     env.execute()
@@ -344,18 +343,17 @@ class TableSinkITCase extends AbstractTestBase {
       .assignAscendingTimestamps(_._1.toLong)
       .toTable(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
 
-    val sink = new TestingUpsertTableSink(Array(0, 1, 2), TimeZone.getDefault)
+    val sink = new TestingUpsertTableSink(Array(0, 1, 2), TimeZone.getDefault).configure(
+      Array[String]("num", "wend", "icnt"),
+      Array[TypeInformation[_]](Types.LONG, Types.SQL_TIMESTAMP, Types.LONG))
     sink.expectedKeys = Some(Array("wend", "num"))
     sink.expectedIsAppendOnly = Some(true)
-    tEnv.registerTableSink(
-      "upsertSink",
-      sink.configure(
-        Array[String]("num", "wend", "icnt"),
-        Array[TypeInformation[_]](Types.LONG, Types.SQL_TIMESTAMP, Types.LONG)))
+    tEnv.registerTableSink("upsertSink", sink)
 
     t.window(Tumble over 5.millis on 'rowtime as 'w)
       .groupBy('w, 'num)
-      .select('num, 'w.end as 'wend, 'id.count as 'icnt)
+      // test query field name is different with registered sink field name
+      .select('num, 'w.end as 'window_end, 'id.count as 'icnt)
       .insertInto("upsertSink")
 
     env.execute()

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamTestSink.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamTestSink.scala
@@ -32,7 +32,6 @@ import org.apache.flink.streaming.api.functions.sink.RichSinkFunction
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.dataformat.{BaseRow, DataFormatConverters, GenericRow}
 import org.apache.flink.table.planner.utils.BaseRowTestUtil
-import org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter
 import org.apache.flink.table.runtime.typeutils.BaseRowTypeInfo
 import org.apache.flink.table.sinks._
 import org.apache.flink.table.types.utils.TypeConversions
@@ -250,9 +249,9 @@ final class TestingUpsertSink(keys: Array[Int], tz: TimeZone)
 
 final class TestingUpsertTableSink(val keys: Array[Int], val tz: TimeZone)
   extends UpsertStreamTableSink[BaseRow] {
-  var fNames: Array[String] = _
-  var fTypes: Array[TypeInformation[_]] = _
-  var sink = new TestingUpsertSink(keys, tz)
+  private var fNames: Array[String] = _
+  private var fTypes: Array[TypeInformation[_]] = _
+  private var sink = new TestingUpsertSink(keys, tz)
   var expectedKeys: Option[Array[String]] = None
   var expectedIsAppendOnly: Option[Boolean] = None
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/util/UpdatingPlanChecker.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/util/UpdatingPlanChecker.scala
@@ -37,8 +37,9 @@ object UpdatingPlanChecker {
   }
 
   /** Extracts the unique keys of the table produced by the plan. */
-  def getUniqueKeyFields(plan: RelNode): Option[Array[String]] = {
-    getUniqueKeyGroups(plan).map(_.map(_._1).toArray)
+  def getUniqueKeyFields(plan: RelNode, sinkFieldNames: Array[String]): Option[Array[String]] = {
+    val relFieldNames = plan.getRowType.getFieldNames
+    getUniqueKeyGroups(plan).map(_.map(r => sinkFieldNames(relFieldNames.indexOf(r._1))).toArray)
   }
 
   /** Extracts the unique keys and groups of the table produced by the plan. */

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/StreamPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/StreamPlanner.scala
@@ -355,7 +355,9 @@ class StreamPlanner(
     val isAppendOnlyTable = UpdatingPlanChecker.isAppendOnly(optimizedPlan)
     sink.setIsAppendOnly(isAppendOnlyTable)
     // extract unique key fields
-    val tableKeys: Option[Array[String]] = UpdatingPlanChecker.getUniqueKeyFields(optimizedPlan)
+    val sinkFieldNames = sink.getTableSchema.getFieldNames
+    val tableKeys: Option[Array[String]] = UpdatingPlanChecker
+      .getUniqueKeyFields(optimizedPlan, sinkFieldNames)
     // check that we have keys if the table has changes (is not append-only)
     tableKeys match {
       case Some(keys) => sink.setKeyFields(keys)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSinkITCase.scala
@@ -283,9 +283,10 @@ class TableSinkITCase extends AbstractTestBase {
 
     t.select('id, 'num, 'text.charLength() as 'len, ('id > 0) as 'cTrue)
       .groupBy('len, 'cTrue)
-      .select('len, 'id.count as 'cnt, 'cTrue)
-      .groupBy('cnt, 'cTrue)
-      .select('cnt, 'len.count as 'lencnt, 'cTrue)
+      // test query field name is different with registered sink field name
+      .select('len, 'id.count as 'count, 'cTrue)
+      .groupBy('count, 'cTrue)
+      .select('count, 'len.count as 'lencnt, 'cTrue)
       .insertInto("upsertSink")
 
     env.execute()
@@ -324,7 +325,8 @@ class TableSinkITCase extends AbstractTestBase {
 
     t.window(Tumble over 5.millis on 'rowtime as 'w)
       .groupBy('w, 'num)
-      .select('num, 'w.end as 'wend, 'id.count as 'icnt)
+      // test query field name is different with registered sink field name
+      .select('num, 'w.end as 'window_end, 'id.count as 'icnt)
       .insertInto("upsertSink")
 
     env.execute()


### PR DESCRIPTION
 Using sink schema field name instead of query schema field name for UpsertStreamTableSink.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.

  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*This pull request  fix sink schema field name was used in  UpsertStreamTableSink instead of query schema field name in blink planner and legacy planner.*


## Brief change log

  - *legacy planner: fix StreamPlanner and UpdatingPlanChecker*
  - *blink planner: fix StreamExecSink and UpdatingPlanChecker*


## Verifying this change
  - * add IT case in  TableSinkITCase for legacy planner and blink planner* 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
