### PR TITLE
[FLINK-15409]Add semicolon after WindowJoinUtil#generateJoinFunction '$collectorTerm.collect($joinedRow)' statement

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowJoinUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowJoinUtil.scala
@@ -127,7 +127,7 @@ object WindowJoinUtil {
       case None =>
         s"""
            |$buildJoinedRow
-           |$collectorTerm.collect($joinedRow)
+           |$collectorTerm.collect($joinedRow);
            |""".stripMargin
       case Some(remainCondition) =>
         val genCond = exprGenerator.generateExpression(remainCondition)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/WindowJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/WindowJoinTest.scala
@@ -24,11 +24,8 @@ import org.apache.flink.table.api.scala._
 import org.apache.flink.table.planner.plan.utils.WindowJoinUtil
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.PythonScalarFunction
 import org.apache.flink.table.planner.utils.{StreamTableTestUtil, TableTestBase, TableTestUtil}
-import org.apache.flink.api.common.functions.RichFlatJoinFunction
-import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 
 import org.apache.calcite.rel.logical.LogicalJoin
-
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -420,6 +417,7 @@ class WindowJoinTest extends TableTestBase {
       query2,
       ">($2, $6)")
   }
+
   private def verifyTimeBoundary(
       timeConditionSql: String,
       expLeftSize: Long,
@@ -468,4 +466,5 @@ class WindowJoinTest extends TableTestBase {
     val actual: String = remainCondition.getOrElse("").toString
     assertEquals(expectConditionStr, actual)
   }
+
 }


### PR DESCRIPTION
## What is the purpose of the change

Add semicolon after WindowJoinUtil#generateJoinFunction '$collectorTerm.collect($joinedRow)' statement

## Brief change log

Add semicolon after WindowJoinUtil#generateJoinFunction '$collectorTerm.collect($joinedRow)' statement.


## Verifying this change

This change added tests and can be verified as follows:

  - WindowJoinTest#testJoinFunctionGenerate

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
