### PR TITLE
[hotfix][docs] Align the documentation of checkpoint directory to the actual implementation

### DIFF
--- a/docs/ops/state/checkpoints.md
+++ b/docs/ops/state/checkpoints.md
@@ -67,16 +67,17 @@ The current checkpoint directory layout ([introduced by FLINK-8531](https://issu
 
 {% highlight yaml %}
 /user-defined-checkpoint-dir
-    |
-    + --shared/
-    + --taskowned/
-    + --chk-00001/
-    + --chk-00002/
-    + --chk-00003/
-    ...
+    /{job-id}
+        |
+        + --shared/
+        + --taskowned/
+        + --chk-1/
+        + --chk-2/
+        + --chk-3/
+        ...
 {% endhighlight %}
 
-The **SHARED** directory is for state that is possibly part of multiple checkpoints, **TASKOWNED** is for state that must never by dropped by the JobManager, and **EXCLUSIVE** is for state that belongs to one checkpoint only. 
+The **SHARED** directory is for state that is possibly part of multiple checkpoints, **TASKOWNED** is for state that must never be dropped by the JobManager, and **EXCLUSIVE** is for state that belongs to one checkpoint only. 
 
 <div class="alert alert-warning">
   <strong>Attention:</strong> The checkpoint directory is not part of a public API and can be changed in the future release.

--- a/docs/ops/state/checkpoints.zh.md
+++ b/docs/ops/state/checkpoints.zh.md
@@ -52,13 +52,14 @@ config.enableExternalizedCheckpoints(ExternalizedCheckpointCleanup.RETAIN_ON_CAN
 
 {% highlight yaml %}
 /user-defined-checkpoint-dir
-    |
-    + --shared/
-    + --taskowned/
-    + --chk-00001/
-    + --chk-00002/
-    + --chk-00003/
-    ...
+    /{job-id}
+        |
+        + --shared/
+        + --taskowned/
+        + --chk-1/
+        + --chk-2/
+        + --chk-3/
+        ...
 {% endhighlight %}
 
 其中 **SHARED** 目录保存了可能被多个 checkpoint 引用的文件，**TASKOWNED** 保存了不会被 JobManager 删除的文件，**EXCLUSIVE** 则保存那些仅被单个 checkpoint 引用的文件。


### PR DESCRIPTION
## What is the purpose of the change
Current documentation of checkpoint directory only describe the initial proposal in FLINK-8531. However, this is not the current real checkpoint directory with actual implementation. Correct this part of description to not confuse users.

## Brief change log

Correct the documentation of `checkpoints.md` and `checkpoints.zh.md`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
