### PR TITLE
[FLINK-15443][jdbc] Fix mismatch between Java float and JDBC float

### DIFF
--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTypeUtil.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTypeUtil.java
@@ -51,7 +51,7 @@ class JDBCTypeUtil {
 		m.put(SHORT_TYPE_INFO, Types.SMALLINT);
 		m.put(INT_TYPE_INFO, Types.INTEGER);
 		m.put(LONG_TYPE_INFO, Types.BIGINT);
-		m.put(FLOAT_TYPE_INFO, Types.FLOAT);
+		m.put(FLOAT_TYPE_INFO, Types.REAL);
 		m.put(DOUBLE_TYPE_INFO, Types.DOUBLE);
 		m.put(SqlTimeTypeInfo.DATE, Types.DATE);
 		m.put(SqlTimeTypeInfo.TIME, Types.TIME);

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSinkITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSinkITCase.java
@@ -73,6 +73,8 @@ public class JDBCUpsertTableSinkITCase extends AbstractTestBase {
 			stat.executeUpdate("CREATE TABLE " + OUTPUT_TABLE2 + " (" +
 					"id INT NOT NULL DEFAULT 0," +
 					"num BIGINT NOT NULL DEFAULT 0)");
+
+			stat.executeUpdate("CREATE TABLE REAL_TABLE (real_data REAL)");
 		}
 	}
 
@@ -84,6 +86,7 @@ public class JDBCUpsertTableSinkITCase extends AbstractTestBase {
 			Statement stat = conn.createStatement()) {
 			stat.execute("DROP TABLE " + OUTPUT_TABLE1);
 			stat.execute("DROP TABLE " + OUTPUT_TABLE2);
+			stat.execute("DROP TABLE REAL_TABLE");
 		}
 	}
 
@@ -113,6 +116,27 @@ public class JDBCUpsertTableSinkITCase extends AbstractTestBase {
 
 		Collections.shuffle(data);
 		return env.fromCollection(data);
+	}
+
+	@Test
+	public void testReal() throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.getConfig().enableObjectReuse();
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+		tEnv.sqlUpdate(
+				"CREATE TABLE upsertSink (" +
+						"  real_data float" +
+						") WITH (" +
+						"  'connector.type'='jdbc'," +
+						"  'connector.url'='" + DB_URL + "'," +
+						"  'connector.table'='REAL_TABLE'" +
+						")");
+
+		tEnv.sqlUpdate("INSERT INTO upsertSink SELECT CAST(1.0 as FLOAT)");
+		env.execute();
+		check(new Row[] {Row.of(1.0f)}, DB_URL, "REAL_TABLE", new String[]{"real_data"});
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

Bug when use JDBC sink with float type.

## Brief change log

In flink 
- SQL, we regard float as java float.
- But in JDBC, real type is java float, float/double are java double.

We have dealt with data very well in JDBCUtils, but mismatch in JDBCTypeUtil to match java float to JDBC float.


## Verifying this change

`JDBCUpsertTableSinkITCase.testReal`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no