### PR TITLE
[FLINK-15465][FLINK-11964][table-runtime-blink] Fix required memory calculation not accurate and hash collision bugs in hash table

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/BaseHybridHashTable.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/BaseHybridHashTable.java
@@ -73,10 +73,6 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 	private static final int MIN_NUM_MEMORY_SEGMENTS = 33;
 	protected final int initPartitionFanOut;
 
-	/**
-	 * The owner to associate with the memory segment.
-	 */
-	private Object owner;
 	private final int avgRecordLen;
 	protected final long buildRowCount;
 
@@ -177,7 +173,6 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 		this.compressionBlockSize = (int) MemorySize.parse(
 			conf.getString(ExecutionConfigOptions.TABLE_EXEC_SPILL_COMPRESSION_BLOCK_SIZE)).getBytes();
 
-		this.owner = owner;
 		this.avgRecordLen = avgRecordLen;
 		this.buildRowCount = buildRowCount;
 		this.tryDistinctBuildRow = tryDistinctBuildRow;
@@ -516,4 +511,10 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 		return code >= 0 ? code : -(code + 1);
 	}
 
+	/**
+	 * Partition level hash again, for avoid two layer hash conflict.
+	 */
+	static int partitionLevelHash(int hash) {
+		return hash ^ (hash >>> 16);
+	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/BinaryHashTable.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/BinaryHashTable.java
@@ -477,7 +477,7 @@ public class BinaryHashTable extends BaseHybridHashTable {
 
 			// first read the partition in
 			final List<MemorySegment> partitionBuffers = readAllBuffers(p.getBuildSideChannel().getChannelID(), p.getBuildSideBlockCount());
-			BinaryHashBucketArea area = new BinaryHashBucketArea(this, (int) p.getBuildSideRecordCount(), maxBucketAreaBuffers);
+			BinaryHashBucketArea area = new BinaryHashBucketArea(this, (int) p.getBuildSideRecordCount(), maxBucketAreaBuffers, false);
 			final BinaryHashPartition newPart = new BinaryHashPartition(area, this.binaryBuildSideSerializer, this.binaryProbeSideSerializer,
 					0, nextRecursionLevel, partitionBuffers, p.getBuildSideRecordCount(), this.segmentSize, p.getLastSegmentLimit());
 			area.setPartition(newPart);
@@ -490,7 +490,7 @@ public class BinaryHashTable extends BaseHybridHashTable {
 			while (pIter.advanceNext()) {
 				final int hashCode = hash(buildSideProjection.apply(pIter.getRow()).hashCode(), nextRecursionLevel);
 				final int pointer = (int) pIter.getPointer();
-				area.insertToBucket(hashCode, pointer, false, true);
+				area.insertToBucket(hashCode, pointer, true);
 			}
 		} else {
 			// go over the complete input and insert every element into the hash table
@@ -624,7 +624,7 @@ public class BinaryHashTable extends BaseHybridHashTable {
 		return largestPartNum;
 	}
 
-	boolean applyCondition(BinaryRow candidate) throws Exception {
+	boolean applyCondition(BinaryRow candidate) {
 		BinaryRow buildKey = buildSideProjection.apply(candidate);
 		// They come from Projection, so we can make sure it is in byte[].
 		boolean equal = buildKey.getSizeInBytes() == probeKey.getSizeInBytes()

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHashPartition.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHashPartition.java
@@ -250,7 +250,7 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
 	 * Returns an iterator for all the values for the given key, or null if no value found.
 	 */
 	public MatchIterator get(long key, int hashCode) {
-		int bucket = hashCode & numBucketsMask;
+		int bucket = findBucket(hashCode);
 
 		int bucketOffset = bucket << 4;
 		MemorySegment segment = buckets[bucketOffset >>> segmentSizeBits];

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHashPartition.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHashPartition.java
@@ -47,6 +47,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
 
+import static org.apache.flink.table.runtime.hashtable.BaseHybridHashTable.partitionLevelHash;
 import static org.apache.flink.table.runtime.hashtable.LongHybridHashTable.hashLong;
 import static org.apache.flink.util.Preconditions.checkArgument;
 
@@ -198,7 +199,7 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
 
 	private static MemorySegment[] listToArray(List<MemorySegment> list) {
 		if (list != null) {
-			return list.toArray(new MemorySegment[list.size()]);
+			return list.toArray(new MemorySegment[0]);
 		}
 		return null;
 	}
@@ -225,15 +226,15 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
 		this.numKeys = 0;
 	}
 
-	static long toAddrAndLen(long address, int size) {
+	private static long toAddrAndLen(long address, int size) {
 		return (address << SIZE_BITS) | size;
 	}
 
-	static long toAddress(long addrAndLen) {
+	private static long toAddress(long addrAndLen) {
 		return addrAndLen >>> SIZE_BITS;
 	}
 
-	static int toLength(long addrAndLen) {
+	private static int toLength(long addrAndLen) {
 		return (int) (addrAndLen & SIZE_MASK);
 	}
 
@@ -244,10 +245,6 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
 		iterator.set(address);
 		return iterator;
 	}
-
-//	public MatchIterator get(long key) {
-//		return get(key, hashLong(key, recursionLevel));
-//	}
 
 	/**
 	 * Returns an iterator for all the values for the given key, or null if no value found.
@@ -291,7 +288,7 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
 			MemorySegment dataSegment,
 			int currentPositionInSegment) throws IOException {
 		assert (numKeys <= numBuckets / 2);
-		int bucketId = hashCode & numBucketsMask;
+		int bucketId = findBucket(hashCode);
 
 		// each bucket occupied 16 bytes (long key + long pointer to data address)
 		int bucketOffset = bucketId * SPARSE_BUCKET_ELEMENT_SIZE_IN_BYTES;
@@ -340,6 +337,10 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
 			dataSegment.putLong(currentPositionInSegment, toAddrAndLen(currAddress, size));
 			segment.putLong(segOffset + 8, address);
 		}
+	}
+
+	private int findBucket(int hash) {
+		return partitionLevelHash(hash) & this.numBucketsMask;
 	}
 
 	private void resize() throws IOException {
@@ -416,10 +417,6 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
 
 	BlockChannelWriter<MemorySegment> getBuildSideChannel() {
 		return this.buildSideChannel;
-	}
-
-	FileIOChannel.ID getProbeSideChannelID() {
-		return probeSideBuffer.getChannel().getChannelID();
 	}
 
 	int getPartitionNumber() {
@@ -622,7 +619,7 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
 			if (row.getSegments().length == 1) {
 				buildSideWriteBuffer.write(row.getSegments()[0], row.getOffset(), sizeInBytes);
 			} else {
-				buildSideSerializer.serializeWithoutLengthSlow(row, buildSideWriteBuffer);
+				BinaryRowSerializer.serializeWithoutLengthSlow(row, buildSideWriteBuffer);
 			}
 		} else {
 			serializeToPages(row);
@@ -642,7 +639,7 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
 		if (row.getSegments().length == 1) {
 			buildSideWriteBuffer.write(row.getSegments()[0], row.getOffset(), sizeInBytes);
 		} else {
-			buildSideSerializer.serializeWithoutLengthSlow(row, buildSideWriteBuffer);
+			BinaryRowSerializer.serializeWithoutLengthSlow(row, buildSideWriteBuffer);
 		}
 	}
 
@@ -729,8 +726,7 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
 
 			if (this.writer == null) {
 				this.targetList.add(current);
-				MemorySegment[] buffers =
-						this.targetList.toArray(new MemorySegment[this.targetList.size()]);
+				MemorySegment[] buffers = this.targetList.toArray(new MemorySegment[0]);
 				this.targetList.clear();
 				return buffers;
 			} else {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHybridHashTable.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHybridHashTable.java
@@ -247,7 +247,7 @@ public abstract class LongHybridHashTable extends BaseHybridHashTable {
 
 			this.denseBuckets = denseBuckets;
 			this.densePartition = new LongHashPartition(this, buildSideSerializer,
-					dataBuffers.toArray(new MemorySegment[dataBuffers.size()]));
+					dataBuffers.toArray(new MemorySegment[0]));
 			freeCurrent();
 		}
 	}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/hashtable/BinaryHashTableTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/hashtable/BinaryHashTableTest.java
@@ -848,6 +848,22 @@ public class BinaryHashTableTest {
 		table.free();
 	}
 
+	@Test
+	public void testBinaryHashBucketAreaNotEnoughMem() throws IOException {
+		MemoryManager memManager = MemoryManagerBuilder.newBuilder().setMemorySize(35 * PAGE_SIZE).build();
+		BinaryHashTable table = newBinaryHashTable(
+				this.buildSideSerializer, this.probeSideSerializer,
+				new MyProjection(), new MyProjection(), memManager,
+				35 * PAGE_SIZE, ioManager);
+		BinaryHashBucketArea area = new BinaryHashBucketArea(table, 100, 1, false);
+		for (int i = 0; i < 100000; i++) {
+			area.insertToBucket(i, i, true);
+		}
+		area.freeMemory();
+		table.close();
+		Assert.assertEquals(35, table.getFreedMemory().size());
+	}
+
 	// ============================================================================================
 
 	/**


### PR DESCRIPTION

## What is the purpose of the change & Brief change log

- In BinaryHashBucketArea.insertToBucket.
When BinaryHashTable.buildTableFromSpilledPartition."Build in memory hash table", it requires memory can put all records, if not, will fail.
Because the linked hash conflict solution, the required memory calculation are not accurate, in this case, we should apply for insufficient memory from heap.
And must be careful, the steal memory should not return to table.

- In HybridHashTable, first select the corresponding partition according to hashCode, and then select the bucket in the partition according to hashCode, using the same hashCode can easily cause hash collision.
Consider doing some mix to hashCode when choosing bucket.
Like JDK HashMap, we can just XOR some shifted bits in the cheapest possible way to reduce systematic lossage, as well as to incorporate impact of the highest bits that would otherwise never be used in index calculations because of table bounds. (bucket use power-of-two masking).  Just like:  (hash ^ (hash >>> 16))
In some cases, if a lot of conflicts occurred, this will lead to job hang, because hash join will degenerate to nested loop join.

## Verifying this change

`BinaryHashTableTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no