### PR TITLE
[hotfix][e2e] Disable Shaded Hadoop S3A with credentials provider e2e test until FLINK-15355 has been fixed

### DIFF
--- a/tools/travis/splits/split_misc.sh
+++ b/tools/travis/splits/split_misc.sh
@@ -82,7 +82,8 @@ fi
 
 run_test "Dependency shading of table modules test" "$END_TO_END_DIR/test-scripts/test_table_shaded_dependencies.sh"
 
-run_test "Shaded Hadoop S3A with credentials provider end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_wordcount.sh hadoop_with_provider"
+# Disabled until FLINK-15355 has been fixed
+#run_test "Shaded Hadoop S3A with credentials provider end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_wordcount.sh hadoop_with_provider"
 
 printf "\n[PASS] All tests passed\n"
 exit 0


### PR DESCRIPTION

## What is the purpose of the change

Further disable 'Shaded Hadoop S3A with credentials provider' e2e test to survive from the issue of FLINK-15355, as indicated by [this comment](https://issues.apache.org/jira/browse/FLINK-15355?focusedCommentId=17005159&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17005159)


## Brief change log

Disable 'Shaded Hadoop S3A with credentials provider' in `split_misc.sh`.

## Verifying this change

This change is a trivial work without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
