### PR TITLE
[FLINK-15481][python] Add `list[str]` to the type hint of the parameter "schema" in `TableEnvironment#from_elements`.

### DIFF
--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -938,7 +938,7 @@ class TableEnvironment(object):
         :param elements: The elements to create a table from.
         :type elements: list
         :param schema: The schema of the table.
-        :type schema: pyflink.table.types.DataType
+        :type schema: pyflink.table.types.DataType or list[str]
         :param verify_schema: Whether to verify the elements against the schema.
         :type verify_schema: bool
         :return: The result table.


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds `list[str]` to the type hint of the parameter "schema" in `TableEnvironment#from_elements`.*

## Brief change log

  - *Add `list[str]` to the type hint of the parameter "schema" in `TableEnvironment#from_elements`.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
