### PR TITLE
[FLINK-15479]Override explainSource method for JDBCTableSource

### DIFF
--- a/flink-connectors/flink-jdbc/pom.xml
+++ b/flink-connectors/flink-jdbc/pom.xml
@@ -45,22 +45,6 @@ under the License.
 			<scope>provided</scope>
 			<optional>true</optional>
 		</dependency>
-		<!-- A planner dependency won't be necessary once FLIP-32 has been completed. -->
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-			<scope>provided</scope>
-			<optional>true</optional>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-			<scope>provided</scope>
-			<optional>true</optional>
-		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -82,6 +66,21 @@ under the License.
 			<version>${project.version}</version>
 			<scope>test</scope>
         </dependency>
+
+		<!-- A planner dependency won't be necessary once FLIP-32 has been completed. -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-connectors/flink-jdbc/pom.xml
+++ b/flink-connectors/flink-jdbc/pom.xml
@@ -56,6 +56,14 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.sources.LookupableTableSource;
 import org.apache.flink.table.sources.ProjectableTableSource;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.table.sources.TableSource;
+import org.apache.flink.table.utils.TableConnectorUtils;
 import org.apache.flink.types.Row;
 
 import java.util.Arrays;
@@ -130,6 +131,11 @@ public class JDBCTableSource implements
 	@Override
 	public TableSchema getTableSchema() {
 		return schema;
+	}
+
+	@Override
+	public String explainSource() {
+		return TableConnectorUtils.generateRuntimeName(getClass(), returnType.getFieldNames());
 	}
 
 	public static Builder builder() {

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceITCase.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.runtime.utils.StreamITCase;
 import org.apache.flink.types.Row;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -53,7 +54,8 @@ public class JDBCTableSourceITCase extends JDBCTestBase {
 		" 'connector.driver' = 'org.apache.derby.jdbc.EmbeddedDriver' " +
 		")";
 
-	static {
+	@BeforeClass
+	public static void createTable() {
 		tEnv.sqlUpdate(TABLE_SOURCE_SQL);
 	}
 

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceITCase.java
@@ -36,11 +36,11 @@ import java.util.List;
  */
 public class JDBCTableSourceITCase extends JDBCTestBase {
 
-	final static StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-	final static EnvironmentSettings bsSettings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
-	final static StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, bsSettings);
+	private static final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+	private static final EnvironmentSettings bsSettings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
+	private static final StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, bsSettings);
 
-	final static String sql = "CREATE TABLE books (" +
+	static final String TABLE_SOURCE_SQL = "CREATE TABLE books (" +
 		" id int, " +
 		" title varchar, " +
 		" author varchar, " +
@@ -54,7 +54,7 @@ public class JDBCTableSourceITCase extends JDBCTestBase {
 		")";
 
 	static {
-		tEnv.sqlUpdate(sql);
+		tEnv.sqlUpdate(TABLE_SOURCE_SQL);
 	}
 
 	@Test

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceITCase.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
+import org.apache.flink.table.runtime.utils.StreamITCase;
+import org.apache.flink.types.Row;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * IT case for {@link JDBCTableSource}.
+ */
+
+public class JDBCTableSourceITCase extends JDBCTestBase {
+
+	@Test
+	public void testFieldsProjection() throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+		StreamITCase.clear();
+
+		JDBCTableSource jdbcTableSource = JDBCTableSource.builder()
+			.setOptions(JDBCOptions.builder()
+				.setDBUrl(DB_URL)
+				.setTableName(INPUT_TABLE)
+				.build())
+			.setSchema(TABLE_SCHEMA)
+			.build();
+		tEnv.registerTableSource(INPUT_TABLE, jdbcTableSource);
+
+		Table result = tEnv.sqlQuery(SELECT_ID_BOOKS);
+
+		DataStream<Row> resultSet = tEnv.toAppendStream(result, Row.class);
+		resultSet.addSink(new StreamITCase.StringSink<>());
+		env.execute();
+
+		List<String> expected = new ArrayList<>();
+		expected.add("1001");
+		expected.add("1002");
+		expected.add("1003");
+		expected.add("1004");
+		expected.add("1005");
+		expected.add("1006");
+		expected.add("1007");
+		expected.add("1008");
+		expected.add("1009");
+		expected.add("1010");
+
+		StreamITCase.compareWithList(expected);
+	}
+
+	@Test
+	public void testAllFieldsSelection() throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+		StreamITCase.clear();
+
+		JDBCTableSource jdbcTableSource = JDBCTableSource.builder()
+			.setOptions(JDBCOptions.builder()
+				.setDBUrl(DB_URL)
+				.setTableName(INPUT_TABLE)
+				.build())
+			.setSchema(TABLE_SCHEMA)
+			.build();
+		tEnv.registerTableSource(INPUT_TABLE, jdbcTableSource);
+
+		Table result = tEnv.sqlQuery(SELECT_ALL_BOOKS);
+
+		DataStream<Row> resultSet = tEnv.toAppendStream(result, Row.class);
+		resultSet.addSink(new StreamITCase.StringSink<>());
+		env.execute();
+
+		List<String> expected = new ArrayList<>();
+		expected.add("1001,Java public for dummies,Tan Ah Teck,11.11,11");
+		expected.add("1002,More Java for dummies,Tan Ah Teck,22.22,22");
+		expected.add("1003,More Java for more dummies,Mohammad Ali,33.33,33");
+		expected.add("1004,A Cup of Java,Kumar,44.44,44");
+		expected.add("1005,A Teaspoon of Java,Kevin Jones,55.55,55");
+		expected.add("1006,A Teaspoon of Java 1.4,Kevin Jones,66.66,66");
+		expected.add("1007,A Teaspoon of Java 1.5,Kevin Jones,77.77,77");
+		expected.add("1008,A Teaspoon of Java 1.6,Kevin Jones,88.88,88");
+		expected.add("1009,A Teaspoon of Java 1.7,Kevin Jones,99.99,99");
+		expected.add("1010,A Teaspoon of Java 1.8,Kevin Jones,null,1010");
+
+		StreamITCase.compareWithList(expected);
+	}
+
+}

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceSinkFactoryTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceSinkFactoryTest.java
@@ -30,8 +30,8 @@ import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.table.sources.TableSourceValidation;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.FieldsDataType;
-
 import org.apache.flink.table.types.logical.RowType;
+
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -189,7 +189,7 @@ public class JDBCTableSourceSinkFactoryTest {
 		List<String> fieldNames = ((RowType) actual.getProducedDataType().getLogicalType()).getFieldNames();
 		String expectedSourceDescription = actual.getClass().getSimpleName()
 			+ "(" + String.join(", ", fieldNames.stream().toArray(String[]::new)) + ")";
-		assertEquals(expectedSourceDescription ,actual.explainSource());
+		assertEquals(expectedSourceDescription, actual.explainSource());
 	}
 
 	@Test

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceSinkFactoryTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTableSourceSinkFactoryTest.java
@@ -31,9 +31,11 @@ import org.apache.flink.table.sources.TableSourceValidation;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.FieldsDataType;
 
+import org.apache.flink.table.types.logical.RowType;
 import org.junit.Test;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -167,7 +169,7 @@ public class JDBCTableSourceSinkFactoryTest {
 	}
 
 	@Test
-	public void testJDBCWithFilter() {
+	public void testJDBCFieldsProjection() {
 		Map<String, String> properties = getBasicProperties();
 		properties.put("connector.driver", "org.apache.derby.jdbc.EmbeddedDriver");
 		properties.put("connector.username", "user");
@@ -182,6 +184,12 @@ public class JDBCTableSourceSinkFactoryTest {
 		assertEquals(projectedFields.get("aaa"), DataTypes.INT());
 		assertNull(projectedFields.get("bbb"));
 		assertEquals(projectedFields.get("ccc"), DataTypes.DOUBLE());
+
+		// test jdbc table source description
+		List<String> fieldNames = ((RowType) actual.getProducedDataType().getLogicalType()).getFieldNames();
+		String expectedSourceDescription = actual.getClass().getSimpleName()
+			+ "(" + String.join(", ", fieldNames.stream().toArray(String[]::new)) + ")";
+		assertEquals(expectedSourceDescription ,actual.explainSource());
 	}
 
 	@Test

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTestBase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTestBase.java
@@ -20,9 +20,6 @@ package org.apache.flink.api.java.io.jdbc;
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
-import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.types.DataType;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTestBase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTestBase.java
@@ -20,6 +20,9 @@ package org.apache.flink.api.java.io.jdbc;
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.types.DataType;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -33,7 +36,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 /**
- * Base test class for JDBC Input and Output formats.
+ * Base test class for JDBC Input and Output.
  */
 public class JDBCTestBase {
 
@@ -46,6 +49,7 @@ public class JDBCTestBase {
 	public static final String OUTPUT_TABLE = "newbooks";
 	public static final String OUTPUT_TABLE_2 = "newbooks2";
 	public static final String SELECT_ALL_BOOKS = "select * from " + INPUT_TABLE;
+	public static final String SELECT_ID_BOOKS = "select id from " + INPUT_TABLE;
 	public static final String SELECT_ALL_NEWBOOKS = "select * from " + OUTPUT_TABLE;
 	public static final String SELECT_ALL_NEWBOOKS_2 = "select * from " + OUTPUT_TABLE_2;
 	public static final String SELECT_EMPTY = "select * from books WHERE QTY < 0";
@@ -88,6 +92,17 @@ public class JDBCTestBase {
 		BasicTypeInfo.STRING_TYPE_INFO,
 		BasicTypeInfo.DOUBLE_TYPE_INFO,
 		BasicTypeInfo.INT_TYPE_INFO);
+
+	public static final TableSchema TABLE_SCHEMA = TableSchema.builder().fields(
+				new String[]{"id", "title", "author", "price", "qty"},
+				new DataType[]{
+					DataTypes.INT(),
+					DataTypes.STRING(),
+					DataTypes.STRING(),
+					DataTypes.DOUBLE(),
+					DataTypes.INT()
+				})
+		.build();
 
 	public static String getCreateQuery(String tableName) {
 		StringBuilder sqlQueryBuilder = new StringBuilder("CREATE TABLE ");

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTestBase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTestBase.java
@@ -93,17 +93,6 @@ public class JDBCTestBase {
 		BasicTypeInfo.DOUBLE_TYPE_INFO,
 		BasicTypeInfo.INT_TYPE_INFO);
 
-	public static final TableSchema TABLE_SCHEMA = TableSchema.builder().fields(
-				new String[]{"id", "title", "author", "price", "qty"},
-				new DataType[]{
-					DataTypes.INT(),
-					DataTypes.STRING(),
-					DataTypes.STRING(),
-					DataTypes.DOUBLE(),
-					DataTypes.INT()
-				})
-		.build();
-
 	public static String getCreateQuery(String tableName) {
 		StringBuilder sqlQueryBuilder = new StringBuilder("CREATE TABLE ");
 		sqlQueryBuilder.append(tableName).append(" (");


### PR DESCRIPTION
## What is the purpose of the change
Override explainSource method for JDBCTableSource.

## Brief change log
Add explainSource for JDBCTableSource.

## Verifying this change

*(Please pick either of the following options)*
This change is a trivial work without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
