### PR TITLE
[FLINK-15375][core] Improve MemorySize to print / parse with better readability.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
@@ -304,7 +304,7 @@ public final class ResourceSpec implements Serializable {
 	// ------------------------------------------------------------------------
 
 	public static Builder newBuilder(double cpuCores, int taskHeapMemoryMB) {
-		return new Builder(new CPUResource(cpuCores), MemorySize.parse(taskHeapMemoryMB + "m"));
+		return new Builder(new CPUResource(cpuCores), MemorySize.ofMebiBytes(taskHeapMemoryMB));
 	}
 
 	/**
@@ -334,7 +334,7 @@ public final class ResourceSpec implements Serializable {
 		}
 
 		public Builder setTaskHeapMemoryMB(int taskHeapMemoryMB) {
-			this.taskHeapMemory = MemorySize.parse(taskHeapMemoryMB + "m");
+			this.taskHeapMemory = MemorySize.ofMebiBytes(taskHeapMemoryMB);
 			return this;
 		}
 
@@ -344,7 +344,7 @@ public final class ResourceSpec implements Serializable {
 		}
 
 		public Builder setOffTaskHeapMemoryMB(int taskOffHeapMemoryMB) {
-			this.taskOffHeapMemory = MemorySize.parse(taskOffHeapMemoryMB + "m");
+			this.taskOffHeapMemory = MemorySize.ofMebiBytes(taskOffHeapMemoryMB);
 			return this;
 		}
 
@@ -354,7 +354,7 @@ public final class ResourceSpec implements Serializable {
 		}
 
 		public Builder setManagedMemoryMB(int managedMemoryMB) {
-			this.managedMemory = MemorySize.parse(managedMemoryMB + "m");
+			this.managedMemory = MemorySize.ofMebiBytes(managedMemoryMB);
 			return this;
 		}
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
@@ -284,9 +284,9 @@ public final class ResourceSpec implements Serializable {
 		}
 		return "ResourceSpec{" +
 			"cpuCores=" + cpuCores.getValue() +
-			", taskHeapMemory=" + taskHeapMemory +
-			", taskOffHeapMemory=" + taskOffHeapMemory +
-			", managedMemory=" + managedMemory + extResources +
+			", taskHeapMemory=" + taskHeapMemory.toHumanReadableString() +
+			", taskOffHeapMemory=" + taskOffHeapMemory.toHumanReadableString() +
+			", managedMemory=" + managedMemory.toHumanReadableString() + extResources +
 			'}';
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
@@ -53,7 +53,7 @@ public class ConfigurationUtils {
 		if (configuration.containsKey(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY.key())) {
 			return MemorySize.parse(configuration.getString(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY));
 		} else if (configuration.containsKey(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY_MB.key())) {
-			return MemorySize.parse(configuration.getInteger(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY_MB) + "m");
+			return MemorySize.ofMebiBytes(configuration.getInteger(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY_MB));
 		} else {
 			//use default value
 			return MemorySize.parse(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY.defaultValue());

--- a/flink-core/src/main/java/org/apache/flink/configuration/MemorySize.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/MemorySize.java
@@ -83,6 +83,10 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
 		this.bytes = bytes;
 	}
 
+	public static MemorySize ofMebiBytes(long mebiBytes) {
+		return new MemorySize(mebiBytes << 20);
+	}
+
 	// ------------------------------------------------------------------------
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/configuration/MemorySize.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/MemorySize.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -54,6 +55,13 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
 
 	public static final MemorySize MAX_VALUE = new MemorySize(Long.MAX_VALUE);
 
+	private static final List<MemoryUnit> ORDERED_UNITS = Arrays.asList(
+		BYTES,
+		KILO_BYTES,
+		MEGA_BYTES,
+		GIGA_BYTES,
+		TERA_BYTES);
+
 	// ------------------------------------------------------------------------
 
 	/** The memory size, in bytes. */
@@ -61,6 +69,9 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
 
 	/** The memorized value returned by toString(). */
 	private transient String stringified;
+
+	/** The memorized value returned by toHumanReadableString(). */
+	private transient String humanReadableStr;
 
 	/**
 	 * Constructs a new MemorySize.
@@ -132,23 +143,16 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
 	}
 
 	private String formatToString() {
-		List<MemoryUnit> orderedUnits = Arrays.asList(
-			BYTES,
-			KILO_BYTES,
-			MEGA_BYTES,
-			GIGA_BYTES,
-			TERA_BYTES);
-
-		MemoryUnit highestIntegerUnit = IntStream.range(0, orderedUnits.size())
+		MemoryUnit highestIntegerUnit = IntStream.range(0, ORDERED_UNITS.size())
 			.sequential()
-			.filter(idx -> bytes % orderedUnits.get(idx).getMultiplier() != 0)
+			.filter(idx -> bytes % ORDERED_UNITS.get(idx).getMultiplier() != 0)
 			.boxed()
 			.findFirst()
 			.map(idx -> {
 				if (idx == 0) {
-					return orderedUnits.get(0);
+					return ORDERED_UNITS.get(0);
 				} else {
-					return orderedUnits.get(idx - 1);
+					return ORDERED_UNITS.get(idx - 1);
 				}
 			}).orElse(BYTES);
 
@@ -156,6 +160,38 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
 			"%d %s",
 			bytes / highestIntegerUnit.getMultiplier(),
 			highestIntegerUnit.getUnits()[1]);
+	}
+
+	public String toHumanReadableString() {
+		if (humanReadableStr == null) {
+			humanReadableStr = formatToHumanReadableString();
+		}
+
+		return humanReadableStr;
+	}
+
+	private String formatToHumanReadableString() {
+		MemoryUnit highestUnit = IntStream.range(0, ORDERED_UNITS.size())
+			.sequential()
+			.filter(idx -> bytes > ORDERED_UNITS.get(idx).getMultiplier())
+			.boxed()
+			.max(Comparator.naturalOrder())
+			.map(ORDERED_UNITS::get)
+			.orElse(BYTES);
+
+		if (highestUnit == BYTES) {
+			return String.format(
+				"%d %s",
+				bytes,
+				BYTES.getUnits()[1]);
+		} else {
+			double approximate = 1.0 * bytes / highestUnit.getMultiplier();
+			return String.format(
+				"%.3f%s (%d bytes)",
+				approximate,
+				highestUnit.getUnits()[1],
+				bytes);
+		}
 	}
 
 	@Override

--- a/flink-core/src/test/java/org/apache/flink/configuration/MemorySizeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/MemorySizeTest.java
@@ -233,4 +233,17 @@ public class MemorySizeTest {
 		final MemorySize memory = new MemorySize(100L);
 		memory.divide(-23L);
 	}
+
+	@Test
+	public void testToHumanReadableString() {
+		assertThat(new MemorySize(0L).toHumanReadableString(), is("0 bytes"));
+		assertThat(new MemorySize(1L).toHumanReadableString(), is("1 bytes"));
+		assertThat(new MemorySize(1024L).toHumanReadableString(), is("1024 bytes"));
+		assertThat(new MemorySize(1025L).toHumanReadableString(), is("1.001kb (1025 bytes)"));
+		assertThat(new MemorySize(1536L).toHumanReadableString(), is("1.500kb (1536 bytes)"));
+		assertThat(new MemorySize(1_000_000L).toHumanReadableString(), is("976.563kb (1000000 bytes)"));
+		assertThat(new MemorySize(1_000_000_000L).toHumanReadableString(), is("953.674mb (1000000000 bytes)"));
+		assertThat(new MemorySize(1_000_000_000_000L).toHumanReadableString(), is("931.323gb (1000000000000 bytes)"));
+		assertThat(new MemorySize(1_000_000_000_000_000L).toHumanReadableString(), is("909.495tb (1000000000000000 bytes)"));
+	}
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesSessionCliTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesSessionCliTest.java
@@ -122,7 +122,7 @@ public class KubernetesSessionCliTest {
 		final int slotsPerTaskManager = 30;
 
 		configuration.setString(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, jobManagerMemory + "m");
-		configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.parse(taskManagerMemory + "m"));
+		configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(taskManagerMemory));
 		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, slotsPerTaskManager);
 
 		final String[] args = {
@@ -153,7 +153,7 @@ public class KubernetesSessionCliTest {
 		final int jobManagerMemory = 1337;
 		configuration.setString(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, jobManagerMemory + "m");
 		final int taskManagerMemory = 7331;
-		configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.parse(taskManagerMemory + "m"));
+		configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(taskManagerMemory));
 		final int slotsPerTaskManager = 42;
 		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, slotsPerTaskManager);
 
@@ -257,7 +257,7 @@ public class KubernetesSessionCliTest {
 
 	private KubernetesSessionCli createFlinkKubernetesCustomCliWithTmTotalMemory(int totalMemory) {
 		Configuration configuration = new Configuration();
-		configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.parse(totalMemory + "m"));
+		configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(totalMemory));
 		return new KubernetesSessionCli(configuration);
 	}
 }

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -429,7 +429,7 @@ public class MesosTaskManagerParameters {
 	}
 
 	private static MemorySize getTotalProcessMemory(final Configuration configuration) {
-		MemorySize legacyTotalProcessMemory = MemorySize.parse(configuration.getInteger(MESOS_RM_TASKS_MEMORY_MB) + "m");
+		MemorySize legacyTotalProcessMemory = MemorySize.ofMebiBytes(configuration.getInteger(MESOS_RM_TASKS_MEMORY_MB));
 		MemorySize unifiedTotalProcessMemory = configuration.get(TaskManagerOptions.TOTAL_PROCESS_MEMORY);
 
 		if (configuration.contains(MESOS_RM_TASKS_MEMORY_MB) &&

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertThat;
  */
 public class MesosTaskManagerParametersTest extends TestLogger {
 	private static final int TOTAL_PROCESS_MEMORY_MB = 1280;
-	private static final MemorySize TOTAL_PROCESS_MEMORY_SIZE = MemorySize.parse(TOTAL_PROCESS_MEMORY_MB + "m");
+	private static final MemorySize TOTAL_PROCESS_MEMORY_SIZE = MemorySize.ofMebiBytes(TOTAL_PROCESS_MEMORY_MB);
 
 	@Test
 	public void testBuildVolumes() throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceSpec.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceSpec.java
@@ -171,14 +171,14 @@ public class TaskExecutorResourceSpec implements Serializable {
 	public String toString() {
 		return "TaskExecutorResourceSpec {"
 			+ "cpuCores=" + cpuCores.getValue().doubleValue()
-			+ ", frameworkHeapSize=" + frameworkHeapSize.toString()
-			+ ", frameworkOffHeapSize=" + frameworkOffHeapMemorySize.toString()
-			+ ", taskHeapSize=" + taskHeapSize.toString()
-			+ ", taskOffHeapSize=" + taskOffHeapSize.toString()
-			+ ", networkMemSize=" + networkMemSize.toString()
-			+ ", managedMemorySize=" + managedMemorySize.toString()
-			+ ", jvmMetaspaceSize=" + jvmMetaspaceSize.toString()
-			+ ", jvmOverheadSize=" + jvmOverheadSize.toString()
+			+ ", frameworkHeapSize=" + frameworkHeapSize.toHumanReadableString()
+			+ ", frameworkOffHeapSize=" + frameworkOffHeapMemorySize.toHumanReadableString()
+			+ ", taskHeapSize=" + taskHeapSize.toHumanReadableString()
+			+ ", taskOffHeapSize=" + taskOffHeapSize.toHumanReadableString()
+			+ ", networkMemSize=" + networkMemSize.toHumanReadableString()
+			+ ", managedMemorySize=" + managedMemorySize.toHumanReadableString()
+			+ ", jvmMetaspaceSize=" + jvmMetaspaceSize.toHumanReadableString()
+			+ ", jvmOverheadSize=" + jvmOverheadSize.toHumanReadableString()
 			+ "}";
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtils.java
@@ -180,12 +180,12 @@ public class TaskExecutorResourceUtils {
 			final MemorySize totalFlinkMemorySize = getTotalFlinkMemorySize(config);
 			if (totalFlinkExcludeNetworkMemorySize.getBytes() > totalFlinkMemorySize.getBytes()) {
 				throw new IllegalConfigurationException(
-					"Sum of configured Framework Heap Memory (" + frameworkHeapMemorySize.toString()
-					+ "), Framework Off-Heap Memory (" + frameworkOffHeapMemorySize.toString()
-					+ "), Task Heap Memory (" + taskHeapMemorySize.toString()
-					+ "), Task Off-Heap Memory (" + taskOffHeapMemorySize.toString()
-					+ ") and Managed Memory (" + managedMemorySize.toString()
-					+ ") exceed configured Total Flink Memory (" + totalFlinkMemorySize.toString() + ").");
+					"Sum of configured Framework Heap Memory (" + frameworkHeapMemorySize.toHumanReadableString()
+					+ "), Framework Off-Heap Memory (" + frameworkOffHeapMemorySize.toHumanReadableString()
+					+ "), Task Heap Memory (" + taskHeapMemorySize.toHumanReadableString()
+					+ "), Task Off-Heap Memory (" + taskOffHeapMemorySize.toHumanReadableString()
+					+ ") and Managed Memory (" + managedMemorySize.toHumanReadableString()
+					+ ") exceed configured Total Flink Memory (" + totalFlinkMemorySize.toHumanReadableString() + ").");
 			}
 			networkMemorySize = totalFlinkMemorySize.subtract(totalFlinkExcludeNetworkMemorySize);
 			sanityCheckNetworkMemoryWithExplicitlySetTotalFlinkAndHeapMemory(config, networkMemorySize, totalFlinkMemorySize);
@@ -237,9 +237,9 @@ public class TaskExecutorResourceUtils {
 
 		if (jvmMetaspaceAndOverhead.getTotalJvmMetaspaceAndOverheadSize().getBytes() > totalProcessMemorySize.getBytes()) {
 			throw new IllegalConfigurationException(
-				"Sum of configured JVM Metaspace (" + jvmMetaspaceAndOverhead.metaspace.toString()
-				+ ") and JVM Overhead (" + jvmMetaspaceAndOverhead.overhead.toString()
-				+ ") exceed configured Total Process Memory (" + totalProcessMemorySize.toString() + ").");
+				"Sum of configured JVM Metaspace (" + jvmMetaspaceAndOverhead.metaspace.toHumanReadableString()
+				+ ") and JVM Overhead (" + jvmMetaspaceAndOverhead.overhead.toHumanReadableString()
+				+ ") exceed configured Total Process Memory (" + totalProcessMemorySize.toHumanReadableString() + ").");
 		}
 		final MemorySize totalFlinkMemorySize = totalProcessMemorySize.subtract(jvmMetaspaceAndOverhead.getTotalJvmMetaspaceAndOverheadSize());
 
@@ -289,12 +289,12 @@ public class TaskExecutorResourceUtils {
 				frameworkHeapMemorySize.add(frameworkOffHeapMemorySize).add(taskHeapMemorySize).add(taskOffHeapMemorySize).add(managedMemorySize);
 			if (totalFlinkExcludeNetworkMemorySize.getBytes() > totalFlinkMemorySize.getBytes()) {
 				throw new IllegalConfigurationException(
-					"Sum of configured Framework Heap Memory (" + frameworkHeapMemorySize.toString()
-						+ "), Framework Off-Heap Memory (" + frameworkOffHeapMemorySize.toString()
-						+ "), Task Heap Memory (" + taskHeapMemorySize.toString()
-						+ "), Task Off-Heap Memory (" + taskOffHeapMemorySize.toString()
-						+ ") and Managed Memory (" + managedMemorySize.toString()
-						+ ") exceed configured Total Flink Memory (" + totalFlinkMemorySize.toString() + ").");
+					"Sum of configured Framework Heap Memory (" + frameworkHeapMemorySize.toHumanReadableString()
+						+ "), Framework Off-Heap Memory (" + frameworkOffHeapMemorySize.toHumanReadableString()
+						+ "), Task Heap Memory (" + taskHeapMemorySize.toHumanReadableString()
+						+ "), Task Off-Heap Memory (" + taskOffHeapMemorySize.toHumanReadableString()
+						+ ") and Managed Memory (" + managedMemorySize.toHumanReadableString()
+						+ ") exceed configured Total Flink Memory (" + totalFlinkMemorySize.toHumanReadableString() + ").");
 			}
 			networkMemorySize = totalFlinkMemorySize.subtract(totalFlinkExcludeNetworkMemorySize);
 			sanityCheckNetworkMemoryWithExplicitlySetTotalFlinkAndHeapMemory(config, networkMemorySize, totalFlinkMemorySize);
@@ -312,12 +312,12 @@ public class TaskExecutorResourceUtils {
 				frameworkHeapMemorySize.add(frameworkOffHeapMemorySize).add(taskOffHeapMemorySize).add(managedMemorySize).add(networkMemorySize);
 			if (totalFlinkExcludeTaskHeapMemorySize.getBytes() > totalFlinkMemorySize.getBytes()) {
 				throw new IllegalConfigurationException(
-					"Sum of configured Framework Heap Memory (" + frameworkHeapMemorySize.toString()
-						+ "), Framework Off-Heap Memory (" + frameworkOffHeapMemorySize.toString()
-						+ "), Task Off-Heap Memory (" + taskOffHeapMemorySize.toString()
-						+ "), Managed Memory (" + managedMemorySize.toString()
-						+ ") and Network Memory (" + networkMemorySize.toString()
-						+ ") exceed configured Total Flink Memory (" + totalFlinkMemorySize.toString() + ").");
+					"Sum of configured Framework Heap Memory (" + frameworkHeapMemorySize.toHumanReadableString()
+						+ "), Framework Off-Heap Memory (" + frameworkOffHeapMemorySize.toHumanReadableString()
+						+ "), Task Off-Heap Memory (" + taskOffHeapMemorySize.toHumanReadableString()
+						+ "), Managed Memory (" + managedMemorySize.toHumanReadableString()
+						+ ") and Network Memory (" + networkMemorySize.toHumanReadableString()
+						+ ") exceed configured Total Flink Memory (" + totalFlinkMemorySize.toHumanReadableString() + ").");
 			}
 			taskHeapMemorySize = totalFlinkMemorySize.subtract(totalFlinkExcludeTaskHeapMemorySize);
 		}
@@ -362,8 +362,8 @@ public class TaskExecutorResourceUtils {
 			final String memoryDescription,
 			final MemorySize base,
 			final RangeFraction rangeFraction) {
-		final long relative = (long) (rangeFraction.fraction * base.getBytes());
-		return new MemorySize(capToMinMax(memoryDescription, relative, rangeFraction));
+		final MemorySize relative = base.multiply(rangeFraction.fraction);
+		return capToMinMax(memoryDescription, relative, rangeFraction);
 	}
 
 	private static MemorySize deriveWithInverseFraction(
@@ -371,31 +371,31 @@ public class TaskExecutorResourceUtils {
 			final MemorySize base,
 			final RangeFraction rangeFraction) {
 		checkArgument(rangeFraction.fraction < 1);
-		final long relative = (long) (rangeFraction.fraction / (1 - rangeFraction.fraction) * base.getBytes());
-		return new MemorySize(capToMinMax(memoryDescription, relative, rangeFraction));
+		final MemorySize relative = base.multiply(rangeFraction.fraction / (1 - rangeFraction.fraction));
+		return capToMinMax(memoryDescription, relative, rangeFraction);
 	}
 
-	private static long capToMinMax(
+	private static MemorySize capToMinMax(
 			final String memoryDescription,
-			final long relative,
+			final MemorySize relative,
 			final RangeFraction rangeFraction) {
-		long size = relative;
+		long size = relative.getBytes();
 		if (size > rangeFraction.maxSize.getBytes()) {
 			LOG.info(
-				"The derived from fraction {} ({}b) is greater than its max value {}, max value will be used instead",
+				"The derived from fraction {} ({}) is greater than its max value {}, max value will be used instead",
 				memoryDescription,
-				relative,
-				rangeFraction.maxSize);
+				relative.toHumanReadableString(),
+				rangeFraction.maxSize.toHumanReadableString());
 			size = rangeFraction.maxSize.getBytes();
 		} else if (size < rangeFraction.minSize.getBytes()) {
 			LOG.info(
-				"The derived from fraction {} ({}b) is less than its min value {}, max value will be used instead",
+				"The derived from fraction {} ({}) is less than its min value {}, max value will be used instead",
 				memoryDescription,
-				relative,
-				rangeFraction.minSize);
+				relative.toHumanReadableString(),
+				rangeFraction.minSize.toHumanReadableString());
 			size = rangeFraction.minSize.getBytes();
 		}
-		return size;
+		return new MemorySize(size);
 	}
 
 	private static MemorySize getFrameworkHeapMemorySize(final Configuration config) {
@@ -462,8 +462,8 @@ public class TaskExecutorResourceUtils {
 					"Inconsistently configured %s (%s) and its min (%s), max (%s) value",
 					fractionOption,
 					fraction,
-					minSize,
-					maxSize),
+					minSize.toHumanReadableString(),
+					maxSize.toHumanReadableString()),
 				e);
 		}
 	}
@@ -535,15 +535,15 @@ public class TaskExecutorResourceUtils {
 			final MemorySize configuredTotalFlinkMemorySize = getTotalFlinkMemorySize(config);
 			if (!configuredTotalFlinkMemorySize.equals(flinkInternalMemory.getTotalFlinkMemorySize())) {
 				throw new IllegalConfigurationException(
-					"Configured/Derived Flink internal memory sizes (total " + flinkInternalMemory.getTotalFlinkMemorySize().toString()
-						+ ") do not add up to the configured Total Flink Memory size (" + configuredTotalFlinkMemorySize.toString()
+					"Configured/Derived Flink internal memory sizes (total " + flinkInternalMemory.getTotalFlinkMemorySize().toHumanReadableString()
+						+ ") do not add up to the configured Total Flink Memory size (" + configuredTotalFlinkMemorySize.toHumanReadableString()
 						+ "). Configured/Derived Flink internal memory sizes are: "
-						+ "Framework Heap Memory (" + flinkInternalMemory.frameworkHeap.toString()
-						+ "), Framework Off-Heap Memory (" + flinkInternalMemory.frameworkOffHeap.toString()
-						+ "), Task Heap Memory (" + flinkInternalMemory.taskHeap.toString()
-						+ "), Task Off-Heap Memory (" + flinkInternalMemory.taskOffHeap.toString()
-						+ "), Network Memory (" + flinkInternalMemory.network.toString()
-						+ "), Managed Memory (" + flinkInternalMemory.managed.toString() + ").");
+						+ "Framework Heap Memory (" + flinkInternalMemory.frameworkHeap.toHumanReadableString()
+						+ "), Framework Off-Heap Memory (" + flinkInternalMemory.frameworkOffHeap.toHumanReadableString()
+						+ "), Task Heap Memory (" + flinkInternalMemory.taskHeap.toHumanReadableString()
+						+ "), Task Off-Heap Memory (" + flinkInternalMemory.taskOffHeap.toHumanReadableString()
+						+ "), Network Memory (" + flinkInternalMemory.network.toHumanReadableString()
+						+ "), Managed Memory (" + flinkInternalMemory.managed.toHumanReadableString() + ").");
 			}
 		}
 	}
@@ -558,12 +558,12 @@ public class TaskExecutorResourceUtils {
 			final MemorySize configuredTotalProcessMemorySize = getTotalProcessMemorySize(config);
 			if (!configuredTotalProcessMemorySize.equals(derivedTotalProcessMemorySize)) {
 				throw new IllegalConfigurationException(
-					"Configured/Derived memory sizes (total " + derivedTotalProcessMemorySize.toString()
-						+ ") do not add up to the configured Total Process Memory size (" + configuredTotalProcessMemorySize.toString()
+					"Configured/Derived memory sizes (total " + derivedTotalProcessMemorySize.toHumanReadableString()
+						+ ") do not add up to the configured Total Process Memory size (" + configuredTotalProcessMemorySize.toHumanReadableString()
 						+ "). Configured/Derived memory sizes are: "
-						+ "Total Flink Memory (" + totalFlinkMemory.toString()
-						+ "), JVM Metaspace (" + jvmMetaspaceAndOverhead.metaspace.toString()
-						+ "), JVM Overhead (" + jvmMetaspaceAndOverhead.overhead.toString() + ").");
+						+ "Total Flink Memory (" + totalFlinkMemory.toHumanReadableString()
+						+ "), JVM Metaspace (" + jvmMetaspaceAndOverhead.metaspace.toHumanReadableString()
+						+ "), JVM Overhead (" + jvmMetaspaceAndOverhead.overhead.toHumanReadableString() + ").");
 			}
 		}
 	}
@@ -591,17 +591,17 @@ public class TaskExecutorResourceUtils {
 			final MemorySize configuredNetworkMemorySize = getNetworkMemorySizeWithLegacyConfig(config);
 			if (!configuredNetworkMemorySize.equals(derivedNetworkMemorySize)) {
 				throw new IllegalConfigurationException(
-					"Derived Network Memory size (" + derivedNetworkMemorySize.toString()
-					+ ") does not match configured Network Memory size (" + configuredNetworkMemorySize.toString() + ").");
+					"Derived Network Memory size (" + derivedNetworkMemorySize.toHumanReadableString()
+					+ ") does not match configured Network Memory size (" + configuredNetworkMemorySize.toHumanReadableString() + ").");
 			}
 		} else {
 			final RangeFraction networkRangeFraction = getNetworkMemoryRangeFraction(config);
 			if (derivedNetworkMemorySize.getBytes() > networkRangeFraction.maxSize.getBytes() ||
 				derivedNetworkMemorySize.getBytes() < networkRangeFraction.minSize.getBytes()) {
 				throw new IllegalConfigurationException("Derived Network Memory size ("
-					+ derivedNetworkMemorySize.toString() + ") is not in configured Network Memory range ["
-					+ networkRangeFraction.minSize.toString() + ", "
-					+ networkRangeFraction.maxSize.toString() + "].");
+					+ derivedNetworkMemorySize.toHumanReadableString() + ") is not in configured Network Memory range ["
+					+ networkRangeFraction.minSize.toHumanReadableString() + ", "
+					+ networkRangeFraction.maxSize.toHumanReadableString() + "].");
 			}
 			if (isNetworkMemoryFractionExplicitlyConfigured(config) &&
 				!derivedNetworkMemorySize.equals(totalFlinkMemorySize.multiply(networkRangeFraction.fraction))) {
@@ -609,9 +609,9 @@ public class TaskExecutorResourceUtils {
 					"The derived Network Memory size ({}) does not match " +
 						"the configured Network Memory fraction ({}) from the configured Total Flink Memory size ({}). " +
 						"The derived Network Memory size will be used.",
-					derivedNetworkMemorySize,
+					derivedNetworkMemorySize.toHumanReadableString(),
 					networkRangeFraction.fraction,
-					totalFlinkMemorySize);
+					totalFlinkMemorySize.toHumanReadableString());
 			}
 		}
 	}
@@ -624,9 +624,9 @@ public class TaskExecutorResourceUtils {
 		if (derivedJvmOverheadSize.getBytes() > jvmOverheadRangeFraction.maxSize.getBytes() ||
 			derivedJvmOverheadSize.getBytes() < jvmOverheadRangeFraction.minSize.getBytes()) {
 			throw new IllegalConfigurationException("Derived JVM Overhead size ("
-				+ derivedJvmOverheadSize.toString() + ") is not in configured JVM Overhead range ["
-				+ jvmOverheadRangeFraction.minSize.toString() + ", "
-				+ jvmOverheadRangeFraction.maxSize.toString() + "].");
+				+ derivedJvmOverheadSize.toHumanReadableString() + ") is not in configured JVM Overhead range ["
+				+ jvmOverheadRangeFraction.minSize.toHumanReadableString() + ", "
+				+ jvmOverheadRangeFraction.maxSize.toHumanReadableString() + "].");
 		}
 		if (isJvmOverheadFractionExplicitlyConfigured(config) &&
 			!derivedJvmOverheadSize.equals(totalProcessMemorySize.multiply(jvmOverheadRangeFraction.fraction))) {
@@ -634,9 +634,9 @@ public class TaskExecutorResourceUtils {
 				"The derived JVM Overhead size ({}) does not match " +
 					"the configured JVM Overhead fraction ({}) from the configured Total Process Memory size ({}). " +
 					"The derived JVM OVerhead size will be used.",
-				derivedJvmOverheadSize,
+				derivedJvmOverheadSize.toHumanReadableString(),
 				jvmOverheadRangeFraction.fraction,
-				totalProcessMemorySize);
+				totalProcessMemorySize.toHumanReadableString());
 		}
 	}
 
@@ -755,7 +755,7 @@ public class TaskExecutorResourceUtils {
 			LOG.info(
 				"'{}' is not specified, use the configured deprecated task manager heap value ({}) for it.",
 				configOption.key(),
-				legacyHeapSize);
+				legacyHeapSize.toHumanReadableString());
 
 			return copiedConfig;
 		}).orElse(configuration);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -486,7 +486,7 @@ public class ResourceProfile implements Serializable {
 		}
 
 		public Builder setTaskHeapMemoryMB(int taskHeapMemoryMB) {
-			this.taskHeapMemory = MemorySize.parse(taskHeapMemoryMB + "m");
+			this.taskHeapMemory = MemorySize.ofMebiBytes(taskHeapMemoryMB);
 			return this;
 		}
 
@@ -496,7 +496,7 @@ public class ResourceProfile implements Serializable {
 		}
 
 		public Builder setTaskOffHeapMemoryMB(int taskOffHeapMemoryMB) {
-			this.taskOffHeapMemory = MemorySize.parse(taskOffHeapMemoryMB + "m");
+			this.taskOffHeapMemory = MemorySize.ofMebiBytes(taskOffHeapMemoryMB);
 			return this;
 		}
 
@@ -506,7 +506,7 @@ public class ResourceProfile implements Serializable {
 		}
 
 		public Builder setManagedMemoryMB(int managedMemoryMB) {
-			this.managedMemory = MemorySize.parse(managedMemoryMB + "m");
+			this.managedMemory = MemorySize.ofMebiBytes(managedMemoryMB);
 			return this;
 		}
 
@@ -516,7 +516,7 @@ public class ResourceProfile implements Serializable {
 		}
 
 		public Builder setNetworkMemoryMB(int networkMemoryMB) {
-			this.networkMemory = MemorySize.parse(networkMemoryMB + "m");
+			this.networkMemory = MemorySize.ofMebiBytes(networkMemoryMB);
 			return this;
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -394,10 +394,10 @@ public class ResourceProfile implements Serializable {
 		}
 		return "ResourceProfile{" +
 			"cpuCores=" + cpuCores.getValue() +
-			", taskHeapMemory=" + taskHeapMemory +
-			", taskOffHeapMemory=" + taskOffHeapMemory +
-			", managedMemory=" + managedMemory +
-			", networkMemory=" + networkMemory + resources +
+			", taskHeapMemory=" + taskHeapMemory.toHumanReadableString() +
+			", taskOffHeapMemory=" + taskOffHeapMemory.toHumanReadableString() +
+			", managedMemory=" + managedMemory.toHumanReadableString() +
+			", networkMemory=" + networkMemory.toHumanReadableString() + resources +
 			'}';
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtilsTest.java
@@ -232,7 +232,7 @@ public class TaskExecutorResourceUtilsTest extends TestLogger {
 		// derive network memory which is bigger than the number of legacy network buffers
 		final int networkMemorySizeMbToDerive = pageSizeMb * (numberOfNetworkBuffers + 1);
 		final Configuration configuration = setupConfigWithFlinkAndTaskHeapToDeriveGivenNetworkMem(networkMemorySizeMbToDerive);
-		configuration.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse(pageSizeMb + "m"));
+		configuration.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.ofMebiBytes(pageSizeMb));
 		configuration.setInteger(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS, numberOfNetworkBuffers);
 		// internal validation should fail
 		TaskExecutorResourceUtils.resourceSpecFromConfig(configuration);
@@ -251,12 +251,12 @@ public class TaskExecutorResourceUtilsTest extends TestLogger {
 			// adjust total Flink memory size to accommodate for more network memory
 			final int adjustedTotalFlinkMemoryMb = taskExecutorResourceSpec.getTotalFlinkMemorySize().getMebiBytes() -
 				derivedNetworkMemorySizeMb + networkMemorySizeToDeriveMb;
-			conf.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.parse(adjustedTotalFlinkMemoryMb + "m"));
+			conf.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.ofMebiBytes(adjustedTotalFlinkMemoryMb));
 		} else if (derivedNetworkMemorySizeMb > networkMemorySizeToDeriveMb) {
 			// reduce derived network memory by increasing task heap size
 			final int adjustedTaskHeapMemoryMb = taskExecutorResourceSpec.getTaskHeapSize().getMebiBytes() +
 				derivedNetworkMemorySizeMb - networkMemorySizeToDeriveMb;
-			conf.set(TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.parse(adjustedTaskHeapMemoryMb + "m"));
+			conf.set(TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.ofMebiBytes(adjustedTaskHeapMemoryMb));
 		}
 
 		final TaskExecutorResourceSpec adjusteedTaskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(conf);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceUtilsTest.java
@@ -241,9 +241,9 @@ public class TaskExecutorResourceUtilsTest extends TestLogger {
 	private static Configuration setupConfigWithFlinkAndTaskHeapToDeriveGivenNetworkMem(
 			final int networkMemorySizeToDeriveMb) {
 		final Configuration conf = new Configuration();
-		conf.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.parse(TOTAL_FLINK_MEM_SIZE.getMebiBytes() + "m"));
-		conf.set(TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.parse(TASK_HEAP_SIZE.getMebiBytes() + "m"));
-		conf.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse(MANAGED_MEM_SIZE.getMebiBytes() + "m"));
+		conf.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, TOTAL_FLINK_MEM_SIZE);
+		conf.set(TaskManagerOptions.TASK_HEAP_MEMORY, TASK_HEAP_SIZE);
+		conf.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MANAGED_MEM_SIZE);
 
 		final TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(conf);
 		final int derivedNetworkMemorySizeMb = taskExecutorResourceSpec.getNetworkMemSize().getMebiBytes();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceBudgetManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceBudgetManagerTest.java
@@ -65,6 +65,6 @@ public class ResourceBudgetManagerTest {
 	}
 
 	private static ResourceProfile createResourceProfile(double cpus, int memory) {
-		return ResourceProfile.newBuilder().setCpuCores(cpus).setTaskHeapMemory(MemorySize.parse(memory + "m")).build();
+		return ResourceProfile.newBuilder().setCpuCores(cpus).setTaskHeapMemory(MemorySize.ofMebiBytes(memory)).build();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
@@ -125,7 +125,7 @@ public class ResourceProfileTest {
 		ResourceSpec rs5 = ResourceSpec.newBuilder(1.0, 100).
 				setGPUResource(2.2).
 				build();
-		MemorySize networkMemory = MemorySize.parse(100 + "m");
+		MemorySize networkMemory = MemorySize.ofMebiBytes(100);
 		assertEquals(ResourceProfile.fromResourceSpec(rs3, networkMemory), ResourceProfile.fromResourceSpec(rs5, networkMemory));
 
 		final ResourceProfile rp1 = ResourceProfile.newBuilder()
@@ -199,7 +199,7 @@ public class ResourceProfileTest {
 		ResourceSpec rs = ResourceSpec.newBuilder(1.0, 100).
 				setGPUResource(1.6).
 				build();
-		ResourceProfile rp = ResourceProfile.fromResourceSpec(rs, MemorySize.parse(50 + "m"));
+		ResourceProfile rp = ResourceProfile.fromResourceSpec(rs, MemorySize.ofMebiBytes(50));
 
 		assertEquals(new CPUResource(1.0), rp.getCpuCores());
 		assertEquals(150, rp.getTotalMemory().getMebiBytes());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
@@ -208,7 +208,7 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 
 	private TaskManagerServicesConfiguration createTaskManagerServiceConfiguration(
 			Configuration config) throws IOException {
-		config.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.parse(TOTAL_FLINK_MEMORY_MB + "m"));
+		config.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.ofMebiBytes(TOTAL_FLINK_MEMORY_MB));
 		TaskExecutorResourceSpec spec = TaskExecutorResourceUtils.resourceSpecFromConfig(config);
 		return TaskManagerServicesConfiguration.fromConfiguration(
 			config,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
@@ -159,7 +159,7 @@ public class TaskManagerRunnerStartupTest extends TestLogger {
 
 	private static Configuration createFlinkConfiguration() {
 		final Configuration config = new Configuration();
-		config.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.parse(TOTAL_FLINK_MEMORY_MB + "m"));
+		config.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.ofMebiBytes(TOTAL_FLINK_MEMORY_MB));
 
 		return config;
 	}

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -273,7 +273,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 		final int slotsPerTaskManager = 30;
 
 		configuration.setString(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, jobManagerMemory + "m");
-		configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.parse(taskManagerMemory + "m"));
+		configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(taskManagerMemory));
 		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, slotsPerTaskManager);
 
 		final String[] args = {"-yjm", String.valueOf(jobManagerMemory) + "m", "-ytm", String.valueOf(taskManagerMemory) + "m", "-ys", String.valueOf(slotsPerTaskManager)};
@@ -300,7 +300,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 		final int jobManagerMemory = 1337;
 		configuration.setString(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, jobManagerMemory + "m");
 		final int taskManagerMemory = 7331;
-		configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.parse(taskManagerMemory + "m"));
+		configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(taskManagerMemory));
 		final int slotsPerTaskManager = 42;
 		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, slotsPerTaskManager);
 
@@ -450,7 +450,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 	private FlinkYarnSessionCli createFlinkYarnSessionCliWithTmTotalMemory(int totalMemomory) throws FlinkException {
 		Configuration configuration = new Configuration();
-		configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.parse(totalMemomory + "m"));
+		configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(totalMemomory));
 		return createFlinkYarnSessionCli(configuration);
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This PR improves readability and usability of `MemorySize`.

## Brief change log

- 70b21198a5e02709ee694a33557b4018bd42c493: Code clean-up in TaskExecutorResourceUtilsTest. Remove unnecessary usage of `MemorySize#toString`.
- 9245f66e85d7002a00c2b3fb6dc62931acb0147e: Introduce `MemorySize#toHumanReadableString`
- 57539a39ba9911352812161f2d3c079cf75898a3: Use `MemorySize#toHumanReadableString` for logs and error messages.
- 65aaf3db7340f912c5fe9e54cb065c38b7c88c0d: Introduce factory method for creating MemorySize from mebibytes conveniently.

## Verifying this change

- Add cases in `MemorySizeTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
