### PR TITLE
[FLINK-15458][conf][docs] Add support for whitelisting ambiguous options 

### DIFF
--- a/docs/_includes/generated/influxdb_reporter_configuration.html
+++ b/docs/_includes/generated/influxdb_reporter_configuration.html
@@ -1,0 +1,66 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>connectTimeout</h5></td>
+            <td style="word-wrap: break-word;">10000</td>
+            <td>Integer</td>
+            <td>(optional) the InfluxDB connect timeout for metrics</td>
+        </tr>
+        <tr>
+            <td><h5>consistency</h5></td>
+            <td style="word-wrap: break-word;">ONE</td>
+            <td><p>Enum</p>Possible values: [ALL, ANY, ONE, QUORUM]</td>
+            <td>(optional) the InfluxDB consistency level for metrics</td>
+        </tr>
+        <tr>
+            <td><h5>db</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>the InfluxDB database to store metrics</td>
+        </tr>
+        <tr>
+            <td><h5>host</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>the InfluxDB server host</td>
+        </tr>
+        <tr>
+            <td><h5>password</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>(optional) InfluxDB username's password used for authentication</td>
+        </tr>
+        <tr>
+            <td><h5>port</h5></td>
+            <td style="word-wrap: break-word;">8086</td>
+            <td>Integer</td>
+            <td>the InfluxDB server port</td>
+        </tr>
+        <tr>
+            <td><h5>retentionPolicy</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>(optional) the InfluxDB retention policy for metrics</td>
+        </tr>
+        <tr>
+            <td><h5>username</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>(optional) InfluxDB username used for authentication</td>
+        </tr>
+        <tr>
+            <td><h5>writeTimeout</h5></td>
+            <td style="word-wrap: break-word;">10000</td>
+            <td>Integer</td>
+            <td>(optional) the InfluxDB write timeout for metrics</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -655,15 +655,7 @@ of your Flink distribution.
 
 Parameters:
 
-- `host` - the InfluxDB server host
-- `port` - (optional) the InfluxDB server port, defaults to `8086`
-- `db` - the InfluxDB database to store metrics
-- `username` - (optional) InfluxDB username used for authentication
-- `password` - (optional) InfluxDB username's password used for authentication
-- `retentionPolicy` - (optional) InfluxDB retention policy, defaults to retention policy defined on the server for the db
-- `consistency` - (optional) InfluxDB consistency level for metrics. Possible values: [ALL, ANY, ONE, QUORUM], default is ONE
-- `connectTimeout` - (optional) the InfluxDB client connect timeout in milliseconds, default is 10000 ms
-- `writeTimeout` - (optional) the InfluxDB client write timeout in milliseconds, default is 10000 ms
+{% include generated/influxdb_reporter_configuration.html %}
 
 Example configuration:
 

--- a/flink-annotations/src/main/java/org/apache/flink/annotation/docs/Documentation.java
+++ b/flink-annotations/src/main/java/org/apache/flink/annotation/docs/Documentation.java
@@ -104,6 +104,16 @@ public final class Documentation {
 		String value() default "";
 	}
 
+	/**
+	 * Annotation used on config option fields or options class to mark them as a suffix-option; i.e., a config option
+	 * where the key is only a suffix, with the prefix being danymically provided at runtime.
+	 */
+	@Target({ElementType.FIELD, ElementType.TYPE})
+	@Retention(RetentionPolicy.RUNTIME)
+	@Internal
+	public @interface SuffixOption {
+	}
+
 	private Documentation(){
 	}
 }

--- a/flink-docs/pom.xml
+++ b/flink-docs/pom.xml
@@ -75,6 +75,11 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-metrics-influxdb_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
 			<!-- necessary for loading the web-submission extension -->
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-runtime-web_${scala.binary.version}</artifactId>

--- a/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
@@ -68,6 +68,7 @@ public class ConfigOptionsDocGenerator {
 		new OptionsClassLocation("flink-mesos", "org.apache.flink.mesos.configuration"),
 		new OptionsClassLocation("flink-mesos", "org.apache.flink.mesos.runtime.clusterframework"),
 		new OptionsClassLocation("flink-metrics/flink-metrics-prometheus", "org.apache.flink.metrics.prometheus"),
+		new OptionsClassLocation("flink-metrics/flink-metrics-influxdb", "org.apache.flink.metrics.influxdb"),
 		new OptionsClassLocation("flink-state-backends/flink-statebackend-rocksdb", "org.apache.flink.contrib.streaming.state"),
 		new OptionsClassLocation("flink-table/flink-table-api-java", "org.apache.flink.table.api.config"),
 		new OptionsClassLocation("flink-python", "org.apache.flink.python"),

--- a/flink-docs/src/test/java/org/apache/flink/docs/configuration/ConfigOptionsDocsCompletenessITCase.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/configuration/ConfigOptionsDocsCompletenessITCase.java
@@ -206,13 +206,10 @@ public class ConfigOptionsDocsCompletenessITCase {
 				List<ConfigOptionsDocGenerator.OptionWithMetaInfo> configOptions = extractConfigOptions(optionsClass);
 				for (ConfigOptionsDocGenerator.OptionWithMetaInfo option : configOptions) {
 					if (predicate.test(option)) {
-						String key = option.option.key();
-						String defaultValue = stringifyDefault(option);
-						String typeValue = typeToHtml(option);
-						String description = htmlFormatter.format(option.option.description());
+						ExistingOption newOption = toExistingOption(option, optionsClass)
 						ExistingOption duplicate = existingOptions.put(
-							key,
-							new ExistingOption(key, defaultValue, typeValue, description, optionsClass));
+							newOption.key,
+							newOption);
 						if (duplicate != null) {
 							// multiple documented options have the same key
 							// we fail here outright as this is not a documentation-completeness problem
@@ -228,6 +225,13 @@ public class ConfigOptionsDocsCompletenessITCase {
 		}
 
 		return existingOptions;
+
+	private static ExistingOption toExistingOption(ConfigOptionsDocGenerator.OptionWithMetaInfo optionWithMetaInfo, Class<?> optionsClass) {
+		String key = optionWithMetaInfo.option.key();
+		String defaultValue = stringifyDefault(optionWithMetaInfo);
+		String typeValue = typeToHtml(optionWithMetaInfo);
+		String description = htmlFormatter.format(optionWithMetaInfo.option.description());
+		return new ExistingOption(key, defaultValue, typeValue, description, optionsClass);
 	}
 
 	private static final class ExistingOption extends Option {

--- a/flink-docs/src/test/java/org/apache/flink/docs/configuration/ConfigOptionsDocsCompletenessITCase.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/configuration/ConfigOptionsDocsCompletenessITCase.java
@@ -35,7 +35,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -63,49 +63,94 @@ public class ConfigOptionsDocsCompletenessITCase {
 
 	@Test
 	public void testCommonSectionCompleteness() throws IOException, ClassNotFoundException {
-		Map<String, DocumentedOption> documentedOptions = parseDocumentedCommonOptions();
-		Map<String, ExistingOption> existingOptions = findExistingOptions(
+		Map<String, List<DocumentedOption>> documentedOptions = parseDocumentedCommonOptions();
+		Map<String, List<ExistingOption>> existingOptions = findExistingOptions(
 			optionWithMetaInfo -> optionWithMetaInfo.field.getAnnotation(Documentation.CommonOption.class) != null);
+
+		assertExistingOptionsAreWellDefined(existingOptions);
 
 		compareDocumentedAndExistingOptions(documentedOptions, existingOptions);
 	}
 
 	@Test
 	public void testFullReferenceCompleteness() throws IOException, ClassNotFoundException {
-		Map<String, DocumentedOption> documentedOptions = parseDocumentedOptions();
-		Map<String, ExistingOption> existingOptions = findExistingOptions(ignored -> true);
+		Map<String, List<DocumentedOption>> documentedOptions = parseDocumentedOptions();
+		Map<String, List<ExistingOption>> existingOptions = findExistingOptions(ignored -> true);
+
+		assertExistingOptionsAreWellDefined(existingOptions);
 
 		compareDocumentedAndExistingOptions(documentedOptions, existingOptions);
 	}
 
-	private static void compareDocumentedAndExistingOptions(Map<String, DocumentedOption> documentedOptions, Map<String, ExistingOption> existingOptions) {
+	private static void assertExistingOptionsAreWellDefined(Map<String, List<ExistingOption>> allOptions) {
+		allOptions.values().stream()
+			.forEach(options -> options.stream()
+				.reduce((option1, option2) -> {
+					if (option1.equals(option2)) {
+						// we allow multiple instances of ConfigOptions with the same key if they are identical
+						return option1;
+					} else {
+						// found a ConfigOption pair with the same key that aren't equal
+						// we fail here outright as this is not a documentation-completeness problem
+						if (!option1.defaultValue.equals(option2.defaultValue)) {
+							String errorMessage = String.format(
+								"Ambiguous option %s due to distinct default values (%s (in %s) vs %s (in %s)).",
+								option1.key,
+								option1.defaultValue,
+								option1.containingClass.getSimpleName(),
+								option2.defaultValue,
+								option2.containingClass.getSimpleName());
+							throw new AssertionError(errorMessage);
+						} else {
+							String errorMessage = String.format(
+								"Ambiguous option %s due to distinct descriptions (%s vs %s).",
+								option1.key,
+								option1.containingClass.getSimpleName(),
+								option2.containingClass.getSimpleName());
+							throw new AssertionError(errorMessage);
+						}
+					}
+				}));
+	}
+
+	private static void compareDocumentedAndExistingOptions(Map<String, List<DocumentedOption>> documentedOptions, Map<String, List<ExistingOption>> existingOptions) {
 		final Collection<String> problems = new ArrayList<>(0);
 
 		// first check that all existing options are properly documented
-		existingOptions.forEach((key, supposedState) -> {
-			DocumentedOption documentedState = documentedOptions.remove(key);
+		existingOptions.forEach((key, supposedStates) -> {
+			List<DocumentedOption> documentedState = documentedOptions.get(key);
 
-			// if nothing matches the docs for this option are up-to-date
-			if (documentedState == null) {
-				// option is not documented at all
-				problems.add("Option " + supposedState.key + " in " + supposedState.containingClass + " is not documented.");
-			} else if (!supposedState.defaultValue.equals(documentedState.defaultValue)) {
-				// default is outdated
-				problems.add("Documented default of " + supposedState.key + " in " + supposedState.containingClass +
-					" is outdated. Expected: " + supposedState.defaultValue + " Actual: " + documentedState.defaultValue);
-			} else if (!supposedState.description.equals(documentedState.description)) {
-				// description is outdated
-				problems.add("Documented description of " + supposedState.key + " in " + supposedState.containingClass +
-					" is outdated.");
+			for (ExistingOption supposedState : supposedStates) {
+				if (documentedState == null || documentedState.isEmpty()) {
+					// option is not documented at all
+					problems.add("Option " + supposedState.key + " in " + supposedState.containingClass + " is not documented.");
+				} else {
+					final Iterator<DocumentedOption> candidates = documentedState.iterator();
+
+					boolean matchFound = false;
+					while (candidates.hasNext() && !matchFound) {
+						DocumentedOption candidate = candidates.next();
+						if (supposedState.defaultValue.equals(candidate.defaultValue) && supposedState.description.equals(candidate.description)) {
+							matchFound = true;
+							candidates.remove();
+						}
+					}
+
+					if (!matchFound) {
+						problems.add(String.format(
+							"Documentation of %s in %s is outdated. Expected: default=(%s) description=(%s).",
+							supposedState.key,
+							supposedState.containingClass.getSimpleName(),
+							supposedState.defaultValue,
+							supposedState.description));
+					}
+				}
 			}
 		});
 
 		// documentation contains an option that no longer exists
-		if (!documentedOptions.isEmpty()) {
-			for (DocumentedOption documentedOption : documentedOptions.values()) {
-				problems.add("Documented option " + documentedOption.key + " does not exist.");
-			}
-		}
+		documentedOptions.values().stream().flatMap(Collection::stream)
+			.forEach(documentedOption -> problems.add("Documented option " + documentedOption.key + " does not exist."));
 
 		if (!problems.isEmpty()) {
 			StringBuilder sb = new StringBuilder("Documentation is outdated, please regenerate it according to the" +
@@ -121,28 +166,13 @@ public class ConfigOptionsDocsCompletenessITCase {
 		}
 	}
 
-	private static Map<String, DocumentedOption> parseDocumentedCommonOptions() throws IOException {
+	private static Map<String, List<DocumentedOption>> parseDocumentedCommonOptions() throws IOException {
 		Path commonSection = Paths.get(System.getProperty("rootDir"), "docs", "_includes", "generated", COMMON_SECTION_FILE_NAME);
 		return parseDocumentedOptionsFromFile(commonSection).stream()
-			.collect(Collectors.toMap(option -> option.key, option -> option, (option1, option2) -> {
-				if (option1.equals(option2)) {
-					// we allow multiple instances of ConfigOptions with the same key if they are identical
-					return option1;
-				} else {
-					// found a ConfigOption pair with the same key that aren't equal
-					// we fail here outright as this is not a documentation-completeness problem
-					if (!option1.defaultValue.equals(option2.defaultValue)) {
-						throw new AssertionError("Documentation contains distinct defaults for " +
-							option1.key + " in " + option1.containingFile + " and " + option2.containingFile + '.');
-					} else {
-						throw new AssertionError("Documentation contains distinct descriptions for " +
-							option1.key + " in " + option1.containingFile + " and " + option2.containingFile + '.');
-					}
-				}
-			}));
+			.collect(Collectors.groupingBy(option -> option.key, Collectors.toList()));
 	}
 
-	private static Map<String, DocumentedOption> parseDocumentedOptions() throws IOException {
+	private static Map<String, List<DocumentedOption>> parseDocumentedOptions() throws IOException {
 		Path includeFolder = Paths.get(System.getProperty("rootDir"), "docs", "_includes", "generated").toAbsolutePath();
 		return Files.list(includeFolder)
 			.filter(path -> path.getFileName().toString().contains("configuration"))
@@ -153,22 +183,7 @@ public class ConfigOptionsDocsCompletenessITCase {
 					return Stream.empty();
 				}
 			})
-			.collect(Collectors.toMap(option -> option.key, option -> option, (option1, option2) -> {
-				if (option1.equals(option2)) {
-					// we allow multiple instances of ConfigOptions with the same key if they are identical
-					return option1;
-				} else {
-					// found a ConfigOption pair with the same key that aren't equal
-					// we fail here outright as this is not a documentation-completeness problem
-					if (!option1.defaultValue.equals(option2.defaultValue)) {
-						throw new AssertionError("Documentation contains distinct defaults for " +
-							option1.key + " in " + option1.containingFile + " and " + option2.containingFile + '.');
-					} else {
-						throw new AssertionError("Documentation contains distinct descriptions for " +
-							option1.key + " in " + option1.containingFile + " and " + option2.containingFile + '.');
-					}
-				}
-			}));
+			.collect(Collectors.groupingBy(option -> option.key, Collectors.toList()));
 	}
 
 	private static Collection<DocumentedOption> parseDocumentedOptionsFromFile(Path file) throws IOException {
@@ -198,33 +213,20 @@ public class ConfigOptionsDocsCompletenessITCase {
 			.collect(Collectors.toList());
 	}
 
-	private static Map<String, ExistingOption> findExistingOptions(Predicate<ConfigOptionsDocGenerator.OptionWithMetaInfo> predicate) throws IOException, ClassNotFoundException {
-		Map<String, ExistingOption> existingOptions = new HashMap<>(32);
+	private static Map<String, List<ExistingOption>> findExistingOptions(Predicate<ConfigOptionsDocGenerator.OptionWithMetaInfo> predicate) throws IOException, ClassNotFoundException {
+		final Collection<ExistingOption> existingOptions = new ArrayList<>();
 
 		for (OptionsClassLocation location : LOCATIONS) {
-			processConfigOptions(System.getProperty("rootDir"), location.getModule(), location.getPackage(), DEFAULT_PATH_PREFIX, optionsClass -> {
-				List<ConfigOptionsDocGenerator.OptionWithMetaInfo> configOptions = extractConfigOptions(optionsClass);
-				for (ConfigOptionsDocGenerator.OptionWithMetaInfo option : configOptions) {
-					if (predicate.test(option)) {
-						ExistingOption newOption = toExistingOption(option, optionsClass)
-						ExistingOption duplicate = existingOptions.put(
-							newOption.key,
-							newOption);
-						if (duplicate != null) {
-							// multiple documented options have the same key
-							// we fail here outright as this is not a documentation-completeness problem
-							if (!(duplicate.description.equals(description))) {
-								throw new AssertionError("Ambiguous option " + key + " due to distinct descriptions.");
-							} else if (!duplicate.defaultValue.equals(defaultValue)) {
-								throw new AssertionError("Ambiguous option " + key + " due to distinct default values (" + defaultValue + " vs " + duplicate.defaultValue + ").");
-							}
-						}
-					}
-				}
-			});
+			processConfigOptions(System.getProperty("rootDir"), location.getModule(), location.getPackage(), DEFAULT_PATH_PREFIX, optionsClass ->
+				extractConfigOptions(optionsClass)
+					.stream()
+					.filter(predicate)
+					.map(optionWithMetaInfo -> toExistingOption(optionWithMetaInfo, optionsClass))
+					.forEach(existingOptions::add));
 		}
 
-		return existingOptions;
+		return existingOptions.stream().collect(Collectors.groupingBy(option -> option.key, Collectors.toList()));
+	}
 
 	private static ExistingOption toExistingOption(ConfigOptionsDocGenerator.OptionWithMetaInfo optionWithMetaInfo, Class<?> optionsClass) {
 		String key = optionWithMetaInfo.option.key();

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporterOptions.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporterOptions.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.metrics.influxdb;
 
+import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.metrics.MetricConfig;
@@ -27,6 +28,7 @@ import org.influxdb.InfluxDB;
 /**
  * Config options for {@link InfluxdbReporter}.
  */
+@Documentation.SuffixOption
 public class InfluxdbReporterOptions {
 
 	public static final ConfigOption<String> HOST = ConfigOptions

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterOptions.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterOptions.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.metrics.prometheus;
 
+import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.description.Description;
@@ -27,6 +28,7 @@ import org.apache.flink.configuration.description.TextElement;
 /**
  * Config options for the {@link PrometheusPushGatewayReporter}.
  */
+@Documentation.SuffixOption
 public class PrometheusPushGatewayReporterOptions {
 
 	public static final ConfigOption<String> HOST = ConfigOptions


### PR DESCRIPTION
The `ConfigOptionsDocsCompletenessITCase` verifies that all existing and documented options are well-defined; as in that for any key there is exactly 1 default and description present, globally.

There is one use-case however where this check is too strict: reporters. These only work with key suffixes (like "port") and hence are failing this check. As a result we don't use the generator mechanism for reporters, which is unfortunate.

This PR introduces a whitelisting mechanism that allows us to define a set of keys for which this check is not performed.
Note that the remaining checks of the test are still applied. (Is the option documented, does the documented option exist, do the defaults/description match).

The changes are mostly a refactoring of the test. Previously the test was checking whether an ambiguous key exists during the discovery of keys, which was now separated.
This implies that during discovery we no longer end up with a 1:1 mapping of key:option, but rather 1:N which is later checked.