### PR TITLE
[FLINK-14091][coordination] Allow updates to connection state when ZKCheckpointIDCounter reconnects to ZK

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultLastStateConnectionStateListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultLastStateConnectionStateListener.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.state.ConnectionState;
+
+import javax.annotation.Nullable;
+
+import java.util.Optional;
+
+public class DefaultLastStateConnectionStateListener implements LastStateConnectionStateListener {
+
+	@Nullable
+	private volatile ConnectionState lastState = null;
+
+	@Override
+	public Optional<ConnectionState> getLastState() {
+		return Optional.ofNullable(lastState);
+	}
+
+	@Override
+	public void stateChanged(CuratorFramework client, ConnectionState newState) {
+		lastState = newState;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/LastStateConnectionStateListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/LastStateConnectionStateListener.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.framework.state.ConnectionStateListener;
+
+import java.util.Optional;
+
+/**
+ * {@link ConnectionStateListener} which records the last state it was notified about.
+ */
+public interface LastStateConnectionStateListener extends ConnectionStateListener {
+
+	/**
+	 * Return the last state the listener was notified about.
+	 *
+	 * @return the last state or none if the listener has not received an update
+	 */
+	Optional<ConnectionState> getLastState();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointIDCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointIDCounter.java
@@ -57,13 +57,13 @@ public class ZooKeeperCheckpointIDCounter implements CheckpointIDCounter {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperCheckpointIDCounter.class);
 
-	/** Curator ZooKeeper client */
+	/** Curator ZooKeeper client. */
 	private final CuratorFramework client;
 
-	/** Path of the shared count */
+	/** Path of the shared count. */
 	private final String counterPath;
 
-	/** Curator recipe for shared counts */
+	/** Curator recipe for shared counts. */
 	private final SharedCount sharedCount;
 
 	private final Collection<ConnectionStateListener> connectionStateListeners;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointIDCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointIDCounter.java
@@ -112,7 +112,7 @@ public class ZooKeeperCheckpointIDCounter implements CheckpointIDCounter {
 	@Override
 	public long getAndIncrement() throws Exception {
 		while (true) {
-			checkConnectionState();
+			connStateListener.checkConnectionState();
 
 			VersionedValue<Integer> current = sharedCount.getVersionedValue();
 			int newCount = current.getValue() + 1;
@@ -131,18 +131,14 @@ public class ZooKeeperCheckpointIDCounter implements CheckpointIDCounter {
 
 	@Override
 	public long get() {
-		checkConnectionState();
+		connStateListener.checkConnectionState();
 
 		return sharedCount.getVersionedValue().getValue();
 	}
 
 	@Override
 	public void setCount(long newId) throws Exception {
-		ConnectionState connState = connStateListener.getLastState();
-
-		if (connState != null) {
-			throw new IllegalStateException("Connection state: " + connState);
-		}
+		connStateListener.checkConnectionState();
 
 		if (newId > Integer.MAX_VALUE) {
 			throw new IllegalArgumentException("ZooKeeper checkpoint counter only supports " +
@@ -151,14 +147,6 @@ public class ZooKeeperCheckpointIDCounter implements CheckpointIDCounter {
 		}
 
 		sharedCount.setCount((int) newId);
-	}
-
-	private void checkConnectionState() {
-		ConnectionState connState = connStateListener.getLastState();
-
-		if (connState != null) {
-			throw new IllegalStateException("Connection state: " + connState);
-		}
 	}
 
 	/**
@@ -171,13 +159,17 @@ public class ZooKeeperCheckpointIDCounter implements CheckpointIDCounter {
 
 		@Override
 		public void stateChanged(CuratorFramework client, ConnectionState newState) {
-			if (newState == ConnectionState.SUSPENDED || newState == ConnectionState.LOST) {
-				lastState = newState;
-			}
+			lastState = newState;
 		}
 
-		private ConnectionState getLastState() {
-			return lastState;
+		private void checkConnectionState() {
+			if (lastState == null) {
+				return;
+			}
+
+			if (lastState != ConnectionState.CONNECTED && lastState != ConnectionState.RECONNECTED) {
+				throw new IllegalStateException("Connection state: " + lastState);
+			}
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointIDCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointIDCounter.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 
@@ -147,6 +148,11 @@ public class ZooKeeperCheckpointIDCounter implements CheckpointIDCounter {
 		}
 
 		sharedCount.setCount((int) newId);
+	}
+
+	@VisibleForTesting
+	ConnectionState getLastState() {
+		return connStateListener.lastState;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
+import org.apache.flink.runtime.checkpoint.DefaultLastStateConnectionStateListener;
 import org.apache.flink.runtime.checkpoint.ZooKeeperCheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.ZooKeeperCompletedCheckpointStore;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
@@ -345,7 +346,7 @@ public class ZooKeeperUtils {
 
 		checkpointIdCounterPath += ZooKeeperJobGraphStore.getPathForJob(jobId);
 
-		return new ZooKeeperCheckpointIDCounter(client, checkpointIdCounterPath);
+		return new ZooKeeperCheckpointIDCounter(client, checkpointIdCounterPath, new DefaultLastStateConnectionStateListener());
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointIDCounterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointIDCounterTest.java
@@ -99,8 +99,10 @@ public abstract class CheckpointIDCounterTest extends TestLogger {
 
 		@Override
 		protected CheckpointIDCounter createCompletedCheckpoints() throws Exception {
-			return new ZooKeeperCheckpointIDCounter(ZooKeeper.getClient(),
-					"/checkpoint-id-counter");
+			return new ZooKeeperCheckpointIDCounter(
+				ZooKeeper.getClient(),
+				"/checkpoint-id-counter",
+				new DefaultLastStateConnectionStateListener());
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZKCheckpointIDCounterMultiServersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZKCheckpointIDCounterMultiServersTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.runtime.zookeeper.ZooKeeperTestEnvironment;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.test.TestingCluster;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link ZooKeeperCheckpointIDCounter} in a ZooKeeper ensemble.
+ */
+public final class ZKCheckpointIDCounterMultiServersTest extends TestLogger {
+
+	private static final ZooKeeperTestEnvironment ZOOKEEPER = new ZooKeeperTestEnvironment(3);
+
+	@AfterClass
+	public static void tearDown() throws Exception {
+		ZOOKEEPER.shutdown();
+	}
+
+	@Before
+	public void cleanUp() throws Exception {
+		ZOOKEEPER.deleteAll();
+	}
+
+	/**
+	 * Tests that {@link ZooKeeperCheckpointIDCounter} can be recovered after a
+	 * connection loss exception from ZooKeeper ensemble.
+	 *
+	 * See also FLINK-14091.
+	 */
+	@Test
+	public void testRecoveredAfterConnectionLoss() throws Exception {
+		CuratorFramework client = ZOOKEEPER.getClient();
+
+		ZooKeeperCheckpointIDCounter idCounter = new ZooKeeperCheckpointIDCounter(client, "/checkpoint-id-counter");
+		idCounter.start();
+
+		AtomicLong localCounter = new AtomicLong(1L);
+
+		assertThat(
+			"ZooKeeperCheckpointIDCounter doesn't properly work.",
+			idCounter.getAndIncrement(),
+			is(localCounter.getAndIncrement()));
+
+		TestingCluster cluster = ZOOKEEPER.getZooKeeperCluster();
+		assertThat(cluster, is(notNullValue()));
+
+		// close the server this client connected to, which triggers a connection loss exception
+		cluster.restartServer(cluster.findConnectionInstance(client.getZookeeperClient().getZooKeeper()));
+
+		// encountered connected loss, this prevents us from getting false positive
+		while (true) {
+			try {
+				idCounter.get();
+			} catch (IllegalStateException ignore) {
+				log.debug("Encountered connection loss.");
+				break;
+			}
+		}
+
+		// recovered from connection loss
+		while (true) {
+			try {
+				long id = idCounter.get();
+				assertThat(id, is(localCounter.get()));
+				break;
+			} catch (IllegalStateException ignore) {
+				log.debug("During ZooKeeper client reconnecting...");
+			}
+		}
+
+		assertThat(idCounter.getLastState(), is(ConnectionState.RECONNECTED));
+		assertThat(
+			"ZooKeeperCheckpointIDCounter doesn't properly work after reconnected.",
+			idCounter.getAndIncrement(),
+			is(localCounter.getAndIncrement()));
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperResource.java
@@ -69,4 +69,9 @@ public class ZooKeeperResource extends ExternalResource {
 			LOG.warn("Could not properly terminate the {}.", getClass().getSimpleName(), e);
 		}
 	}
+
+	public void restart() throws Exception {
+		Preconditions.checkNotNull(zooKeeperServer);
+		zooKeeperServer.restart();
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperTestEnvironment.java
@@ -18,16 +18,17 @@
 
 package org.apache.flink.runtime.zookeeper;
 
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.test.TestingCluster;
-import org.apache.curator.test.TestingServer;
-import org.apache.curator.utils.ZKPaths;
-
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.test.TestingCluster;
+import org.apache.curator.test.TestingServer;
+import org.apache.curator.utils.ZKPaths;
 import org.apache.zookeeper.KeeperException;
+
+import javax.annotation.Nullable;
 
 import java.util.List;
 
@@ -118,6 +119,11 @@ public class ZooKeeperTestEnvironment {
 
 	public String getClientNamespace() {
 		return client.getNamespace();
+	}
+
+	@Nullable
+	public TestingCluster getZooKeeperCluster() {
+		return zooKeeperCluster;
 	}
 
 	public List<String> getChildren(String path) throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

`ZKCheckpointIDCounter` doesn't tolerate ZK suspended & reconnected while it could do. This causes that job can not trigger checkpoint forever after zookeeper change leader.

## Brief change log

Allow updates to connection state when ZKCheckpointIDCounter reconnects to ZK.

## Verifying this change

This change is a trivial fix that can be reasoned by code.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
