### PR TITLE
[hotfix][runtime] Fix variable name typos in TaskInformation.java and…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/TaskInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/TaskInformation.java
@@ -42,7 +42,7 @@ public class TaskInformation implements Serializable {
 	private final int numberOfSubtasks;
 
 	/** The maximum parallelism == number of key groups */
-	private final int maxNumberOfSubtaks;
+	private final int maxNumberOfSubtasks;
 
 	/** Class name of the invokable to run */
 	private final String invokableClassName;
@@ -54,13 +54,13 @@ public class TaskInformation implements Serializable {
 			JobVertexID jobVertexId,
 			String taskName,
 			int numberOfSubtasks,
-			int maxNumberOfSubtaks,
+			int maxNumberOfSubtasks,
 			String invokableClassName,
 			Configuration taskConfiguration) {
 		this.jobVertexId = Preconditions.checkNotNull(jobVertexId);
 		this.taskName = Preconditions.checkNotNull(taskName);
 		this.numberOfSubtasks = Preconditions.checkNotNull(numberOfSubtasks);
-		this.maxNumberOfSubtaks = Preconditions.checkNotNull(maxNumberOfSubtaks);
+		this.maxNumberOfSubtasks = Preconditions.checkNotNull(maxNumberOfSubtasks);
 		this.invokableClassName = Preconditions.checkNotNull(invokableClassName);
 		this.taskConfiguration = Preconditions.checkNotNull(taskConfiguration);
 	}
@@ -77,8 +77,8 @@ public class TaskInformation implements Serializable {
 		return numberOfSubtasks;
 	}
 
-	public int getMaxNumberOfSubtaks() {
-		return maxNumberOfSubtaks;
+	public int getMaxNumberOfSubtasks() {
+		return maxNumberOfSubtasks;
 	}
 
 	public String getInvokableClassName() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -310,7 +310,7 @@ public class Task implements Runnable, TaskActions, PartitionProducerStateProvid
 
 		this.taskInfo = new TaskInfo(
 				taskInformation.getTaskName(),
-				taskInformation.getMaxNumberOfSubtaks(),
+				taskInformation.getMaxNumberOfSubtasks(),
 				subtaskIndex,
 				taskInformation.getNumberOfSubtasks(),
 				attemptNumber,


### PR DESCRIPTION
## What is the purpose of the change

Fix variable name typos in TaskInformation.java and Task.java

## Brief change log

* TaskInformation: Changed maxNumberOfSubtaks to maxNumberOfSubtasks, with its relative get method. Changed the maxNumberOfSubtaks in its constructor parameter to maxNumberOfSubtasks.
* Task: Correspondingly changed taskInformation.getMaxNumberOfSubtaks() to taskInformation.getMaxNumberOfSubtasks().

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): (no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
