### PR TITLE
[FLINK-15420][table-planner-blink] Cast string to timestamp will loos…

### DIFF
--- a/flink-python/pyflink/table/tests/test_udf.py
+++ b/flink-python/pyflink/table/tests/test_udf.py
@@ -212,7 +212,7 @@ class UserDefinedFunctionTests(object):
                              "'flink',"
                              "cast ('2014-09-13' as DATE),"
                              "cast ('12:00:00' as TIME),"
-                             "cast ('1999-09-10 05:20:10' as TIMESTAMP))"
+                             "cast ('1999-9-10 05:20:10' as TIMESTAMP))"
                              " from test_table").insert_into("Results")
         self.t_env.execute("test")
         actual = source_sink_utils.results()

--- a/flink-python/pyflink/table/tests/test_udf.py
+++ b/flink-python/pyflink/table/tests/test_udf.py
@@ -212,7 +212,7 @@ class UserDefinedFunctionTests(object):
                              "'flink',"
                              "cast ('2014-09-13' as DATE),"
                              "cast ('12:00:00' as TIME),"
-                             "cast ('1999-9-10 05:20:10' as TIMESTAMP))"
+                             "cast ('1999-09-10 05:20:10' as TIMESTAMP))"
                              " from test_table").insert_into("Results")
         self.t_env.execute("test")
         actual = source_sink_utils.results()

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1030,8 +1030,7 @@ object ScalarOperatorGens {
         resultNullable = true) {
         operandTerm =>
           s"""
-             |$SQL_TIMESTAMP.fromEpochMillis(
-             | ${qualifyMethod(BuiltInMethod.STRING_TO_TIMESTAMP.method)}($operandTerm.toString()))
+             |${qualifyMethod(BuiltInMethods.STRING_TO_TIMESTAMP)}($operandTerm.toString())
            """.stripMargin
       }
 
@@ -2282,8 +2281,7 @@ object ScalarOperatorGens {
         s"${qualifyMethod(BuiltInMethods.STRING_TO_TIME)}($operandTerm.toString())"
       case TIMESTAMP_WITHOUT_TIME_ZONE =>
         s"""
-           |${SQL_TIMESTAMP}.fromEpochMillis(
-           |  ${qualifyMethod(BuiltInMethod.STRING_TO_TIMESTAMP.method)}($operandTerm.toString()))
+           |${qualifyMethod(BuiltInMethods.STRING_TO_TIMESTAMP)}($operandTerm.toString())
            |""".stripMargin
       case _ => throw new UnsupportedOperationException
     }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -115,6 +115,11 @@ class TemporalTypesTest extends ExpressionTestBase {
     testSqlApi(
       "CAST('1500-04-30 12:00:00.123456789' AS TIMESTAMP)",
       "1500-04-30 12:00:00.123456")
+
+    testSqlApi(
+      "CAST('1999-9-10 05:20:10.123456' AS TIMESTAMP)",
+      "1999-09-10 05:20:10.123456"
+    )
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -106,6 +106,15 @@ class TemporalTypesTest extends ExpressionTestBase {
     testSqlApi(
       "TIMESTAMP '1500-04-30 12:00:00.1234'",
       "1500-04-30 12:00:00.1234")
+
+    testSqlApi(
+      "CAST('1500-04-30 12:00:00.123456789' AS TIMESTAMP(9))",
+      "1500-04-30 12:00:00.123456789")
+
+    // by default, it's TIMESTAMP(6)
+    testSqlApi(
+      "CAST('1500-04-30 12:00:00.123456789' AS TIMESTAMP)",
+      "1500-04-30 12:00:00.123456")
   }
 
   @Test

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
@@ -253,7 +254,13 @@ public class SqlDateTimeUtils {
 				return SqlTimestamp.fromLocalDateTime(ldt);
 			}
 		} catch (DateTimeParseException e) {
-			return null;
+			// fall back to support cases like '1999-9-10 05:20:10'
+			try {
+				Timestamp ts = Timestamp.valueOf(dateStr);
+				return SqlTimestamp.fromTimestamp(ts);
+			} catch (IllegalArgumentException ie) {
+				return null;
+			}
 		}
 	}
 


### PR DESCRIPTION
…e precision


## What is the purpose of the change

Now Casting string to timestamp in blink planner only support millisecond's precision. For example: 
`cast('2010-10-14 12:22:22.123456' as timestamp(9))` returns '2010-10-14 12:22:22.123'. This is a bug and this PR fix it.

## Brief change log

- 9bbb283 let casting string to timestamp support nanosecond's precision.

## Verifying this change

This change added tests 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
