### PR TITLE
[FLINK-15485][tests] Reopen tests when blocking issue has been resolved.

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/ModifiedMonotonicityTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/ModifiedMonotonicityTest.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.planner.utils.{StreamTableTestUtil, TableTestBase,
 
 import org.apache.calcite.sql.validate.SqlMonotonicity.{CONSTANT, DECREASING, INCREASING, NOT_MONOTONIC}
 import org.junit.Assert.assertEquals
-import org.junit.{Ignore, Test}
+import org.junit.Test
 
 class ModifiedMonotonicityTest extends TableTestBase {
 
@@ -95,9 +95,7 @@ class ModifiedMonotonicityTest extends TableTestBase {
     util.verifyPlanWithTrait(query)
   }
 
-  @Ignore
   @Test
-  // TODO remove ignore after window aggregate supported
   def testTumbleFunAndRegularAggFunInGroupBy(): Unit = {
     val sql = "SELECT b, d, weightedAvg(c, a) FROM " +
       " (SELECT a, b, c, count(*) d," +
@@ -108,9 +106,7 @@ class ModifiedMonotonicityTest extends TableTestBase {
     verifyMonotonicity(sql, new RelModifiedMonotonicity(Array(CONSTANT, CONSTANT, NOT_MONOTONIC)))
   }
 
-  @Ignore
   @Test
-  // TODO remove ignore after anti-join supported
   def testAntiJoin(): Unit = {
     val sql = "SELECT * FROM AA WHERE NOT EXISTS (SELECT b1 from BB WHERE a1 = b1)"
     verifyMonotonicity(sql, null)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -448,7 +448,6 @@ class CalcITCase extends BatchTestBase {
       ))
   }
 
-  @Ignore // TODO support agg
   @Test
   def testExternalTypeFunc2(): Unit = {
     registerFunction("func1", RowFunc)
@@ -597,7 +596,6 @@ class CalcITCase extends BatchTestBase {
       Seq(row("Hello"), row("Hello world")))
   }
 
-  @Ignore // TODO support substring
   @Test
   def testComplexNotInLargeValues(): Unit = {
     checkResult(
@@ -794,7 +792,6 @@ class CalcITCase extends BatchTestBase {
     )
   }
 
-  @Ignore //TODO support cast string to bigint.
   @Test
   def testSelectStarFromNestedValues2(): Unit = {
     val table = BatchTableEnvUtil.fromCollection(tEnv, Seq(
@@ -1069,7 +1066,6 @@ class CalcITCase extends BatchTestBase {
     * T[h]h:[m]m:[s]s.[ms][ms][ms][us][us][us]-[h]h:[m]m
     * T[h]h:[m]m:[s]s.[ms][ms][ms][us][us][us]+[h]h:[m]m
     */
-  @Ignore
   @Test
   def testTimestampCompareWithDateString(): Unit = {
     //j 2015-05-20 10:00:00.887

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CorrelateITCase2.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CorrelateITCase2.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase._
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedTableFunctions.StringSplit
 import org.apache.flink.table.planner.runtime.utils.TestData._
 
-import org.junit.{Before, Ignore, Test}
+import org.junit.{Before, Test}
 
 import scala.collection.Seq
 
@@ -87,7 +87,6 @@ class CorrelateITCase2 extends BatchTestBase {
     )
   }
 
-  @Ignore
   @Test
   def testConstantTableFunc2(): Unit = {
     registerFunction("str_split", new StringSplit())
@@ -121,7 +120,6 @@ class CorrelateITCase2 extends BatchTestBase {
       ))
   }
 
-  @Ignore // TODO substring
   @Test
   def testConstantTableFunc3(): Unit = {
     registerFunction("str_split", new StringSplit())
@@ -133,7 +131,6 @@ class CorrelateITCase2 extends BatchTestBase {
     )
   }
 
-  @Ignore
   @Test
   def testConstantTableFuncWithSubString(): Unit = {
     registerFunction("str_split", new StringSplit())

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/MiscITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/MiscITCase.scala
@@ -317,7 +317,6 @@ class MiscITCase extends BatchTestBase {
     )
   }
 
-  @Ignore // TODO support lazy from source
   @Test
   def testExcept(): Unit = {
     checkQuery2(
@@ -376,7 +375,6 @@ class MiscITCase extends BatchTestBase {
     )
   }
 
-  @Ignore // TODO support lazy from source
   @Test
   def testIntersect(): Unit = {
     checkQuery(
@@ -512,7 +510,6 @@ class MiscITCase extends BatchTestBase {
     )
   }
 
-  @Ignore // TODO support lazy from source
   @Test
   def testCompareFunctionWithSubquery(): Unit = {
     checkResult("SELECT " +

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateITCaseBase.scala
@@ -28,7 +28,7 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TestData._
 import org.apache.flink.types.Row
 
-import org.junit.{Before, Ignore, Test}
+import org.junit.{Before, Test}
 
 import scala.collection.Seq
 
@@ -362,10 +362,9 @@ abstract class AggregateITCaseBase(testName: String) extends BatchTestBase {
     )
   }
 
-  @Ignore
   @Test
   def testGroupByRegexp(): Unit = {
-    val expr = "regexp_extract(f0, '([a-z]+)\\\\[', 1)"
+    val expr = "regexp_extract(f0, '([a-z]+)\\[', 1)"
     checkQuery(
       Seq(("some[thing]", "random-string")),
       s"select $expr, count(*) from TableName group by $expr",
@@ -447,7 +446,6 @@ abstract class AggregateITCaseBase(testName: String) extends BatchTestBase {
     )
   }
 
-  @Ignore
   @Test
   def testGroupingInsideWindowFunction(): Unit = {
     checkQuery(
@@ -792,7 +790,6 @@ abstract class AggregateITCaseBase(testName: String) extends BatchTestBase {
   // NOTE: select from values -- supported by Spark, but not Blink
   //       "select sum(a) over () from values 1.0, 2.0, 3.0 T(a)"
 
-  @Ignore
   @Test
   def testDecimalSumAvgOverWindow(): Unit = {
     checkQuery(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/SortAggITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/SortAggITCase.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.UserDefinedFunctionTestUtils.{MyPojo, MyToPojoFunc}
 import org.apache.flink.table.planner.utils.{CountAccumulator, CountAggFunction, IntSumAggFunction}
 
-import org.junit.{Ignore, Test}
+import org.junit.Test
 
 import java.lang
 import java.lang.{Iterable => JIterable}
@@ -71,8 +71,7 @@ class SortAggITCase
       "SELECT simplePrimitiveArrayUdaf(id) FROM RangeT",
       Seq(row(499999500000L)))
   }
-
-  @Ignore
+  
   @Test
   def testMultiSetAggBufferGroupBy(): Unit = {
     checkResult(
@@ -249,7 +248,6 @@ class SortAggITCase
     )
   }
 
-  @Ignore
   @Test
   def testFirstValueOnString(): Unit = {
     checkResult(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
@@ -641,7 +641,6 @@ class AggregateITCase(
     assertMapStrEquals(expected.sorted.toString, sink.getRetractResults.sorted.toString)
   }
 
-  @Ignore("[FLINK-12088]: JOIN is not supported")
   @Test
   def testGroupBySingleValue(): Unit = {
     val data = new mutable.MutableList[(Int, Long, String)]

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/GroupWindowTableAggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/GroupWindowTableAggregateITCase.scala
@@ -31,11 +31,10 @@ import org.apache.flink.table.planner.utils.Top3
 import org.apache.flink.types.Row
 import org.apache.flink.table.planner.runtime.utils.TestData._
 import org.junit.Assert._
-import org.junit.{Ignore, Test}
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
-@Ignore("Remove this ignore when FLINK-13740 is solved.")
 @RunWith(classOf[Parameterized])
 class GroupWindowTableAggregateITCase(mode: StateBackendMode)
   extends StreamingWithStateTestBase(mode) {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableAggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableAggregateITCase.scala
@@ -30,12 +30,11 @@ import org.apache.flink.types.Row
 import org.junit.Assert.assertEquals
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
-import org.junit.{Before, Ignore, Test}
+import org.junit.{Before, Test}
 
 /**
   * Tests of groupby (without window) table aggregations
   */
-@Ignore("Remove this ignore when FLINK-13740 is solved.")
 @RunWith(classOf[Parameterized])
 class TableAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode) {
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/SetOperatorsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/SetOperatorsTest.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.CommonTestData.NonPojo
 import org.apache.flink.table.utils.TableTestBase
 import org.apache.flink.table.utils.TableTestUtil._
-import org.junit.{Ignore, Test}
+import org.junit.Test
 
 class SetOperatorsTest extends TableTestBase {
 
@@ -159,13 +159,57 @@ class SetOperatorsTest extends TableTestBase {
   }
 
   @Test
-  @Ignore // Calcite bug
   def testNotInWithFilter(): Unit = {
     val util = batchTestUtil()
-    util.addTable[(Int, Long, String)]("A", 'a, 'b, 'c)
-    util.addTable[(Int, Long, Int, String, Long)]("B", 'a, 'b, 'c, 'd, 'e)
+    val tableA = util.addTable[(Int, Long, String)]("A", 'a, 'b, 'c)
+    val tableB = util.addTable[(Int, Long, Int, String, Long)]("B", 'a, 'b, 'c, 'd, 'e)
 
-    val expected = "FAIL"
+    val expected = unaryNode(
+      "DataSetCalc",
+      binaryNode(
+        "DataSetJoin",
+        unaryNode(
+          "DataSetCalc",
+          binaryNode(
+            "DataSetSingleRowJoin",
+            unaryNode(
+              "DataSetCalc",
+              batchTableNode(tableB),
+              term("select", "d"),
+              term("where", "<(CAST(d), 5:BIGINT)")
+            ),
+            unaryNode(
+              "DataSetAggregate",
+              unaryNode(
+                "DataSetCalc",
+                batchTableNode(tableA),
+                term("select", "a")
+              ),
+              term("select", "COUNT(*) AS $f0, COUNT(a) AS $f1")
+            ),
+            term("where", "true"),
+            term("join", "d, $f0, $f1"),
+            term("joinType", "NestedLoopInnerJoin")
+          ),
+          term("select", "d, $f0, $f1, d AS d0")
+        ),
+        unaryNode(
+          "DataSetAggregate",
+          unaryNode(
+            "DataSetCalc",
+            batchTableNode(tableA),
+            term("select", "a, true AS $f1")
+          ),
+          term("groupBy", "a"),
+          term("select", "a, MIN($f1) AS $f1")
+        ),
+        term("where", "=(d0, a)"),
+        term("join", "d, $f0, $f1, d0, a, $f10"),
+        term("joinType", "LeftOuterJoin")
+      ),
+      term("select", "d"),
+      term("where", "OR(=($f0, 0:BIGINT), AND(IS NULL($f10), >=($f1, $f0), IS NOT NULL(d0)))")
+    )
 
     util.verifySql(
       "SELECT d FROM B WHERE d NOT IN (SELECT a FROM A) AND d < 5",

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/ExpressionReductionRulesTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/ExpressionReductionRulesTest.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.table.plan
 
 import org.apache.flink.api.scala._
-import org.apache.flink.configuration.PipelineOptions
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.utils.{Func1, RichFunc1}
@@ -28,9 +27,8 @@ import org.apache.flink.table.functions.python.{PythonEnv, PythonFunction}
 import org.apache.flink.table.utils.TableTestBase
 import org.apache.flink.table.utils.TableTestUtil._
 
-import org.junit.{Ignore, Test}
+import org.junit.Test
 
-import scala.collection.JavaConverters._
 
 class ExpressionReductionRulesTest extends TableTestBase {
 
@@ -469,19 +467,20 @@ class ExpressionReductionRulesTest extends TableTestBase {
     util.verifySql(sqlQuery, expected)
   }
 
-  // TODO this NPE is caused by Calcite, it shall pass when [CALCITE-1860] is fixed
-  @Ignore
+  @Test
   def testReduceDeterministicUDF(): Unit = {
     val util = streamTestUtil()
     val table = util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
-
-    // if isDeterministic = true, will cause a Calcite NPE, which will be fixed in [CALCITE-1860]
     val result = table
       .select('a, 'b, 'c, DeterministicNullFunc() as 'd)
       .where("d.isNull")
       .select('a, 'b, 'c)
 
-    val expected: String = streamTableNode(table)
+    val expected: String = unaryNode("DataStreamCalc",
+      streamTableNode(table),
+      term("select", "a", "b", "c"),
+      term("where", s"IS NULL(null:VARCHAR(65536))")
+    )
 
     util.verifyTable(result, expected)
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/SetOperatorsITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/SetOperatorsITCase.scala
@@ -158,8 +158,6 @@ class SetOperatorsITCase(
   }
 
   @Test
-  @Ignore
-  // calcite sql parser doesn't support EXCEPT ALL
   def testExceptAll(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = BatchTableEnvironment.create(env, config)


### PR DESCRIPTION
[FLINK-15485][tests] Reopen tests when blocking issue has been resolved.
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.

  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*This pull request reopens tests that close by FLINK-12088 、FLINK-13740、CALCITE-1860 which have been resolved.*


## Brief change log

  - *update file org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala*
  - *update file org/apache/flink/table/planner/runtime/stream/table/GroupWindowTableAggregateITCase.scala*
  - *org/apache/flink/table/planner/runtime/stream/table/TableAggregateITCase.scala*
  - *update file org/apache/flink/table/plan/ExpressionReductionRulesTest.scala*



## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
