### PR TITLE
[hotfix][docs] Fix a typo in [flink-example] - CollectionExecutionExample.java

### DIFF
--- a/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/misc/CollectionExecutionExample.java
+++ b/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/misc/CollectionExecutionExample.java
@@ -81,7 +81,7 @@ public class CollectionExecutionExample {
 		User[] usersArray = { new User(1, "Peter"), new User(2, "John"), new User(3, "Bill") };
 
 		EMail[] emailsArray = {new EMail(1, "Re: Meeting", "How about 1pm?"),
-							new EMail(1, "Re: Meeting", "Sorry, I'm not availble"),
+							new EMail(1, "Re: Meeting", "Sorry, I'm not available"),
 							new EMail(3, "Re: Re: Project proposal", "Give me a few more days to think about it.")};
 
 		// convert objects into a DataSet


### PR DESCRIPTION
## What is the purpose of the change

*Fix a typo in [flink-example] - CollectionExecutionExample.java*

## Brief change log

*Fix a typo in [flink-example] - CollectionExecutionExample.java*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
