### PR TITLE
[FLINK-15386] Fix logic error in SingleJobSubmittedJobGraphStore.putJobGraph and add unit tests

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SingleJobSubmittedJobGraphStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SingleJobSubmittedJobGraphStore.java
@@ -60,7 +60,7 @@ public class SingleJobSubmittedJobGraphStore implements SubmittedJobGraphStore {
 
 	@Override
 	public void putJobGraph(SubmittedJobGraph jobGraph) throws Exception {
-		if (!jobGraph.getJobId().equals(jobGraph.getJobId())) {
+		if (!this.jobGraph.getJobID().equals(jobGraph.getJobId())) {
 			throw new FlinkException("Cannot put additional jobs into this submitted job graph store.");
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/SingleJobSubmittedJobGraphStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/SingleJobSubmittedJobGraphStoreTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmanager.SubmittedJobGraph;
+import org.apache.flink.util.FlinkException;
+
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test {@link SingleJobSubmittedJobGraphStore} functionality.
+ */
+public class SingleJobSubmittedJobGraphStoreTest {
+
+	@Rule public ExpectedException expectedException = ExpectedException.none();
+
+	private static SingleJobSubmittedJobGraphStore singleJobSubmittedJobGraphStore;
+	private static JobID thisJobID;
+	private static JobGraph thisJobGraph;
+	private static JobID otherJobID;
+
+	@BeforeClass
+	public static void init() {
+		thisJobID = new JobID(100, 100);
+		otherJobID = new JobID(999, 999);
+
+		thisJobGraph = new JobGraph(thisJobID, "thisJobGraph");
+		singleJobSubmittedJobGraphStore = new SingleJobSubmittedJobGraphStore(thisJobGraph);
+	}
+
+	@Test
+	public void testPutJobGraph() throws Exception {
+		assertEquals(1, singleJobSubmittedJobGraphStore.getJobIds().size());
+
+		SubmittedJobGraph otherSubmittedJobGraph = new SubmittedJobGraph(new JobGraph(otherJobID, "otherJobGraph"));
+		//no-op
+		singleJobSubmittedJobGraphStore.putJobGraph(new SubmittedJobGraph(thisJobGraph));
+
+		expectedException.expect(FlinkException.class);
+		singleJobSubmittedJobGraphStore.putJobGraph(otherSubmittedJobGraph);
+	}
+
+	@Test
+	public void testRecoverJobGraph() throws Exception {
+		SubmittedJobGraph submittedJobGraph = singleJobSubmittedJobGraphStore.recoverJobGraph(thisJobID);
+
+		assertEquals(1, singleJobSubmittedJobGraphStore.getJobIds().size());
+		assertEquals(submittedJobGraph.getJobId(), thisJobID);
+
+		expectedException.expect(FlinkException.class);
+		singleJobSubmittedJobGraphStore.recoverJobGraph(otherJobID);
+	}
+
+	@Test
+	public void testRemoveJobGraph() {
+		assertEquals(1, singleJobSubmittedJobGraphStore.getJobIds().size());
+		//no-op
+		singleJobSubmittedJobGraphStore.removeJobGraph(thisJobID);
+		assertEquals(1, singleJobSubmittedJobGraphStore.getJobIds().size());
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull requests fixes a minor error in  SingleJobSubmittedJobGraphStore `putJobGraph` function.

## Brief change log

  - *Fix SingleJobSubmittedJobGraphStore putJobGraph function*
  - *Add unit tests for SingleJobSubmittedJobGraphStore*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added SingleJobSubmittedJobGraphStoreTest that validates `putJobGraph` throws `FlinkException` when the input is a different jobGraph*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
