### PR TITLE
[FLINK-15430][table-planner-blink] Fix Java 64K method compiling limi…

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CalcCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CalcCodeGenerator.scala
@@ -56,7 +56,8 @@ object CalcCodeGenerator {
       calcProgram,
       condition,
       eagerInputUnboxingCode = true,
-      retainHeader = retainHeader)
+      retainHeader = retainHeader,
+      allowSplit = true)
 
     val genOperator =
       OperatorCodeGenerator.generateOneInputStreamOperator[BaseRow, BaseRow](
@@ -119,7 +120,8 @@ object CalcCodeGenerator {
       collectorTerm: String = CodeGenUtils.DEFAULT_OPERATOR_COLLECTOR_TERM,
       eagerInputUnboxingCode: Boolean,
       retainHeader: Boolean = false,
-      outputDirectly: Boolean = false): String = {
+      outputDirectly: Boolean = false,
+      allowSplit: Boolean = false): String = {
 
     val projection = calcProgram.getProjectList.map(calcProgram.expandLocalRef)
     val exprGenerator = new ExprCodeGenerator(ctx, false)
@@ -151,7 +153,8 @@ object CalcCodeGenerator {
         exprGenerator.generateResultExpression(
           projectionExprs,
           outRowType,
-          outRowClass)
+          outRowClass,
+          allowSplit = allowSplit)
       }
 
       val projectionExpressionCode = projectionExpression.code

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
@@ -426,9 +426,12 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
     */
   def addReusableTimestamp(): String = {
     val fieldTerm = s"timestamp"
+
+    reusableMemberStatements.add(s"private $SQL_TIMESTAMP $fieldTerm;")
+
     val field =
       s"""
-         |final $SQL_TIMESTAMP $fieldTerm =
+         |$fieldTerm =
          |  $SQL_TIMESTAMP.fromEpochMillis(java.lang.System.currentTimeMillis());
          |""".stripMargin
     reusablePerRecordStatements.add(field)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
@@ -109,9 +109,9 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
   private var currentMethodNameForLocalVariables = "DEFAULT"
 
   /**
-   * Flag indicating whether split has occurred.
+   * Flag that indicates whether the generated code is split into several methods.
    */
-  private var isSplit = false
+  private var isCodeSplit = false
 
   // map of local variable statements. It will be placed in method if method code not excess
   // max code length, otherwise will be placed in member area of the class. The statements
@@ -148,8 +148,12 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
     reusableLocalVariableStatements(methodName) = mutable.LinkedHashSet[String]()
   }
 
-  def setSplit(): Unit = {
-    isSplit = true
+  /**
+   * Set the flag [[isCodeSplit]] to be true, which indicates the generated code is split into
+   * several methods.
+   */
+  def setCodeSplit(): Unit = {
+    isCodeSplit = true
   }
 
   /**
@@ -206,7 +210,7 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
     */
   def reuseMemberCode(): String = {
     val result = reusableMemberStatements.mkString("\n")
-    if (isSplit) {
+    if (isCodeSplit) {
       val localVariableAsMember = reusableLocalVariableStatements.map(
         statements => statements._2.map("private " + _).mkString("\n")
       ).mkString("\n")
@@ -221,7 +225,7 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
     *         if generated code is split or in local variables of method
     */
   def reuseLocalVariableCode(methodName: String = null): String = {
-    if (isSplit) {
+    if (isCodeSplit) {
       GeneratedExpression.NO_CODE
     } else if (methodName == null) {
       reusableLocalVariableStatements(currentMethodNameForLocalVariables).mkString("\n")

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
@@ -296,7 +296,7 @@ class ExprCodeGenerator(ctx: CodeGeneratorContext, nullableInput: Boolean)
     val maxCodeLength = ctx.tableConfig.getMaxGeneratedCodeLength
     val setFieldsCode = if (allowSplit && totalLen > maxCodeLength) {
       // do the split.
-      ctx.setSplit()
+      ctx.setCodeSplit()
       setFieldsCodes.map(project => {
         val methodName = newName("split")
         val method =

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
@@ -301,7 +301,7 @@ class ExprCodeGenerator(ctx: CodeGeneratorContext, nullableInput: Boolean)
         val methodName = newName("split")
         val method =
           s"""
-            |private void $methodName() throw Exception {
+            |private void $methodName() throws Exception {
             |  $project
             |}
             |""".stripMargin

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GeneratedExpression.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GeneratedExpression.scala
@@ -77,14 +77,14 @@ case class GeneratedExpression(
   def deepCopy(ctx: CodeGeneratorContext): GeneratedExpression = {
     // only copy when type is mutable
     if (TypeCheckUtils.isMutable(resultType)) {
-      val newResultTerm = newName("field")
       // if the type need copy, it must be a boxed type
       val typeTerm = boxedTypeTermForType(resultType)
       val serTerm = ctx.addReusableTypeSerializer(resultType)
+      val newResultTerm = ctx.addReusableLocalVariable(typeTerm, "field")
       val newCode =
         s"""
            |$code
-           |$typeTerm $newResultTerm = $resultTerm;
+           |$newResultTerm = $resultTerm;
            |if (!$nullTerm) {
            |  $newResultTerm = ($typeTerm) ($serTerm.copy($newResultTerm));
            |}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/MatchCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/MatchCodeGenerator.scala
@@ -421,13 +421,13 @@ class MatchCodeGenerator(
         expr
 
       case None =>
-        val nullTerm = newName("isNull")
+        val nullTerm = ctx.addReusableLocalVariable("boolean", "isNull")
 
         ctx.addReusableMember(s"$eventTypeTerm $keyRowTerm;")
 
         val keyCode =
           j"""
-             |boolean $nullTerm = true;
+             |$nullTerm = true;
              |for (java.util.Map.Entry entry : $input1Term.entrySet()) {
              |  java.util.List value = (java.util.List) entry.getValue();
              |  if (value != null && value.size() > 0) {
@@ -539,7 +539,8 @@ class MatchCodeGenerator(
   }
 
   private def findEventByLogicalPosition(patternFieldAlpha: String): GeneratedExpression = {
-    val Seq(rowNameTerm, isRowNull) = newNames("row", "isRowNull")
+    val isRowNull = ctx.addReusableLocalVariable("boolean", "isRowNull")
+    val rowNameTerm = ctx.addReusableLocalVariable(eventTypeTerm, "row")
 
     val listName = findEventsByPatternName(patternFieldAlpha).resultTerm
     val resultIndex = if (first) {
@@ -550,8 +551,8 @@ class MatchCodeGenerator(
 
     val funcCode =
       j"""
-         |$eventTypeTerm $rowNameTerm = null;
-         |boolean $isRowNull = true;
+         |$rowNameTerm = null;
+         |$isRowNull = true;
          |if ($listName.size() > $offset) {
          |  $rowNameTerm = (($eventTypeTerm) $listName.get($resultIndex));
          |  $isRowNull = false;
@@ -620,8 +621,6 @@ class MatchCodeGenerator(
     }
 
     private def generateAggAccess(aggCall: RexCall): GeneratedExpression = {
-      val singleAggResultTerm = newName("result")
-      val singleAggNullTerm = newName("nullTerm")
       val singleAggResultType = FlinkTypeFactory.toLogicalType(aggCall.`type`)
       val primitiveSingleAggResultTypeTerm = primitiveTypeTermForType(singleAggResultType)
       val boxedSingleAggResultTypeTerm = boxedTypeTermForType(singleAggResultType)
@@ -637,10 +636,12 @@ class MatchCodeGenerator(
       ctx.addReusablePerRecordStatement(codeForAgg)
 
       val defaultValue = primitiveDefaultValue(singleAggResultType)
+
+      val singleAggNullTerm = ctx.addReusableLocalVariable("boolean", "nullTerm")
+      val singleAggResultTerm = ctx.addReusableLocalVariable(
+        primitiveSingleAggResultTypeTerm, "result")
       val codeForSingleAgg = if (ctx.nullCheck) {
         j"""
-           |boolean $singleAggNullTerm;
-           |$primitiveSingleAggResultTypeTerm $singleAggResultTerm;
            |if ($allAggRowTerm.getField(${aggregates.size}) != null) {
            |  $singleAggResultTerm = ($boxedSingleAggResultTypeTerm) $allAggRowTerm
            |    .getField(${aggregates.size});

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenHelper.scala
@@ -405,7 +405,8 @@ object HashAggCodeGenHelper {
       outRow = currentAggBufferTerm,
       outRowWriter = None,
       reusedOutRow = true,
-      outRowAlreadyExists = true
+      outRowAlreadyExists = true,
+      allowSplit = false
     )
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CalcITCase.scala
@@ -260,4 +260,28 @@ class CalcITCase extends StreamingTestBase {
     val expected = List("2,2,Hello", "3,2,Hello world")
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
   }
+
+  @Test
+  def testLongProjectionList(): Unit = {
+
+    val t = env.fromCollection(TestData.smallTupleData3)
+      .toTable(tEnv, 'a, 'b, 'c)
+    tEnv.createTemporaryView("MyTable", t)
+
+    val selectList = Stream.range(3, 200)
+      .map(i => s"CASE WHEN a IS NOT NULL AND a > $i THEN 0 WHEN a < 0 THEN 0 ELSE $i END")
+      .mkString(",")
+    val sqlQuery = s"select $selectList from MyTable"
+
+    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val sink = new TestingAppendSink
+    result.addSink(sink)
+    env.execute()
+
+    val expected = Stream.range(3, 200).map(_.toString).mkString(",")
+    assertEquals(sink.getAppendResults.size, TestData.smallTupleData3.size)
+    sink.getAppendResults.foreach( result =>
+      assertEquals(expected, result)
+    )
+  }
 }


### PR DESCRIPTION
…tation for blink planner

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix blink planner code generation exceeds 64k java method limitation.

## Brief change log

- Add isSplit field in CodeGeneratorContext
- Split expressions when exceeds threshold in ExprCodeGenerator
- Use reuseableLocalVariable in GeneratedExpression.deepCopy


## Verifying this change

This change added tests and can be verified as follows:

- CalcITCase. testLongProjectionList


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
