### PR TITLE
[FLINK-15421][table-planner-blink] Fix TimestampMaxAggFunction/TimestampMinAggFunction to accept LocalDateTime values

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunction.java
@@ -33,7 +33,7 @@ import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 
 import java.sql.Date;
 import java.sql.Time;
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -367,13 +367,13 @@ public abstract class MaxWithRetractAggFunction<T extends Comparable>
 	/**
 	 * Built-in Timestamp Max with retraction aggregate function.
 	 */
-	public static class TimestampMaxWithRetractAggFunction extends MaxWithRetractAggFunction<Timestamp> {
+	public static class TimestampMaxWithRetractAggFunction extends MaxWithRetractAggFunction<LocalDateTime> {
 
 		private static final long serialVersionUID = -7096481949093142944L;
 
 		@Override
-		protected TypeInformation<Timestamp> getValueTypeInfo() {
-			return Types.SQL_TIMESTAMP;
+		protected TypeInformation<LocalDateTime> getValueTypeInfo() {
+			return Types.LOCAL_DATE_TIME;
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunction.java
@@ -33,7 +33,7 @@ import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
 
 import java.sql.Date;
 import java.sql.Time;
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -367,13 +367,13 @@ public abstract class MinWithRetractAggFunction<T extends Comparable>
 	/**
 	 * Built-in Timestamp Min with retraction aggregate function.
 	 */
-	public static class TimestampMinWithRetractAggFunction extends MinWithRetractAggFunction<Timestamp> {
+	public static class TimestampMinWithRetractAggFunction extends MinWithRetractAggFunction<LocalDateTime> {
 
 		private static final long serialVersionUID = -7494198823345305907L;
 
 		@Override
-		protected TypeInformation<Timestamp> getValueTypeInfo() {
-			return Types.SQL_TIMESTAMP;
+		protected TypeInformation<LocalDateTime> getValueTypeInfo() {
+			return Types.LOCAL_DATE_TIME;
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunctionTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunctionTest.java
@@ -40,6 +40,8 @@ import java.lang.reflect.Method;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
 
@@ -433,17 +435,17 @@ public abstract class MaxWithRetractAggFunctionTest<T> extends AggFunctionTestBa
 	/**
 	 * Test for TimestampMaxWithRetractAggFunction.
 	 */
-	public static class TimestampMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest<Timestamp> {
+	public static class TimestampMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest<LocalDateTime> {
 
 		@Override
-		protected List<List<Timestamp>> getInputValueSets() {
+		protected List<List<LocalDateTime>> getInputValueSets() {
 			return Arrays.asList(
 					Arrays.asList(
-							new Timestamp(0),
-							new Timestamp(1000),
-							new Timestamp(100),
+							new Timestamp(0).toLocalDateTime(),
+							new Timestamp(1000).toLocalDateTime(),
+							new Timestamp(100).toLocalDateTime(),
 							null,
-							new Timestamp(10)
+							new Timestamp(10).toLocalDateTime()
 					),
 					Arrays.asList(
 							null,
@@ -454,22 +456,22 @@ public abstract class MaxWithRetractAggFunctionTest<T> extends AggFunctionTestBa
 					),
 					Arrays.asList(
 							null,
-							new Timestamp(1)
+							new Timestamp(1).toLocalDateTime()
 					)
 			);
 		}
 
 		@Override
-		protected List<Timestamp> getExpectedResults() {
+		protected List<LocalDateTime> getExpectedResults() {
 			return Arrays.asList(
-					new Timestamp(1000),
+					new Timestamp(1000).toLocalDateTime(),
 					null,
-					new Timestamp(1)
+					new Timestamp(1).toLocalDateTime()
 			);
 		}
 
 		@Override
-		protected AggregateFunction<Timestamp, MaxWithRetractAccumulator<Timestamp>> getAggregator() {
+		protected AggregateFunction<LocalDateTime, MaxWithRetractAccumulator<LocalDateTime>> getAggregator() {
 			return new TimestampMaxWithRetractAggFunction();
 		}
 	}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunctionTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunctionTest.java
@@ -41,7 +41,6 @@ import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunctionTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunctionTest.java
@@ -40,6 +40,7 @@ import java.lang.reflect.Method;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
@@ -425,17 +426,17 @@ public abstract class MinWithRetractAggFunctionTest<T> extends AggFunctionTestBa
 	 * Test for TimestampMinWithRetractAggFunction.
 	 */
 	public static class TimestampMinWithRetractAggFunctionTest
-			extends MinWithRetractAggFunctionTest<Timestamp> {
+			extends MinWithRetractAggFunctionTest<LocalDateTime> {
 
 		@Override
-		protected List<List<Timestamp>> getInputValueSets() {
+		protected List<List<LocalDateTime>> getInputValueSets() {
 			return Arrays.asList(
 					Arrays.asList(
-							new Timestamp(0),
-							new Timestamp(1000),
-							new Timestamp(100),
+							new Timestamp(0).toLocalDateTime(),
+							new Timestamp(1000).toLocalDateTime(),
+							new Timestamp(100).toLocalDateTime(),
 							null,
-							new Timestamp(10)
+							new Timestamp(10).toLocalDateTime()
 					),
 					Arrays.asList(
 							null,
@@ -446,22 +447,22 @@ public abstract class MinWithRetractAggFunctionTest<T> extends AggFunctionTestBa
 					),
 					Arrays.asList(
 							null,
-							new Timestamp(1)
+							new Timestamp(1).toLocalDateTime()
 					)
 			);
 		}
 
 		@Override
-		protected List<Timestamp> getExpectedResults() {
+		protected List<LocalDateTime> getExpectedResults() {
 			return Arrays.asList(
-					new Timestamp(0),
+					new Timestamp(0).toLocalDateTime(),
 					null,
-					new Timestamp(1)
+					new Timestamp(1).toLocalDateTime()
 			);
 		}
 
 		@Override
-		protected AggregateFunction<Timestamp, MinWithRetractAccumulator<Timestamp>> getAggregator() {
+		protected AggregateFunction<LocalDateTime, MinWithRetractAccumulator<LocalDateTime>> getAggregator() {
 			return new TimestampMinWithRetractAggFunction();
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

The MaxWithRetractAggFunction/MinWithRetractAggFunction in blink planner not support "accumulate(acc, Object value)" generic object with third-part data formats. We only support internal/external format in this usage. In this PR, we use LocalDateTime(the default external format of TimestampType) in TimestampMaxAggFunction/TimestampMinAggFunction to fix the ClassCastException. This PR **only fix release 1.9**. For release 1.10 or above, see https://github.com/apache/flink/pull/10722

## Brief change log

- b0bd11c use LocalDateTime in `TimestampMaxAggFunction` and `TimestampMinAggFunction`

## Verifying this change

This change added tests 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
