### PR TITLE
[FLINK-15406][state-processor-api] RocksDB savepoints with heap timers cannot be restored by non-process functions

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/LazyTimerService.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/LazyTimerService.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.output.operators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.streaming.api.TimerService;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+
+import java.util.function.Supplier;
+
+/**
+ * A timer service that initializes its internal
+ * timer service lazily.
+ */
+@Internal
+public class LazyTimerService implements TimerService {
+
+	private final Supplier<InternalTimerService<VoidNamespace>> supplier;
+
+	private final ProcessingTimeService processingTimeService;
+
+	private InternalTimerService<VoidNamespace> internalTimerService;
+
+	LazyTimerService(Supplier<InternalTimerService<VoidNamespace>> supplier, ProcessingTimeService processingTimeService) {
+		this.supplier = supplier;
+		this.processingTimeService = processingTimeService;
+	}
+
+	@Override
+	public long currentProcessingTime() {
+		return processingTimeService.getCurrentProcessingTime();
+	}
+
+	@Override
+	public long currentWatermark() {
+		// The watermark does not advance
+		// when bootstrapping state.
+		return Long.MIN_VALUE;
+	}
+
+	@Override
+	public void registerProcessingTimeTimer(long time) {
+		ensureInitialized();
+		internalTimerService.registerEventTimeTimer(VoidNamespace.INSTANCE, time);
+	}
+
+	@Override
+	public void registerEventTimeTimer(long time) {
+		ensureInitialized();
+		internalTimerService.registerProcessingTimeTimer(VoidNamespace.INSTANCE, time);
+	}
+
+	@Override
+	public void deleteProcessingTimeTimer(long time) {
+		ensureInitialized();
+		internalTimerService.deleteProcessingTimeTimer(VoidNamespace.INSTANCE, time);
+	}
+
+	@Override
+	public void deleteEventTimeTimer(long time) {
+		ensureInitialized();
+		internalTimerService.deleteEventTimeTimer(VoidNamespace.INSTANCE, time);
+	}
+
+	private void ensureInitialized() {
+		if (internalTimerService == null) {
+			internalTimerService = supplier.get();
+		}
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/KeyedStateBootstrapOperatorTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/KeyedStateBootstrapOperatorTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.output;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.state.api.functions.KeyedStateBootstrapFunction;
+import org.apache.flink.state.api.output.operators.KeyedStateBootstrapOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamMap;
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Test writing keyed bootstrap state.
+ */
+public class KeyedStateBootstrapOperatorTest {
+
+	private static final ValueStateDescriptor<Long> descriptor = new ValueStateDescriptor<Long>("state", Types.LONG);
+
+	@Rule
+	public TemporaryFolder folder = new TemporaryFolder();
+
+	@Test
+	public void testNonTimerStatesRestorableByNonProcessesOperator() throws Exception {
+		Path path = new Path(folder.newFolder().toURI());
+
+		OperatorSubtaskState state;
+		KeyedStateBootstrapOperator<Long, Long> bootstrapOperator = new KeyedStateBootstrapOperator<>(0L, path, new SimpleBootstrapFunction());
+		try (KeyedOneInputStreamOperatorTestHarness<Long, Long, TaggedOperatorSubtaskState> harness = getHarness(bootstrapOperator)) {
+			harness.open();
+
+			harness.processElement(1L, 0L);
+			harness.processElement(2L, 0L);
+			harness.processElement(3L, 0L);
+			bootstrapOperator.endInput();
+
+			state = harness.extractOutputValues().get(0).state;
+		}
+
+		StreamMap<Long, Long> mapOperator = new StreamMap<>(new StreamingFunction());
+		try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Long> harness = getHarness(mapOperator)) {
+
+			harness.initializeState(state);
+			harness.open();
+
+			harness.processElement(1L, 0L);
+			harness.processElement(2L, 0L);
+			harness.processElement(3L, 0L);
+
+			Assert.assertThat(harness.extractOutputValues(), Matchers.containsInAnyOrder(1L, 2L, 3L));
+
+			harness.snapshot(0L, 0L);
+		}
+	}
+
+	private <T> KeyedOneInputStreamOperatorTestHarness<Long, Long, T> getHarness(OneInputStreamOperator<Long, T> bootstrapOperator) throws Exception {
+		KeyedOneInputStreamOperatorTestHarness<Long, Long, T> harness = new KeyedOneInputStreamOperatorTestHarness<>(
+			bootstrapOperator, id -> id, Types.LONG, 128, 1, 0);
+
+		harness.setStateBackend(new RocksDBStateBackend(folder.newFolder().toURI()));
+		return harness;
+	}
+
+	private static class SimpleBootstrapFunction extends KeyedStateBootstrapFunction<Long, Long> {
+
+		private ValueState<Long> state;
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			state = getRuntimeContext().getState(descriptor);
+		}
+
+		@Override
+		public void processElement(Long value, Context ctx) throws Exception {
+			state.update(value);
+		}
+	}
+
+	private static class StreamingFunction extends RichMapFunction<Long, Long> {
+
+		private ValueState<Long> state;
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			state = getRuntimeContext().getState(descriptor);
+		}
+
+		@Override
+		public Long map(Long value) throws Exception {
+			return state.value();
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

The keyed bootstrap operator creates an internal timer service regardless of whether or not timers are used by the bootstrap function. The AbstractStreamOperator has a special case for handling heap-based timers during the snapshot when RocksDB is the configured state backend. This case will fail if the operator 1) does not support timers such as Map and FlatMap and 2) the operator contains a timer service. This change makes the creation of the timer service lazy so that keyed Map and FlatMap operators can be bootstrapped by the state proc api. 

This change should be merged into release-1.10 and master.

## Brief change log

- Introduce a LazyTimerService

## Verifying this change

UT

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
