### PR TITLE
[FLINK-13595][connector/kafka][test] Close the KafkaAdminClient with ...

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironment.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironment.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -200,5 +201,16 @@ public abstract class KafkaTestEnvironment {
 		NetworkFailuresProxy proxy = new NetworkFailuresProxy(0, remoteHost, remotePort);
 		networkFailuresProxies.add(proxy);
 		return proxy;
+	}
+
+	protected void maybePrintDanglingThreadStacktrace(String threadNameKeyword) {
+		for (Map.Entry<Thread, StackTraceElement[]> threadEntry : Thread.getAllStackTraces().entrySet()) {
+			if (threadEntry.getKey().getName().contains(threadNameKeyword)) {
+				System.out.println("Dangling thread found:");
+				for (StackTraceElement ste : threadEntry.getValue()) {
+					System.out.println(ste);
+				}
+			}
+		}
 	}
 }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
@@ -155,13 +155,14 @@ public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
 		String clientId = Long.toString(new Random().nextLong());
 		props.put("client.id", clientId);
 		AdminClient adminClient = AdminClient.create(props);
+		// We do not use a try-catch clause here so we can apply a timeout to the admin client closure.
 		try {
 			tryDelete(adminClient, topic);
 		} catch (Exception e) {
 			e.printStackTrace();
 			fail(String.format("Delete test topic : %s failed, %s", topic, e.getMessage()));
 		} finally {
-			adminClient.close(Duration.ofMillis(30000L));
+			adminClient.close(Duration.ofMillis(5000L));
 			maybePrintDanglingThreadStacktrace(clientId);
 		}
 	}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.BindException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -57,6 +58,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -148,11 +150,19 @@ public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
 	@Override
 	public void deleteTestTopic(String topic) {
 		LOG.info("Deleting topic {}", topic);
-		try (AdminClient adminClient = AdminClient.create(getStandardProperties())) {
+		Properties props = getSecureProperties();
+		props.putAll(getStandardProperties());
+		String clientId = Long.toString(new Random().nextLong());
+		props.put("client.id", clientId);
+		AdminClient adminClient = AdminClient.create(props);
+		try {
 			tryDelete(adminClient, topic);
 		} catch (Exception e) {
 			e.printStackTrace();
 			fail(String.format("Delete test topic : %s failed, %s", topic, e.getMessage()));
+		} finally {
+			adminClient.close(Duration.ofMillis(30000L));
+			maybePrintDanglingThreadStacktrace(clientId);
 		}
 	}
 


### PR DESCRIPTION
…a timeout. Print stacktrace if a long closure happens.

## What is the purpose of the change
Fix the test failure caused by long closing time of the the `KafkaAdminClient`.

## Brief change log
Use the `close(Duration)` method in `KafkaAdminClient` with a timeout. It looks that this does not guarantee the timeout will be honored due to the bug in `KafkaAdminClient`. Therefore we also print the stacktrace of the dangling `KafkaAdminClient` thread in case this happens again. 

## Verifying this change

This change is already covered by existing tests that delete Kafka topics.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
