### PR TITLE
[FLINK-15346][connectors / filesystem] Support treat empty column as null option in CsvTableSourceFactory

### DIFF
--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1866,7 +1866,8 @@ CREATE TABLE MyUserTable (
   'format.quote-character' = '"',         -- optional: single character for string values, empty by default
   'format.comment-prefix' = '#',          -- optional: string to indicate comments, empty by default
   'format.ignore-first-line' = 'false',   -- optional: boolean flag to ignore the first line, by default it is not skipped
-  'format.ignore-parse-errors' = 'true'   -- optional: skip records with parse error instead of failing by default
+  'format.ignore-parse-errors' = 'true',  -- optional: skip records with parse error instead of failing by default
+  'format.empty-column-as-null' = 'true'  -- optional: treat empty column as null, false by default
 )
 {% endhighlight %}
 </div>
@@ -1883,6 +1884,7 @@ CREATE TABLE MyUserTable (
     .commentPrefix('#')               // optional: string to indicate comments, empty by default
     .ignoreFirstLine()                // optional: ignore the first line, by default it is not skipped
     .ignoreParseErrors()              // optional: skip records with parse error instead of failing by default
+    .emptyColumnAsNull()              // optional: treat empty column as null, false by default
 )
 {% endhighlight %}
 </div>
@@ -1899,6 +1901,7 @@ CREATE TABLE MyUserTable (
     .comment_prefix('#')                    # optional: string to indicate comments, empty by default
     .ignore_first_line()                    # optional: ignore the first line, by default it is not skipped
     .ignore_parse_errors()                  # optional: skip records with parse error instead of failing by default
+    .emptyColumnAsNull()                    # optional: treat empty column as null, false by default
 )
 {% endhighlight %}
 </div>
@@ -1918,6 +1921,7 @@ format:
   comment-prefix: '#'        # optional: string to indicate comments, empty by default
   ignore-first-line: false   # optional: boolean flag to ignore the first line, by default it is not skipped
   ignore-parse-errors: true  # optional: skip records with parse error instead of failing by default
+  empty-column-as-null: true # optional: treat empty column as null, false by default
 {% endhighlight %}
 </div>
 </div>

--- a/docs/dev/table/connect.zh.md
+++ b/docs/dev/table/connect.zh.md
@@ -1866,7 +1866,8 @@ CREATE TABLE MyUserTable (
   'format.quote-character' = '"',         -- optional: single character for string values, empty by default
   'format.comment-prefix' = '#',          -- optional: string to indicate comments, empty by default
   'format.ignore-first-line' = 'false',   -- optional: boolean flag to ignore the first line, by default it is not skipped
-  'format.ignore-parse-errors' = 'true'   -- optional: skip records with parse error instead of failing by default
+  'format.ignore-parse-errors' = 'true',  -- optional: skip records with parse error instead of failing by default
+  'format.empty-column-as-null' = 'true'  -- optional: treat empty column as null, false by default
 )
 {% endhighlight %}
 </div>
@@ -1883,6 +1884,7 @@ CREATE TABLE MyUserTable (
     .commentPrefix('#')               // optional: string to indicate comments, empty by default
     .ignoreFirstLine()                // optional: ignore the first line, by default it is not skipped
     .ignoreParseErrors()              // optional: skip records with parse error instead of failing by default
+    .emptyColumnAsNull()              // optional: treat empty column as null, false by default
 )
 {% endhighlight %}
 </div>
@@ -1899,6 +1901,7 @@ CREATE TABLE MyUserTable (
     .comment_prefix('#')                    # optional: string to indicate comments, empty by default
     .ignore_first_line()                    # optional: ignore the first line, by default it is not skipped
     .ignore_parse_errors()                  # optional: skip records with parse error instead of failing by default
+    .emptyColumnAsNull()                    # optional: treat empty column as null, false by default
 )
 {% endhighlight %}
 </div>
@@ -1918,6 +1921,7 @@ format:
   comment-prefix: '#'        # optional: string to indicate comments, empty by default
   ignore-first-line: false   # optional: boolean flag to ignore the first line, by default it is not skipped
   ignore-parse-errors: true  # optional: skip records with parse error instead of failing by default
+  empty-column-as-null: true # optional: treat empty column as null, false by default
 {% endhighlight %}
 </div>
 </div>

--- a/flink-python/pyflink/table/descriptors.py
+++ b/flink-python/pyflink/table/descriptors.py
@@ -378,6 +378,15 @@ class OldCsv(FormatDescriptor):
         self._j_csv = self._j_csv.ignoreFirstLine()
         return self
 
+    def empty_column_as_null(self):
+        """
+        Treat empty column as null, false by default.
+
+        :return: This :class:`OldCsv` object.
+        """
+        self._j_csv = self._j_csv.emptyColumnAsNull()
+        return self
+
 
 class Csv(FormatDescriptor):
     """

--- a/flink-python/pyflink/table/tests/test_descriptor.py
+++ b/flink-python/pyflink/table/tests/test_descriptor.py
@@ -419,6 +419,15 @@ class OldCsvDescriptorTests(PyFlinkTestCase):
                     'format.property-version': '1'}
         self.assertEqual(expected, properties)
 
+    def test_empty_column_as_null(self):
+        csv = OldCsv().empty_column_as_null()
+
+        properties = csv.to_properties()
+        expected = {'format.empty-column-as-null': 'true',
+                    'format.type': 'csv',
+                    'format.property-version': '1'}
+        self.assertEqual(expected, properties)
+
     def test_field(self):
         csv = OldCsv()
 

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/descriptors/OldCsv.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/descriptors/OldCsv.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.flink.table.descriptors.FormatDescriptorValidator.FORMAT_DERIVE_SCHEMA;
 import static org.apache.flink.table.descriptors.OldCsvValidator.FORMAT_COMMENT_PREFIX;
+import static org.apache.flink.table.descriptors.OldCsvValidator.FORMAT_EMPTY_COLUMN_AS_NULL;
 import static org.apache.flink.table.descriptors.OldCsvValidator.FORMAT_FIELDS;
 import static org.apache.flink.table.descriptors.OldCsvValidator.FORMAT_FIELD_DELIMITER;
 import static org.apache.flink.table.descriptors.OldCsvValidator.FORMAT_IGNORE_FIRST_LINE;
@@ -67,6 +68,7 @@ public class OldCsv extends FormatDescriptor {
 	private Optional<Character> quoteCharacter = Optional.empty();
 	private Optional<String> commentPrefix = Optional.empty();
 	private Optional<Boolean> isIgnoreFirstLine = Optional.empty();
+	private Optional<Boolean> emptyColumnAsNull = Optional.empty();
 	private Optional<Boolean> lenient = Optional.empty();
 	private Optional<Boolean> deriveSchema = Optional.empty();
 
@@ -213,6 +215,14 @@ public class OldCsv extends FormatDescriptor {
 	}
 
 	/**
+	 * Treat empty column as null, false by default.
+	 */
+	public OldCsv emptyColumnAsNull() {
+		this.emptyColumnAsNull = Optional.of(true);
+		return this;
+	}
+
+	/**
 	 * Derives the format schema from the table's schema. Required if no format schema is defined.
 	 *
 	 * <p>This allows for defining schema information only once.
@@ -253,6 +263,7 @@ public class OldCsv extends FormatDescriptor {
 		quoteCharacter.ifPresent(character -> properties.putCharacter(FORMAT_QUOTE_CHARACTER, character));
 		commentPrefix.ifPresent(s -> properties.putString(FORMAT_COMMENT_PREFIX, s));
 		isIgnoreFirstLine.ifPresent(aBoolean -> properties.putBoolean(FORMAT_IGNORE_FIRST_LINE, aBoolean));
+		emptyColumnAsNull.ifPresent(r -> properties.putBoolean(FORMAT_EMPTY_COLUMN_AS_NULL, r));
 		lenient.ifPresent(aBoolean -> properties.putBoolean(FORMAT_IGNORE_PARSE_ERRORS, aBoolean));
 
 		return properties.asMap();

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/descriptors/OldCsvValidator.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/descriptors/OldCsvValidator.java
@@ -38,6 +38,7 @@ public class OldCsvValidator extends FormatDescriptorValidator {
 	public static final String FORMAT_COMMENT_PREFIX = "format.comment-prefix";
 	public static final String FORMAT_IGNORE_FIRST_LINE = "format.ignore-first-line";
 	public static final String FORMAT_IGNORE_PARSE_ERRORS = "format.ignore-parse-errors";
+	public static final String FORMAT_EMPTY_COLUMN_AS_NULL = "format.empty-column-as-null";
 	public static final String FORMAT_FIELDS = "format.fields";
 
 	@Override
@@ -50,6 +51,7 @@ public class OldCsvValidator extends FormatDescriptorValidator {
 		properties.validateString(FORMAT_COMMENT_PREFIX, true, 1);
 		properties.validateBoolean(FORMAT_IGNORE_FIRST_LINE, true);
 		properties.validateBoolean(FORMAT_IGNORE_PARSE_ERRORS, true);
+		properties.validateBoolean(FORMAT_EMPTY_COLUMN_AS_NULL, true);
 		properties.validateBoolean(FormatDescriptorValidator.FORMAT_DERIVE_SCHEMA, true);
 
 		final boolean hasSchema = properties.hasPrefix(FORMAT_FIELDS);

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/CsvTableSourceFactoryBase.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/CsvTableSourceFactoryBase.java
@@ -45,6 +45,7 @@ import static org.apache.flink.table.descriptors.FileSystemValidator.CONNECTOR_T
 import static org.apache.flink.table.descriptors.FormatDescriptorValidator.FORMAT_PROPERTY_VERSION;
 import static org.apache.flink.table.descriptors.FormatDescriptorValidator.FORMAT_TYPE;
 import static org.apache.flink.table.descriptors.OldCsvValidator.FORMAT_COMMENT_PREFIX;
+import static org.apache.flink.table.descriptors.OldCsvValidator.FORMAT_EMPTY_COLUMN_AS_NULL;
 import static org.apache.flink.table.descriptors.OldCsvValidator.FORMAT_FIELDS;
 import static org.apache.flink.table.descriptors.OldCsvValidator.FORMAT_FIELD_DELIMITER;
 import static org.apache.flink.table.descriptors.OldCsvValidator.FORMAT_IGNORE_FIRST_LINE;
@@ -85,6 +86,7 @@ public abstract class CsvTableSourceFactoryBase implements TableFactory {
 		properties.add(FORMAT_COMMENT_PREFIX);
 		properties.add(FORMAT_IGNORE_FIRST_LINE);
 		properties.add(FORMAT_IGNORE_PARSE_ERRORS);
+		properties.add(FORMAT_EMPTY_COLUMN_AS_NULL);
 		properties.add(CONNECTOR_PATH);
 		// schema
 		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_TYPE);
@@ -146,6 +148,12 @@ public abstract class CsvTableSourceFactoryBase implements TableFactory {
 		params.getOptionalBoolean(FORMAT_IGNORE_PARSE_ERRORS).ifPresent(flag -> {
 			if (flag) {
 				csvTableSourceBuilder.ignoreParseErrors();
+			}
+		});
+
+		params.getOptionalBoolean(FORMAT_EMPTY_COLUMN_AS_NULL).ifPresent(flag -> {
+			if (flag) {
+				csvTableSourceBuilder.emptyColumnAsNull();
 			}
 		});
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/descriptors/OldCsvTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/descriptors/OldCsvTest.scala
@@ -64,6 +64,7 @@ class OldCsvTest extends DescriptorTestBase {
         Array[TypeInformation[_]](Types.INT, Types.STRING)))
       .quoteCharacter('#')
       .ignoreFirstLine()
+      .emptyColumnAsNull()
 
     val desc3 = new OldCsv()
       .commentPrefix("#")
@@ -93,7 +94,8 @@ class OldCsvTest extends DescriptorTestBase {
       "format.fields.1.name" -> "row",
       "format.fields.1.data-type" -> "VARCHAR(2147483647)",
       "format.quote-character" -> "#",
-      "format.ignore-first-line" -> "true")
+      "format.ignore-first-line" -> "true",
+      "format.empty-column-as-null" -> "true")
 
     val props3 = Map(
       "format.type" -> "csv",


### PR DESCRIPTION
Support treat empty column as null option in CsvTableSourceFactory

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.

  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*We have supported emptyColumnAsNull feature in  is supported CsvTableSource,  but don't surpport in CsvTableSourceFactory which will be called when user use YAML or DDL to define a CsvSoure from now. This pull request improve it.*


## Brief change log

  - *Add supported properties `emptyColumnAsNull` in CsvTableSourceFactoryBase.java*
  - *Add `emptyColumnAsNull` implement  in OldCsv.java and OldCsvValidator.java*
  - *Support `emptyColumnAsNull` in descriptors.py for Python API*

## Verifying this change

Add unit test in OldCsvTest.scala
Add python unit test in test_descriptor.py

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
* update docs in connect.md and connect.zh.md* 
