### PR TITLE
[FLINK-15012][checkpoint] Introduce shutdown to CheckpointStorageCoordinatorView to clean up checkpoint directory.

### DIFF
--- a/docs/_includes/generated/checkpointing_configuration.html
+++ b/docs/_includes/generated/checkpointing_configuration.html
@@ -45,6 +45,12 @@
             <td>This option configures local recovery for this state backend. By default, local recovery is deactivated. Local recovery currently only covers keyed state backends. Currently, MemoryStateBackend does not support local recovery and ignore this option.</td>
         </tr>
         <tr>
+            <td><h5>state.checkpoints.cleanup.recursive-on-shutdown</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>The option configures whether directories of checkpoint storage would be cleaned up recursively if necessary on shutdown. Be careful when enable this feature, never set savepoint location mixed with checkpoint location to avoid unexpected savepoint data lost.</td>
+        </tr>
+        <tr>
             <td><h5>state.checkpoints.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/_includes/generated/common_state_backends_section.html
+++ b/docs/_includes/generated/common_state_backends_section.html
@@ -27,6 +27,12 @@
             <td>The default directory for savepoints. Used by the state backends that write savepoints to file systems (MemoryStateBackend, FsStateBackend, RocksDBStateBackend).</td>
         </tr>
         <tr>
+            <td><h5>state.checkpoints.cleanup.recursive-on-shutdown</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>The option configures whether directories of checkpoint storage would be cleaned up recursively if necessary on shutdown. Be careful when enable this feature, never set savepoint location mixed with checkpoint location to avoid unexpected savepoint data lost.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.incremental</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/ops/state/savepoints.md
+++ b/docs/ops/state/savepoints.md
@@ -188,6 +188,10 @@ If you neither configure a default nor specify a custom target directory, trigge
 <strong>Attention:</strong> The target directory has to be a location accessible by both the JobManager(s) and TaskManager(s) e.g. a location on a distributed file-system.
 </div>
 
+<div class="alert alert-warning">
+<strong>Attention:</strong> Never set the target directory mixed with checkpoint location to avoid unexpected savepoint data lost once `state.checkpoints.cleanup.recursive-on-shutdown` is enabled.
+</div>
+
 ## F.A.Q
 
 ### Should I assign IDs to all operators in my job?

--- a/docs/ops/state/savepoints.zh.md
+++ b/docs/ops/state/savepoints.zh.md
@@ -178,6 +178,9 @@ state.savepoints.dir: hdfs:///flink/savepoints
 <strong>注意:</strong>目标目录必须是 JobManager(s) 和 TaskManager(s) 可访问的位置，例如，分布式文件系统上的位置。
 </div>
 
+<div class="alert alert-warning">
+<strong>注意:</strong>当启用`state.checkpoints.cleanup.recursive-on-shutdown`功能时，切勿将savepoint目录与checkpoint设置在同一个位置，以避免意外的savepoint数据丢失。
+</div>
 
 ## F.A.Q
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -133,6 +133,18 @@ public class CheckpointingOptions {
 				"in a Flink supported filesystem. The storage path must be accessible from all participating processes/nodes" +
 				"(i.e. all TaskManagers and JobManagers).");
 
+	/** The default directory used for storing the data files and meta data of checkpoints in a Flink supported filesystem.
+	 * The storage path must be accessible from all participating processes/nodes(i.e. all TaskManagers and JobManagers).*/
+	@Documentation.Section(
+		value = Documentation.Sections.COMMON_STATE_BACKENDS,
+		position = 4)
+	public static final ConfigOption<Boolean> CHECKPOINTS_CLEANUP_RECURSIVE = ConfigOptions
+		.key("state.checkpoints.cleanup.recursive-on-shutdown")
+		.booleanType()
+		.defaultValue(false)
+		.withDescription("The option configures whether directories of checkpoint storage would be cleaned up recursively if necessary on shutdown. " +
+			"Be careful when enable this feature, never set savepoint location mixed with checkpoint location to avoid unexpected savepoint data lost.");
+
 	/** The minimum size of state data files. All state chunks smaller than that
 	 * are stored inline in the root checkpoint metadata file. */
 	@Documentation.Section(Documentation.Sections.EXPERT_STATE_BACKENDS)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageCoordinatorView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageCoordinatorView.java
@@ -103,4 +103,13 @@ public interface CheckpointStorageCoordinatorView {
 	CheckpointStorageLocation initializeLocationForSavepoint(
 		long checkpointId,
 		@Nullable String externalLocationPointer) throws IOException;
+
+	/**
+	 * Shuts down the checkpoint storage on the coordinator side.
+	 *
+	 * @param cleanUpOnShutDown Whether to clear files when shutting down this storage.
+	 *
+	 * @throws IOException Thrown if the storage cannot be shut down well due to an I/O exception.
+	 */
+	void shutDown(boolean cleanUpOnShutDown) throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/AbstractFsCheckpointStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/AbstractFsCheckpointStorage.java
@@ -169,6 +169,15 @@ public abstract class AbstractFsCheckpointStorage implements CheckpointStorage {
 
 	protected abstract CheckpointStorageLocation createSavepointLocation(FileSystem fs, Path location) throws IOException;
 
+	@Override
+	public void shutDown(boolean cleanUpOnShutDown) throws IOException {
+		if (cleanUpOnShutDown) {
+			discardCheckpointDirectories(false);
+		}
+	}
+
+	protected abstract void discardCheckpointDirectories(boolean cleanUpDirectoryRecursively) throws IOException;
+
 	// ------------------------------------------------------------------------
 	//  Creating and resolving paths
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/AbstractFsCheckpointStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/AbstractFsCheckpointStorage.java
@@ -73,6 +73,9 @@ public abstract class AbstractFsCheckpointStorage implements CheckpointStorage {
 	@Nullable
 	private final Path defaultSavepointDirectory;
 
+	/** The flag */
+	private final boolean cleanUpRecursivelyOnShutDown;
+
 	/**
 	 * Creates a new checkpoint storage.
 	 *
@@ -81,10 +84,12 @@ public abstract class AbstractFsCheckpointStorage implements CheckpointStorage {
 	 */
 	protected AbstractFsCheckpointStorage(
 			JobID jobId,
-			@Nullable Path defaultSavepointDirectory) {
+			@Nullable Path defaultSavepointDirectory,
+			boolean cleanUpRecursivelyOnShutDown) {
 
 		this.jobId = checkNotNull(jobId);
 		this.defaultSavepointDirectory = defaultSavepointDirectory;
+		this.cleanUpRecursivelyOnShutDown = cleanUpRecursivelyOnShutDown;
 	}
 
 	/**
@@ -172,7 +177,7 @@ public abstract class AbstractFsCheckpointStorage implements CheckpointStorage {
 	@Override
 	public void shutDown(boolean cleanUpOnShutDown) throws IOException {
 		if (cleanUpOnShutDown) {
-			discardCheckpointDirectories(false);
+			discardCheckpointDirectories(cleanUpRecursivelyOnShutDown);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorage.java
@@ -60,14 +60,16 @@ public class FsCheckpointStorage extends AbstractFsCheckpointStorage {
 			@Nullable Path defaultSavepointDirectory,
 			JobID jobId,
 			int fileSizeThreshold,
-			int writeBufferSize) throws IOException {
+			int writeBufferSize,
+			boolean cleanUpRecursivelyOnShutDown) throws IOException {
 
 		this(checkpointBaseDirectory.getFileSystem(),
 				checkpointBaseDirectory,
 				defaultSavepointDirectory,
 				jobId,
 				fileSizeThreshold,
-				writeBufferSize);
+				writeBufferSize,
+				cleanUpRecursivelyOnShutDown);
 	}
 
 	public FsCheckpointStorage(
@@ -76,9 +78,10 @@ public class FsCheckpointStorage extends AbstractFsCheckpointStorage {
 			@Nullable Path defaultSavepointDirectory,
 			JobID jobId,
 			int fileSizeThreshold,
-			int writeBufferSize) throws IOException {
+			int writeBufferSize,
+			boolean cleanUpRecursivelyOnShutDown) {
 
-		super(jobId, defaultSavepointDirectory);
+		super(jobId, defaultSavepointDirectory, cleanUpRecursivelyOnShutDown);
 
 		checkArgument(fileSizeThreshold >= 0);
 		checkArgument(writeBufferSize >= 0);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -356,7 +356,7 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
 	 * @param configuration The configuration
 	 */
 	private FsStateBackend(FsStateBackend original, ReadableConfig configuration, ClassLoader classLoader) {
-		super(original.getCheckpointPath(), original.getSavepointPath(), configuration);
+		super(original.getCheckpointPath(), original.getSavepointPath(), original.cleanupStorageRecursively, configuration);
 
 		// if asynchronous snapshots were configured, use that setting,
 		// else check the configuration
@@ -487,7 +487,8 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
 			getSavepointPath(),
 			jobId,
 			getMinFileSizeThreshold(),
-			getWriteBufferSize());
+			getWriteBufferSize(),
+			isCleanupStorageRecursively());
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryBackendCheckpointStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryBackendCheckpointStorage.java
@@ -70,9 +70,10 @@ public class MemoryBackendCheckpointStorage extends AbstractFsCheckpointStorage 
 			JobID jobId,
 			@Nullable Path checkpointsBaseDirectory,
 			@Nullable Path defaultSavepointLocation,
-			int maxStateSize) throws IOException {
+			int maxStateSize,
+			boolean cleanUpRecursivelyOnShutDown) throws IOException {
 
-		super(jobId, defaultSavepointLocation);
+		super(jobId, defaultSavepointLocation, cleanUpRecursivelyOnShutDown);
 
 		checkArgument(maxStateSize > 0);
 		this.maxStateSize = maxStateSize;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryBackendCheckpointStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryBackendCheckpointStorage.java
@@ -160,6 +160,13 @@ public class MemoryBackendCheckpointStorage extends AbstractFsCheckpointStorage 
 		return new PersistentMetadataCheckpointStorageLocation(fs, location, maxStateSize);
 	}
 
+	@Override
+	protected void discardCheckpointDirectories(boolean cleanUpDirectoryRecursively) throws IOException {
+		if (fileSystem != null) {
+			fileSystem.delete(checkpointsDirectory, cleanUpDirectoryRecursively);
+		}
+	}
+
 	// ------------------------------------------------------------------------
 	//  Utilities
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
@@ -219,7 +219,8 @@ public class MemoryStateBackend extends AbstractFileStateBackend implements Conf
 			TernaryBoolean asynchronousSnapshots) {
 
 		super(checkpointPath == null ? null : new Path(checkpointPath),
-				savepointPath == null ? null : new Path(savepointPath));
+			savepointPath == null ? null : new Path(savepointPath),
+			TernaryBoolean.UNDEFINED);
 
 		checkArgument(maxStateSize > 0, "maxStateSize must be > 0");
 		this.maxStateSize = maxStateSize;
@@ -235,7 +236,7 @@ public class MemoryStateBackend extends AbstractFileStateBackend implements Conf
 	 * @param classLoader The class loader
 	 */
 	private MemoryStateBackend(MemoryStateBackend original, ReadableConfig configuration, ClassLoader classLoader) {
-		super(original.getCheckpointPath(), original.getSavepointPath(), configuration);
+		super(original.getCheckpointPath(), original.getSavepointPath(), original.cleanupStorageRecursively, configuration);
 
 		this.maxStateSize = original.maxStateSize;
 
@@ -292,7 +293,7 @@ public class MemoryStateBackend extends AbstractFileStateBackend implements Conf
 
 	@Override
 	public CheckpointStorage createCheckpointStorage(JobID jobId) throws IOException {
-		return new MemoryBackendCheckpointStorage(jobId, getCheckpointPath(), getSavepointPath(), maxStateSize);
+		return new MemoryBackendCheckpointStorage(jobId, getCheckpointPath(), getSavepointPath(), maxStateSize, isCleanupStorageRecursively());
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/AbstractFileCheckpointStorageTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/AbstractFileCheckpointStorageTestBase.java
@@ -229,6 +229,29 @@ public abstract class AbstractFileCheckpointStorageTestBase {
 		catch (IOException ignored) {}
 	}
 
+	@Test
+	public void testCleanUpOnShutDown() throws Exception {
+		verifyStorageShutDownAsExpected(true);
+	}
+
+	@Test
+	public void testNotCleanUpOnShutDown() throws Exception {
+		verifyStorageShutDownAsExpected(false);
+	}
+
+	private void verifyStorageShutDownAsExpected(boolean cleanUpOnShutDown) throws Exception {
+		CheckpointStorage checkpointStorage = createCheckpointStorage(randomTempPath());
+		checkpointStorage.initializeBaseLocations();
+		CheckpointStorageLocation checkpointStorageLocation = checkpointStorage.initializeLocationForCheckpoint(177L);
+		// discard pending checkpoint before shutdown storage.
+		checkpointStorageLocation.disposeOnFailure();
+		checkpointStorage.shutDown(cleanUpOnShutDown);
+
+		verifyDirectoriesCleanUpAsExpected(checkpointStorage, !cleanUpOnShutDown);
+	}
+
+	protected abstract void verifyDirectoriesCleanUpAsExpected(CheckpointStorage checkpointStorage, boolean expectedDirectoriesExistence);
+
 	// ------------------------------------------------------------------------
 	//  savepoints
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageTest.java
@@ -61,13 +61,13 @@ public class FsCheckpointStorageTest extends AbstractFileCheckpointStorageTestBa
 	// ------------------------------------------------------------------------
 
 	@Override
-	protected CheckpointStorage createCheckpointStorage(Path checkpointDir) throws Exception {
-		return new FsCheckpointStorage(checkpointDir, null, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE);
+	protected CheckpointStorage createCheckpointStorage(Path checkpointDir, boolean cleanUpRecursivelyOnShutDown) throws Exception {
+		return new FsCheckpointStorage(checkpointDir, null, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE, cleanUpRecursivelyOnShutDown);
 	}
 
 	@Override
 	protected CheckpointStorage createCheckpointStorageWithSavepointDir(Path checkpointDir, Path savepointDir) throws Exception {
-		return new FsCheckpointStorage(checkpointDir, savepointDir, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE);
+		return new FsCheckpointStorage(checkpointDir, savepointDir, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE, false);
 	}
 
 	@Override
@@ -90,7 +90,7 @@ public class FsCheckpointStorageTest extends AbstractFileCheckpointStorageTestBa
 		final Path defaultSavepointDir = Path.fromLocalFile(tmp.newFolder());
 
 		final FsCheckpointStorage storage = new FsCheckpointStorage(
-				Path.fromLocalFile(tmp.newFolder()), defaultSavepointDir, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE);
+				Path.fromLocalFile(tmp.newFolder()), defaultSavepointDir, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE, false);
 
 		final FsCheckpointStorageLocation savepointLocation = (FsCheckpointStorageLocation)
 				storage.initializeLocationForSavepoint(52452L, null);
@@ -109,7 +109,7 @@ public class FsCheckpointStorageTest extends AbstractFileCheckpointStorageTestBa
 		final Path savepointDir = Path.fromLocalFile(tmp.newFolder());
 
 		final FsCheckpointStorage storage = new FsCheckpointStorage(
-				Path.fromLocalFile(tmp.newFolder()), null, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE);
+				Path.fromLocalFile(tmp.newFolder()), null, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE, false);
 
 		final FsCheckpointStorageLocation savepointLocation = (FsCheckpointStorageLocation)
 				storage.initializeLocationForSavepoint(52452L, savepointDir.toString());
@@ -129,7 +129,7 @@ public class FsCheckpointStorageTest extends AbstractFileCheckpointStorageTestBa
 
 		// we chose a small size threshold here to force the state to disk
 		final FsCheckpointStorage storage = new FsCheckpointStorage(
-				Path.fromLocalFile(tmp.newFolder()),  null, new JobID(), 10, WRITE_BUFFER_SIZE);
+				Path.fromLocalFile(tmp.newFolder()),  null, new JobID(), 10, WRITE_BUFFER_SIZE, false);
 
 		final StreamStateHandle stateHandle;
 
@@ -210,7 +210,7 @@ public class FsCheckpointStorageTest extends AbstractFileCheckpointStorageTestBa
 	@Test
 	public void testStorageLocationMkdirs() throws Exception {
 		FsCheckpointStorage storage = new FsCheckpointStorage(
-				randomTempPath(), null, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE);
+				randomTempPath(), null, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE, false);
 
 		File baseDir = new File(storage.getCheckpointsDirectory().getPath());
 		assertFalse(baseDir.exists());
@@ -221,7 +221,7 @@ public class FsCheckpointStorageTest extends AbstractFileCheckpointStorageTestBa
 
 		// mkdir would not be called when resolveCheckpointStorageLocation
 		storage = new FsCheckpointStorage(
-				randomTempPath(), null, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE);
+				randomTempPath(), null, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE, false);
 
 		FsCheckpointStorageLocation location = (FsCheckpointStorageLocation)
 				storage.resolveCheckpointStorageLocation(177, CheckpointStorageLocationReference.getDefault());
@@ -239,7 +239,8 @@ public class FsCheckpointStorageTest extends AbstractFileCheckpointStorageTestBa
 			null,
 			new JobID(),
 			FILE_SIZE_THRESHOLD,
-			WRITE_BUFFER_SIZE);
+			WRITE_BUFFER_SIZE,
+			false);
 
 		final FsCheckpointStorageLocation checkpointStreamFactory =
 			(FsCheckpointStorageLocation) storage.resolveCheckpointStorageLocation(1L, CheckpointStorageLocationReference.getDefault());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageTest.java
@@ -39,9 +39,11 @@ import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -66,6 +68,17 @@ public class FsCheckpointStorageTest extends AbstractFileCheckpointStorageTestBa
 	@Override
 	protected CheckpointStorage createCheckpointStorageWithSavepointDir(Path checkpointDir, Path savepointDir) throws Exception {
 		return new FsCheckpointStorage(checkpointDir, savepointDir, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE);
+	}
+
+	@Override
+	protected void verifyDirectoriesCleanUpAsExpected(CheckpointStorage checkpointStorage, boolean expectedDirectoriesExistence) {
+		FsCheckpointStorage storage = (FsCheckpointStorage) checkpointStorage;
+		File checkpointDirectory = new File(storage.getCheckpointsDirectory().getPath());
+		File sharedStateDirectory = new File(storage.getSharedStateDirectory().getPath());
+		File taskOwnedStateDirectory = new File(storage.getTaskOwnedStateDirectory().getPath());
+		assertThat(checkpointDirectory.exists(), equalTo(expectedDirectoriesExistence));
+		assertThat(sharedStateDirectory.exists(), equalTo(expectedDirectoriesExistence));
+		assertThat(taskOwnedStateDirectory.exists(), equalTo(expectedDirectoriesExistence));
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStateBackendEntropyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStateBackendEntropyTest.java
@@ -58,7 +58,7 @@ public class FsStateBackendEntropyTest {
 		final String checkpointDirStr = checkpointDir.toString();
 
 		final FsCheckpointStorage storage = new FsCheckpointStorage(
-				fs, checkpointDir, null, new JobID(), 1024, 4096);
+				fs, checkpointDir, null, new JobID(), 1024, 4096, false);
 		storage.initializeBaseLocations();
 
 		final FsCheckpointStorageLocation location = (FsCheckpointStorageLocation)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/memory/MemoryCheckpointStorageTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/memory/MemoryCheckpointStorageTest.java
@@ -59,13 +59,13 @@ public class MemoryCheckpointStorageTest extends AbstractFileCheckpointStorageTe
 	// ------------------------------------------------------------------------
 
 	@Override
-	protected CheckpointStorage createCheckpointStorage(Path checkpointDir) throws Exception {
-		return new MemoryBackendCheckpointStorage(new JobID(), checkpointDir, null, DEFAULT_MAX_STATE_SIZE);
+	protected CheckpointStorage createCheckpointStorage(Path checkpointDir, boolean cleanUpRecursivelyOnShutDown) throws Exception {
+		return new MemoryBackendCheckpointStorage(new JobID(), checkpointDir, null, DEFAULT_MAX_STATE_SIZE, cleanUpRecursivelyOnShutDown);
 	}
 
 	@Override
 	protected CheckpointStorage createCheckpointStorageWithSavepointDir(Path checkpointDir, Path savepointDir) throws Exception {
-		return new MemoryBackendCheckpointStorage(new JobID(), checkpointDir, savepointDir, DEFAULT_MAX_STATE_SIZE);
+		return new MemoryBackendCheckpointStorage(new JobID(), checkpointDir, savepointDir, DEFAULT_MAX_STATE_SIZE, false);
 	}
 
 	// ------------------------------------------------------------------------
@@ -120,7 +120,7 @@ public class MemoryCheckpointStorageTest extends AbstractFileCheckpointStorageTe
 	@Test
 	public void testNonPersistentCheckpointLocation() throws Exception {
 		MemoryBackendCheckpointStorage storage = new MemoryBackendCheckpointStorage(
-				new JobID(), null, null, DEFAULT_MAX_STATE_SIZE);
+				new JobID(), null, null, DEFAULT_MAX_STATE_SIZE, false);
 
 		CheckpointStorageLocation location = storage.initializeLocationForCheckpoint(9);
 
@@ -145,7 +145,7 @@ public class MemoryCheckpointStorageTest extends AbstractFileCheckpointStorageTe
 		// non persistent memory state backend for checkpoint
 		{
 			MemoryBackendCheckpointStorage storage = new MemoryBackendCheckpointStorage(
-					new JobID(), null, null, DEFAULT_MAX_STATE_SIZE);
+					new JobID(), null, null, DEFAULT_MAX_STATE_SIZE, false);
 			CheckpointStorageLocation location = storage.initializeLocationForCheckpoint(42);
 			assertTrue(location.getLocationReference().isDefaultReference());
 		}
@@ -153,7 +153,7 @@ public class MemoryCheckpointStorageTest extends AbstractFileCheckpointStorageTe
 		// non persistent memory state backend for checkpoint
 		{
 			MemoryBackendCheckpointStorage storage = new MemoryBackendCheckpointStorage(
-					new JobID(), randomTempPath(), null, DEFAULT_MAX_STATE_SIZE);
+					new JobID(), randomTempPath(), null, DEFAULT_MAX_STATE_SIZE, false);
 			CheckpointStorageLocation location = storage.initializeLocationForCheckpoint(42);
 			assertTrue(location.getLocationReference().isDefaultReference());
 		}
@@ -161,7 +161,7 @@ public class MemoryCheckpointStorageTest extends AbstractFileCheckpointStorageTe
 		// memory state backend for savepoint
 		{
 			MemoryBackendCheckpointStorage storage = new MemoryBackendCheckpointStorage(
-					new JobID(), null, null, DEFAULT_MAX_STATE_SIZE);
+					new JobID(), null, null, DEFAULT_MAX_STATE_SIZE, false);
 			CheckpointStorageLocation location = storage.initializeLocationForSavepoint(
 					1337, randomTempPath().toString());
 			assertTrue(location.getLocationReference().isDefaultReference());
@@ -173,7 +173,7 @@ public class MemoryCheckpointStorageTest extends AbstractFileCheckpointStorageTe
 		final List<String> state = Arrays.asList("Flopsy", "Mopsy", "Cotton Tail", "Peter");
 
 		final MemoryBackendCheckpointStorage storage = new MemoryBackendCheckpointStorage(
-				new JobID(), null, null, DEFAULT_MAX_STATE_SIZE);
+				new JobID(), null, null, DEFAULT_MAX_STATE_SIZE, false);
 
 		StreamStateHandle stateHandle;
 
@@ -196,7 +196,7 @@ public class MemoryCheckpointStorageTest extends AbstractFileCheckpointStorageTe
 	@Test
 	public void testStorageLocationMkdirs() throws Exception {
 		MemoryBackendCheckpointStorage storage = new MemoryBackendCheckpointStorage(
-			new JobID(), randomTempPath(), null, DEFAULT_MAX_STATE_SIZE);
+			new JobID(), randomTempPath(), null, DEFAULT_MAX_STATE_SIZE, false);
 
 		File baseDir = new File(storage.getCheckpointsDirectory().getPath());
 		assertFalse(baseDir.exists());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/memory/MemoryCheckpointStorageTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/memory/MemoryCheckpointStorageTest.java
@@ -37,10 +37,12 @@ import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -202,5 +204,13 @@ public class MemoryCheckpointStorageTest extends AbstractFileCheckpointStorageTe
 		// mkdirs only be called when initializeLocationForCheckpoint
 		storage.initializeLocationForCheckpoint(177L);
 		assertTrue(baseDir.exists());
+	}
+
+	@Override
+	protected void verifyDirectoriesCleanUpAsExpected(CheckpointStorage checkpointStorage, boolean expectedDirectoriesExistence) {
+		MemoryBackendCheckpointStorage storage = (MemoryBackendCheckpointStorage) checkpointStorage;
+		assertNotNull(storage.getCheckpointsDirectory());
+		File checkpointsDirectory = new File(storage.getCheckpointsDirectory().getPath());
+		assertThat(checkpointsDirectory.exists(), equalTo(expectedDirectoriesExistence));
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/BackendForTestStream.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/BackendForTestStream.java
@@ -105,6 +105,11 @@ public class BackendForTestStream extends MemoryStateBackend {
 		}
 
 		@Override
+		public void shutDown(boolean cleanUpOnShutDown) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
 		public CheckpointStreamFactory resolveCheckpointStorageLocation(long checkpointId, CheckpointStorageLocationReference reference) {
 			return streamFactory;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
@@ -110,6 +110,11 @@ public class MockStateBackend extends AbstractStateBackend {
 			}
 
 			@Override
+			public void shutDown(boolean cleanUpOnShutDown) {
+
+			}
+
+			@Override
 			public CheckpointStreamFactory resolveCheckpointStorageLocation(long checkpointId, CheckpointStorageLocationReference reference) {
 				return null;
 			}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -273,7 +273,7 @@ public class StreamTaskTerminationTest extends TestLogger {
 
 		@Override
 		public CheckpointStorage createCheckpointStorage(JobID jobId) throws IOException {
-			return new MemoryBackendCheckpointStorage(jobId, null, null, Integer.MAX_VALUE);
+			return new MemoryBackendCheckpointStorage(jobId, null, null, Integer.MAX_VALUE, false);
 		}
 
 		@Override

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StateBackendITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StateBackendITCase.java
@@ -108,7 +108,7 @@ public class StateBackendITCase extends AbstractTestBase {
 
 		@Override
 		public CheckpointStorage createCheckpointStorage(JobID jobId) throws IOException {
-			return new MemoryBackendCheckpointStorage(jobId, null, null, 1_000_000);
+			return new MemoryBackendCheckpointStorage(jobId, null, null, 1_000_000, false);
 		}
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change

Even we enable `ExternalizedCheckpointCleanup.DELETE_ON_CANCELLATION`, current job level checkpoint directory and its sub-directory `shared` and `taskowned` would still left on job cancellation.
Introduce shutdown to `CheckpointStorageCoordinatorView` to clean up these checkpoint directories which created by itself.

## Brief change log

  - Introduce new inerfaces of`setCheckpointProperties` and `shutdown` to `CheckpointStorageCoordinatorView`.
  - Make some getters in `CheckpointProperties` as public.
  - Add documentation to warn users not to set savepoint target directory as the same as the checkpoint directory.

## Verifying this change
This change added tests and can be verified as follows:

  - Added `testShutDownStorageOnNeverRetain`, `testShutDownStorageOnRetainWhenCanceled` and `testShutDownStorageOnRetainWhenFailed` to `AbstractFileCheckpointStorageTestBase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes**
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? docs