### PR TITLE
[FLINK-15435][python] Fix ExecutionConfigTests.test_equals_and_hash when cpu core number is 6

### DIFF
--- a/flink-python/pyflink/common/tests/test_execution_config.py
+++ b/flink-python/pyflink/common/tests/test_execution_config.py
@@ -277,6 +277,7 @@ class ExecutionConfigTests(PyFlinkTestCase):
         self.assertEqual(hash(config1), hash(config2))
 
         config1.set_parallelism(12)
+        config2.set_parallelism(11)
 
         self.assertNotEqual(config1, config2)
 


### PR DESCRIPTION
## Brief change log 

Fix ExecutionConfigTests.test_equals_and_hash. It fails when default parallelism is 12.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
