### PR TITLE
[FLINK-14925][table-planner-blink] the return type of TO_TIMESTAMP sh…

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -644,14 +644,10 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 		OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.INTEGER),
 		SqlFunctionCategory.STRING);
 
-	// TODO: the return type of TO_TIMESTAMP should be TIMESTAMP(9)
-	//  but conversion of DataType and TypeInformation only support TIMESTAMP(3) now.
-	//  change to TIMESTAMP(9) when FLINK-14645 is fixed.
-	//  https://issues.apache.org/jira/browse/FLINK-14925
 	public static final SqlFunction TO_TIMESTAMP = new SqlFunction(
 		"TO_TIMESTAMP",
 		SqlKind.OTHER_FUNCTION,
-		ReturnTypes.cascade(ReturnTypes.explicit(SqlTypeName.TIMESTAMP, 3), SqlTypeTransforms.FORCE_NULLABLE),
+		ReturnTypes.cascade(ReturnTypes.explicit(SqlTypeName.TIMESTAMP, 9), SqlTypeTransforms.FORCE_NULLABLE),
 		null,
 		OperandTypes.or(
 			OperandTypes.family(SqlTypeFamily.CHARACTER),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
@@ -352,16 +352,16 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
   @Test
   def testInsertSourceTableWithFuncField(): Unit = {
     val sourceData = List(
-      toRow(1, "1990-02-10 12:34:56"),
-      toRow(2, "2019-09-10 09:23:41"),
-      toRow(3, "2019-09-10 09:23:42"),
+      toRow(1, "1990-02-10 12:34:56.123456789"),
+      toRow(2, "2019-09-10 09:23:41.123456"),
+      toRow(3, "2019-09-10 09:23:42.123"),
       toRow(1, "2019-09-10 09:23:43"),
       toRow(2, "2019-09-10 09:23:44")
     )
     val expected = List(
-      toRow(1, "1990-02-10 12:34:56", localDateTime("1990-02-10 12:34:56")),
-      toRow(2, "2019-09-10 09:23:41", localDateTime("2019-09-10 09:23:41")),
-      toRow(3, "2019-09-10 09:23:42", localDateTime("2019-09-10 09:23:42")),
+      toRow(1, "1990-02-10 12:34:56.123456789", localDateTime("1990-02-10 12:34:56.123456789")),
+      toRow(2, "2019-09-10 09:23:41.123456", localDateTime("2019-09-10 09:23:41.123456")),
+      toRow(3, "2019-09-10 09:23:42.123", localDateTime("2019-09-10 09:23:42.123")),
       toRow(1, "2019-09-10 09:23:43", localDateTime("2019-09-10 09:23:43")),
       toRow(2, "2019-09-10 09:23:44", localDateTime("2019-09-10 09:23:44"))
     )
@@ -381,7 +381,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |create table t2(
         |  a int,
         |  b varchar,
-        |  c timestamp(3)
+        |  c timestamp(9)
         |) with (
         |  'connector' = 'COLLECTION'
         |)


### PR DESCRIPTION
…ould be Timestamp(9) instead of Timestamp(3)


## What is the purpose of the change

This PR change the return type of TO_TIMESTAMP to TIMESTAMP(9) instead of TIMESTAMP(3). 

## Brief change log

- c79aff3 change the return type of TO_TIMESTAMP to TIMESTAMP(9)

## Verifying this change

This change is already covered by existing tests, such as *TemporalTypesTest* and *CatalogTableITCase*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
