### PR TITLE
[FLINK-15327][runtime] No warning of InterruptedException during cancel.

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -41,6 +41,8 @@ import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.TestHarnessUtil;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.function.CheckedSupplier;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -370,7 +372,18 @@ public class SourceStreamTaskTest {
 	}
 
 	@Test
-	public void testInterruptedNotSwallowed() throws Exception {
+	public void testInterruptionExceptionNotSwallowed() throws Exception {
+		testInterruptionExceptionNotSwallowed(InterruptedException::new);
+	}
+
+	@Test
+	public void testWrappedInterruptionExceptionNotSwallowed() throws Exception {
+		testInterruptionExceptionNotSwallowed(() ->
+			new RuntimeException(new FlinkRuntimeException(new InterruptedException())));
+	}
+
+	private void testInterruptionExceptionNotSwallowed(InterruptedSource.ExceptionGenerator exceptionGenerator)
+			throws Exception {
 		final StreamTaskTestHarness<String> testHarness = new StreamTaskTestHarness<>(
 			SourceStreamTask::new,
 			BasicTypeInfo.STRING_TYPE_INFO);
@@ -379,7 +392,7 @@ public class SourceStreamTaskTest {
 		testHarness
 			.setupOperatorChain(
 				new OperatorID(),
-				new StreamSource<>(new InterruptedSource()))
+				new StreamSource<>(new InterruptedSource(exceptionGenerator)))
 			.chain(
 				new OperatorID(),
 				new TestBoundedOneInputStreamOperator("Operator1"),
@@ -403,24 +416,21 @@ public class SourceStreamTaskTest {
 	 * A source that locks if cancellation attempts to cleanly shut down.
 	 */
 	public static class InterruptedSource implements SourceFunction<String> {
+		interface ExceptionGenerator extends CheckedSupplier<Exception>, Serializable {}
+
 		private static final long serialVersionUID = 8713065281092996042L;
 
-		private static CompletableFuture<Void> isRunning = new CompletableFuture<>();
+		private ExceptionGenerator exceptionGenerator;
 
-		public static void reset() {
-			isRunning = new CompletableFuture<>();
-		}
-
-		public static void awaitRunning() throws ExecutionException, InterruptedException {
-			isRunning.get();
+		public InterruptedSource(final ExceptionGenerator exceptionGenerator) {
+			this.exceptionGenerator = exceptionGenerator;
 		}
 
 		@Override
 		public void run(SourceContext<String> ctx) throws Exception {
 			synchronized (ctx.getCheckpointLock()) {
-				isRunning.complete(null);
 				Thread.currentThread().interrupt();
-				throw new InterruptedException();
+				throw exceptionGenerator.get();
 			}
 		}
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

InterruptedException are previously only handled when wrapped in
WrappingRuntimeException. This patch looks through the whole exception
chain.

## Brief change log

 - Look for InterruptedException in whole exception in StreamTask.
 - Reenable previously flaky nightly tests.


## Verifying this change

- Reenabled flaky nightly tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no**)**
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
