### PR TITLE
[hotfix][doc] Fix temporal_tables correlate with a changing dimension table section

### DIFF
--- a/docs/dev/table/streaming/temporal_tables.md
+++ b/docs/dev/table/streaming/temporal_tables.md
@@ -90,7 +90,7 @@ In Flink, this is represented by a [*Temporal Table Function*](#temporal-table-f
 
 On the other hand, some use cases require to join a changing dimension table which is an external database table.
 
-Let's assume that `LatestRates` is a table (e.g. stored in) which is materialized with the latest rate. The `LatestRates` is the materialized history `RatesHistory`. Then the content of `LatestRates` table at time `10:58` will be:
+Let's assume that `LatestRates` is a table (e.g. stored in HBase) which is materialized with the latest rate. The `LatestRates` is the materialized history `RatesHistory`. Then the content of `LatestRates` table at time `10:58` will be:
 
 {% highlight text %}
 10:58> SELECT * FROM LatestRates;


### PR DESCRIPTION
##  What is the purpose of the change

Fix doc temporal_tables, correlate with a changing dimension table section.

## Brief change log

-

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
