### PR TITLE
[FLINK-15437][yarn] Apply dynamic properties early on client side.

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnConfigKeys.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnConfigKeys.java
@@ -33,7 +33,6 @@ public class YarnConfigKeys {
 	public static final String ENV_CLIENT_HOME_DIR = "_CLIENT_HOME_DIR";
 	public static final String ENV_CLIENT_SHIP_FILES = "_CLIENT_SHIP_FILES";
 	public static final String ENV_SLOTS = "_SLOTS";
-	public static final String ENV_DYNAMIC_PROPERTIES = "_DYNAMIC_PROPERTIES";
 
 	public static final String ENV_FLINK_CLASSPATH = "_FLINK_CLASSPATH";
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -156,6 +156,9 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 
 	private final ClusterClientServiceLoader clusterClientServiceLoader;
 
+	@Nullable
+	private String dynamicPropertiesEncoded = null;
+
 	public FlinkYarnSessionCli(
 			Configuration configuration,
 			String configurationDirectory,
@@ -403,7 +406,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 			configuration.setString(YarnConfigOptions.APPLICATION_QUEUE, queueName);
 		}
 
-		final String dynamicPropertiesEncoded = encodeDynamicProperties(commandLine);
+		dynamicPropertiesEncoded = encodeDynamicProperties(commandLine);
 		if (dynamicPropertiesEncoded != null && !dynamicPropertiesEncoded.isEmpty()) {
 			configuration.setString(YarnConfigOptionsInternal.DYNAMIC_PROPERTIES, dynamicPropertiesEncoded);
 		}
@@ -568,7 +571,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 						writeYarnPropertiesFile(
 							yarnApplicationId,
 							clusterSpecification.getNumberTaskManagers() * clusterSpecification.getSlotsPerTaskManager(),
-							yarnClusterDescriptor.getDynamicPropertiesEncoded());
+							dynamicPropertiesEncoded);
 					} catch (Exception e) {
 						try {
 							clusterClient.close();

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -372,6 +372,14 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 			effectiveConfiguration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, Integer.parseInt(commandLine.getOptionValue(slots.getOpt())));
 		}
 
+		dynamicPropertiesEncoded = encodeDynamicProperties(commandLine);
+		if (!dynamicPropertiesEncoded.isEmpty()) {
+			Map<String, String> dynProperties = getDynamicProperties(dynamicPropertiesEncoded);
+			for (Map.Entry<String, String> dynProperty : dynProperties.entrySet()) {
+				effectiveConfiguration.setString(dynProperty.getKey(), dynProperty.getValue());
+			}
+		}
+
 		if (isYarnPropertiesFileMode(commandLine)) {
 			return applyYarnProperties(effectiveConfiguration);
 		} else {
@@ -404,11 +412,6 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 		if (commandLine.hasOption(queue.getOpt())) {
 			final String queueName = commandLine.getOptionValue(queue.getOpt());
 			configuration.setString(YarnConfigOptions.APPLICATION_QUEUE, queueName);
-		}
-
-		dynamicPropertiesEncoded = encodeDynamicProperties(commandLine);
-		if (dynamicPropertiesEncoded != null && !dynamicPropertiesEncoded.isEmpty()) {
-			configuration.setString(YarnConfigOptionsInternal.DYNAMIC_PROPERTIES, dynamicPropertiesEncoded);
 		}
 
 		final boolean detached = commandLine.hasOption(YARN_DETACHED_OPTION.getOpt()) || commandLine.hasOption(DETACHED_OPTION.getOpt());

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptionsInternal.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptionsInternal.java
@@ -29,12 +29,6 @@ import static org.apache.flink.configuration.ConfigOptions.key;
 @Internal
 public class YarnConfigOptionsInternal {
 
-	public static final ConfigOption<String> DYNAMIC_PROPERTIES =
-			key("$internal.yarn.dynamic-properties")
-					.stringType()
-					.noDefaultValue()
-					.withDescription("**DO NOT USE** Specify YARN dynamic properties.");
-
 	public static final ConfigOption<String> APPLICATION_LOG_CONFIG_FILE =
 			key("$internal.yarn.log-config-file")
 					.stringType()

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
@@ -51,8 +51,7 @@ import java.util.Map;
 public class YarnEntrypointUtils {
 
 	public static SecurityContext installSecurityContext(
-			Configuration configuration,
-			String workingDirectory) throws Exception {
+			Configuration configuration) throws Exception {
 
 		SecurityConfiguration sc = new SecurityConfiguration(configuration);
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
@@ -34,7 +34,6 @@ import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.yarn.Utils;
 import org.apache.flink.yarn.YarnConfigKeys;
-import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
 
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
@@ -67,9 +66,6 @@ public class YarnEntrypointUtils {
 
 		final String zooKeeperNamespace = env.get(YarnConfigKeys.ENV_ZOOKEEPER_NAMESPACE);
 
-		final Map<String, String> dynamicProperties = FlinkYarnSessionCli.getDynamicProperties(
-			env.get(YarnConfigKeys.ENV_DYNAMIC_PROPERTIES));
-
 		final String hostname = env.get(ApplicationConstants.Environment.NM_HOST.key());
 		Preconditions.checkState(
 			hostname != null,
@@ -83,10 +79,6 @@ public class YarnEntrypointUtils {
 //		final String portRange = configuration.getString(
 //			ConfigConstants.YARN_APPLICATION_MASTER_PORT,
 //			ConfigConstants.DEFAULT_YARN_JOB_MANAGER_PORT);
-
-		for (Map.Entry<String, String> property : dynamicProperties.entrySet()) {
-			configuration.setString(property.getKey(), property.getValue());
-		}
 
 		if (zooKeeperNamespace != null) {
 			configuration.setString(HighAvailabilityOptions.HA_CLUSTER_ID, zooKeeperNamespace);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
@@ -60,7 +60,7 @@ public class YarnEntrypointUtils {
 		return SecurityUtils.getInstalledContext();
 	}
 
-	public static Configuration loadConfiguration(String workingDirectory, Map<String, String> env, Logger log) {
+	public static Configuration loadConfiguration(String workingDirectory, Map<String, String> env) {
 		Configuration configuration = GlobalConfiguration.loadConfiguration(workingDirectory);
 
 		final String remoteKeytabPrincipal = env.get(YarnConfigKeys.KEYTAB_PRINCIPAL);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypoint.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypoint.java
@@ -47,19 +47,15 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 public class YarnJobClusterEntrypoint extends JobClusterEntrypoint {
 
-	private final String workingDirectory;
-
 	public YarnJobClusterEntrypoint(
-			Configuration configuration,
-			String workingDirectory) {
+		Configuration configuration) {
 
 		super(configuration);
-		this.workingDirectory = Preconditions.checkNotNull(workingDirectory);
 	}
 
 	@Override
 	protected SecurityContext installSecurityContext(Configuration configuration) throws Exception {
-		return YarnEntrypointUtils.installSecurityContext(configuration, workingDirectory);
+		return YarnEntrypointUtils.installSecurityContext(configuration);
 	}
 
 	@Override
@@ -118,8 +114,7 @@ public class YarnJobClusterEntrypoint extends JobClusterEntrypoint {
 		Configuration configuration = YarnEntrypointUtils.loadConfiguration(workingDirectory, env, LOG);
 
 		YarnJobClusterEntrypoint yarnJobClusterEntrypoint = new YarnJobClusterEntrypoint(
-			configuration,
-			workingDirectory);
+			configuration);
 
 		ClusterEntrypoint.runClusterEntrypoint(yarnJobClusterEntrypoint);
 	}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypoint.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypoint.java
@@ -111,7 +111,7 @@ public class YarnJobClusterEntrypoint extends JobClusterEntrypoint {
 			LOG.warn("Could not log YARN environment information.", e);
 		}
 
-		Configuration configuration = YarnEntrypointUtils.loadConfiguration(workingDirectory, env, LOG);
+		Configuration configuration = YarnEntrypointUtils.loadConfiguration(workingDirectory, env);
 
 		YarnJobClusterEntrypoint yarnJobClusterEntrypoint = new YarnJobClusterEntrypoint(
 			configuration);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnSessionClusterEntrypoint.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnSessionClusterEntrypoint.java
@@ -40,18 +40,14 @@ import java.util.Map;
  */
 public class YarnSessionClusterEntrypoint extends SessionClusterEntrypoint {
 
-	private final String workingDirectory;
-
 	public YarnSessionClusterEntrypoint(
-			Configuration configuration,
-			String workingDirectory) {
+		Configuration configuration) {
 		super(configuration);
-		this.workingDirectory = Preconditions.checkNotNull(workingDirectory);
 	}
 
 	@Override
 	protected SecurityContext installSecurityContext(Configuration configuration) throws Exception {
-		return YarnEntrypointUtils.installSecurityContext(configuration, workingDirectory);
+		return YarnEntrypointUtils.installSecurityContext(configuration);
 	}
 
 	@Override
@@ -86,9 +82,7 @@ public class YarnSessionClusterEntrypoint extends SessionClusterEntrypoint {
 
 		Configuration configuration = YarnEntrypointUtils.loadConfiguration(workingDirectory, env, LOG);
 
-		YarnSessionClusterEntrypoint yarnSessionClusterEntrypoint = new YarnSessionClusterEntrypoint(
-			configuration,
-			workingDirectory);
+		YarnSessionClusterEntrypoint yarnSessionClusterEntrypoint = new YarnSessionClusterEntrypoint(configuration);
 
 		ClusterEntrypoint.runClusterEntrypoint(yarnSessionClusterEntrypoint);
 	}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnSessionClusterEntrypoint.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnSessionClusterEntrypoint.java
@@ -80,7 +80,7 @@ public class YarnSessionClusterEntrypoint extends SessionClusterEntrypoint {
 			LOG.warn("Could not log YARN environment information.", e);
 		}
 
-		Configuration configuration = YarnEntrypointUtils.loadConfiguration(workingDirectory, env, LOG);
+		Configuration configuration = YarnEntrypointUtils.loadConfiguration(workingDirectory, env);
 
 		YarnSessionClusterEntrypoint yarnSessionClusterEntrypoint = new YarnSessionClusterEntrypoint(configuration);
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtilsTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtilsTest.java
@@ -27,8 +27,6 @@ import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
@@ -45,8 +43,6 @@ import static org.junit.Assert.assertThat;
  * Tests for the {@link YarnEntrypointUtils}.
  */
 public class YarnEntrypointUtilsTest extends TestLogger {
-
-	private static final Logger LOG = LoggerFactory.getLogger(YarnEntrypointUtilsTest.class);
 
 	@ClassRule
 	public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
@@ -104,7 +100,7 @@ public class YarnEntrypointUtilsTest extends TestLogger {
 		env.put(ApplicationConstants.Environment.NM_HOST.key(), "foobar");
 
 		BootstrapTools.writeConfiguration(initialConfiguration, new File(workingDirectory, "flink-conf.yaml"));
-		return YarnEntrypointUtils.loadConfiguration(workingDirectory.getAbsolutePath(), env, LOG);
+		return YarnEntrypointUtils.loadConfiguration(workingDirectory.getAbsolutePath(), env);
 	}
 
 }

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypointTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypointTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.yarn.entrypoint;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.util.FileUtils;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
 import org.junit.Test;
@@ -39,7 +38,7 @@ public class YarnJobClusterEntrypointTest {
 	public void testCreateDispatcherResourceManagerComponentFactoryFailIfUsrLibDirDoesNotExist() throws IOException {
 		final Configuration configuration = new Configuration();
 		configuration.setString(YarnConfigOptions.CLASSPATH_INCLUDE_USER_JAR, YarnConfigOptions.UserJarInclusion.DISABLED.toString());
-		final YarnJobClusterEntrypoint yarnJobClusterEntrypoint = new YarnJobClusterEntrypoint(configuration, FileUtils.getCurrentWorkingDirectory().toString());
+		final YarnJobClusterEntrypoint yarnJobClusterEntrypoint = new YarnJobClusterEntrypoint(configuration);
 		try {
 			yarnJobClusterEntrypoint.createDispatcherResourceManagerComponentFactory(configuration);
 			fail();


### PR DESCRIPTION
## What is the purpose of the change

This PR applies dynamic properties early on client side, to make sure the client uses the correct configurations set via dynamic properties.

## Brief change log

- 475b6421a1d94a5073e177d217311d9f195307cd: Write yarn properties file without `YarnClusterDescriptor`.
- 322a65907fc3ee936a1ceca930e5427b235e6dc4: Apply dynamic properties early on client side.

## Verifying this change

- Updated `FlinkYarnSessionCliTest#testDynamicProperties`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
