### PR TITLE
[FLINK-15421][table-planner-blink] Fix TimestampMaxAggFunction/Timest…

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunction.java
@@ -27,13 +27,14 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.table.api.dataview.MapView;
 import org.apache.flink.table.dataformat.BinaryString;
 import org.apache.flink.table.dataformat.Decimal;
+import org.apache.flink.table.dataformat.SqlTimestamp;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.runtime.typeutils.BinaryStringTypeInfo;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
+import org.apache.flink.table.runtime.typeutils.SqlTimestampTypeInfo;
 
 import java.sql.Date;
 import java.sql.Time;
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -367,13 +368,21 @@ public abstract class MaxWithRetractAggFunction<T extends Comparable>
 	/**
 	 * Built-in Timestamp Max with retraction aggregate function.
 	 */
-	public static class TimestampMaxWithRetractAggFunction extends MaxWithRetractAggFunction<Timestamp> {
+	public static class TimestampMaxWithRetractAggFunction extends MaxWithRetractAggFunction<SqlTimestamp> {
 
 		private static final long serialVersionUID = -7096481949093142944L;
 
+		public void accumulate(MaxWithRetractAccumulator<SqlTimestamp> acc, SqlTimestamp value) throws Exception {
+			super.accumulate(acc, value);
+		}
+
+		public void retract(MaxWithRetractAccumulator<SqlTimestamp> acc, SqlTimestamp value) throws Exception {
+			super.retract(acc, value);
+		}
+
 		@Override
-		protected TypeInformation<Timestamp> getValueTypeInfo() {
-			return Types.SQL_TIMESTAMP;
+		protected TypeInformation<SqlTimestamp> getValueTypeInfo() {
+			return new SqlTimestampTypeInfo(3);
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunction.java
@@ -372,6 +372,12 @@ public abstract class MaxWithRetractAggFunction<T extends Comparable>
 
 		private static final long serialVersionUID = -7096481949093142944L;
 
+		private final int precision;
+
+		public TimestampMaxWithRetractAggFunction(int precision) {
+			this.precision = precision;
+		}
+
 		public void accumulate(MaxWithRetractAccumulator<SqlTimestamp> acc, SqlTimestamp value) throws Exception {
 			super.accumulate(acc, value);
 		}
@@ -382,7 +388,7 @@ public abstract class MaxWithRetractAggFunction<T extends Comparable>
 
 		@Override
 		protected TypeInformation<SqlTimestamp> getValueTypeInfo() {
-			return new SqlTimestampTypeInfo(3);
+			return new SqlTimestampTypeInfo(precision);
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunction.java
@@ -27,9 +27,11 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.table.api.dataview.MapView;
 import org.apache.flink.table.dataformat.BinaryString;
 import org.apache.flink.table.dataformat.Decimal;
+import org.apache.flink.table.dataformat.SqlTimestamp;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.runtime.typeutils.BinaryStringTypeInfo;
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
+import org.apache.flink.table.runtime.typeutils.SqlTimestampTypeInfo;
 
 import java.sql.Date;
 import java.sql.Time;
@@ -367,13 +369,21 @@ public abstract class MinWithRetractAggFunction<T extends Comparable>
 	/**
 	 * Built-in Timestamp Min with retraction aggregate function.
 	 */
-	public static class TimestampMinWithRetractAggFunction extends MinWithRetractAggFunction<Timestamp> {
+	public static class TimestampMinWithRetractAggFunction extends MinWithRetractAggFunction<SqlTimestamp> {
 
 		private static final long serialVersionUID = -7494198823345305907L;
 
+		public void accumulate(MinWithRetractAccumulator<SqlTimestamp> acc, SqlTimestamp value) throws Exception {
+			super.accumulate(acc, value);
+		}
+
+		public void retract(MinWithRetractAccumulator<SqlTimestamp> acc, SqlTimestamp value) throws Exception {
+			super.retract(acc, value);
+		}
+
 		@Override
-		protected TypeInformation<Timestamp> getValueTypeInfo() {
-			return Types.SQL_TIMESTAMP;
+		protected TypeInformation<SqlTimestamp> getValueTypeInfo() {
+			return new SqlTimestampTypeInfo(3);
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunction.java
@@ -35,7 +35,6 @@ import org.apache.flink.table.runtime.typeutils.SqlTimestampTypeInfo;
 
 import java.sql.Date;
 import java.sql.Time;
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunction.java
@@ -372,6 +372,12 @@ public abstract class MinWithRetractAggFunction<T extends Comparable>
 
 		private static final long serialVersionUID = -7494198823345305907L;
 
+		private final int precision;
+
+		public TimestampMinWithRetractAggFunction(int precision) {
+			this.precision = precision;
+		}
+
 		public void accumulate(MinWithRetractAccumulator<SqlTimestamp> acc, SqlTimestamp value) throws Exception {
 			super.accumulate(acc, value);
 		}
@@ -382,7 +388,7 @@ public abstract class MinWithRetractAggFunction<T extends Comparable>
 
 		@Override
 		protected TypeInformation<SqlTimestamp> getValueTypeInfo() {
-			return new SqlTimestampTypeInfo(3);
+			return new SqlTimestampTypeInfo(precision);
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
@@ -43,8 +43,6 @@ import org.apache.calcite.sql.fun._
 import org.apache.calcite.sql.{SqlAggFunction, SqlKind, SqlRankFunction}
 import java.util
 
-import org.apache.flink.table.dataformat.SqlTimestamp
-
 import scala.collection.JavaConversions._
 
 /**
@@ -308,10 +306,9 @@ class AggFunctionFactory(
           new TimeMinWithRetractAggFunction
         case DATE =>
           new DateMinWithRetractAggFunction
-        case TIMESTAMP_WITHOUT_TIME_ZONE
-            if SqlTimestamp.isCompact(argTypes(0).asInstanceOf[TimestampType].getPrecision) =>
-          // TODO: support TimestampMinWithRetractAggFunction for high precision timestamp
-          new TimestampMinWithRetractAggFunction
+        case TIMESTAMP_WITHOUT_TIME_ZONE =>
+          val d = argTypes(0).asInstanceOf[TimestampType]
+          new TimestampMinWithRetractAggFunction(d.getPrecision)
         case t =>
           throw new TableException(s"Min with retract aggregate function does not " +
             s"support type: ''$t''.\nPlease re-check the data type.")
@@ -413,10 +410,9 @@ class AggFunctionFactory(
           new TimeMaxWithRetractAggFunction
         case DATE =>
           new DateMaxWithRetractAggFunction
-        case TIMESTAMP_WITHOUT_TIME_ZONE
-            if SqlTimestamp.isCompact(argTypes(0).asInstanceOf[TimestampType].getPrecision) =>
-          // TODO: support TimestampMaxWithRetractAggFunction for high precision timestamp
-          new TimestampMaxWithRetractAggFunction
+        case TIMESTAMP_WITHOUT_TIME_ZONE =>
+          val d = argTypes(0).asInstanceOf[TimestampType]
+          new TimestampMaxWithRetractAggFunction(d.getPrecision)
         case t =>
           throw new TableException(s"Max with retract aggregate function does not " +
             s"support type: ''$t''.\nPlease re-check the data type.")

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunctionTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunctionTest.java
@@ -43,7 +43,6 @@ import org.junit.runners.Parameterized;
 import java.lang.reflect.Method;
 import java.sql.Date;
 import java.sql.Time;
-import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunctionTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunctionTest.java
@@ -251,10 +251,10 @@ public class MaxWithRetractAggFunctionTest<T> extends AggFunctionTestBase<T, Max
 						)
 				),
 				/**
-				 * Test for TimestampMaxWithRetractAggFunction.
+				 * Test for TimestampMaxWithRetractAggFunction with millisecond's precision.
 				 */
 				new AggFunctionTestSpec<>(
-						new TimestampMaxWithRetractAggFunction(),
+						new TimestampMaxWithRetractAggFunction(3),
 						Arrays.asList(
 								Arrays.asList(
 										SqlTimestamp.fromEpochMillis(0),
@@ -279,6 +279,39 @@ public class MaxWithRetractAggFunctionTest<T> extends AggFunctionTestBase<T, Max
 								SqlTimestamp.fromEpochMillis(1000),
 								null,
 								SqlTimestamp.fromEpochMillis(1)
+						)
+				),
+				/**
+				 * Test for TimestampMaxWithRetractAggFunction with nanosecond's precision.
+				 */
+				new AggFunctionTestSpec<>(
+						new TimestampMaxWithRetractAggFunction(9),
+						Arrays.asList(
+								Arrays.asList(
+										SqlTimestamp.fromEpochMillis(0, 0),
+										SqlTimestamp.fromEpochMillis(1000, 0),
+										SqlTimestamp.fromEpochMillis(1000, 1),
+										SqlTimestamp.fromEpochMillis(100, 0),
+										null,
+										SqlTimestamp.fromEpochMillis(10, 0)
+								),
+								Arrays.asList(
+										null,
+										null,
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										SqlTimestamp.fromEpochMillis(1, 0),
+										SqlTimestamp.fromEpochMillis(1, 1)
+								)
+						),
+						Arrays.asList(
+								SqlTimestamp.fromEpochMillis(1000, 1),
+								null,
+								SqlTimestamp.fromEpochMillis(1, 1)
 						)
 				),
 				/**

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunctionTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunctionTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.functions.aggfunctions;
 
 import org.apache.flink.table.dataformat.BinaryString;
 import org.apache.flink.table.dataformat.Decimal;
+import org.apache.flink.table.dataformat.SqlTimestamp;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.planner.functions.aggfunctions.MaxWithRetractAggFunction.BooleanMaxWithRetractAggFunction;
 import org.apache.flink.table.planner.functions.aggfunctions.MaxWithRetractAggFunction.ByteMaxWithRetractAggFunction;
@@ -257,11 +258,11 @@ public class MaxWithRetractAggFunctionTest<T> extends AggFunctionTestBase<T, Max
 						new TimestampMaxWithRetractAggFunction(),
 						Arrays.asList(
 								Arrays.asList(
-										new Timestamp(0),
-										new Timestamp(1000),
-										new Timestamp(100),
+										SqlTimestamp.fromEpochMillis(0),
+										SqlTimestamp.fromEpochMillis(1000),
+										SqlTimestamp.fromEpochMillis(100),
 										null,
-										new Timestamp(10)
+										SqlTimestamp.fromEpochMillis(10)
 								),
 								Arrays.asList(
 										null,
@@ -272,13 +273,13 @@ public class MaxWithRetractAggFunctionTest<T> extends AggFunctionTestBase<T, Max
 								),
 								Arrays.asList(
 										null,
-										new Timestamp(1)
+										SqlTimestamp.fromEpochMillis(1)
 								)
 						),
 						Arrays.asList(
-								new Timestamp(1000),
+								SqlTimestamp.fromEpochMillis(1000),
 								null,
-								new Timestamp(1)
+								SqlTimestamp.fromEpochMillis(1)
 						)
 				),
 				/**

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunctionTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunctionTest.java
@@ -43,7 +43,6 @@ import org.junit.runners.Parameterized;
 import java.lang.reflect.Method;
 import java.sql.Date;
 import java.sql.Time;
-import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunctionTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunctionTest.java
@@ -251,10 +251,10 @@ public class MinWithRetractAggFunctionTest<T> extends AggFunctionTestBase<T, Min
 						)
 				),
 				/**
-				 * Test for TimestampMinWithRetractAggFunction.
+				 * Test for TimestampMinWithRetractAggFunction with millisecond's precision.
 				 */
 				new AggFunctionTestSpec<>(
-						new TimestampMinWithRetractAggFunction(),
+						new TimestampMinWithRetractAggFunction(3),
 						Arrays.asList(
 								Arrays.asList(
 										SqlTimestamp.fromEpochMillis(0),
@@ -281,6 +281,40 @@ public class MinWithRetractAggFunctionTest<T> extends AggFunctionTestBase<T, Min
 								SqlTimestamp.fromEpochMillis(1)
 						)
 				),
+				/**
+				 * Test for TimestampMinWithRetractAggFunction with nanosecond's precision.
+				 */
+				new AggFunctionTestSpec<>(
+						new TimestampMinWithRetractAggFunction(9),
+						Arrays.asList(
+								Arrays.asList(
+										SqlTimestamp.fromEpochMillis(0, 1),
+										SqlTimestamp.fromEpochMillis(0, 2),
+										SqlTimestamp.fromEpochMillis(1000, 0),
+										SqlTimestamp.fromEpochMillis(100, 0),
+										null,
+										SqlTimestamp.fromEpochMillis(10, 0)
+								),
+								Arrays.asList(
+										null,
+										null,
+										null,
+										null,
+										null
+								),
+								Arrays.asList(
+										null,
+										SqlTimestamp.fromEpochMillis(1, 1),
+										SqlTimestamp.fromEpochMillis(1, 2)
+								)
+						),
+						Arrays.asList(
+								SqlTimestamp.fromEpochMillis(0, 1),
+								null,
+								SqlTimestamp.fromEpochMillis(1, 1)
+						)
+				),
+
 				/**
 				 * Test for DateMinWithRetractAggFunction.
 				 */

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunctionTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunctionTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.functions.aggfunctions;
 
 import org.apache.flink.table.dataformat.BinaryString;
 import org.apache.flink.table.dataformat.Decimal;
+import org.apache.flink.table.dataformat.SqlTimestamp;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.planner.functions.aggfunctions.MinWithRetractAggFunction.BooleanMinWithRetractAggFunction;
 import org.apache.flink.table.planner.functions.aggfunctions.MinWithRetractAggFunction.ByteMinWithRetractAggFunction;
@@ -257,11 +258,11 @@ public class MinWithRetractAggFunctionTest<T> extends AggFunctionTestBase<T, Min
 						new TimestampMinWithRetractAggFunction(),
 						Arrays.asList(
 								Arrays.asList(
-										new Timestamp(0),
-										new Timestamp(1000),
-										new Timestamp(100),
+										SqlTimestamp.fromEpochMillis(0),
+										SqlTimestamp.fromEpochMillis(1000),
+										SqlTimestamp.fromEpochMillis(100),
 										null,
-										new Timestamp(10)
+										SqlTimestamp.fromEpochMillis(10)
 								),
 								Arrays.asList(
 										null,
@@ -272,13 +273,13 @@ public class MinWithRetractAggFunctionTest<T> extends AggFunctionTestBase<T, Min
 								),
 								Arrays.asList(
 										null,
-										new Timestamp(1)
+										SqlTimestamp.fromEpochMillis(1)
 								)
 						),
 						Arrays.asList(
-								new Timestamp(0),
+								SqlTimestamp.fromEpochMillis(0),
 								null,
-								new Timestamp(1)
+								SqlTimestamp.fromEpochMillis(1)
 						)
 				),
 				/**

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TimestampITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TimestampITCase.scala
@@ -172,4 +172,25 @@ class TimestampITCase extends StreamingTestBase{
     )
     assertEquals(expected.sorted, sink.getRetractResults.sorted)
   }
+
+  @Test
+  def testMaxMinWithRetractOnTimestamp(): Unit = {
+    val sink = new TestingRetractSink()
+    tEnv.sqlQuery(
+      s"""
+         |SELECT MAX(y), MIN(x)
+         |FROM
+         |  (SELECT b, MAX(c) AS x, MIN(c) AS y FROM T GROUP BY b, c)
+         |GROUP BY b
+       """.stripMargin)
+      .toRetractStream[Row].addSink(sink)
+    env.execute()
+    val expected = Seq(
+      "1969-01-01T00:00:00.123456789,1969-01-01T00:00:00.123456789",
+      "1970-01-01T00:00:00.123,1970-01-01T00:00:00.123",
+      "1970-01-01T00:00:00.123456,1970-01-01T00:00:00.123456",
+      "null,null"
+    )
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
@@ -38,6 +38,7 @@ import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 import org.apache.flink.table.runtime.typeutils.LegacyInstantTypeInfo;
 import org.apache.flink.table.runtime.typeutils.LegacyLocalDateTimeTypeInfo;
 import org.apache.flink.table.runtime.typeutils.LegacyTimestampTypeInfo;
+import org.apache.flink.table.runtime.typeutils.SqlTimestampTypeInfo;
 import org.apache.flink.table.types.CollectionDataType;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.KeyValueDataType;
@@ -255,6 +256,9 @@ public class DataFormatConverters {
 				} else if (typeInfo instanceof BigDecimalTypeInfo) {
 					BigDecimalTypeInfo decimalType = (BigDecimalTypeInfo) typeInfo;
 					return new BigDecimalConverter(decimalType.precision(), decimalType.scale());
+				} else if (typeInfo instanceof SqlTimestampTypeInfo) {
+					SqlTimestampTypeInfo sqlTimestampTypeInfo = (SqlTimestampTypeInfo) typeInfo;
+					return new SqlTimestampConverter(sqlTimestampTypeInfo.getPrecision());
 				} else if (typeInfo instanceof LegacyLocalDateTimeTypeInfo) {
 					LegacyLocalDateTimeTypeInfo dateTimeType = (LegacyLocalDateTimeTypeInfo) typeInfo;
 					return new LocalDateTimeConverter(dateTimeType.getPrecision());

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/LogicalTypeDataTypeConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/LogicalTypeDataTypeConverter.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 import org.apache.flink.table.runtime.typeutils.LegacyInstantTypeInfo;
 import org.apache.flink.table.runtime.typeutils.LegacyLocalDateTimeTypeInfo;
 import org.apache.flink.table.runtime.typeutils.LegacyTimestampTypeInfo;
+import org.apache.flink.table.runtime.typeutils.SqlTimestampTypeInfo;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.DecimalType;
@@ -103,6 +104,9 @@ public class LogicalTypeDataTypeConverter {
 				} else if (typeInfo instanceof BigDecimalTypeInfo) {
 					BigDecimalTypeInfo decimalType = (BigDecimalTypeInfo) typeInfo;
 					return new DecimalType(decimalType.precision(), decimalType.scale());
+				} else if (typeInfo instanceof SqlTimestampTypeInfo) {
+					SqlTimestampTypeInfo sqlTimestampTypeInfo = (SqlTimestampTypeInfo) typeInfo;
+					return new TimestampType(sqlTimestampTypeInfo.getPrecision());
 				} else if (typeInfo instanceof LegacyLocalDateTimeTypeInfo) {
 					LegacyLocalDateTimeTypeInfo dateTimeType = (LegacyLocalDateTimeTypeInfo) typeInfo;
 					return new TimestampType(dateTimeType.getPrecision());


### PR DESCRIPTION
…ampMinAggFunction to accept SqlTimestamp values

## What is the purpose of the change

The `MaxWithRetractAggFunction`/`MinWithRetractAggFunction` in blink planner not support "accumulate(acc, Object value)" generic object with third-part data formats. We only support internal/external format in this usage. In this PR, we use SqlTimestamp(the internal format of TimestampType) in `TimestampMaxAggFunction`/`TimestampMinAggFunction` to fix the `ClassCastException`

## Brief change log
- 5a8613d use SqlTimestamp in `TimestampMaxAggFunction` and `TimestampMinAggFunction`

## Verifying this change

This change added tests 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
