### PR TITLE
[FLINK-15431][CEP] Add numLateRecordsDropped/lateRecordsDroppedRate/watermarkLatency in CepOperator

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
@@ -43,9 +43,6 @@ import org.apache.flink.cep.nfa.sharedbuffer.SharedBufferAccessor;
 import org.apache.flink.cep.time.TimerService;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
-import org.apache.flink.metrics.Gauge;
-import org.apache.flink.metrics.Meter;
-import org.apache.flink.metrics.MeterView;
 import org.apache.flink.runtime.state.KeyedStateFunction;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.VoidNamespace;
@@ -90,8 +87,6 @@ public class CepOperator<IN, KEY, OUT>
 	private static final long serialVersionUID = -4166778210774160757L;
 
 	private static final String LATE_ELEMENTS_DROPPED_METRIC_NAME = "numLateRecordsDropped";
-	private static final String LATE_ELEMENTS_DROPPED_RATE_METRIC_NAME = "lateRecordsDroppedRate";
-	private static final String WATERMARK_LATENCY_METRIC_NAME = "watermarkLatency";
 
 	private final boolean isProcessingTime;
 
@@ -147,8 +142,6 @@ public class CepOperator<IN, KEY, OUT>
 	// ------------------------------------------------------------------------
 
 	private transient Counter numLateRecordsDropped;
-	private transient Meter lateRecordsDroppedRate;
-	private transient Gauge<Long> watermarkLatency;
 
 	public CepOperator(
 			final TypeSerializer<IN> inputSerializer,
@@ -240,17 +233,6 @@ public class CepOperator<IN, KEY, OUT>
 
 		// metrics
 		this.numLateRecordsDropped = metrics.counter(LATE_ELEMENTS_DROPPED_METRIC_NAME);
-		this.lateRecordsDroppedRate = metrics.meter(
-			LATE_ELEMENTS_DROPPED_RATE_METRIC_NAME,
-			new MeterView(numLateRecordsDropped, 60));
-		this.watermarkLatency = metrics.gauge(WATERMARK_LATENCY_METRIC_NAME, () -> {
-			long watermark = timerService.currentWatermark();
-			if (watermark < 0) {
-				return 0L;
-			} else {
-				return timerService.currentProcessingTime() - watermark;
-			}
-		});
 	}
 
 	@Override
@@ -300,7 +282,7 @@ public class CepOperator<IN, KEY, OUT>
 			} else if (lateDataOutputTag != null) {
 				output.collect(lateDataOutputTag, element);
 			} else {
-				lateRecordsDroppedRate.markEvent();
+				numLateRecordsDropped.inc();
 			}
 		}
 	}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
@@ -42,6 +42,10 @@ import org.apache.flink.cep.nfa.sharedbuffer.SharedBuffer;
 import org.apache.flink.cep.nfa.sharedbuffer.SharedBufferAccessor;
 import org.apache.flink.cep.time.TimerService;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.MeterView;
 import org.apache.flink.runtime.state.KeyedStateFunction;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.VoidNamespace;
@@ -84,6 +88,10 @@ public class CepOperator<IN, KEY, OUT>
 		implements OneInputStreamOperator<IN, OUT>, Triggerable<KEY, VoidNamespace> {
 
 	private static final long serialVersionUID = -4166778210774160757L;
+
+	private static final String LATE_ELEMENTS_DROPPED_METRIC_NAME = "numLateRecordsDropped";
+	private static final String LATE_ELEMENTS_DROPPED_RATE_METRIC_NAME = "lateRecordsDroppedRate";
+	private static final String WATERMARK_LATENCY_METRIC_NAME = "watermarkLatency";
 
 	private final boolean isProcessingTime;
 
@@ -133,6 +141,14 @@ public class CepOperator<IN, KEY, OUT>
 
 	/** Thin context passed to NFA that gives access to time related characteristics. */
 	private transient TimerService cepTimerService;
+
+	// ------------------------------------------------------------------------
+	// Metrics
+	// ------------------------------------------------------------------------
+
+	private transient Counter numLateRecordsDropped;
+	private transient Meter lateRecordsDroppedRate;
+	private transient Gauge<Long> watermarkLatency;
 
 	public CepOperator(
 			final TypeSerializer<IN> inputSerializer,
@@ -221,6 +237,20 @@ public class CepOperator<IN, KEY, OUT>
 		context = new ContextFunctionImpl();
 		collector = new TimestampedCollector<>(output);
 		cepTimerService = new TimerServiceImpl();
+
+		// metrics
+		this.numLateRecordsDropped = metrics.counter(LATE_ELEMENTS_DROPPED_METRIC_NAME);
+		this.lateRecordsDroppedRate = metrics.meter(
+			LATE_ELEMENTS_DROPPED_RATE_METRIC_NAME,
+			new MeterView(numLateRecordsDropped, 60));
+		this.watermarkLatency = metrics.gauge(WATERMARK_LATENCY_METRIC_NAME, () -> {
+			long watermark = timerService.currentWatermark();
+			if (watermark < 0) {
+				return 0L;
+			} else {
+				return timerService.currentProcessingTime() - watermark;
+			}
+		});
 	}
 
 	@Override
@@ -269,6 +299,8 @@ public class CepOperator<IN, KEY, OUT>
 
 			} else if (lateDataOutputTag != null) {
 				output.collect(lateDataOutputTag, element);
+			} else {
+				lateRecordsDroppedRate.markEvent();
 			}
 		}
 	}
@@ -541,5 +573,10 @@ public class CepOperator<IN, KEY, OUT>
 			counter += elements.size();
 		}
 		return counter;
+	}
+
+	@VisibleForTesting
+	long getLateRecordsNumber() {
+		return numLateRecordsDropped.getCount();
 	}
 }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
@@ -790,6 +790,31 @@ public class CEPOperatorTest extends TestLogger {
 	}
 
 	@Test
+	public void testCEPOperatorLateRecordsMetric() throws Exception {
+		Event startEvent = new Event(41, "c", 1.0);
+		Event middle1Event1 = new Event(41, "a", 2.0);
+		Event middle1Event2 = new Event(41, "a", 3.0);
+		Event middle1Event3 = new Event(41, "a", 4.0);
+
+		CepOperator<Event, Integer, Map<String, List<Event>>> operator = getKeyedCepOperator(false);
+		OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness = CepOperatorTestUtilities.getCepTestHarness(operator);
+		try {
+			harness.open();
+			harness.processWatermark(0);
+			harness.processElement(startEvent, 1L);
+			harness.processWatermark(2L);
+			harness.processElement(middle1Event1, 1L);
+			harness.processElement(middle1Event2, 3L);
+			harness.processWatermark(4L);
+			harness.processElement(middle1Event3, 3L);
+
+			assertEquals(2L, operator.getLateRecordsNumber());
+		} finally {
+			harness.close();
+		}
+	}
+
+	@Test
 	public void testCEPOperatorCleanupProcessingTime() throws Exception {
 
 		Event startEvent1 = new Event(42, "start", 1.0);


### PR DESCRIPTION
## What is the purpose of the change 

This pr adds numLateRecordsDropped/lateRecordsDroppedRate/watermarkLatency metric in CepOperator. 

## Brief change log

adds numLateRecordsDropped/lateRecordsDroppedRate/watermarkLatency


## Verifying this change

This change added tests and can be verified as follows:

CEPOperatorTest. testCEPOperatorLateRecordsMetric

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)
