### PR TITLE
[FLINK-15411][table-planner-blink] Fix prune partition on DATE/TIME/TIMESTAMP columns

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -107,6 +107,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.catalog.config.CatalogConfig.FLINK_PROPERTY_PREFIX;
+import static org.apache.flink.table.filesystem.PartitionPathUtils.unescapePathName;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -953,7 +954,7 @@ public class HiveCatalog extends AbstractCatalog {
 		Map<String, String> spec = new HashMap<>(partKeyVals.length);
 		for (String keyVal : partKeyVals) {
 			String[] kv = keyVal.split("=");
-			spec.put(kv[0], kv[1]);
+			spec.put(unescapePathName(kv[0]), unescapePathName(kv[1]));
 		}
 		return new CatalogPartitionSpec(spec);
 	}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTableUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTableUtil.java
@@ -265,8 +265,18 @@ public class HiveTableUtil {
 					.toHiveObject(value);
 			String res = value.toString();
 			LogicalTypeRoot typeRoot = dataType.getLogicalType().getTypeRoot();
-			if (typeRoot == LogicalTypeRoot.VARCHAR || typeRoot == LogicalTypeRoot.CHAR) {
-				res = "'" + res.replace("'", "''") + "'";
+			switch (typeRoot) {
+				case CHAR:
+				case VARCHAR:
+					res = "'" + res.replace("'", "''") + "'";
+					break;
+				case DATE:
+				case TIMESTAMP_WITHOUT_TIME_ZONE:
+				case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+					// hive not support partition filter push down with these types.
+					return null;
+				default:
+					break;
 			}
 			return res;
 		}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
@@ -215,6 +215,9 @@ public class HiveTableSourceTest {
 					.addRow(new Object[]{2}).commit("p1=2,p2='b'");
 			HiveTestUtils.createTextTableInserter(hiveShell, "db1", "part")
 					.addRow(new Object[]{3}).commit("p1=3,p2='c'");
+			// test string partition columns with special characters
+			HiveTestUtils.createTextTableInserter(hiveShell, "db1", "part")
+					.addRow(new Object[]{4}).commit("p1=4,p2='c:2'");
 			TableEnvironment tableEnv = HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode();
 			TestPartitionFilterCatalog catalog = new TestPartitionFilterCatalog(
 					hiveCatalog.getName(), hiveCatalog.getDefaultDatabase(), hiveCatalog.getHiveConf(), hiveCatalog.getHiveVersion());
@@ -224,9 +227,9 @@ public class HiveTableSourceTest {
 			String[] explain = tableEnv.explain(query).split("==.*==\n");
 			assertFalse(catalog.fallback);
 			String optimizedPlan = explain[2];
-			assertTrue(optimizedPlan, optimizedPlan.contains("PartitionPruned: true, PartitionNums: 2"));
+			assertTrue(optimizedPlan, optimizedPlan.contains("PartitionPruned: true, PartitionNums: 3"));
 			List<Row> results = TableUtils.collectToList(query);
-			assertEquals("[2, 3]", results.toString());
+			assertEquals("[2, 3, 4]", results.toString());
 
 			query = tableEnv.sqlQuery("select x from db1.part where p1>2 and p2<='a' order by x");
 			explain = tableEnv.explain(query).split("==.*==\n");
@@ -251,6 +254,46 @@ public class HiveTableSourceTest {
 			assertTrue(optimizedPlan, optimizedPlan.contains("PartitionPruned: true, PartitionNums: 2"));
 			results = TableUtils.collectToList(query);
 			assertEquals("[1, 2]", results.toString());
+
+			query = tableEnv.sqlQuery("select x from db1.part where p2 = 'c:2' order by x");
+			explain = tableEnv.explain(query).split("==.*==\n");
+			assertFalse(catalog.fallback);
+			optimizedPlan = explain[2];
+			assertTrue(optimizedPlan, optimizedPlan.contains("PartitionPruned: true, PartitionNums: 1"));
+			results = TableUtils.collectToList(query);
+			assertEquals("[4]", results.toString());
+		} finally {
+			hiveShell.execute("drop database db1 cascade");
+		}
+	}
+
+	@Test
+	public void testPartitionFilterDateTimestamp() throws Exception {
+		hiveShell.execute("create database db1");
+		try {
+			hiveShell.execute("create table db1.part(x int) partitioned by (p1 date,p2 timestamp)");
+			HiveTestUtils.createTextTableInserter(hiveShell, "db1", "part")
+					.addRow(new Object[]{1}).commit("p1=date '2018-08-08',p2=timestamp '2018-08-08 08:08:08'");
+			HiveTestUtils.createTextTableInserter(hiveShell, "db1", "part")
+					.addRow(new Object[]{2}).commit("p1=date '2018-08-09',p2=timestamp '2018-08-08 08:08:09'");
+			HiveTestUtils.createTextTableInserter(hiveShell, "db1", "part")
+					.addRow(new Object[]{3}).commit("p1=date '2018-08-10',p2=timestamp '2018-08-08 08:08:10'");
+
+			TableEnvironment tableEnv = HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode();
+			TestPartitionFilterCatalog catalog = new TestPartitionFilterCatalog(
+					hiveCatalog.getName(), hiveCatalog.getDefaultDatabase(), hiveCatalog.getHiveConf(), hiveCatalog.getHiveVersion());
+			tableEnv.registerCatalog(catalog.getName(), catalog);
+			tableEnv.useCatalog(catalog.getName());
+
+			Table query = tableEnv.sqlQuery(
+					"select x from db1.part where p1>cast('2018-08-09' as date) and p2<>cast('2018-08-08 08:08:09' as timestamp)");
+			String[] explain = tableEnv.explain(query).split("==.*==\n");
+			assertTrue(catalog.fallback);
+			String optimizedPlan = explain[2];
+			assertTrue(optimizedPlan, optimizedPlan.contains("PartitionPruned: true, PartitionNums: 1"));
+			List<Row> results = TableUtils.collectToList(query);
+			assertEquals("[3]", results.toString());
+			System.out.println(results);
 		} finally {
 			hiveShell.execute("drop database db1 cascade");
 		}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -514,6 +514,13 @@ object ScalarOperatorGens {
           s"$leftTerm.compareTo($rightTerm) $operator 0"
       }
 
+      // both sides are timestamp with local zone
+      else if (isTimestampWithLocalZone(left.resultType) &&
+          isTimestampWithLocalZone(right.resultType)) {
+        (leftTerm, rightTerm) =>
+          s"$leftTerm.compareTo($rightTerm) $operator 0"
+      }
+
       // both sides are temporal of same type
       else if (isTemporal(left.resultType) &&
           isInteroperable(left.resultType, right.resultType)) {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -28,12 +28,13 @@ import org.apache.flink.table.planner.utils.DateTimeTestUtil
 import org.apache.flink.table.planner.utils.DateTimeTestUtil._
 import org.apache.flink.table.typeutils.TimeIntervalTypeInfo
 import org.apache.flink.types.Row
+
 import org.junit.Test
+
 import java.sql.Timestamp
 import java.text.SimpleDateFormat
-import java.time.{Instant, ZoneId}
+import java.time.{Instant, ZoneId, ZoneOffset}
 import java.util.{Locale, TimeZone}
-
 import org.apache.flink.table.runtime.typeutils.{LegacyInstantTypeInfo, LegacyLocalDateTimeTypeInfo}
 
 class TemporalTypesTest extends ExpressionTestBase {
@@ -784,6 +785,10 @@ class TemporalTypesTest extends ExpressionTestBase {
     testSqlApi(timestampTz("2018-03-14 19:00:00.010"), "2018-03-14 19:00:00.01")
 
     testSqlApi(
+      timestampTz("2018-03-14 19:00:00.010") + " > " + "f25",
+      "true")
+
+    testSqlApi(
       s"${timestampTz("2018-03-14 01:02:03.123456789", 9)}",
       "2018-03-14 01:02:03.123456789")
 
@@ -1189,7 +1194,7 @@ class TemporalTypesTest extends ExpressionTestBase {
   // ----------------------------------------------------------------------------------------------
 
   override def testData: Row = {
-    val testData = new Row(25)
+    val testData = new Row(26)
     testData.setField(0, localDate("1990-10-14"))
     testData.setField(1, DateTimeTestUtil.localTime("10:20:45"))
     testData.setField(2, localDateTime("1990-10-14 10:20:45.123"))
@@ -1220,6 +1225,7 @@ class TemporalTypesTest extends ExpressionTestBase {
     testData.setField(23, localDateTime("1970-01-01 00:00:00.123456789")
       .atZone(config.getLocalTimeZone).toInstant)
     testData.setField(24, localDateTime("1970-01-01 00:00:00.123456789"))
+    testData.setField(25, localDateTime("1970-01-01 00:00:00.123456789").toInstant(ZoneOffset.UTC))
     testData
   }
 
@@ -1249,7 +1255,8 @@ class TemporalTypesTest extends ExpressionTestBase {
       /* 21 */ Types.LONG,
       /* 22 */ Types.INT,
       /* 23 */ new LegacyInstantTypeInfo(9),
-      /* 24 */ new LegacyLocalDateTimeTypeInfo(9)
+      /* 24 */ new LegacyLocalDateTimeTypeInfo(9),
+      /* 25 */ Types.INSTANT
     )
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/PartitionPrunerTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/PartitionPrunerTest.scala
@@ -22,13 +22,18 @@ import org.apache.flink.table.functions.FunctionIdentifier
 import org.apache.flink.table.planner.expressions.utils.Func1
 import org.apache.flink.table.planner.functions.utils.ScalarSqlFunction
 
+import org.apache.calcite.rex.RexUtil
+import org.apache.calcite.sql.`type`.SqlTypeName
+import org.apache.calcite.sql.`type`.SqlTypeName.DATE
 import org.apache.calcite.sql.fun.SqlStdOperatorTable
+import org.apache.calcite.util.{DateString, TimeString, TimestampString}
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 import java.math.BigDecimal
 import java.util.{List => JList, Map => JMap}
 
+import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
 
 /**
@@ -112,6 +117,75 @@ class PartitionPrunerTest extends RexNodeTestBase {
     assertEquals(2, prunedPartitions.size())
     assertEquals("150", prunedPartitions.get(0).get("amount"))
     assertEquals("200", prunedPartitions.get(1).get("amount"))
+  }
+
+  @Test
+  def testTimePrunePartitions(): Unit = {
+    val f0 = rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.DATE), 0)
+    val f1 = rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.TIME, 0), 1)
+    val f2 = rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.TIMESTAMP, 3), 2)
+    val f3 = rexBuilder.makeInputRef(
+      typeFactory.createSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, 3), 3)
+
+    val c0 = rexBuilder.makeCall(
+      SqlStdOperatorTable.GREATER_THAN,
+      f0,
+      rexBuilder.makeDateLiteral(new DateString("2018-08-06")))
+
+    val c1 = rexBuilder.makeCall(
+      SqlStdOperatorTable.GREATER_THAN,
+      f1,
+      rexBuilder.makeTimeLiteral(new TimeString("12:08:06"), 0))
+
+    val c2 = rexBuilder.makeCall(
+      SqlStdOperatorTable.GREATER_THAN,
+      f2,
+      rexBuilder.makeTimestampLiteral(new TimestampString("2018-08-06 12:08:06.123"), 3))
+
+    val c3 = rexBuilder.makeCall(
+      SqlStdOperatorTable.GREATER_THAN,
+      f3,
+      rexBuilder.makeTimestampWithLocalTimeZoneLiteral(
+        new TimestampString("2018-08-06 12:08:06.123"), 3))
+
+    val condition = RexUtil.composeConjunction(rexBuilder, Seq(c0, c1, c2, c3))
+
+    val partitionFieldNames = Array("f0", "f1", "f2", "f3")
+    val partitionFieldTypes = Array(
+      DataTypes.DATE().getLogicalType,
+      DataTypes.TIME(0).getLogicalType,
+      DataTypes.TIMESTAMP(3).getLogicalType,
+      DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).getLogicalType)
+
+    val allPartitions: JList[JMap[String, String]] = List(
+      Map(
+        "f0" -> "2018-08-05",
+        "f1" -> "12:08:07",
+        "f2" -> "2018-08-06 12:08:06.124",
+        "f3" -> "2018-08-06 12:08:06.124").asJava,
+      Map(
+        "f0" -> "2018-08-07",
+        "f1" -> "12:08:05",
+        "f2" -> "2018-08-06 12:08:06.124",
+        "f3" -> "2018-08-06 12:08:06.124").asJava,
+      Map(
+        "f0" -> "2018-08-07",
+        "f1" -> "12:08:07",
+        "f2" -> "2018-08-06 12:08:06.124",
+        "f3" -> "2018-08-06 12:08:06.124").asJava
+    ).asJava
+
+    val config = new TableConfig
+    val prunedPartitions = PartitionPruner.prunePartitions(
+      config,
+      partitionFieldNames,
+      partitionFieldTypes,
+      allPartitions,
+      condition
+    )
+
+    assertEquals(1, prunedPartitions.size())
+    assertEquals(allPartitions(2), prunedPartitions(0))
   }
 
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractorTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractorTest.scala
@@ -798,15 +798,15 @@ class RexNodeExtractorTest extends RexNodeTestBase {
   }
 
   @Test
-  def testExtractPartitionPredicates_UnsupportedType(): Unit = {
+  def testExtractPartitionPredicatesDate(): Unit = {
     // amount
-    val t0 = rexBuilder.makeInputRef(allFieldTypes.get(2), 2)
+    val t0 = rexBuilder.makeInputRef(allFieldTypes.get(2), 1)
     // 100
     val t1 = rexBuilder.makeExactLiteral(BigDecimal.valueOf(100L))
     val c1 = rexBuilder.makeCall(SqlStdOperatorTable.GREATER_THAN, t0, t1)
     // date
     val t2 = rexBuilder.makeInputRef(
-      typeFactory.createFieldTypeFromLogicalType(DataTypes.DATE().getLogicalType), 1)
+      typeFactory.createFieldTypeFromLogicalType(DataTypes.DATE().getLogicalType), 0)
     // 2019-04-14
     val t3 = rexBuilder.makeDateLiteral(DateString.fromDaysSinceEpoch(18000))
     val c2 = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, t2, t3)
@@ -820,10 +820,9 @@ class RexNodeExtractorTest extends RexNodeTestBase {
         rexBuilder,
         Array("date")
       )
-    assertTrue(partitionPredicate1.isAlwaysTrue)
-    assertEquals(c3, nonPartitionPredicate1)
+    assertEquals(c2, partitionPredicate1)
+    assertEquals(c1, nonPartitionPredicate1)
 
-    // date is not supported
     val (partitionPredicate2, nonPartitionPredicate2) =
       RexNodeExtractor.extractPartitionPredicates(
         c3,
@@ -832,8 +831,8 @@ class RexNodeExtractorTest extends RexNodeTestBase {
         rexBuilder,
         Array("date", "amount")
       )
-    assertTrue(partitionPredicate2.isAlwaysTrue)
-    assertEquals(c3, nonPartitionPredicate2)
+    assertEquals(c3, partitionPredicate2)
+    assertTrue(nonPartitionPredicate2.isAlwaysTrue)
 
     val (partitionPredicate3, nonPartitionPredicate3) =
       RexNodeExtractor.extractPartitionPredicates(

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionPathUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionPathUtils.java
@@ -146,7 +146,7 @@ public class PartitionPathUtils {
 		return fullPartSpec;
 	}
 
-	private static String unescapePathName(String path) {
+	public static String unescapePathName(String path) {
 		StringBuilder sb = new StringBuilder();
 		for (int i = 0; i < path.length(); i++) {
 			char c = path.charAt(i);


### PR DESCRIPTION

## What is the purpose of the change

When use DATE/TIME/TIMESTAMP partition columns, planner will not do partition pruning, that lead to read all partitions.

## Brief change log

- Fix comparison of timestamp with local time zone
- Fix prune partition on DATE/TIME/TIMESTAMP columns
- Fix listPartitions in HiveCatalog & Add time prune partition tests

## Verifying this change

- HiveTableSourceTest.testPartitionFilterDateTimestamp
- PartitionPruneTest.testTimePrunePartitions

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no