### PR TITLE
[FLINK-15501] Remove the wrong doc of ExecutionVertexSchedulingRequirements#getExecutionVertexId

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirements.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirements.java
@@ -73,11 +73,6 @@ public class ExecutionVertexSchedulingRequirements {
 		this.preferredLocations = checkNotNull(preferredLocations);
 	}
 
-	/**
-	 * a {@link ExecutionVertex#MAX_DISTINCT_LOCATIONS_TO_CONSIDER} test.
-	 *
-	 * @return
-	 */
 	public ExecutionVertexID getExecutionVertexId() {
 		return executionVertexId;
 	}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request removes the wrong doc of ExecutionVertexSchedulingRequirements#getExecutionVertexId*


## Brief change log

  - *Remove the wrong doc of ExecutionVertexSchedulingRequirements#getExecutionVertexId*

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
