### PR TITLE
[FLINK-15403][task] Allow the CancelTaskException to be thrown from mailbox thread

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
@@ -249,7 +249,8 @@ public class TaskExecutorResourceUtils {
 	}
 
 	private static JvmMetaspaceAndOverhead deriveJvmMetaspaceAndOverheadFromTotalFlinkMemory(
-		final Configuration config, final MemorySize totalFlinkMemorySize) {
+			final Configuration config,
+			final MemorySize totalFlinkMemorySize) {
 		final MemorySize jvmMetaspaceSize = getJvmMetaspaceSize(config);
 		final MemorySize jvmOverheadSize = deriveJvmOverheadWithInverseFraction(config,
 			totalFlinkMemorySize.add(jvmMetaspaceSize));
@@ -257,7 +258,8 @@ public class TaskExecutorResourceUtils {
 	}
 
 	private static FlinkInternalMemory deriveInternalMemoryFromTotalFlinkMemory(
-		final Configuration config, final MemorySize totalFlinkMemorySize) {
+			final Configuration config,
+			final MemorySize totalFlinkMemorySize) {
 		final MemorySize frameworkHeapMemorySize = getFrameworkHeapMemorySize(config);
 		final MemorySize frameworkOffHeapMemorySize = getFrameworkOffHeapMemorySize(config);
 		final MemorySize taskOffHeapMemorySize = getTaskOffHeapMemorySize(config);
@@ -516,7 +518,10 @@ public class TaskExecutorResourceUtils {
 		}
 	}
 
-	private static void sanityCheckTotalProcessMemory(final Configuration config, final MemorySize totalFlinkMemory, final JvmMetaspaceAndOverhead jvmMetaspaceAndOverhead) {
+	private static void sanityCheckTotalProcessMemory(
+			final Configuration config,
+			final MemorySize totalFlinkMemory,
+			final JvmMetaspaceAndOverhead jvmMetaspaceAndOverhead) {
 		final MemorySize derivedTotalProcessMemorySize =
 			totalFlinkMemory.add(jvmMetaspaceAndOverhead.metaspace).add(jvmMetaspaceAndOverhead.overhead);
 		if (isTotalProcessMemorySizeExplicitlyConfigured(config)) {
@@ -533,7 +538,10 @@ public class TaskExecutorResourceUtils {
 		}
 	}
 
-	private static void sanityCheckShuffleMemory(final Configuration config, final MemorySize derivedShuffleMemorySize, final MemorySize totalFlinkMemorySize) {
+	private static void sanityCheckShuffleMemory(
+			final Configuration config,
+			final MemorySize derivedShuffleMemorySize,
+			final MemorySize totalFlinkMemorySize) {
 		if (isUsingLegacyShuffleConfigs(config)) {
 			final MemorySize configuredShuffleMemorySize = getShuffleMemorySizeWithLegacyConfig(config);
 			if (!configuredShuffleMemorySize.equals(derivedShuffleMemorySize)) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -92,11 +92,10 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 	 * Allocates all {@link MemorySegment} instances managed by this pool.
 	 */
 	public NetworkBufferPool(
-		int numberOfSegmentsToAllocate,
-		int segmentSize,
-		int numberOfSegmentsToRequest,
-		Duration requestSegmentsTimeout) {
-
+			int numberOfSegmentsToAllocate,
+			int segmentSize,
+			int numberOfSegmentsToRequest,
+			Duration requestSegmentsTimeout) {
 		this.totalNumberOfMemorySegments = numberOfSegmentsToAllocate;
 		this.memorySegmentSize = segmentSize;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -503,11 +503,6 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 				throw e;
 			}
 		}
-		catch (CancelTaskException e) {
-			if (!canceled) {
-				LOG.error("Received CancelTaskException while we are not canceled. This is a bug and should be reported", e);
-			}
-		}
 		catch (Exception e) {
 			if (canceled) {
 				LOG.warn("Error while canceling task.", e);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -427,6 +427,41 @@ public class StreamTaskTest extends TestLogger {
 		}
 	}
 
+	/**
+	 *  CancelTaskException can be thrown in a down stream task, for example if an upstream task
+	 *  was cancelled first and those two tasks were connected via
+	 *  {@link org.apache.flink.runtime.io.network.partition.consumer.LocalInputChannel}.
+	 *  {@link StreamTask} should be able to correctly handle such situation.
+	 */
+	@Test
+	public void testCancelTaskExceptionHandling() throws Exception {
+		StreamConfig cfg = new StreamConfig(new Configuration());
+		Task task = createTask(CancelThrowingTask.class, cfg, new Configuration());
+
+		task.startTaskThread();
+		task.getExecutingThread().join();
+
+		assertEquals(ExecutionState.CANCELED, task.getExecutionState());
+	}
+
+	/**
+	 * A task that throws {@link CancelTaskException}.
+	 */
+	public static class CancelThrowingTask extends StreamTask<String, AbstractStreamOperator<String>> {
+
+		public CancelThrowingTask(Environment env) {
+			super(env);
+		}
+
+		@Override
+		protected void init() {}
+
+		@Override
+		protected void processInput(MailboxDefaultAction.Controller controller) {
+			throw new CancelTaskException();
+		}
+	}
+
 	@Test
 	public void testDecliningCheckpointStreamOperator() throws Exception {
 		DeclineDummyEnvironment declineDummyEnvironment = new DeclineDummyEnvironment();


### PR DESCRIPTION
CancelTaskException can be thrown for example from LocalInputChannel#getNextBuffer even if the current (down stream) task hasn't YET been canceled. This restores the behaviour to before [FLINK-15317].
    
StreamTask is able to correctly process/handle CancelTaskException.

## Verifying this change

This adds a new test and is also covered by some end to end tests that were able to detect the issue in the first place.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
