### PR TITLE
[FLINK-15448][runtime] Log host informations for TaskManager failures.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -1144,9 +1144,18 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		@Override
 		public void notifyHeartbeatTimeout(ResourceID resourceID) {
 			validateRunsInMainThread();
+
+			final Tuple2<TaskManagerLocation, TaskExecutorGateway> taskManagerInfo = registeredTaskManagers.get(resourceID);
+			final String taskManagerIdStr;
+			if (taskManagerInfo != null) {
+				taskManagerIdStr = taskManagerInfo.f0.toString();
+			} else {
+				taskManagerIdStr = resourceID.toString();
+			}
+
 			disconnectTaskManager(
 				resourceID,
-				new TimeoutException("Heartbeat of TaskManager with id " + resourceID + " timed out."));
+				new TimeoutException("Heartbeat of TaskManager with id " + taskManagerIdStr + " timed out."));
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -1120,11 +1120,22 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 		@Override
 		public void notifyHeartbeatTimeout(final ResourceID resourceID) {
 			validateRunsInMainThread();
-			log.info("The heartbeat of TaskManager with id {} timed out.", resourceID);
+
+			final WorkerRegistration workerRegistration = taskExecutors.get(resourceID);
+			final String taskManagerIdStr;
+
+			if (workerRegistration != null) {
+				taskManagerIdStr = String.format("%s @ %s (dataPort=%d)",
+					resourceID, workerRegistration.getTaskExecutorGateway().getHostname(), workerRegistration.getDataPort());
+			} else {
+				taskManagerIdStr = resourceID.toString();
+			}
+
+			log.info("The heartbeat of TaskManager with id {} timed out.", taskManagerIdStr);
 
 			closeTaskManagerConnection(
 				resourceID,
-				new TimeoutException("The heartbeat of TaskManager with id " + resourceID + "  timed out."));
+				new TimeoutException("The heartbeat of TaskManager with id " + taskManagerIdStr + "  timed out."));
 		}
 
 		@Override


### PR DESCRIPTION

## What is the purpose of the change

To provide host information in case of TaskManager failures, so users could find the log file more conveniently.

## Brief change log

  - Add host information when logging TaskManager failures. 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
