### PR TITLE
[FLINK-13027][fs-connector] SFS bulk-encoded writer supports customized checkpoint policy

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/rollingpolicies/CheckpointRollingPolicy.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/rollingpolicies/CheckpointRollingPolicy.java
@@ -22,27 +22,30 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.streaming.api.functions.sink.filesystem.PartFileInfo;
 import org.apache.flink.streaming.api.functions.sink.filesystem.RollingPolicy;
 
+import java.io.IOException;
+
 /**
- * A {@link RollingPolicy} which rolls (ONLY) on every checkpoint.
+ * An abstract {@link RollingPolicy} which rolls on every checkpoint.
  */
 @PublicEvolving
-public final class OnCheckpointRollingPolicy<IN, BucketID> extends CheckpointRollingPolicy<IN, BucketID> {
-
-	private static final long serialVersionUID = 1L;
-
-	private OnCheckpointRollingPolicy() {}
-
-	@Override
-	public boolean shouldRollOnEvent(PartFileInfo<BucketID> partFileState, IN element) {
-		return false;
+public abstract class CheckpointRollingPolicy<IN, BucketID> implements RollingPolicy<IN, BucketID> {
+	public boolean shouldRollOnCheckpoint(PartFileInfo<BucketID> partFileState) {
+		return true;
 	}
 
-	@Override
-	public boolean shouldRollOnProcessingTime(PartFileInfo<BucketID> partFileState, long currentTime) {
-		return false;
-	}
+	public abstract boolean shouldRollOnEvent(final PartFileInfo<BucketID> partFileState, IN element) throws IOException;
 
-	public static <IN, BucketID> OnCheckpointRollingPolicy<IN, BucketID> build() {
-		return new OnCheckpointRollingPolicy<>();
+	public abstract boolean shouldRollOnProcessingTime(final PartFileInfo<BucketID> partFileState, final long currentTime) throws IOException;
+
+	/**
+	 * The base abstract builder class for {@link CheckpointRollingPolicy}.
+	 */
+	public abstract static class PolicyBuilder<IN, BucketID, T extends PolicyBuilder<IN, BucketID, T>> {
+		@SuppressWarnings("unchecked")
+		protected T self() {
+			return (T) this;
+		}
+
+		public abstract CheckpointRollingPolicy<IN, BucketID> build();
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
@@ -27,6 +27,7 @@ import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
 import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.DefaultRollingPolicy;
+import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.OnCheckpointRollingPolicy;
 import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 
@@ -157,6 +158,7 @@ public class TestUtils {
 			.forBulkFormat(new Path(outDir.toURI()), writer)
 			.withBucketAssigner(bucketer)
 			.withBucketCheckInterval(bucketCheckInterval)
+			.withRollingPolicy(OnCheckpointRollingPolicy.build())
 			.withBucketFactory(bucketFactory)
 			.withOutputFileConfig(outputFileConfig)
 			.build();
@@ -197,6 +199,7 @@ public class TestUtils {
 		StreamingFileSink<Tuple2<String, Integer>> sink = StreamingFileSink
 				.forBulkFormat(new Path(outDir.toURI()), writer)
 				.withNewBucketAssigner(bucketer)
+				.withRollingPolicy(OnCheckpointRollingPolicy.build())
 				.withBucketCheckInterval(bucketCheckInterval)
 				.withBucketFactory(bucketFactory)
 				.withOutputFileConfig(outputFileConfig)


### PR DESCRIPTION
backport of https://github.com/apache/flink/pull/10653