### PR TITLE
[FLINK-15510] Pretty Print StreamGraph JSON Plan

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/JSONGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/JSONGenerator.java
@@ -57,23 +57,14 @@ public class JSONGenerator {
 		ObjectNode json = mapper.createObjectNode();
 		ArrayNode nodes = mapper.createArrayNode();
 		json.put("nodes", nodes);
-		List<Integer> operatorIDs = new ArrayList<Integer>(streamGraph.getVertexIDs());
-		Collections.sort(operatorIDs, new Comparator<Integer>() {
-			@Override
-			public int compare(Integer idOne, Integer idTwo) {
-				boolean isIdOneSinkId = streamGraph.getSinkIDs().contains(idOne);
-				boolean isIdTwoSinkId = streamGraph.getSinkIDs().contains(idTwo);
-				// put sinks at the back
-				if (isIdOneSinkId == isIdTwoSinkId) {
-					return idOne.compareTo(idTwo);
-				} else if (isIdOneSinkId) {
-					return 1;
-				} else {
-					return -1;
-				}
-			}
-		});
-		visit(nodes, operatorIDs, new HashMap<Integer, Integer>());
+
+		List<Integer> operatorIDs = new ArrayList<>(streamGraph.getVertexIDs());
+		Comparator<Integer> operatorIDComparator = Comparator
+			.comparingInt((Integer id) -> streamGraph.getSinkIDs().contains(id) ? 1 : 0)
+			.thenComparingInt(id -> id);
+		operatorIDs.sort(operatorIDComparator);
+
+		visit(nodes, operatorIDs, new HashMap<>());
 
 		return json.toPrettyString();
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/JSONGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/JSONGenerator.java
@@ -74,7 +74,8 @@ public class JSONGenerator {
 			}
 		});
 		visit(nodes, operatorIDs, new HashMap<Integer, Integer>());
-		return json.toString();
+
+		return json.toPrettyString();
 	}
 
 	private void visit(ArrayNode jsonArray, List<Integer> toVisit,


### PR DESCRIPTION
## What is the purpose of the change

Currently we print StreamGraph JSON as string without pretty printer. The output is less than awesome. We can simply switch to `toPrettyString`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
