### PR TITLE
[FLINK-15424][StateBackend] Make AppendintState#add refuse to add null element

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/state/AppendingState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/AppendingState.java
@@ -60,10 +60,11 @@ public interface AppendingState<IN, OUT> extends State {
 	 * to the list of values. The next time {@link #get()} is called (for the same state
 	 * partition) the returned state will represent the updated list.
 	 *
-	 * <p>If null is passed in, the state value will remain unchanged.
+	 * <p>AppendingState refuses to add null element.
 	 *
 	 * @param value The new value for the state.
 	 *
+	 * @throws NullPointerException Thrown if the passed in parameter is null.
 	 * @throws Exception Thrown if the system cannot access the state.
 	 */
 	void add(IN value) throws Exception;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapAggregatingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapAggregatingState.java
@@ -94,12 +94,8 @@ class HeapAggregatingState<K, N, IN, ACC, OUT>
 
 	@Override
 	public void add(IN value) throws IOException {
+		Preconditions.checkNotNull(value, "You cannot add null to an AggregatingState.");
 		final N namespace = currentNamespace;
-
-		if (value == null) {
-			clear();
-			return;
-		}
 
 		try {
 			stateTable.transform(namespace, value, aggregateTransformation);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapFoldingState.java
@@ -94,11 +94,7 @@ class HeapFoldingState<K, N, T, ACC>
 
 	@Override
 	public void add(T value) throws IOException {
-
-		if (value == null) {
-			clear();
-			return;
-		}
+		Preconditions.checkNotNull(value, "You cannot add null to a FoldingState.");
 
 		try {
 			stateTable.transform(currentNamespace, value, foldTransformation);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapReducingState.java
@@ -91,11 +91,7 @@ class HeapReducingState<K, N, V>
 
 	@Override
 	public void add(V value) throws IOException {
-
-		if (value == null) {
-			clear();
-			return;
-		}
+		Preconditions.checkNotNull(value, "You cannot add null to a ReducingState.");
 
 		try {
 			stateTable.transform(currentNamespace, value, reduceTransformation);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlFoldingState.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.state.ttl;
 
 import org.apache.flink.api.common.state.AggregatingState;
 import org.apache.flink.runtime.state.internal.InternalFoldingState;
+import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -1768,6 +1768,21 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 	}
 
 	@Test
+	public void testReducingStateAddNull() throws Exception {
+		AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+		try {
+			ReducingStateDescriptor<String> kvId = new ReducingStateDescriptor<>("id", new AppendingReduce(), String.class);
+
+			ReducingState<String> state = backend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
+			expectedException.expect(NullPointerException.class);
+			state.add(null);
+		} finally {
+			backend.close();
+			backend.dispose();
+		}
+	}
+
+	@Test
 	@SuppressWarnings("unchecked")
 	public void testReducingState() throws Exception {
 		CheckpointStreamFactory streamFactory = createStreamFactory();
@@ -2034,6 +2049,24 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			assertThat("State backend is not empty.", keyedBackend.numKeyValueStateEntries(), is(0));
 		}
 		finally {
+			keyedBackend.close();
+			keyedBackend.dispose();
+		}
+	}
+
+	@Test
+	public void testAggregatingStateAddNull() throws Exception {
+		final AggregatingStateDescriptor<Long, MutableLong, Long> stateDescr =
+			new AggregatingStateDescriptor<>("my-state", new MutableAggregatingAddingFunction(), MutableLong.class);
+
+		AbstractKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE);
+
+		try {
+			AggregatingState<Long, Long> state =
+				keyedBackend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescr);
+			expectedException.expect(NullPointerException.class);
+			state.add(null);
+		} finally {
 			keyedBackend.close();
 			keyedBackend.dispose();
 		}
@@ -2382,6 +2415,25 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 		finally {
 			keyedBackend.close();
 			keyedBackend.dispose();
+		}
+	}
+
+	@Test
+	public void testFoldingStateAddNull() throws Exception {
+		AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+
+		try {
+			FoldingStateDescriptor<Integer, String> kvId = new FoldingStateDescriptor<>("id",
+				"Fold-Initial:",
+				new AppendingFold(),
+				String.class);
+
+			FoldingState<Integer, String> state = backend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
+			expectedException.expect(NullPointerException.class);
+			state.add(null);
+		} finally {
+			backend.close();
+			backend.dispose();
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalFoldingState.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalFoldingState.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.internal.InternalFoldingState;
+import org.apache.flink.util.Preconditions;
 
 /** In memory mock internal folding state. */
 @SuppressWarnings("deprecation")
@@ -42,6 +43,7 @@ class MockInternalFoldingState<K, N, T, ACC>
 
 	@Override
 	public void add(T value) throws Exception {
+		Preconditions.checkNotNull(value, "You cannot add null to a FoldingState.");
 		updateInternal(foldFunction.fold(get(), value));
 	}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.internal.InternalAggregatingState;
 import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.Preconditions;
 
 import org.rocksdb.ColumnFamilyHandle;
 
@@ -97,6 +98,7 @@ class RocksDBAggregatingState<K, N, T, ACC, R>
 
 	@Override
 	public void add(T value) {
+		Preconditions.checkNotNull(value, "You cannot add null to an AggregatingState.");
 		byte[] key = getKeyBytes();
 		ACC accumulator = getInternal(key);
 		accumulator = accumulator == null ? aggFunction.createAccumulator() : accumulator;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
@@ -27,6 +27,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.internal.InternalFoldingState;
+import org.apache.flink.util.Preconditions;
 
 import org.rocksdb.ColumnFamilyHandle;
 
@@ -93,6 +94,7 @@ class RocksDBFoldingState<K, N, T, ACC>
 
 	@Override
 	public void add(T value) throws Exception {
+		Preconditions.checkNotNull(value, "You cannot add null to a FoldingState.");
 		byte[] key = getKeyBytes();
 		ACC accumulator = getInternal(key);
 		accumulator = accumulator == null ? getDefaultValue() : accumulator;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.internal.InternalReducingState;
 import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.Preconditions;
 
 import org.rocksdb.ColumnFamilyHandle;
 
@@ -90,6 +91,7 @@ class RocksDBReducingState<K, N, V>
 
 	@Override
 	public void add(V value) throws Exception {
+		Preconditions.checkNotNull(value, "You cannot add null to a ReducingState.");
 		byte[] key = getKeyBytes();
 		V oldValue = getInternal(key);
 		V newValue = oldValue == null ? value : reduceFunction.reduce(oldValue, value);


### PR DESCRIPTION
## What is the purpose of the change

Make `AppendingState#add` refuse to add null elment, and update the java doc

## Brief change log

1. Update the java doc of AppendingState#add about refusing to add null element
2. Make all implementations of AppendingState#add respect the java doc
3. Add ut tests cover this scenario


## Verifying this change

This change added tests and can be verified as follows:

- StateBackendTestBase#{`testListStateAddNull`, `testReducingStateAddNull`, `testFoldingStateAddNull`, `testAggregatingStateAddNull`}

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
