### PR TITLE
[FLINK-15490][kafka][test-stability] Enable idempotence producing in …

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironment.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironment.java
@@ -125,6 +125,14 @@ public abstract class KafkaTestEnvironment {
 
 	public abstract List<KafkaServer> getBrokers();
 
+	public Properties getIdempotentProducerConfig() {
+		Properties props = new Properties();
+		props.put("enable.idempotence", "true");
+		props.put("acks", "all");
+		props.put("retries", "3");
+		return props;
+	}
+
 	// -- consumer / producer instances:
 	public <T> FlinkKafkaConsumerBase<T> getConsumer(List<String> topics, DeserializationSchema<T> deserializationSchema, Properties props) {
 		return getConsumer(topics, new KafkaDeserializationSchemaWrapper<T>(deserializationSchema), props);

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/DataGenerators.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/DataGenerators.java
@@ -104,6 +104,8 @@ public class DataGenerators {
 		if (secureProps != null) {
 			props.putAll(testServer.getSecureProperties());
 		}
+		// Ensure the producer enables idempotence.
+		props.putAll(testServer.getIdempotentProducerConfig());
 
 		stream = stream.rebalance();
 		testServer.produceIntoKafka(stream, topic,


### PR DESCRIPTION
…KafkaITCase to avoid intermittent test failure.

## What is the purpose of the change
Kafka IT case produces messages without enabling idempotence for `KafkaProducer`. This may cause occasional failure in some tests with duplication check. This patch enables idempotent Kafka producer.

## Brief change log
Enable idempotent Kafka producer in KafkaITCase.


## Verifying this change
This change fixes an existing test case, i.e. KafkaITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
