### PR TITLE
[FLINK-15445][connectors/jdbc] JDBC Table Source didn't work for Type…

### DIFF
--- a/flink-connectors/flink-jdbc/pom.xml
+++ b/flink-connectors/flink-jdbc/pom.xml
@@ -89,5 +89,12 @@ under the License.
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/flink-connectors/flink-jdbc/pom.xml
+++ b/flink-connectors/flink-jdbc/pom.xml
@@ -77,13 +77,6 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>

--- a/flink-connectors/flink-jdbc/pom.xml
+++ b/flink-connectors/flink-jdbc/pom.xml
@@ -89,6 +89,14 @@ under the License.
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
@@ -102,7 +102,7 @@ public class JDBCTableSource implements
 
 	@Override
 	public DataStream<Row> getDataStream(StreamExecutionEnvironment execEnv) {
-		return execEnv.createInput(getInputFormat(), getReturnType()).name(explainSource());
+		return execEnv.createInput(getInputFormat(), returnType).name(explainSource());
 	}
 
 	@Override
@@ -114,11 +114,6 @@ public class JDBCTableSource implements
 				.setFieldNames(returnType.getFieldNames())
 				.setKeyNames(lookupKeys)
 				.build();
-	}
-
-	@Override
-	public TypeInformation<Row> getReturnType() {
-		return returnType;
 	}
 
 	@Override
@@ -201,16 +196,8 @@ public class JDBCTableSource implements
 
 	@Override
 	public String explainSource() {
-		if (selectFields == null) {
-			return String.format(
-				"JDBCTableSource(read fields: %s)", String.join(", ", schema.getFieldNames()));
-		} else {
-			String[] fields = new String[selectFields.length];
-			for (int i = 0; i < selectFields.length; i++) {
-				fields[i] = schema.getFieldName(selectFields[i]).get();
-			}
-			return String.format("JDBCTableSource(read fields: %s)", String.join(", ", fields));
-		}
+		return String.format(
+			"JDBCTableSource(read fields: %s)", String.join(", ", returnType.getFieldNames()));
 	}
 
 	/**

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
@@ -194,12 +194,6 @@ public class JDBCTableSource implements
 		}
 	}
 
-	@Override
-	public String explainSource() {
-		return String.format(
-			"JDBCTableSource(read fields: %s)", String.join(", ", returnType.getFieldNames()));
-	}
-
 	/**
 	 * Builder for a {@link JDBCTableSource}.
 	 */

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.sources.LookupableTableSource;
 import org.apache.flink.table.sources.ProjectableTableSource;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.table.sources.TableSource;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.utils.TableConnectorUtils;
 import org.apache.flink.types.Row;
 
@@ -111,6 +112,11 @@ public class JDBCTableSource implements
 	@Override
 	public TypeInformation<Row> getReturnType() {
 		return returnType;
+	}
+
+	@Override
+	public DataType getProducedDataType() {
+		return schema.toRowDataType();
 	}
 
 	@Override

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.api.java.io.jdbc;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.io.jdbc.dialect.JDBCDialect;
 import org.apache.flink.api.java.io.jdbc.split.NumericBetweenParametersProvider;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
@@ -199,6 +199,20 @@ public class JDBCTableSource implements
 		}
 	}
 
+	@Override
+	public String explainSource() {
+		if (selectFields == null) {
+			return String.format(
+				"JDBCTableSource(read fields: %s)", String.join(", ", schema.getFieldNames()));
+		} else {
+			String[] fields = new String[selectFields.length];
+			for (int i = 0; i < selectFields.length; i++) {
+				fields[i] = schema.getFieldName(selectFields[i]).get();
+			}
+			return String.format("JDBCTableSource(read fields: %s)", String.join(", ", fields));
+		}
+	}
+
 	/**
 	 * Builder for a {@link JDBCTableSource}.
 	 */

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
@@ -74,15 +74,12 @@ public class JDBCTableSource implements
 
 		this.selectFields = selectFields;
 
-		final TypeInformation<?>[] schemaTypeInfos = schema.getFieldTypes();
 		final DataType[] schemaDataTypes = schema.getFieldDataTypes();
 		final String[] schemaFieldNames = schema.getFieldNames();
 		if (selectFields != null) {
-			TypeInformation<?>[] typeInfos = new TypeInformation[selectFields.length];
 			DataType[] dataTypes = new DataType[selectFields.length];
 			String[] fieldNames = new String[selectFields.length];
 			for (int i = 0; i < selectFields.length; i++) {
-				typeInfos[i] = schemaTypeInfos[selectFields[i]];
 				dataTypes[i] = schemaDataTypes[selectFields[i]];
 				fieldNames[i] = schemaFieldNames[selectFields[i]];
 			}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceSinkFactory.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceSinkFactory.java
@@ -130,11 +130,8 @@ public class JDBCTableSourceSinkFactory implements
 		TableSchema schema = TableSchemaUtils.getPhysicalSchema(
 			descriptorProperties.getTableSchema(SCHEMA));
 
-		JDBCOptions options = getJDBCOptions(descriptorProperties);
-		options.getDialect().validate(schema);
-
 		return JDBCTableSource.builder()
-			.setOptions(options)
+			.setOptions(getJDBCOptions(descriptorProperties))
 			.setReadOptions(getJDBCReadOptions(descriptorProperties))
 			.setLookupOptions(getJDBCLookupOptions(descriptorProperties))
 			.setSchema(schema)
@@ -147,11 +144,8 @@ public class JDBCTableSourceSinkFactory implements
 		TableSchema schema = TableSchemaUtils.getPhysicalSchema(
 			descriptorProperties.getTableSchema(SCHEMA));
 
-		JDBCOptions options = getJDBCOptions(descriptorProperties);
-		options.getDialect().validate(schema);
-
 		final JDBCUpsertTableSink.Builder builder = JDBCUpsertTableSink.builder()
-			.setOptions(options)
+			.setOptions(getJDBCOptions(descriptorProperties))
 			.setTableSchema(schema);
 
 		descriptorProperties.getOptionalInt(CONNECTOR_WRITE_FLUSH_MAX_ROWS).ifPresent(builder::setFlushMaxSize);

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceSinkFactory.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceSinkFactory.java
@@ -130,8 +130,11 @@ public class JDBCTableSourceSinkFactory implements
 		TableSchema schema = TableSchemaUtils.getPhysicalSchema(
 			descriptorProperties.getTableSchema(SCHEMA));
 
+		JDBCOptions options = getJDBCOptions(descriptorProperties);
+		options.getDialect().validate(schema);
+
 		return JDBCTableSource.builder()
-			.setOptions(getJDBCOptions(descriptorProperties))
+			.setOptions(options)
 			.setReadOptions(getJDBCReadOptions(descriptorProperties))
 			.setLookupOptions(getJDBCLookupOptions(descriptorProperties))
 			.setSchema(schema)
@@ -144,8 +147,11 @@ public class JDBCTableSourceSinkFactory implements
 		TableSchema schema = TableSchemaUtils.getPhysicalSchema(
 			descriptorProperties.getTableSchema(SCHEMA));
 
+		JDBCOptions options = getJDBCOptions(descriptorProperties);
+		options.getDialect().validate(schema);
+
 		final JDBCUpsertTableSink.Builder builder = JDBCUpsertTableSink.builder()
-			.setOptions(getJDBCOptions(descriptorProperties))
+			.setOptions(options)
 			.setTableSchema(schema);
 
 		descriptorProperties.getOptionalInt(CONNECTOR_WRITE_FLUSH_MAX_ROWS).ifPresent(builder::setFlushMaxSize);

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialect.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialect.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.java.io.jdbc.dialect;
 
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -39,11 +40,10 @@ public interface JDBCDialect extends Serializable {
 
 	/**
 	 * Check if this dialect instance support a specific data type in table schema.
-	 *
-	 * @param schema the table schema
+	 * @param schema the table schema.
+	 * @exception ValidationException in case of the table schema contains unsupported type.
 	 */
-	default void validate(TableSchema schema) {
-		return;
+	default void validate(TableSchema schema) throws ValidationException {
 	}
 
 	/**

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialect.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialect.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.java.io.jdbc.dialect;
 
+import org.apache.flink.table.api.TableSchema;
+
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Optional;
@@ -34,6 +36,15 @@ public interface JDBCDialect extends Serializable {
 	 * @return True if the dialect can be applied on the given jdbc url.
 	 */
 	boolean canHandle(String url);
+
+	/**
+	 * Check if this dialect instance support a specific data type in table schema.
+	 *
+	 * @param schema the table schema
+	 */
+	default void validate(TableSchema schema) {
+		return;
+	}
 
 	/**
 	 * @return the default driver class name, if user not configure the driver class name,

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialects.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialects.java
@@ -69,7 +69,7 @@ public final class JDBCDialects {
 						(dt.getLogicalType() instanceof VarBinaryType
 							&& Integer.MAX_VALUE != ((VarBinaryType) dt.getLogicalType()).getLength())) {
 					throw new ValidationException(
-							String.format("The %s dialect don't support type: %s.",
+							String.format("The %s dialect doesn't support type: %s.",
 									dialectName(),
 									dt.toString()));
 				}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialects.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialects.java
@@ -23,7 +23,9 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LegacyTypeInformationType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.VarBinaryType;
 
 import java.util.Arrays;
 import java.util.List;
@@ -32,6 +34,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.DECIMAL;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.VARBINARY;
 
 /**
  * Default Jdbc dialects.
@@ -56,38 +59,87 @@ public final class JDBCDialects {
 		return Optional.empty();
 	}
 
-	private static class DerbyDialect implements JDBCDialect {
+	private abstract static class AbstractDialect implements JDBCDialect {
+
+		@Override
+		public void validate(TableSchema schema) throws ValidationException {
+			for (int i = 0; i < schema.getFieldCount(); i++) {
+				DataType dt = schema.getFieldDataType(i).get();
+				String fieldName = schema.getFieldName(i).get();
+
+				// TODO: We can't convert VARBINARY(n) data type to
+				//  PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO in LegacyTypeInfoDataTypeConverter
+				//  when n is smaller than Integer.MAX_VALUE
+				if (unsupportedTypes().contains(dt.getLogicalType().getTypeRoot()) ||
+						(!(dt.getLogicalType() instanceof LegacyTypeInformationType) &&
+						(VARBINARY == dt.getLogicalType().getTypeRoot()
+							&& Integer.MAX_VALUE != ((VarBinaryType) dt.getLogicalType()).getLength()))) {
+					throw new ValidationException(
+							String.format("The dialect don't support type: %s.", dt.toString()));
+				}
+
+				// only validate precision of DECIMAL type for blink planner
+				if (!(dt.getLogicalType() instanceof LegacyTypeInformationType)
+						&& DECIMAL == dt.getLogicalType().getTypeRoot()) {
+					int precision = ((DecimalType) dt.getLogicalType()).getPrecision();
+					if (precision > maxDecimalPrecision()
+							|| precision < minDecimalPrecision()) {
+						throw new ValidationException(
+								String.format("The precision of %s is out of the range [%d, %d].",
+										fieldName,
+										minDecimalPrecision(),
+										maxDecimalPrecision()));
+					}
+				}
+
+				// only validate precision of DECIMAL type for blink planner
+				if (!(dt.getLogicalType() instanceof LegacyTypeInformationType)
+						&& TIMESTAMP_WITHOUT_TIME_ZONE == dt.getLogicalType().getTypeRoot()) {
+					int precision = ((TimestampType) dt.getLogicalType()).getPrecision();
+					if (precision > maxTimestampPrecision()
+							|| precision < minTimestampPrecision()) {
+						throw new ValidationException(
+								String.format("The precision of %s is out of the range [%d, %d].",
+										fieldName,
+										minTimestampPrecision(),
+										maxTimestampPrecision()));
+					}
+				}
+			}
+		}
+
+		public abstract int maxDecimalPrecision();
+
+		public abstract int minDecimalPrecision();
+
+		public abstract int maxTimestampPrecision();
+
+		public abstract int minTimestampPrecision();
+
+		/**
+		 * Defines the unsupported types for the dialect.
+		 * @return a list of logical type roots.
+		 */
+		public abstract List<LogicalTypeRoot> unsupportedTypes();
+	}
+
+	private static class DerbyDialect extends AbstractDialect {
 
 		private static final long serialVersionUID = 1L;
 
-		private static final int MAX_DERBY_DECIMAL_PRECISION = 31;
+		// Define MAX/MIN precision of TIMESTAMP type according to derby docs:
+		// http://db.apache.org/derby/docs/10.14/ref/rrefsqlj27620.html
+		private static final int MAX_TIMESTAMP_PRECISION = 9;
+		private static final int MIN_TIMESTAMP_PRECISION = 1;
 
-		private static final int MIN_DERBY_DECIMAL_PRECISION = 1;
+		// Define MAX/MIN precision of DECIMAL type according to derby docs:
+		// http://db.apache.org/derby/docs/10.14/ref/rrefsqlj15260.html
+		private static final int MAX_DECIMAL_PRECISION = 31;
+		private static final int MIN_DECIMAL_PRECISION = 1;
 
 		@Override
 		public boolean canHandle(String url) {
 			return url.startsWith("jdbc:derby:");
-		}
-
-		@Override
-		public void validate(TableSchema schema) {
-			for (int i = 0; i < schema.getFieldCount(); i++) {
-				DataType dt = schema.getFieldDataType(i).get();
-				String fieldName = schema.getFieldName(i).get();
-				// We only validate precision of DECIMAL type for blink planner.
-				if (!(dt.getLogicalType() instanceof LegacyTypeInformationType)
-						&& DECIMAL == dt.getLogicalType().getTypeRoot()) {
-					int precision = ((DecimalType) dt.getLogicalType()).getPrecision();
-					if (precision > MAX_DERBY_DECIMAL_PRECISION
-							|| precision < MIN_DERBY_DECIMAL_PRECISION) {
-						throw new ValidationException(
-								String.format("The precision of %s is out of the range [%d, %d].",
-										fieldName,
-										MIN_DERBY_DECIMAL_PRECISION,
-										MAX_DERBY_DECIMAL_PRECISION));
-					}
-				}
-			}
 		}
 
 		@Override
@@ -99,37 +151,70 @@ public final class JDBCDialects {
 		public String quoteIdentifier(String identifier) {
 			return identifier;
 		}
+
+		@Override
+		public int maxDecimalPrecision() {
+			return MAX_DECIMAL_PRECISION;
+		}
+
+		@Override
+		public int minDecimalPrecision() {
+			return MIN_DECIMAL_PRECISION;
+		}
+
+		@Override
+		public int maxTimestampPrecision() {
+			return MAX_TIMESTAMP_PRECISION;
+		}
+
+		@Override
+		public int minTimestampPrecision() {
+			return MIN_TIMESTAMP_PRECISION;
+		}
+
+		@Override
+		public List<LogicalTypeRoot> unsupportedTypes() {
+			// The data types used in Derby are list at
+			// http://db.apache.org/derby/docs/10.14/ref/crefsqlj31068.html
+
+			// TODO: We can't convert BINARY data type to
+			//  PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO in LegacyTypeInfoDataTypeConverter.
+			return Arrays.asList(
+					LogicalTypeRoot.BINARY,
+					LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE,
+					LogicalTypeRoot.TIMESTAMP_WITH_TIME_ZONE,
+					LogicalTypeRoot.INTERVAL_YEAR_MONTH,
+					LogicalTypeRoot.INTERVAL_DAY_TIME,
+					LogicalTypeRoot.ARRAY,
+					LogicalTypeRoot.MULTISET,
+					LogicalTypeRoot.MAP,
+					LogicalTypeRoot.ROW,
+					LogicalTypeRoot.DISTINCT_TYPE,
+					LogicalTypeRoot.STRUCTURED_TYPE,
+					LogicalTypeRoot.NULL,
+					LogicalTypeRoot.RAW,
+					LogicalTypeRoot.SYMBOL,
+					LogicalTypeRoot.UNRESOLVED);
+		}
 	}
 
-	private static class MySQLDialect implements JDBCDialect {
+	private static class MySQLDialect extends AbstractDialect {
 
 		private static final long serialVersionUID = 1L;
 
-		private static final int MAX_MYSQL_TIMESTAMP_PRECISION = 6;
+		// Define MAX/MIN precision of TIMESTAMP type according to Mysql docs:
+		// https://dev.mysql.com/doc/refman/8.0/en/fractional-seconds.html
+		private static final int MAX_TIMESTAMP_PRECISION = 6;
+		private static final int MIN_TIMESTAMP_PRECISION = 1;
 
-		private static final int MIN_MYSQL_TIMESTAMP_PRECISION = 0;
+		// Define MAX/MIN precision of DECIMAL type according to Mysql docs:
+		// https://dev.mysql.com/doc/refman/8.0/en/fixed-point-types.html
+		private static final int MAX_DECIMAL_PRECISION = 65;
+		private static final int MIN_DECIMAL_PRECISION = 1;
 
 		@Override
 		public boolean canHandle(String url) {
 			return url.startsWith("jdbc:mysql:");
-		}
-
-		@Override
-		public void validate(TableSchema schema) {
-			for (int i = 0; i < schema.getFieldCount(); i++) {
-				DataType dt = schema.getFieldDataType(i).get();
-				String fieldName = schema.getFieldName(i).get();
-				if (TIMESTAMP_WITHOUT_TIME_ZONE == dt.getLogicalType().getTypeRoot()) {
-					int precision = ((TimestampType) dt.getLogicalType()).getPrecision();
-					if (precision > MAX_MYSQL_TIMESTAMP_PRECISION) {
-						throw new ValidationException(
-								String.format("The precision of %s is out of range [%d, %d].",
-										fieldName,
-										MIN_MYSQL_TIMESTAMP_PRECISION,
-										MAX_MYSQL_TIMESTAMP_PRECISION));
-					}
-				}
-			}
 		}
 
 		@Override
@@ -158,37 +243,71 @@ public final class JDBCDialects {
 					" ON DUPLICATE KEY UPDATE " + updateClause
 			);
 		}
+
+		@Override
+		public int maxDecimalPrecision() {
+			return MAX_DECIMAL_PRECISION;
+		}
+
+		@Override
+		public int minDecimalPrecision() {
+			return MIN_DECIMAL_PRECISION;
+		}
+
+		@Override
+		public int maxTimestampPrecision() {
+			return MAX_TIMESTAMP_PRECISION;
+		}
+
+		@Override
+		public int minTimestampPrecision() {
+			return MIN_TIMESTAMP_PRECISION;
+		}
+
+		@Override
+		public List<LogicalTypeRoot> unsupportedTypes() {
+			// The data types used in Mysql are list at:
+			// https://dev.mysql.com/doc/refman/8.0/en/data-types.html
+
+			// TODO: We can't convert BINARY data type to
+			//  PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO in LegacyTypeInfoDataTypeConverter.
+			return Arrays.asList(
+					LogicalTypeRoot.BINARY,
+					LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE,
+					LogicalTypeRoot.TIMESTAMP_WITH_TIME_ZONE,
+					LogicalTypeRoot.INTERVAL_YEAR_MONTH,
+					LogicalTypeRoot.INTERVAL_DAY_TIME,
+					LogicalTypeRoot.ARRAY,
+					LogicalTypeRoot.MULTISET,
+					LogicalTypeRoot.MAP,
+					LogicalTypeRoot.ROW,
+					LogicalTypeRoot.DISTINCT_TYPE,
+					LogicalTypeRoot.STRUCTURED_TYPE,
+					LogicalTypeRoot.NULL,
+					LogicalTypeRoot.RAW,
+					LogicalTypeRoot.SYMBOL,
+					LogicalTypeRoot.UNRESOLVED
+			);
+		}
 	}
 
-	private static class PostgresDialect implements JDBCDialect {
+	private static class PostgresDialect extends AbstractDialect {
 
 		private static final long serialVersionUID = 1L;
 
-		private static final int MAX_POSTGRES_TIMESTAMP_PRECISION = 6;
+		// Define MAX/MIN precision of TIMESTAMP type according to PostgreSQL docs:
+		// https://www.postgresql.org/docs/12/datatype-datetime.html
+		private static final int MAX_TIMESTAMP_PRECISION = 6;
+		private static final int MIN_TIMESTAMP_PRECISION = 1;
 
-		private static final int MIN_POSTGRES_TIMESTAMP_PRECISION = 0;
+		// Define MAX/MIN precision of TIMESTAMP type according to PostgreSQL docs:
+		// https://www.postgresql.org/docs/12/datatype-numeric.html#DATATYPE-NUMERIC-DECIMAL
+		private static final int MAX_DECIMAL_PRECISION = 1000;
+		private static final int MIN_DECIMAL_PRECISION = 1;
 
 		@Override
 		public boolean canHandle(String url) {
 			return url.startsWith("jdbc:postgresql:");
-		}
-
-		@Override
-		public void validate(TableSchema schema) {
-			for (int i = 0; i < schema.getFieldCount(); i++) {
-				DataType dt = schema.getFieldDataType(i).get();
-				String fieldName = schema.getFieldName(i).get();
-				if (TIMESTAMP_WITHOUT_TIME_ZONE == dt.getLogicalType().getTypeRoot()) {
-					int precision = ((TimestampType) dt.getLogicalType()).getPrecision();
-					if (precision > MAX_POSTGRES_TIMESTAMP_PRECISION) {
-						throw new ValidationException(
-								String.format("The precision of %s is out of range [%d, %d].",
-										fieldName,
-										MIN_POSTGRES_TIMESTAMP_PRECISION,
-										MAX_POSTGRES_TIMESTAMP_PRECISION));
-					}
-				}
-			}
 		}
 
 		@Override
@@ -211,6 +330,52 @@ public final class JDBCDialects {
 							" ON CONFLICT (" + uniqueColumns + ")" +
 							" DO UPDATE SET " + updateClause
 			);
+		}
+
+		@Override
+		public int maxDecimalPrecision() {
+			return MAX_DECIMAL_PRECISION;
+		}
+
+		@Override
+		public int minDecimalPrecision() {
+			return MIN_DECIMAL_PRECISION;
+		}
+
+		@Override
+		public int maxTimestampPrecision() {
+			return MAX_TIMESTAMP_PRECISION;
+		}
+
+		@Override
+		public int minTimestampPrecision() {
+			return MIN_TIMESTAMP_PRECISION;
+		}
+
+		@Override
+		public List<LogicalTypeRoot> unsupportedTypes() {
+			// The data types used in PostgreSQL are list at:
+			// https://www.postgresql.org/docs/12/datatype.html
+
+			// TODO: We can't convert BINARY data type to
+			//  PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO in LegacyTypeInfoDataTypeConverter.
+			return Arrays.asList(
+					LogicalTypeRoot.BINARY,
+					LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE,
+					LogicalTypeRoot.TIMESTAMP_WITH_TIME_ZONE,
+					LogicalTypeRoot.INTERVAL_YEAR_MONTH,
+					LogicalTypeRoot.INTERVAL_DAY_TIME,
+					LogicalTypeRoot.MULTISET,
+					LogicalTypeRoot.MAP,
+					LogicalTypeRoot.ROW,
+					LogicalTypeRoot.DISTINCT_TYPE,
+					LogicalTypeRoot.STRUCTURED_TYPE,
+					LogicalTypeRoot.NULL,
+					LogicalTypeRoot.RAW,
+					LogicalTypeRoot.SYMBOL,
+					LogicalTypeRoot.UNRESOLVED
+			);
+
 		}
 	}
 }

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialects.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialects.java
@@ -22,7 +22,6 @@ import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
-import org.apache.flink.table.types.logical.LegacyTypeInformationType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.VarBinaryType;
@@ -31,10 +30,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import static org.apache.flink.table.types.logical.LogicalTypeRoot.DECIMAL;
-import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE;
-import static org.apache.flink.table.types.logical.LogicalTypeRoot.VARBINARY;
 
 /**
  * Default Jdbc dialects.

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialects.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialects.java
@@ -22,6 +22,7 @@ import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LegacyTypeInformationType;
 import org.apache.flink.table.types.logical.TimestampType;
 
 import java.util.Arrays;
@@ -73,7 +74,9 @@ public final class JDBCDialects {
 			for (int i = 0; i < schema.getFieldCount(); i++) {
 				DataType dt = schema.getFieldDataType(i).get();
 				String fieldName = schema.getFieldName(i).get();
-				if (DECIMAL == dt.getLogicalType().getTypeRoot()) {
+				// We only validate precision of DECIMAL type for blink planner.
+				if (!(dt.getLogicalType() instanceof LegacyTypeInformationType)
+						&& DECIMAL == dt.getLogicalType().getTypeRoot()) {
 					int precision = ((DecimalType) dt.getLogicalType()).getPrecision();
 					if (precision > MAX_DERBY_DECIMAL_PRECISION
 							|| precision < MIN_DERBY_DECIMAL_PRECISION) {

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/table/descriptors/JDBCValidator.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/table/descriptors/JDBCValidator.java
@@ -21,9 +21,13 @@ package org.apache.flink.table.descriptors;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.java.io.jdbc.dialect.JDBCDialect;
 import org.apache.flink.api.java.io.jdbc.dialect.JDBCDialects;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.utils.TableSchemaUtils;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Optional;
+
+import static org.apache.flink.table.descriptors.Schema.SCHEMA;
 
 /**
  * The validator for JDBC.
@@ -72,6 +76,9 @@ public class JDBCValidator extends ConnectorDescriptorValidator {
 		final String url = properties.getString(CONNECTOR_URL);
 		final Optional<JDBCDialect> dialect = JDBCDialects.get(url);
 		Preconditions.checkState(dialect.isPresent(), "Cannot handle such jdbc url: " + url);
+
+		TableSchema schema = TableSchemaUtils.getPhysicalSchema(properties.getTableSchema(SCHEMA));
+		dialect.get().validate(schema);
 
 		Optional<String> password = properties.getOptionalString(CONNECTOR_PASSWORD);
 		if (password.isPresent()) {

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCDataTypeTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCDataTypeTest.java
@@ -103,26 +103,26 @@ public class JDBCDataTypeTest {
 			createTestItem("postgresql", "ARRAY<INTEGER>"),
 
 			// Unsupported types throws errors.
-			createTestItem("derby", "BINARY", "The derby dialect don't support type: BINARY(1)."),
-			createTestItem("derby", "VARBINARY(10)", "The derby dialect don't support type: VARBINARY(10)."),
+			createTestItem("derby", "BINARY", "The derby dialect doesn't support type: BINARY(1)."),
+			createTestItem("derby", "VARBINARY(10)", "The derby dialect doesn't support type: VARBINARY(10)."),
 			createTestItem("derby", "TIMESTAMP(3) WITH LOCAL TIME ZONE",
-					"The derby dialect don't support type: TIMESTAMP(3) WITH LOCAL TIME ZONE."),
+					"The derby dialect doesn't support type: TIMESTAMP(3) WITH LOCAL TIME ZONE."),
 			createTestItem("derby", "DECIMAL(38, 18)",
 					"The precision of field 'f0' is out of the DECIMAL precision range [1, 31] supported by derby dialect."),
 
-			createTestItem("mysql", "BINARY", "The mysql dialect don't support type: BINARY(1)."),
-			createTestItem("mysql", "VARBINARY(10)", "The mysql dialect don't support type: VARBINARY(10)."),
+			createTestItem("mysql", "BINARY", "The mysql dialect doesn't support type: BINARY(1)."),
+			createTestItem("mysql", "VARBINARY(10)", "The mysql dialect doesn't support type: VARBINARY(10)."),
 			createTestItem("mysql", "TIMESTAMP(9) WITHOUT TIME ZONE",
 					"The precision of field 'f0' is out of the TIMESTAMP precision range [1, 6] supported by mysql dialect."),
 			createTestItem("mysql", "TIMESTAMP(3) WITH LOCAL TIME ZONE",
-					"The mysql dialect don't support type: TIMESTAMP(3) WITH LOCAL TIME ZONE."),
+					"The mysql dialect doesn't support type: TIMESTAMP(3) WITH LOCAL TIME ZONE."),
 
-			createTestItem("postgresql", "BINARY", "The postgresql dialect don't support type: BINARY(1)."),
-			createTestItem("postgresql", "VARBINARY(10)", "The postgresql dialect don't support type: VARBINARY(10)."),
+			createTestItem("postgresql", "BINARY", "The postgresql dialect doesn't support type: BINARY(1)."),
+			createTestItem("postgresql", "VARBINARY(10)", "The postgresql dialect doesn't support type: VARBINARY(10)."),
 			createTestItem("postgresql", "TIMESTAMP(9) WITHOUT TIME ZONE",
 					"The precision of field 'f0' is out of the TIMESTAMP precision range [1, 6] supported by postgresql dialect."),
 			createTestItem("postgresql", "TIMESTAMP(3) WITH LOCAL TIME ZONE",
-					"The postgresql dialect don't support type: TIMESTAMP(3) WITH LOCAL TIME ZONE.")
+					"The postgresql dialect doesn't support type: TIMESTAMP(3) WITH LOCAL TIME ZONE.")
 		);
 	}
 

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCDataTypeTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCDataTypeTest.java
@@ -22,12 +22,14 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import javax.annotation.Nullable;
+
 import java.util.Arrays;
 import java.util.List;
 

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCDataTypeTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCDataTypeTest.java
@@ -103,26 +103,26 @@ public class JDBCDataTypeTest {
 			createTestItem("postgresql", "ARRAY<INTEGER>"),
 
 			// Unsupported types throws errors.
-			createTestItem("derby", "BINARY", "The dialect don't support type: BINARY(1)."),
-			createTestItem("derby", "VARBINARY(10)", "The dialect don't support type: VARBINARY(10)."),
+			createTestItem("derby", "BINARY", "The derby dialect don't support type: BINARY(1)."),
+			createTestItem("derby", "VARBINARY(10)", "The derby dialect don't support type: VARBINARY(10)."),
 			createTestItem("derby", "TIMESTAMP(3) WITH LOCAL TIME ZONE",
-					"The dialect don't support type: TIMESTAMP(3) WITH LOCAL TIME ZONE."),
+					"The derby dialect don't support type: TIMESTAMP(3) WITH LOCAL TIME ZONE."),
 			createTestItem("derby", "DECIMAL(38, 18)",
-					"The precision of f0 is out of the range [1, 31]."),
+					"The precision of field 'f0' is out of the DECIMAL precision range [1, 31] supported by derby dialect."),
 
-			createTestItem("mysql", "BINARY", "The dialect don't support type: BINARY(1)."),
-			createTestItem("mysql", "VARBINARY(10)", "The dialect don't support type: VARBINARY(10)."),
+			createTestItem("mysql", "BINARY", "The mysql dialect don't support type: BINARY(1)."),
+			createTestItem("mysql", "VARBINARY(10)", "The mysql dialect don't support type: VARBINARY(10)."),
 			createTestItem("mysql", "TIMESTAMP(9) WITHOUT TIME ZONE",
-					"The precision of f0 is out of the range [1, 6]."),
+					"The precision of field 'f0' is out of the TIMESTAMP precision range [1, 6] supported by mysql dialect."),
 			createTestItem("mysql", "TIMESTAMP(3) WITH LOCAL TIME ZONE",
-					"The dialect don't support type: TIMESTAMP(3) WITH LOCAL TIME ZONE."),
+					"The mysql dialect don't support type: TIMESTAMP(3) WITH LOCAL TIME ZONE."),
 
-			createTestItem("postgresql", "BINARY", "The dialect don't support type: BINARY(1)."),
-			createTestItem("postgresql", "VARBINARY(10)", "The dialect don't support type: VARBINARY(10)."),
+			createTestItem("postgresql", "BINARY", "The postgresql dialect don't support type: BINARY(1)."),
+			createTestItem("postgresql", "VARBINARY(10)", "The postgresql dialect don't support type: VARBINARY(10)."),
 			createTestItem("postgresql", "TIMESTAMP(9) WITHOUT TIME ZONE",
-					"The precision of f0 is out of the range [1, 6]."),
+					"The precision of field 'f0' is out of the TIMESTAMP precision range [1, 6] supported by postgresql dialect."),
 			createTestItem("postgresql", "TIMESTAMP(3) WITH LOCAL TIME ZONE",
-					"The dialect don't support type: TIMESTAMP(3) WITH LOCAL TIME ZONE.")
+					"The postgresql dialect don't support type: TIMESTAMP(3) WITH LOCAL TIME ZONE.")
 		);
 	}
 

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCDataTypeTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCDataTypeTest.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Tests for all DataTypes and Dialects of JDBC connector.
+ */
+@RunWith(Parameterized.class)
+public class JDBCDataTypeTest {
+
+	private static final String DDL_FORMAT = "CREATE TABLE T(\n" +
+		"f0 %s\n" +
+		") WITH (\n" +
+		"  'connector.type'='jdbc',\n" +
+		"  'connector.url'='" + "jdbc:%s:memory:test" + "',\n" +
+		"  'connector.table'='myTable'\n" +
+		")";
+
+	@Parameterized.Parameters(name = "{index}: {0}")
+	public static List<TestItem> testData() {
+		return Arrays.asList(
+			createTestItem("derby", "CHAR"),
+			createTestItem("derby", "VARCHAR"),
+			createTestItem("derby", "BOOLEAN"),
+			createTestItem("derby", "TINYINT"),
+			createTestItem("derby", "SMALLINT"),
+			createTestItem("derby", "INTEGER"),
+			createTestItem("derby", "BIGINT"),
+			createTestItem("derby", "FLOAT"),
+			createTestItem("derby", "DOUBLE"),
+			createTestItem("derby", "DECIMAL(10, 4)"),
+			createTestItem("derby", "DATE"),
+			createTestItem("derby", "TIME"),
+			createTestItem("derby", "TIMESTAMP(3)"),
+			createTestItem("derby", "TIMESTAMP WITHOUT TIME ZONE"),
+			createTestItem("derby", "TIMESTAMP(9) WITHOUT TIME ZONE"),
+			createTestItem("derby", "VARBINARY"),
+
+			createTestItem("mysql", "CHAR"),
+			createTestItem("mysql", "VARCHAR"),
+			createTestItem("mysql", "BOOLEAN"),
+			createTestItem("mysql", "TINYINT"),
+			createTestItem("mysql", "SMALLINT"),
+			createTestItem("mysql", "INTEGER"),
+			createTestItem("mysql", "BIGINT"),
+			createTestItem("mysql", "FLOAT"),
+			createTestItem("mysql", "DOUBLE"),
+			createTestItem("mysql", "DECIMAL(10, 4)"),
+			createTestItem("mysql", "DECIMAL(38, 18)"),
+			createTestItem("mysql", "DATE"),
+			createTestItem("mysql", "TIME"),
+			createTestItem("mysql", "TIMESTAMP(3)"),
+			createTestItem("mysql", "TIMESTAMP WITHOUT TIME ZONE"),
+			createTestItem("mysql", "VARBINARY"),
+
+			createTestItem("postgresql", "CHAR"),
+			createTestItem("postgresql", "VARCHAR"),
+			createTestItem("postgresql", "BOOLEAN"),
+			createTestItem("postgresql", "TINYINT"),
+			createTestItem("postgresql", "SMALLINT"),
+			createTestItem("postgresql", "INTEGER"),
+			createTestItem("postgresql", "BIGINT"),
+			createTestItem("postgresql", "FLOAT"),
+			createTestItem("postgresql", "DOUBLE"),
+			createTestItem("postgresql", "DECIMAL(10, 4)"),
+			createTestItem("postgresql", "DECIMAL(38, 18)"),
+			createTestItem("postgresql", "DATE"),
+			createTestItem("postgresql", "TIME"),
+			createTestItem("postgresql", "TIMESTAMP(3)"),
+			createTestItem("postgresql", "TIMESTAMP WITHOUT TIME ZONE"),
+			createTestItem("postgresql", "VARBINARY"),
+			createTestItem("postgresql", "ARRAY<INTEGER>"),
+
+			// Unsupported types throws errors.
+			createTestItem("derby", "BINARY", "The dialect don't support type: BINARY(1)."),
+			createTestItem("derby", "VARBINARY(10)", "The dialect don't support type: VARBINARY(10)."),
+			createTestItem("derby", "TIMESTAMP(3) WITH LOCAL TIME ZONE",
+					"The dialect don't support type: TIMESTAMP(3) WITH LOCAL TIME ZONE."),
+			createTestItem("derby", "DECIMAL(38, 18)",
+					"The precision of f0 is out of the range [1, 31]."),
+
+			createTestItem("mysql", "BINARY", "The dialect don't support type: BINARY(1)."),
+			createTestItem("mysql", "VARBINARY(10)", "The dialect don't support type: VARBINARY(10)."),
+			createTestItem("mysql", "TIMESTAMP(9) WITHOUT TIME ZONE",
+					"The precision of f0 is out of the range [1, 6]."),
+			createTestItem("mysql", "TIMESTAMP(3) WITH LOCAL TIME ZONE",
+					"The dialect don't support type: TIMESTAMP(3) WITH LOCAL TIME ZONE."),
+
+			createTestItem("postgresql", "BINARY", "The dialect don't support type: BINARY(1)."),
+			createTestItem("postgresql", "VARBINARY(10)", "The dialect don't support type: VARBINARY(10)."),
+			createTestItem("postgresql", "TIMESTAMP(9) WITHOUT TIME ZONE",
+					"The precision of f0 is out of the range [1, 6]."),
+			createTestItem("postgresql", "TIMESTAMP(3) WITH LOCAL TIME ZONE",
+					"The dialect don't support type: TIMESTAMP(3) WITH LOCAL TIME ZONE.")
+		);
+	}
+
+	private static TestItem createTestItem(Object... args) {
+		assert args.length >= 2;
+		TestItem item = TestItem.fromDialetAndType((String) args[0], (String) args[1]);
+		if (args.length == 3) {
+			item.withExpectError((String) args[2]);
+		}
+		return item;
+	}
+
+	@Parameterized.Parameter
+	public TestItem testItem;
+
+	@Test
+	public void testDataTypeValidate() {
+		String sqlDDL = String.format(DDL_FORMAT, testItem.dataTypeExpr, testItem.dialect);
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		EnvironmentSettings envSettings = EnvironmentSettings.newInstance()
+				.useBlinkPlanner()
+				.inStreamingMode()
+				.build();
+		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, envSettings);
+
+		tEnv.sqlUpdate(sqlDDL);
+
+		if (testItem.expectError != null) {
+			try {
+				tEnv.sqlQuery("SELECT * FROM T");
+			} catch (Exception ex) {
+				Assert.assertTrue(ex.getCause() instanceof ValidationException);
+				Assert.assertEquals(testItem.expectError, ex.getCause().getMessage());
+			}
+		} else {
+			tEnv.sqlQuery("SELECT * FROM T");
+		}
+	}
+
+	//~ Inner Class
+	private static class TestItem {
+
+		private final String dialect;
+
+		private final String dataTypeExpr;
+
+		@Nullable
+		private String expectError;
+
+		private TestItem(String dialect, String dataTypeExpr) {
+			this.dialect = dialect;
+			this.dataTypeExpr = dataTypeExpr;
+		}
+
+		static TestItem fromDialetAndType(String dialect, String dataTypeExpr) {
+			return new TestItem(dialect, dataTypeExpr);
+		}
+
+		TestItem withExpectError(String expectError) {
+			this.expectError = expectError;
+			return this;
+		}
+
+		@Override
+		public String toString() {
+			return String.format("Dialect: %s, DataType: %s", dialect, dataTypeExpr);
+		}
+	}
+}

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceITCase.java
@@ -57,12 +57,17 @@ public class JDBCTableSourceITCase extends AbstractTestBase {
 			statement.executeUpdate("CREATE TABLE " + INPUT_TABLE + " (" +
 					"id BIGINT NOT NULL," +
 					"timestamp6_col TIMESTAMP, " +
+					"timestamp9_col TIMESTAMP, " +
 					"time_col TIME, " +
+					"real_col FLOAT(23), " +    // A precision of 23 or less makes FLOAT equivalent to REAL.
+					"double_col FLOAT(24)," +   // A precision of 24 or greater makes FLOAT equivalent to DOUBLE PRECISION.
 					"decimal_col DECIMAL(10, 4))");
 			statement.executeUpdate("INSERT INTO " + INPUT_TABLE + " VALUES (" +
-					"1, TIMESTAMP('2020-01-01 15:35:00.123456'), TIME('15:35:00'), 100.1234)");
+					"1, TIMESTAMP('2020-01-01 15:35:00.123456'), TIMESTAMP('2020-01-01 15:35:00.123456789'), " +
+					"TIME('15:35:00'), 1.175E-37, 1.79769E+308, 100.1234)");
 			statement.executeUpdate("INSERT INTO " + INPUT_TABLE + " VALUES (" +
-					"2, TIMESTAMP('2020-01-01 15:36:01.123456'), TIME('15:36:01'), 101.1234)");
+					"2, TIMESTAMP('2020-01-01 15:36:01.123456'), TIMESTAMP('2020-01-01 15:36:01.123456789'), " +
+					"TIME('15:36:01'), -1.175E-37, -1.79769E+308, 101.1234)");
 		}
 	}
 
@@ -89,7 +94,10 @@ public class JDBCTableSourceITCase extends AbstractTestBase {
 			"CREATE TABLE " + INPUT_TABLE + "(" +
 				"id BIGINT," +
 				"timestamp6_col TIMESTAMP(6)," +
+				"timestamp9_col TIMESTAMP(9)," +
 				"time_col TIME," +
+				"real_col FLOAT," +
+				"double_col DOUBLE," +
 				"decimal_col DECIMAL(10, 4)" +
 				") WITH (" +
 				"  'connector.type'='jdbc'," +
@@ -105,8 +113,8 @@ public class JDBCTableSourceITCase extends AbstractTestBase {
 
 		List<String> expected =
 			Arrays.asList(
-				"1,2020-01-01T15:35:00.123456,15:35,100.1234",
-				"2,2020-01-01T15:36:01.123456,15:36:01,101.1234");
+				"1,2020-01-01T15:35:00.123456,2020-01-01T15:35:00.123456789,15:35,1.175E-37,1.79769E308,100.1234",
+				"2,2020-01-01T15:36:01.123456,2020-01-01T15:36:01.123456789,15:36:01,-1.175E-37,-1.79769E308,101.1234");
 		StreamITCase.compareWithList(expected);
 	}
 
@@ -123,7 +131,9 @@ public class JDBCTableSourceITCase extends AbstractTestBase {
 			"CREATE TABLE " + INPUT_TABLE + "(" +
 				"id BIGINT," +
 				"timestamp6_col TIMESTAMP(6)," +
+				"timestamp9_col TIMESTAMP(9)," +
 				"time_col TIME," +
+				"real_col FLOAT," +
 				"decimal_col DECIMAL(10, 4)" +
 				") WITH (" +
 				"  'connector.type'='jdbc'," +

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceITCase.java
@@ -20,7 +20,6 @@ package org.apache.flink.api.java.io.jdbc;
 
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
-import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.runtime.utils.StreamITCase;
 import org.apache.flink.test.util.AbstractTestBase;

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceITCase.java
@@ -154,31 +154,4 @@ public class JDBCTableSourceITCase extends AbstractTestBase {
 				"2020-01-01T15:36:01.123456,101.1234");
 		StreamITCase.compareWithList(expected);
 	}
-
-	@Test(expected = TableException.class)
-	public void testInvalidPrecisionOfJDBCSource() throws Exception {
-		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		EnvironmentSettings envSettings = EnvironmentSettings.newInstance()
-				.useBlinkPlanner()
-				.inStreamingMode()
-				.build();
-		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, envSettings);
-
-		tEnv.sqlUpdate(
-			"CREATE TABLE " + INPUT_TABLE + "(" +
-				"id BIGINT," +
-				"timestamp6_col TIMESTAMP(6)," +
-				"timestamp9_col TIMESTAMP(9)," +
-				"time_col TIME," +
-				"real_col FLOAT," +
-				"decimal_col DECIMAL(38, 4)" +
-				") WITH (" +
-				"  'connector.type'='jdbc'," +
-				"  'connector.url'='" + DB_URL + "'," +
-				"  'connector.table'='" + INPUT_TABLE + "'" +
-				")"
-		);
-
-		tEnv.sqlQuery("SELECT * FROM " + INPUT_TABLE);
-	}
 }

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceITCase.java
@@ -18,93 +18,95 @@
 
 package org.apache.flink.api.java.io.jdbc;
 
-import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
-import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.runtime.utils.StreamITCase;
+import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
 
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
 import java.util.List;
 
+
 /**
- * IT case for {@link JDBCTableSource}.
+ * ITCase for {@link JDBCTableSource}.
  */
-public class JDBCTableSourceITCase extends JDBCTestBase {
+public class JDBCTableSourceITCase extends AbstractTestBase {
 
-	private static final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-	private static final EnvironmentSettings bsSettings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
-	private static final StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, bsSettings);
+	public static final String DRIVER_CLASS = "org.apache.derby.jdbc.EmbeddedDriver";
+	public static final String DB_URL = "jdbc:derby:memory:test";
+	public static final String INPUT_TABLE = "jdbcSource";
 
-	static final String TABLE_SOURCE_SQL = "CREATE TABLE books (" +
-		" id int, " +
-		" title varchar, " +
-		" author varchar, " +
-		" price double, " +
-		" qty int " +
-		") with (" +
-		" 'connector.type' = 'jdbc', " +
-		" 'connector.url' = 'jdbc:derby:memory:ebookshop', " +
-		" 'connector.table' = 'books', " +
-		" 'connector.driver' = 'org.apache.derby.jdbc.EmbeddedDriver' " +
-		")";
+	@Before
+	public void before() throws ClassNotFoundException, SQLException {
+		System.setProperty("derby.stream.error.field", JDBCTestBase.class.getCanonicalName() + ".DEV_NULL");
+		Class.forName(DRIVER_CLASS);
 
-	@BeforeClass
-	public static void createTable() {
-		tEnv.sqlUpdate(TABLE_SOURCE_SQL);
+		try (
+			Connection conn = DriverManager.getConnection(DB_URL + ";create=true");
+			Statement statement = conn.createStatement()) {
+			statement.executeUpdate("CREATE TABLE " + INPUT_TABLE + " (" +
+					"id BIGINT NOT NULL," +
+					"timestamp6_col TIMESTAMP, " +
+					"time_col TIME, " +
+					"decimal_col DECIMAL(10, 4))");
+			statement.executeUpdate("INSERT INTO " + INPUT_TABLE + " VALUES (" +
+					"1, TIMESTAMP('2020-01-01 15:35:00.123456'), TIME('15:35:00'), 100.1234)");
+			statement.executeUpdate("INSERT INTO " + INPUT_TABLE + " VALUES (" +
+					"2, TIMESTAMP('2020-01-01 15:36:01.123456'), TIME('15:36:01'), 101.1234)");
+		}
+	}
+
+	@After
+	public void clearOutputTable() throws Exception {
+		Class.forName(DRIVER_CLASS);
+		try (
+			Connection conn = DriverManager.getConnection(DB_URL);
+			Statement stat = conn.createStatement()) {
+			stat.execute("DROP TABLE " + INPUT_TABLE);
+		}
 	}
 
 	@Test
-	public void testFieldsProjection() throws Exception {
-		StreamITCase.clear();
+	public void testJDBCSource() throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		EnvironmentSettings envSettings = EnvironmentSettings.newInstance()
+			.useBlinkPlanner()
+			.inStreamingMode()
+			.build();
+		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, envSettings);
 
-		Table result = tEnv.sqlQuery(SELECT_ID_BOOKS);
-		DataStream<Row> resultSet = tEnv.toAppendStream(result, Row.class);
-		resultSet.addSink(new StreamITCase.StringSink<>());
+		tEnv.sqlUpdate(
+			"CREATE TABLE " + INPUT_TABLE + "(" +
+				"id BIGINT," +
+				"timestamp6_col TIMESTAMP(6)," +
+				"time_col TIME," +
+				"decimal_col DECIMAL(10, 4)" +
+				") WITH (" +
+				"  'connector.type'='jdbc'," +
+				"  'connector.url'='" + DB_URL + "'," +
+				"  'connector.table'='" + INPUT_TABLE + "'" +
+				")"
+		);
+
+		StreamITCase.clear();
+		tEnv.toAppendStream(tEnv.sqlQuery("SELECT * FROM " + INPUT_TABLE), Row.class)
+			.addSink(new StreamITCase.StringSink<>());
 		env.execute();
 
-		List<String> expected = new ArrayList<>();
-		expected.add("1001");
-		expected.add("1002");
-		expected.add("1003");
-		expected.add("1004");
-		expected.add("1005");
-		expected.add("1006");
-		expected.add("1007");
-		expected.add("1008");
-		expected.add("1009");
-		expected.add("1010");
-
+		List<String> expected =
+			Arrays.asList(
+				"1,2020-01-01T15:35:00.123456,15:35,100.1234",
+				"2,2020-01-01T15:36:01.123456,15:36:01,101.1234");
 		StreamITCase.compareWithList(expected);
 	}
-
-	@Test
-	public void testAllFieldsSelection() throws Exception {
-		StreamITCase.clear();
-
-		Table result = tEnv.sqlQuery(SELECT_ALL_BOOKS);
-		DataStream<Row> resultSet = tEnv.toAppendStream(result, Row.class);
-		resultSet.addSink(new StreamITCase.StringSink<>());
-		env.execute();
-
-		List<String> expected = new ArrayList<>();
-		expected.add("1001,Java public for dummies,Tan Ah Teck,11.11,11");
-		expected.add("1002,More Java for dummies,Tan Ah Teck,22.22,22");
-		expected.add("1003,More Java for more dummies,Mohammad Ali,33.33,33");
-		expected.add("1004,A Cup of Java,Kumar,44.44,44");
-		expected.add("1005,A Teaspoon of Java,Kevin Jones,55.55,55");
-		expected.add("1006,A Teaspoon of Java 1.4,Kevin Jones,66.66,66");
-		expected.add("1007,A Teaspoon of Java 1.5,Kevin Jones,77.77,77");
-		expected.add("1008,A Teaspoon of Java 1.6,Kevin Jones,88.88,88");
-		expected.add("1009,A Teaspoon of Java 1.7,Kevin Jones,99.99,99");
-		expected.add("1010,A Teaspoon of Java 1.8,Kevin Jones,null,1010");
-
-		StreamITCase.compareWithList(expected);
-	}
-
 }

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceITCase.java
@@ -78,7 +78,7 @@ public class JDBCTableSourceITCase extends AbstractTestBase {
 		try (
 			Connection conn = DriverManager.getConnection(DB_URL);
 			Statement stat = conn.createStatement()) {
-			stat.execute("DROP TABLE " + INPUT_TABLE);
+			stat.executeUpdate("DROP TABLE " + INPUT_TABLE);
 		}
 	}
 
@@ -165,7 +165,7 @@ public class JDBCTableSourceITCase extends AbstractTestBase {
 		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, envSettings);
 
 		tEnv.sqlUpdate(
-		"CREATE TABLE " + INPUT_TABLE + "(" +
+			"CREATE TABLE " + INPUT_TABLE + "(" +
 				"id BIGINT," +
 				"timestamp6_col TIMESTAMP(6)," +
 				"timestamp9_col TIMESTAMP(9)," +

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceSinkFactoryTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceSinkFactoryTest.java
@@ -52,7 +52,7 @@ public class JDBCTableSourceSinkFactoryTest {
 		.field("aaa", DataTypes.INT())
 		.field("bbb", DataTypes.STRING())
 		.field("ccc", DataTypes.DOUBLE())
-		.field("ddd", DataTypes.DECIMAL(38, 18))
+		.field("ddd", DataTypes.DECIMAL(31, 18))
 		.field("eee", DataTypes.TIMESTAMP(3))
 		.build();
 


### PR DESCRIPTION
…s with precision (or/and scale)

## What is the purpose of the change

JDBC table source didn't work for types with precision (and/or scale) in blink planner, such as TIMESTAMP(6), DECIMAL(10, 4). The ValidationException described in FLINK-15445 would be thrown. The root cause is JDBCTableSource didn't override `getProducedDataType` interface, and returns wrong datatype. This PR fix it and add an itcase to verify.

## Brief change log

- 6daa934 Override `getProducedDataType()` for JDBCTableSource and add tests to verify
- 2cc4e7b Override 'explainSource()` API to explain the pushdown applied and add test to verify
- ed26962 Add `validate` API to check if this dialect instance support a specific data type
- a12d3d5 Refactor the validation of data types for dialects

## Verifying this change

This change added tests 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
