### PR TITLE
[FLINK-15281][table-planner-blink] Map Flink's TypeInference to Calcite's interfaces

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ObjectIdentifier.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ObjectIdentifier.java
@@ -21,6 +21,8 @@ package org.apache.flink.table.catalog;
 import org.apache.flink.util.Preconditions;
 
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 import static org.apache.flink.table.utils.EncodingUtils.escapeIdentifier;
@@ -70,6 +72,13 @@ public final class ObjectIdentifier implements Serializable {
 
 	public ObjectPath toObjectPath() {
 		return new ObjectPath(databaseName, objectName);
+	}
+
+	/**
+	 * List of the component names of this object identifier.
+	 */
+	public List<String> toList() {
+		return Arrays.asList(getCatalogName(), getDatabaseName(), getObjectName());
 	}
 
 	/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.expressions;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.CallContext;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.utils.ValueDataTypeConverter;
 import org.apache.flink.table.utils.EncodingUtils;
@@ -74,6 +75,9 @@ public final class ValueLiteralExpression implements ResolvedExpression {
 
 	/**
 	 * Returns the value (excluding null) as an instance of the given class.
+	 *
+	 * <p>Note to implementers: Whenever we add a new class here, make sure to also update the planner
+	 * for supporting the class via {@link CallContext#getArgumentValue(int, Class)}.
 	 */
 	@SuppressWarnings("unchecked")
 	public <T> Optional<T> getValueAs(Class<T> clazz) {
@@ -150,6 +154,7 @@ public final class ValueLiteralExpression implements ResolvedExpression {
 
 		// we can offer more conversions in the future, these conversions must not necessarily
 		// comply with the logical type conversions
+
 		return Optional.ofNullable((T) convertedValue);
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/FunctionIdentifier.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/FunctionIdentifier.java
@@ -25,7 +25,6 @@ import org.apache.flink.util.StringUtils;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -96,12 +95,9 @@ public final class FunctionIdentifier implements Serializable {
 	/**
 	 * List of the component names of this function identifier.
 	 */
-	public List<String> getNames() {
+	public List<String> toList() {
 		if (objectIdentifier != null) {
-			return Arrays.asList(
-				objectIdentifier.getCatalogName(),
-				objectIdentifier.getDatabaseName(),
-				objectIdentifier.getObjectName());
+			return objectIdentifier.toList();
 		} else if (functionName != null) {
 			return Collections.singletonList(functionName);
 		} else {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/ConstantArgumentCount.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/ConstantArgumentCount.java
@@ -60,16 +60,20 @@ public final class ConstantArgumentCount implements ArgumentCount {
 	}
 
 	public static ArgumentCount any() {
-		return new ConstantArgumentCount(0, OPEN_INTERVAL);
+		return new ConstantArgumentCount(OPEN_INTERVAL, OPEN_INTERVAL);
 	}
 
 	@Override
 	public boolean isValidCount(int count) {
-		return count >= minCount && (maxCount == OPEN_INTERVAL || count <= maxCount);
+		return (minCount == OPEN_INTERVAL || count >= minCount) &&
+			(maxCount == OPEN_INTERVAL || count <= maxCount);
 	}
 
 	@Override
 	public Optional<Integer> getMinCount() {
+		if (minCount == OPEN_INTERVAL) {
+			return Optional.empty();
+		}
 		return Optional.of(minCount);
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/ConstantArgumentCount.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/ConstantArgumentCount.java
@@ -60,20 +60,16 @@ public final class ConstantArgumentCount implements ArgumentCount {
 	}
 
 	public static ArgumentCount any() {
-		return new ConstantArgumentCount(OPEN_INTERVAL, OPEN_INTERVAL);
+		return new ConstantArgumentCount(0, OPEN_INTERVAL);
 	}
 
 	@Override
 	public boolean isValidCount(int count) {
-		return (minCount == OPEN_INTERVAL || count >= minCount) &&
-			(maxCount == OPEN_INTERVAL || count <= maxCount);
+		return count >= minCount && (maxCount == OPEN_INTERVAL || count <= maxCount);
 	}
 
 	@Override
 	public Optional<Integer> getMinCount() {
-		if (minCount == OPEN_INTERVAL) {
-			return Optional.empty();
-		}
 		return Optional.of(minCount);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
@@ -420,9 +420,8 @@ public class InputTypeStrategiesTest {
 		final FunctionDefinitionMock functionDefinitionMock = new FunctionDefinitionMock();
 		functionDefinitionMock.functionKind = FunctionKind.SCALAR;
 
-		final DataTypeLookupMock dataTypeLookupMock = new DataTypeLookupMock();
-
 		final CallContextMock callContextMock = new CallContextMock();
+		callContextMock.lookup = new DataTypeLookupMock();
 		callContextMock.functionDefinition = functionDefinitionMock;
 		callContextMock.argumentDataTypes = actualArgumentTypes;
 		callContextMock.argumentLiterals = IntStream.range(0, actualArgumentTypes.size())

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/bridging/BridgingSqlAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/bridging/BridgingSqlAggFunction.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.bridging;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.functions.FunctionIdentifier;
+import org.apache.flink.table.functions.FunctionKind;
+import org.apache.flink.table.functions.FunctionRequirement;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.types.inference.TypeInference;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.util.Optionality;
+
+import java.util.List;
+
+import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createName;
+import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createParamTypes;
+import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createSqlFunctionCategory;
+import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createSqlIdentifier;
+import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createSqlOperandTypeChecker;
+import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createSqlOperandTypeInference;
+import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createSqlReturnTypeInference;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Bridges {@link FunctionDefinition} to Calcite's representation of a aggregating function
+ * (either a system or user-defined function).
+ */
+@Internal
+public final class BridgingSqlAggFunction extends SqlAggFunction {
+
+	private final FunctionIdentifier identifier;
+
+	private final FunctionDefinition definition;
+
+	private final TypeInference typeInference;
+
+	private final List<RelDataType> paramTypes;
+
+	private BridgingSqlAggFunction(
+			FlinkTypeFactory typeFactory,
+			SqlKind kind,
+			FunctionIdentifier identifier,
+			FunctionDefinition definition,
+			TypeInference typeInference) {
+		super(
+			createName(identifier),
+			createSqlIdentifier(identifier),
+			kind,
+			createSqlReturnTypeInference(definition, typeInference),
+			createSqlOperandTypeInference(definition, typeInference),
+			createSqlOperandTypeChecker(definition, typeInference),
+			createSqlFunctionCategory(identifier),
+			createOrderRequirement(),
+			createOverWindowRequirement(definition),
+			createGroupOrderRequirement());
+
+		this.identifier = identifier;
+		this.definition = definition;
+		this.typeInference = typeInference;
+		this.paramTypes = createParamTypes(typeFactory, typeInference);
+	}
+
+	/**
+	 * Creates an instance of a aggregating function (either a system or user-defined function).
+	 *
+	 * @param typeFactory used for resolving typed arguments
+	 * @param kind commonly used SQL standard function; use {@link SqlKind#OTHER_FUNCTION} if this function
+	 *             cannot be mapped to a common function kind.
+	 * @param identifier catalog identifier
+	 * @param definition system or user-defined {@link FunctionDefinition}
+	 * @param typeInference type inference logic
+	 */
+	public static BridgingSqlAggFunction of(
+			FlinkTypeFactory typeFactory,
+			SqlKind kind,
+			FunctionIdentifier identifier,
+			FunctionDefinition definition,
+			TypeInference typeInference) {
+
+		checkState(
+			definition.getKind() == FunctionKind.AGGREGATE || definition.getKind() == FunctionKind.TABLE_AGGREGATE,
+			"Aggregating function kind expected.");
+
+		return new BridgingSqlAggFunction(
+			typeFactory,
+			kind,
+			identifier,
+			definition,
+			typeInference);
+	}
+
+	public FunctionIdentifier getIdentifier() {
+		return identifier;
+	}
+
+	public FunctionDefinition getDefinition() {
+		return definition;
+	}
+
+	public TypeInference getTypeInference() {
+		return typeInference;
+	}
+
+	@Override
+	public List<RelDataType> getParamTypes() {
+		return paramTypes;
+	}
+
+	@Override
+	public List<String> getParamNames() {
+		if (typeInference.getNamedArguments().isPresent()) {
+			return typeInference.getNamedArguments().get();
+		}
+		return super.getParamNames();
+	}
+
+	@Override
+	public boolean isDeterministic() {
+		return definition.isDeterministic();
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private static boolean createOrderRequirement() {
+		return false;
+	}
+
+	private static boolean createOverWindowRequirement(FunctionDefinition definition) {
+		return definition.getRequirements().contains(FunctionRequirement.OVER_WINDOW_ONLY);
+	}
+
+	private static Optionality createGroupOrderRequirement() {
+		return Optionality.FORBIDDEN;
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/bridging/BridgingSqlAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/bridging/BridgingSqlAggFunction.java
@@ -43,7 +43,7 @@ import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.cr
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
- * Bridges {@link FunctionDefinition} to Calcite's representation of a aggregating function
+ * Bridges {@link FunctionDefinition} to Calcite's representation of an aggregating function
  * (either a system or user-defined function).
  */
 @Internal

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/bridging/BridgingSqlFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/bridging/BridgingSqlFunction.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.bridging;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.functions.FunctionIdentifier;
+import org.apache.flink.table.functions.FunctionKind;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.types.inference.TypeInference;
+
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlKind;
+
+import java.util.List;
+
+import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createName;
+import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createParamTypes;
+import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createSqlFunctionCategory;
+import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createSqlIdentifier;
+import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createSqlOperandTypeChecker;
+import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createSqlOperandTypeInference;
+import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createSqlReturnTypeInference;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Bridges {@link FunctionDefinition} to Calcite's representation of a scalar or table function
+ * (either a system or user-defined function).
+ */
+@Internal
+public final class BridgingSqlFunction extends SqlFunction {
+
+	private final FunctionIdentifier identifier;
+
+	private final FunctionDefinition definition;
+
+	private final TypeInference typeInference;
+
+	private BridgingSqlFunction(
+			FlinkTypeFactory typeFactory,
+			SqlKind kind,
+			FunctionIdentifier identifier,
+			FunctionDefinition definition,
+			TypeInference typeInference) {
+		super(
+			createName(identifier),
+			createSqlIdentifier(identifier),
+			kind,
+			createSqlReturnTypeInference(definition, typeInference),
+			createSqlOperandTypeInference(definition, typeInference),
+			createSqlOperandTypeChecker(definition, typeInference),
+			createParamTypes(typeFactory, typeInference),
+			createSqlFunctionCategory(identifier));
+
+		this.identifier = identifier;
+		this.definition = definition;
+		this.typeInference = typeInference;
+	}
+
+	/**
+	 * Creates an instance of a scalar or table function (either a system or user-defined function).
+	 *
+	 * @param typeFactory used for resolving typed arguments
+	 * @param kind commonly used SQL standard function; use {@link SqlKind#OTHER_FUNCTION} if this function
+	 *             cannot be mapped to a common function kind.
+	 * @param identifier catalog identifier
+	 * @param definition system or user-defined {@link FunctionDefinition}
+	 * @param typeInference type inference logic
+	 */
+	public static BridgingSqlFunction of(
+			FlinkTypeFactory typeFactory,
+			SqlKind kind,
+			FunctionIdentifier identifier,
+			FunctionDefinition definition,
+			TypeInference typeInference) {
+
+		checkState(
+			definition.getKind() == FunctionKind.SCALAR || definition.getKind() == FunctionKind.TABLE,
+			"Scala or table function kind expected.");
+
+		return new BridgingSqlFunction(
+			typeFactory,
+			kind,
+			identifier,
+			definition,
+			typeInference);
+	}
+
+	public FunctionIdentifier getIdentifier() {
+		return identifier;
+	}
+
+	public FunctionDefinition getDefinition() {
+		return definition;
+	}
+
+	public TypeInference getTypeInference() {
+		return typeInference;
+	}
+
+	@Override
+	public List<String> getParamNames() {
+		if (typeInference.getNamedArguments().isPresent()) {
+			return typeInference.getNamedArguments().get();
+		}
+		return super.getParamNames();
+	}
+
+	@Override
+	public boolean isDeterministic() {
+		return definition.isDeterministic();
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/bridging/BridgingUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/bridging/BridgingUtils.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.bridging;
+
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.functions.FunctionIdentifier;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.functions.inference.TypeInferenceOperandChecker;
+import org.apache.flink.table.planner.functions.inference.TypeInferenceOperandInference;
+import org.apache.flink.table.planner.functions.inference.TypeInferenceReturnInference;
+import org.apache.flink.table.types.inference.TypeInference;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlOperandTypeChecker;
+import org.apache.calcite.sql.type.SqlOperandTypeInference;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Utilities for bridging {@link FunctionDefinition} with Calcite's representation of functions.
+ */
+final class BridgingUtils {
+
+	static String createName(FunctionIdentifier identifier) {
+		if (identifier.getSimpleName().isPresent()) {
+			return identifier.getSimpleName().get();
+		}
+		return identifier.getIdentifier()
+			.map(ObjectIdentifier::getObjectName)
+			.orElseThrow(IllegalStateException::new);
+	}
+
+	static @Nullable SqlIdentifier createSqlIdentifier(FunctionIdentifier identifier) {
+		return identifier.getIdentifier()
+			.map(i -> new SqlIdentifier(i.toList(), SqlParserPos.ZERO))
+			.orElse(null); // null indicates a built-in system function
+	}
+
+	static SqlReturnTypeInference createSqlReturnTypeInference(
+			FunctionDefinition definition,
+			TypeInference typeInference) {
+		return new TypeInferenceReturnInference(definition, typeInference);
+	}
+
+	static SqlOperandTypeInference createSqlOperandTypeInference(
+			FunctionDefinition definition,
+			TypeInference typeInference) {
+		return new TypeInferenceOperandInference(definition, typeInference);
+	}
+
+	static SqlOperandTypeChecker createSqlOperandTypeChecker(
+			FunctionDefinition definition,
+			TypeInference typeInference) {
+		return new TypeInferenceOperandChecker(definition, typeInference);
+	}
+
+	static @Nullable List<RelDataType> createParamTypes(
+			FlinkTypeFactory typeFactory,
+			TypeInference typeInference) {
+		return typeInference.getTypedArguments()
+			.map(dataTypes ->
+				dataTypes.stream()
+					.map(dataType -> typeFactory.createFieldTypeFromLogicalType(dataType.getLogicalType()))
+					.collect(Collectors.toList()))
+			.orElse(null);
+	}
+
+	static SqlFunctionCategory createSqlFunctionCategory(FunctionIdentifier identifier) {
+		if (identifier.getSimpleName().isPresent()) {
+			return SqlFunctionCategory.SYSTEM;
+		}
+		return SqlFunctionCategory.USER_DEFINED_FUNCTION;
+	}
+
+	private BridgingUtils() {
+		// no instantiation
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/AbstractSqlCallContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/AbstractSqlCallContext.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.inference;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.catalog.DataTypeLookup;
+import org.apache.flink.table.expressions.ValueLiteralExpression;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.types.inference.CallContext;
+
+import org.apache.calcite.sql.SqlIntervalLiteral;
+import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.util.DateString;
+import org.apache.calcite.util.TimeString;
+import org.apache.calcite.util.TimestampString;
+
+import java.time.Duration;
+import java.time.Period;
+
+/**
+ * A {@link CallContext} backed by {@link SqlOperatorBinding}.
+ */
+@Internal
+public abstract class AbstractSqlCallContext implements CallContext {
+
+	private final DataTypeLookup lookup;
+
+	private final FunctionDefinition definition;
+
+	private final String name;
+
+	protected AbstractSqlCallContext(
+			DataTypeLookup lookup,
+			FunctionDefinition definition,
+			String name) {
+		this.lookup = lookup;
+		this.definition = definition;
+		this.name = name;
+	}
+
+	@Override
+	public DataTypeLookup getDataTypeLookup() {
+		return lookup;
+	}
+
+	@Override
+	public FunctionDefinition getFunctionDefinition() {
+		return definition;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Helper interface for abstracting accessing literals.
+	 */
+	protected interface LiteralValueAccessor {
+		<T> T getValueAs(Class<T> clazz);
+	}
+
+	/**
+	 * Bridges to {@link ValueLiteralExpression#getValueAs(Class)}.
+	 */
+	@SuppressWarnings("unchecked")
+	protected static <T, V> T getLiteralValueAs(LiteralValueAccessor accessor, Class<T> clazz) {
+		final Object value = accessor.getValueAs(Object.class);
+		final Class<?> valueClass = value.getClass();
+
+		Object convertedValue = null;
+
+		if (clazz == Duration.class) {
+			final long longVal = accessor.getValueAs(Long.class);
+			convertedValue = Duration.ofMillis(longVal);
+		}
+
+		else if (clazz == Period.class) {
+			final long longVal = accessor.getValueAs(Long.class);
+			if (longVal <= Integer.MAX_VALUE && longVal >= Integer.MIN_VALUE) {
+				convertedValue = Period.ofMonths((int) longVal);
+			}
+		}
+
+		else if (valueClass == SqlIntervalLiteral.IntervalValue.class && clazz == Integer.class) {
+			final long longVal = accessor.getValueAs(Long.class);
+			if (longVal <= Integer.MAX_VALUE && longVal >= Integer.MIN_VALUE) {
+				convertedValue = (int) longVal;
+			}
+		}
+
+		else if (clazz == java.sql.Date.class) {
+			final DateString dateString = accessor.getValueAs(DateString.class);
+			convertedValue = java.sql.Date.valueOf(dateString.toString());
+		}
+
+		else if (clazz == java.time.LocalDate.class) {
+			final DateString dateString = accessor.getValueAs(DateString.class);
+			convertedValue = java.time.LocalDate.parse(dateString.toString());
+		}
+
+		else if (clazz == java.sql.Time.class) {
+			final TimeString timeString = accessor.getValueAs(TimeString.class);
+			convertedValue = java.sql.Time.valueOf(timeString.toString());
+		}
+
+		else if (clazz == java.time.LocalTime.class) {
+			final TimeString timeString = accessor.getValueAs(TimeString.class);
+			convertedValue = java.time.LocalTime.parse(timeString.toString());
+		}
+
+		else if (clazz == java.sql.Timestamp.class) {
+			final TimestampString timestampString = accessor.getValueAs(TimestampString.class);
+			convertedValue = java.sql.Timestamp.valueOf(timestampString.toString());
+		}
+
+		else if (clazz == java.time.LocalDateTime.class) {
+			final TimestampString timestampString = accessor.getValueAs(TimestampString.class);
+			convertedValue = java.time.LocalDateTime.parse(timestampString.toString().replace(' ', 'T'));
+		}
+
+		if (convertedValue != null) {
+			return (T) convertedValue;
+		}
+
+		return accessor.getValueAs(clazz);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/AbstractSqlCallContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/AbstractSqlCallContext.java
@@ -81,7 +81,7 @@ public abstract class AbstractSqlCallContext implements CallContext {
 	 * Bridges to {@link ValueLiteralExpression#getValueAs(Class)}.
 	 */
 	@SuppressWarnings("unchecked")
-	protected static <T, V> T getLiteralValueAs(LiteralValueAccessor accessor, Class<T> clazz) {
+	protected static <T> T getLiteralValueAs(LiteralValueAccessor accessor, Class<T> clazz) {
 		final Object value = accessor.getValueAs(Object.class);
 		final Class<?> valueClass = value.getClass();
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/ArgumentCountRange.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/ArgumentCountRange.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.inference;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.types.inference.ArgumentCount;
+
+import org.apache.calcite.sql.SqlOperandCountRange;
+
+/**
+ * A {@link SqlOperandCountRange} backed by {@link ArgumentCount}.
+ */
+@Internal
+public final class ArgumentCountRange implements SqlOperandCountRange {
+
+	private final ArgumentCount argumentCount;
+
+	public ArgumentCountRange(ArgumentCount argumentCount) {
+		this.argumentCount = argumentCount;
+	}
+
+	@Override
+	public boolean isValidCount(int count) {
+		return argumentCount.isValidCount(count);
+	}
+
+	@Override
+	public int getMin() {
+		return argumentCount.getMinCount().orElse(-1);
+	}
+
+	@Override
+	public int getMax() {
+		return argumentCount.getMaxCount().orElse(-1);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/CallBindingCallContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/CallBindingCallContext.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.inference;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.utils.TypeConversions;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlCallBinding;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlUtil;
+
+import javax.annotation.Nullable;
+
+import java.util.AbstractList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A {@link CallContext} backed by {@link SqlCallBinding}. Compared to {@link OperatorBindingCallContext},
+ * this class is able to reorder arguments.
+ */
+@Internal
+public final class CallBindingCallContext extends AbstractSqlCallContext {
+
+	private final List<SqlNode> adaptedArguments;
+
+	private final List<DataType> argumentDataTypes;
+
+	private final @Nullable DataType outputType;
+
+	public CallBindingCallContext(
+			FunctionDefinition definition,
+			SqlCallBinding binding,
+			@Nullable RelDataType outputType) {
+		super(
+			((FlinkTypeFactory) binding.getTypeFactory()).getDataTypeLookup(),
+			definition,
+			binding.getOperator().getNameAsId().toString());
+
+		this.adaptedArguments = binding.operands(); // reorders the operands
+		this.argumentDataTypes = new AbstractList<DataType>() {
+			@Override
+			public DataType get(int pos) {
+				final RelDataType relDataType = binding.getValidator().deriveType(
+					binding.getScope(),
+					adaptedArguments.get(pos));
+				final LogicalType logicalType = FlinkTypeFactory.toLogicalType(relDataType);
+				return TypeConversions.fromLogicalToDataType(logicalType);
+			}
+
+			@Override
+			public int size() {
+				return binding.getOperandCount();
+			}
+		};
+		this.outputType = convertOutputType(binding, outputType);
+	}
+
+	@Override
+	public boolean isArgumentLiteral(int pos) {
+		return SqlUtil.isLiteral(adaptedArguments.get(pos), false);
+	}
+
+	@Override
+	public boolean isArgumentNull(int pos) {
+		return SqlUtil.isNullLiteral(adaptedArguments.get(pos), false);
+	}
+
+	@Override
+	public <T> Optional<T> getArgumentValue(int pos, Class<T> clazz) {
+		try {
+			final SqlLiteral literal = SqlLiteral.unchain(adaptedArguments.get(pos));
+			return Optional.ofNullable(getLiteralValueAs(literal::getValueAs, clazz));
+		} catch (IllegalArgumentException e) {
+			return Optional.empty();
+		}
+	}
+
+	@Override
+	public List<DataType> getArgumentDataTypes() {
+		return argumentDataTypes;
+	}
+
+	@Override
+	public Optional<DataType> getOutputDataType() {
+		return Optional.ofNullable(outputType);
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private static @Nullable DataType convertOutputType(SqlCallBinding binding, @Nullable RelDataType returnType) {
+		if (returnType == null || returnType.equals(binding.getValidator().getUnknownType())) {
+			return null;
+		} else {
+			final LogicalType logicalType = FlinkTypeFactory.toLogicalType(returnType);
+			return TypeConversions.fromLogicalToDataType(logicalType);
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/OperatorBindingCallContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/OperatorBindingCallContext.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.inference;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.utils.TypeConversions;
+
+import org.apache.calcite.sql.SqlOperatorBinding;
+
+import java.util.AbstractList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A {@link CallContext} backed by {@link SqlOperatorBinding}.
+ */
+@Internal
+public final class OperatorBindingCallContext extends AbstractSqlCallContext {
+
+	private final SqlOperatorBinding binding;
+
+	private final List<DataType> argumentDataTypes;
+
+	public OperatorBindingCallContext(
+			FunctionDefinition definition,
+			SqlOperatorBinding binding) {
+		super(
+			((FlinkTypeFactory) binding.getTypeFactory()).getDataTypeLookup(),
+			definition,
+			binding.getOperator().getNameAsId().toString());
+
+		this.binding = binding;
+		this.argumentDataTypes = new AbstractList<DataType>() {
+			@Override
+			public DataType get(int pos) {
+				final LogicalType logicalType = FlinkTypeFactory.toLogicalType(binding.getOperandType(pos));
+				return TypeConversions.fromLogicalToDataType(logicalType);
+			}
+
+			@Override
+			public int size() {
+				return binding.getOperandCount();
+			}
+		};
+	}
+
+	@Override
+	public boolean isArgumentLiteral(int pos) {
+		return binding.isOperandLiteral(pos, false);
+	}
+
+	@Override
+	public boolean isArgumentNull(int pos) {
+		return binding.isOperandNull(pos, false);
+	}
+
+	@Override
+	public <T> Optional<T> getArgumentValue(int pos, Class<T> clazz) {
+		try {
+			return Optional.ofNullable(
+				getLiteralValueAs(
+					new LiteralValueAccessor() {
+						@Override
+						public <R> R getValueAs(Class<R> clazz) {
+							return binding.getOperandLiteralValue(pos, clazz);
+						}
+					},
+					clazz));
+		} catch (IllegalArgumentException e) {
+			return Optional.empty();
+		}
+	}
+
+	@Override
+	public List<DataType> getArgumentDataTypes() {
+		return argumentDataTypes;
+	}
+
+	@Override
+	public Optional<DataType> getOutputDataType() {
+		return Optional.empty();
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/TypeInferenceOperandChecker.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/TypeInferenceOperandChecker.java
@@ -153,7 +153,6 @@ public final class TypeInferenceOperandChecker implements SqlOperandTypeChecker 
 	/**
 	 * Adopted from {@link org.apache.calcite.sql.validate.implicit.AbstractTypeCoercion}.
 	 */
-	@Deprecated
 	private void updateInferredType(SqlValidator validator, SqlNode node, RelDataType type) {
 		validator.setValidatedNodeType(node, type);
 		final SqlValidatorNamespace namespace = validator.getNamespace(node);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/TypeInferenceOperandChecker.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/TypeInferenceOperandChecker.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.inference;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.TypeInference;
+import org.apache.flink.table.types.inference.TypeInferenceUtil;
+import org.apache.flink.table.types.inference.utils.AdaptedCallContext;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlCallBinding;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperandCountRange;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlOperandTypeChecker;
+import org.apache.calcite.sql.type.SqlTypeUtil;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.sql.validate.SqlValidatorNamespace;
+
+import java.util.List;
+
+import static org.apache.flink.table.types.inference.TypeInferenceUtil.adaptArguments;
+import static org.apache.flink.table.types.inference.TypeInferenceUtil.createInvalidCallException;
+import static org.apache.flink.table.types.inference.TypeInferenceUtil.createInvalidInputException;
+import static org.apache.flink.table.types.inference.TypeInferenceUtil.createUnexpectedException;
+
+/**
+ * A {@link SqlOperandTypeChecker} backed by {@link TypeInference}.
+ *
+ * <p>Note: This class must be kept in sync with {@link TypeInferenceUtil}.
+ */
+@Internal
+public final class TypeInferenceOperandChecker implements SqlOperandTypeChecker {
+
+	private final FunctionDefinition definition;
+
+	private final TypeInference typeInference;
+
+	private final SqlOperandCountRange countRange;
+
+	public TypeInferenceOperandChecker(
+			FunctionDefinition definition,
+			TypeInference typeInference) {
+		this.definition = definition;
+		this.typeInference = typeInference;
+		this.countRange = new ArgumentCountRange(typeInference.getInputTypeStrategy().getArgumentCount());
+	}
+
+	@Override
+	public boolean checkOperandTypes(SqlCallBinding callBinding, boolean throwOnFailure) {
+		final CallContext callContext = new CallBindingCallContext(definition, callBinding, null);
+		try {
+			return checkOperandTypesOrError(callBinding, callContext);
+		}
+		catch (ValidationException e) {
+			if (throwOnFailure) {
+				throw createInvalidCallException(callContext, e);
+			}
+			return false;
+		} catch (Throwable t) {
+			throw createUnexpectedException(callContext, t);
+		}
+	}
+
+	@Override
+	public SqlOperandCountRange getOperandCountRange() {
+		return countRange;
+	}
+
+	@Override
+	public String getAllowedSignatures(SqlOperator op, String opName) {
+		return TypeInferenceUtil.generateSignature(opName, definition, typeInference);
+	}
+
+	@Override
+	public Consistency getConsistency() {
+		return Consistency.NONE;
+	}
+
+	@Override
+	public boolean isOptional(int i) {
+		return false;
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private boolean checkOperandTypesOrError(SqlCallBinding callBinding, CallContext callContext) {
+		final AdaptedCallContext adaptedCallContext;
+		try {
+			adaptedCallContext = adaptArguments(
+				typeInference,
+				callContext,
+				null);
+		} catch (ValidationException e) {
+			throw createInvalidInputException(
+				typeInference,
+				callContext,
+				e);
+		}
+
+		insertImplicitCasts(callBinding, adaptedCallContext.getArgumentDataTypes());
+
+		return true;
+	}
+
+	private void insertImplicitCasts(SqlCallBinding callBinding, List<DataType> expectedDataTypes) {
+		final FlinkTypeFactory flinkTypeFactory = (FlinkTypeFactory) callBinding.getTypeFactory();
+		final List<SqlNode> operands = callBinding.operands();
+		for (int i = 0; i < operands.size(); i++) {
+			final LogicalType expectedType = expectedDataTypes.get(i).getLogicalType();
+			final RelDataType expectedRelDataType = flinkTypeFactory.createFieldTypeFromLogicalType(expectedType);
+
+			final SqlNode castedOperand = castTo(operands.get(i), expectedRelDataType);
+			callBinding.getCall().setOperand(i, castedOperand);
+			updateInferredType(callBinding.getValidator(), castedOperand, expectedRelDataType);
+		}
+	}
+
+	/**
+	 * Adopted from {@link org.apache.calcite.sql.validate.implicit.AbstractTypeCoercion}.
+	 */
+	private SqlNode castTo(SqlNode node, RelDataType type) {
+		return SqlStdOperatorTable.CAST.createCall(
+			SqlParserPos.ZERO,
+			node,
+			SqlTypeUtil.convertTypeToSpec(type).withNullable(type.isNullable()));
+	}
+
+	/**
+	 * Adopted from {@link org.apache.calcite.sql.validate.implicit.AbstractTypeCoercion}.
+	 */
+	@Deprecated
+	private void updateInferredType(SqlValidator validator, SqlNode node, RelDataType type) {
+		validator.setValidatedNodeType(node, type);
+		final SqlValidatorNamespace namespace = validator.getNamespace(node);
+		if (namespace != null) {
+			namespace.setType(type);
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/TypeInferenceOperandInference.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/TypeInferenceOperandInference.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.inference;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.TypeInference;
+import org.apache.flink.table.types.inference.TypeInferenceUtil;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.SqlCallBinding;
+import org.apache.calcite.sql.type.SqlOperandTypeInference;
+
+import java.util.List;
+
+import static org.apache.flink.table.types.inference.TypeInferenceUtil.createUnexpectedException;
+
+/**
+ * A {@link SqlOperandTypeInference} backed by {@link TypeInference}.
+ *
+ * <p>Note: This class must be kept in sync with {@link TypeInferenceUtil}.
+ */
+@Internal
+public final class TypeInferenceOperandInference implements SqlOperandTypeInference {
+
+	private final FunctionDefinition definition;
+
+	private final TypeInference typeInference;
+
+	public TypeInferenceOperandInference(
+			FunctionDefinition definition,
+			TypeInference typeInference) {
+		this.definition = definition;
+		this.typeInference = typeInference;
+	}
+
+	@Override
+	public void inferOperandTypes(SqlCallBinding callBinding, RelDataType returnType, RelDataType[] operandTypes) {
+		final CallContext callContext = new CallBindingCallContext(definition, callBinding, returnType);
+		try {
+			inferOperandTypesOrError(callBinding.getTypeFactory(), callContext, operandTypes);
+		} catch (Throwable t) {
+			throw createUnexpectedException(callContext, t);
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private void inferOperandTypesOrError(RelDataTypeFactory typeFactory, CallContext callContext, RelDataType[] operandTypes) {
+		final FlinkTypeFactory flinkTypeFactory = (FlinkTypeFactory) typeFactory;
+
+		final List<DataType> expectedDataTypes;
+		// typed arguments have highest priority
+		if (typeInference.getTypedArguments().isPresent()) {
+			expectedDataTypes = typeInference.getTypedArguments().get();
+		} else {
+			expectedDataTypes = typeInference.getInputTypeStrategy()
+				.inferInputTypes(callContext, false)
+				.orElse(null);
+		}
+
+		// early out for invalid input
+		if (expectedDataTypes == null || expectedDataTypes.size() != operandTypes.length) {
+			return;
+		}
+
+		for (int i = 0; i < operandTypes.length; i++) {
+			final LogicalType inferredType = expectedDataTypes.get(i).getLogicalType();
+			operandTypes[i] = flinkTypeFactory.createFieldTypeFromLogicalType(inferredType);
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/TypeInferenceReturnInference.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/TypeInferenceReturnInference.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.inference;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.TypeInference;
+import org.apache.flink.table.types.inference.TypeInferenceUtil;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+
+import static org.apache.flink.table.types.inference.TypeInferenceUtil.createInvalidCallException;
+import static org.apache.flink.table.types.inference.TypeInferenceUtil.createUnexpectedException;
+import static org.apache.flink.table.types.inference.TypeInferenceUtil.inferOutputType;
+
+/**
+ * A {@link SqlReturnTypeInference} backed by {@link TypeInference}.
+ *
+ * <p>Note: This class must be kept in sync with {@link TypeInferenceUtil}.
+ */
+@Internal
+public final class TypeInferenceReturnInference implements SqlReturnTypeInference {
+
+	private final FunctionDefinition definition;
+
+	private final TypeInference typeInference;
+
+	public TypeInferenceReturnInference(
+			FunctionDefinition definition,
+			TypeInference typeInference) {
+		this.definition = definition;
+		this.typeInference = typeInference;
+	}
+
+	@Override
+	public RelDataType inferReturnType(SqlOperatorBinding opBinding) {
+		final FlinkTypeFactory typeFactory = (FlinkTypeFactory) opBinding.getTypeFactory();
+		final CallContext callContext = new OperatorBindingCallContext(definition, opBinding);
+		try {
+			return inferReturnTypeOrError(typeFactory, callContext);
+		}
+		catch (ValidationException e) {
+			throw createInvalidCallException(callContext, e);
+		} catch (Throwable t) {
+			throw createUnexpectedException(callContext, t);
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private RelDataType inferReturnTypeOrError(FlinkTypeFactory typeFactory, CallContext callContext) {
+		final LogicalType inferredType = inferOutputType(callContext, typeInference.getOutputTypeStrategy())
+			.getLogicalType();
+		return typeFactory.createFieldTypeFromLogicalType(inferredType);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
@@ -29,7 +29,6 @@ import org.apache.flink.table.types.logical._
 import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
 import org.apache.flink.types.Nothing
 import org.apache.flink.util.Preconditions.checkArgument
-
 import org.apache.calcite.avatica.util.TimeUnit
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl
 import org.apache.calcite.rel.RelNode
@@ -39,9 +38,11 @@ import org.apache.calcite.sql.`type`.SqlTypeName._
 import org.apache.calcite.sql.`type`.{BasicSqlType, MapSqlType, SqlTypeName}
 import org.apache.calcite.sql.parser.SqlParserPos
 import org.apache.calcite.util.ConversionUtil
-
 import java.nio.charset.Charset
 import java.util
+import java.util.Optional
+
+import org.apache.flink.table.catalog.{DataTypeLookup, UnresolvedIdentifier}
 
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
@@ -54,6 +55,17 @@ import scala.collection.mutable
 class FlinkTypeFactory(typeSystem: RelDataTypeSystem) extends JavaTypeFactoryImpl(typeSystem) {
 
   private val seenTypes = mutable.HashMap[LogicalType, RelDataType]()
+
+  def getDataTypeLookup: DataTypeLookup = new DataTypeLookup {
+    override def lookupDataType(name: String): Optional[DataType] =
+      throw new UnsupportedOperationException("Looking up a data type is not supported yet.")
+
+    override def lookupDataType(identifier: UnresolvedIdentifier): Optional[DataType] =
+      throw new UnsupportedOperationException("Looking up a data type is not supported yet.")
+
+    override def resolveRawDataType(clazz: Class[_]): DataType =
+      throw new UnsupportedOperationException("Looking up a data type is not supported yet.")
+  }
 
   /**
     * Create a calcite field type in table schema from [[LogicalType]]. It use

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/AggSqlFunction.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/AggSqlFunction.scala
@@ -57,7 +57,7 @@ class AggSqlFunction(
     requiresOver: Boolean,
     returnTypeInfer: Option[SqlReturnTypeInference] = None)
   extends SqlUserDefinedAggFunction(
-    new SqlIdentifier(identifier.getNames, SqlParserPos.ZERO),
+    new SqlIdentifier(identifier.toList, SqlParserPos.ZERO),
     returnTypeInfer.getOrElse(createReturnTypeInference(
       fromDataTypeToLogicalType(externalResultType), typeFactory)),
     createOperandTypeInference(displayName, aggregateFunction, typeFactory, externalAccType),

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/ScalarSqlFunction.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/ScalarSqlFunction.scala
@@ -50,7 +50,7 @@ class ScalarSqlFunction(
     typeFactory: FlinkTypeFactory,
     returnTypeInfer: Option[SqlReturnTypeInference] = None)
   extends SqlFunction(
-    new SqlIdentifier(identifier.getNames, SqlParserPos.ZERO),
+    new SqlIdentifier(identifier.toList, SqlParserPos.ZERO),
     returnTypeInfer.getOrElse(createReturnTypeInference(displayName, scalarFunction, typeFactory)),
     createOperandTypeInference(displayName, scalarFunction, typeFactory),
     createOperandTypeChecker(displayName, scalarFunction),

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/TableSqlFunction.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/TableSqlFunction.scala
@@ -56,7 +56,7 @@ class TableSqlFunction(
     functionImpl: FlinkTableFunction,
     operandTypeInfer: Option[SqlOperandTypeChecker] = None)
   extends SqlUserDefinedTableFunction(
-    new SqlIdentifier(identifier.getNames, SqlParserPos.ZERO),
+    new SqlIdentifier(identifier.toList, SqlParserPos.ZERO),
     ReturnTypes.CURSOR,
     // type inference has the UNKNOWN operand types.
     createOperandTypeInference(displayName, udtf, typeFactory),


### PR DESCRIPTION
## What is the purpose of the change

This PR connects Flink's new type inference to Calcite's type inference. It ensures that both Table API and SQL have exactly the same behavior and similar exception messages.

Note: This PR does not contain tests yet. They will be added as part of FLINK-15487 for testing end-to-end functionality.

## Brief change log

- Implementation of `SqlFunction` and `SqlAggFunction`

## Verifying this change

Manually verified until code generation with some additional changes that will be part of FLINK-15487.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
